### PR TITLE
Fix trace task activity ordering and terminal supplement resume

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,6 +1,14 @@
 # Crabot 项目进度
 
-> 最后更新：2026-07-01 — 修复 recent terminal supplement 的 checkpoint 来源
+> 最后更新：2026-07-02 — 修复 Traces UI 活动排序、terminal supplement trace 续写与 null stopReason 误完成
+
+## 2026-07-02 — 修复 Traces UI 活动排序、terminal supplement trace 续写与 null stopReason 误完成
+
+- Traces 主列表的 task 行改按最后活动时间排序：`activity_at = max(task.updated_at, 最近关联 dispatcher started_at)`；标题/摘要优先显示最近 dispatcher 消息，避免旧 task 收到 supplement 后仍沉在创建时间位置、也避免只能看到原始长标题。
+- `list_conversation_units` 搜索把关键词传给 `search_traces`，并在 Admin 侧对 orphan/related dispatcher 二次过滤，避免搜一个补充消息时混入大量无关孤儿对话。
+- terminal supplement resume 才把历史 worker trace id 写入 `resumeFrom.resumeTraceId`，`handleExecuteTask` 通过 `TraceStore.reactivateTraceById()` 复用已完成 worker trace 继续追加 spans；普通 restart resume 不携带 `resumeTraceId`，仍走 `resumableCheckpoints` + `reactivateResumableTrace(task_id)`。修复同一 task 每次 terminal supplement 生成一条新 worker trace 的问题，同时避免把 restart 语义污染成历史 trace revive。旧历史数据里已产生的多 worker trace 不自动合并。
+- 明确区分 `stopReason='end_turn'` 与 `stopReason=null`：任意已送达 `send_message(intent='info')` 仍允许作为“已有交付”收口；但 LLM stream 没有 terminal stopReason 时按失败处理，不能把空输出误标 completed（对应 trace `6646e158` 的事故形态）。
+- 验证：Admin 定向回归 2 个通过；Agent resume/trace-store/query-loop 定向回归 14 个通过；query-loop 全量 33 个通过；`crabot-admin` / `crabot-agent` / `crabot-admin/web` `tsc --noEmit` 均通过。
 
 ## 2026-07-01 — 修复 recent terminal supplement 的 checkpoint 来源
 

--- a/crabot-admin/src/admin-web-api.test.ts
+++ b/crabot-admin/src/admin-web-api.test.ts
@@ -6,7 +6,7 @@ import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest
 import http from 'node:http'
 import fs from 'node:fs/promises'
 import AdminModule from './index.js'
-import type { ChannelMessageRef, DialogObjectApplication, Friend, FriendPermissionConfig, LoginResponse } from './types.js'
+import type { ChannelMessageRef, DialogObjectApplication, Friend, FriendPermissionConfig, ListConversationUnitsResult, LoginResponse, Task } from './types.js'
 import { AdminErrorCode, createCliAccessConfig } from './types.js'
 import { newCredentialsFromPassword, writeCredentials } from './credentials.js'
 
