### PR TITLE
Fix reactivated trace status in trace lists

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -7,6 +7,7 @@
 - Traces 主列表的 task 行改按最后活动时间排序：`activity_at = max(task.updated_at, 最近关联 dispatcher started_at)`；标题/摘要优先显示最近 dispatcher 消息，避免旧 task 收到 supplement 后仍沉在创建时间位置、也避免只能看到原始长标题。
 - `list_conversation_units` 搜索把关键词传给 `search_traces`，并在 Admin 侧对 orphan/related dispatcher 二次过滤，避免搜一个补充消息时混入大量无关孤儿对话。
 - terminal supplement resume 才把历史 worker trace id 写入 `resumeFrom.resumeTraceId`，`handleExecuteTask` 通过 `TraceStore.reactivateTraceById()` 复用已完成 worker trace 继续追加 spans；普通 restart resume 不携带 `resumeTraceId`，仍走 `resumableCheckpoints` + `reactivateResumableTrace(task_id)`。修复同一 task 每次 terminal supplement 生成一条新 worker trace 的问题，同时避免把 restart 语义污染成历史 trace revive。旧历史数据里已产生的多 worker trace 不自动合并。
+- `reactivateTraceById()` 同步刷新 `traceIndex` / `taskIndex`，避免详情页 full trace 已 running、列表 search/index 仍显示 completed 的状态漂移。
 - 明确区分 `stopReason='end_turn'` 与 `stopReason=null`：任意已送达 `send_message(intent='info')` 仍允许作为“已有交付”收口；但 LLM stream 没有 terminal stopReason 时按失败处理，不能把空输出误标 completed（对应 trace `6646e158` 的事故形态）。
 - 验证：Admin 定向回归 2 个通过；Agent resume/trace-store/query-loop 定向回归 14 个通过；query-loop 全量 33 个通过；`crabot-admin` / `crabot-agent` / `crabot-admin/web` `tsc --noEmit` 均通过。
 

--- a/crabot-agent/src/core/trace-store.ts
+++ b/crabot-agent/src/core/trace-store.ts
@@ -244,6 +244,12 @@ export class TraceStore {
     trace.outcome = undefined
     this.traces.set(trace.trace_id, trace)
     if (!this.order.includes(trace.trace_id)) this.order.push(trace.trace_id)
+    const existingIdx = this.traceIndex.findIndex(e => e.trace_id === trace.trace_id)
+    const existing = existingIdx >= 0 ? this.traceIndex[existingIdx] : undefined
+    const nextEntry = this.traceToIndexEntry(trace, existing?.file ?? '', existing?.file_offset ?? 0)
+    if (existingIdx >= 0) this.traceIndex[existingIdx] = nextEntry
+    else this.traceIndex.push(nextEntry)
+    if (trace.related_task_id) this.addToTaskIndex(trace.related_task_id, trace.trace_id)
     return trace
   }
 

--- a/crabot-agent/src/core/trace-store.ts
+++ b/crabot-agent/src/core/trace-store.ts
@@ -244,12 +244,7 @@ export class TraceStore {
     trace.outcome = undefined
     this.traces.set(trace.trace_id, trace)
     if (!this.order.includes(trace.trace_id)) this.order.push(trace.trace_id)
-    const existingIdx = this.traceIndex.findIndex(e => e.trace_id === trace.trace_id)
-    const existing = existingIdx >= 0 ? this.traceIndex[existingIdx] : undefined
-    const nextEntry = this.traceToIndexEntry(trace, existing?.file ?? '', existing?.file_offset ?? 0)
-    if (existingIdx >= 0) this.traceIndex[existingIdx] = nextEntry
-    else this.traceIndex.push(nextEntry)
-    if (trace.related_task_id) this.addToTaskIndex(trace.related_task_id, trace.trace_id)
+    this.refreshTraceIndexFromMemory(trace)
     return trace
   }
 
@@ -287,6 +282,7 @@ export class TraceStore {
         this.resumableCheckpoints.set(taskId, { traceId: trace.trace_id, checkpoint: trace.resume_checkpoint })
         this.traces.set(trace.trace_id, trace)
         if (!this.order.includes(trace.trace_id)) this.order.push(trace.trace_id)
+        this.refreshTraceIndexFromMemory(trace)
       } catch { /* skip malformed */ }
     }
   }
