### PR TITLE
[codex] Fix resume checkpoint tool result integrity

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -10,6 +10,12 @@
 - Legacy-only `session-configs.json` 缺少 `channel_id/platform_session_id`，不安全自动迁移；这类旧配置保持无效，避免错误套用到另一个会话。
 - 验证：三个 channel session-manager 测试与 build；Admin schedule repair / backup gather / target_session 测试与 build；Admin Web schedule 保存测试与 build。
 
+## 2026-07-04 — 修复 resume checkpoint 悬空 tool_use 导致 OpenAI 400
+
+- 根因：普通工具路径在 `toolResults` 入栈前触发 `onTurn`，worker checkpoint flush 把半截 `messages` 落盘；terminal supplement / restart resume 重放该 checkpoint 时，OpenAI 拒绝无 output 的 function call。
+- 修复：`query-loop` 改为先写 tool result 再触发 `onTurn`；`exitsLoop` / `turnZeroOnly` 早退或拒绝路径对同轮所有 `tool_use` 补齐 tool result；新增 `tool-message-integrity` 共享校验，`isResumable` 拒绝历史坏 checkpoint。
+- 验证：`resume-checkpoint.test.ts`、`query-loop.test.ts`、`query-loop-exit-tools.test.ts` 通过，并覆盖多 tool_use + exitsLoop / turnZeroOnly 混合场景。
+
 ## 2026-07-03 — 修复 async goal audit 结果未持久化与 no-delivery 空审计
 
 - 根因：admin-chat 里用户看到的“收到...”来自 dispatcher `immediate_reply` / supplement ack，经 `chat_callback` 写入聊天消息；它不是 worker 的 `send_message` 工具调用。实际 worker trace 没有 `send_message`，所以 goal gate 判断“从未向人类交付”是成立的。

--- a/crabot-agent/src/core/resume-checkpoint.ts
+++ b/crabot-agent/src/core/resume-checkpoint.ts
@@ -1,12 +1,14 @@
 import type { ResumeCheckpoint } from '../types.js'
 import type { EngineMessage } from '../engine/types.js'
 import { redactSecrets } from '../engine/redact-secrets.js'
+import { hasDanglingToolUse } from '../engine/tool-message-integrity.js'
 
-export type ResumeGuard = { ok: true } | { ok: false; reason: 'empty_checkpoint' | 'version_mismatch' }
+export type ResumeGuard = { ok: true } | { ok: false; reason: 'empty_checkpoint' | 'version_mismatch' | 'dangling_tool_use' }
 
 export function isResumable(cp: ResumeCheckpoint, currentVersion: string): ResumeGuard {
   if (cp.agent_version !== currentVersion) return { ok: false, reason: 'version_mismatch' }
   if (!cp.messages || cp.messages.length === 0) return { ok: false, reason: 'empty_checkpoint' }
+  if (hasDanglingToolUse(cp.messages)) return { ok: false, reason: 'dangling_tool_use' }
   return { ok: true }
 }
 

--- a/crabot-agent/src/engine/progress-digest.ts
+++ b/crabot-agent/src/engine/progress-digest.ts
@@ -2,6 +2,7 @@ import type { LLMAdapter } from './llm-adapter'
 import { callNonStreaming } from './llm-adapter'
 import type { EngineMessage, EngineMessagesRef, EngineTurnEvent } from './types'
 import { createUserMessage } from './types'
+import { hasDanglingToolUse } from './tool-message-integrity.js'
 
 /**
  * 进度汇报（fork 模式）。
@@ -219,29 +220,4 @@ export class ProgressDigest {
       .join('')
       .trim()
   }
-}
-
-// --- Helpers ---
-
-/**
- * 末尾是否有"孤立 tool_use"：最后一条 assistant 含 tool_use 块，但后面没有
- * 配对的 tool_result。LLM API 严格要求 function_call 配 output，否则 400。
- */
-function hasDanglingToolUse(messages: ReadonlyArray<EngineMessage>): boolean {
-  // 从尾向前找最后一条 assistant
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const m = messages[i]
-    if (m.role !== 'assistant') continue
-    // 找到最后一条 assistant：看它有没有 tool_use 块
-    const hasToolUse = Array.isArray(m.content)
-      && m.content.some((b) => (b as { type?: string }).type === 'tool_use')
-    if (!hasToolUse) return false
-    // 有 tool_use → 检查后面是否有 tool_result（用 toolResults 字段判定 EngineToolResultMessage）
-    for (let j = i + 1; j < messages.length; j++) {
-      const after = messages[j] as { toolResults?: unknown }
-      if (Array.isArray(after.toolResults) && after.toolResults.length > 0) return false
-    }
-    return true
-  }
-  return false
 }

