### PR TITLE
[codex] Gate agent reports by human input epoch

### DIFF
--- a/crabot-agent/src/agent/agent-handler.ts
+++ b/crabot-agent/src/agent/agent-handler.ts
@@ -808,7 +808,7 @@ export class AgentHandler {
     // runWorkerLoop 检查 activeTasks.get(task_id)——提前写入即可完成 todoStore/goalRevisionUnlocked 的恢复。
     let currentInitialMessages: ReadonlyArray<EngineMessage> | undefined
     if (params.resumeFrom) {
-      const { initialMessages, todoItems, goalRevisionUnlocked, cwd: resumedCwd, lastDeliveredInfoEpoch } = params.resumeFrom
+      const { initialMessages, todoItems, goalRevisionUnlocked, cwd: resumedCwd, humanInputEpoch, lastDeliveredInfoEpoch } = params.resumeFrom
       // §3.4 修复：resume 走 initialMessages 分支，query-loop 会忽略 prompt，导致 runWorkerLoop
       // 里 buildTaskMessage 的 friend 队列 drain 被丢弃（drain-and-discard）。这里在 resume 装配处
       // 主动 drain 一次并注入首轮消息，否则宕机期间到达的 bg-notification（如 re-adopt 的 shell 退出）
@@ -828,6 +828,7 @@ export class AgentHandler {
           ? createUserMessage(`${resumeBgNotif}\n\n${wakeup.content}`)
           : wakeup
       currentInitialMessages = [...initialMessages, wakeupMsg]
+      const resumedHumanInputEpoch = (humanInputEpoch ?? 0) + (params.resumeFrom.terminalSupplementText ? 1 : 0)
       // 预建 taskState 让 runWorkerLoop 直接复用（不再用 new TodoStore()）
       if (!this.activeTasks.has(task.task_id)) {
         this.activeTasks.set(task.task_id, {
@@ -843,7 +844,7 @@ export class AgentHandler {
           activeAuditId: undefined,
           activeAsyncSubagentIds: new Set<string>(),
           everSentMessage: false,
-          humanInputEpoch: params.resumeFrom.terminalSupplementText ? 1 : 0,
+          humanInputEpoch: resumedHumanInputEpoch,
           ...(lastDeliveredInfoEpoch !== undefined ? { lastDeliveredInfoEpoch } : {}),
           everBufferedMessage: false,
           silentNoDeliveryRetries: 0,
@@ -1906,6 +1907,7 @@ export class AgentHandler {
                 worker_state: {
                   todo_items: [...taskState.todoStore.list()],
                   goal_revision_unlocked: taskState.goalRevisionUnlocked,
+                  human_input_epoch: taskState.humanInputEpoch,
                   last_delivered_info_epoch: taskState.lastDeliveredInfoEpoch,
                   ...(taskState.cwd !== undefined ? { cwd: taskState.cwd } : {}),
                 },
@@ -2926,6 +2928,7 @@ export class AgentHandler {
           worker_state: {
             todo_items: [...taskState.todoStore.list()],
             goal_revision_unlocked: taskState.goalRevisionUnlocked,
+            human_input_epoch: taskState.humanInputEpoch,
             last_delivered_info_epoch: taskState.lastDeliveredInfoEpoch,
             ...(taskState.cwd !== undefined ? { cwd: taskState.cwd } : {}),
           },

--- a/crabot-agent/src/agent/agent-handler.ts
+++ b/crabot-agent/src/agent/agent-handler.ts
@@ -808,7 +808,7 @@ export class AgentHandler {
     // runWorkerLoop 检查 activeTasks.get(task_id)——提前写入即可完成 todoStore/goalRevisionUnlocked 的恢复。
     let currentInitialMessages: ReadonlyArray<EngineMessage> | undefined
     if (params.resumeFrom) {
-      const { initialMessages, todoItems, goalRevisionUnlocked, cwd: resumedCwd } = params.resumeFrom
+      const { initialMessages, todoItems, goalRevisionUnlocked, cwd: resumedCwd, lastDeliveredInfoEpoch } = params.resumeFrom
       // §3.4 修复：resume 走 initialMessages 分支，query-loop 会忽略 prompt，导致 runWorkerLoop
       // 里 buildTaskMessage 的 friend 队列 drain 被丢弃（drain-and-discard）。这里在 resume 装配处
       // 主动 drain 一次并注入首轮消息，否则宕机期间到达的 bg-notification（如 re-adopt 的 shell 退出）
@@ -843,6 +843,8 @@ export class AgentHandler {
           activeAuditId: undefined,
           activeAsyncSubagentIds: new Set<string>(),
           everSentMessage: false,
+          humanInputEpoch: params.resumeFrom.terminalSupplementText ? 1 : 0,
+          ...(lastDeliveredInfoEpoch !== undefined ? { lastDeliveredInfoEpoch } : {}),
           everBufferedMessage: false,
           silentNoDeliveryRetries: 0,
           ...(goalRevisionUnlocked !== undefined ? { goalRevisionUnlocked } : {}),
@@ -998,6 +1000,7 @@ export class AgentHandler {
         activeAuditId: undefined,
         activeAsyncSubagentIds: new Set<string>(),
         everSentMessage: false,
+        humanInputEpoch: 0,
         everBufferedMessage: false,
         silentNoDeliveryRetries: 0,
       }
@@ -1211,6 +1214,9 @@ export class AgentHandler {
           // PR-2 effect：追加 task.messages（role='agent'）—— spec 2026-06-09 §4.2 invariant #3 叠加。
           onDispatched: (entry, sendResult) => {
             taskState.everSentMessage = true
+            if (entry.intent === 'info') {
+              taskState.lastDeliveredInfoEpoch = entry.human_input_epoch ?? taskState.humanInputEpoch
+            }
             this.appendAgentMessageBestEffort(taskState.taskId, entry, sendResult)
           },
           // 进 buffer ≠ 送达：audit fail 会整体丢弃 buffer。endTurnGate 用此标志
@@ -1218,6 +1224,7 @@ export class AgentHandler {
           onBuffered: () => {
             taskState.everBufferedMessage = true
           },
+          getHumanInputEpoch: () => taskState.humanInputEpoch,
           // send_message 工具自愈相对 file_path 用：当前 task cwd（set_cwd 改的 taskState.cwd）。
           getCwd,
           // 透传 sub-agent trace 上下文：让 audit gate 触发的 audit subagent
@@ -1663,6 +1670,9 @@ export class AgentHandler {
               // PR-2 effect：append task.messages（role='agent'）— spec 2026-06-09 §4.2 invariant #3。
               onDispatched: (entry, sendResult) => {
                 taskState.everSentMessage = true
+                if (entry.intent === 'info') {
+                  taskState.lastDeliveredInfoEpoch = entry.human_input_epoch ?? taskState.humanInputEpoch
+                }
                 this.appendAgentMessageBestEffort(taskState.taskId, entry, sendResult)
               },
             }
@@ -1896,6 +1906,7 @@ export class AgentHandler {
                 worker_state: {
                   todo_items: [...taskState.todoStore.list()],
                   goal_revision_unlocked: taskState.goalRevisionUnlocked,
+                  last_delivered_info_epoch: taskState.lastDeliveredInfoEpoch,
                   ...(taskState.cwd !== undefined ? { cwd: taskState.cwd } : {}),
                 },
                 ...(taskState.resumeWorkerContext ? { worker_context: taskState.resumeWorkerContext } : {}),
@@ -2148,6 +2159,7 @@ export class AgentHandler {
       activeAuditId: undefined,
       activeAsyncSubagentIds: new Set<string>(),
       everSentMessage: false,
+      humanInputEpoch: 0,
       everBufferedMessage: false,
       silentNoDeliveryRetries: 0,
     })
@@ -2828,6 +2840,7 @@ export class AgentHandler {
       .join('\n')
 
     if (supplement) {
+      taskState.humanInputEpoch++
       const humanQueue = this.humanQueues.get(taskId)
       if (humanQueue) {
         const template = this.isGoalModeEnabled(taskState.triggerType)
@@ -2913,6 +2926,7 @@ export class AgentHandler {
           worker_state: {
             todo_items: [...taskState.todoStore.list()],
             goal_revision_unlocked: taskState.goalRevisionUnlocked,
+            last_delivered_info_epoch: taskState.lastDeliveredInfoEpoch,
             ...(taskState.cwd !== undefined ? { cwd: taskState.cwd } : {}),
           },
           ...(taskState.resumeWorkerContext ? { worker_context: taskState.resumeWorkerContext } : {}),

--- a/crabot-agent/src/agent/end-turn-gate.ts
+++ b/crabot-agent/src/agent/end-turn-gate.ts
@@ -101,9 +101,9 @@ export function createAsyncAuditEndTurnGate(
     //    - 从未 audit（agent 全程没 send_message 触发过 audit）
     //    - 上一轮 audit fail，agent 看完 detailedReport 又直接 end_turn（buffer 在 fail 时已 drop）
     //    - 上一轮 audit aborted（改 goal 触发），agent 看完 abort marker 又直接 end_turn
-    //    按 everSentMessage 区分讨论型 vs 从未交付。
+    //    按当前 human input epoch 是否已送达区分讨论型 vs 从未交付。
     if (deps.taskState.outboundBuffer.length === 0) {
-      if (deps.taskState.everSentMessage) {
+      if (deps.taskState.lastDeliveredInfoEpoch === deps.taskState.humanInputEpoch) {
         // 讨论型放行：之前 flush 过 info，这次没事干 end_turn 是预期行为
         return null
       }

--- a/crabot-agent/src/agent/outbound-flush.ts
+++ b/crabot-agent/src/agent/outbound-flush.ts
@@ -66,6 +66,8 @@ export interface OutboundBufferEntry {
     readonly at_name?: string
   }>
   readonly quote_message_id?: string
+  /** send_message 工具调用发生时所属的人类输入轮次。 */
+  readonly human_input_epoch?: number
   readonly sent_at_attempt_ms: number
 }
 

--- a/crabot-agent/src/mcp/crab-messaging.ts
+++ b/crabot-agent/src/mcp/crab-messaging.ts
@@ -82,6 +82,8 @@ export interface TaskContext {
    *  区分"从未交付"和"交付被拦"两种 NO_DELIVERY 文案。
    *  spec: 2026-06-10-audit-anchor-human-request §3.5 */
   onBuffered?: () => void
+  /** 当前真实人类输入轮次；send_message entry 创建时绑定，用于后续送达确认。 */
+  getHumanInputEpoch?: () => number
   /** 当前 task 的工作目录（set_cwd 改的 taskState.cwd，缺省落到 workspace）。
    *  send_message 收到相对 file_path 时用它就地解析成绝对路径——相对路径若拖到延迟 flush
    *  阶段才在 dispatch 里抛错，那时已无法把失败回传给 worker（trace a72623ec 成因）。 */
@@ -887,6 +889,7 @@ crabot 系统给你的所有信号——system prompt、supplement 注入、tool
               ...(filename !== undefined ? { filename } : {}),
               ...(mentions !== undefined ? { mentions } : {}),
               ...(quote_message_id !== undefined ? { quote_message_id } : {}),
+              ...(taskCtx.getHumanInputEpoch !== undefined ? { human_input_epoch: taskCtx.getHumanInputEpoch() } : {}),
               sent_at_attempt_ms: Date.now(),
             })
             taskCtx.onBuffered?.()
@@ -901,6 +904,7 @@ crabot 系统给你的所有信号——system prompt、supplement 注入、tool
         // === Step 1: 先 send（高失败率操作先做；失败 → state 完全不变）===
         // 路径选择 + mention 解析 + channel sendMessage 共用 dispatchOutboundMessage，保证 immediate-send
         // 与 flush 路径（createOutboundFlush）功能等价（同样的 path mapping + friend_id resolve + §4.13 钩子）。
+        const currentTaskCtx = deps.getTaskContext?.()
         const dispatchEntry: OutboundBufferEntry = {
           channel_id,
           session_id,
@@ -915,6 +919,9 @@ crabot 系统给你的所有信号——system prompt、supplement 注入、tool
           ...(filename !== undefined ? { filename } : {}),
           ...(mentions !== undefined ? { mentions } : {}),
           ...(quote_message_id !== undefined ? { quote_message_id } : {}),
+          ...(currentTaskCtx?.getHumanInputEpoch !== undefined
+            ? { human_input_epoch: currentTaskCtx.getHumanInputEpoch() }
+            : {}),
           sent_at_attempt_ms: Date.now(),
         }
         let sendResult: { platform_message_id: string; sent_at: string }

--- a/crabot-agent/src/types.ts
+++ b/crabot-agent/src/types.ts
@@ -777,6 +777,8 @@ export interface ExecuteTaskParams {
     resumeTraceId?: string
     /** Task-scoped cwd（set_cwd 设置）；从 checkpoint worker_state.cwd 恢复，缺失则回退 home。 */
     cwd?: string
+    /** checkpoint 恢复用：当前 worker 对话里的真实人类输入轮次。 */
+    humanInputEpoch?: number
     /** checkpoint 恢复用：最近一次成功 info/default send_message 送达对应的人类输入轮次。 */
     lastDeliveredInfoEpoch?: number
     terminalSupplementText?: string
@@ -1171,6 +1173,8 @@ export interface WorkerStateSnapshot {
    * 持久——否则跨重启 resume 后 cwd 回退到 home，相对路径解析错位、后续上下文出问题。
    */
   cwd?: string
+  /** 当前 worker 对话里的真实人类输入轮次。 */
+  human_input_epoch?: number
   /** 最近一次成功 info/default send_message 送达对应的人类输入轮次。 */
   last_delivered_info_epoch?: number
 }

--- a/crabot-agent/src/types.ts
+++ b/crabot-agent/src/types.ts
@@ -777,6 +777,8 @@ export interface ExecuteTaskParams {
     resumeTraceId?: string
     /** Task-scoped cwd（set_cwd 设置）；从 checkpoint worker_state.cwd 恢复，缺失则回退 home。 */
     cwd?: string
+    /** checkpoint 恢复用：最近一次成功 info/default send_message 送达对应的人类输入轮次。 */
+    lastDeliveredInfoEpoch?: number
     terminalSupplementText?: string
   }
 }
@@ -869,6 +871,18 @@ export interface WorkerTaskState {
    * spec: 2026-06-07-goal-audit-async-buffered-info-design.md §4.13.3
    */
   everSentMessage: boolean
+  /**
+   * 当前 worker 对话里的真实人类输入轮次。
+   *
+   * 初始触发消息是 epoch 0；每次 live supplement 或 terminal-supplement resume 注入
+   * 新的人类补充时递增。send_message 工具调用创建 entry 时绑定当前 epoch；
+   * 成功送达后把 lastDeliveredInfoEpoch 写成该 entry 的调用 epoch。
+   * 这样 end_turn 收口判定看的是"最后一次人类输入之后是否已汇报"，而不是 task 历史上
+   * 是否曾经发过消息。
+   */
+  humanInputEpoch: number
+  /** 最近一次成功送达 info/默认 send_message 时对应的 humanInputEpoch。 */
+  lastDeliveredInfoEpoch?: number
   /**
    * Task 生命周期内是否至少一次 send_message(intent='info') 进过 outboundBuffer
    * （即"worker 交付过但可能被 audit 拦下/丢弃"）。一旦置 true 不再清零。
@@ -1157,6 +1171,8 @@ export interface WorkerStateSnapshot {
    * 持久——否则跨重启 resume 后 cwd 回退到 home，相对路径解析错位、后续上下文出问题。
    */
   cwd?: string
+  /** 最近一次成功 info/default send_message 送达对应的人类输入轮次。 */
+  last_delivered_info_epoch?: number
 }
 
 /**

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -2074,6 +2074,7 @@ export class UnifiedAgent extends ModuleBase {
             todoItems: entry.checkpoint.worker_state.todo_items,
             goalRevisionUnlocked: entry.checkpoint.worker_state.goal_revision_unlocked,
             cwd: entry.checkpoint.worker_state.cwd,
+            lastDeliveredInfoEpoch: entry.checkpoint.worker_state.last_delivered_info_epoch,
             ...(mode === 'terminal_supplement' ? { resumeTraceId: entry.traceId } : {}),
             ...(params.terminalSupplementText !== undefined ? { terminalSupplementText: params.terminalSupplementText } : {}),
           },

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -2074,6 +2074,7 @@ export class UnifiedAgent extends ModuleBase {
             todoItems: entry.checkpoint.worker_state.todo_items,
             goalRevisionUnlocked: entry.checkpoint.worker_state.goal_revision_unlocked,
             cwd: entry.checkpoint.worker_state.cwd,
+            humanInputEpoch: entry.checkpoint.worker_state.human_input_epoch,
             lastDeliveredInfoEpoch: entry.checkpoint.worker_state.last_delivered_info_epoch,
             ...(mode === 'terminal_supplement' ? { resumeTraceId: entry.traceId } : {}),
             ...(params.terminalSupplementText !== undefined ? { terminalSupplementText: params.terminalSupplementText } : {}),

--- a/crabot-agent/tests/agent/agent-handler.test.ts
+++ b/crabot-agent/tests/agent/agent-handler.test.ts
@@ -853,6 +853,47 @@ describe('AgentHandler', () => {
       const gateResult = await callArgs.options.endTurnGate()
       expect(gateResult).toBeNull()
     })
+
+    it('跨重启 resume：恢复 humanInputEpoch，live supplement 后旧汇报不算当前轮汇报', async () => {
+      mockRunEngine.mockImplementation(async () => {
+        await new Promise(resolve => setTimeout(resolve, 20))
+        return makeEngineResult()
+      })
+      const rpcCall = vi.fn().mockResolvedValue({
+        task: { id: 'task_1', goal: { objective: 'finish current user request' } },
+      })
+      const handler = new AgentHandler(
+        {
+          modelId: 'test-model',
+          format: 'anthropic' as const,
+          env: { ANTHROPIC_BASE_URL: 'http://localhost:4000', ANTHROPIC_API_KEY: 'test-key' },
+        },
+        { systemPrompt: 'You are a helpful worker.' },
+        {
+          deps: {
+            rpcClient: { call: rpcCall } as never,
+            moduleId: 'agent-test',
+            resolveChannelPort: async () => 3003,
+            getAdminPort: async () => 3001,
+            getMemoryPort: async () => 3002,
+          },
+        },
+      )
+      await handler.executeTask({
+        task: makeTask({ goal: { objective: 'finish current user request' } } as never),
+        context: makeContext(),
+        resumeFrom: {
+          initialMessages: [{ id: 'm1', role: 'user', content: 'resume me', timestamp: 1 }] as never,
+          todoItems: [],
+          humanInputEpoch: 1,
+          lastDeliveredInfoEpoch: 0,
+        },
+      })
+
+      const callArgs = mockRunEngine.mock.calls[0][0]
+      const gateResult = await callArgs.options.endTurnGate()
+      expect(gateResult).toBe(GOAL_MODE_NO_DELIVERY_PROMPT)
+    })
   })
 
   describe('resolveSceneAnchorLabel', () => {

--- a/crabot-agent/tests/agent/agent-handler.test.ts
+++ b/crabot-agent/tests/agent/agent-handler.test.ts
@@ -6,12 +6,15 @@ import { AgentHandler } from '../../src/agent/agent-handler.js'
 import { BgEntityRegistry } from '../../src/engine/bg-entities/registry.js'
 import { createSkillTool } from '../../src/engine/tools/skill-tool.js'
 import { resolveSceneAnchorLabel } from '../../src/mcp/crab-memory.js'
+import { createCrabMessagingServer } from '../../src/mcp/crab-messaging.js'
 import type {
   ExecuteTaskParams,
   WorkerAgentContext,
   ChannelMessage,
 } from '../../src/types.js'
 import type { BgEntityRecord } from '../../src/engine/bg-entities/types.js'
+import type { ToolDefinition } from '../../src/engine/types.js'
+import { GOAL_MODE_NO_DELIVERY_PROMPT } from '../../src/agent/end-turn-gate.js'
 
 // Mock the engine's runEngine function
 vi.mock('../../src/engine/index.js', async (importOriginal) => {
@@ -38,6 +41,41 @@ function makeHandler() {
     systemPrompt: 'You are a helpful worker.',
   }
   return new AgentHandler(sdkEnv, config)
+}
+
+function makeMessagingHandler(rpcCall: ReturnType<typeof vi.fn>) {
+  return new AgentHandler(
+    {
+      modelId: 'test-model',
+      format: 'anthropic' as const,
+      env: { ANTHROPIC_BASE_URL: 'http://localhost:4000', ANTHROPIC_API_KEY: 'test-key' },
+    },
+    { systemPrompt: 'You are a helpful worker.' },
+    {
+      deps: {
+        rpcClient: { call: rpcCall } as never,
+        moduleId: 'agent-test',
+        resolveChannelPort: async () => 3003,
+        getAdminPort: async () => 3001,
+        getMemoryPort: async () => 3002,
+      },
+      mcpConfigFactory: taskCtx => ({
+        'crab-messaging': createCrabMessagingServer({
+          rpcClient: { call: rpcCall } as never,
+          moduleId: 'agent-test',
+          resolveChannelPort: async () => 3003,
+          getAdminPort: async () => 3001,
+          getTaskContext: () => taskCtx,
+        }),
+      }),
+    },
+  )
+}
+
+function findTool(tools: ReadonlyArray<ToolDefinition>, name: string): ToolDefinition {
+  const tool = tools.find(t => t.name === name || t.name.endsWith(`__${name}`))
+  if (!tool) throw new Error(`tool ${name} not found`)
+  return tool
 }
 
 function makeTask(overrides?: Partial<ExecuteTaskParams['task']>): ExecuteTaskParams['task'] {
@@ -478,6 +516,84 @@ describe('AgentHandler', () => {
       resolveEngine!(makeEngineResult())
       await promise
     })
+
+    it('buffered info send_message uses call-time humanInputEpoch when later dispatched', async () => {
+      mockRunEngine.mockImplementation(async () => {
+        await new Promise(resolve => setTimeout(resolve, 60))
+        return makeEngineResult()
+      })
+      const rpcCall = vi.fn().mockImplementation(async (_port: number, method: string) => {
+        if (method === 'send_message') return { platform_message_id: 'mid-info', sent_at: 'now' }
+        return { task: { id: 'task_1', goal: { objective: 'finish current user request' } } }
+      })
+      const handler = makeMessagingHandler(rpcCall)
+
+      const promise = handler.executeTask({ task: makeTask(), context: makeContext() })
+      await new Promise(resolve => setTimeout(resolve, 20))
+      const callArgs = mockRunEngine.mock.calls[0][0]
+      const tools = (callArgs.options.tools as () => ReadonlyArray<ToolDefinition>)()
+      const sendMessage = findTool(tools, 'send_message')
+
+      await sendMessage.call({
+        channel_id: 'channel_1',
+        session_id: 'session_1',
+        content: '旧输入下的汇报',
+      }, {} as never)
+      handler.deliverHumanResponse('task_1', [{
+        platform_message_id: 'msg_human_epoch_1',
+        session: { session_id: 'session_1', channel_id: 'channel_1', type: 'private' },
+        sender: { friend_id: 'friend_1', platform_user_id: 'user_1', platform_display_name: 'Test User' },
+        content: { type: 'text', text: '新的补充' },
+        features: { is_mention_crab: false },
+        platform_timestamp: '2024-01-01T00:02:00Z',
+      }])
+
+      await sendMessage.call({
+        channel_id: 'channel_1',
+        session_id: 'session_1',
+        content: '新输入下的汇报',
+      }, {} as never)
+
+      const taskState = (handler as any).activeTasks.get('task_1')
+      expect(taskState.lastDeliveredInfoEpoch).toBe(0)
+      expect(taskState.outboundBuffer).toHaveLength(1)
+      expect(taskState.outboundBuffer[0].human_input_epoch).toBe(1)
+
+      await promise
+      handler.dispose()
+    })
+
+    it('ask_human dispatch does not count as info delivery for current epoch', async () => {
+      mockRunEngine.mockImplementation(async () => {
+        await new Promise(resolve => setTimeout(resolve, 60))
+        return makeEngineResult()
+      })
+      const rpcCall = vi.fn().mockImplementation(async (_port: number, method: string) => {
+        if (method === 'send_message') return { platform_message_id: 'mid-ask', sent_at: 'now' }
+        if (method === 'update_task_status') return { task: { id: 'task_1', status: 'waiting_human' } }
+        return { task: { id: 'task_1', goal: { objective: 'finish current user request' } } }
+      })
+      const handler = makeMessagingHandler(rpcCall)
+
+      const promise = handler.executeTask({ task: makeTask(), context: makeContext() })
+      await new Promise(resolve => setTimeout(resolve, 20))
+      const callArgs = mockRunEngine.mock.calls[0][0]
+      const tools = (callArgs.options.tools as () => ReadonlyArray<ToolDefinition>)()
+      const sendMessage = findTool(tools, 'send_message')
+
+      await sendMessage.call({
+        channel_id: 'channel_1',
+        session_id: 'session_1',
+        content: '需要你确认一下',
+        intent: 'ask_human',
+      }, {} as never)
+
+      const gateResult = await callArgs.options.endTurnGate()
+      expect(gateResult).toBe(GOAL_MODE_NO_DELIVERY_PROMPT)
+
+      await promise
+      handler.dispose()
+    })
   })
 
   describe('cancelTask', () => {
@@ -696,6 +812,46 @@ describe('AgentHandler', () => {
       } finally {
         rmSync(projectDir, { recursive: true, force: true })
       }
+    })
+
+    it('跨重启 resume：恢复 lastDeliveredInfoEpoch，避免已汇报任务被误判未汇报', async () => {
+      mockRunEngine.mockImplementation(async () => {
+        await new Promise(resolve => setTimeout(resolve, 20))
+        return makeEngineResult()
+      })
+      const rpcCall = vi.fn().mockResolvedValue({
+        task: { id: 'task_1', goal: { objective: 'finish current user request' } },
+      })
+      const handler = new AgentHandler(
+        {
+          modelId: 'test-model',
+          format: 'anthropic' as const,
+          env: { ANTHROPIC_BASE_URL: 'http://localhost:4000', ANTHROPIC_API_KEY: 'test-key' },
+        },
+        { systemPrompt: 'You are a helpful worker.' },
+        {
+          deps: {
+            rpcClient: { call: rpcCall } as never,
+            moduleId: 'agent-test',
+            resolveChannelPort: async () => 3003,
+            getAdminPort: async () => 3001,
+            getMemoryPort: async () => 3002,
+          },
+        },
+      )
+      await handler.executeTask({
+        task: makeTask({ goal: { objective: 'finish current user request' } } as never),
+        context: makeContext(),
+        resumeFrom: {
+          initialMessages: [{ id: 'm1', role: 'user', content: 'resume me', timestamp: 1 }] as never,
+          todoItems: [],
+          lastDeliveredInfoEpoch: 0,
+        },
+      })
+
+      const callArgs = mockRunEngine.mock.calls[0][0]
+      const gateResult = await callArgs.options.endTurnGate()
+      expect(gateResult).toBeNull()
     })
   })
 

--- a/crabot-agent/tests/agent/deliver-human-response.test.ts
+++ b/crabot-agent/tests/agent/deliver-human-response.test.ts
@@ -76,6 +76,7 @@ describe('deliverHumanResponse 渲染媒体', () => {
         session_type: 'private',
       },
       todoStore: { get current() { return [] } },
+      humanInputEpoch: 0,
     })
     ;(handler as any).humanQueues.set(taskId, {
       push: (content: string) => pushed.push(content),
@@ -163,12 +164,24 @@ describe('deliverHumanResponse 渲染媒体', () => {
     expect(taskState.goalRevisionUnlocked).toBe(true)
   })
 
+  it('投递真实 supplement → 推进 humanInputEpoch', () => {
+    const taskState = (handler as any).activeTasks.get('task-test')
+    expect(taskState.humanInputEpoch).toBe(0)
+
+    handler.deliverHumanResponse('task-test' as TaskId, [
+      msg({ content: { type: 'text', text: '补充一个条件' } as any }),
+    ])
+
+    expect(taskState.humanInputEpoch).toBe(1)
+  })
+
   it('全空消息（无内容投递）→ 不发券', () => {
     handler.deliverHumanResponse('task-test' as TaskId, [
       msg({ content: { type: 'text', text: '' } }),
     ])
     const taskState = (handler as any).activeTasks.get('task-test')
     expect(taskState.goalRevisionUnlocked).toBeFalsy()
+    expect(taskState.humanInputEpoch).toBe(0)
   })
 
   it('全为空消息（无 text 也无 media）不 push humanQueue，但 status 仍更新为 executing', () => {
@@ -234,6 +247,7 @@ describe('deliverHumanResponse template variant', () => {
         session_type: 'private',
       },
       todoStore: { get current() { return [] } },
+      humanInputEpoch: 0,
     })
     ;(handler as any).humanQueues.set(taskId, {
       push: (content: string) => pushed.push(content),

--- a/crabot-agent/tests/agent/end-turn-gate-async.test.ts
+++ b/crabot-agent/tests/agent/end-turn-gate-async.test.ts
@@ -62,6 +62,7 @@ function makeTaskState(overrides: Partial<WorkerTaskState> = {}): WorkerTaskStat
     activeAsyncSubagentIds: new Set<string>(),
     // §4.13 默认：未发过、零计数。具体测试按需 override 模拟"讨论型 / 已塞过 N 次 prompt"等场景。
     everSentMessage: false,
+    humanInputEpoch: 0,
     everBufferedMessage: false,
     silentNoDeliveryRetries: 0,
     ...overrides,
@@ -86,6 +87,8 @@ function makeHarness(opts: {
   spawnThrows?: Error
   /** §4.13 — 显式控制初始 everSentMessage / silentNoDeliveryRetries */
   everSentMessage?: boolean
+  humanInputEpoch?: number
+  lastDeliveredInfoEpoch?: number
   silentNoDeliveryRetries?: number
 } = {}): Harness {
   const goal: GoalAuditTaskGoal | undefined =
@@ -97,6 +100,8 @@ function makeHarness(opts: {
   const taskState = makeTaskState({
     outboundBuffer: [...(opts.bufferEntries ?? [makeBufferEntry()])],
     ...(opts.everSentMessage !== undefined ? { everSentMessage: opts.everSentMessage } : {}),
+    ...(opts.humanInputEpoch !== undefined ? { humanInputEpoch: opts.humanInputEpoch } : {}),
+    ...(opts.lastDeliveredInfoEpoch !== undefined ? { lastDeliveredInfoEpoch: opts.lastDeliveredInfoEpoch } : {}),
     ...(opts.silentNoDeliveryRetries !== undefined ? { silentNoDeliveryRetries: opts.silentNoDeliveryRetries } : {}),
   })
 
@@ -143,7 +148,12 @@ describe('createAsyncAuditEndTurnGate', () => {
   })
 
   it('empty outboundBuffer + everSentMessage=true → returns null (讨论型放行；§4.13.4)', async () => {
-    const h = makeHarness({ bufferEntries: [], everSentMessage: true })
+    const h = makeHarness({
+      bufferEntries: [],
+      everSentMessage: true,
+      humanInputEpoch: 1,
+      lastDeliveredInfoEpoch: 1,
+    })
     const gate = createAsyncAuditEndTurnGate(h.deps)
 
     const result = await gate()
@@ -338,6 +348,8 @@ describe('createAsyncAuditEndTurnGate § 4.13 二级分支', () => {
     const h = makeHarness({
       bufferEntries: [],
       everSentMessage: true,
+      humanInputEpoch: 1,
+      lastDeliveredInfoEpoch: 1,
       silentNoDeliveryRetries: 0,
     })
     const gate = createAsyncAuditEndTurnGate(h.deps)
@@ -352,10 +364,31 @@ describe('createAsyncAuditEndTurnGate § 4.13 二级分支', () => {
     expect(h.taskState.silentNoDeliveryRetries).toBe(0)
   })
 
+  it('terminal supplement 后仅有历史送达不算本轮已汇报：current epoch 未送达 → 注入 NO_DELIVERY prompt', async () => {
+    const h = makeHarness({
+      bufferEntries: [],
+      everSentMessage: true,
+      humanInputEpoch: 2,
+      lastDeliveredInfoEpoch: 1,
+      silentNoDeliveryRetries: 0,
+    })
+    const gate = createAsyncAuditEndTurnGate(h.deps)
+
+    const result = await gate()
+
+    expect(result).toBe(GOAL_MODE_NO_DELIVERY_PROMPT)
+    expect(h.taskState.silentNoDeliveryRetries).toBe(1)
+    expect(h.rpcCall).not.toHaveBeenCalled()
+    expect(h.spawnFn).not.toHaveBeenCalled()
+    expect(h.taskState.activeAuditId).toBeUndefined()
+  })
+
   it('讨论型也不受 retries 影响：everSentMessage=true 在 retries=5 时仍 null', async () => {
     const h = makeHarness({
       bufferEntries: [],
       everSentMessage: true,
+      humanInputEpoch: 1,
+      lastDeliveredInfoEpoch: 1,
       silentNoDeliveryRetries: 5,
     })
     const gate = createAsyncAuditEndTurnGate(h.deps)

--- a/crabot-agent/tests/mcp/send-message-buffer.test.ts
+++ b/crabot-agent/tests/mcp/send-message-buffer.test.ts
@@ -91,6 +91,7 @@ describe('send_message buffering (goal mode)', () => {
         hasGoal: () => true, // ← goal mode
         outboundBuffer: buffer,
         hasActiveAudit: () => false, // ← 工作态
+        getHumanInputEpoch: () => 7,
       }),
     })
 
@@ -110,6 +111,7 @@ describe('send_message buffering (goal mode)', () => {
       session_id: 's1',
       content: '正在干活',
       intent: 'info',
+      human_input_epoch: 7,
     })
     expect(buffer[0].sent_at_attempt_ms).toBeGreaterThan(0)
 

--- a/crabot-agent/tests/unified-agent-resume-task.test.ts
+++ b/crabot-agent/tests/unified-agent-resume-task.test.ts
@@ -212,6 +212,30 @@ describe('UnifiedAgent.handleResumeTask — I1: task_origin 从 task.source 重�
     expect(options.resumeFrom?.terminalSupplementText).toBeUndefined()
     expect(options.resumeFrom?.resumeTraceId).toBeUndefined()
   })
+
+  it('restart resume 从 checkpoint worker_state 传递 lastDeliveredInfoEpoch', async () => {
+    const { agent, executeScheduledTaskInBackground } = buildAgent({
+      getResumableCheckpoint: vi.fn().mockReturnValue({
+        traceId: 'trace-running',
+        checkpoint: {
+          agent_version: AGENT_VERSION,
+          messages: [{ id: 'm1', role: 'user', content: 'hi', timestamp: 1 }],
+          worker_state: { todo_items: [], last_delivered_info_epoch: 0 },
+          system_prompt: 'SP',
+        },
+      }),
+    })
+
+    const result = await agent.handleResumeTask({ task_id: 'task-1' })
+
+    expect(result.resumed).toBe(true)
+    const [, , options] = executeScheduledTaskInBackground.mock.calls[0] as [
+      unknown,
+      unknown,
+      { resumeFrom?: { lastDeliveredInfoEpoch?: number } },
+    ]
+    expect(options.resumeFrom?.lastDeliveredInfoEpoch).toBe(0)
+  })
 })
 
 describe('UnifiedAgent.handleResumeTaskWithSupplement', () => {

--- a/crabot-agent/tests/unified-agent-resume-task.test.ts
+++ b/crabot-agent/tests/unified-agent-resume-task.test.ts
@@ -213,14 +213,14 @@ describe('UnifiedAgent.handleResumeTask — I1: task_origin 从 task.source 重�
     expect(options.resumeFrom?.resumeTraceId).toBeUndefined()
   })
 
-  it('restart resume 从 checkpoint worker_state 传递 lastDeliveredInfoEpoch', async () => {
+  it('restart resume 从 checkpoint worker_state 传递 humanInputEpoch 和 lastDeliveredInfoEpoch', async () => {
     const { agent, executeScheduledTaskInBackground } = buildAgent({
       getResumableCheckpoint: vi.fn().mockReturnValue({
         traceId: 'trace-running',
         checkpoint: {
           agent_version: AGENT_VERSION,
           messages: [{ id: 'm1', role: 'user', content: 'hi', timestamp: 1 }],
-          worker_state: { todo_items: [], last_delivered_info_epoch: 0 },
+          worker_state: { todo_items: [], human_input_epoch: 1, last_delivered_info_epoch: 0 },
           system_prompt: 'SP',
         },
       }),
@@ -232,8 +232,9 @@ describe('UnifiedAgent.handleResumeTask — I1: task_origin 从 task.source 重�
     const [, , options] = executeScheduledTaskInBackground.mock.calls[0] as [
       unknown,
       unknown,
-      { resumeFrom?: { lastDeliveredInfoEpoch?: number } },
+      { resumeFrom?: { humanInputEpoch?: number; lastDeliveredInfoEpoch?: number } },
     ]
+    expect(options.resumeFrom?.humanInputEpoch).toBe(1)
     expect(options.resumeFrom?.lastDeliveredInfoEpoch).toBe(0)
   })
 })


### PR DESCRIPTION
## Summary
- Gate empty `end_turn` completion by whether an info/default `send_message` was delivered for the current human input epoch.
- Bind `send_message` entries to the human input epoch at tool-call time, so delayed flush/audit pass does not misattribute old messages to newer supplements.
- Persist and restore `last_delivered_info_epoch` through worker checkpoints, and keep `ask_human` excluded from info-report delivery state.

## Why
Reused/resumed tasks could treat any historical successful `send_message(intent=info)` as sufficient reporting, even after a later human supplement. That allowed a worker to end after handling the supplement internally without sending a final info report back to the user.

## Test Plan
- [x] `npm --prefix crabot-agent test -- --run tests/agent/end-turn-gate-async.test.ts tests/agent/agent-handler.test.ts tests/agent/deliver-human-response.test.ts tests/mcp/send-message-buffer.test.ts tests/unified-agent-resume-task.test.ts tests/agent/outbound-flush.test.ts tests/mcp/crab-messaging-ask-human.test.ts`
- [x] `git diff --check`
- [ ] `npm --prefix crabot-agent run build` currently fails on existing `src/lsp/lsp-client.ts` module resolution for `vscode-languageserver-protocol`.
