### PR TITLE
[codex] fix stable channel session targets

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,14 +1,14 @@
 # Crabot 项目进度
 
-> 最后更新：2026-07-03 — 修复 Channel Session 随机 ID 导致的计划任务目标失效
+> 最后更新：2026-07-04 — 稳定 Channel Session ID 与无痛备份导入
 
-## 2026-07-03 — 修复 Channel Session 随机 ID 导致的计划任务目标失效
+## 2026-07-04 — 稳定 Channel Session ID 与无痛备份导入
 
-- 根因不是上游 IM session 过期：微信 `chatroomName`、飞书 `open_id/chat_id`、Telegram chat id 都是稳定的平台会话标识；问题是 Channel 层把平台会话包了一层随机内部 `Session.id`，Schedule 持久化引用该随机 ID 后，`sessions.json` 重建/迁移/重扫会让同一平台会话生成新 ID，旧 schedule 触发时 `send_message` 查不到 session。
-- WeChat / Feishu / Telegram 的 `SessionManager` 改为按 `channel_id + platform_session_id` 派生 8 位 base36 短稳定内部 session id；加载旧 `sessions.json` 时把旧随机 id / 早期 UUID 形稳定 id 保留为内存 alias，兼容当前磁盘里仍存在的旧引用。
-- `Schedule.target_session` 增加可选 `platform_session_id`；Admin Web 保存计划任务目标时一并写入平台会话 ID，后续即使内部 ID 变化也能确定性修复。
-- Admin 启动迁移和 schedule 触发前都会修复 stale `target_session`：优先验证现有 `session_id`；失效后只在存在 `platform_session_id` 时按平台会话 ID 精确匹配当前 session。旧数据缺平台 ID 时不自动改写目标，避免猜错私聊或群聊。
-- 验证：wechat/feishu/telegram session manager 单测通过；admin schedule migration / target_session / task schedule 回归通过；admin、admin web、三个 channel `tsc --noEmit` 通过。
+- `Session.id` 明确为 Admin/Agent 使用的稳定对话指针，由 `channel_id + platform_session_id` 确定性派生；WeChat/Feishu/Telegram 加载旧 `sessions.json` 时把 legacy 随机 ID canonicalize 到 stable ID，legacy ID 仅作为兼容 lookup alias。
+- `Schedule.target_session` 同时保存 `session_id` 和可选 `platform_session_id`：前者是运行时发送主指针，后者是迁移/修复锚点。Admin 只按 `channel_id + type + platform_session_id` 做确定性修复；缺证据的 legacy-only stale 引用保持无效，不做 fuzzy repair。
+- 备份/导入不依赖 channel-local `sessions.json`。只要导入后 channel 实例和平台原生会话 ID 不变，重新发现会话即可得到同一 stable `Session.id`，导入的 schedule/config 能重新对上。
+- Legacy-only `session-configs.json` 缺少 `channel_id/platform_session_id`，不安全自动迁移；这类旧配置保持无效，避免错误套用到另一个会话。
+- 验证：三个 channel session-manager 测试与 build；Admin schedule repair / backup gather / target_session 测试与 build；Admin Web schedule 保存测试与 build。
 
 ## 2026-07-02 — 修复 Traces UI 活动排序、terminal supplement trace 续写与 null stopReason 误完成
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,6 +1,14 @@
 # Crabot 项目进度
 
-> 最后更新：2026-07-02 — 修复 Traces UI 活动排序、terminal supplement trace 续写与 null stopReason 误完成
+> 最后更新：2026-07-03 — 修复 Channel Session 随机 ID 导致的计划任务目标失效
+
+## 2026-07-03 — 修复 Channel Session 随机 ID 导致的计划任务目标失效
+
+- 根因不是上游 IM session 过期：微信 `chatroomName`、飞书 `open_id/chat_id`、Telegram chat id 都是稳定的平台会话标识；问题是 Channel 层把平台会话包了一层随机内部 `Session.id`，Schedule 持久化引用该随机 ID 后，`sessions.json` 重建/迁移/重扫会让同一平台会话生成新 ID，旧 schedule 触发时 `send_message` 查不到 session。
+- WeChat / Feishu / Telegram 的 `SessionManager` 改为按 `channel_id + platform_session_id` 派生 8 位 base36 短稳定内部 session id；加载旧 `sessions.json` 时把旧随机 id / 早期 UUID 形稳定 id 保留为内存 alias，兼容当前磁盘里仍存在的旧引用。
+- `Schedule.target_session` 增加可选 `platform_session_id`；Admin Web 保存计划任务目标时一并写入平台会话 ID，后续即使内部 ID 变化也能确定性修复。
+- Admin 启动迁移和 schedule 触发前都会修复 stale `target_session`：优先验证现有 `session_id`；失效后只在存在 `platform_session_id` 时按平台会话 ID 精确匹配当前 session。旧数据缺平台 ID 时不自动改写目标，避免猜错私聊或群聊。
+- 验证：wechat/feishu/telegram session manager 单测通过；admin schedule migration / target_session / task schedule 回归通过；admin、admin web、三个 channel `tsc --noEmit` 通过。
 
 ## 2026-07-02 — 修复 Traces UI 活动排序、terminal supplement trace 续写与 null stopReason 误完成
 

--- a/crabot-admin/src/backup/gather.test.ts
+++ b/crabot-admin/src/backup/gather.test.ts
@@ -126,4 +126,67 @@ describe('gatherCategories', () => {
     )
     expect(keptDir).toBe('# b')
   })
+
+  it('exports stable schedule/config references without channel-local sessions cache', async () => {
+    await fs.writeFile(
+      path.join(adminDir, 'channel-instances.json'),
+      JSON.stringify([{ id: 'wechat-1', type: 'wechat', name: 'wechat' }]),
+    )
+    await fs.mkdir(path.join(adminDir, 'channels', 'wechat-1'), { recursive: true })
+    await fs.writeFile(
+      path.join(adminDir, 'channels', 'wechat-1', 'sessions.json'),
+      JSON.stringify([{ id: 'cache-only-session', platform_session_id: '12345@chatroom' }]),
+    )
+    await fs.writeFile(
+      path.join(adminDir, 'schedules.json'),
+      JSON.stringify([
+        {
+          id: 'sched-1',
+          name: 'stable schedule',
+          trigger: { type: 'cron', expression: '0 0 * * *' },
+          task_template: { type: 'routine', title: 'daily', priority: 'normal', tags: [] },
+          enabled: true,
+          target_session: {
+            channel_id: 'wechat-1',
+            session_id: 'stable-abc',
+            platform_session_id: '12345@chatroom',
+            type: 'group',
+          },
+          created_at: '2026-07-04T00:00:00.000Z',
+          updated_at: '2026-07-04T00:00:00.000Z',
+        },
+      ]),
+    )
+    await fs.writeFile(
+      path.join(adminDir, 'session-configs.json'),
+      JSON.stringify([{ session_id: 'stable-abc', config: { updated_at: '2026-07-04T00:00:00.000Z' } }]),
+    )
+
+    await gatherCategories({
+      staging,
+      selection: { categories: ['channels', 'tasks', 'config'], includeSecrets: true },
+      deps: deps(),
+    })
+
+    await expect(
+      fs.access(path.join(staging, 'payload', 'channels', 'channels', 'wechat-1', 'sessions.json')),
+    ).rejects.toThrow()
+
+    const schedules = JSON.parse(
+      await fs.readFile(path.join(staging, 'payload', 'tasks', 'schedules.json'), 'utf-8'),
+    )
+    expect(schedules[0].target_session).toEqual({
+      channel_id: 'wechat-1',
+      session_id: 'stable-abc',
+      platform_session_id: '12345@chatroom',
+      type: 'group',
+    })
+
+    const sessionConfigs = JSON.parse(
+      await fs.readFile(path.join(staging, 'payload', 'config', 'session-configs.json'), 'utf-8'),
+    )
+    expect(sessionConfigs).toEqual([
+      { session_id: 'stable-abc', config: { updated_at: '2026-07-04T00:00:00.000Z' } },
+    ])
+  })
 })

