### PR TITLE
[codex] fix memory curate incremental inbox scan

### DIFF
--- a/crabot-admin/builtins/skills/memory-curate/SKILL.md
+++ b/crabot-admin/builtins/skills/memory-curate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: memory-curate
-description: "记忆整理：扫 inbox 候选，去重 + 多因子打分，高分高置信晋升 confirmed。仅当任务标题以'记忆整理'开头或 trigger=memory_curate 时使用，与 daily-reflection 互斥（daily-reflection 用于深度反思，会读 trace 并委派 sub-agent）。"
+description: "记忆整理：按 schedule watermark 增量扫描 inbox 候选，去重 + 多因子打分，高分高置信晋升 confirmed。仅当任务标题以'记忆整理'开头或 trigger=memory_curate 时使用，与 daily-reflection 互斥（daily-reflection 用于深度反思，会读 trace 并委派 sub-agent）。"
 version: "2.0.0"
 ---
 
@@ -8,25 +8,28 @@ version: "2.0.0"
 
 ## Overview
 
-每小时（默认）跑一次：扫近期 inbox 中的 fact/lesson 候选，做去重 + 多因子打分。
+每小时（默认）跑一次：按本次 schedule 的 `ingestion_time_start` 到 `ingestion_time_end` 增量扫描 inbox 中的 fact/lesson 候选，做去重 + 多因子打分。
 高分 + 高置信 → `update_long_term` 升级到 confirmed；
 低分 / 模糊 → 留给 daily-reflection 深加工。
 **这是机械整理，不是反思**：仅做去重 hash 比对、IDF / entity_priority / 高 proximity 阈值过滤，不调贵 LLM、不读 trace、不委派 sub-agent。
 
 ## 流程
 
-### Step 1：拉 inbox 候选
+### Step 1：增量拉 inbox 候选
 
 ```
-mcp__crab-memory__search_long_term({
-  query: "*",
-  filters: { status: "inbox" },
-  k: 50,
-  include: "brief"
+mcp__crab-memory__list_entries({
+  status: "inbox",
+  ingestion_time_start: "<任务 input.ingestion_time_start；若缺失则从任务描述的整理范围起点解析>",
+  ingestion_time_end: "<任务 input.ingestion_time_end；若缺失则从任务描述的整理范围终点解析>",
+  limit: 100,
+  offset: 0
 })
 ```
 
-> 现实现需要查询字符串；可用 `"recent"` 占位 + filters 过滤。如不够，用 `mcp__crab-memory__list_recent({ window_days: 1 })` 拉最近 24 小时新增的全部条目。
+如返回数量达到 `limit`，继续用 `offset += 100` 翻页，直到返回少于 `limit`。
+
+**禁止**用长期记忆语义检索工具拉 inbox 候选。记忆整理是增量列表处理，不是语义召回；不要传无主题查询，也不要请求 full body。
 
 ### Step 2：去重
 

--- a/crabot-admin/src/builtin-schedules.test.ts
+++ b/crabot-admin/src/builtin-schedules.test.ts
@@ -81,6 +81,18 @@ describe('AdminModule - ensureBuiltinSchedules', () => {
     expect(memoryCurate!.task_template.type).toBe('memory_curate')
   })
 