--- a/crabot-agent/src/engine/query-loop.ts
+++ b/crabot-agent/src/engine/query-loop.ts
@@ -837,8 +837,9 @@ export async function runEngine(params: RunEngineParams): Promise<EngineResult> 
       }
     }
 
-    // exitsLoop 检测：若任一 tool_use 是 exitsLoop 工具，直接退出 loop
-    // 不调用 call、不 push tool_result、不 fire normal onTurn
+    // exitsLoop 检测：若任一 tool_use 是 exitsLoop 工具，直接退出 loop。
+    // 不调用 call，但仍 push 合成 tool_result，保证 finalMessages / checkpoint
+    // 可被 LLM API 重放（assistant tool_use 不能悬空）。
     const exitBlock = processed.toolUseBlocks.find(b => {
       const def = currentTools.find(t => t.name === b.name)
       return def?.exitsLoop === true
@@ -848,6 +849,11 @@ export async function runEngine(params: RunEngineParams): Promise<EngineResult> 
         name: exitBlock.name,
         input: exitBlock.input as Record<string, unknown>,
       }
+      messages.push(createBatchToolResultMessage([{
+        tool_use_id: exitBlock.id,
+        content: '[exit_tool]',
+        is_error: false,
+      }]))
       // Fire onTurn with this single tool call for trace recording
       fireOnTurn({
         turnNumber: totalTurns,
@@ -896,31 +902,6 @@ export async function runEngine(params: RunEngineParams): Promise<EngineResult> 
       })
     }
 
-    // Fire onTurn callback
-    fireOnTurn({
-      turnNumber: totalTurns,
-      assistantText: processed.text,
-      toolCalls: processed.toolUseBlocks.map((b, i) => {
-        const r = toolResults[i]
-        const tc: EngineTurnEvent['toolCalls'][number] = {
-          id: b.id,
-          name: b.name,
-          input: b.input,
-          output: r?.content ?? '',
-          isError: r?.is_error ?? false,
-          ...(r?.duration_ms !== undefined ? { durationMs: r.duration_ms } : {}),
-          ...(r?.started_at_ms !== undefined ? { startedAtMs: r.started_at_ms } : {}),
-        }
-        return tc
-      }),
-      stopReason,
-      llmCallMs,
-      llmStartedAtMs,
-      ...(forcedSummaryAttempt !== undefined ? { forcedSummaryAttempt } : {}),
-      ...(response.usage ? { usage: response.usage } : {}),
-      ...(response.diagnostics ? { diagnostics: response.diagnostics } : {}),
-    })
-
     // Process images based on model capability
     let processedResults: typeof toolResults
     if (options.supportsVision) {
@@ -946,12 +927,32 @@ export async function runEngine(params: RunEngineParams): Promise<EngineResult> 
     // Add tool results as a single batched message
     messages.push(createBatchToolResultMessage(processedResults))
 
-    // Refresh messagesRef again after tool_result push: fireOnTurn 上方触发的
-    // refresh 此刻拍下的快照里只有 assistant(tool_use) 还没有 tool_result——
-    // ProgressDigest 异步 fork 时若读到这个半截状态，调 OpenAI Responses API
-    // 会 400（function_call 缺 output）。这里再刷一次让 ref 反映完整的 tool_use
-    // + tool_result 配对。
-    refreshMessagesRef()
+    // Fire onTurn only after tool_result is in messages. Checkpoint/resume and
+    // progress observers treat onTurn as the clean turn boundary, so every
+    // assistant tool_use must already have matching toolResults here.
+    fireOnTurn({
+      turnNumber: totalTurns,
+      assistantText: processed.text,
+      toolCalls: processed.toolUseBlocks.map((b, i) => {
+        const r = toolResults[i]
+        const tc: EngineTurnEvent['toolCalls'][number] = {
+          id: b.id,
+          name: b.name,
+          input: b.input,
+          output: r?.content ?? '',
+          isError: r?.is_error ?? false,
+          ...(r?.duration_ms !== undefined ? { durationMs: r.duration_ms } : {}),
+          ...(r?.started_at_ms !== undefined ? { startedAtMs: r.started_at_ms } : {}),
+        }
+        return tc
+      }),
+      stopReason,
+      llmCallMs,
+      llmStartedAtMs,
+      ...(forcedSummaryAttempt !== undefined ? { forcedSummaryAttempt } : {}),
+      ...(response.usage ? { usage: response.usage } : {}),
+      ...(response.diagnostics ? { diagnostics: response.diagnostics } : {}),
+    })
 
     // ── Post-tool barrier check ──
     // 工具可能在执行中 setBarrier（如 send_message(intent='ask_human')）。

--- a/crabot-agent/src/engine/query-loop.ts
+++ b/crabot-agent/src/engine/query-loop.ts
@@ -830,7 +830,7 @@ export async function runEngine(params: RunEngineParams): Promise<EngineResult> 
             name: b.name,
             input: b.input,
             output: violatingResults.find(r => r.tool_use_id === b.id)?.content ?? '',
-            isError: violatingResults.some(r => r.tool_use_id === b.id),
+            isError: violatingResults.find(r => r.tool_use_id === b.id)?.is_error ?? false,
           })),
           stopReason,
           llmCallMs,