@@ -943,6 +939,15 @@ export class TraceStore {
     if (!existing.includes(traceId)) {
       this.taskIndex.set(taskId, [...existing, traceId])
     }
+  }
+
+  private refreshTraceIndexFromMemory(trace: AgentTrace): void {
+    const existingIdx = this.traceIndex.findIndex(e => e.trace_id === trace.trace_id)
+    const existing = existingIdx >= 0 ? this.traceIndex[existingIdx] : undefined
+    const nextEntry = this.traceToIndexEntry(trace, existing?.file ?? '', existing?.file_offset ?? 0)
+    if (existingIdx >= 0) this.traceIndex[existingIdx] = nextEntry
+    else this.traceIndex.push(nextEntry)
+    if (trace.related_task_id) this.addToTaskIndex(trace.related_task_id, trace.trace_id)
   }
 
   private traceToIndexEntry(trace: AgentTrace, file: string, fileOffset: number): TraceIndexEntry {

--- a/crabot-agent/tests/core/trace-store.test.ts
+++ b/crabot-agent/tests/core/trace-store.test.ts
@@ -848,6 +848,8 @@ describe('TraceStore reactivateResumableTrace（resume 续写复用旧 trace）'
       expect(reactivated!.trace_id).toBe(trace.trace_id)
       expect(reactivated!.status).toBe('running')
       expect(reactivated!.outcome).toBeUndefined()
+      expect(store2.searchTraces({ task_id: 'task-terminal' }).traces[0]!.status).toBe('running')
+      expect(store2.searchTraces({ task_id: 'task-terminal', status: 'completed' }).traces).toHaveLength(0)
 
       const span2 = store2.startSpan(trace.trace_id, { type: 'llm_call', details: { iteration: 2 } })
       store2.endSpan(trace.trace_id, span2.span_id, 'completed')

--- a/crabot-agent/tests/core/trace-store.test.ts
+++ b/crabot-agent/tests/core/trace-store.test.ts
@@ -858,4 +858,31 @@ describe('TraceStore reactivateResumableTrace（resume 续写复用旧 trace）'
       fs.rmSync(dir, { recursive: true, force: true })
     }
   })
+
+  it('重启后 searchTraces 仍以 per-task checkpoint 中的 running trace 状态为准', () => {
+    const dir = makeTempDir()
+    try {
+      const store1 = new TraceStore(10, dir)
+      const trace = store1.startTrace({
+        module_id: 'agent-1',
+        trigger: { type: 'task', summary: '历史已完成任务' },
+        related_task_id: 'task-terminal',
+      })
+      store1.flushWorkerCheckpoint('task-terminal', trace.trace_id, {
+        agent_version: 'v1',
+        system_prompt: 'sys',
+        messages: [{ id: 'm1', role: 'user', content: 'hi', timestamp: 1 }] as never,
+        worker_state: { todo_items: [], goal_revision_unlocked: false },
+      })
+      store1.endTrace(trace.trace_id, 'completed', { summary: 'done' })
+
+      const store2 = new TraceStore(10, dir)
+      const resumed = store2.getTrace(trace.trace_id)
+      expect(resumed?.status).toBe('running')
+      expect(store2.searchTraces({ task_id: 'task-terminal' }).traces[0]!.status).toBe('running')
+      expect(store2.searchTraces({ task_id: 'task-terminal', status: 'completed' }).traces).toHaveLength(0)
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
 })


### PR DESCRIPTION
## Summary
- Sync `traceIndex` and `taskIndex` when `TraceStore.reactivateTraceById()` reopens a completed worker trace.
- Prevent Admin Traces list/search rows from showing a reactivated terminal-supplement worker trace as completed while the detail view shows running.
- Add regression coverage that `searchTraces({ task_id })` reflects the reactivated running status and no longer matches `status: completed`.

## Test Plan
- `corepack pnpm exec vitest run tests/core/trace-store.test.ts -t "按历史 trace_id"` in `crabot-agent`
- `corepack pnpm exec vitest run tests/core/trace-store.test.ts -t "reactivateResumableTrace|按历史 trace_id|finds the latest resume checkpoint"` in `crabot-agent`
- `corepack pnpm exec tsc --noEmit` in `crabot-agent`