+  it('should seed 记忆整理 with explicit watermark input for incremental inbox curation', async () => {
+    const result = await (admin as unknown as { handleListSchedules: (params: { page: number; page_size: number; filter: Record<string, unknown> }) => Promise<{ items: Schedule[] }> }).handleListSchedules({ page: 1, page_size: 50, filter: {} })
+    const memoryCurate = result.items.find(s => s.name === '记忆整理')
+    expect(memoryCurate, '记忆整理 should exist').toBeDefined()
+    expect(memoryCurate!.task_template.description).toContain('{{watermark}}')
+    expect(memoryCurate!.task_template.description).toContain('{{datetime}}')
+    expect(memoryCurate!.task_template.input).toMatchObject({
+      ingestion_time_start: '{{watermark}}',
+      ingestion_time_end: '{{datetime}}',
+    })
+  })
+
   it('should seed 记忆维护 (cron, 0 4 * * *)', async () => {
     const result = await (admin as unknown as { handleListSchedules: (params: { page: number; page_size: number; filter: Record<string, unknown> }) => Promise<{ items: Schedule[] }> }).handleListSchedules({ page: 1, page_size: 50, filter: {} })
     const memoryMaintenance = result.items.find(s => s.name === '记忆维护')

--- a/crabot-admin/src/index.ts
+++ b/crabot-admin/src/index.ts
@@ -6167,8 +6167,12 @@ export class AdminModule extends ModuleBase {
         task_template: {
           type: 'memory_curate',
           title: '记忆整理 — {{datetime}}',
-          description: '第一步必须调用 Skill("memory-curate")，禁止加载其他 reflection skill。流程：扫近期 inbox → 去重 → 多因子打分 → 晋升 confirmed / 丢弃 / 留待 daily-reflection。',
+          description: '第一步必须调用 Skill("memory-curate")，禁止加载其他 reflection skill。整理范围：{{watermark}} 到 {{datetime}}。流程：按 ingestion_time 增量列出此窗口内的 inbox → 去重 → 多因子打分 → 晋升 confirmed / 丢弃 / 留待 daily-reflection。禁止用 search_long_term 拉 inbox 候选。',
           priority: 'low',
+          input: {
+            ingestion_time_start: '{{watermark}}',
+            ingestion_time_end: '{{datetime}}',
+          },
           tags: ['memory_curate', 'builtin'],
         },
       },

--- a/crabot-agent/src/mcp/crab-memory.ts
+++ b/crabot-agent/src/mcp/crab-memory.ts
@@ -225,6 +225,10 @@ const LIST_ENTRIES_SCHEMA = {
     .describe('按审核状态过滤'),
   tags: z.array(z.string()).optional()
     .describe('按标签过滤'),
+  ingestion_time_start: z.string().optional()
+    .describe('按入库时间过滤，包含起点；ISO8601。记忆整理按 schedule watermark 增量扫描时使用'),
+  ingestion_time_end: z.string().optional()
+    .describe('按入库时间过滤，排除终点；ISO8601。记忆整理按 schedule 当前时间增量扫描时使用'),
   limit: z.number().int().min(1).max(200).optional()
     .describe('返回数量上限'),
   offset: z.number().int().min(0).optional()

--- a/crabot-agent/tests/mcp/crab-memory-skill-contract.test.ts
+++ b/crabot-agent/tests/mcp/crab-memory-skill-contract.test.ts
@@ -18,6 +18,7 @@ import path from 'node:path'
 const REPO_ROOT = path.join(__dirname, '..', '..', '..')
 const CRAB_MEMORY_TS = path.join(REPO_ROOT, 'crabot-agent', 'src', 'mcp', 'crab-memory.ts')
 const SKILLS_DIR = path.join(REPO_ROOT, 'crabot-admin', 'builtins', 'skills')
+const MEMORY_CURATE_SKILL = path.join(SKILLS_DIR, 'memory-curate', 'SKILL.md')
 
 function extractRegisteredToolNames(): Set<string> {
   const src = fs.readFileSync(CRAB_MEMORY_TS, 'utf-8')
@@ -79,6 +80,18 @@ describe('crab-memory MCP server ↔ SKILL.md 引用契约', () => {
       `SKILL 引用了未在 crab-memory.ts 注册的工具，跑起来必 "tool not found":\n  ` +
         violations.join('\n  '),
     ).toEqual([])
+  })
+})
+
+describe('memory-curate 增量整理契约', () => {
+  it('使用 list_entries 按 ingestion_time 窗口拉 inbox，不用 search_long_term 做无主题扫描', () => {
+    const md = fs.readFileSync(MEMORY_CURATE_SKILL, 'utf-8')
+    expect(md).toContain('mcp__crab-memory__list_entries')
+    expect(md).toContain('ingestion_time_start')
+    expect(md).toContain('ingestion_time_end')
+    expect(md).not.toContain('mcp__crab-memory__search_long_term')
+    expect(md).not.toContain('query: "*"')
+    expect(md).not.toContain('include: "full"')
   })
 })
 

--- a/crabot-memory/src/long_term_v2/rpc.py
+++ b/crabot-memory/src/long_term_v2/rpc.py
@@ -542,13 +542,18 @@ class LongTermV2Rpc:
         status = params.get("status")
         author = params.get("author")
         tags = params.get("tags") or []
+        ingestion_time_start = params.get("ingestion_time_start")
+        ingestion_time_end = params.get("ingestion_time_end")
         limit = int(params.get("limit", 100))
         offset = int(params.get("offset", 0))
         sort = params.get("sort", "ingestion_time_desc")
 
         rows = self.index.list_entries(
             type_=type_, status=status,
-            tags=tags, limit=limit, offset=offset, sort=sort,
+            tags=tags,
+            ingestion_time_start=ingestion_time_start,
+            ingestion_time_end=ingestion_time_end,
+            limit=limit, offset=offset, sort=sort,
         )
         items = [
             item for r in rows

--- a/crabot-memory/src/long_term_v2/sqlite_index.py
+++ b/crabot-memory/src/long_term_v2/sqlite_index.py
@@ -415,11 +415,13 @@ class SqliteIndex:
         type_: str | None = None,
         status: str | None = None,
         tags: list[str] | None = None,
+        ingestion_time_start: str | None = None,
+        ingestion_time_end: str | None = None,
         limit: int = 100,
         offset: int = 0,
         sort: str = "ingestion_time_desc",
     ) -> list[dict]:
-        """按 type/status/tags 过滤，按 sort 排序，分页返回。
+        """按 type/status/tags/ingestion_time 过滤，按 sort 排序，分页返回。
 
         Note: there is no `author` column on the `memories` table. Author
         filtering must happen at the RPC layer after loading the entry's
@@ -433,6 +435,12 @@ class SqliteIndex:
         if status:
             where.append("status = ?")
             params.append(status)
+        if ingestion_time_start:
+            where.append("ingestion_time >= ?")
+            params.append(ingestion_time_start)
+        if ingestion_time_end:
+            where.append("ingestion_time < ?")
+            params.append(ingestion_time_end)
         where_sql = "WHERE " + " AND ".join(where) if where else ""
 
         order = {

--- a/crabot-memory/tests/long_term_v2/test_rpc_phase4.py
+++ b/crabot-memory/tests/long_term_v2/test_rpc_phase4.py
@@ -3,6 +3,8 @@ import pytest
 from src.long_term_v2.store import MemoryStore
 from src.long_term_v2.sqlite_index import SqliteIndex
 from src.long_term_v2.rpc import LongTermV2Rpc
+from src.long_term_v2.schema import MemoryEntry, MemoryFrontmatter, SourceRef, ImportanceFactors
+from src.long_term_v2.paths import entry_path
 
 
 _BASE_PARAMS = {
@@ -36,6 +38,31 @@ def _write_payload(**overrides):
     return payload
 
 
+def _seed_entry(rpc, mem_id, brief, *, status, ingestion_time):
+    fm = MemoryFrontmatter(
+        id=mem_id,
+        type="fact",
+        maturity="observed",
+        brief=brief,
+        author="user",
+        source_ref=SourceRef(type="manual"),
+        source_trust=5,
+        content_confidence=5,
+        importance_factors=ImportanceFactors(
+            proximity=0.5, surprisal=0.5, entity_priority=0.5, unambiguity=0.5,
+        ),
+        event_time="2026-04-23T10:00:00Z",
+        ingestion_time=ingestion_time,
+    )
+    entry = MemoryEntry(frontmatter=fm, body=f"body {brief}")
+    rpc.store.write(entry, status=status)
+    rpc.index.upsert(
+        entry,
+        path=entry_path(rpc.store.data_root, status, "fact", mem_id),
+        status=status,
+    )
+
+
 @pytest.mark.asyncio
 async def test_list_entries_returns_written_entry(rpc):
     w = await rpc.write_long_term(_write_payload(brief="alpha"))
@@ -64,6 +91,25 @@ async def test_list_entries_filters_by_status(rpc):
     res = await rpc.list_entries({"status": "confirmed"})
     assert res["total"] == 1
     assert res["items"][0]["brief"] == "confirmed"
+
+
+@pytest.mark.asyncio
+async def test_list_entries_filters_by_ingestion_time_window(rpc):
+    _seed_entry(rpc, "mem-l-before", "before", status="inbox",
+                ingestion_time="2026-04-23T09:59:59Z")
+    _seed_entry(rpc, "mem-l-in-window", "in-window", status="inbox",
+                ingestion_time="2026-04-23T10:30:00Z")
+    _seed_entry(rpc, "mem-l-confirmed", "confirmed in window", status="confirmed",
+                ingestion_time="2026-04-23T10:40:00Z")
+
+    res = await rpc.list_entries({
+        "status": "inbox",
+        "ingestion_time_start": "2026-04-23T10:00:00Z",
+        "ingestion_time_end": "2026-04-23T11:00:00Z",
+    })
+
+    assert res["total"] == 1
+    assert res["items"][0]["brief"] == "in-window"
 
 
 @pytest.mark.asyncio

--- a/crabot-memory/tests/long_term_v2/test_sqlite_index.py
+++ b/crabot-memory/tests/long_term_v2/test_sqlite_index.py
@@ -172,6 +172,30 @@ def test_list_entries_sort_ingestion_time_desc(tmp_path):
     assert [r["id"] for r in rows_asc] == ["mem-l-old", "mem-l-new"]
 
 
+def test_list_entries_filters_by_ingestion_time_window(tmp_path):
+    idx = SqliteIndex(str(tmp_path / "idx.db"))
+    idx.upsert(
+        _make_typed_entry("mem-l-before", ingestion_time="2026-04-23T09:59:59Z"),
+        path="/tmp/before.md", status="inbox",
+    )
+    idx.upsert(
+        _make_typed_entry("mem-l-in-window", ingestion_time="2026-04-23T10:30:00Z"),
+        path="/tmp/in-window.md", status="inbox",
+    )
+    idx.upsert(
+        _make_typed_entry("mem-l-after", ingestion_time="2026-04-23T11:00:00Z"),
+        path="/tmp/after.md", status="inbox",
+    )
+
+    rows = idx.list_entries(
+        status="inbox",
+        ingestion_time_start="2026-04-23T10:00:00Z",
+        ingestion_time_end="2026-04-23T11:00:00Z",
+    )
+
+    assert [r["id"] for r in rows] == ["mem-l-in-window"]
+
+
 def test_extend_observation_window_adds_days(tmp_path):
     from src.long_term_v2.sqlite_index import SqliteIndex
     from src.long_term_v2.schema import (


### PR DESCRIPTION
## Summary

Fix `memory_curate` so it incrementally lists inbox entries by ingestion-time window instead of using semantic long-term search over inbox.

## Root Cause

The builtin memory-curate skill still instructed the agent to call long-term semantic search with an unbounded-style query for inbox candidates. That made each run vulnerable to repeated broad scans and model drift toward requesting too much long-term memory content.

## Changes

- Add optional `ingestion_time_start` / `ingestion_time_end` filters to long-term memory `list_entries`.
- Expose those filters in the crab-memory MCP `list_entries` schema.
- Seed the builtin `记忆整理` schedule with explicit `{{watermark}}` → `{{datetime}}` input.
- Update the `memory-curate` skill to use paginated `list_entries` over that window and forbid semantic inbox scans.
- Add regression tests for memory filtering, schedule seed input, and skill/tool contract.

## Validation

- `cd crabot-memory && uv run pytest tests/long_term_v2/test_rpc_phase4.py tests/long_term_v2/test_sqlite_index.py` → 23 passed
- `cd crabot-admin && ./node_modules/.bin/vitest run src/builtin-schedules.test.ts src/task-schedule.test.ts` → 41 passed
- `cd crabot-agent && ./node_modules/.bin/vitest run tests/mcp/crab-memory-skill-contract.test.ts` → 8 passed
- `cd crabot-admin && ./node_modules/.bin/tsc --noEmit` → passed
- `cd crabot-agent && ./node_modules/.bin/tsc --noEmit` → passed
- `git diff --check` → passed

Note: admin vitest emits existing environment noise for missing `crabot-channel-feishu/dist/onboard.js` and refused event publish connections, but the suite exits successfully.