--- a/crabot-admin/src/index.ts
+++ b/crabot-admin/src/index.ts
@@ -4289,8 +4289,11 @@ export class AdminModule extends ModuleBase {
 
       try {
         const sessions = await this.listChannelSessions(channelId as ModuleId)
-        if (platformSessionId) {
-          const match = sessions.find((s) => s.platform_session_id === platformSessionId)
+        const expectedType = scheduleForLookup?.target_session?.type
+        if (platformSessionId && expectedType) {
+          const match = sessions.find(
+            (s) => s.platform_session_id === platformSessionId && s.type === expectedType,
+          )
           if (match) {
             return {
               session_id: match.id,

--- a/crabot-admin/src/index.ts
+++ b/crabot-admin/src/index.ts
@@ -4276,21 +4276,10 @@ export class AdminModule extends ModuleBase {
 
   private async repairScheduleTargetSessionReference(schedule: Schedule): Promise<Schedule> {
     const targetSessionLookup: TargetSessionRepairLookup = async (channelId, sessionId, platformSessionId, scheduleForLookup) => {
-      try {
-        const session = await this.resolveChannelSession(channelId as ModuleId, sessionId)
-        return {
-          session_id: session.id,
-          type: session.type,
-          ...(session.platform_session_id ? { platform_session_id: session.platform_session_id } : {}),
-        }
-      } catch {
-        // Continue below: stale internal id may still be repairable via current session list.
-      }
-
-      try {
-        const sessions = await this.listChannelSessions(channelId as ModuleId)
-        const expectedType = scheduleForLookup?.target_session?.type
-        if (platformSessionId && expectedType) {
+      const expectedType = scheduleForLookup?.target_session?.type
+      if (platformSessionId && expectedType) {
+        try {
+          const sessions = await this.listChannelSessions(channelId as ModuleId)
           const match = sessions.find(
             (s) => s.platform_session_id === platformSessionId && s.type === expectedType,
           )
@@ -4301,9 +4290,19 @@ export class AdminModule extends ModuleBase {
               type: match.type,
             }
           }
+          return undefined
+        } catch {
+          return undefined
         }
+      }
 
-        return undefined
+      try {
+        const session = await this.resolveChannelSession(channelId as ModuleId, sessionId)
+        return {
+          session_id: session.id,
+          type: session.type,
+          ...(session.platform_session_id ? { platform_session_id: session.platform_session_id } : {}),
+        }
       } catch {
         return undefined
       }

--- a/crabot-admin/src/index.ts
+++ b/crabot-admin/src/index.ts
@@ -184,7 +184,9 @@ import { buildOnboardFinishResponse } from './onboard-finish-response.js'
 import { ChannelManager } from './channel-manager.js'
 import {
   migrateScheduleTargetSession,
+  repairScheduleTargetSession,
   type SessionTypeLookup,
+  type TargetSessionRepairLookup,
 } from './schedule-migration.js'
 import { ModuleInstaller } from './module-installer.js'
 import { ChatManager, buildChatTaskSnapshot } from './chat-manager.js'
@@ -3293,6 +3295,7 @@ export class AdminModule extends ModuleBase {
     id: string
     channel_id: ModuleId
     type: 'private' | 'group'
+    platform_session_id?: string
     title: string
     participants: Array<{ friend_id?: FriendId; platform_user_id: string; role: 'owner' | 'admin' | 'member' }>
   }> {
@@ -3311,6 +3314,7 @@ export class AdminModule extends ModuleBase {
           id: string
           channel_id: ModuleId
           type: 'private' | 'group'
+          platform_session_id?: string
           title: string
           participants: Array<{ friend_id?: FriendId; platform_user_id: string; role: 'owner' | 'admin' | 'member' }>
         }
@@ -3328,6 +3332,61 @@ export class AdminModule extends ModuleBase {
     )
 
     return result.session
+  }
+
+  private async listChannelSessions(channelId: ModuleId): Promise<Array<{
+    id: string
+    channel_id: ModuleId
+    type: 'private' | 'group'
+    platform_session_id: string
+    title: string
+  }>> {
+    const modules = await this.rpcClient.resolve(
+      { module_id: channelId },
+      this.config.moduleId
+    )
+    if (modules.length === 0) {
+      throw new Error('Channel module not found')
+    }
+
+    type ChannelSessionListResult = {
+      items: Array<{
+        id: string
+        channel_id: ModuleId
+        type: 'private' | 'group'
+        platform_session_id: string
+        title: string
+      }>
+      pagination: { page: number; page_size: number; total_items: number; total_pages: number }
+    }
+
+    const pageSize = 500
+    const all: Array<{
+      id: string
+      channel_id: ModuleId
+      type: 'private' | 'group'
+      platform_session_id: string
+      title: string
+    }> = []
+    let page = 1
+    let totalPages = 1
+
+    do {
+      const result = await this.rpcClient.call<
+        { pagination: { page: number; page_size: number } },
+        ChannelSessionListResult
+      >(
+        modules[0].port,
+        'get_sessions',
+        { pagination: { page, page_size: pageSize } },
+        this.config.moduleId,
+      )
+      all.push(...result.items)
+      totalPages = Math.max(1, result.pagination.total_pages)
+      page++
+    } while (page <= totalPages)
+
+    return all
   }
 
   private async resolveChannelIdentityFromPrivateSession(channelId: ModuleId, sessionId: string): Promise<ChannelIdentity> {
@@ -4197,8 +4256,9 @@ export class AdminModule extends ModuleBase {
     let migratedCount = 0
     for (const schedule of Array.from(this.schedules.values())) {
       const migrated = await migrateScheduleTargetSession(schedule, sessionTypeLookup)
-      if (migrated !== schedule) {
-        this.schedules.set(migrated.id, migrated)
+      const repaired = await this.repairScheduleTargetSessionReference(migrated)
+      if (repaired !== schedule) {
+        this.schedules.set(repaired.id, repaired)
         migratedCount++
       }
     }
@@ -4212,6 +4272,41 @@ export class AdminModule extends ModuleBase {
         `[Admin] Migrated ${migratedCount} schedule(s) to target_session field`,
       )
     }
+  }
+
+  private async repairScheduleTargetSessionReference(schedule: Schedule): Promise<Schedule> {
+    const targetSessionLookup: TargetSessionRepairLookup = async (channelId, sessionId, platformSessionId, scheduleForLookup) => {
+      try {
+        const session = await this.resolveChannelSession(channelId as ModuleId, sessionId)
+        return {
+          session_id: session.id,
+          type: session.type,
+          ...(session.platform_session_id ? { platform_session_id: session.platform_session_id } : {}),
+        }
+      } catch {
+        // Continue below: stale internal id may still be repairable via current session list.
+      }
+
+      try {
+        const sessions = await this.listChannelSessions(channelId as ModuleId)
+        if (platformSessionId) {
+          const match = sessions.find((s) => s.platform_session_id === platformSessionId)
+          if (match) {
+            return {
+              session_id: match.id,
+              platform_session_id: match.platform_session_id,
+              type: match.type,
+            }
+          }
+        }
+
+        return undefined
+      } catch {
+        return undefined
+      }
+    }
+
+    return repairScheduleTargetSession(schedule, targetSessionLookup)
   }
 
   /**
@@ -5840,6 +5935,12 @@ export class AdminModule extends ModuleBase {
    * 替换模板变量 → RPC 调 Agent create_task_from_schedule → 更新 Schedule 状态
    */
   private async handleScheduleTrigger(schedule: Schedule): Promise<{ task_id: string } | void> {
+    const repairedSchedule = await this.repairScheduleTargetSessionReference(schedule)
+    if (repairedSchedule !== schedule) {
+      this.schedules.set(repairedSchedule.id, repairedSchedule)
+      schedule = repairedSchedule
+    }
+
     const now = new Date()
 
     // 替换模板变量

--- a/crabot-admin/src/schedule-migration.test.ts
+++ b/crabot-admin/src/schedule-migration.test.ts
@@ -14,7 +14,9 @@ import { describe, it, expect } from 'vitest'
 import type { Schedule, ScheduleTargetSession } from './types.js'
 import {
   migrateScheduleTargetSession,
+  repairScheduleTargetSession,
   type SessionTypeLookup,
+  type TargetSessionRepairLookup,
 } from './schedule-migration.js'
 
 function makeSchedule(overrides: Partial<Schedule> = {}): Schedule {
@@ -235,5 +237,88 @@ describe('migrateScheduleTargetSession', () => {
     const lookup: SessionTypeLookup = async () => 'group'
     const migrated = await migrateScheduleTargetSession(schedule, lookup)
     expect(migrated).toBe(schedule)
+  })
+})
+
+describe('repairScheduleTargetSession', () => {
+  it('preserves valid target_session', async () => {
+    const schedule = makeSchedule({
+      target_session: {
+        channel_id: 'wechat-X',
+        session_id: 'valid-session',
+        type: 'group',
+      },
+    })
+
+    const lookup: TargetSessionRepairLookup = async () => ({
+      session_id: 'valid-session',
+      type: 'group',
+    })
+
+    expect(await repairScheduleTargetSession(schedule, lookup)).toBe(schedule)
+  })
+
+  it('rewrites stale target_session to the current session id', async () => {
+    const schedule = makeSchedule({
+      target_session: {
+        channel_id: 'wechat-X',
+        session_id: 'stale-session',
+        type: 'group',
+      },
+    })
+
+    const lookup: TargetSessionRepairLookup = async () => ({
+      session_id: 'current-session',
+      type: 'group',
+    })
+
+    const repaired = await repairScheduleTargetSession(schedule, lookup)
+
+    expect(repaired).not.toBe(schedule)
+    expect(repaired.target_session).toEqual({
+      channel_id: 'wechat-X',
+      session_id: 'current-session',
+      type: 'group',
+    })
+    expect(new Date(repaired.updated_at).getTime()).toBeGreaterThan(
+      new Date(schedule.updated_at).getTime(),
+    )
+  })
+
+  it('uses platform_session_id when present for deterministic repair', async () => {
+    const schedule = makeSchedule({
+      target_session: {
+        channel_id: 'wechat-X',
+        session_id: 'stale-session',
+        platform_session_id: '12345@chatroom',
+        type: 'group',
+      },
+    })
+
+    let seenPlatformSessionId: string | undefined
+    const lookup: TargetSessionRepairLookup = async (_channelId, _sessionId, platformSessionId) => {
+      seenPlatformSessionId = platformSessionId
+      return { session_id: 'current-session', type: 'group' }
+    }
+
+    const repaired = await repairScheduleTargetSession(schedule, lookup)
+
+    expect(seenPlatformSessionId).toBe('12345@chatroom')
+    expect(repaired.target_session?.session_id).toBe('current-session')
+    expect(repaired.target_session?.platform_session_id).toBe('12345@chatroom')
+  })
+
+  it('preserves schedule when lookup cannot repair', async () => {
+    const schedule = makeSchedule({
+      target_session: {
+        channel_id: 'wechat-X',
+        session_id: 'stale-session',
+        type: 'group',
+      },
+    })
+
+    const lookup: TargetSessionRepairLookup = async () => undefined
+
+    expect(await repairScheduleTargetSession(schedule, lookup)).toBe(schedule)
   })
 })

--- a/crabot-admin/src/schedule-migration.test.ts
+++ b/crabot-admin/src/schedule-migration.test.ts
@@ -308,6 +308,25 @@ describe('repairScheduleTargetSession', () => {
     expect(repaired.target_session?.platform_session_id).toBe('12345@chatroom')
   })
 
+  it('preserves schedule when resolved session conflicts with stored platform_session_id', async () => {
+    const schedule = makeSchedule({
+      target_session: {
+        channel_id: 'wechat-X',
+        session_id: 'wrong-current-session',
+        platform_session_id: '12345@chatroom',
+        type: 'group',
+      },
+    })
+
+    const lookup: TargetSessionRepairLookup = async () => ({
+      session_id: 'wrong-current-session',
+      platform_session_id: '67890@chatroom',
+      type: 'group',
+    })
+
+    expect(await repairScheduleTargetSession(schedule, lookup)).toBe(schedule)
+  })
+
   it('preserves schedule when lookup cannot repair', async () => {
     const schedule = makeSchedule({
       target_session: {

--- a/crabot-admin/src/schedule-migration.ts
+++ b/crabot-admin/src/schedule-migration.ts
@@ -113,6 +113,13 @@ export async function repairScheduleTargetSession(
 
   if (!resolved) return schedule
   if (resolved.type !== target.type) return schedule
+  if (
+    target.platform_session_id
+    && resolved.platform_session_id
+    && resolved.platform_session_id !== target.platform_session_id
+  ) {
+    return schedule
+  }
   const platformSessionId = resolved.platform_session_id ?? target.platform_session_id
   const same =
     resolved.session_id === target.session_id

--- a/crabot-admin/src/schedule-migration.ts
+++ b/crabot-admin/src/schedule-migration.ts
@@ -28,6 +28,13 @@ export type SessionTypeLookup = (
   sessionId: string,
 ) => Promise<'private' | 'group' | undefined>
 
+export type TargetSessionRepairLookup = (
+  channelId: string,
+  sessionId: string,
+  platformSessionId?: string,
+  schedule?: Schedule,
+) => Promise<{ session_id: string; platform_session_id?: string; type: 'private' | 'group' } | undefined>
+
 /**
  * 迁移单个 schedule：把 task_template.input.target_channel_id + target_session_id
  * 提升为顶层 target_session 字段。
@@ -80,6 +87,45 @@ export async function migrateScheduleTargetSession(
     task_template: {
       ...schedule.task_template,
       input: newInput,
+    },
+    updated_at: new Date().toISOString(),
+  }
+}
+
+export async function repairScheduleTargetSession(
+  schedule: Schedule,
+  lookupTargetSession: TargetSessionRepairLookup,
+): Promise<Schedule> {
+  const target = schedule.target_session
+  if (!target) return schedule
+
+  let resolved: Awaited<ReturnType<TargetSessionRepairLookup>>
+  try {
+    resolved = await lookupTargetSession(
+      target.channel_id,
+      target.session_id,
+      target.platform_session_id,
+      schedule,
+    )
+  } catch {
+    resolved = undefined
+  }
+
+  if (!resolved) return schedule
+  const platformSessionId = resolved.platform_session_id ?? target.platform_session_id
+  const same =
+    resolved.session_id === target.session_id
+    && resolved.type === target.type
+    && platformSessionId === target.platform_session_id
+  if (same) return schedule
+
+  return {
+    ...schedule,
+    target_session: {
+      channel_id: target.channel_id,
+      session_id: resolved.session_id,
+      ...(platformSessionId ? { platform_session_id: platformSessionId } : {}),
+      type: resolved.type,
     },
     updated_at: new Date().toISOString(),
   }

--- a/crabot-admin/src/schedule-migration.ts
+++ b/crabot-admin/src/schedule-migration.ts
@@ -112,6 +112,7 @@ export async function repairScheduleTargetSession(
   }
 
   if (!resolved) return schedule
+  if (resolved.type !== target.type) return schedule
   const platformSessionId = resolved.platform_session_id ?? target.platform_session_id
   const same =
     resolved.session_id === target.session_id

--- a/crabot-admin/src/task-schedule.test.ts
+++ b/crabot-admin/src/task-schedule.test.ts
@@ -868,6 +868,73 @@ describe('AdminModule - Schedule Management', () => {
         type: 'group',
       })
     })
+
+    it('does not repair target_session to a session with the wrong type', async () => {
+      const defaultCallImplementation = triggerCallSpy.getMockImplementation()
+      triggerCallSpy.mockImplementation(
+        (_port: unknown, method: string, params: unknown) => {
+          if (method === 'create_task_from_schedule') {
+            return Promise.resolve({ task_id: 'mock-task-id', assigned_worker: 'mock-worker' })
+          }
+          if (method === 'get_session') {
+            return Promise.reject(new Error(`Session not found: ${(params as { session_id?: string }).session_id}`))
+          }
+          if (method === 'get_sessions') {
+            return Promise.resolve({
+              items: [
+                {
+                  id: 'private-session-with-same-platform-id',
+                  channel_id: 'wechat-棉花糖',
+                  type: 'private',
+                  platform_session_id: '54213229026@chatroom',
+                  title: 'Wrong private target',
+                },
+              ],
+              pagination: { page: 1, page_size: 500, total_items: 1, total_pages: 1 },
+            })
+          }
+          return defaultCallImplementation?.(_port, method, params) ?? Promise.resolve({})
+        }
+      )
+
+      try {
+        const schedResult = await makeProtocolRequest<{ schedule: Schedule }>(
+          TEST_PROTOCOL_PORT,
+          'create_schedule',
+          {
+            name: 'Wrong type repair guard',
+            trigger: { type: 'cron', expression: '0 0 * * *' },
+            task_template: {
+              type: 'routine',
+              title: 'Daily AI News',
+              priority: 'normal',
+              tags: [],
+            },
+            target_session: {
+              channel_id: 'wechat-棉花糖',
+              session_id: 'stale-random-session-id',
+              platform_session_id: '54213229026@chatroom',
+              type: 'group',
+            },
+          }
+        )
+
+        expect(schedResult.success).toBe(true)
+        await makeProtocolRequest(TEST_PROTOCOL_PORT, 'trigger_now', { schedule_id: schedResult.data!.schedule.id })
+
+        const agentCall = triggerCallSpy.mock.calls.findLast((call) => call[1] === 'create_task_from_schedule')
+        expect(agentCall).toBeTruthy()
+        const payload = agentCall![2] as { target_session?: Record<string, unknown> }
+        expect(payload.target_session).toEqual({
+          channel_id: 'wechat-棉花糖',
+          session_id: 'stale-random-session-id',
+          platform_session_id: '54213229026@chatroom',
+          type: 'group',
+        })
+      } finally {
+        triggerCallSpy.mockImplementation(defaultCallImplementation)
+      }
+    })
   })
 
   describe('assign_worker', () => {

--- a/crabot-admin/src/task-schedule.test.ts
+++ b/crabot-admin/src/task-schedule.test.ts
@@ -869,6 +869,79 @@ describe('AdminModule - Schedule Management', () => {
       })
     })
 
+    it('prefers stored platform_session_id over a mismatched resolvable session_id', async () => {
+      const defaultCallImplementation = triggerCallSpy.getMockImplementation()
+      triggerCallSpy.mockImplementation(
+        (_port: unknown, method: string, params: unknown) => {
+          if (method === 'create_task_from_schedule') {
+            return Promise.resolve({ task_id: 'mock-task-id', assigned_worker: 'mock-worker' })
+          }
+          if (method === 'get_session') {
+            return Promise.resolve({
+              id: (params as { session_id?: string }).session_id,
+              channel_id: 'wechat-棉花糖',
+              type: 'group',
+              platform_session_id: '11111111111@chatroom',
+              title: 'Wrong current group',
+            })
+          }
+          if (method === 'get_sessions') {
+            return Promise.resolve({
+              items: [
+                {
+                  id: 'current-claude-codex-session',
+                  channel_id: 'wechat-棉花糖',
+                  type: 'group',
+                  platform_session_id: '54213229026@chatroom',
+                  title: 'Claude&codex开发工具',
+                },
+              ],
+              pagination: { page: 1, page_size: 500, total_items: 1, total_pages: 1 },
+            })
+          }
+          return defaultCallImplementation?.(_port, method, params) ?? Promise.resolve({})
+        }
+      )
+
+      try {
+        const schedResult = await makeProtocolRequest<{ schedule: Schedule }>(
+          TEST_PROTOCOL_PORT,
+          'create_schedule',
+          {
+            name: 'Mismatched platform repair anchor',
+            trigger: { type: 'cron', expression: '0 0 * * *' },
+            task_template: {
+              type: 'routine',
+              title: 'Daily AI News',
+              priority: 'normal',
+              tags: [],
+            },
+            target_session: {
+              channel_id: 'wechat-棉花糖',
+              session_id: 'wrong-current-session',
+              platform_session_id: '54213229026@chatroom',
+              type: 'group',
+            },
+          }
+        )
+
+        expect(schedResult.success).toBe(true)
+        await makeProtocolRequest(TEST_PROTOCOL_PORT, 'trigger_now', { schedule_id: schedResult.data!.schedule.id })
+
+        const agentCall = triggerCallSpy.mock.calls.findLast((call) => call[1] === 'create_task_from_schedule')
+        expect(agentCall).toBeTruthy()
+        const payload = agentCall![2] as { target_session?: Record<string, unknown> }
+        expect(payload.target_session).toEqual({
+          channel_id: 'wechat-棉花糖',
+          session_id: 'current-claude-codex-session',
+          platform_session_id: '54213229026@chatroom',
+          type: 'group',
+        })
+      } finally {
+        triggerCallSpy.mockImplementation(defaultCallImplementation)
+      }
+    })
+
     it('does not repair target_session to a session with the wrong type', async () => {
       const defaultCallImplementation = triggerCallSpy.getMockImplementation()
       triggerCallSpy.mockImplementation(

--- a/crabot-admin/src/task-schedule.test.ts
+++ b/crabot-admin/src/task-schedule.test.ts
@@ -615,15 +615,56 @@ describe('AdminModule - Schedule Management', () => {
 
   describe('trigger_now', () => {
     let triggerCallSpy: ReturnType<typeof vi.spyOn>
+    let resolveSpy: ReturnType<typeof vi.spyOn>
 
     beforeAll(() => {
-      triggerCallSpy = vi.spyOn(RpcClient.prototype, 'call').mockImplementation(
-        (_port: unknown, method: string, _params: unknown) => {
-          if (method === 'resolve') {
-            return Promise.resolve({ modules: [{ module_id: 'mock-agent', port: 19999, module_type: 'agent' }] })
+      resolveSpy = vi.spyOn(RpcClient.prototype, 'resolve').mockImplementation(
+        (params: { module_id?: string; module_type?: string }) => {
+          if (params.module_id === 'wechat-棉花糖') {
+            return Promise.resolve([{ module_id: 'wechat-棉花糖', port: 19998, module_type: 'channel' }])
           }
+          return Promise.resolve([{ module_id: 'mock-agent', port: 19999, module_type: 'agent' }])
+        }
+      )
+      triggerCallSpy = vi.spyOn(RpcClient.prototype, 'call').mockImplementation(
+        (_port: unknown, method: string, params: unknown) => {
           if (method === 'create_task_from_schedule') {
             return Promise.resolve({ task_id: 'mock-task-id', assigned_worker: 'mock-worker' })
+          }
+          if (method === 'get_session') {
+            return Promise.reject(new Error(`Session not found: ${(params as { session_id?: string }).session_id}`))
+          }
+          if (method === 'get_sessions') {
+            const page = (params as { pagination?: { page?: number } }).pagination?.page ?? 1
+            return Promise.resolve({
+              items: page === 1
+                ? [
+                    {
+                      id: 'other-session-on-page-1',
+                      channel_id: 'wechat-棉花糖',
+                      type: 'group',
+                      platform_session_id: '11111111111@chatroom',
+                      title: '第一页其他群',
+                    },
+                    {
+                      id: 'current-master-private-session',
+                      channel_id: 'wechat-棉花糖',
+                      type: 'private',
+                      platform_session_id: 'master-user',
+                      title: 'Task Master',
+                    },
+                  ]
+                : [
+                    {
+                      id: 'current-claude-codex-session',
+                      channel_id: 'wechat-棉花糖',
+                      type: 'group',
+                      platform_session_id: '54213229026@chatroom',
+                      title: 'Claude&codex开发工具',
+                    },
+              ],
+              pagination: { page, page_size: 500, total_items: 502, total_pages: 2 },
+            })
           }
           return Promise.resolve({})
         }
@@ -632,6 +673,7 @@ describe('AdminModule - Schedule Management', () => {
 
     afterAll(() => {
       triggerCallSpy.mockRestore()
+      resolveSpy.mockRestore()
     })
 
     it('should trigger a schedule via Agent RPC', async () => {
@@ -699,6 +741,132 @@ describe('AdminModule - Schedule Management', () => {
       expect((payload.input as Record<string, unknown>).rendered_marker).toContain('watermark=')
       const nested = (payload.input as Record<string, unknown>).nested as Record<string, unknown>
       expect((nested as { date: string }).date).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+    })
+
+    it('does not fuzzy-repair stale group target_session without platform_session_id', async () => {
+      const schedResult = await makeProtocolRequest<{ schedule: Schedule }>(
+        TEST_PROTOCOL_PORT,
+        'create_schedule',
+        {
+          name: 'GitHub AI News to Claude&codex开发工具',
+          description: '发送到微信 Claude&codex开发工具 群',
+          trigger: { type: 'cron', expression: '0 0 * * *' },
+          task_template: {
+            type: 'routine',
+            title: 'Daily AI News',
+            description: '发送到 Claude&codex开发工具',
+            priority: 'normal',
+            tags: [],
+          },
+          target_session: {
+            channel_id: 'wechat-棉花糖',
+            session_id: 'stale-random-session-id',
+            type: 'group',
+          },
+        }
+      )
+
+      expect(schedResult.success).toBe(true)
+
+      await makeProtocolRequest(TEST_PROTOCOL_PORT, 'trigger_now', { schedule_id: schedResult.data!.schedule.id })
+
+      const agentCall = triggerCallSpy.mock.calls.findLast((call) => call[1] === 'create_task_from_schedule')
+      expect(agentCall).toBeTruthy()
+      const payload = agentCall![2] as { target_session?: Record<string, unknown> }
+      expect(payload.target_session).toEqual({
+        channel_id: 'wechat-棉花糖',
+        session_id: 'stale-random-session-id',
+        type: 'group',
+      })
+    })
+
+    it('does not repair stale private target_session to master without platform_session_id', async () => {
+      const createMaster = await makeProtocolRequest<{ friend: Friend }>(
+        TEST_PROTOCOL_PORT,
+        'create_friend',
+        {
+          display_name: 'Schedule Master',
+          permission: 'master',
+          channel_identities: [
+            {
+              channel_id: 'wechat-棉花糖',
+              platform_user_id: 'master-user',
+              platform_display_name: 'Task Master',
+            },
+          ],
+        }
+      )
+      expect(createMaster.success).toBe(true)
+
+      const schedResult = await makeProtocolRequest<{ schedule: Schedule }>(
+        TEST_PROTOCOL_PORT,
+        'create_schedule',
+        {
+          name: 'Legacy private schedule',
+          trigger: { type: 'cron', expression: '0 0 * * *' },
+          task_template: {
+            type: 'routine',
+            title: 'Private reminder',
+            priority: 'normal',
+            tags: [],
+          },
+          target_session: {
+            channel_id: 'wechat-棉花糖',
+            session_id: 'stale-non-master-private-session',
+            type: 'private',
+          },
+        }
+      )
+
+      expect(schedResult.success).toBe(true)
+
+      await makeProtocolRequest(TEST_PROTOCOL_PORT, 'trigger_now', { schedule_id: schedResult.data!.schedule.id })
+
+      const agentCall = triggerCallSpy.mock.calls.findLast((call) => call[1] === 'create_task_from_schedule')
+      expect(agentCall).toBeTruthy()
+      const payload = agentCall![2] as { target_session?: Record<string, unknown> }
+      expect(payload.target_session).toEqual({
+        channel_id: 'wechat-棉花糖',
+        session_id: 'stale-non-master-private-session',
+        type: 'private',
+      })
+    })
+
+    it('repairs stale target_session deterministically when platform_session_id is present', async () => {
+      const schedResult = await makeProtocolRequest<{ schedule: Schedule }>(
+        TEST_PROTOCOL_PORT,
+        'create_schedule',
+        {
+          name: 'GitHub AI News',
+          trigger: { type: 'cron', expression: '0 0 * * *' },
+          task_template: {
+            type: 'routine',
+            title: 'Daily AI News',
+            priority: 'normal',
+            tags: [],
+          },
+          target_session: {
+            channel_id: 'wechat-棉花糖',
+            session_id: 'stale-random-session-id',
+            platform_session_id: '54213229026@chatroom',
+            type: 'group',
+          },
+        }
+      )
+
+      expect(schedResult.success).toBe(true)
+
+      await makeProtocolRequest(TEST_PROTOCOL_PORT, 'trigger_now', { schedule_id: schedResult.data!.schedule.id })
+
+      const agentCall = triggerCallSpy.mock.calls.findLast((call) => call[1] === 'create_task_from_schedule')
+      expect(agentCall).toBeTruthy()
+      const payload = agentCall![2] as { target_session?: Record<string, unknown> }
+      expect(payload.target_session).toEqual({
+        channel_id: 'wechat-棉花糖',
+        session_id: 'current-claude-codex-session',
+        platform_session_id: '54213229026@chatroom',
+        type: 'group',
+      })
     })
   })
 

--- a/crabot-admin/src/types.ts
+++ b/crabot-admin/src/types.ts
@@ -796,6 +796,8 @@ export interface ScheduleTaskTemplate {
 export interface ScheduleTargetSession {
   channel_id: ModuleId
   session_id: SessionId
+  /** Stable platform-native conversation id, used to repair stale internal session ids. */
+  platform_session_id?: string
   type: 'private' | 'group'
 }
 

--- a/crabot-admin/web/src/pages/Schedules/ScheduleList.test.tsx
+++ b/crabot-admin/web/src/pages/Schedules/ScheduleList.test.tsx
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { buildScheduleTargetSession } from './ScheduleList'
+
+describe('buildScheduleTargetSession', () => {
+  it('preserves existing platform_session_id when sessions are not loaded during edit', () => {
+    expect(buildScheduleTargetSession(
+      { targetChannelId: 'wechat-1', targetSessionId: 'stable-1', targetSessionType: 'group' },
+      [],
+      { channel_id: 'wechat-1', session_id: 'stable-1', platform_session_id: '12345@chatroom', type: 'group' },
+    )).toEqual({
+      channel_id: 'wechat-1',
+      session_id: 'stable-1',
+      platform_session_id: '12345@chatroom',
+      type: 'group',
+    })
+  })
+
+  it('does not carry platform_session_id when user changes target session', () => {
+    expect(buildScheduleTargetSession(
+      { targetChannelId: 'wechat-1', targetSessionId: 'stable-2', targetSessionType: 'group' },
+      [],
+      { channel_id: 'wechat-1', session_id: 'stable-1', platform_session_id: '12345@chatroom', type: 'group' },
+    )).toEqual({
+      channel_id: 'wechat-1',
+      session_id: 'stable-2',
+      type: 'group',
+    })
+  })
+})

--- a/crabot-admin/web/src/pages/Schedules/ScheduleList.tsx
+++ b/crabot-admin/web/src/pages/Schedules/ScheduleList.tsx
@@ -114,7 +114,11 @@ const EMPTY_FORM: ScheduleFormState = {
   targetSessionType: '',
 }
 
-function formToPayload(form: ScheduleFormState): CreateScheduleData {
+function formToPayload(
+  form: ScheduleFormState,
+  sessions: ChannelSession[],
+  existingSchedule?: Schedule | null,
+): CreateScheduleData {
   let trigger: ScheduleTrigger
   switch (form.triggerType) {
     case 'cron':
@@ -140,6 +144,18 @@ function formToPayload(form: ScheduleFormState): CreateScheduleData {
   }
 
   const targetSet = !!(form.targetChannelId && form.targetSessionId && form.targetSessionType)
+  const targetSession = targetSet
+    ? sessions.find(s => s.id === form.targetSessionId)
+    : undefined
+  const existingTargetSession = existingSchedule?.target_session
+  const platformSessionId = targetSession?.platform_session_id
+    ?? (
+      targetSet
+      && existingTargetSession?.channel_id === form.targetChannelId
+      && existingTargetSession.session_id === form.targetSessionId
+        ? existingTargetSession.platform_session_id
+        : undefined
+    )
 
   return {
     name: form.name.trim(),
@@ -152,6 +168,7 @@ function formToPayload(form: ScheduleFormState): CreateScheduleData {
           target_session: {
             channel_id: form.targetChannelId,
             session_id: form.targetSessionId,
+            ...(platformSessionId ? { platform_session_id: platformSessionId } : {}),
             type: form.targetSessionType as 'private' | 'group',
           },
         }
@@ -331,7 +348,7 @@ export const ScheduleList: React.FC = () => {
 
     setSaving(true)
     try {
-      const payload = formToPayload(form)
+      const payload = formToPayload(form, sessions, editingSchedule)
       if (editingId) {
         // 更新路径：若用户清空了原本配置过的 target_session，传 null 显式清除
         const wasTargetSet = !!editingSchedule?.target_session

--- a/crabot-admin/web/src/pages/Schedules/ScheduleList.tsx
+++ b/crabot-admin/web/src/pages/Schedules/ScheduleList.tsx
@@ -114,6 +114,32 @@ const EMPTY_FORM: ScheduleFormState = {
   targetSessionType: '',
 }
 
+export function buildScheduleTargetSession(
+  form: Pick<ScheduleFormState, 'targetChannelId' | 'targetSessionId' | 'targetSessionType'>,
+  sessions: ChannelSession[],
+  existingTargetSession?: Schedule['target_session'],
+): Schedule['target_session'] | undefined {
+  const targetSet = !!(form.targetChannelId && form.targetSessionId && form.targetSessionType)
+  if (!targetSet) return undefined
+
+  const targetSession = sessions.find((s) => s.id === form.targetSessionId)
+  const platformSessionId = targetSession?.platform_session_id
+    ?? (
+      existingTargetSession?.channel_id === form.targetChannelId
+      && existingTargetSession.session_id === form.targetSessionId
+      && existingTargetSession.type === form.targetSessionType
+        ? existingTargetSession.platform_session_id
+        : undefined
+    )
+
+  return {
+    channel_id: form.targetChannelId,
+    session_id: form.targetSessionId,
+    ...(platformSessionId ? { platform_session_id: platformSessionId } : {}),
+    type: form.targetSessionType as 'private' | 'group',
+  }
+}
+
 function formToPayload(
   form: ScheduleFormState,
   sessions: ChannelSession[],
@@ -143,19 +169,15 @@ function formToPayload(
     tags: form.taskTags.split(',').map(s => s.trim()).filter(Boolean),
   }
 
-  const targetSet = !!(form.targetChannelId && form.targetSessionId && form.targetSessionType)
-  const targetSession = targetSet
-    ? sessions.find(s => s.id === form.targetSessionId)
-    : undefined
-  const existingTargetSession = existingSchedule?.target_session
-  const platformSessionId = targetSession?.platform_session_id
-    ?? (
-      targetSet
-      && existingTargetSession?.channel_id === form.targetChannelId
-      && existingTargetSession.session_id === form.targetSessionId
-        ? existingTargetSession.platform_session_id
-        : undefined
-    )
+  const targetSession = buildScheduleTargetSession(
+    {
+      targetChannelId: form.targetChannelId,
+      targetSessionId: form.targetSessionId,
+      targetSessionType: form.targetSessionType,
+    },
+    sessions,
+    existingSchedule?.target_session,
+  )
 
   return {
     name: form.name.trim(),
@@ -163,16 +185,7 @@ function formToPayload(
     enabled: form.enabled,
     trigger,
     task_template,
-    ...(targetSet
-      ? {
-          target_session: {
-            channel_id: form.targetChannelId,
-            session_id: form.targetSessionId,
-            ...(platformSessionId ? { platform_session_id: platformSessionId } : {}),
-            type: form.targetSessionType as 'private' | 'group',
-          },
-        }
-      : {}),
+    ...(targetSession ? { target_session: targetSession } : {}),
   }
 }
 

--- a/crabot-admin/web/src/types/index.ts
+++ b/crabot-admin/web/src/types/index.ts
@@ -674,6 +674,7 @@ export interface Schedule {
   target_session?: {
     channel_id: string
     session_id: string
+    platform_session_id?: string
     type: 'private' | 'group'
   }
   last_triggered_at?: string

--- a/crabot-channel-feishu/src/session-manager.ts
+++ b/crabot-channel-feishu/src/session-manager.ts
@@ -243,11 +243,18 @@ export class SessionManager {
           ? Object.values(raw.sessions)
           : []
       for (const session of sessions) {
+        if (!session.platform_session_id) continue
+        const legacyId = session.id
         const stableId = this.stableSessionId(session.platform_session_id)
-        this.sessions.set(session.id, session)
-        this.platformToId.set(session.platform_session_id, session.id)
-        if (stableId !== session.id) {
-          this.aliases.set(stableId, session.id)
+        const canonical: Session = {
+          ...session,
+          id: stableId,
+          channel_id: this.channelId,
+        }
+        this.sessions.set(stableId, canonical)
+        this.platformToId.set(canonical.platform_session_id, stableId)
+        if (legacyId && legacyId !== stableId) {
+          this.aliases.set(legacyId, stableId)
         }
       }
     } catch (err) {

--- a/crabot-channel-feishu/src/session-manager.ts
+++ b/crabot-channel-feishu/src/session-manager.ts
@@ -7,7 +7,8 @@
 
 import fs from 'node:fs'
 import path from 'node:path'
-import { generateId, generateTimestamp } from 'crabot-shared'
+import crypto from 'node:crypto'
+import { generateTimestamp } from 'crabot-shared'
 import type {
   ModuleId,
   Session,
@@ -32,6 +33,7 @@ function isBetterTitle(incoming: string, current: string, platformSessionId: str
 export class SessionManager {
   private sessions: Map<string, Session> = new Map()
   private platformToId: Map<string, string> = new Map()
+  private aliases: Map<string, string> = new Map()
   private readonly filePath: string
   private readonly channelId: ModuleId
 
@@ -156,21 +158,25 @@ export class SessionManager {
     if (!existing) return undefined
     this.sessions.delete(existing.id)
     this.platformToId.delete(platformSessionId)
+    this.deleteAliasesFor(existing.id)
     this.save()
     return existing
   }
 
   removeById(sessionId: string): Session | undefined {
-    const existing = this.sessions.get(sessionId)
+    const canonicalId = this.aliases.get(sessionId) ?? sessionId
+    const existing = this.sessions.get(canonicalId)
     if (!existing) return undefined
     this.sessions.delete(existing.id)
     this.platformToId.delete(existing.platform_session_id)
+    this.deleteAliasesFor(existing.id)
     this.save()
     return existing
   }
 
   findById(sessionId: string): Session | undefined {
-    return this.sessions.get(sessionId)
+    const canonicalId = this.aliases.get(sessionId) ?? sessionId
+    return this.sessions.get(canonicalId)
   }
 
   findByPlatformId(platformSessionId: string): Session | undefined {
@@ -191,7 +197,7 @@ export class SessionManager {
   }): Session {
     const now = generateTimestamp()
     const session: Session = {
-      id: generateId(),
+      id: this.stableSessionId(params.platform_session_id),
       channel_id: this.channelId,
       type: params.type,
       platform_session_id: params.platform_session_id,
@@ -237,11 +243,31 @@ export class SessionManager {
           ? Object.values(raw.sessions)
           : []
       for (const session of sessions) {
+        const stableId = this.stableSessionId(session.platform_session_id)
         this.sessions.set(session.id, session)
         this.platformToId.set(session.platform_session_id, session.id)
+        if (stableId !== session.id) {
+          this.aliases.set(stableId, session.id)
+        }
       }
     } catch (err) {
       console.warn('[SessionManager] Failed to parse sessions:', err)
+    }
+  }
+
+  private stableSessionId(platformSessionId: string): string {
+    const digest = crypto
+      .createHash('sha256')
+      .update(`${this.channelId}\0${platformSessionId}`)
+      .digest()
+    return digest.readUIntBE(0, 6).toString(36).padStart(8, '0').slice(0, 8)
+  }
+
+  private deleteAliasesFor(canonicalId: string): void {
+    for (const [alias, target] of Array.from(this.aliases.entries())) {
+      if (target === canonicalId) {
+        this.aliases.delete(alias)
+      }
     }
   }
 

--- a/crabot-channel-feishu/tests/session-manager.test.ts
+++ b/crabot-channel-feishu/tests/session-manager.test.ts
@@ -44,7 +44,7 @@ describe('upsert (private)', () => {
     expect(second.session.id).toMatch(/^[0-9a-z]{8}$/)
   })
 
-  it('keeps loaded session ids canonical and accepts new short stable ids as aliases', () => {
+  it('canonicalizes loaded legacy session ids to stable ids and keeps legacy lookup aliases', () => {
     fs.writeFileSync(path.join(tmpDir, 'sessions.json'), JSON.stringify([
       {
         id: 'legacy-feishu-session-id',
@@ -59,46 +59,25 @@ describe('upsert (private)', () => {
         created_at: '2026-01-01T00:00:00.000Z',
         updated_at: '2026-01-01T00:00:00.000Z',
       },
-      {
-        id: 'f3080c32-210f-57f3-6e5c-c8f1a6166c69',
-        channel_id: 'channel-feishu-test',
-        type: 'private',
-        platform_session_id: 'ou_bob',
-        title: 'Bob',
-        participants: [{ platform_user_id: 'ou_bob', role: 'member' }],
-        permissions: { desktop: false, network: { mode: 'allow_all', rules: [] }, storage: [] },
-        memory_scopes: ['ou_bob'],
-        workspace_path: '',
-        created_at: '2026-01-01T00:00:00.000Z',
-        updated_at: '2026-01-01T00:00:00.000Z',
-      },
     ]), 'utf-8')
 
-    const fresh = new SessionManager('channel-feishu-test', tmpDir)
-    const session = fresh.findByPlatformId('ou_alice')
-    const uuidSession = fresh.findByPlatformId('ou_bob')
-    const probe = new SessionManager('channel-feishu-test', path.join(tmpDir, 'short-id-probe'))
-    const shortId = probe.upsert({
+    const probe = new SessionManager('channel-feishu-test', path.join(tmpDir, 'stable-id-probe'))
+    const stableId = probe.upsert({
       platform_session_id: 'ou_alice',
       type: 'private',
       title: 'Alice',
       sender_id: 'ou_alice',
       sender_name: 'Alice',
-    }).session
-    const uuidShortId = probe.upsert({
-      platform_session_id: 'ou_bob',
-      type: 'private',
-      title: 'Bob',
-      sender_id: 'ou_bob',
-      sender_name: 'Bob',
-    }).session
+    }).session.id
 
-    expect(session?.id).toBe('legacy-feishu-session-id')
-    expect(uuidSession?.id).toBe('f3080c32-210f-57f3-6e5c-c8f1a6166c69')
-    expect(shortId.id).toMatch(/^[0-9a-z]{8}$/)
-    expect(uuidShortId.id).toMatch(/^[0-9a-z]{8}$/)
-    expect(fresh.findById(shortId.id)?.id).toBe('legacy-feishu-session-id')
-    expect(fresh.findById(uuidShortId.id)?.id).toBe('f3080c32-210f-57f3-6e5c-c8f1a6166c69')
+    const fresh = new SessionManager('channel-feishu-test', tmpDir)
+    const session = fresh.findByPlatformId('ou_alice')
+
+    expect(stableId).toMatch(/^[0-9a-z]{8}$/)
+    expect(session?.id).toBe(stableId)
+    expect(fresh.findById(stableId)?.id).toBe(stableId)
+    expect(fresh.findById('legacy-feishu-session-id')?.id).toBe(stableId)
+    expect(fresh.listSessions('private').map((s) => s.id)).toEqual([stableId])
   })
 
   it('first call creates a private session', () => {
@@ -266,8 +245,9 @@ describe('removeByPlatformId', () => {
     ]), 'utf-8')
 
     const fresh = new SessionManager('channel-feishu-test', tmpDir)
-    expect(fresh.findById(shortId)?.id).toBe('legacy-feishu-session-id')
-    fresh.removeById(shortId)
+    expect(fresh.findById(shortId)?.id).toBe(shortId)
+    expect(fresh.findById('legacy-feishu-session-id')?.id).toBe(shortId)
+    fresh.removeById('legacy-feishu-session-id')
 
     const recreated = fresh.upsert({
       platform_session_id: 'ou_alice',

--- a/crabot-channel-feishu/tests/session-manager.test.ts
+++ b/crabot-channel-feishu/tests/session-manager.test.ts
@@ -21,6 +21,86 @@ afterEach(() => {
 })
 
 describe('upsert (private)', () => {
+  it('derives a stable session id from channel and platform session id', () => {
+    const first = mgr.upsert({
+      platform_session_id: 'ou_alice',
+      type: 'private',
+      title: 'Alice',
+      sender_id: 'ou_alice',
+      sender_name: 'Alice',
+    })
+
+    fs.rmSync(path.join(tmpDir, 'sessions.json'), { force: true })
+    const fresh = new SessionManager('channel-feishu-test', tmpDir)
+    const second = fresh.upsert({
+      platform_session_id: 'ou_alice',
+      type: 'private',
+      title: 'Alice',
+      sender_id: 'ou_alice',
+      sender_name: 'Alice',
+    })
+
+    expect(second.session.id).toBe(first.session.id)
+    expect(second.session.id).toMatch(/^[0-9a-z]{8}$/)
+  })
+
+  it('keeps loaded session ids canonical and accepts new short stable ids as aliases', () => {
+    fs.writeFileSync(path.join(tmpDir, 'sessions.json'), JSON.stringify([
+      {
+        id: 'legacy-feishu-session-id',
+        channel_id: 'channel-feishu-test',
+        type: 'private',
+        platform_session_id: 'ou_alice',
+        title: 'Alice',
+        participants: [{ platform_user_id: 'ou_alice', role: 'member' }],
+        permissions: { desktop: false, network: { mode: 'allow_all', rules: [] }, storage: [] },
+        memory_scopes: ['ou_alice'],
+        workspace_path: '',
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-01T00:00:00.000Z',
+      },
+      {
+        id: 'f3080c32-210f-57f3-6e5c-c8f1a6166c69',
+        channel_id: 'channel-feishu-test',
+        type: 'private',
+        platform_session_id: 'ou_bob',
+        title: 'Bob',
+        participants: [{ platform_user_id: 'ou_bob', role: 'member' }],
+        permissions: { desktop: false, network: { mode: 'allow_all', rules: [] }, storage: [] },
+        memory_scopes: ['ou_bob'],
+        workspace_path: '',
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-01T00:00:00.000Z',
+      },
+    ]), 'utf-8')
+
+    const fresh = new SessionManager('channel-feishu-test', tmpDir)
+    const session = fresh.findByPlatformId('ou_alice')
+    const uuidSession = fresh.findByPlatformId('ou_bob')
+    const probe = new SessionManager('channel-feishu-test', path.join(tmpDir, 'short-id-probe'))
+    const shortId = probe.upsert({
+      platform_session_id: 'ou_alice',
+      type: 'private',
+      title: 'Alice',
+      sender_id: 'ou_alice',
+      sender_name: 'Alice',
+    }).session
+    const uuidShortId = probe.upsert({
+      platform_session_id: 'ou_bob',
+      type: 'private',
+      title: 'Bob',
+      sender_id: 'ou_bob',
+      sender_name: 'Bob',
+    }).session
+
+    expect(session?.id).toBe('legacy-feishu-session-id')
+    expect(uuidSession?.id).toBe('f3080c32-210f-57f3-6e5c-c8f1a6166c69')
+    expect(shortId.id).toMatch(/^[0-9a-z]{8}$/)
+    expect(uuidShortId.id).toMatch(/^[0-9a-z]{8}$/)
+    expect(fresh.findById(shortId.id)?.id).toBe('legacy-feishu-session-id')
+    expect(fresh.findById(uuidShortId.id)?.id).toBe('f3080c32-210f-57f3-6e5c-c8f1a6166c69')
+  })
+
   it('first call creates a private session', () => {
     const { session, created } = mgr.upsert({
       platform_session_id: 'ou_alice',
@@ -157,6 +237,48 @@ describe('removeByPlatformId', () => {
     mgr.removeByPlatformId('ou_alice')
     expect(mgr.findById(r.session.id)).toBeUndefined()
     expect(mgr.findByPlatformId('ou_alice')).toBeUndefined()
+  })
+
+  it('clears stable aliases when deleting a loaded legacy session by id', () => {
+    const probe = new SessionManager('channel-feishu-test', path.join(tmpDir, 'short-id-probe'))
+    const shortId = probe.upsert({
+      platform_session_id: 'ou_alice',
+      type: 'private',
+      title: 'Alice',
+      sender_id: 'ou_alice',
+      sender_name: 'Alice',
+    }).session.id
+
+    fs.writeFileSync(path.join(tmpDir, 'sessions.json'), JSON.stringify([
+      {
+        id: 'legacy-feishu-session-id',
+        channel_id: 'channel-feishu-test',
+        type: 'private',
+        platform_session_id: 'ou_alice',
+        title: 'Alice',
+        participants: [{ platform_user_id: 'ou_alice', role: 'member' }],
+        permissions: { desktop: false, network: { mode: 'allow_all', rules: [] }, storage: [] },
+        memory_scopes: ['ou_alice'],
+        workspace_path: '',
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-01T00:00:00.000Z',
+      },
+    ]), 'utf-8')
+
+    const fresh = new SessionManager('channel-feishu-test', tmpDir)
+    expect(fresh.findById(shortId)?.id).toBe('legacy-feishu-session-id')
+    fresh.removeById(shortId)
+
+    const recreated = fresh.upsert({
+      platform_session_id: 'ou_alice',
+      type: 'private',
+      title: 'Alice',
+      sender_id: 'ou_alice',
+      sender_name: 'Alice',
+    }).session
+
+    expect(recreated.id).toBe(shortId)
+    expect(fresh.findById(shortId)?.id).toBe(shortId)
   })
 })
 

--- a/crabot-channel-telegram/src/message-store.ts
+++ b/crabot-channel-telegram/src/message-store.ts
@@ -123,6 +123,30 @@ export class MessageStore {
     return records.find((r) => r.platform_message_id === platformMessageId)
   }
 
+  async migrateSessionId(fromSessionId: string, toSessionId: string): Promise<void> {
+    if (fromSessionId === toSessionId) return
+
+    const fromPath = this.sessionFilePath(fromSessionId)
+    const toPath = this.sessionFilePath(toSessionId)
+    if (!fsSync.existsSync(fromPath)) return
+
+    if (!fsSync.existsSync(toPath)) {
+      await fs.rename(fromPath, toPath)
+      return
+    }
+
+    const [stableContent, legacyContent] = await Promise.all([
+      fs.readFile(toPath, 'utf-8'),
+      fs.readFile(fromPath, 'utf-8'),
+    ])
+    if (legacyContent) {
+      const prefix = stableContent && !stableContent.endsWith('\n') ? '\n' : ''
+      const suffix = legacyContent.endsWith('\n') ? '' : '\n'
+      await fs.appendFile(toPath, prefix + legacyContent + suffix, 'utf-8')
+    }
+    await fs.unlink(fromPath)
+  }
+
   // ── 内部方法 ──────────────────────────────────────────────────────────────
 
   private sessionFilePath(sessionId: string): string {

--- a/crabot-channel-telegram/src/message-store.ts
+++ b/crabot-channel-telegram/src/message-store.ts
@@ -23,6 +23,7 @@ export class MessageStore {
   private readonly messagesDir: string
   private readonly cacheConfig: TelegramCacheConfig
   private cleanupTimer: ReturnType<typeof setInterval> | null = null
+  private migrationLocks = new Map<string, Promise<void>>()
 
   constructor(dataDir: string, cacheConfig?: Partial<TelegramCacheConfig>) {
     this.messagesDir = path.join(dataDir, 'messages')
@@ -126,25 +127,58 @@ export class MessageStore {
   async migrateSessionId(fromSessionId: string, toSessionId: string): Promise<void> {
     if (fromSessionId === toSessionId) return
 
+    const key = `${fromSessionId}\0${toSessionId}`
+    const existing = this.migrationLocks.get(key)
+    if (existing) return existing
+
+    const migration = this.migrateSessionIdLocked(fromSessionId, toSessionId)
+      .finally(() => {
+        if (this.migrationLocks.get(key) === migration) {
+          this.migrationLocks.delete(key)
+        }
+      })
+    this.migrationLocks.set(key, migration)
+    return migration
+  }
+
+  private async migrateSessionIdLocked(fromSessionId: string, toSessionId: string): Promise<void> {
     const fromPath = this.sessionFilePath(fromSessionId)
     const toPath = this.sessionFilePath(toSessionId)
     if (!fsSync.existsSync(fromPath)) return
 
     if (!fsSync.existsSync(toPath)) {
-      await fs.rename(fromPath, toPath)
+      try {
+        await fs.rename(fromPath, toPath)
+      } catch (error) {
+        if (isNotFoundError(error)) return
+        throw error
+      }
       return
     }
 
-    const [stableContent, legacyContent] = await Promise.all([
-      fs.readFile(toPath, 'utf-8'),
-      fs.readFile(fromPath, 'utf-8'),
-    ])
+    let stableContent: string
+    let legacyContent: string
+    try {
+      const contents = await Promise.all([
+        fs.readFile(toPath, 'utf-8'),
+        fs.readFile(fromPath, 'utf-8'),
+      ])
+      stableContent = contents[0]
+      legacyContent = contents[1]
+    } catch (error) {
+      if (isNotFoundError(error)) return
+      throw error
+    }
     if (legacyContent) {
       const prefix = stableContent && !stableContent.endsWith('\n') ? '\n' : ''
       const suffix = legacyContent.endsWith('\n') ? '' : '\n'
       await fs.appendFile(toPath, prefix + legacyContent + suffix, 'utf-8')
     }
-    await fs.unlink(fromPath)
+    try {
+      await fs.unlink(fromPath)
+    } catch (error) {
+      if (!isNotFoundError(error)) throw error
+    }
   }
 
   // ── 内部方法 ──────────────────────────────────────────────────────────────
@@ -218,4 +252,8 @@ export class MessageStore {
       }
     }
   }
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT'
 }

--- a/crabot-channel-telegram/src/message-store.ts
+++ b/crabot-channel-telegram/src/message-store.ts
@@ -127,11 +127,11 @@ export class MessageStore {
   async migrateSessionId(fromSessionId: string, toSessionId: string): Promise<void> {
     if (fromSessionId === toSessionId) return
 
-    const key = `${fromSessionId}\0${toSessionId}`
-    const existing = this.migrationLocks.get(key)
-    if (existing) return existing
-
-    const migration = this.migrateSessionIdLocked(fromSessionId, toSessionId)
+    const key = `to:${toSessionId}`
+    const previous = this.migrationLocks.get(key) ?? Promise.resolve()
+    const migration = previous
+      .catch(() => undefined)
+      .then(() => this.migrateSessionIdLocked(fromSessionId, toSessionId))
       .finally(() => {
         if (this.migrationLocks.get(key) === migration) {
           this.migrationLocks.delete(key)
@@ -144,33 +144,20 @@ export class MessageStore {
   private async migrateSessionIdLocked(fromSessionId: string, toSessionId: string): Promise<void> {
     const fromPath = this.sessionFilePath(fromSessionId)
     const toPath = this.sessionFilePath(toSessionId)
-    if (!fsSync.existsSync(fromPath)) return
 
-    if (!fsSync.existsSync(toPath)) {
-      try {
-        await fs.rename(fromPath, toPath)
-      } catch (error) {
-        if (isNotFoundError(error)) return
-        throw error
-      }
-      return
-    }
-
-    let stableContent: string
     let legacyContent: string
     try {
-      const contents = await Promise.all([
-        fs.readFile(toPath, 'utf-8'),
-        fs.readFile(fromPath, 'utf-8'),
-      ])
-      stableContent = contents[0]
-      legacyContent = contents[1]
+      legacyContent = await fs.readFile(fromPath, 'utf-8')
     } catch (error) {
       if (isNotFoundError(error)) return
       throw error
     }
+
     if (legacyContent) {
-      const prefix = stableContent && !stableContent.endsWith('\n') ? '\n' : ''
+      const stableNeedsNewline = fsSync.existsSync(toPath)
+        && fsSync.statSync(toPath).size > 0
+        && !fsSync.readFileSync(toPath, 'utf-8').endsWith('\n')
+      const prefix = stableNeedsNewline ? '\n' : ''
       const suffix = legacyContent.endsWith('\n') ? '' : '\n'
       await fs.appendFile(toPath, prefix + legacyContent + suffix, 'utf-8')
     }

--- a/crabot-channel-telegram/src/message-store.ts
+++ b/crabot-channel-telegram/src/message-store.ts
@@ -154,12 +154,15 @@ export class MessageStore {
     }
 
     if (legacyContent) {
-      const stableNeedsNewline = fsSync.existsSync(toPath)
-        && fsSync.statSync(toPath).size > 0
-        && !fsSync.readFileSync(toPath, 'utf-8').endsWith('\n')
-      const prefix = stableNeedsNewline ? '\n' : ''
-      const suffix = legacyContent.endsWith('\n') ? '' : '\n'
-      await fs.appendFile(toPath, prefix + legacyContent + suffix, 'utf-8')
+      const stableContent = fsSync.existsSync(toPath) ? fsSync.readFileSync(toPath, 'utf-8') : ''
+      const existingMessageIds = collectPlatformMessageIds(stableContent)
+      const linesToAppend = legacyContent
+        .split('\n')
+        .filter((line) => shouldAppendJsonlLine(line, existingMessageIds))
+      if (linesToAppend.length > 0) {
+        const prefix = stableContent && !stableContent.endsWith('\n') ? '\n' : ''
+        await fs.appendFile(toPath, prefix + linesToAppend.join('\n') + '\n', 'utf-8')
+      }
     }
     try {
       await fs.unlink(fromPath)
@@ -243,4 +246,29 @@ export class MessageStore {
 
 function isNotFoundError(error: unknown): boolean {
   return typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT'
+}
+
+function collectPlatformMessageIds(content: string): Set<string> {
+  const ids = new Set<string>()
+  for (const line of content.split('\n')) {
+    if (!line.trim()) continue
+    const id = platformMessageIdFromLine(line)
+    if (id) ids.add(id)
+  }
+  return ids
+}
+
+function shouldAppendJsonlLine(line: string, existingMessageIds: Set<string>): boolean {
+  if (!line.trim()) return false
+  const id = platformMessageIdFromLine(line)
+  return !id || !existingMessageIds.has(id)
+}
+
+function platformMessageIdFromLine(line: string): string | undefined {
+  try {
+    const parsed = JSON.parse(line) as { platform_message_id?: unknown }
+    return typeof parsed.platform_message_id === 'string' ? parsed.platform_message_id : undefined
+  } catch {
+    return undefined
+  }
 }

--- a/crabot-channel-telegram/src/session-manager.ts
+++ b/crabot-channel-telegram/src/session-manager.ts
@@ -94,6 +94,10 @@ export class SessionManager {
       .map(([legacyId]) => legacyId)
   }
 
+  legacyAliasPairs(): Array<{ legacyId: string; stableId: string }> {
+    return Array.from(this.aliases.entries()).map(([legacyId, stableId]) => ({ legacyId, stableId }))
+  }
+
   private ensureParticipant(session: Session, userId: string): boolean {
     const exists = session.participants.some((p) => p.platform_user_id === userId)
     if (exists) return false

--- a/crabot-channel-telegram/src/session-manager.ts
+++ b/crabot-channel-telegram/src/session-manager.ts
@@ -87,6 +87,13 @@ export class SessionManager {
     return type ? all.filter((s) => s.type === type) : all
   }
 
+  legacyIdsFor(sessionId: string): string[] {
+    const canonicalId = this.aliases.get(sessionId) ?? sessionId
+    return Array.from(this.aliases.entries())
+      .filter(([, targetId]) => targetId === canonicalId)
+      .map(([legacyId]) => legacyId)
+  }
+
   private ensureParticipant(session: Session, userId: string): boolean {
     const exists = session.participants.some((p) => p.platform_user_id === userId)
     if (exists) return false

--- a/crabot-channel-telegram/src/session-manager.ts
+++ b/crabot-channel-telegram/src/session-manager.ts
@@ -7,7 +7,8 @@
 
 import fs from 'node:fs'
 import path from 'node:path'
-import { generateId, generateTimestamp } from 'crabot-shared'
+import crypto from 'node:crypto'
+import { generateTimestamp } from 'crabot-shared'
 import type { ModuleId, Session, SessionType, SessionPermissions } from './types.js'
 
 const DEFAULT_PERMISSIONS: SessionPermissions = {
@@ -19,6 +20,7 @@ const DEFAULT_PERMISSIONS: SessionPermissions = {
 export class SessionManager {
   private sessions: Map<string, Session> = new Map()
   private platformToId: Map<string, string> = new Map()
+  private aliases: Map<string, string> = new Map()
   private readonly filePath: string
   private readonly channelId: ModuleId
 
@@ -45,7 +47,7 @@ export class SessionManager {
     }
 
     const session: Session = {
-      id: generateId(),
+      id: this.stableSessionId(params.platform_session_id),
       channel_id: this.channelId,
       type: params.type,
       platform_session_id: params.platform_session_id,
@@ -71,7 +73,8 @@ export class SessionManager {
   }
 
   findById(sessionId: string): Session | undefined {
-    return this.sessions.get(sessionId)
+    const canonicalId = this.aliases.get(sessionId) ?? sessionId
+    return this.sessions.get(canonicalId)
   }
 
   findByPlatformId(platformSessionId: string): Session | undefined {
@@ -110,12 +113,24 @@ export class SessionManager {
           ? Object.values(raw.sessions)
           : []
       for (const session of sessions) {
+        const stableId = this.stableSessionId(session.platform_session_id)
         this.sessions.set(session.id, session)
         this.platformToId.set(session.platform_session_id, session.id)
+        if (stableId !== session.id) {
+          this.aliases.set(stableId, session.id)
+        }
       }
     } catch (error) {
       console.warn('[SessionManager] Failed to load sessions:', error)
     }
+  }
+
+  private stableSessionId(platformSessionId: string): string {
+    const digest = crypto
+      .createHash('sha256')
+      .update(`${this.channelId}\0${platformSessionId}`)
+      .digest()
+    return digest.readUIntBE(0, 6).toString(36).padStart(8, '0').slice(0, 8)
   }
 
   private save(): void {

--- a/crabot-channel-telegram/src/session-manager.ts
+++ b/crabot-channel-telegram/src/session-manager.ts
@@ -113,11 +113,18 @@ export class SessionManager {
           ? Object.values(raw.sessions)
           : []
       for (const session of sessions) {
+        if (!session.platform_session_id) continue
+        const legacyId = session.id
         const stableId = this.stableSessionId(session.platform_session_id)
-        this.sessions.set(session.id, session)
-        this.platformToId.set(session.platform_session_id, session.id)
-        if (stableId !== session.id) {
-          this.aliases.set(stableId, session.id)
+        const canonical: Session = {
+          ...session,
+          id: stableId,
+          channel_id: this.channelId,
+        }
+        this.sessions.set(stableId, canonical)
+        this.platformToId.set(canonical.platform_session_id, stableId)
+        if (legacyId && legacyId !== stableId) {
+          this.aliases.set(legacyId, stableId)
         }
       }
     } catch (error) {

--- a/crabot-channel-telegram/src/telegram-channel.ts
+++ b/crabot-channel-telegram/src/telegram-channel.ts
@@ -518,7 +518,7 @@ export class TelegramChannel extends ModuleBase {
     const sentAt = generateTimestamp()
 
     await this.messageStore.appendOutbound({
-      sessionId: params.session_id,
+      sessionId: session.id,
       platformMessageId: firstId,
       text: text || '[非文本消息]',
       contentType: params.content.type,
@@ -747,7 +747,7 @@ export class TelegramChannel extends ModuleBase {
     const page = params.limit ? undefined : (params.pagination?.page ?? 1)
 
     const { items, total } = await this.messageStore.query({
-      sessionId: params.session_id,
+      sessionId: session.id,
       keyword: params.keyword,
       timeRange: params.time_range,
       page: page,
@@ -769,7 +769,7 @@ export class TelegramChannel extends ModuleBase {
     const session = this.sessionManager.findById(params.session_id)
     if (!session) throw new Error('Session not found')
 
-    const msg = await this.messageStore.findByMessageId(params.session_id, params.platform_message_id)
+    const msg = await this.messageStore.findByMessageId(session.id, params.platform_message_id)
     if (!msg) throw new Error('Message not found')
 
     return storedMessageToProtocol(msg)

--- a/crabot-channel-telegram/src/telegram-channel.ts
+++ b/crabot-channel-telegram/src/telegram-channel.ts
@@ -517,7 +517,7 @@ export class TelegramChannel extends ModuleBase {
     const firstId = String(sentIds[0])
     const sentAt = generateTimestamp()
 
-    await this.messageStore.migrateSessionId(params.session_id, session.id)
+    await this.migrateLegacySessionHistory(params.session_id, session.id)
     await this.messageStore.appendOutbound({
       sessionId: session.id,
       platformMessageId: firstId,
@@ -747,7 +747,7 @@ export class TelegramChannel extends ModuleBase {
     const pageSize = params.limit ?? params.pagination?.page_size ?? 20
     const page = params.limit ? undefined : (params.pagination?.page ?? 1)
 
-    await this.messageStore.migrateSessionId(params.session_id, session.id)
+    await this.migrateLegacySessionHistory(params.session_id, session.id)
     const { items, total } = await this.messageStore.query({
       sessionId: session.id,
       keyword: params.keyword,
@@ -771,11 +771,21 @@ export class TelegramChannel extends ModuleBase {
     const session = this.sessionManager.findById(params.session_id)
     if (!session) throw new Error('Session not found')
 
-    await this.messageStore.migrateSessionId(params.session_id, session.id)
+    await this.migrateLegacySessionHistory(params.session_id, session.id)
     const msg = await this.messageStore.findByMessageId(session.id, params.platform_message_id)
     if (!msg) throw new Error('Message not found')
 
     return storedMessageToProtocol(msg)
+  }
+
+  private async migrateLegacySessionHistory(requestedSessionId: string, canonicalSessionId: string): Promise<void> {
+    const legacyIds = new Set([
+      requestedSessionId,
+      ...this.sessionManager.legacyIdsFor(canonicalSessionId),
+    ])
+    for (const legacyId of legacyIds) {
+      await this.messageStore.migrateSessionId(legacyId, canonicalSessionId)
+    }
   }
 
   private async handleGetPlatformUserInfo(params: { platform_user_id: string }) {

--- a/crabot-channel-telegram/src/telegram-channel.ts
+++ b/crabot-channel-telegram/src/telegram-channel.ts
@@ -517,6 +517,7 @@ export class TelegramChannel extends ModuleBase {
     const firstId = String(sentIds[0])
     const sentAt = generateTimestamp()
 
+    await this.messageStore.migrateSessionId(params.session_id, session.id)
     await this.messageStore.appendOutbound({
       sessionId: session.id,
       platformMessageId: firstId,
@@ -746,6 +747,7 @@ export class TelegramChannel extends ModuleBase {
     const pageSize = params.limit ?? params.pagination?.page_size ?? 20
     const page = params.limit ? undefined : (params.pagination?.page ?? 1)
 
+    await this.messageStore.migrateSessionId(params.session_id, session.id)
     const { items, total } = await this.messageStore.query({
       sessionId: session.id,
       keyword: params.keyword,
@@ -769,6 +771,7 @@ export class TelegramChannel extends ModuleBase {
     const session = this.sessionManager.findById(params.session_id)
     if (!session) throw new Error('Session not found')
 
+    await this.messageStore.migrateSessionId(params.session_id, session.id)
     const msg = await this.messageStore.findByMessageId(session.id, params.platform_message_id)
     if (!msg) throw new Error('Message not found')
 

--- a/crabot-channel-telegram/src/telegram-channel.ts
+++ b/crabot-channel-telegram/src/telegram-channel.ts
@@ -153,6 +153,7 @@ export class TelegramChannel extends ModuleBase {
     await fs.mkdir(path.join(this.dataDir, 'media'), { recursive: true })
 
     await this.mediaHandleStore.init()
+    await this.migrateKnownLegacySessionHistories()
     this.messageStore.startCleanup()
     this.mediaCleaner.startCleanup()
 
@@ -785,6 +786,12 @@ export class TelegramChannel extends ModuleBase {
     ])
     for (const legacyId of legacyIds) {
       await this.messageStore.migrateSessionId(legacyId, canonicalSessionId)
+    }
+  }
+
+  private async migrateKnownLegacySessionHistories(): Promise<void> {
+    for (const { legacyId, stableId } of this.sessionManager.legacyAliasPairs()) {
+      await this.messageStore.migrateSessionId(legacyId, stableId)
     }
   }
 

--- a/crabot-channel-telegram/tests/session-manager.test.ts
+++ b/crabot-channel-telegram/tests/session-manager.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { SessionManager } from '../src/session-manager.js'
+
+let dataDir: string
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'telegram-session-'))
+})
+
+afterEach(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true })
+})
+
+describe('SessionManager', () => {
+  it('derives a stable session id from channel and platform session id', () => {
+    const m1 = new SessionManager('telegram-test', dataDir)
+    const first = m1.upsert({
+      platform_session_id: '7692507087',
+      type: 'private',
+      title: 'FuFu',
+      sender_user_id: '7692507087',
+      sender_name: 'FuFu',
+    })
+
+    fs.rmSync(path.join(dataDir, 'sessions.json'), { force: true })
+
+    const m2 = new SessionManager('telegram-test', dataDir)
+    const second = m2.upsert({
+      platform_session_id: '7692507087',
+      type: 'private',
+      title: 'FuFu',
+      sender_user_id: '7692507087',
+      sender_name: 'FuFu',
+    })
+
+    expect(second.session.id).toBe(first.session.id)
+    expect(second.session.id).toMatch(/^[0-9a-z]{8}$/)
+  })
+
+  it('keeps loaded session ids canonical and accepts new short stable ids as aliases', () => {
+    fs.writeFileSync(path.join(dataDir, 'sessions.json'), JSON.stringify([
+      {
+        id: 'legacy-telegram-session-id',
+        channel_id: 'telegram-test',
+        type: 'private',
+        platform_session_id: '7692507087',
+        title: 'FuFu',
+        participants: [{ platform_user_id: '7692507087', role: 'member' }],
+        permissions: { desktop: false, network: { mode: 'allow_all', rules: [] }, storage: [] },
+        memory_scopes: ['7692507087'],
+        workspace_path: '',
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-01T00:00:00.000Z',
+      },
+      {
+        id: '21c6ef56-a63b-e1dd-d3f6-a337320ac3aa',
+        channel_id: 'telegram-test',
+        type: 'private',
+        platform_session_id: '123456789',
+        title: 'Other',
+        participants: [{ platform_user_id: '123456789', role: 'member' }],
+        permissions: { desktop: false, network: { mode: 'allow_all', rules: [] }, storage: [] },
+        memory_scopes: ['123456789'],
+        workspace_path: '',
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-01T00:00:00.000Z',
+      },
+    ]), 'utf-8')
+
+    const manager = new SessionManager('telegram-test', dataDir)
+    const session = manager.findByPlatformId('7692507087')
+    const uuidSession = manager.findByPlatformId('123456789')
+    const probe = new SessionManager('telegram-test', path.join(dataDir, 'short-id-probe'))
+    const shortId = probe.upsert({
+      platform_session_id: '7692507087',
+      type: 'private',
+      title: 'FuFu',
+      sender_user_id: '7692507087',
+      sender_name: 'FuFu',
+    }).session
+    const uuidShortId = probe.upsert({
+      platform_session_id: '123456789',
+      type: 'private',
+      title: 'Other',
+      sender_user_id: '123456789',
+      sender_name: 'Other',
+    }).session
+
+    expect(session?.id).toBe('legacy-telegram-session-id')
+    expect(uuidSession?.id).toBe('21c6ef56-a63b-e1dd-d3f6-a337320ac3aa')
+    expect(shortId.id).toMatch(/^[0-9a-z]{8}$/)
+    expect(uuidShortId.id).toMatch(/^[0-9a-z]{8}$/)
+    expect(manager.findById(shortId.id)?.id).toBe('legacy-telegram-session-id')
+    expect(manager.findById(uuidShortId.id)?.id).toBe('21c6ef56-a63b-e1dd-d3f6-a337320ac3aa')
+  })
+})

--- a/crabot-channel-telegram/tests/session-manager.test.ts
+++ b/crabot-channel-telegram/tests/session-manager.test.ts
@@ -40,7 +40,7 @@ describe('SessionManager', () => {
     expect(second.session.id).toMatch(/^[0-9a-z]{8}$/)
   })
 
-  it('keeps loaded session ids canonical and accepts new short stable ids as aliases', () => {
+  it('canonicalizes loaded legacy session ids to stable ids and keeps legacy lookup aliases', () => {
     fs.writeFileSync(path.join(dataDir, 'sessions.json'), JSON.stringify([
       {
         id: 'legacy-telegram-session-id',
@@ -55,45 +55,24 @@ describe('SessionManager', () => {
         created_at: '2026-01-01T00:00:00.000Z',
         updated_at: '2026-01-01T00:00:00.000Z',
       },
-      {
-        id: '21c6ef56-a63b-e1dd-d3f6-a337320ac3aa',
-        channel_id: 'telegram-test',
-        type: 'private',
-        platform_session_id: '123456789',
-        title: 'Other',
-        participants: [{ platform_user_id: '123456789', role: 'member' }],
-        permissions: { desktop: false, network: { mode: 'allow_all', rules: [] }, storage: [] },
-        memory_scopes: ['123456789'],
-        workspace_path: '',
-        created_at: '2026-01-01T00:00:00.000Z',
-        updated_at: '2026-01-01T00:00:00.000Z',
-      },
     ]), 'utf-8')
 
-    const manager = new SessionManager('telegram-test', dataDir)
-    const session = manager.findByPlatformId('7692507087')
-    const uuidSession = manager.findByPlatformId('123456789')
-    const probe = new SessionManager('telegram-test', path.join(dataDir, 'short-id-probe'))
-    const shortId = probe.upsert({
+    const probe = new SessionManager('telegram-test', path.join(dataDir, 'stable-id-probe'))
+    const stableId = probe.upsert({
       platform_session_id: '7692507087',
       type: 'private',
       title: 'FuFu',
       sender_user_id: '7692507087',
       sender_name: 'FuFu',
-    }).session
-    const uuidShortId = probe.upsert({
-      platform_session_id: '123456789',
-      type: 'private',
-      title: 'Other',
-      sender_user_id: '123456789',
-      sender_name: 'Other',
-    }).session
+    }).session.id
 
-    expect(session?.id).toBe('legacy-telegram-session-id')
-    expect(uuidSession?.id).toBe('21c6ef56-a63b-e1dd-d3f6-a337320ac3aa')
-    expect(shortId.id).toMatch(/^[0-9a-z]{8}$/)
-    expect(uuidShortId.id).toMatch(/^[0-9a-z]{8}$/)
-    expect(manager.findById(shortId.id)?.id).toBe('legacy-telegram-session-id')
-    expect(manager.findById(uuidShortId.id)?.id).toBe('21c6ef56-a63b-e1dd-d3f6-a337320ac3aa')
+    const manager = new SessionManager('telegram-test', dataDir)
+    const session = manager.findByPlatformId('7692507087')
+
+    expect(stableId).toMatch(/^[0-9a-z]{8}$/)
+    expect(session?.id).toBe(stableId)
+    expect(manager.findById(stableId)?.id).toBe(stableId)
+    expect(manager.findById('legacy-telegram-session-id')?.id).toBe(stableId)
+    expect(manager.listSessions('private').map((s) => s.id)).toEqual([stableId])
   })
 })

--- a/crabot-channel-telegram/tests/telegram-channel-session-alias.test.ts
+++ b/crabot-channel-telegram/tests/telegram-channel-session-alias.test.ts
@@ -231,4 +231,88 @@ describe('MessageStore session history migration', () => {
     expect(items.map((m) => m.platform_message_id)).toEqual(['stable-message-1', 'legacy-message-1'])
     expect(fs.existsSync(path.join(messagesDir, `${legacyId}.jsonl`))).toBe(false)
   })
+
+  it('serializes concurrent migrations from different legacy files into one stable file', async () => {
+    const store = new MessageStore(tmpDir)
+    const stableId = 'stable-session-id'
+    const legacyA = 'legacy-session-a'
+    const legacyB = 'legacy-session-b'
+    const messagesDir = path.join(tmpDir, 'messages')
+    fs.mkdirSync(messagesDir, { recursive: true })
+
+    const writeRecord = (sessionId: string, platformMessageId: string, text: string) => {
+      fs.writeFileSync(
+        path.join(messagesDir, `${sessionId}.jsonl`),
+        JSON.stringify({
+          platform_message_id: platformMessageId,
+          direction: 'inbound',
+          sender_platform_user_id: '7692507087',
+          sender_name: 'FuFu',
+          content_type: 'text',
+          text,
+          timestamp: '2026-01-01T00:00:00.000Z',
+        }) + '\n',
+        'utf-8',
+      )
+    }
+
+    writeRecord(stableId, 'stable-message-1', 'stable history')
+    writeRecord(legacyA, 'legacy-message-a', 'legacy history a')
+    writeRecord(legacyB, 'legacy-message-b', 'legacy history b')
+
+    await expect(Promise.all([
+      store.migrateSessionId(legacyA, stableId),
+      store.migrateSessionId(legacyB, stableId),
+    ])).resolves.toEqual([undefined, undefined])
+
+    const { items } = await store.query({ sessionId: stableId })
+    expect(items.map((m) => m.platform_message_id).sort()).toEqual([
+      'legacy-message-a',
+      'legacy-message-b',
+      'stable-message-1',
+    ])
+    expect(fs.existsSync(path.join(messagesDir, `${legacyA}.jsonl`))).toBe(false)
+    expect(fs.existsSync(path.join(messagesDir, `${legacyB}.jsonl`))).toBe(false)
+  })
+
+  it('preserves both legacy files when concurrent target migration creates the stable file', async () => {
+    const store = new MessageStore(tmpDir)
+    const stableId = 'stable-session-id'
+    const legacyA = 'legacy-session-a'
+    const legacyB = 'legacy-session-b'
+    const messagesDir = path.join(tmpDir, 'messages')
+    fs.mkdirSync(messagesDir, { recursive: true })
+
+    for (const [sessionId, platformMessageId] of [
+      [legacyA, 'legacy-message-a'],
+      [legacyB, 'legacy-message-b'],
+    ]) {
+      fs.writeFileSync(
+        path.join(messagesDir, `${sessionId}.jsonl`),
+        JSON.stringify({
+          platform_message_id: platformMessageId,
+          direction: 'inbound',
+          sender_platform_user_id: '7692507087',
+          sender_name: 'FuFu',
+          content_type: 'text',
+          text: platformMessageId,
+          timestamp: '2026-01-01T00:00:00.000Z',
+        }) + '\n',
+        'utf-8',
+      )
+    }
+
+    await expect(Promise.all([
+      store.migrateSessionId(legacyA, stableId),
+      store.migrateSessionId(legacyB, stableId),
+    ])).resolves.toEqual([undefined, undefined])
+
+    const { items } = await store.query({ sessionId: stableId })
+    expect(items.map((m) => m.platform_message_id).sort()).toEqual([
+      'legacy-message-a',
+      'legacy-message-b',
+    ])
+    expect(fs.existsSync(path.join(messagesDir, `${legacyA}.jsonl`))).toBe(false)
+    expect(fs.existsSync(path.join(messagesDir, `${legacyB}.jsonl`))).toBe(false)
+  })
 })

--- a/crabot-channel-telegram/tests/telegram-channel-session-alias.test.ts
+++ b/crabot-channel-telegram/tests/telegram-channel-session-alias.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path'
 import os from 'node:os'
 
 import { TelegramChannel } from '../src/telegram-channel'
+import { MessageStore } from '../src/message-store'
 
 let tmpDir: string
 let channel: TelegramChannel
@@ -183,6 +184,51 @@ describe('TelegramChannel session aliases', () => {
       'stable-message-1',
       'legacy-message-1',
     ])
+    expect(fs.existsSync(path.join(messagesDir, `${legacyId}.jsonl`))).toBe(false)
+  })
+})
+
+describe('MessageStore session history migration', () => {
+  it('serializes concurrent migrations for the same legacy file without duplicates', async () => {
+    const store = new MessageStore(tmpDir)
+    const legacyId = 'legacy-session-id'
+    const stableId = 'stable-session-id'
+    const messagesDir = path.join(tmpDir, 'messages')
+    fs.mkdirSync(messagesDir, { recursive: true })
+    fs.writeFileSync(
+      path.join(messagesDir, `${stableId}.jsonl`),
+      JSON.stringify({
+        platform_message_id: 'stable-message-1',
+        direction: 'outbound',
+        sender_platform_user_id: 'self',
+        sender_name: 'Crabot',
+        content_type: 'text',
+        text: 'stable history',
+        timestamp: '2026-01-01T00:01:00.000Z',
+      }) + '\n',
+      'utf-8',
+    )
+    fs.writeFileSync(
+      path.join(messagesDir, `${legacyId}.jsonl`),
+      JSON.stringify({
+        platform_message_id: 'legacy-message-1',
+        direction: 'inbound',
+        sender_platform_user_id: '7692507087',
+        sender_name: 'FuFu',
+        content_type: 'text',
+        text: 'legacy history',
+        timestamp: '2026-01-01T00:00:00.000Z',
+      }) + '\n',
+      'utf-8',
+    )
+
+    await expect(Promise.all([
+      store.migrateSessionId(legacyId, stableId),
+      store.migrateSessionId(legacyId, stableId),
+    ])).resolves.toEqual([undefined, undefined])
+
+    const { items } = await store.query({ sessionId: stableId })
+    expect(items.map((m) => m.platform_message_id)).toEqual(['stable-message-1', 'legacy-message-1'])
     expect(fs.existsSync(path.join(messagesDir, `${legacyId}.jsonl`))).toBe(false)
   })
 })

--- a/crabot-channel-telegram/tests/telegram-channel-session-alias.test.ts
+++ b/crabot-channel-telegram/tests/telegram-channel-session-alias.test.ts
@@ -186,6 +186,68 @@ describe('TelegramChannel session aliases', () => {
     ])
     expect(fs.existsSync(path.join(messagesDir, `${legacyId}.jsonl`))).toBe(false)
   })
+
+  it('migrates known legacy history files during startup before handling stable-id requests', async () => {
+    const legacyId = 'legacy-telegram-session-id'
+    fs.writeFileSync(path.join(tmpDir, 'sessions.json'), JSON.stringify([
+      {
+        id: legacyId,
+        channel_id: 'telegram-test',
+        type: 'private',
+        platform_session_id: '7692507087',
+        title: 'FuFu',
+        participants: [{ platform_user_id: '7692507087', role: 'member' }],
+        permissions: { desktop: false, network: { mode: 'allow_all', rules: [] }, storage: [] },
+        memory_scopes: ['7692507087'],
+        workspace_path: '',
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-01T00:00:00.000Z',
+      },
+    ]), 'utf-8')
+
+    channel = new TelegramChannel({
+      module_id: 'telegram-test',
+      module_type: 'channel',
+      version: '0.1.0',
+      protocol_version: '0.1.0',
+      port: 0,
+      data_dir: tmpDir,
+      telegram: {
+        bot_token: 'token-secret',
+        mode: 'polling',
+        webhook_url: undefined,
+        webhook_secret: undefined,
+        markdown_format: 'off',
+      },
+    })
+
+    const session = (channel as any).sessionManager.findById(legacyId)
+    const stableId = session.id
+    const messagesDir = path.join(tmpDir, 'messages')
+    fs.mkdirSync(messagesDir, { recursive: true })
+    fs.writeFileSync(
+      path.join(messagesDir, `${legacyId}.jsonl`),
+      JSON.stringify({
+        platform_message_id: 'startup-legacy-message',
+        direction: 'inbound',
+        sender_platform_user_id: '7692507087',
+        sender_name: 'FuFu',
+        content_type: 'text',
+        text: 'startup legacy history',
+        timestamp: '2026-01-01T00:00:00.000Z',
+      }) + '\n',
+      'utf-8',
+    )
+
+    await (channel as any).migrateKnownLegacySessionHistories()
+
+    const canonicalHistory = await (channel as any).handleGetHistory({
+      session_id: stableId,
+      pagination: { page: 1, page_size: 20 },
+    })
+    expect(canonicalHistory.items.map((m: any) => m.platform_message_id)).toEqual(['startup-legacy-message'])
+    expect(fs.existsSync(path.join(messagesDir, `${legacyId}.jsonl`))).toBe(false)
+  })
 })
 
 describe('MessageStore session history migration', () => {
@@ -229,6 +291,40 @@ describe('MessageStore session history migration', () => {
 
     const { items } = await store.query({ sessionId: stableId })
     expect(items.map((m) => m.platform_message_id)).toEqual(['stable-message-1', 'legacy-message-1'])
+    expect(fs.existsSync(path.join(messagesDir, `${legacyId}.jsonl`))).toBe(false)
+  })
+
+  it('does not duplicate records already merged into stable history when retried', async () => {
+    const store = new MessageStore(tmpDir)
+    const legacyId = 'legacy-session-id'
+    const stableId = 'stable-session-id'
+    const messagesDir = path.join(tmpDir, 'messages')
+    fs.mkdirSync(messagesDir, { recursive: true })
+    const mergedRecord = {
+      platform_message_id: 'legacy-message-1',
+      direction: 'inbound',
+      sender_platform_user_id: '7692507087',
+      sender_name: 'FuFu',
+      content_type: 'text',
+      text: 'legacy history',
+      timestamp: '2026-01-01T00:00:00.000Z',
+    }
+    fs.writeFileSync(
+      path.join(messagesDir, `${stableId}.jsonl`),
+      JSON.stringify({ ...mergedRecord, text: 'already merged' }) + '\n',
+      'utf-8',
+    )
+    fs.writeFileSync(
+      path.join(messagesDir, `${legacyId}.jsonl`),
+      JSON.stringify(mergedRecord) + '\n',
+      'utf-8',
+    )
+
+    await store.migrateSessionId(legacyId, stableId)
+
+    const { items } = await store.query({ sessionId: stableId })
+    expect(items.map((m) => m.platform_message_id)).toEqual(['legacy-message-1'])
+    expect(items[0].text).toBe('already merged')
     expect(fs.existsSync(path.join(messagesDir, `${legacyId}.jsonl`))).toBe(false)
   })
 

--- a/crabot-channel-telegram/tests/telegram-channel-session-alias.test.ts
+++ b/crabot-channel-telegram/tests/telegram-channel-session-alias.test.ts
@@ -165,12 +165,8 @@ describe('TelegramChannel session aliases', () => {
       session_id: stableId,
       pagination: { page: 1, page_size: 20 },
     })
-    const legacyHistory = await (channel as any).handleGetHistory({
-      session_id: legacyId,
-      pagination: { page: 1, page_size: 20 },
-    })
-    const legacyMessage = await (channel as any).handleGetMessage({
-      session_id: legacyId,
+    const canonicalMessage = await (channel as any).handleGetMessage({
+      session_id: stableId,
       platform_message_id: 'legacy-message-1',
     })
     const migratedCanonicalHistory = await (channel as any).handleGetHistory({
@@ -178,9 +174,11 @@ describe('TelegramChannel session aliases', () => {
       pagination: { page: 1, page_size: 20 },
     })
 
-    expect(canonicalHistory.items.map((m: any) => m.platform_message_id)).toEqual(['stable-message-1'])
-    expect(legacyHistory.items.map((m: any) => m.platform_message_id)).toEqual(['stable-message-1', 'legacy-message-1'])
-    expect(legacyMessage.content.text).toBe('legacy history')
+    expect(canonicalHistory.items.map((m: any) => m.platform_message_id)).toEqual([
+      'stable-message-1',
+      'legacy-message-1',
+    ])
+    expect(canonicalMessage.content.text).toBe('legacy history')
     expect(migratedCanonicalHistory.items.map((m: any) => m.platform_message_id)).toEqual([
       'stable-message-1',
       'legacy-message-1',

--- a/crabot-channel-telegram/tests/telegram-channel-session-alias.test.ts
+++ b/crabot-channel-telegram/tests/telegram-channel-session-alias.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+
+import { TelegramChannel } from '../src/telegram-channel'
+
+let tmpDir: string
+let channel: TelegramChannel
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tg-session-alias-'))
+  channel = new TelegramChannel({
+    module_id: 'telegram-test',
+    module_type: 'channel',
+    version: '0.1.0',
+    protocol_version: '0.1.0',
+    port: 0,
+    data_dir: tmpDir,
+    telegram: {
+      bot_token: 'token-secret',
+      mode: 'polling',
+      webhook_url: undefined,
+      webhook_secret: undefined,
+      markdown_format: 'off',
+    },
+  })
+})
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+})
+
+describe('TelegramChannel session aliases', () => {
+  it('uses canonical session id for message store access after resolving a legacy alias', async () => {
+    const legacyId = 'legacy-telegram-session-id'
+    fs.writeFileSync(path.join(tmpDir, 'sessions.json'), JSON.stringify([
+      {
+        id: legacyId,
+        channel_id: 'telegram-test',
+        type: 'private',
+        platform_session_id: '7692507087',
+        title: 'FuFu',
+        participants: [{ platform_user_id: '7692507087', role: 'member' }],
+        permissions: { desktop: false, network: { mode: 'allow_all', rules: [] }, storage: [] },
+        memory_scopes: ['7692507087'],
+        workspace_path: '',
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-01T00:00:00.000Z',
+      },
+    ]), 'utf-8')
+
+    channel = new TelegramChannel({
+      module_id: 'telegram-test',
+      module_type: 'channel',
+      version: '0.1.0',
+      protocol_version: '0.1.0',
+      port: 0,
+      data_dir: tmpDir,
+      telegram: {
+        bot_token: 'token-secret',
+        mode: 'polling',
+        webhook_url: undefined,
+        webhook_secret: undefined,
+        markdown_format: 'off',
+      },
+    })
+
+    const session = (channel as any).sessionManager.findById(legacyId)
+    const stableId = session.id
+    ;(channel as any).client.sendMessage = vi.fn(async () => ({ message_id: 101 }))
+
+    await (channel as any).handleSendMessage({
+      session_id: legacyId,
+      content: { type: 'text', text: 'hello through alias' },
+    })
+
+    const canonicalHistory = await (channel as any).handleGetHistory({
+      session_id: stableId,
+      pagination: { page: 1, page_size: 20 },
+    })
+    const legacyHistory = await (channel as any).handleGetHistory({
+      session_id: legacyId,
+      pagination: { page: 1, page_size: 20 },
+    })
+    const legacyMessage = await (channel as any).handleGetMessage({
+      session_id: legacyId,
+      platform_message_id: '101',
+    })
+
+    expect(stableId).toMatch(/^[0-9a-z]{8}$/)
+    expect(canonicalHistory.items).toHaveLength(1)
+    expect(legacyHistory.items).toHaveLength(1)
+    expect(legacyMessage.platform_message_id).toBe('101')
+    expect(fs.existsSync(path.join(tmpDir, 'messages', `${stableId}.jsonl`))).toBe(true)
+    expect(fs.existsSync(path.join(tmpDir, 'messages', `${legacyId}.jsonl`))).toBe(false)
+  })
+})

--- a/crabot-channel-telegram/tests/telegram-channel-session-alias.test.ts
+++ b/crabot-channel-telegram/tests/telegram-channel-session-alias.test.ts
@@ -95,4 +95,96 @@ describe('TelegramChannel session aliases', () => {
     expect(fs.existsSync(path.join(tmpDir, 'messages', `${stableId}.jsonl`))).toBe(true)
     expect(fs.existsSync(path.join(tmpDir, 'messages', `${legacyId}.jsonl`))).toBe(false)
   })
+
+  it('migrates existing legacy message history files when resolving a legacy alias', async () => {
+    const legacyId = 'legacy-telegram-session-id'
+    fs.writeFileSync(path.join(tmpDir, 'sessions.json'), JSON.stringify([
+      {
+        id: legacyId,
+        channel_id: 'telegram-test',
+        type: 'private',
+        platform_session_id: '7692507087',
+        title: 'FuFu',
+        participants: [{ platform_user_id: '7692507087', role: 'member' }],
+        permissions: { desktop: false, network: { mode: 'allow_all', rules: [] }, storage: [] },
+        memory_scopes: ['7692507087'],
+        workspace_path: '',
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-01T00:00:00.000Z',
+      },
+    ]), 'utf-8')
+
+    channel = new TelegramChannel({
+      module_id: 'telegram-test',
+      module_type: 'channel',
+      version: '0.1.0',
+      protocol_version: '0.1.0',
+      port: 0,
+      data_dir: tmpDir,
+      telegram: {
+        bot_token: 'token-secret',
+        mode: 'polling',
+        webhook_url: undefined,
+        webhook_secret: undefined,
+        markdown_format: 'off',
+      },
+    })
+
+    const session = (channel as any).sessionManager.findById(legacyId)
+    const stableId = session.id
+    const messagesDir = path.join(tmpDir, 'messages')
+    fs.mkdirSync(messagesDir, { recursive: true })
+    fs.writeFileSync(
+      path.join(messagesDir, `${legacyId}.jsonl`),
+      JSON.stringify({
+        platform_message_id: 'legacy-message-1',
+        direction: 'inbound',
+        sender_platform_user_id: '7692507087',
+        sender_name: 'FuFu',
+        content_type: 'text',
+        text: 'legacy history',
+        timestamp: '2026-01-01T00:00:00.000Z',
+      }) + '\n',
+      'utf-8',
+    )
+    fs.writeFileSync(
+      path.join(messagesDir, `${stableId}.jsonl`),
+      JSON.stringify({
+        platform_message_id: 'stable-message-1',
+        direction: 'outbound',
+        sender_platform_user_id: 'self',
+        sender_name: 'Crabot',
+        content_type: 'text',
+        text: 'stable history',
+        timestamp: '2026-01-01T00:01:00.000Z',
+      }) + '\n',
+      'utf-8',
+    )
+
+    const canonicalHistory = await (channel as any).handleGetHistory({
+      session_id: stableId,
+      pagination: { page: 1, page_size: 20 },
+    })
+    const legacyHistory = await (channel as any).handleGetHistory({
+      session_id: legacyId,
+      pagination: { page: 1, page_size: 20 },
+    })
+    const legacyMessage = await (channel as any).handleGetMessage({
+      session_id: legacyId,
+      platform_message_id: 'legacy-message-1',
+    })
+    const migratedCanonicalHistory = await (channel as any).handleGetHistory({
+      session_id: stableId,
+      pagination: { page: 1, page_size: 20 },
+    })
+
+    expect(canonicalHistory.items.map((m: any) => m.platform_message_id)).toEqual(['stable-message-1'])
+    expect(legacyHistory.items.map((m: any) => m.platform_message_id)).toEqual(['stable-message-1', 'legacy-message-1'])
+    expect(legacyMessage.content.text).toBe('legacy history')
+    expect(migratedCanonicalHistory.items.map((m: any) => m.platform_message_id)).toEqual([
+      'stable-message-1',
+      'legacy-message-1',
+    ])
+    expect(fs.existsSync(path.join(messagesDir, `${legacyId}.jsonl`))).toBe(false)
+  })
 })

--- a/crabot-channel-wechat/src/session-manager.ts
+++ b/crabot-channel-wechat/src/session-manager.ts
@@ -7,7 +7,8 @@
 
 import fs from 'node:fs'
 import path from 'node:path'
-import { generateId, generateTimestamp } from 'crabot-shared'
+import crypto from 'node:crypto'
+import { generateTimestamp } from 'crabot-shared'
 import type { ModuleId, Session, SessionType, SessionParticipant, SessionPermissions } from './types.js'
 
 const DEFAULT_PERMISSIONS: SessionPermissions = {
@@ -26,6 +27,7 @@ function isBetterTitle(incoming: string, current: string, platformSessionId: str
 export class SessionManager {
   private sessions: Map<string, Session> = new Map()
   private platformToId: Map<string, string> = new Map()
+  private aliases: Map<string, string> = new Map()
   private readonly filePath: string
   private readonly channelId: ModuleId
 
@@ -110,7 +112,7 @@ export class SessionManager {
   }): Session {
     const now = generateTimestamp()
     const session: Session = {
-      id: generateId(),
+      id: this.stableSessionId(params.platform_session_id),
       channel_id: this.channelId,
       type: params.type,
       platform_session_id: params.platform_session_id,
@@ -129,7 +131,8 @@ export class SessionManager {
   }
 
   findById(sessionId: string): Session | undefined {
-    return this.sessions.get(sessionId)
+    const canonicalId = this.aliases.get(sessionId) ?? sessionId
+    return this.sessions.get(canonicalId)
   }
 
   findByPlatformId(platformSessionId: string): Session | undefined {
@@ -167,12 +170,24 @@ export class SessionManager {
           ? Object.values(raw.sessions)
           : []
       for (const session of sessions) {
+        const stableId = this.stableSessionId(session.platform_session_id)
         this.sessions.set(session.id, session)
         this.platformToId.set(session.platform_session_id, session.id)
+        if (stableId !== session.id) {
+          this.aliases.set(stableId, session.id)
+        }
       }
     } catch (error) {
       console.warn('[SessionManager] Failed to load sessions:', error)
     }
+  }
+
+  private stableSessionId(platformSessionId: string): string {
+    const digest = crypto
+      .createHash('sha256')
+      .update(`${this.channelId}\0${platformSessionId}`)
+      .digest()
+    return digest.readUIntBE(0, 6).toString(36).padStart(8, '0').slice(0, 8)
   }
 
   private save(): void {

--- a/crabot-channel-wechat/src/session-manager.ts
+++ b/crabot-channel-wechat/src/session-manager.ts
@@ -170,11 +170,18 @@ export class SessionManager {
           ? Object.values(raw.sessions)
           : []
       for (const session of sessions) {
+        if (!session.platform_session_id) continue
+        const legacyId = session.id
         const stableId = this.stableSessionId(session.platform_session_id)
-        this.sessions.set(session.id, session)
-        this.platformToId.set(session.platform_session_id, session.id)
-        if (stableId !== session.id) {
-          this.aliases.set(stableId, session.id)
+        const canonical: Session = {
+          ...session,
+          id: stableId,
+          channel_id: this.channelId,
+        }
+        this.sessions.set(stableId, canonical)
+        this.platformToId.set(canonical.platform_session_id, stableId)
+        if (legacyId && legacyId !== stableId) {
+          this.aliases.set(legacyId, stableId)
         }
       }
     } catch (error) {

--- a/crabot-channel-wechat/tests/session-manager.test.ts
+++ b/crabot-channel-wechat/tests/session-manager.test.ts
@@ -37,7 +37,7 @@ describe('SessionManager.upsertGroupSessionFromSnapshot', () => {
     expect(second.session.id).toMatch(/^[0-9a-z]{8}$/)
   })
 
-  it('keeps loaded session ids canonical and accepts new short stable ids as aliases', () => {
+  it('canonicalizes loaded legacy session ids to stable ids and keeps legacy lookup aliases', () => {
     fs.writeFileSync(path.join(dataDir, 'sessions.json'), JSON.stringify([
       {
         id: 'legacy-session-id',
@@ -52,15 +52,36 @@ describe('SessionManager.upsertGroupSessionFromSnapshot', () => {
         created_at: '2026-01-01T00:00:00.000Z',
         updated_at: '2026-01-01T00:00:00.000Z',
       },
+    ]), 'utf-8')
+
+    const probe = new SessionManager('vongcloud-wechat', path.join(dataDir, 'stable-id-probe'))
+    const stableId = probe.upsertGroupSessionFromSnapshot({
+      platform_session_id: '12345@chatroom',
+      title: '工作群',
+      participants: [{ platform_user_id: 'wxid_a', role: 'member' }],
+    }).session.id
+
+    const manager = new SessionManager('vongcloud-wechat', dataDir)
+    const session = manager.findByPlatformId('12345@chatroom')
+
+    expect(stableId).toMatch(/^[0-9a-z]{8}$/)
+    expect(session?.id).toBe(stableId)
+    expect(manager.findById(stableId)?.id).toBe(stableId)
+    expect(manager.findById('legacy-session-id')?.id).toBe(stableId)
+    expect(manager.listSessions('group').map((s) => s.id)).toEqual([stableId])
+  })
+
+  it('persists canonical stable ids after updating a loaded legacy session', () => {
+    fs.writeFileSync(path.join(dataDir, 'sessions.json'), JSON.stringify([
       {
-        id: '5d03c46a-2401-67e1-7693-2caa111b4963',
+        id: 'legacy-session-id',
         channel_id: 'vongcloud-wechat',
         type: 'group',
-        platform_session_id: '67890@chatroom',
-        title: '旧稳定ID群',
-        participants: [{ platform_user_id: 'wxid_b', role: 'member' }],
+        platform_session_id: '12345@chatroom',
+        title: '12345@chatroom',
+        participants: [{ platform_user_id: 'wxid_a', role: 'member' }],
         permissions: { desktop: false, network: { mode: 'allow_all', rules: [] }, storage: [] },
-        memory_scopes: ['67890@chatroom'],
+        memory_scopes: ['12345@chatroom'],
         workspace_path: '',
         created_at: '2026-01-01T00:00:00.000Z',
         updated_at: '2026-01-01T00:00:00.000Z',
@@ -68,26 +89,19 @@ describe('SessionManager.upsertGroupSessionFromSnapshot', () => {
     ]), 'utf-8')
 
     const manager = new SessionManager('vongcloud-wechat', dataDir)
-    const session = manager.findByPlatformId('12345@chatroom')
-    const uuidSession = manager.findByPlatformId('67890@chatroom')
-    const probe = new SessionManager('vongcloud-wechat', path.join(dataDir, 'short-id-probe'))
-    const shortId = probe.upsertGroupSessionFromSnapshot({
+    const stableId = manager.findById('legacy-session-id')!.id
+    manager.upsert({
       platform_session_id: '12345@chatroom',
+      type: 'group',
       title: '工作群',
-      participants: [{ platform_user_id: 'wxid_a', role: 'member' }],
-    }).session
-    const uuidShortId = probe.upsertGroupSessionFromSnapshot({
-      platform_session_id: '67890@chatroom',
-      title: '旧稳定ID群',
-      participants: [{ platform_user_id: 'wxid_b', role: 'member' }],
-    }).session
+      sender_wxid: 'wxid_b',
+      sender_name: 'Bob',
+    })
 
-    expect(session?.id).toBe('legacy-session-id')
-    expect(uuidSession?.id).toBe('5d03c46a-2401-67e1-7693-2caa111b4963')
-    expect(shortId.id).toMatch(/^[0-9a-z]{8}$/)
-    expect(uuidShortId.id).toMatch(/^[0-9a-z]{8}$/)
-    expect(manager.findById(shortId.id)?.id).toBe('legacy-session-id')
-    expect(manager.findById(uuidShortId.id)?.id).toBe('5d03c46a-2401-67e1-7693-2caa111b4963')
+    const saved = JSON.parse(fs.readFileSync(path.join(dataDir, 'sessions.json'), 'utf-8')) as Array<{ id: string }>
+    expect(saved).toHaveLength(1)
+    expect(saved[0].id).toBe(stableId)
+    expect(saved[0].id).not.toBe('legacy-session-id')
   })
 
   it('creates a new group session with full participant snapshot', () => {

--- a/crabot-channel-wechat/tests/session-manager.test.ts
+++ b/crabot-channel-wechat/tests/session-manager.test.ts
@@ -16,6 +16,80 @@ afterEach(() => {
 })
 
 describe('SessionManager.upsertGroupSessionFromSnapshot', () => {
+  it('derives a stable session id from channel and platform session id', () => {
+    const m1 = new SessionManager('vongcloud-wechat', dataDir)
+    const first = m1.upsertGroupSessionFromSnapshot({
+      platform_session_id: '12345@chatroom',
+      title: '工作群',
+      participants: [{ platform_user_id: 'wxid_a', role: 'member' }],
+    })
+
+    fs.rmSync(path.join(dataDir, 'sessions.json'), { force: true })
+
+    const m2 = new SessionManager('vongcloud-wechat', dataDir)
+    const second = m2.upsertGroupSessionFromSnapshot({
+      platform_session_id: '12345@chatroom',
+      title: '工作群',
+      participants: [{ platform_user_id: 'wxid_a', role: 'member' }],
+    })
+
+    expect(second.session.id).toBe(first.session.id)
+    expect(second.session.id).toMatch(/^[0-9a-z]{8}$/)
+  })
+
+  it('keeps loaded session ids canonical and accepts new short stable ids as aliases', () => {
+    fs.writeFileSync(path.join(dataDir, 'sessions.json'), JSON.stringify([
+      {
+        id: 'legacy-session-id',
+        channel_id: 'vongcloud-wechat',
+        type: 'group',
+        platform_session_id: '12345@chatroom',
+        title: '工作群',
+        participants: [{ platform_user_id: 'wxid_a', role: 'member' }],
+        permissions: { desktop: false, network: { mode: 'allow_all', rules: [] }, storage: [] },
+        memory_scopes: ['12345@chatroom'],
+        workspace_path: '',
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-01T00:00:00.000Z',
+      },
+      {
+        id: '5d03c46a-2401-67e1-7693-2caa111b4963',
+        channel_id: 'vongcloud-wechat',
+        type: 'group',
+        platform_session_id: '67890@chatroom',
+        title: '旧稳定ID群',
+        participants: [{ platform_user_id: 'wxid_b', role: 'member' }],
+        permissions: { desktop: false, network: { mode: 'allow_all', rules: [] }, storage: [] },
+        memory_scopes: ['67890@chatroom'],
+        workspace_path: '',
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-01T00:00:00.000Z',
+      },
+    ]), 'utf-8')
+
+    const manager = new SessionManager('vongcloud-wechat', dataDir)
+    const session = manager.findByPlatformId('12345@chatroom')
+    const uuidSession = manager.findByPlatformId('67890@chatroom')
+    const probe = new SessionManager('vongcloud-wechat', path.join(dataDir, 'short-id-probe'))
+    const shortId = probe.upsertGroupSessionFromSnapshot({
+      platform_session_id: '12345@chatroom',
+      title: '工作群',
+      participants: [{ platform_user_id: 'wxid_a', role: 'member' }],
+    }).session
+    const uuidShortId = probe.upsertGroupSessionFromSnapshot({
+      platform_session_id: '67890@chatroom',
+      title: '旧稳定ID群',
+      participants: [{ platform_user_id: 'wxid_b', role: 'member' }],
+    }).session
+
+    expect(session?.id).toBe('legacy-session-id')
+    expect(uuidSession?.id).toBe('5d03c46a-2401-67e1-7693-2caa111b4963')
+    expect(shortId.id).toMatch(/^[0-9a-z]{8}$/)
+    expect(uuidShortId.id).toMatch(/^[0-9a-z]{8}$/)
+    expect(manager.findById(shortId.id)?.id).toBe('legacy-session-id')
+    expect(manager.findById(uuidShortId.id)?.id).toBe('5d03c46a-2401-67e1-7693-2caa111b4963')
+  })
+
   it('creates a new group session with full participant snapshot', () => {
     const manager = new SessionManager('vongcloud-wechat', dataDir)
 


### PR DESCRIPTION
## Summary

- canonicalize WeChat, Feishu, and Telegram `Session.id` values to short stable IDs derived from `channel_id + platform_session_id`
- keep legacy random IDs as lookup aliases only; public `get_sessions`, `get_session`, and message/event surfaces return canonical stable IDs
- preserve `Schedule.target_session.platform_session_id` and repair stale schedule targets deterministically via `channel_id + type + platform_session_id`
- prefer the stored `platform_session_id` repair anchor over a mismatched but resolvable `session_id`, so stale targets cannot silently drift to another platform conversation
- leave legacy-only stale targets without `platform_session_id` invalid instead of guessing by master private session, group title, nickname, schedule name, description, or template text
- keep backup/import correctness independent of channel-local `sessions.json`; future stable schedule/config references are exported from Admin-owned data
- update protocol/design docs to define the stable session ID contract and legacy-only session-config migration limit

## Root Cause

Upstream IM conversation identifiers are stable enough for this purpose, but channel modules previously wrapped them in random internal `Session.id` values. Schedules and session-scoped Admin data persisted those random IDs, so rebuilding, importing, or migrating channel-local `sessions.json` could leave references pointing at stale IDs.

## Stable session migration update

- Channel sessions now canonicalize legacy random IDs to stable IDs derived from `channel_id + platform_session_id`.
- Legacy IDs remain lookup aliases only; public `get_sessions` and events return stable IDs.
- Schedule repair is deterministic and type-checked via `channel_id + type + platform_session_id`.
- Legacy-only stale targets without `platform_session_id` are intentionally left invalid; no fuzzy repair.
- Backup/import no longer depends on channel-local `sessions.json` for future stable schedule/config references.

## Validation

- `crabot-channel-wechat`: `corepack pnpm vitest run tests/session-manager.test.ts` (7 passed) + `corepack pnpm run build`
- `crabot-channel-feishu`: `corepack pnpm vitest run tests/session-manager.test.ts` (17 passed) + `corepack pnpm run build`
- `crabot-channel-telegram`: `./node_modules/.bin/vitest run tests/session-manager.test.ts` (2 passed) + `./node_modules/.bin/tsc`
- `crabot-admin`: `corepack pnpm vitest run src/task-schedule.test.ts src/schedule-migration.test.ts src/schedule-target-session.test.ts src/backup/gather.test.ts` (60 passed) + `corepack pnpm run build`
- `crabot-admin`: `corepack pnpm vitest run src/schedule-migration.test.ts src/task-schedule.test.ts` (46 passed) for the platform-anchor mismatch regression
- `crabot-admin/web`: `corepack pnpm vitest run src/pages/Schedules/ScheduleList.test.tsx` (2 passed) + `corepack pnpm run build`
- `crabot-admin`: `corepack pnpm vitest run src/backup/gather.test.ts src/backup/categories.test.ts` (13 passed) for the backup-export regression

Notes:
- Admin focused tests still log existing event-publish `ECONNREFUSED` noise in this isolated test setup, but assertions pass and the command exits 0.
- `crabot-channel-telegram/pnpm-workspace.yaml` is an unrelated untracked local file that makes `pnpm` treat the package directory as an invalid workspace, so Telegram verification used the package-local `vitest` and `tsc` binaries.
