### PR TITLE
fix(agent): 异步 subagent 按自身 model 自建 adapter + 失败原因透传

### DIFF
--- a/crabot-agent/src/agent/agent-handler.ts
+++ b/crabot-agent/src/agent/agent-handler.ts
@@ -344,6 +344,21 @@ export function adapterFromSdkEnv(sdkEnv: SdkEnvConfig) {
 }
 
 /**
+ * 按 subagent / auditor 解析出的 model（LLMConnectionInfo）自建 adapter。
+ * 同步(runSubAgentDirect)、异步(runSubAgentAsync)、goal_audit 三条派发路径共用，
+ * 确保子 agent 始终用自己 provider 的 endpoint/apikey，绝不复用父 agent 的 adapter
+ * （否则会把子模型名发到父端点，如 deepseek 模型打到 Codex 镜像 → HTTP 400）。
+ */
+function adapterFromModel(model: SubAgentConfig['model']) {
+  return createAdapter({
+    endpoint: model.endpoint,
+    apikey: model.apikey,
+    format: model.format,
+    ...(model.account_id ? { accountId: model.account_id } : {}),
+  })
+}
+
+/**
  * 给 skills 列表算一个身份 hash 用于热加载防抖去重。
  *
  * 新协议下 admin 传 `{name, skill_dir}` 引用、不传 content；agent 直接 fs.read skill_dir，
@@ -1165,7 +1180,6 @@ export class AgentHandler {
                 session_id: context.task_origin?.session_id,
                 channel_id: context.task_origin?.channel_id,
               },
-              adapter,
             },
           })
           // wrap：异步路径返回 `{agent_id, status:'launched'}` → 抓出来加入 taskState.activeAsyncSubagentIds，
@@ -2896,12 +2910,7 @@ export class AgentHandler {
     })
 
     // 3. build adapter from subagent's resolved model
-    const subAdapter = createAdapter({
-      endpoint: subagent.model.endpoint,
-      apikey: subagent.model.apikey,
-      format: subagent.model.format,
-      ...(subagent.model.account_id ? { accountId: subagent.model.account_id } : {}),
-    })
+    const subAdapter = adapterFromModel(subagent.model)
 
     // 4. resolve hook registry based on hook_preset
     const hookRegistry = subagent.hook_preset === 'coding_expert'
@@ -3291,12 +3300,7 @@ export class AgentHandler {
         if (!auditor) {
           throw new Error('builtin-goal-auditor subagent not configured')
         }
-        const auditAdapter = createAdapter({
-          endpoint: auditor.model.endpoint,
-          apikey: auditor.model.apikey,
-          format: auditor.model.format,
-          ...(auditor.model.account_id ? { accountId: auditor.model.account_id } : {}),
-        })
+        const auditAdapter = adapterFromModel(auditor.model)
         const auditPermission = opts.getAuditPermissionConfig()
         return {
           goal,
@@ -3335,10 +3339,9 @@ export class AgentHandler {
     readonly traceConfig?: SubAgentTraceConfig
     /** 是否允许异步派发（master + 私聊 session）。false 时总走同步。 */
     readonly asyncEnabled?: boolean