@@ -424,6 +424,90 @@ describe('Admin Web API', () => {
       )
       const startCall = callSpy.mock.calls.find(c => c[1] === 'start_task')
       expect(startCall?.[2]).toHaveProperty('resolved_permissions')
+    })
+  })
+
+  describe('list_conversation_units activity ordering', () => {
+    const taskIds = ['test-activity-old', 'test-activity-new']
+
+    afterEach(() => {
+      for (const id of taskIds) admin['tasks'].delete(id as never)
+    })
+
+    it('orders task rows by last activity instead of original creation time', async () => {
+      const revivedOldTask = makeTask({
+        id: 'test-activity-old',
+        title: '开卷考试策略 v2',
+        created_at: '2026-07-01T16:15:15.921Z',
+        updated_at: '2026-07-02T00:17:45.462Z',
+        messages: [
+          { id: 'm-old-1', role: 'human', content: '原始需求', timestamp: '2026-07-01T16:15:15.921Z' },
+          { id: 'm-old-2', role: 'human', content: '那你现在还不赶紧去做？', timestamp: '2026-07-02T00:12:42.281Z' },
+        ],
+      })
+      const newlyCreatedTask = makeTask({
+        id: 'test-activity-new',
+        title: '较新创建但没有后续活动',
+        created_at: '2026-07-02T00:10:00.000Z',
+        updated_at: '2026-07-02T00:10:00.000Z',
+        messages: [
+          { id: 'm-new-1', role: 'human', content: '新任务', timestamp: '2026-07-02T00:10:00.000Z' },
+        ],
+      })
+      admin['tasks'].set(revivedOldTask.id as never, revivedOldTask)
+      admin['tasks'].set(newlyCreatedTask.id as never, newlyCreatedTask)
+
+      const result = await admin['handleListConversationUnits']({
+        page: 1,
+        page_size: 10,
+        filter: { trigger_type: 'task' },
+      }) as ListConversationUnitsResult
+
+      const ids = result.items
+        .filter((u): u is Extract<typeof u, { kind: 'task' }> => u.kind === 'task')
+        .map((u) => u.task.id)
+      expect(ids.indexOf('test-activity-old')).toBeLessThan(ids.indexOf('test-activity-new'))
+    })
+
+    it('filters orphan dispatcher traces by the search keyword', async () => {
+      const callAgentRpc = vi.spyOn(admin as unknown as { callAgentRpc: (...args: unknown[]) => Promise<unknown> }, 'callAgentRpc')
+        .mockResolvedValue({
+          traces: [
+            {
+              trace_id: 'trace-match',
+              trigger_type: 'message',
+              trigger_summary: '[private×1] needle message',
+              started_at: '2026-07-02T00:12:37.518Z',
+              status: 'completed',
+              span_count: 1,
+            },
+            {
+              trace_id: 'trace-unrelated',
+              trigger_type: 'message',
+              trigger_summary: '[group×1] unrelated chatter',
+              started_at: '2026-07-02T00:13:37.518Z',
+              status: 'completed',
+              span_count: 1,
+            },
+          ],
+          total: 2,
+        })
+
+      const result = await admin['handleListConversationUnits']({
+        page: 1,
+        page_size: 10,
+        filter: { trigger_type: 'message', search: 'needle' },
+      }) as ListConversationUnitsResult
+
+      expect(callAgentRpc).toHaveBeenCalledWith(
+        'search_traces',
+        expect.objectContaining({ keyword: 'needle' }),
+      )
+      expect(result.items).toHaveLength(1)
+      expect(result.items[0]).toMatchObject({
+        kind: 'orphan_dispatcher',
+        trace: { trace_id: 'trace-match' },
+      })
     })
   })
 
@@ -1484,6 +1568,22 @@ function makePrivateMessageRef(params: {
       is_mention_crab: false,
     },
     platform_timestamp: '2026-04-19T00:00:00.000Z',
+  }
+}
+
+function makeTask(overrides: Partial<Task> & Pick<Task, 'id' | 'title' | 'created_at' | 'updated_at'>): Task {
+  return {
+    id: overrides.id,
+    status: overrides.status ?? 'completed',
+    priority: overrides.priority ?? 'normal',
+    title: overrides.title,
+    source: overrides.source ?? { origin: 'human', channel_id: 'telegram-001', session_id: 'session-1', trigger_type: 'message' },
+    messages: overrides.messages ?? [],
+    tags: overrides.tags ?? [],
+    created_at: overrides.created_at,
+    updated_at: overrides.updated_at,
+    ...(overrides.completed_at ? { completed_at: overrides.completed_at } : {}),
+    ...(overrides.result ? { result: overrides.result } : {}),
   }
 }
 