@@ -857,7 +857,7 @@ export async function runEngine(params: RunEngineParams): Promise<EngineResult> 
       const exitToolResultById = new Map(processed.toolUseBlocks.map(b => {
         const def = currentTools.find(t => t.name === b.name)
         const content = def?.exitsLoop === true ? '[exit_tool]' : '[skipped: exitsLoop tool selected]'
-        return [b.id, { content, isError: false }] as const
+        return [b.id, { content, isError: def?.exitsLoop !== true }] as const
       }))
       messages.push(createBatchToolResultMessage(processed.toolUseBlocks.map(b => {
         const r = exitToolResultById.get(b.id)

--- a/crabot-agent/src/engine/query-loop.ts
+++ b/crabot-agent/src/engine/query-loop.ts
@@ -802,19 +802,24 @@ export async function runEngine(params: RunEngineParams): Promise<EngineResult> 
     // turnZeroOnly 强制：在 turn 0 之后的轮次，turnZeroOnly 工具调用被拒绝
     const isAfterTurnZero = totalTurns > 1  // totalTurns=1 表示刚处理完 turn 0 响应
     if (isAfterTurnZero) {
-      const violatingResults = processed.toolUseBlocks
-        .filter(b => {
-          const def = currentTools.find(t => t.name === b.name)
-          return def?.turnZeroOnly === true
-        })
+      const violatingBlocks = processed.toolUseBlocks
+        .filter(b => currentTools.find(t => t.name === b.name)?.turnZeroOnly === true)
+      const violatingIds = new Set(violatingBlocks.map(b => b.id))
+      const turnZeroViolationMessage = (name: string) =>
+        `[Tool '${name}' is only callable on turn 0; the trigger message has already been processed. If you need to early-exit, you cannot do so anymore—proceed with the task normally.]`
+
+      if (violatingBlocks.length > 0) {
+        const violatingResults = processed.toolUseBlocks
         .map(b => ({
           tool_use_id: b.id,
-          content: `[Tool '${b.name}' is only callable on turn 0; the trigger message has already been processed. If you need to early-exit, you cannot do so anymore—proceed with the task normally.]`,
-          is_error: true,
+          content: violatingIds.has(b.id)
+            ? turnZeroViolationMessage(b.name)
+            : '[skipped: turnZeroOnly violation in same turn]',
+          is_error: violatingIds.has(b.id),
         }))
 
-      if (violatingResults.length > 0) {
-        // 全转 error tool result，跳过 executeToolBatches；下一轮 LLM 重试
+        // 本轮只要有 turnZeroOnly 违规，就跳过实际工具执行；但必须为所有
+        // tool_use 补齐 tool_result，否则下一轮重放会触发 LLM API 400。
         messages.push(createBatchToolResultMessage(violatingResults))
         // fire onTurn for trace recording
         fireOnTurn({
@@ -849,22 +854,33 @@ export async function runEngine(params: RunEngineParams): Promise<EngineResult> 
         name: exitBlock.name,
         input: exitBlock.input as Record<string, unknown>,
       }
-      messages.push(createBatchToolResultMessage([{
-        tool_use_id: exitBlock.id,
-        content: '[exit_tool]',
-        is_error: false,
-      }]))
-      // Fire onTurn with this single tool call for trace recording
+      const exitToolResultById = new Map(processed.toolUseBlocks.map(b => {
+        const def = currentTools.find(t => t.name === b.name)
+        const content = def?.exitsLoop === true ? '[exit_tool]' : '[skipped: exitsLoop tool selected]'
+        return [b.id, { content, isError: false }] as const
+      }))
+      messages.push(createBatchToolResultMessage(processed.toolUseBlocks.map(b => {
+        const r = exitToolResultById.get(b.id)
+        return {
+          tool_use_id: b.id,
+          content: r?.content ?? '[skipped: exitsLoop tool selected]',
+          is_error: r?.isError ?? false,
+        }
+      })))
+      // Fire onTurn for trace recording after all same-turn tool_use blocks have results.
       fireOnTurn({
         turnNumber: totalTurns,
         assistantText: processed.text,
-        toolCalls: [{
-          id: exitBlock.id,
-          name: exitBlock.name,
-          input: exitBlock.input,
-          output: '[exit_tool]',
-          isError: false,
-        }],
+        toolCalls: processed.toolUseBlocks.map(b => {
+          const r = exitToolResultById.get(b.id)
+          return {
+            id: b.id,
+            name: b.name,
+            input: b.input,
+            output: r?.content ?? '[skipped: exitsLoop tool selected]',
+            isError: r?.isError ?? false,
+          }
+        }),
         stopReason,
         llmCallMs,
         llmStartedAtMs,

--- a/crabot-agent/src/engine/tool-message-integrity.ts
+++ b/crabot-agent/src/engine/tool-message-integrity.ts
@@ -1,0 +1,32 @@
+import type { EngineMessage } from './types.js'
+
+export type ToolMessageIntegrity =
+  | { ok: true }
+  | { ok: false; danglingToolUseIds: string[] }
+
+export function checkToolMessageIntegrity(messages: ReadonlyArray<EngineMessage>): ToolMessageIntegrity {
+  const open = new Set<string>()
+  for (const message of messages) {
+    if (message.role === 'assistant') {
+      for (const block of message.content) {
+        if (block.type === 'tool_use') {
+          open.add(block.id)
+        }
+      }
+      continue
+    }
+
+    if ('toolResults' in message) {
+      for (const result of message.toolResults) {
+        open.delete(result.tool_use_id)
+      }
+    }
+  }
+
+  if (open.size === 0) return { ok: true }
+  return { ok: false, danglingToolUseIds: [...open] }
+}
+
+export function hasDanglingToolUse(messages: ReadonlyArray<EngineMessage>): boolean {
+  return !checkToolMessageIntegrity(messages).ok
+}

--- a/crabot-agent/src/engine/types.ts
+++ b/crabot-agent/src/engine/types.ts
@@ -151,8 +151,8 @@ export interface ToolDefinition {
   readonly turnZeroOnly?: boolean
   /**
    * 调用后引擎立刻退出 loop，把工具调用信息（name + input）写入 EngineResult.exitToolCall。
-   * 引擎不调用 `call` 函数（exit 工具本身无需执行），也不 push tool_result——
-   * 直接 buildResult('completed', ...) 返回。
+   * 引擎不调用 `call` 函数（exit 工具本身无需执行），但会为本轮所有 tool_use
+   * push 合成 tool_result，确保 finalMessages / checkpoint 可被 LLM API 重放。
    *
    * 用于"调完就走"的早退工具（如 submit_audit_result）。
    */

--- a/crabot-agent/tests/core/resume-checkpoint.test.ts
+++ b/crabot-agent/tests/core/resume-checkpoint.test.ts
@@ -27,6 +27,51 @@ describe('isResumable', () => {
     expect(r.ok).toBe(false)
     if (!r.ok) expect(r.reason).toBe('empty_checkpoint')
   })
+
+  it('存在悬空 tool_use → 拒绝，避免 resume 重放到 LLM 触发 400', () => {
+    const r = isResumable({
+      ...base,
+      messages: [
+        { id: 'm1', role: 'user' as const, content: 'hi', timestamp: 1 },
+        {
+          id: 'm2',
+          role: 'assistant' as const,
+          stopReason: 'tool_use' as const,
+          timestamp: 2,
+          content: [
+            { type: 'tool_use' as const, id: 'call_1', name: 'Read', input: { path: '/tmp/a' } },
+          ],
+        },
+      ],
+    }, '1.0.0')
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.reason).toBe('dangling_tool_use')
+  })
+
+  it('tool_use 有匹配 toolResults → 可 resume', () => {
+    const r = isResumable({
+      ...base,
+      messages: [
+        { id: 'm1', role: 'user' as const, content: 'hi', timestamp: 1 },
+        {
+          id: 'm2',
+          role: 'assistant' as const,
+          stopReason: 'tool_use' as const,
+          timestamp: 2,
+          content: [
+            { type: 'tool_use' as const, id: 'call_1', name: 'Read', input: { path: '/tmp/a' } },
+          ],
+        },
+        {
+          id: 'm3',
+          role: 'user' as const,
+          timestamp: 3,
+          toolResults: [{ tool_use_id: 'call_1', content: 'ok', is_error: false }],
+        },
+      ],
+    }, '1.0.0')
+    expect(r.ok).toBe(true)
+  })
 })
 
 describe('buildResumeWakeupMessage', () => {

--- a/crabot-agent/tests/engine/query-loop-exit-tools.test.ts
+++ b/crabot-agent/tests/engine/query-loop-exit-tools.test.ts
@@ -46,6 +46,14 @@ const dummyTurnZeroTool: ToolDefinition = {
   call: async () => ({ output: 'should not execute', isError: false }),
 }
 
+const harmlessTool: ToolDefinition = {
+  name: 'harmless',
+  description: 'no-op',
+  inputSchema: { type: 'object' as const, properties: {}, required: [] },
+  isReadOnly: true,
+  call: async () => ({ output: 'done', isError: false }),
+}
+
 describe('query-loop: exitsLoop 工具退出', () => {
   it('turn 0 调用 exitsLoop 工具 → engine 立刻退出，exitToolCall 暴露 name + input', async () => {
     const adapter = makeAdapter([
@@ -88,6 +96,46 @@ describe('query-loop: exitsLoop 工具退出', () => {
     expect((adapter.stream as unknown as ReturnType<typeof vi.fn>).mock.calls.length).toBe(1)
   })
 
+  it('同轮存在其他 tool_use 时，exitsLoop 早退仍补齐所有 tool_result', async () => {
+    const adapter = makeAdapter([
+      {
+        toolCalls: [
+          { name: 'do_exit', id: 'exit_1', input: { reason: 'done' } },
+          { name: 'harmless', id: 'h1', input: {} },
+        ],
+        stopReason: 'tool_use',
+      },
+    ])
+    const result = await runEngine({
+      prompt: 'test',
+      adapter,
+      options: {
+        tools: [dummyExitTool, harmlessTool],
+        systemPrompt: '',
+        model: 'test',
+      },
+    })
+
+    expect(result.outcome).toBe('completed')
+    expect(result.finalMessages).toEqual([
+      expect.objectContaining({ role: 'user', content: 'test' }),
+      expect.objectContaining({
+        role: 'assistant',
+        content: expect.arrayContaining([
+          expect.objectContaining({ type: 'tool_use', id: 'exit_1', name: 'do_exit' }),
+          expect.objectContaining({ type: 'tool_use', id: 'h1', name: 'harmless' }),
+        ]),
+      }),
+      expect.objectContaining({
+        role: 'user',
+        toolResults: [
+          expect.objectContaining({ tool_use_id: 'exit_1', content: '[exit_tool]', is_error: false }),
+          expect.objectContaining({ tool_use_id: 'h1', content: '[skipped: exitsLoop tool selected]', is_error: false }),
+        ],
+      }),
+    ])
+  })
+
   it('未触发 exit 工具时 exitToolCall undefined', async () => {
     const adapter = makeAdapter([{ text: '正常结束', stopReason: 'end_turn' }])
     const result = await runEngine({
@@ -106,13 +154,6 @@ describe('query-loop: exitsLoop 工具退出', () => {
 
 describe('query-loop: turnZeroOnly 拒绝', () => {
   it('turn ≥ 1 调用 turnZeroOnly 工具 → 返回 error tool_result，下一轮继续', async () => {
-    const harmlessTool: ToolDefinition = {
-      name: 'harmless',
-      description: 'no-op',
-      inputSchema: { type: 'object' as const, properties: {}, required: [] },
-      isReadOnly: true,
-      call: async () => ({ output: 'done', isError: false }),
-    }
     const adapter = makeAdapter([
       // turn 0: 调一个普通工具 → tool_use 进入 turn 1
       { toolCalls: [{ name: 'harmless', id: 'h1', input: {} }], stopReason: 'tool_use' },
@@ -134,6 +175,44 @@ describe('query-loop: turnZeroOnly 拒绝', () => {
     expect(result.outcome).toBe('completed')
     expect(result.totalTurns).toBe(3)
     expect(result.finalText).toBe('收到拒绝，结束')
+  })
+
+  it('turn ≥ 1 同轮含普通工具和 turnZeroOnly 违规工具时，补齐所有 tool_result', async () => {
+    const adapter = makeAdapter([
+      // turn 0: 调一个普通工具 → tool_use 进入 turn 1
+      { toolCalls: [{ name: 'harmless', id: 'h1', input: {} }], stopReason: 'tool_use' },
+      // turn 1: 同轮普通工具 + turnZeroOnly 违规工具
+      {
+        toolCalls: [
+          { name: 'harmless', id: 'h2', input: {} },
+          { name: 'turn_zero_only', id: 'tz1', input: {} },
+        ],
+        stopReason: 'tool_use',
+      },
+      { text: '收到拒绝，结束', stopReason: 'end_turn' },
+    ])
+    const result = await runEngine({
+      prompt: 'test',
+      adapter,
+      options: {
+        tools: [harmlessTool, dummyTurnZeroTool],
+        systemPrompt: '',
+        model: 'test',
+      },
+    })
+
+    expect(result.outcome).toBe('completed')
+    expect(result.finalMessages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: 'user',
+          toolResults: [
+            expect.objectContaining({ tool_use_id: 'h2', content: '[skipped: turnZeroOnly violation in same turn]', is_error: false }),
+            expect.objectContaining({ tool_use_id: 'tz1', is_error: true }),
+          ],
+        }),
+      ]),
+    )
   })
 
   it('turn 0 调用 turnZeroOnly 工具 → 正常执行（边界条件）', async () => {

--- a/crabot-agent/tests/engine/query-loop-exit-tools.test.ts
+++ b/crabot-agent/tests/engine/query-loop-exit-tools.test.ts
@@ -69,6 +69,21 @@ describe('query-loop: exitsLoop 工具退出', () => {
       name: 'do_exit',
       input: { reason: 'turn 0 决定退出' },
     })
+    expect(result.finalMessages).toEqual([
+      expect.objectContaining({ role: 'user', content: 'test' }),
+      expect.objectContaining({
+        role: 'assistant',
+        content: expect.arrayContaining([
+          expect.objectContaining({ type: 'tool_use', id: 'call_1', name: 'do_exit' }),
+        ]),
+      }),
+      expect.objectContaining({
+        role: 'user',
+        toolResults: [
+          expect.objectContaining({ tool_use_id: 'call_1', content: '[exit_tool]', is_error: false }),
+        ],
+      }),
+    ])
     expect(result.totalTurns).toBe(1)
     expect((adapter.stream as unknown as ReturnType<typeof vi.fn>).mock.calls.length).toBe(1)
   })

--- a/crabot-agent/tests/engine/query-loop-exit-tools.test.ts
+++ b/crabot-agent/tests/engine/query-loop-exit-tools.test.ts
@@ -54,6 +54,14 @@ const harmlessTool: ToolDefinition = {
   call: async () => ({ output: 'done', isError: false }),
 }
 
+const sendMessageTool: ToolDefinition = {
+  name: 'send_message',
+  description: 'send message',
+  inputSchema: { type: 'object' as const, properties: {}, required: [] },
+  isReadOnly: false,
+  call: async () => ({ output: 'sent', isError: false }),
+}
+
 describe('query-loop: exitsLoop 工具退出', () => {
   it('turn 0 调用 exitsLoop 工具 → engine 立刻退出，exitToolCall 暴露 name + input', async () => {
     const adapter = makeAdapter([
@@ -97,6 +105,7 @@ describe('query-loop: exitsLoop 工具退出', () => {
   })
 
   it('同轮存在其他 tool_use 时，exitsLoop 早退仍补齐所有 tool_result', async () => {
+    const turns: Array<{ name: string; isError: boolean }> = []
     const adapter = makeAdapter([
       {
         toolCalls: [
@@ -113,6 +122,9 @@ describe('query-loop: exitsLoop 工具退出', () => {
         tools: [dummyExitTool, harmlessTool],
         systemPrompt: '',
         model: 'test',
+        onTurn: (event) => {
+          turns.push(...event.toolCalls.map(tc => ({ name: tc.name, isError: tc.isError })))
+        },
       },
     })
 
@@ -130,7 +142,58 @@ describe('query-loop: exitsLoop 工具退出', () => {
         role: 'user',
         toolResults: [
           expect.objectContaining({ tool_use_id: 'exit_1', content: '[exit_tool]', is_error: false }),
-          expect.objectContaining({ tool_use_id: 'h1', content: '[skipped: exitsLoop tool selected]', is_error: false }),
+          expect.objectContaining({ tool_use_id: 'h1', content: '[skipped: exitsLoop tool selected]', is_error: true }),
+        ],
+      }),
+    ])
+    expect(turns).toEqual([
+      { name: 'do_exit', isError: false },
+      { name: 'harmless', isError: true },
+    ])
+  })
+
+  it('submit_audit_result 同轮跳过 send_message 时，send_message 不算成功交付', async () => {
+    let delivered = false
+    const adapter = makeAdapter([
+      {
+        toolCalls: [
+          { name: 'do_exit', id: 'exit_1', input: { pass: true } },
+          { name: 'send_message', id: 'msg_1', input: { intent: 'info', text: 'done' } },
+        ],
+        stopReason: 'tool_use',
+      },
+    ])
+    const result = await runEngine({
+      prompt: 'test',
+      adapter,
+      options: {
+        tools: [dummyExitTool, sendMessageTool],
+        systemPrompt: '',
+        model: 'test',
+        onTurn: (event) => {
+          for (const tc of event.toolCalls) {
+            if (tc.name === 'send_message' && !tc.isError) delivered = true
+          }
+        },
+      },
+    })
+
+    expect(result.outcome).toBe('completed')
+    expect(delivered).toBe(false)
+    expect(result.finalMessages).toEqual([
+      expect.objectContaining({ role: 'user', content: 'test' }),
+      expect.objectContaining({
+        role: 'assistant',
+        content: expect.arrayContaining([
+          expect.objectContaining({ type: 'tool_use', id: 'exit_1', name: 'do_exit' }),
+          expect.objectContaining({ type: 'tool_use', id: 'msg_1', name: 'send_message' }),
+        ]),
+      }),
+      expect.objectContaining({
+        role: 'user',
+        toolResults: [
+          expect.objectContaining({ tool_use_id: 'exit_1', content: '[exit_tool]', is_error: false }),
+          expect.objectContaining({ tool_use_id: 'msg_1', content: '[skipped: exitsLoop tool selected]', is_error: true }),
         ],
       }),
     ])
@@ -178,6 +241,7 @@ describe('query-loop: turnZeroOnly 拒绝', () => {
   })
 
   it('turn ≥ 1 同轮含普通工具和 turnZeroOnly 违规工具时，补齐所有 tool_result', async () => {
+    const turnToolCalls: Array<Array<{ name: string; isError: boolean }>> = []
     const adapter = makeAdapter([
       // turn 0: 调一个普通工具 → tool_use 进入 turn 1
       { toolCalls: [{ name: 'harmless', id: 'h1', input: {} }], stopReason: 'tool_use' },
@@ -198,6 +262,9 @@ describe('query-loop: turnZeroOnly 拒绝', () => {
         tools: [harmlessTool, dummyTurnZeroTool],
         systemPrompt: '',
         model: 'test',
+        onTurn: (event) => {
+          turnToolCalls.push(event.toolCalls.map(tc => ({ name: tc.name, isError: tc.isError })))
+        },
       },
     })
 
@@ -213,6 +280,10 @@ describe('query-loop: turnZeroOnly 拒绝', () => {
         }),
       ]),
     )
+    expect(turnToolCalls[1]).toEqual([
+      { name: 'harmless', isError: false },
+      { name: 'turn_zero_only', isError: true },
+    ])
   })
 
   it('turn 0 调用 turnZeroOnly 工具 → 正常执行（边界条件）', async () => {

--- a/crabot-agent/tests/engine/query-loop.test.ts
+++ b/crabot-agent/tests/engine/query-loop.test.ts
@@ -185,6 +185,54 @@ describe('runEngine', () => {
     )
   })
 
+  it('refreshes messagesRef with tool results before onTurn observers run', async () => {
+    const readTool = defineTool({
+      name: 'Read',
+      description: 'Read a file',
+      inputSchema: {},
+      isReadOnly: true,
+      call: async () => ({ output: 'file content', isError: false }),
+    })
+    const messagesRef = { current: [] as EngineMessage[] }
+    const snapshots: EngineMessage[][] = []
+
+    const adapter = mockAdapter([
+      toolUseResponse('tu-1', 'Read', { path: '/test' }),
+      textResponse('Done'),
+    ])
+
+    await runEngine({
+      prompt: 'Read it',
+      adapter,
+      options: baseOptions({
+        tools: [readTool],
+        messagesRef,
+        onTurn: () => snapshots.push(messagesRef.current.slice()),
+      }),
+    })
+
+    const firstTurnSnapshot = snapshots[0]
+    expect(firstTurnSnapshot).toEqual([
+      expect.objectContaining({ role: 'user', content: 'Read it' }),
+      expect.objectContaining({
+        role: 'assistant',
+        content: expect.arrayContaining([
+          expect.objectContaining({ type: 'tool_use', id: 'tu-1', name: 'Read' }),
+        ]),
+      }),
+      expect.objectContaining({
+        role: 'user',
+        toolResults: [
+          expect.objectContaining({
+            tool_use_id: 'tu-1',
+            content: expect.stringContaining('file content'),
+            is_error: false,
+          }),
+        ],
+      }),
+    ])
+  })
+
   it('returns aborted when abort signal fires', async () => {
     const controller = new AbortController()
 


### PR DESCRIPTION
## Summary

- Move normal tool-turn `onTurn` notification after the batched tool result is appended, so checkpoint flushes observe a complete assistant `tool_use` + user `toolResults` pair.
- Add a shared tool message integrity guard and reject resume checkpoints that still contain dangling tool calls.
- Add a synthetic tool result for `exitsLoop` early exit so `finalMessages` remains safe to replay through strict LLM APIs.

## Root Cause

The normal query-loop tool path fired `onTurn` before pushing the corresponding tool result into `messages`. Worker checkpoint flushes treat `onTurn` as a clean turn boundary, so they could persist a half-turn checkpoint containing an assistant tool call without the required tool output. Later resume / progress digest replay could send that history to the OpenAI Responses path and hit HTTP 400: `No tool output found for function call ...`.

## Validation

- `pnpm --filter crabot-agent test -- --run tests/core/resume-checkpoint.test.ts tests/core/trace-store.test.ts tests/engine/progress-digest.test.ts tests/engine/query-loop.test.ts tests/engine/query-loop-exit-tools.test.ts tests/unified-agent-resume-task.test.ts` passed: 6 files, 121 tests.
- `pnpm --filter crabot-agent build` passed.
- Full `pnpm --filter crabot-agent test -- --run` was run and had one pre-existing unrelated failure: `tests/dispatcher/dispatcher.test.ts > dispatch > userPrompt renders recent completed and failed candidates under 可补充任务` expected `## 可补充任务`, but received `## 当前正在运行的本 session task`.