-    /** 异步派发时的 subagent 上下文（owner 信息、adapter） */
+    /** 异步派发时的 subagent 上下文（owner 信息） */
     readonly asyncCtx?: {
       readonly owner: import('../engine/bg-entities/types.js').BgEntityOwner
-      readonly adapter: import('../engine/llm-adapter.js').LLMAdapter
     }
   }): RunSubAgentFn {
     return async (subagent, input, ctx) => {
@@ -3361,7 +3364,6 @@ export class AgentHandler {
     input: RunSubAgentInput & { sync?: boolean },
     asyncCtx: {
       readonly owner: import('../engine/bg-entities/types.js').BgEntityOwner
-      readonly adapter: import('../engine/llm-adapter.js').LLMAdapter
     },
     deps: {
       readonly parentTools: ReadonlyArray<import('../engine/types.js').ToolDefinition>
@@ -3374,7 +3376,8 @@ export class AgentHandler {
     const { spawnPersistentAgent } = await import('../engine/bg-entities/bg-agent.js')
 
     const subModel = subagent.model
-    const subAdapter = asyncCtx.adapter
+    // 异步 subagent 必须按自己的 model 自建 adapter，不复用父 adapter（同步路径一致）。
+    const subAdapter = adapterFromModel(subModel)
 
     // 子 agent 工具集：从父工具里过滤（同 runSubAgentDirect 路径）
     const subTools = filterToolsForSubAgent(
@@ -3422,13 +3425,18 @@ export class AgentHandler {
         : {}),
       onExit: (info) => {
         if (!deps.humanQueue) return
+        const failed = info.status === 'failed'
         const notification = [
           '<sub_agent_notification>',
           `<agent_id>${info.entity_id}</agent_id>`,
           `<description>${info.task_description.slice(0, 200)}</description>`,
           `<status>${info.status}</status>`,
           `<runtime_ms>${info.runtime_ms}</runtime_ms>`,
+          failed && info.error ? `<error>${info.error.slice(0, 500)}</error>` : '',
           info.result_file ? `<output_file>${info.result_file}</output_file>` : '',
+          // 失败时由你（main）决定如何处理：若是接口/网络/额度类失败（HTTP 4xx/5xx、超时等），
+          // 通常应通知人类；若是任务逻辑问题，可自行续办或调整方案。
+          failed ? '<guidance>子任务失败，请判断失败性质并决定是否通知人类（接口类失败通常应通知）。</guidance>' : '',
           '</sub_agent_notification>',
         ].filter(Boolean).join('\n')
         deps.humanQueue.push(notification)

--- a/crabot-agent/src/agent/subagent-coordinator-tools.ts
+++ b/crabot-agent/src/agent/subagent-coordinator-tools.ts
@@ -84,6 +84,11 @@ function createGetSubagentOutputTool(deps: SubagentCoordinatorDeps): ToolDefinit
       if (rec.type !== 'agent') return { output: `${agentId} is not an agent`, isError: true }
 
       const agent = rec as import('../engine/bg-entities/types.js').BgAgentRegistryRecord
+      // 失败的 subagent 通常没有 result_file（或为空）：把失败原因回传给父 agent，
+      // 让它决定如何处理（接口类失败通常应通知人类），而不是吞成 "(empty output)"。
+      if (agent.status === 'failed' && agent.error) {
+        return { output: `Agent ${agentId} failed: ${agent.error}`, isError: true }
+      }
       if (!agent.result_file) {
         return {
           output: `Agent ${agentId} status=${agent.status}; result file not yet available`,

--- a/crabot-agent/src/engine/bg-entities/bg-agent.ts
+++ b/crabot-agent/src/engine/bg-entities/bg-agent.ts
@@ -15,6 +15,7 @@ import * as path from 'node:path'
 import type { LLMAdapter } from '../llm-adapter.js'
 import type { ToolDefinition, ToolPermissionConfig } from '../types.js'
 import { runEngine } from '../query-loop.js'
+import { getErrorMessage } from '../tools/utils.js'
 import { getBgEntitiesLogsDir } from '../../core/data-paths.js'
 import type { BgEntityRegistry } from './registry.js'
 import type { BgEntityOwner, BgAgentRegistryRecord } from './types.js'
@@ -90,6 +91,8 @@ export interface SpawnPersistentAgentOpts {
     runtime_ms: number
     spawned_at: string
     result_file: string | null
+    /** 失败原因（status='failed' 时填），供 caller 把失败原因回传给父 agent / 通知人类。 */
+    error?: string
     outcome?: 'completed' | 'failed' | 'max_turns' | 'aborted'
     exitToolCall?: { readonly name: string; readonly input: Record<string, unknown> }
     finalText?: string
@@ -202,6 +205,8 @@ export async function spawnPersistentAgent(opts: SpawnPersistentAgentOpts): Prom
         result.outcome === 'completed' ? ('completed' as const) : ('failed' as const)
       const exitCode = result.outcome === 'completed' ? 0 : 1
       const runtimeMs = Date.now() - agentSpawnedAtMs
+      // 失败原因：一路透传给 trace / registry / onExit，让父 agent 能拿到失败原因。
+      const failureError = endedStatus === 'failed' && result.error ? result.error : undefined
       if (opts.traceContext) {
         emitInstantSpan(opts.traceContext, 'bg_entity_exit', {
           entity_id,
@@ -214,9 +219,7 @@ export async function spawnPersistentAgent(opts: SpawnPersistentAgentOpts): Prom
       if (subTrace && subTraceStore) {
         subTraceStore.endTrace(subTrace.trace_id, endedStatus, {
           summary: (result.finalText ?? '').slice(0, 200),
-          ...(endedStatus === 'failed' && result.error
-            ? { error: result.error.slice(0, 200) }
-            : {}),
+          ...(failureError ? { error: failureError.slice(0, 200) } : {}),
         })
       }
       await opts.registry
@@ -225,6 +228,7 @@ export async function spawnPersistentAgent(opts: SpawnPersistentAgentOpts): Prom
           result_file: resultFile,
           exit_code: exitCode,
           ended_at: new Date().toISOString(),
+          ...(failureError ? { error: failureError } : {}),
         } as Partial<BgAgentRegistryRecord>)
         .catch(() => {})
       if (opts.onExit) {
@@ -237,6 +241,7 @@ export async function spawnPersistentAgent(opts: SpawnPersistentAgentOpts): Prom
             runtime_ms: runtimeMs,
             spawned_at: now,
             result_file: resultFile,
+            ...(failureError ? { error: failureError } : {}),
             outcome: result.outcome,
             ...(result.exitToolCall ? { exitToolCall: result.exitToolCall } : {}),
             finalText: result.finalText ?? '',
@@ -245,10 +250,11 @@ export async function spawnPersistentAgent(opts: SpawnPersistentAgentOpts): Prom
           console.error(`[bg-agent] onExit callback failed for ${entity_id}:`, err)
         }
       }
-    } catch {
+    } catch (err) {
       // Handles both abort and unexpected errors.
       // registry.update's status-guard prevents overwriting an already-killed entry.
       const runtimeMs = Date.now() - agentSpawnedAtMs
+      const errMsg = getErrorMessage(err) || 'sub-agent aborted or errored'
       if (opts.traceContext) {
         emitInstantSpan(opts.traceContext, 'bg_entity_exit', {
           entity_id,
@@ -260,8 +266,8 @@ export async function spawnPersistentAgent(opts: SpawnPersistentAgentOpts): Prom
       }
       if (subTrace && subTraceStore) {
         subTraceStore.endTrace(subTrace.trace_id, 'failed', {
-          summary: 'sub-agent aborted or errored',
-          error: 'sub-agent aborted or errored',
+          summary: errMsg.slice(0, 200),
+          error: errMsg.slice(0, 200),
         })
       }
       await opts.registry
@@ -269,6 +275,7 @@ export async function spawnPersistentAgent(opts: SpawnPersistentAgentOpts): Prom
           status: 'failed' as const,
           exit_code: 1,
           ended_at: new Date().toISOString(),
+          error: errMsg,
         } as Partial<BgAgentRegistryRecord>)
         .catch(() => {})
       if (opts.onExit) {
@@ -281,6 +288,7 @@ export async function spawnPersistentAgent(opts: SpawnPersistentAgentOpts): Prom
             runtime_ms: runtimeMs,
             spawned_at: now,
             result_file: null,
+            error: errMsg,
           })
         } catch (err) {
           console.error(`[bg-agent] onExit callback failed for ${entity_id}:`, err)

--- a/crabot-agent/src/engine/bg-entities/types.ts
+++ b/crabot-agent/src/engine/bg-entities/types.ts
@@ -39,6 +39,8 @@ export interface BgAgentRegistryRecord extends BgEntityBase {
   readonly task_description: string
   readonly messages_log_file: string
   result_file: string | null
+  /** 失败原因（status='failed' 时填）。供 get_subagent_output 把失败原因回传给父 agent。 */
+  error?: string | null
 }
 
 export type BgEntityRecord = BgShellRegistryRecord | BgAgentRegistryRecord

--- a/crabot-agent/src/engine/retry-utils.ts
+++ b/crabot-agent/src/engine/retry-utils.ts
@@ -100,6 +100,14 @@ function extractBodyCode(body: string): string | null {
       }
       const topCode = (obj as { code?: unknown }).code
       if (typeof topCode === 'string') return topCode
+      // OpenAI 风格永久错误（如 invalid_request_error）只在 error.type 给判别符，不带 code。
+      // 黑名单里就列了 invalid_request_error，必须把 type 也纳入识别——否则 HTTP 400
+      // invalid_request_error 会落到状态码默认重试，白烧整轮时间预算（见 deepseek 模型打到
+      // Codex 端点的 400 案例）。优先级最低：code 命中时不会走到这里。
+      if (err && typeof err === 'object') {
+        const nestedType = (err as { type?: unknown }).type
+        if (typeof nestedType === 'string') return nestedType
+      }
     }
   } catch { /* not JSON */ }
   return null

--- a/crabot-agent/tests/engine/retry-utils.test.ts
+++ b/crabot-agent/tests/engine/retry-utils.test.ts
@@ -165,6 +165,23 @@ describe('streamWithRetry', () => {
     expect(isRetryableError(err)).toBe(false)
   })
 
+  it('treats OpenAI-style {error:{type:invalid_request_error}} (no code) as non-retryable', async () => {
+    // 真实形态：mirror/Codex 端点拒绝非兼容模型时返回 error.type 而非 error.code。
+    // 旧实现只读 code → 漏判 → HTTP 400 被当可重试，白烧整轮时间预算。
+    const err = new HttpResponseError(
+      400,
+      JSON.stringify({
+        error: {
+          message: "The 'deepseek-v4-flash' model is not supported when using Codex with a ChatGPT account.",
+          type: 'invalid_request_error',
+        },
+      }),
+      'openai-adapter',
+    )
+    expect(err.bodyCode).toBe('invalid_request_error')
+    expect(isRetryableError(err)).toBe(false)
+  })
+
   it('treats DashScope data_inspection_failed (content moderation) as non-retryable', async () => {
     // 阿里云百炼把内容审核拦截塞进 HTTP 400 + `{error:{code:"data_inspection_failed"}}`。
     // 重试 10 次会原样重发被拦的输入 → 必须 fail-fast。


### PR DESCRIPTION
根因：runSubAgentAsync 复用了父 agent 的 adapter（asyncCtx.adapter，指向父端点）， 只换 model_id —— 导致子模型名被发到父端点（如 deepseek 模型打到 Codex 镜像 mirror.xinshu → HTTP 400 "model not supported when using Codex with a ChatGPT account"）。 该 bug 自 6666353（2026-05 异步 subagent）潜伏，与近期流式改造无关。

- runSubAgentAsync 改为按 subagent.model 自建 adapter（对齐同步 runSubAgentDirect）
- 抽 adapterFromModel helper，统一同步 / 异步 / goal_audit 三处 adapter 构造
- retry-utils.extractBodyCode 兜底读 error.type：黑名单里本就列了 invalid_request_error， 但它是 error.type 不是 error.code，旧实现漏判 → HTTP 400 永久错误被当可重试白烧 ~300s
- subagent 失败原因一路透传给 main：bg-agent onExit/registry 带 error、 get_subagent_output 失败返回原因（不再吞成 "(empty output)"）、 <sub_agent_notification> 加 <error>/<guidance>，由 main 决定如何处理及是否通知人类
- 补 retry-utils 测试：{error:{type:invalid_request_error}}（无 code）应判不可重试