--- a/crabot-admin/src/admin-web-api.test.ts
+++ b/crabot-admin/src/admin-web-api.test.ts
@@ -435,6 +435,8 @@ describe('Admin Web API', () => {
     })
 
     it('orders task rows by last activity instead of original creation time', async () => {
+      vi.spyOn(admin as unknown as { callAgentRpc: (...args: unknown[]) => Promise<unknown> }, 'callAgentRpc')
+        .mockResolvedValue({ traces: [], total: 0 })
       const revivedOldTask = makeTask({
         id: 'test-activity-old',
         title: '开卷考试策略 v2',
@@ -467,6 +469,57 @@ describe('Admin Web API', () => {
         .filter((u): u is Extract<typeof u, { kind: 'task' }> => u.kind === 'task')
         .map((u) => u.task.id)
       expect(ids.indexOf('test-activity-old')).toBeLessThan(ids.indexOf('test-activity-new'))
+    })
+
+    it('uses related dispatcher activity even when listing task-only rows', async () => {
+      const oldTask = makeTask({
+        id: 'test-activity-old',
+        title: '旧标题',
+        created_at: '2026-07-01T16:15:15.921Z',
+        updated_at: '2026-07-01T16:15:15.921Z',
+        messages: [
+          { id: 'm-old-1', role: 'human', content: '原始需求', timestamp: '2026-07-01T16:15:15.921Z' },
+        ],
+      })
+      const newTask = makeTask({
+        id: 'test-activity-new',
+        title: '较新创建但没有后续活动',
+        created_at: '2026-07-02T00:10:00.000Z',
+        updated_at: '2026-07-02T00:10:00.000Z',
+        messages: [
+          { id: 'm-new-1', role: 'human', content: '新任务', timestamp: '2026-07-02T00:10:00.000Z' },
+        ],
+      })
+      admin['tasks'].set(oldTask.id as never, oldTask)
+      admin['tasks'].set(newTask.id as never, newTask)
+      vi.spyOn(admin as unknown as { callAgentRpc: (...args: unknown[]) => Promise<unknown> }, 'callAgentRpc')
+        .mockResolvedValue({
+          traces: [
+            {
+              trace_id: 'trace-related',
+              trigger_type: 'message',
+              trigger_summary: '那你现在还不赶紧去做？',
+              started_at: '2026-07-02T00:12:42.281Z',
+              status: 'completed',
+              span_count: 1,
+              related_task_id: 'test-activity-old',
+            },
+          ],
+          total: 1,
+        })
+
+      const result = await admin['handleListConversationUnits']({
+        page: 1,
+        page_size: 10,
+        filter: { trigger_type: 'task' },
+      }) as ListConversationUnitsResult
+
+      const taskUnits = result.items.filter((u): u is Extract<typeof u, { kind: 'task' }> => u.kind === 'task')
+      const oldUnit = taskUnits.find((u) => u.task.id === 'test-activity-old')
+      expect(oldUnit?.activity_at).toBe('2026-07-02T00:12:42.281Z')
+      expect(oldUnit?.activity_summary).toBe('那你现在还不赶紧去做？')
+      expect(taskUnits.findIndex((u) => u.task.id === 'test-activity-old'))
+        .toBeLessThan(taskUnits.findIndex((u) => u.task.id === 'test-activity-new'))
     })
 
     it('filters orphan dispatcher traces by the search keyword', async () => {

--- a/crabot-admin/src/index.ts
+++ b/crabot-admin/src/index.ts
@@ -5299,7 +5299,7 @@ export class AdminModule extends ModuleBase {
     const triggerType = params.filter?.trigger_type ?? 'all'
     let orphans: TraceSummary[] = []
     let relatedDispatchByTask = new Map<string, TraceSummary[]>()
-    if (triggerType !== 'task') {
+    if (triggerType === 'all' || triggerType === 'task' || triggerType === 'message') {
       try {
         const result = await this.callAgentRpc<
           { keyword?: string; status?: string; time_range?: { start: string; end: string }; limit: number },
@@ -5316,7 +5316,9 @@ export class AdminModule extends ModuleBase {
           !keyword ||
           t.trigger_summary.toLowerCase().includes(keyword) ||
           (t.outcome_summary?.toLowerCase().includes(keyword) ?? false)
-        orphans = result.traces.filter((t) => t.trigger_type === 'message' && !t.related_task_id && matchesKeyword(t))
+        orphans = triggerType === 'task'
+          ? []
+          : result.traces.filter((t) => t.trigger_type === 'message' && !t.related_task_id && matchesKeyword(t))
         relatedDispatchByTask = result.traces
           .filter((t) => t.trigger_type === 'message' && Boolean(t.related_task_id) && matchesKeyword(t))
           .reduce((acc, t) => {

--- a/crabot-admin/src/index.ts
+++ b/crabot-admin/src/index.ts
@@ -5256,8 +5256,8 @@ export class AdminModule extends ModuleBase {
    * 列出 conversation units（task + 孤儿 dispatcher trace 按时间合并 + 分页）。
    *
    * 后端 union 分页：
-   *  1. 拉所有满足 filter 的 task（按 task.created_at）
-   *  2. 拉所有满足 filter 的孤儿 dispatcher trace（按 trace.started_at），通过 agent RPC
+   *  1. 拉所有满足 filter 的 task
+   *  2. 拉所有满足 filter 的 dispatcher trace（按 trace.started_at），通过 agent RPC
    *  3. union 后按统一时间字段排序
    *  4. 按 page / page_size 切片
    *
@@ -5294,10 +5294,11 @@ export class AdminModule extends ModuleBase {
       }
     }
 
-    // 2. 拉孤儿 dispatcher trace（trigger_type=all from agent，admin 侧过滤孤儿）
+    // 2. 拉 dispatcher trace（trigger_type=all from agent，admin 侧过滤 orphan / related）
     // trigger_type filter: 'message' = 仅孤儿 dispatcher；'task' = 仅 task；'all' = 全部
     const triggerType = params.filter?.trigger_type ?? 'all'
     let orphans: TraceSummary[] = []
+    let relatedDispatchByTask = new Map<string, TraceSummary[]>()
     if (triggerType !== 'task') {
       try {
         const result = await this.callAgentRpc<
@@ -5305,11 +5306,26 @@ export class AdminModule extends ModuleBase {
           { traces: Array<TraceSummary & { related_task_id?: string }>; total: number }
         >('search_traces', {
           limit: 1000,
+          ...(params.filter?.search ? { keyword: params.filter.search } : {}),
           ...(params.filter?.created_after && params.filter?.created_before
             ? { time_range: { start: params.filter.created_after, end: params.filter.created_before } }
             : {}),
         })
-        orphans = result.traces.filter((t) => t.trigger_type === 'message' && !t.related_task_id)
+        const keyword = params.filter?.search?.toLowerCase()
+        const matchesKeyword = (t: TraceSummary): boolean =>
+          !keyword ||
+          t.trigger_summary.toLowerCase().includes(keyword) ||
+          (t.outcome_summary?.toLowerCase().includes(keyword) ?? false)
+        orphans = result.traces.filter((t) => t.trigger_type === 'message' && !t.related_task_id && matchesKeyword(t))
+        relatedDispatchByTask = result.traces
+          .filter((t) => t.trigger_type === 'message' && Boolean(t.related_task_id) && matchesKeyword(t))
+          .reduce((acc, t) => {
+            const taskId = t.related_task_id!
+            const list = acc.get(taskId)
+            if (list) list.push(t)
+            else acc.set(taskId, [t])
+            return acc
+          }, new Map<string, TraceSummary[]>())
       } catch (err) {
         console.warn('[Admin] list_conversation_units: agent search_traces failed:', err instanceof Error ? err.message : err)
       }
@@ -5319,19 +5335,31 @@ export class AdminModule extends ModuleBase {
     }
 
     // 3. union + 时间排序
-    const taskUnits: ConversationUnit[] = tasks.map((t) => ({
-      kind: 'task' as const,
-      task: t,
-      trace_count: 0,  // 列表层占位；前端展开时 lazy load
-      worker_trace_id: null,  // 同上
-    }))
+    const taskUnits: ConversationUnit[] = tasks.map((t) => {
+      const relatedDispatches = relatedDispatchByTask.get(t.id) ?? []
+      const latestDispatch = relatedDispatches
+        .slice()
+        .sort((a, b) => b.started_at.localeCompare(a.started_at))[0]
+      const activityAt = [t.updated_at, latestDispatch?.started_at]
+        .filter((x): x is string => Boolean(x))
+        .sort()
+        .at(-1) ?? t.updated_at
+      return {
+        kind: 'task' as const,
+        task: t,
+        activity_at: activityAt,
+        activity_summary: latestDispatch?.trigger_summary ?? t.title,
+        trace_count: 0,  // 列表层占位；前端展开时 lazy load
+        worker_trace_id: null,  // 同上
+      }
+    })
     const orphanUnits: ConversationUnit[] = orphans.map((t) => ({
       kind: 'orphan_dispatcher' as const,
       trace: t,
     }))
 
     const timeOf = (u: ConversationUnit): string =>
-      u.kind === 'task' ? u.task.created_at : u.trace.started_at
+      u.kind === 'task' ? u.activity_at : u.trace.started_at
 
     const all = [...taskUnits, ...orphanUnits]
     const sortOrder = params.sort?.order ?? 'desc'

--- a/crabot-admin/src/types.ts
+++ b/crabot-admin/src/types.ts
@@ -921,7 +921,7 @@ export type ListTasksResult = PaginatedResult<Task>
 // Conversation Units —— spec 2026-06-09-task-trace-tool-unification.md §4.3
 // ============================================================================
 // Admin UI 主列表的混合渲染单元：task 维度 + 孤儿 dispatcher trace 按时间合并。
-// 替代旧的 TraceTable grouped/flat 模式。后端原生分页（task.created_at / trace.started_at
+// 替代旧的 TraceTable grouped/flat 模式。后端原生分页（task activity / trace.started_at
 // 作为统一时间字段）。
 
 /** Admin 视角下的 trace 元数据子集（agent 模块 TraceIndexEntry 的简化版）。 */
@@ -947,6 +947,10 @@ export type ConversationUnit =
   | {
       kind: 'task'
       task: Task
+      /** 主列表排序/展示使用的最后活动时间：max(task.updated_at, related dispatcher/task trace time). */
+      activity_at: string
+      /** 主列表摘要：优先显示最近 dispatcher trigger_summary，回退 task.title。 */
+      activity_summary: string
       /** 含 dispatcher + worker + subagents trace 总数（lazy load tree 时再拉完整） */
       trace_count: number
       /** 主 worker trace_id；无 worker 时为 null */

--- a/crabot-admin/web/src/pages/Traces/index.tsx
+++ b/crabot-admin/web/src/pages/Traces/index.tsx
@@ -615,12 +615,12 @@ function ConversationUnitRow({
           </Tooltip>
         </td>
         <td style={{ ...tCell, maxWidth: 280, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-          <Tooltip content={t.title}>
-            <span style={{ fontWeight: 500 }}>{t.title}</span>
+          <Tooltip content={`${unit.activity_summary}\n\nTask: ${t.title}`}>
+            <span style={{ fontWeight: 500 }}>{unit.activity_summary}</span>
           </Tooltip>
         </td>
         <td style={{ ...tCell, fontSize: 11, fontVariantNumeric: 'tabular-nums', whiteSpace: 'nowrap' }}>
-          {formatTime(t.created_at)}
+          {formatTime(unit.activity_at)}
         </td>
         <td style={{ ...tCell, fontSize: 11, color: 'var(--text-muted)', fontVariantNumeric: 'tabular-nums', whiteSpace: 'nowrap' }}>
           {formatDuration(dur)}

--- a/crabot-admin/web/src/services/trace.ts
+++ b/crabot-admin/web/src/services/trace.ts
@@ -263,6 +263,8 @@ export type ConversationUnit =
   | {
       kind: 'task'
       task: ConvTaskBrief
+      activity_at: string
+      activity_summary: string
       trace_count: number
       worker_trace_id: string | null
     }

--- a/crabot-agent/src/agent/agent-handler.ts
+++ b/crabot-agent/src/agent/agent-handler.ts
@@ -1086,7 +1086,8 @@ export class AgentHandler {
       const conversationLog: ConversationEntry[] = (context.trigger_messages ?? []).map(
         (m) => ({ role: 'human' as const, content: formatMessageContent(m) }),
       )
-      // sentInfoMessage：send_message(intent='info') 成功至少一次；forced_summary 判断依据
+      // sentInfoMessage：send_message(intent='info') 成功至少一次。明确 end_turn 场景下，
+      // 任意已送达 info 都允许作为"已有交付"收口；无法可靠判断某条 info 是过程播报还是真交付。
       let sentInfoMessage = false
       // 任务触发类型：scheduled 任务始终抑制 forced_summary
       const workerTriggerType: 'scheduled' | 'message' =
@@ -1630,10 +1631,10 @@ export class AgentHandler {
           ...(context.resolved_permissions ? { resolvedPermissions: context.resolved_permissions } : {}),
           contentReviewer: this.buildContentReviewer(),
           sessionType: context.task_origin?.session_type ?? 'private',
-          // spec §4.13.5 修订：去掉 goalSetCache 触发条件，让 silent end_turn 拦截 + audit gate 各管各、不再彼此假设兜底。
-          // - 第 1 道闸（FORCED_SUMMARY_PROMPT）：sentInfoMessage=false 时拦截
-          // - 第 2 道闸（endTurnGate §4.13.4 二级分支）：goal 设了但 everSentMessage=false 时拦截
-          // 两者独立计数、独立兜底；任何一道闸触发都不放过"goal mode + 静默 end_turn + 0 交付"。
+          // 一旦有 info 送达，就允许后续 silent end_turn 作为正常收口：系统无法可靠判断
+          // 某条 info 是过程播报还是真实交付，只能尊重已送达事实。scheduled 任务同样保持静默收口。
+          // 注意：这只适用于明确 stopReason='end_turn' 的收口；stopReason=null 是 adapter/stream
+          // 终态缺失，query-loop 会按失败处理，不能借此完成 task。
           suppressForcedSummary: () => workerTriggerType === 'scheduled' || sentInfoMessage,
           // Goal mode 缓冲消息 flush 钩子：engine 在 stop_reason='tool_use' 续 turn 之前
           // 和 endTurnGate 返回 null 后调用。把 taskState.outboundBuffer 里截留的 info

--- a/crabot-agent/src/core/trace-store.ts
+++ b/crabot-agent/src/core/trace-store.ts
@@ -230,6 +230,23 @@ export class TraceStore {
     return trace
   }
 
+  /**
+   * Terminal supplement resume 用：从已完成的历史 worker trace 继续追加 spans。
+   * 与 reactivateResumableTrace 不同，这里的 checkpoint 来自已落盘 trace.resume_checkpoint，
+   * 不在 resumableCheckpoints 集合里。
+   */
+  reactivateTraceById(traceId: string): import('../types.js').AgentTrace | null {
+    const trace = this.traces.get(traceId) ?? this.readTraceFromIndex(traceId)
+    if (!trace) return null
+    trace.status = 'running'
+    trace.ended_at = undefined
+    trace.duration_ms = undefined
+    trace.outcome = undefined
+    this.traces.set(trace.trace_id, trace)
+    if (!this.order.includes(trace.trace_id)) this.order.push(trace.trace_id)
+    return trace
+  }
+
   /** admin 放弃 resume 时调用：finalize 成 failed 落日期文件 + 清 running 文件。 */
   finalizeUnresumedCheckpoint(taskId: string): void {
     const entry = this.resumableCheckpoints.get(taskId)

--- a/crabot-agent/src/engine/query-loop.ts
+++ b/crabot-agent/src/engine/query-loop.ts
@@ -494,6 +494,23 @@ export async function runEngine(params: RunEngineParams): Promise<EngineResult> 
 
     finalText = processed.text
 
+    if (stopReason === null) {
+      fireOnTurn(buildSilentTurnEvent(
+        totalTurns, processed.text, stopReason, llmCallMs, llmStartedAtMs, forcedSummaryAttempt, response.usage,
+      ))
+      return buildResult(
+        'failed',
+        finalText,
+        totalTurns,
+        contextManager,
+        messages,
+        exitToolCall,
+        toolCallCount,
+        wroteMemoryOrScene,
+        'LLM stream missing terminal stopReason; task was not completed.',
+      )
+    }
+
     if (stopReason !== 'tool_use') {
       // end_turn 收口前最后一次 supplement check：防止 LLM end_turn 与 finalize 落盘之间
       // 的微秒级窗口窃听不到 supplement。supplement 自然取代 forced summary——LLM 看到

--- a/crabot-agent/src/types.ts
+++ b/crabot-agent/src/types.ts
@@ -773,6 +773,8 @@ export interface ExecuteTaskParams {
     initialMessages: import('./engine/types.js').EngineMessage[]
     todoItems: import('./agent/worker-todo-store.js').TodoItem[]
     goalRevisionUnlocked?: boolean
+    /** Historical/completed worker trace to continue for terminal supplement resume. */
+    resumeTraceId?: string
     /** Task-scoped cwd（set_cwd 设置）；从 checkpoint worker_state.cwd 恢复，缺失则回退 home。 */
     cwd?: string
     terminalSupplementText?: string

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -2074,6 +2074,7 @@ export class UnifiedAgent extends ModuleBase {
             todoItems: entry.checkpoint.worker_state.todo_items,
             goalRevisionUnlocked: entry.checkpoint.worker_state.goal_revision_unlocked,
             cwd: entry.checkpoint.worker_state.cwd,
+            ...(mode === 'terminal_supplement' ? { resumeTraceId: entry.traceId } : {}),
             ...(params.terminalSupplementText !== undefined ? { terminalSupplementText: params.terminalSupplementText } : {}),
           },
         },
@@ -2183,7 +2184,11 @@ export class UnifiedAgent extends ModuleBase {
     // 让一个 task 跨重启是**一条连续 trace**，而非每个 run 一条；新 run 的 span 追加到旧 trace 上。
     // 非 resume，或复用失败（罕见边界），正常新建。
     const reactivated = taskParams.resumeFrom
-      ? this.traceStore.reactivateResumableTrace(taskParams.task.task_id)
+      ? (
+          taskParams.resumeFrom.resumeTraceId
+            ? this.traceStore.reactivateTraceById(taskParams.resumeFrom.resumeTraceId)
+            : this.traceStore.reactivateResumableTrace(taskParams.task.task_id)
+        )
       : null
     const trace = reactivated ?? this.traceStore.startTrace({
       module_id: this.config.moduleId,

--- a/crabot-agent/tests/core/trace-store.test.ts
+++ b/crabot-agent/tests/core/trace-store.test.ts
@@ -797,4 +797,39 @@ describe('TraceStore reactivateResumableTrace（resume 续写复用旧 trace）'
     const store = new TraceStore(10)
     expect(store.reactivateResumableTrace('nope')).toBeNull()
   })
+
+  it('按历史 trace_id 复用已完成 worker trace，供 terminal supplement 续写', () => {
+    const dir = makeTempDir()
+    try {
+      const store1 = new TraceStore(10, dir)
+      const trace = store1.startTrace({
+        module_id: 'agent-1',
+        trigger: { type: 'task', summary: '历史已完成任务' },
+        related_task_id: 'task-terminal',
+      })
+      const span = store1.startSpan(trace.trace_id, { type: 'llm_call', details: { iteration: 1 } })
+      store1.endSpan(trace.trace_id, span.span_id, 'completed')
+      store1.flushWorkerCheckpoint('task-terminal', trace.trace_id, {
+        agent_version: 'v1',
+        system_prompt: 'sys',
+        messages: [{ id: 'm1', role: 'user', content: 'hi', timestamp: 1 }] as never,
+        worker_state: { todo_items: [], goal_revision_unlocked: false },
+      })
+      store1.endTrace(trace.trace_id, 'completed', { summary: 'done' })
+      store1.clearCheckpointFile('task-terminal')
+
+      const store2 = new TraceStore(10, dir)
+      const reactivated = store2.reactivateTraceById(trace.trace_id)
+      expect(reactivated).not.toBeNull()
+      expect(reactivated!.trace_id).toBe(trace.trace_id)
+      expect(reactivated!.status).toBe('running')
+      expect(reactivated!.outcome).toBeUndefined()
+
+      const span2 = store2.startSpan(trace.trace_id, { type: 'llm_call', details: { iteration: 2 } })
+      store2.endSpan(trace.trace_id, span2.span_id, 'completed')
+      expect(store2.getTrace(trace.trace_id)!.spans).toHaveLength(2)
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
 })

--- a/crabot-agent/tests/engine/query-loop.test.ts
+++ b/crabot-agent/tests/engine/query-loop.test.ts
@@ -61,6 +61,13 @@ function silentEndTurnResponse(): ReadonlyArray<StreamChunk> {
   ]
 }
 
+function nullStopResponse(): ReadonlyArray<StreamChunk> {
+  return [
+    { type: 'message_start', messageId: 'msg-1' },
+    { type: 'message_end', stopReason: null, usage: { inputTokens: 10, outputTokens: 0 } },
+  ]
+}
+
 // --- Tests ---
 
 describe('runEngine', () => {
@@ -235,6 +242,19 @@ describe('runEngine', () => {
     expect(result.error).toContain('Network timeout')
   })
 
+  it('returns failed when LLM stream ends without a terminal stopReason', async () => {
+    const adapter = mockAdapter([nullStopResponse()])
+
+    const result = await runEngine({
+      prompt: 'Hi',
+      adapter,
+      options: baseOptions({ suppressForcedSummary: () => true }),
+    })
+
+    expect(result.outcome).toBe('failed')
+    expect(result.error).toContain('missing terminal stopReason')
+  })
+
   it('returns failed when adapter yields error chunk', async () => {
     const adapter = mockAdapter([
       [
@@ -327,6 +347,25 @@ describe('runEngine', () => {
 
       expect(gate).toHaveBeenCalledOnce()
       expect(result.outcome).toBe('completed')
+    })
+
+    it('suppressForcedSummary=false + silent end_turn: forces a follow-up instead of completing empty', async () => {
+      const adapter = mockAdapter([
+        silentEndTurnResponse(),
+        textResponse('补充后的最终交付'),
+      ])
+
+      const result = await runEngine({
+        prompt: 'test',
+        adapter,
+        options: baseOptions({
+          suppressForcedSummary: () => false,
+        }),
+      })
+
+      expect(result.outcome).toBe('completed')
+      expect(result.finalText).toBe('补充后的最终交付')
+      expect(result.totalTurns).toBe(2)
     })
 
     it('text end_turn: endTurnGate 也会被调用', async () => {

--- a/crabot-agent/tests/unified-agent-resume-task.test.ts
+++ b/crabot-agent/tests/unified-agent-resume-task.test.ts
@@ -187,6 +187,31 @@ describe('UnifiedAgent.handleResumeTask — I1: task_origin 从 task.source 重�
     // 新行为：不 consume；旧 trace 由 reactivateResumableTrace 复用续写，一个 task 一条连续 trace。
     expect(consumeResumableCheckpoint).not.toHaveBeenCalled()
   })
+
+  it('restart resume 不携带历史 trace id，继续由 resumable checkpoint 复用 running trace', async () => {
+    const { agent, executeScheduledTaskInBackground } = buildAgent({
+      getResumableCheckpoint: vi.fn().mockReturnValue({
+        traceId: 'trace-running',
+        checkpoint: {
+          agent_version: AGENT_VERSION,
+          messages: [{ id: 'm1', role: 'user', content: 'hi', timestamp: 1 }],
+          worker_state: { todo_items: [] },
+          system_prompt: 'SP',
+        },
+      }),
+    })
+
+    const result = await agent.handleResumeTask({ task_id: 'task-1' })
+
+    expect(result.resumed).toBe(true)
+    const [, , options] = executeScheduledTaskInBackground.mock.calls[0] as [
+      unknown,
+      unknown,
+      { resumeFrom?: { terminalSupplementText?: string; resumeTraceId?: string } },
+    ]
+    expect(options.resumeFrom?.terminalSupplementText).toBeUndefined()
+    expect(options.resumeFrom?.resumeTraceId).toBeUndefined()
+  })
 })
 
 describe('UnifiedAgent.handleResumeTaskWithSupplement', () => {
@@ -215,9 +240,10 @@ describe('UnifiedAgent.handleResumeTaskWithSupplement', () => {
     const [, , options] = executeScheduledTaskInBackground.mock.calls[0] as [
       unknown,
       unknown,
-      { resumeFrom?: { terminalSupplementText?: string } },
+      { resumeFrom?: { terminalSupplementText?: string; resumeTraceId?: string } },
     ]
     expect(options.resumeFrom?.terminalSupplementText).toBe('继续刚才失败的任务')
+    expect(options.resumeFrom?.resumeTraceId).toBe('trace-completed')
   })
 })
 


### PR DESCRIPTION
## Summary
- Sort Admin Traces task rows by latest task/dispatcher activity and surface the latest dispatcher summary/time for easier lookup.
- Reuse completed worker traces for terminal supplement resume while keeping restart resume on `resumableCheckpoints`.
- Treat missing LLM terminal `stopReason` as failure instead of completing a task with an empty/null final turn.

## Test Plan
- `corepack pnpm exec vitest run src/admin-web-api.test.ts -t "list_conversation_units activity ordering"` in `crabot-admin`
- `corepack pnpm exec vitest run tests/unified-agent-resume-task.test.ts tests/core/trace-store.test.ts tests/engine/query-loop.test.ts -t "handleResumeTaskWithSupplement|reactivateResumableTrace|reactivateTraceById|endTurnGate|silent end_turn retry|without a terminal stopReason|restart resume 不携带历史 trace id"` in `crabot-agent`
- `corepack pnpm exec vitest run tests/engine/query-loop.test.ts` in `crabot-agent`
- `corepack pnpm exec tsc --noEmit` in `crabot-agent`
- `corepack pnpm exec tsc --noEmit` in `crabot-admin`
- `corepack pnpm exec tsc --noEmit` in `crabot-admin/web`
