### PR TITLE
fix(dispatcher): 群聊多 bot 收件人误判修复——self-handle 用群昵称 + 收件人前置段

### DIFF
--- a/crabot-agent/src/dispatcher/dispatcher-prompt.ts
+++ b/crabot-agent/src/dispatcher/dispatcher-prompt.ts
@@ -23,6 +23,11 @@ export function assembleDispatcherPrompt(ctx: DispatchContext): string {
   const parts: string[] = []
   parts.push(PRODUCT_SELF)
   parts.push('')
+  // 群聊才有收件人歧义（多人 + 多 bot 共存）；私聊/admin chat 只有两方，不需要这段
+  if (ctx.sessionType === 'group') {
+    parts.push(GROUP_RECIPIENT_PREAMBLE)
+    parts.push('')
+  }
   parts.push(buildDispatchRules(ctx.sessionType, hasActiveTasks))
   parts.push('')
   if (ctx.crabSelfHandle) {
@@ -51,6 +56,14 @@ const PRODUCT_SELF = `## 你是 Crabot 的消息分诊器
 
 你不直接与人类对话——你的判断会让系统调起相应的 agent 实例执行任务，或把消息作为补充投递给已经在跑的任务，或者忽略（仅群聊）。`
 
+const GROUP_RECIPIENT_PREAMBLE = `## 分诊前置：先判收件人（最高优先级）
+
+判断 new_task / supplement / stay_silent 之前，先逐条判断这条消息发给谁。**收件人判定优先于“消息里有动词/任务/服务器/代码”等任务特征。**
+
+- 明确发给我的信号：消息带 mention="@you"，或正文出现「你在本渠道的身份」段里我的 @handle，或当前消息明确在追问我刚才发出的内容。满足才可 new_task / supplement。
+- 正文 @ 了其他人/其他 bot、又没有同时明确 @ 我 → 默认不是发给我。
+- 仅当没有指定个人收件人的公共群请求，才继续判断我是否该承担。`
+
 function buildDispatchRules(
   sessionType: DispatchContext['sessionType'],
   hasActiveTasks: boolean,
@@ -72,6 +85,7 @@ const SUPPLEMENT_WHITELIST_REMINDER =
  */
 const NEW_TASK_IMMEDIATE_REPLY_HINT =
   `   - immediate_reply（可选）：worker 需要动手（查记忆/查配置/查日志/调命令/读代码/多步推理）才能答的任务，在 worker 起来前先发一句简短 ack 让用户知道收到了（worker 看历史不会重复 ack）
+     · 前提：先确认这条确实发给我再考虑；不要因为有动词/服务器/命令/代码等任务特征就跳过收件人判定
      · 倾向带：**需要 agent 动手才能答的请求**——即使字面是单一问句也算（如「服务器 X 的 root 密码是多少」「为什么接口返回 500」「这个表怎么同步的」） / 动词类指令（写/查/调研/分析/做/帮我/给我一个示例） / 多步骤连接词（然后/还要/最后） / 涉及代码生成 / 用户发来代码片段/日志/截图描述让 crab 排查 / 场景画像明示
      · 倾向不带：寒暄（在吗/谢谢/好的，agent 会立即回） / **agent 不用动手就能秒回的字面常识问句**（今天几号 / 你是谁 / 你用的什么模型） / 简短 ack（嗯/行/👍） / 用户单纯分享想法不带请求
      · 拿不准：不带（错带显得啰嗦；而且拿不准时大概率也不知道该写什么 ack）
@@ -121,7 +135,7 @@ const GROUP_RULES_WITH_ACTIVE = `## 分诊规则（群聊）
    - text 用户原话（去掉无关客套即可）。**不要替 agent 解读意图**
 
 2. **new_task** — 某条消息发起一个跟我相关的新任务。
-   - text 用户原话（去掉无关客套即可）。**不要替 agent 提炼意图或加方向性引导**
+   - text 用户原话，**必须保留 @对象、收件人说明与否定范围（如「不是给 X 的」）**，只删与收件人无关的寒暄。**不要替 agent 提炼意图或加方向性引导**
 ${NEW_TASK_IMMEDIATE_REPLY_HINT}
 
 3. **stay_silent** — 这批（或这部分）消息跟我无关。
@@ -141,7 +155,7 @@ const GROUP_RULES_NO_ACTIVE = `## 分诊规则（群聊）
 当前没有任何活跃任务。群聊批次（多消息多用户）的每个动作可以是：
 
 1. **new_task** — 某条消息发起一个跟我相关的新任务。
-   - text 用户原话（去掉无关客套即可）。**不要替 agent 提炼意图或加方向性引导**
+   - text 用户原话，**必须保留 @对象、收件人说明与否定范围（如「不是给 X 的」）**，只删与收件人无关的寒暄。**不要替 agent 提炼意图或加方向性引导**
 ${NEW_TASK_IMMEDIATE_REPLY_HINT}
 
 2. **stay_silent** — 这批（或这部分）消息跟我无关。

--- a/crabot-channel-wechat/src/wechat-channel.ts
+++ b/crabot-channel-wechat/src/wechat-channel.ts
@@ -299,6 +299,13 @@ export class WechatChannel extends ModuleBase {
       ? await this.getCrabGroupNick(platformSessionId, event.puppet.wxid)
       : undefined
 
+    // dispatcher / worker 用它区分"哪个 @ 是发给我的"。微信正文里的 @ 是 @昵称，
+    // self 锚点必须用群昵称才能跟正文对得上；wxid 永远不出现在正文里、对照不上
+    // （实测会导致 bot 认不出 @ 自己 / 误判收件人）。群昵称取不到时回退 wxid。
+    const crabSelfHandle = crabDisplayName
+      ? `@${crabDisplayName}`
+      : (event.puppet?.wxid ? `@${event.puppet.wxid}` : undefined)
+
     // 构建 ChannelMessage
     const channelMessage: ChannelMessage = {
       platform_message_id: event.message.id,
@@ -328,10 +335,7 @@ export class WechatChannel extends ModuleBase {
         channel_id: this.config.moduleId,
         message: channelMessage,
         ...(crabDisplayName !== undefined ? { crab_display_name: crabDisplayName } : {}),
-        // 群里多机器人共存时，dispatcher / worker 用它区分"哪个 @ 是发给我的"。
-        // 微信消息正文 @ 通常是 @昵称，但 puppet.wxid 是稳定标识，至少让 LLM 拥有
-        // 一个可对照的 self 锚点。
-        ...(event.puppet?.wxid ? { crab_self_handle: `@${event.puppet.wxid}` } : {}),
+        ...(crabSelfHandle ? { crab_self_handle: crabSelfHandle } : {}),
       },
       timestamp: generateTimestamp(),
     }

--- a/docs/fix-wechat-self-handle-nickname.md
+++ b/docs/fix-wechat-self-handle-nickname.md
@@ -1,0 +1,75 @@
+# 修复方案：微信群分诊误判（dispatcher self-handle 应用群昵称而非 wxid）
+
+## 1. 症状
+
+群里同时挂多个 crabot 实例 + 真人。同一条消息引发两类**方向相反**的误判：
+
+- **棉花糖**（master=fufu）：gaozhi 发了一条 `@实事求是 你可以通过 ssh ... 部署环境 ... 这条指令就是发送给你的不是给fufu的`，明确点名另一个 bot 且排除 fufu。棉花糖**却派 worker 去执行**（dispatcher 输出 `new_task`）。
+- **实事求是**（master=gaozhi）：gaozhi `@实事求是` 让它部署，它**却 `stay_silent`**（trace 理由“用户在询问群成员 FuFu，不是在叫我”）。
+
+线上 trace：棉花糖侧 `403b4f9a`。
+
+## 2. 根因（已实测定位到单点）
+
+dispatcher 注入给 LLM 的“自我身份”锚点是 **bot 的 wxid**：
+
+`crabot-channel-wechat/src/wechat-channel.ts:334`
+```js
+...(event.puppet?.wxid ? { crab_self_handle: `@${event.puppet.wxid}` } : {}),
+```
+
+dispatcher 身份段（`crabot-agent/src/dispatcher/dispatcher-prompt.ts` 的 `buildSelfIdentitySection`）据此告诉模型：
+> 你的 @handle: `@<wxid>`；正文出现它才是 @ 你；**其它 @xxx 是发给别人的，不要错把发给别人的内容当成发给自己的指令。**
+
+但微信群消息正文里的 @ 全是**群昵称**（`@实事求是` / `@棉花糖🐶` / `@FuFu🐑`），**永远不会**出现 wxid。于是这个 self 锚点恒定匹配不上，模型既无法确认“`@实事求是` ≠ 我”，也无法解析“这条指令就是发送给你的”里的“你”，最终在“一条字面可执行的部署指令”面前误判。
+
+## 3. 实测证据（忠实复现 + 变量隔离）
+
+用 trace `403b4f9a` 的真实输入（`get_history` 取回当时 6h 窗口 47 条历史 + 触发批次 3 条 + 实际 provider）重建 dispatcher 的 system+user prompt，喂**同一个模型 gpt-5.5**，逐个施加修改：
+
+| 变量 | self-handle | 历史发送者名 | gpt-5.5 实测 |
+|---|---|---|---|
+| baseline（忠实复现） | `@<wxid>` | wxid | **new_task ×3/3** ← 与线上一致 |
+| 只改 self-handle | `@棉花糖🐶` | wxid | **stay_silent ×2/2** |
+| 只改历史名 | `@<wxid>` | 昵称 | **new_task ×2/2**（无效） |
+| 两个都改 | `@棉花糖🐶` | 昵称 | **stay_silent ×2/2** |
+
+baseline 复现出的 new_task 正文与线上 trace 一字不差。**结论：self-handle 改群昵称是决定性修复（单独即 2/2 翻转）；历史名解析单独无效。**
+
+修改后模型的 stay_silent 理由（原话）：“消息是在指派 @实事求是，并讨论 @FuFu🐑，未提到我”。
+
+## 4. 修复方案
+
+### 4.1 主修复（必须、决定性）
+
+`crabot-channel-wechat/src/wechat-channel.ts:334`：self-handle 取值改用同函数上方已解析好的群昵称 `crabDisplayName`（来自 `getCrabGroupNick`，约 line 299），取不到时回退 wxid：
+
+```js
+// 当前
+...(event.puppet?.wxid ? { crab_self_handle: `@${event.puppet.wxid}` } : {}),
+
+// 改为
+const selfHandle = crabDisplayName
+  ? `@${crabDisplayName}`
+  : (event.puppet?.wxid ? `@${event.puppet.wxid}` : undefined)
+...(selfHandle ? { crab_self_handle: selfHandle } : {}),
+```
+
+- `crabDisplayName` 仅群聊解析（私聊为 undefined）——私聊本就两方对话、无需区分 @，自动回退 wxid 或省略即可。
+- 效果：棉花糖 self=`@棉花糖🐶` → `@实事求是`/`@FuFu🐑` 都 ≠ 自己 → stay_silent（正确）；实事求是 self=`@实事求是` → 认出自己的 @ → 动手（正确）。**同一处修复同时治好正反两侧。**
+
+### 4.2 次要修复（建议，非本案决定性）
+
+1. **历史发送者名解析**：`connectorMsgToProtocolItem`（`wechat-channel.ts`）当前 `platform_display_name = content.group_sender`（原始 wxid）。应复用 live 入站路径（connector 端 `buildAndEmitRawEvent` 用 group 成员 `chatroom_nick`）那套解析，让历史发送者也呈现昵称。提升多 bot 群历史可读性（实测对本案无影响，但属真实缺陷）。
+2. **`_self` 身份识别**：`connectorMsgToProtocolItem` 用 `_self` 标识 bot 自己的历史消息，而 `resolveSenderIdentity`（`crabot-agent/src/utils/sender-identity.ts`）判的是 `self`/`assistant`（少个下划线）→ bot 自己的历史消息被标 `identity="stranger"`，认不出自己的发言。建议对齐标识。
+3. **（上游 wechat-connector）引用消息发送者解析**：`enrichQuoteMessageContent` 只查 contact 表 + refermsg `<displayname>`，不查 group 成员名册，导致引用前缀泄漏原始 wxid（如 `> assfox:` 本应是 `> gaozhi:`）。
+
+## 5. 不采纳的方案
+
+- **不**把 `is_mention_crab` 升级为硬 gate（“没 @ 就强制沉默”）：会误伤合法的“master 不重新 @、直接追加指令”等无 @ 场景；且不解决“认不出自己”的根因——实测中“只改历史名仍 new_task”恰恰说明问题在**身份识别**而非 mention 信号。
+
+## 6. 影响面 / 风险 / 回归
+
+- 主修复仅改 1 处取值；行为变化：dispatcher 身份段锚点从 wxid 变群昵称。
+- 风险：群昵称可能含特殊字符或群内重复昵称——但相比“wxid 永不匹配”是**严格改善**；昵称匹配失败时退化为当前行为（wxid），不会更差。
+- 需回归：群聊 `@bot` 应触发响应、`@他人` 不应触发；私聊不受影响；多 bot 同群时各自只认自己的昵称。


### PR DESCRIPTION
## 背景
微信群里多个 crabot 共存时,dispatcher 收件人判错:棉花糖把明确 @ 另一个 bot(实事求是)、还声明"不是给fufu的"的部署指令抓去执行(`new_task`);对称地,实事求是被 @ 时反而 `stay_silent`。线上 trace `403b4f9a`。

## 根因(实测定位)
微信 `crab_self_handle` 用了 `@<wxid>`,而群正文里的 @ 是 `@昵称`、wxid 永不出现 → dispatcher 身份段"其它@是别人的"让 bot 既认不出 @ 自己、也解析不了"发送给你的"里的"你"。正反两侧同根。

## 改动(双层)
- **数据层** `wechat-channel.ts`:`crab_self_handle` 改用群昵称 `@${crabDisplayName}`,取不到才回退 wxid。
- **提示词层** `dispatcher-prompt.ts`(防御纵深):群聊加「先判收件人(最高优先级)」前置段;`new_task.text` 保留 @对象/否定范围;`immediate_reply` 加"先确认发给我"前提。

## 实测验证
用 trace 真实输入复刻 dispatcher prompt 喂 gpt-5.5:最终版从 `new_task`(误判)翻成 `stay_silent` **3/3**。隔离实验证明 **self-handle 是决定性修复**,纯 prompt 改单独无效(完整对照见 `docs/fix-wechat-self-handle-nickname.md`)。

## 部署提醒
源码改动,需重新构建 + 重启微信频道模块才生效(未部署)。