### PR TITLE
[codex] Preserve resume execution semantics

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,6 +1,13 @@
 # Crabot 项目进度
 
-> 最后更新：2026-07-06 — LLM 流缺终态改为可重试协议错误
+> 最后更新：2026-07-08 — 修复 resume 执行入口语义污染
+
+## 2026-07-08 — 修复 resume 执行入口语义污染
+
+- 根因：`resume_task` / terminal supplement revive 复用了 `ScheduledTaskRunner.executeScheduledTaskInBackground`，该 runner 硬编码 `source.trigger_type='scheduled'`，导致 human message task 续跑后关闭 goal/end-turn delivery gate，空 `end_turn` 可直接完成。
+- 修复：新增通用 Agent Loop Substrate，scheduled / human resume 通过显式 source/profile 进入同一个 worker loop；`ScheduledTaskRunner` 只保留真实 scheduled 任务组装职责；resume 后台执行失败会 best-effort 标 Admin task failed。
+- 回归：human resume / terminal supplement revive 保留 `trigger_type='message'` 和 delivery epoch gate；scheduled resume 仍保持 scheduled silent policy；`send_master_private` 收紧为 scheduled/system 场景工具，human message task 不再暴露。
+- 验证：`crabot-agent` resume/scheduled、agent-handler、messaging focused vitest 与 `tsc --noEmit`。
 
 ## 2026-07-06 — LLM 流缺终态改为可重试协议错误
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5,9 +5,9 @@
 ## 2026-07-08 — 修复 resume 执行入口语义污染
 
 - 根因：`resume_task` / terminal supplement revive 复用了 `ScheduledTaskRunner.executeScheduledTaskInBackground`，该 runner 硬编码 `source.trigger_type='scheduled'`，导致 human message task 续跑后关闭 goal/end-turn delivery gate，空 `end_turn` 可直接完成。
-- 修复：新增通用 Agent Loop Substrate，scheduled / human resume 通过显式 source/profile 进入同一个 worker loop；`ScheduledTaskRunner` 只保留真实 scheduled 任务组装职责；resume 后台执行失败会 best-effort 标 Admin task failed。
+- 修复：新增通用 Agent Loop Substrate，scheduled / human resume 通过显式 source/profile 进入同一个 worker loop；`ScheduledTaskRunner` 只保留真实 scheduled 任务组装职责；resume 后台执行失败会 best-effort 标 Admin task failed；失败任务只保留 Admin result / trace / log，不再写短期或长期记忆。
 - 回归：human resume / terminal supplement revive 保留 `trigger_type='message'` 和 delivery epoch gate；scheduled resume 仍保持 scheduled silent policy；`send_master_private` 收紧为 scheduled/system 场景工具，human message task 不再暴露。
-- 验证：`crabot-agent` resume/scheduled、agent-handler、messaging focused vitest 与 `tsc --noEmit`。
+- 验证：`crabot-agent` resume/scheduled、memory-writer、agent-handler、messaging focused vitest 与 `tsc --noEmit`。
 
 ## 2026-07-06 — LLM 流缺终态改为可重试协议错误
 

--- a/crabot-agent/src/agent/agent-handler.ts
+++ b/crabot-agent/src/agent/agent-handler.ts
@@ -2648,8 +2648,9 @@ export class AgentHandler {
   }
 
   /**
-   * 把 outcome_brief / process_highlights 同时落到 admin（update_task_outcome）和短期/长期记忆。
-   * RPC 失败 best-effort（log + 继续）；memory write 在 finalizeMemoryWrite 里也是 fire-and-forget。
+   * 把 outcome_brief / process_highlights 落到 admin（update_task_outcome）。
+   * 只有 completed 任务写短期/长期记忆；failed/max_turns/aborted 只保留在 task result / trace，
+   * 避免把临时错误或阻塞叙述污染后续跨 task 上下文。
    */
   private async writeOutcome(
     taskId: TaskId,
@@ -2664,7 +2665,9 @@ export class AgentHandler {
       outcome_brief: outcomeBrief,
       process_highlights: processHighlights,
     }, 'update_task_outcome')
-    this.finalizeMemoryWrite(taskId, { outcome, outcome_brief: outcomeBrief, process_highlights: processHighlights }, context)
+    if (outcome === 'completed') {
+      this.finalizeMemoryWrite(taskId, { outcome, outcome_brief: outcomeBrief, process_highlights: processHighlights }, context)
+    }
   }
 
   /** finalize 阶段调 admin RPC 的 best-effort 包装：失败只 log 不抛，让后续步骤继续跑。 */
@@ -2749,15 +2752,13 @@ export class AgentHandler {
   }
 
   /**
-   * 任务结束（成功 / 失败）后写短期记忆 + 长期记忆候选。
-   * - completed：reflection 来自 reflectFn 的真实总结
-   * - failed：reflection 来自 engine.error 截断兜底
+   * 任务成功完成后写短期记忆 + 长期记忆候选。
    * 两个写入均 fire-and-forget：失败只打日志，不影响 task 状态。
    */
   private finalizeMemoryWrite(
     taskId: TaskId,
     reflection: {
-      outcome: 'completed' | 'failed'
+      outcome: 'completed'
       outcome_brief: string
       process_highlights: readonly string[]
     },
@@ -2774,8 +2775,6 @@ export class AgentHandler {
     const scopes = context.memory_permissions?.write_scopes ?? []
 
     const taskTitle = this.activeTasks.get(taskId)?.title ?? taskId
-    const outcomeLabel = reflection.outcome === 'completed' ? '完成' : '失败'
-
     this.memoryWriter.writeTaskFinished({
       task_id: taskId,
       task_title: taskTitle,
@@ -2795,13 +2794,13 @@ export class AgentHandler {
     this.memoryWriter.quickCapture({
       type: 'lesson',
       brief: `${taskTitle} → ${reflection.outcome_brief}`.slice(0, 80),
-      content: `任务 ${taskId}（${taskTitle}）${outcomeLabel}：${reflection.outcome_brief}`,
+      content: `任务 ${taskId}（${taskTitle}）完成：${reflection.outcome_brief}`,
       source_ref: { type: 'conversation', task_id: taskId, channel_id: channelId, session_id: sessionId },
       entities: [],
       tags: [`task_outcome:${reflection.outcome}`],
       importance_factors: {
         proximity: 0.6,
-        surprisal: reflection.outcome === 'failed' ? 0.8 : 0.4,
+        surprisal: 0.4,
         entity_priority: 0.5,
         unambiguity: 0.6,
       },

--- a/crabot-agent/src/mcp/crab-messaging.ts
+++ b/crabot-agent/src/mcp/crab-messaging.ts
@@ -314,7 +314,8 @@ export function buildMessagingTools(
   sandboxPathMappingsRef?: { current: PathMapping[] },
 ): MessagingTool[] {
   const { rpcClient, moduleId, getAdminPort, resolveChannelPort } = deps
-  const isDailyReflection = deps.getTaskContext?.()?.taskType === 'daily_reflection'
+  const taskCtx = deps.getTaskContext?.() ?? null
+  const isDailyReflection = taskCtx?.taskType === 'daily_reflection'
 
   // 解析飞书 channel port 的公共 helper（供 read_feishu_document / feishu_raw_get / feishu_download_file 共用）
   async function resolveFeishuChannelPort(args: Record<string, unknown>): Promise<
@@ -1274,6 +1275,8 @@ crabot 系统给你的所有信号——system prompt、supplement 注入、tool
 
   return isDailyReflection
     ? allTools.filter(t => DAILY_REFLECTION_ALLOWED_TOOLS.has(t.name))
+    : taskCtx?.triggerType === 'message'
+      ? allTools.filter(t => t.name !== 'send_master_private')
     : allTools
 }
 

--- a/crabot-agent/src/orchestration/agent-loop-substrate.ts
+++ b/crabot-agent/src/orchestration/agent-loop-substrate.ts
@@ -1,0 +1,43 @@
+import type { AgentHandler } from '../agent/agent-handler.js'
+import type { ExecuteTaskParams, ExecuteTaskResult } from '../types.js'
+
+export type AgentLoopExecuteTaskFn = (
+  params: ExecuteTaskParams & { related_task_id?: string }
+) => Promise<ExecuteTaskResult & { trace_id?: string }>
+
+export class AgentLoopSubstrate {
+  private agentHandler: AgentHandler | null = null
+
+  constructor(private executeTaskFn?: AgentLoopExecuteTaskFn) {}
+
+  setWorkerHandler(handler: AgentHandler): void {
+    this.agentHandler = handler
+  }
+
+  async executeAgentLoop(
+    params: ExecuteTaskParams & { related_task_id?: string },
+  ): Promise<ExecuteTaskResult & { trace_id?: string }> {
+    if (this.executeTaskFn) return this.executeTaskFn(params)
+    if (!this.agentHandler) {
+      throw new Error('AgentLoopSubstrate worker handler is not configured')
+    }
+    return this.agentHandler.executeTask(params)
+  }
+
+  executeAgentLoopInBackground(
+    params: ExecuteTaskParams & { related_task_id?: string },
+    label = 'agent loop',
+    onError?: (error: unknown) => void | Promise<void>,
+  ): void {
+    this.executeAgentLoop(params).catch((err) => {
+      const msg = err instanceof Error ? err.message : String(err)
+      console.error(`[AgentLoopSubstrate] Unexpected error in ${label}: ${msg}`)
+      if (onError) {
+        Promise.resolve(onError(err)).catch((callbackErr) => {
+          const callbackMsg = callbackErr instanceof Error ? callbackErr.message : String(callbackErr)
+          console.error(`[AgentLoopSubstrate] Error handler failed in ${label}: ${callbackMsg}`)
+        })
+      }
+    })
+  }
+}

--- a/crabot-agent/src/orchestration/memory-writer.ts
+++ b/crabot-agent/src/orchestration/memory-writer.ts
@@ -59,10 +59,11 @@ export class MemoryWriter {
     private getMemoryPort: () => number | Promise<number>
   ) {}
 
-  /** Task 完成/失败事件 */
+  /** Task 成功完成事件；失败任务只保留在 Admin task result / trace，不写跨 task 记忆。 */
   async writeTaskFinished(params: WriteTaskFinishedParams): Promise<void> {
-    const outcomeLabel = params.outcome === 'completed' ? '完成' : '失败'
-    const head = `任务 ${params.task_id}（${params.task_title}）${outcomeLabel}：${params.outcome_brief}`
+    if (params.outcome !== 'completed') return
+
+    const head = `任务 ${params.task_id}（${params.task_title}）完成：${params.outcome_brief}`
 
     const lines: string[] = [head]
     if (params.process_highlights.length > 0) {

--- a/crabot-agent/src/orchestration/scheduled-task-runner.ts
+++ b/crabot-agent/src/orchestration/scheduled-task-runner.ts
@@ -175,7 +175,8 @@ export class ScheduledTaskRunner {
           ...(opts?.resumeFrom ? { resumeFrom: opts.resumeFrom } : {}),
         })
       } catch (error) {
-        // worker handler 自身崩溃（throw）——兜底：标失败 + 写失败记忆
+        // worker handler 自身崩溃（throw）——兜底标失败；失败详情留在 task result / trace / log，
+        // 不写跨 task 记忆，避免把临时错误污染后续上下文。
         const msg = error instanceof Error ? error.message : String(error)
         console.error(`[ScheduledTaskRunner] Background scheduled task ${task.id} failed: ${msg}`)
 
@@ -188,19 +189,6 @@ export class ScheduledTaskRunner {
           )
         } catch { /* best effort */ }
 
-        this.finalizeTaskMemory({
-          taskId: task.id,
-          taskTitle: task.title,
-          outcome: 'failed',
-          outcomeBrief: msg.slice(0, 200),
-          processHighlights: [],
-          friendName: 'system',
-          friendId: '',
-          channelId: '',
-          sessionId: '',
-          visibility: 'internal',
-          scopes: [],
-        })
       }
     }
 
@@ -209,60 +197,4 @@ export class ScheduledTaskRunner {
     })
   }
 
-  /**
-   * worker handler 自身崩溃时的失败记忆兜底写入（短期 + 长期）。两者均 fire-and-forget。
-   *
-   * 成功路径的记忆已由 agent-handler.finalizeMemoryWrite 内部写入，dispatcher 不再重复。
-   */
-  private finalizeTaskMemory(args: {
-    taskId: string
-    taskTitle: string
-    outcome: 'completed' | 'failed'
-    outcomeBrief: string
-    processHighlights: readonly string[]
-    friendName: string
-    friendId: string
-    channelId: string
-    sessionId: string
-    visibility: 'private' | 'internal' | 'public'
-    scopes: string[]
-    traceId?: string
-  }): void {
-    const {
-      taskId, taskTitle, outcome, outcomeBrief, processHighlights,
-      friendName, friendId, channelId, sessionId, visibility, scopes, traceId,
-    } = args
-
-    this.memoryWriter.writeTaskFinished({
-      task_id: taskId,
-      task_title: taskTitle,
-      outcome,
-      outcome_brief: outcomeBrief,
-      process_highlights: [...processHighlights],
-      friend_name: friendName,
-      friend_id: friendId,
-      channel_id: channelId,
-      session_id: sessionId,
-      visibility,
-      scopes,
-      ...(traceId ? { trace_id: traceId } : {}),
-    }).catch(() => {})
-
-    const briefSrc = `${taskTitle} → ${outcomeBrief}`.slice(0, 80)
-    const outcomeLabel = outcome === 'completed' ? '完成' : '失败'
-    this.memoryWriter.quickCapture({
-      type: 'lesson',
-      brief: briefSrc,
-      content: `任务 ${taskId}（${taskTitle}）${outcomeLabel}：${outcomeBrief}`,
-      source_ref: { type: 'conversation', task_id: taskId, channel_id: channelId, session_id: sessionId },
-      entities: [],
-      tags: [`task_outcome:${outcome}`],
-      importance_factors: {
-        proximity: 0.6,
-        surprisal: outcome === 'failed' ? 0.8 : 0.4,
-        entity_priority: 0.5,
-        unambiguity: 0.6,
-      },
-    }).catch(() => undefined)
-  }
 }

--- a/crabot-agent/src/orchestration/scheduled-task-runner.ts
+++ b/crabot-agent/src/orchestration/scheduled-task-runner.ts
@@ -10,11 +10,11 @@ import { SYSTEM_SESSION, type RpcClient } from 'crabot-shared'
 import type {
   ChannelMessage,
   ExecuteTaskParams,
-  ExecuteTaskResult,
   WorkerAgentContext,
 } from '../types.js'
 import type { AgentHandler } from '../agent/agent-handler.js'
 import { MemoryWriter } from './memory-writer.js'
+import { AgentLoopSubstrate } from './agent-loop-substrate.js'
 
 /** Admin create_task 返回的任务信息 */
 interface AdminTask {
@@ -37,21 +37,19 @@ interface AdminTask {
 }
 
 export class ScheduledTaskRunner {
-  private agentHandler: AgentHandler | null = null
-
   constructor(
     private rpcClient: RpcClient,
     private moduleId: string,
     private memoryWriter: MemoryWriter,
     private getAdminPort: () => number | Promise<number>,
-    private executeTaskFn?: (params: ExecuteTaskParams & { related_task_id?: string }) => Promise<ExecuteTaskResult & { trace_id?: string }>,
+    private agentLoopSubstrate: AgentLoopSubstrate,
   ) {}
 
   /**
    * 设置本地 Worker Handler 引用（UnifiedAgent 在初始化 Worker 后调用）
    */
   setWorkerHandler(handler: AgentHandler): void {
-    this.agentHandler = handler
+    this.agentLoopSubstrate.setWorkerHandler(handler)
   }
 
   /**
@@ -171,18 +169,11 @@ export class ScheduledTaskRunner {
         }
 
         // worker handler 内部已完成：update_task_status + update_task_outcome + 记忆写入
-        if (this.executeTaskFn) {
-          await this.executeTaskFn({
-            ...taskPayload,
-            related_task_id: task.id,
-            ...(opts?.resumeFrom ? { resumeFrom: opts.resumeFrom } : {}),
-          })
-        } else {
-          await this.agentHandler!.executeTask({
-            ...taskPayload,
-            ...(opts?.resumeFrom ? { resumeFrom: opts.resumeFrom } : {}),
-          })
-        }
+        await this.agentLoopSubstrate.executeAgentLoop({
+          ...taskPayload,
+          related_task_id: task.id,
+          ...(opts?.resumeFrom ? { resumeFrom: opts.resumeFrom } : {}),
+        })
       } catch (error) {
         // worker handler 自身崩溃（throw）——兜底：标失败 + 写失败记忆
         const msg = error instanceof Error ? error.message : String(error)

--- a/crabot-agent/src/types.ts
+++ b/crabot-agent/src/types.ts
@@ -395,7 +395,7 @@ export interface TaskSummary {
    * `scheduled` 表示由调度引擎创建的定时/巡检任务，Front 在 prompt 中需要标记，
    * 且不允许 supplement_task；engine 收到针对 scheduled 的 supplement 时改走 create_task。
    */
-  trigger_type?: 'manual' | 'scheduled' | 'auto' | 'event'
+  trigger_type?: 'manual' | 'scheduled' | 'auto' | 'event' | 'message'
   updated_at?: string
   created_at?: string
   /**
@@ -758,9 +758,9 @@ export interface ExecuteTaskParams {
     plan?: string
     task_type?: string
     /** 任务来源信息。Schedule 路径由 ScheduledTaskRunner 填入 trigger_type='scheduled'；
-     *  trigger 路径合成 task 不填此字段（视为 'message'）。 */
+     *  trigger 路径合成 task 可能显式填入 trigger_type='message'；旧调用不填时也视为 'message'。 */
     source?: {
-      trigger_type?: 'manual' | 'scheduled' | 'auto' | 'event'
+      trigger_type?: 'manual' | 'scheduled' | 'auto' | 'event' | 'message'
     }
   }
   context: WorkerAgentContext

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -39,6 +39,7 @@ import { SessionManager } from './orchestration/session-manager.js'
 import { PermissionChecker } from './orchestration/permission-checker.js'
 import { WorkerSelector } from './orchestration/worker-selector.js'
 import { ContextAssembler } from './orchestration/context-assembler.js'
+import { AgentLoopSubstrate } from './orchestration/agent-loop-substrate.js'
 import { ScheduledTaskRunner } from './orchestration/scheduled-task-runner.js'
 import { MemoryWriter } from './orchestration/memory-writer.js'
 import { AttentionScheduler, type AttentionConfig, type BufferedMessage } from './orchestration/attention-scheduler.js'
@@ -96,6 +97,10 @@ function toToolPermissionConfig(
     : { mode: 'denyList' as const, toolNames: deniedTools }
 }
 
+function normalizeResumeTriggerType(triggerType: string | undefined): 'message' | 'scheduled' {
+  return triggerType === 'scheduled' ? 'scheduled' : 'message'
+}
+
 /**
  * Admin Web 对话的 master Friend 常量。channel_identities 不参与 admin chat 流程，
  * created_at / updated_at 用零值——master 没有真实账户创建时刻语义。
@@ -127,6 +132,7 @@ export class UnifiedAgent extends ModuleBase {
   private permissionChecker: PermissionChecker
   private workerSelector: WorkerSelector
   private contextAssembler: ContextAssembler
+  private agentLoopSubstrate: AgentLoopSubstrate
   private scheduledTaskRunner: ScheduledTaskRunner
   private memoryWriter: MemoryWriter
   private attentionScheduler: AttentionScheduler
@@ -255,12 +261,13 @@ export class UnifiedAgent extends ModuleBase {
       config.module_id,
       async () => await this.getMemoryPort()
     )
+    this.agentLoopSubstrate = new AgentLoopSubstrate((params) => this.handleExecuteTask(params))
     this.scheduledTaskRunner = new ScheduledTaskRunner(
       this.rpcClient,
       config.module_id,
       this.memoryWriter,
       async () => await this.getAdminPort(),
-      (params) => this.handleExecuteTask(params),
+      this.agentLoopSubstrate,
     )
 
     // 初始化群聊注意力调度（从 extra 读取配置，fallback 到协议默认值）
@@ -349,6 +356,7 @@ export class UnifiedAgent extends ModuleBase {
         this.agentHandler = this.createWorkerHandler(
           this.sdkEnvWorker, workerPersonality,
           createMcpConfigs, config.builtin_tool_config, config.skills)
+        this.agentLoopSubstrate.setWorkerHandler(this.agentHandler)
         this.scheduledTaskRunner.setWorkerHandler(this.agentHandler)
         // 让 ContextAssembler 同进程同步读取 worker 实时快照（用于 Front 汇报进度）
         this.contextAssembler.setLiveSnapshotProvider(
@@ -2021,7 +2029,7 @@ export class UnifiedAgent extends ModuleBase {
               channel_id?: string
               session_id?: string
               friend_id?: string
-              trigger_type: string
+              trigger_type?: string
             }
           }
         }
@@ -2055,25 +2063,49 @@ export class UnifiedAgent extends ModuleBase {
         ...(wc?.scene_profile ? { scene_profile: wc.scene_profile } : {}),
       }
 
-      this.scheduledTaskRunner.executeScheduledTaskInBackground(
-        {
-          id: task.id,
-          title: task.title,
+      const triggerType = normalizeResumeTriggerType(task.source?.trigger_type)
+      const taskSource = {
+        ...(task.source ?? {}),
+        trigger_type: triggerType,
+      }
+      const taskPayload: ExecuteTaskParams & { related_task_id?: string } = {
+        task: {
+          task_id: task.id,
+          task_title: task.title,
           priority: task.priority,
           plan: task.plan,
+          source: taskSource,
         },
-        resumedContext,
-        {
-          resumeFrom: {
-            initialMessages: [...entry.checkpoint.messages],
-            todoItems: entry.checkpoint.worker_state.todo_items,
-            goalRevisionUnlocked: entry.checkpoint.worker_state.goal_revision_unlocked,
-            cwd: entry.checkpoint.worker_state.cwd,
-            humanInputEpoch: entry.checkpoint.worker_state.human_input_epoch,
-            lastDeliveredInfoEpoch: entry.checkpoint.worker_state.last_delivered_info_epoch,
-            ...(mode === 'terminal_supplement' ? { resumeTraceId: entry.traceId } : {}),
-            ...(params.terminalSupplementText !== undefined ? { terminalSupplementText: params.terminalSupplementText } : {}),
-          },
+        context: resumedContext,
+        related_task_id: task.id,
+        resumeFrom: {
+          initialMessages: [...entry.checkpoint.messages],
+          todoItems: entry.checkpoint.worker_state.todo_items,
+          goalRevisionUnlocked: entry.checkpoint.worker_state.goal_revision_unlocked,
+          cwd: entry.checkpoint.worker_state.cwd,
+          humanInputEpoch: entry.checkpoint.worker_state.human_input_epoch,
+          lastDeliveredInfoEpoch: entry.checkpoint.worker_state.last_delivered_info_epoch,
+          ...(mode === 'terminal_supplement' ? { resumeTraceId: entry.traceId } : {}),
+          ...(params.terminalSupplementText !== undefined ? { terminalSupplementText: params.terminalSupplementText } : {}),
+        },
+      }
+
+      this.agentLoopSubstrate.executeAgentLoopInBackground(
+        taskPayload,
+        `resume task ${task.id}`,
+        async (error) => {
+          const msg = error instanceof Error ? error.message : String(error)
+          try {
+            await this.rpcClient.call(
+              adminPort,
+              'update_task_status',
+              { task_id: task.id, status: 'failed', error: msg },
+              this.config.moduleId,
+            )
+          } catch (updateError) {
+            const updateMsg = updateError instanceof Error ? updateError.message : String(updateError)
+            console.error(`[${this.config.moduleId}] Failed to mark resumed task ${task.id} failed: ${updateMsg}`)
+          }
         },
       )
       // 不再 consumeResumableCheckpoint（那会 finalize 旧 trace + 另起新 trace = 一个 task 两条
@@ -2452,6 +2484,7 @@ export class UnifiedAgent extends ModuleBase {
           this.agentHandler = this.createWorkerHandler(
             newWorkerSdkEnv, workerPersonality,
             createMcpConfigs, this.agentConfig?.builtin_tool_config, this.agentConfig?.skills)
+          this.agentLoopSubstrate.setWorkerHandler(this.agentHandler)
           this.scheduledTaskRunner.setWorkerHandler(this.agentHandler)
           console.log(`[${this.config.moduleId}] Worker Agent SDK env created from config push`)
         }

--- a/crabot-agent/tests/agent/agent-handler.test.ts
+++ b/crabot-agent/tests/agent/agent-handler.test.ts
@@ -28,7 +28,7 @@ vi.mock('../../src/engine/index.js', async (importOriginal) => {
 import { runEngine } from '../../src/engine/index.js'
 const mockRunEngine = vi.mocked(runEngine)
 
-function makeHandler() {
+function makeHandler(options?: ConstructorParameters<typeof AgentHandler>[2]) {
   const sdkEnv = {
     modelId: 'test-model',
     format: 'anthropic' as const,
@@ -40,7 +40,7 @@ function makeHandler() {
   const config = {
     systemPrompt: 'You are a helpful worker.',
   }
-  return new AgentHandler(sdkEnv, config)
+  return new AgentHandler(sdkEnv, config, options)
 }
 
 function makeMessagingHandler(rpcCall: ReturnType<typeof vi.fn>) {
@@ -158,6 +158,49 @@ describe('AgentHandler', () => {
 
       expect(result.task_id).toBe('task_1')
       expect(result.outcome).toBe('failed')
+    })
+
+    it('does not write task memory for failed engine outcomes', async () => {
+      mockRunEngine.mockResolvedValue(makeEngineResult({
+        outcome: 'failed',
+        finalText: 'API error',
+        error: 'API error',
+      }))
+      const rpcCall = vi.fn().mockResolvedValue({ task: {} })
+      const memoryWriter = {
+        writeTaskFinished: vi.fn().mockResolvedValue(undefined),
+        quickCapture: vi.fn().mockResolvedValue(undefined),
+      }
+
+      const handler = makeHandler({
+        deps: {
+          rpcClient: { call: rpcCall } as never,
+          moduleId: 'agent-test',
+          getAdminPort: async () => 3001,
+        },
+        memoryWriter: memoryWriter as never,
+      })
+
+      const result = await handler.executeTask({
+        task: makeTask({ task_id: 'task_1' }),
+        context: makeContext(),
+      })
+
+      expect(result.outcome).toBe('failed')
+      expect(rpcCall).toHaveBeenCalledWith(
+        3001,
+        'update_task_status',
+        expect.objectContaining({ task_id: 'task_1', status: 'failed' }),
+        'agent-test',
+      )
+      expect(rpcCall).toHaveBeenCalledWith(
+        3001,
+        'update_task_outcome',
+        expect.objectContaining({ task_id: 'task_1', outcome_brief: 'API error' }),
+        'agent-test',
+      )
+      expect(memoryWriter.writeTaskFinished).not.toHaveBeenCalled()
+      expect(memoryWriter.quickCapture).not.toHaveBeenCalled()
     })
 
     it('should call runEngine with correct parameters', async () => {

--- a/crabot-agent/tests/agent/agent-handler.test.ts
+++ b/crabot-agent/tests/agent/agent-handler.test.ts
@@ -620,7 +620,7 @@ describe('AgentHandler', () => {
       })
 
       await handler.executeTask({
-        task: makeTask({ source: { trigger_type: 'message' } as never }),
+        task: makeTask({ source: { trigger_type: 'message' } }),
         context: {
           ...makeContext(),
           task_origin: {
@@ -688,7 +688,7 @@ describe('AgentHandler', () => {
       } as never
 
       const result = await handler.executeTask({
-        task: makeTask({ source: { trigger_type: 'message' } as never }),
+        task: makeTask({ source: { trigger_type: 'message' } }),
         context: makeContext(),
       }, traceCallback)
 
@@ -727,7 +727,7 @@ describe('AgentHandler', () => {
       const handler = makeMessagingHandler(rpcCall)
 
       await handler.executeTask({
-        task: makeTask({ source: { trigger_type: 'message' } as never }),
+        task: makeTask({ source: { trigger_type: 'message' } }),
         context: {
           ...makeContext(),
           task_origin: {
@@ -1041,6 +1041,99 @@ describe('AgentHandler', () => {
       const callArgs = mockRunEngine.mock.calls[0][0]
       const gateResult = await callArgs.options.endTurnGate()
       expect(gateResult).toBe(GOAL_MODE_NO_DELIVERY_PROMPT)
+    })
+
+    it('resumed message task with goal keeps human no-delivery gate active', async () => {
+      mockRunEngine.mockImplementation(async () => {
+        await new Promise(resolve => setTimeout(resolve, 20))
+        return makeEngineResult()
+      })
+      const rpcCall = vi.fn().mockResolvedValue({
+        task: { id: 'task_1', goal: { objective: 'finish current user request' } },
+      })
+      const handler = new AgentHandler(
+        {
+          modelId: 'test-model',
+          format: 'anthropic' as const,
+          env: { ANTHROPIC_BASE_URL: 'http://localhost:4000', ANTHROPIC_API_KEY: 'test-key' },
+        },
+        { systemPrompt: 'You are a helpful worker.' },
+        {
+          deps: {
+            rpcClient: { call: rpcCall } as never,
+            moduleId: 'agent-test',
+            resolveChannelPort: async () => 3003,
+            getAdminPort: async () => 3001,
+            getMemoryPort: async () => 3002,
+          },
+        },
+      )
+      await handler.executeTask({
+        task: makeTask({
+          source: { trigger_type: 'message' },
+        }),
+        context: makeContext(),
+        resumeFrom: {
+          initialMessages: [{ id: 'm1', role: 'user', content: 'resume me', timestamp: 1 }] as never,
+          todoItems: [],
+          humanInputEpoch: 31,
+          lastDeliveredInfoEpoch: 23,
+        },
+      })
+
+      const callArgs = mockRunEngine.mock.calls[0][0]
+      expect(callArgs.options.suppressForcedSummary()).toBe(false)
+      expect(callArgs.options.endTurnGate).toBeDefined()
+      const gateResult = await callArgs.options.endTurnGate()
+      expect(gateResult).toBe(GOAL_MODE_NO_DELIVERY_PROMPT)
+      handler.dispose()
+    })
+
+    it('resumed scheduled task suppresses forced summary and skips human no-delivery gate', async () => {
+      mockRunEngine.mockImplementation(async () => {
+        await new Promise(resolve => setTimeout(resolve, 20))
+        return makeEngineResult()
+      })
+      const rpcCall = vi.fn().mockResolvedValue({
+        task: { id: 'task_1', goal: { objective: 'finish scheduled task' } },
+      })
+      const handler = new AgentHandler(
+        {
+          modelId: 'test-model',
+          format: 'anthropic' as const,
+          env: { ANTHROPIC_BASE_URL: 'http://localhost:4000', ANTHROPIC_API_KEY: 'test-key' },
+        },
+        { systemPrompt: 'You are a helpful worker.' },
+        {
+          deps: {
+            rpcClient: { call: rpcCall } as never,
+            moduleId: 'agent-test',
+            resolveChannelPort: async () => 3003,
+            getAdminPort: async () => 3001,
+            getMemoryPort: async () => 3002,
+          },
+        },
+      )
+      await handler.executeTask({
+        task: makeTask({
+          source: { trigger_type: 'scheduled' },
+        }),
+        context: makeContext(),
+        resumeFrom: {
+          initialMessages: [{ id: 'm1', role: 'user', content: 'resume me', timestamp: 1 }] as never,
+          todoItems: [],
+          humanInputEpoch: 31,
+          lastDeliveredInfoEpoch: 23,
+        },
+      })
+
+      const callArgs = mockRunEngine.mock.calls[0][0]
+      expect(callArgs.options.suppressForcedSummary()).toBe(true)
+      if (callArgs.options.endTurnGate) {
+        const gateResult = await callArgs.options.endTurnGate()
+        expect(gateResult).toBeNull()
+      }
+      handler.dispose()
     })
   })
 

--- a/crabot-agent/tests/mcp/crab-messaging-send-master-private.test.ts
+++ b/crabot-agent/tests/mcp/crab-messaging-send-master-private.test.ts
@@ -71,12 +71,26 @@ describe('daily_reflection task messaging tool whitelist', () => {
 
     expect(findTool(tools, 'send_message')).toBeDefined()
     expect(findTool(tools, 'send_private_message')).toBeDefined()
+    expect(findTool(tools, 'send_master_private')).toBeDefined()
     expect(findTool(tools, 'lookup_friend')).toBeDefined()
     expect(findTool(tools, 'list_groups')).toBeDefined()
     expect(findTool(tools, 'list_sessions')).toBeDefined()
   })
 
-  it('message 触发的任务保留全部工具', () => {
+  it('无 task context 的非 worker/front 场景不被误过滤', () => {
+    const tools = buildMessagingTools({
+      rpcClient: { call: vi.fn() } as never,
+      moduleId: 'front',
+      getAdminPort: async () => 19001,
+      resolveChannelPort: async () => 19009,
+    })
+
+    expect(findTool(tools, 'send_master_private')).toBeDefined()
+    expect(findTool(tools, 'send_message')).toBeDefined()
+    expect(findTool(tools, 'send_private_message')).toBeDefined()
+  })
+
+  it('message 触发的任务不暴露 send_master_private', () => {
     const tools = buildMessagingTools({
       rpcClient: { call: vi.fn() } as never,
       moduleId: 'worker',
@@ -92,7 +106,7 @@ describe('daily_reflection task messaging tool whitelist', () => {
 
     expect(findTool(tools, 'send_message')).toBeDefined()
     expect(findTool(tools, 'send_private_message')).toBeDefined()
-    expect(findTool(tools, 'send_master_private')).toBeDefined()
+    expect(findTool(tools, 'send_master_private')).toBeUndefined()
     expect(findTool(tools, 'lookup_friend')).toBeDefined()
     expect(findTool(tools, 'list_sessions')).toBeDefined()
   })

--- a/crabot-agent/tests/orchestration/memory-writer.test.ts
+++ b/crabot-agent/tests/orchestration/memory-writer.test.ts
@@ -198,7 +198,7 @@ describe('writeTaskFinished — Phase 2 structured content', () => {
     expect(content).toMatch(/- GitHub API 403/)
   })
 
-  it('outcome failed 时 content 用"失败"措辞', async () => {
+  it('outcome failed 时不写 task_finished 记忆', async () => {
     const calls: any[] = []
     const rpcClient = { call: vi.fn((_p, _m, payload) => { calls.push(payload); return Promise.resolve({}) }) } as any
     const writer = new MemoryWriter(rpcClient, 'agent-test', () => 19002)
@@ -217,6 +217,6 @@ describe('writeTaskFinished — Phase 2 structured content', () => {
       scopes: [],
     })
 
-    expect(calls[0].content).toMatch(/^任务 t-3（失败任务）失败：API 限流/)
+    expect(calls).toHaveLength(0)
   })
 })

--- a/crabot-agent/tests/orchestration/scheduled-task-runner.test.ts
+++ b/crabot-agent/tests/orchestration/scheduled-task-runner.test.ts
@@ -7,6 +7,7 @@
  */
 
 import { describe, it, expect, vi } from 'vitest'
+import { AgentLoopSubstrate } from '../../src/orchestration/agent-loop-substrate.js'
 import { ScheduledTaskRunner } from '../../src/orchestration/scheduled-task-runner.js'
 import { MemoryWriter } from '../../src/orchestration/memory-writer.js'
 import type {
@@ -37,13 +38,14 @@ function setupRunner() {
     task_id: 'task-x' as any,
     outcome: 'completed' as const,
   })
+  const substrate = new AgentLoopSubstrate(executeTaskFn as never)
 
   const runner = new ScheduledTaskRunner(
     rpcClient,
     'agent-1',
     memoryWriter,
     () => 18000,
-    executeTaskFn,
+    substrate,
   )
 
   return { runner, executeTaskFn, rpcCall }

--- a/crabot-agent/tests/orchestration/scheduled-task-runner.test.ts
+++ b/crabot-agent/tests/orchestration/scheduled-task-runner.test.ts
@@ -30,11 +30,14 @@ function makeWorkerContext(): WorkerAgentContext {
 }
 
 /** Common harness: 拦截 update_task_status RPC + 捕获 executeTaskFn 收到的 payload */
-function setupRunner() {
+function setupRunner(opts?: {
+  executeTaskFn?: ReturnType<typeof vi.fn>
+  memoryWriter?: Pick<MemoryWriter, 'writeTaskFinished' | 'quickCapture' | 'runMaintenance'>
+}) {
   const rpcCall = vi.fn().mockResolvedValue({ data: { status: 'ok' } })
   const rpcClient: any = { call: rpcCall }
-  const memoryWriter = new MemoryWriter(rpcClient, 'agent-1', () => 18000)
-  const executeTaskFn = vi.fn().mockResolvedValue({
+  const memoryWriter = opts?.memoryWriter ?? new MemoryWriter(rpcClient, 'agent-1', () => 18000)
+  const executeTaskFn = opts?.executeTaskFn ?? vi.fn().mockResolvedValue({
     task_id: 'task-x' as any,
     outcome: 'completed' as const,
   })
@@ -243,5 +246,50 @@ describe('ScheduledTaskRunner — M3: resumeFrom 时跳过 planning/executing �
     const statuses = statusCalls.map((c: unknown[]) => (c[2] as { status?: string }).status)
     expect(statuses).toContain('planning')
     expect(statuses).toContain('executing')
+  })
+})
+
+describe('ScheduledTaskRunner — failed worker loop memory boundary', () => {
+  it('worker crash only marks scheduled task failed and does not write failure memory', async () => {
+    const executeTaskFn = vi.fn().mockRejectedValue(new Error('worker crashed'))
+    const memoryWriter = {
+      writeTaskFinished: vi.fn().mockResolvedValue(undefined),
+      quickCapture: vi.fn().mockResolvedValue(undefined),
+      runMaintenance: vi.fn().mockResolvedValue(undefined),
+    }
+    const { runner, rpcCall } = setupRunner({ executeTaskFn, memoryWriter })
+
+    runner.executeScheduledTaskInBackground(
+      {
+        id: 'task-crash',
+        title: '崩溃任务',
+        description: '会崩',
+        priority: 'normal',
+      },
+      makeWorkerContext(),
+    )
+
+    await waitForExecute(executeTaskFn)
+    for (let i = 0; i < 50; i++) {
+      const failedCall = rpcCall.mock.calls.find((c: unknown[]) => {
+        const body = c[2] as { task_id?: string; status?: string }
+        return c[1] === 'update_task_status' && body.task_id === 'task-crash' && body.status === 'failed'
+      })
+      if (failedCall) break
+      await new Promise(r => setTimeout(r, 10))
+    }
+
+    expect(rpcCall).toHaveBeenCalledWith(
+      18000,
+      'update_task_status',
+      expect.objectContaining({
+        task_id: 'task-crash',
+        status: 'failed',
+        error: 'worker crashed',
+      }),
+      'agent-1',
+    )
+    expect(memoryWriter.writeTaskFinished).not.toHaveBeenCalled()
+    expect(memoryWriter.quickCapture).not.toHaveBeenCalled()
   })
 })

--- a/crabot-agent/tests/unified-agent-resume-task.test.ts
+++ b/crabot-agent/tests/unified-agent-resume-task.test.ts
@@ -8,6 +8,15 @@
 import { describe, it, expect, vi } from 'vitest'
 import { UnifiedAgent } from '../src/unified-agent.js'
 import { AGENT_VERSION } from '../src/constants.js'
+import { AgentLoopSubstrate } from '../src/orchestration/agent-loop-substrate.js'
+
+async function waitFor(condition: () => boolean): Promise<void> {
+  for (let i = 0; i < 50; i++) {
+    if (condition()) return
+    await new Promise(resolve => setTimeout(resolve, 10))
+  }
+  throw new Error('condition was not met within 500ms')
+}
 
 /** 构造最小可调用的 handleResumeTask 宿主对象（原型绕过） */
 function buildAgent(deps: {
@@ -18,7 +27,8 @@ function buildAgent(deps: {
   isResumableOk?: boolean
   rpcCallResult?: unknown
   assembleScheduledTaskContextResult?: unknown
-  executeScheduledTaskInBackground?: ReturnType<typeof vi.fn>
+  executeAgentLoopInBackground?: ReturnType<typeof vi.fn>
+  agentLoopSubstrate?: { executeAgentLoopInBackground: (...args: never[]) => void }
   rpcCallError?: Error
   assembleError?: Error
 }) {
@@ -45,27 +55,32 @@ function buildAgent(deps: {
   }
 
   // rpcClient stub
+  const defaultGetTaskResult = deps.rpcCallResult ?? {
+    task: {
+      id: 'task-1',
+      title: '测试任务',
+      description: '描述',
+      priority: 'normal',
+      source: {
+        origin: 'human',
+        channel_id: 'wechat-x',
+        session_id: 'sess-y',
+        friend_id: 'friend-z',
+        trigger_type: 'message',
+      },
+    },
+  }
+  let rpcCall: ReturnType<typeof vi.fn>
   if (deps.rpcCallError) {
-    agent.rpcClient = { call: vi.fn().mockRejectedValue(deps.rpcCallError) }
+    rpcCall = vi.fn().mockRejectedValue(deps.rpcCallError)
+    agent.rpcClient = { call: rpcCall }
   } else {
+    rpcCall = vi.fn().mockImplementation((_port: number, method: string) => {
+      if (method === 'get_task') return Promise.resolve(defaultGetTaskResult)
+      return Promise.resolve({ ok: true })
+    })
     agent.rpcClient = {
-      call: vi.fn().mockResolvedValue(
-        deps.rpcCallResult ?? {
-          task: {
-            id: 'task-1',
-            title: '测试任务',
-            description: '描述',
-            priority: 'normal',
-            source: {
-              origin: 'human',
-              channel_id: 'wechat-x',
-              session_id: 'sess-y',
-              friend_id: 'friend-z',
-              trigger_type: 'message',
-            },
-          },
-        }
-      ),
+      call: rpcCall,
     }
   }
 
@@ -90,9 +105,9 @@ function buildAgent(deps: {
     }
   }
 
-  // scheduledTaskRunner stub
-  const executeScheduledTaskInBackground = deps.executeScheduledTaskInBackground ?? vi.fn()
-  agent.scheduledTaskRunner = { executeScheduledTaskInBackground }
+  // agentLoopSubstrate stub
+  const executeAgentLoopInBackground = deps.executeAgentLoopInBackground ?? vi.fn()
+  agent.agentLoopSubstrate = deps.agentLoopSubstrate ?? { executeAgentLoopInBackground }
 
   // getAdminPort
   agent.getAdminPort = vi.fn().mockResolvedValue(18000)
@@ -108,7 +123,8 @@ function buildAgent(deps: {
         sessionId: string
       ) => Promise<{ outcome: 'revived'; traceId?: string } | { outcome: 'fallback'; reason?: string }>
     },
-    executeScheduledTaskInBackground,
+    executeAgentLoopInBackground,
+    rpcCall,
     consumeResumableCheckpoint,
     finalizeUnresumedCheckpoint,
     traceStore: agent.traceStore as {
@@ -122,32 +138,57 @@ function buildAgent(deps: {
 
 describe('UnifiedAgent.handleResumeTask — I1: task_origin 从 task.source 重建', () => {
   it('returns not_configured instead of claiming resumed when worker handler is not ready', async () => {
-    const { agent, executeScheduledTaskInBackground, finalizeUnresumedCheckpoint } = buildAgent({})
+    const { agent, executeAgentLoopInBackground, finalizeUnresumedCheckpoint } = buildAgent({})
 
     const result = await agent.handleResumeTask({ task_id: 'task-1' })
 
     expect(result).toEqual({ resumed: false, reason: 'not_configured' })
-    expect(executeScheduledTaskInBackground).not.toHaveBeenCalled()
+    expect(executeAgentLoopInBackground).not.toHaveBeenCalled()
     expect(finalizeUnresumedCheckpoint).not.toHaveBeenCalled()
   })
 
   it('human 来源：task_origin.channel_id/session_id/friend_id 与 task.source 一致', async () => {
-    const { agent, executeScheduledTaskInBackground } = buildAgent({})
+    const { agent, executeAgentLoopInBackground } = buildAgent({})
     ;(agent as unknown as { agentHandler: { hasActiveTask: () => boolean } }).agentHandler = { hasActiveTask: () => false }
 
     const result = await agent.handleResumeTask({ task_id: 'task-1' })
 
     expect(result.resumed).toBe(true)
-    expect(executeScheduledTaskInBackground).toHaveBeenCalledOnce()
+    expect(executeAgentLoopInBackground).toHaveBeenCalledOnce()
 
-    const [, workerContext] = executeScheduledTaskInBackground.mock.calls[0] as [unknown, { task_origin?: { channel_id: string; session_id: string; friend_id?: string } }]
+    const [payload] = executeAgentLoopInBackground.mock.calls[0] as [{
+      context: { task_origin?: { channel_id: string; session_id: string; friend_id?: string } }
+    }]
+    const workerContext = payload.context
     expect(workerContext.task_origin?.channel_id).toBe('wechat-x')
     expect(workerContext.task_origin?.session_id).toBe('sess-y')
     expect(workerContext.task_origin?.friend_id).toBe('friend-z')
   })
 
+  it('restart resume human task: executes worker loop with source.trigger_type=message, never scheduled', async () => {
+    const { agent, executeAgentLoopInBackground } = buildAgent({})
+    ;(agent as unknown as { agentHandler: { hasActiveTask: () => boolean } }).agentHandler = { hasActiveTask: () => false }
+
+    const result = await agent.handleResumeTask({ task_id: 'task-1' })
+
+    expect(result.resumed).toBe(true)
+    expect(executeAgentLoopInBackground).toHaveBeenCalledOnce()
+    const [payload] = executeAgentLoopInBackground.mock.calls[0] as [{
+      task: { source?: { trigger_type?: string } }
+      context: { task_origin?: { channel_id: string; session_id: string; friend_id?: string } }
+      resumeFrom?: { initialMessages?: unknown[] }
+    }]
+    expect(payload.task.source?.trigger_type).toBe('message')
+    expect(payload.context.task_origin).toEqual({
+      channel_id: 'wechat-x',
+      session_id: 'sess-y',
+      friend_id: 'friend-z',
+    })
+    expect(payload.resumeFrom?.initialMessages).toHaveLength(1)
+  })
+
   it('system 来源（无 channel_id）：task_origin 为 undefined，用 system session 兜底', async () => {
-    const { agent, executeScheduledTaskInBackground } = buildAgent({
+    const { agent, executeAgentLoopInBackground } = buildAgent({
       rpcCallResult: {
         task: {
           id: 'task-2',
@@ -166,12 +207,12 @@ describe('UnifiedAgent.handleResumeTask — I1: task_origin 从 task.source 重�
     const result = await agent.handleResumeTask({ task_id: 'task-2' })
 
     expect(result.resumed).toBe(true)
-    const [, workerContext] = executeScheduledTaskInBackground.mock.calls[0] as [unknown, { task_origin?: unknown }]
-    expect(workerContext.task_origin).toBeUndefined()
+    const [payload] = executeAgentLoopInBackground.mock.calls[0] as [{ context: { task_origin?: unknown } }]
+    expect(payload.context.task_origin).toBeUndefined()
   })
 
   it('source 字段缺失时：task_origin 为 undefined', async () => {
-    const { agent, executeScheduledTaskInBackground } = buildAgent({
+    const { agent, executeAgentLoopInBackground } = buildAgent({
       rpcCallResult: {
         task: {
           id: 'task-3',
@@ -186,8 +227,8 @@ describe('UnifiedAgent.handleResumeTask — I1: task_origin 从 task.source 重�
     const result = await agent.handleResumeTask({ task_id: 'task-3' })
 
     expect(result.resumed).toBe(true)
-    const [, workerContext] = executeScheduledTaskInBackground.mock.calls[0] as [unknown, { task_origin?: unknown }]
-    expect(workerContext.task_origin).toBeUndefined()
+    const [payload] = executeAgentLoopInBackground.mock.calls[0] as [{ context: { task_origin?: unknown } }]
+    expect(payload.context.task_origin).toBeUndefined()
   })
 
   it('成功 resume 后不 finalize 旧 trace（改由 handleExecuteTask 的 reactivate 复用续写，一个 task 一条连续 trace）', async () => {
@@ -202,8 +243,33 @@ describe('UnifiedAgent.handleResumeTask — I1: task_origin 从 task.source 重�
     expect(consumeResumableCheckpoint).not.toHaveBeenCalled()
   })
 
+  it('background worker loop reject 时：把 resumed task 标记为 failed，不 consume checkpoint', async () => {
+    const executeTaskFn = vi.fn().mockRejectedValue(new Error('worker crashed after resume'))
+    const substrate = new AgentLoopSubstrate(executeTaskFn as never)
+    const { agent, rpcCall, consumeResumableCheckpoint } = buildAgent({
+      agentLoopSubstrate: substrate,
+    })
+    ;(agent as unknown as { agentHandler: { hasActiveTask: () => boolean } }).agentHandler = { hasActiveTask: () => false }
+
+    const result = await agent.handleResumeTask({ task_id: 'task-1' })
+
+    expect(result.resumed).toBe(true)
+    await waitFor(() => rpcCall.mock.calls.some((call: unknown[]) => call[1] === 'update_task_status'))
+    expect(rpcCall).toHaveBeenCalledWith(
+      18000,
+      'update_task_status',
+      {
+        task_id: 'task-1',
+        status: 'failed',
+        error: 'worker crashed after resume',
+      },
+      'test-agent',
+    )
+    expect(consumeResumableCheckpoint).not.toHaveBeenCalled()
+  })
+
   it('restart resume 不携带历史 trace id，继续由 resumable checkpoint 复用 running trace', async () => {
-    const { agent, executeScheduledTaskInBackground } = buildAgent({
+    const { agent, executeAgentLoopInBackground } = buildAgent({
       getResumableCheckpoint: vi.fn().mockReturnValue({
         traceId: 'trace-running',
         checkpoint: {
@@ -219,17 +285,15 @@ describe('UnifiedAgent.handleResumeTask — I1: task_origin 从 task.source 重�
     const result = await agent.handleResumeTask({ task_id: 'task-1' })
 
     expect(result.resumed).toBe(true)
-    const [, , options] = executeScheduledTaskInBackground.mock.calls[0] as [
-      unknown,
-      unknown,
-      { resumeFrom?: { terminalSupplementText?: string; resumeTraceId?: string } },
-    ]
-    expect(options.resumeFrom?.terminalSupplementText).toBeUndefined()
-    expect(options.resumeFrom?.resumeTraceId).toBeUndefined()
+    const [payload] = executeAgentLoopInBackground.mock.calls[0] as [{
+      resumeFrom?: { terminalSupplementText?: string; resumeTraceId?: string }
+    }]
+    expect(payload.resumeFrom?.terminalSupplementText).toBeUndefined()
+    expect(payload.resumeFrom?.resumeTraceId).toBeUndefined()
   })
 
   it('restart resume 从 checkpoint worker_state 传递 humanInputEpoch 和 lastDeliveredInfoEpoch', async () => {
-    const { agent, executeScheduledTaskInBackground } = buildAgent({
+    const { agent, executeAgentLoopInBackground } = buildAgent({
       getResumableCheckpoint: vi.fn().mockReturnValue({
         traceId: 'trace-running',
         checkpoint: {
@@ -245,19 +309,37 @@ describe('UnifiedAgent.handleResumeTask — I1: task_origin 从 task.source 重�
     const result = await agent.handleResumeTask({ task_id: 'task-1' })
 
     expect(result.resumed).toBe(true)
-    const [, , options] = executeScheduledTaskInBackground.mock.calls[0] as [
-      unknown,
-      unknown,
-      { resumeFrom?: { humanInputEpoch?: number; lastDeliveredInfoEpoch?: number } },
-    ]
-    expect(options.resumeFrom?.humanInputEpoch).toBe(1)
-    expect(options.resumeFrom?.lastDeliveredInfoEpoch).toBe(0)
+    const [payload] = executeAgentLoopInBackground.mock.calls[0] as [{
+      resumeFrom?: { humanInputEpoch?: number; lastDeliveredInfoEpoch?: number }
+    }]
+    expect(payload.resumeFrom?.humanInputEpoch).toBe(1)
+    expect(payload.resumeFrom?.lastDeliveredInfoEpoch).toBe(0)
+  })
+
+  it('restart resume scheduled task: preserves scheduled source instead of forcing message', async () => {
+    const { agent, executeAgentLoopInBackground } = buildAgent({
+      rpcCallResult: {
+        task: {
+          id: 'task-scheduled',
+          title: '系统巡检',
+          priority: 'normal',
+          source: { origin: 'system', trigger_type: 'scheduled' },
+        },
+      },
+    })
+    ;(agent as unknown as { agentHandler: { hasActiveTask: () => boolean } }).agentHandler = { hasActiveTask: () => false }
+
+    const result = await agent.handleResumeTask({ task_id: 'task-scheduled' })
+
+    expect(result.resumed).toBe(true)
+    const [payload] = executeAgentLoopInBackground.mock.calls[0] as [{ task: { source?: { trigger_type?: string } } }]
+    expect(payload.task.source?.trigger_type).toBe('scheduled')
   })
 })
 
 describe('UnifiedAgent.handleResumeTaskWithSupplement', () => {
   it('schedules background execution with terminalSupplementText in resumeFrom', async () => {
-    const { agent, executeScheduledTaskInBackground } = buildAgent({
+    const { agent, executeAgentLoopInBackground } = buildAgent({
       findLatestResumeCheckpointByTaskId: vi.fn().mockReturnValue({
         traceId: 'trace-completed',
         checkpoint: {
@@ -277,15 +359,50 @@ describe('UnifiedAgent.handleResumeTaskWithSupplement', () => {
     })
 
     expect(result.resumed).toBe(true)
-    expect(executeScheduledTaskInBackground).toHaveBeenCalledOnce()
+    expect(executeAgentLoopInBackground).toHaveBeenCalledOnce()
 
-    const [, , options] = executeScheduledTaskInBackground.mock.calls[0] as [
-      unknown,
-      unknown,
-      { resumeFrom?: { terminalSupplementText?: string; resumeTraceId?: string } },
-    ]
-    expect(options.resumeFrom?.terminalSupplementText).toBe('继续刚才失败的任务')
-    expect(options.resumeFrom?.resumeTraceId).toBe('trace-completed')
+    const [payload] = executeAgentLoopInBackground.mock.calls[0] as [{
+      resumeFrom?: { terminalSupplementText?: string; resumeTraceId?: string }
+    }]
+    expect(payload.resumeFrom?.terminalSupplementText).toBe('继续刚才失败的任务')
+    expect(payload.resumeFrom?.resumeTraceId).toBe('trace-completed')
+  })
+
+  it('terminal supplement revive human task: executes worker loop as message with terminal supplement resume data', async () => {
+    const { agent, executeAgentLoopInBackground } = buildAgent({
+      findLatestResumeCheckpointByTaskId: vi.fn().mockReturnValue({
+        traceId: 'trace-completed',
+        checkpoint: {
+          agent_version: AGENT_VERSION,
+          messages: [{ id: 'm-history', role: 'user', content: 'history', timestamp: 1 }],
+          worker_state: { todo_items: [], human_input_epoch: 31, last_delivered_info_epoch: 23 },
+          system_prompt: 'SP-history',
+        },
+      }),
+      getResumableCheckpoint: vi.fn().mockReturnValue(undefined),
+    })
+    ;(agent as unknown as { agentHandler: { hasActiveTask: () => boolean } }).agentHandler = { hasActiveTask: () => false }
+
+    const result = await agent.handleResumeTaskWithSupplement({
+      task_id: 'task-1',
+      supplement_text: '继续刚才失败的任务',
+    })
+
+    expect(result.resumed).toBe(true)
+    const [payload] = executeAgentLoopInBackground.mock.calls[0] as [{
+      task: { source?: { trigger_type?: string } }
+      resumeFrom?: {
+        terminalSupplementText?: string
+        resumeTraceId?: string
+        humanInputEpoch?: number
+        lastDeliveredInfoEpoch?: number
+      }
+    }]
+    expect(payload.task.source?.trigger_type).toBe('message')
+    expect(payload.resumeFrom?.terminalSupplementText).toBe('继续刚才失败的任务')
+    expect(payload.resumeFrom?.resumeTraceId).toBe('trace-completed')
+    expect(payload.resumeFrom?.humanInputEpoch).toBe(31)
+    expect(payload.resumeFrom?.lastDeliveredInfoEpoch).toBe(23)
   })
 })
 


### PR DESCRIPTION
## Summary

- Replace the resume/revive dependency on `ScheduledTaskRunner` with a neutral `AgentLoopSubstrate` so resumed human tasks keep `source.trigger_type='message'`.
- Preserve scheduled semantics for real scheduled tasks, including system_event trigger construction and silent completion behavior.
- Hide `send_master_private` from human message tasks while keeping it available for scheduled/system and daily_reflection scenarios.

## Root Cause

`resume_task` / terminal supplement revive reused `ScheduledTaskRunner.executeScheduledTaskInBackground()`, which hardcoded `source.trigger_type='scheduled'`. A revived human task could therefore run as scheduled, disabling goal/end-turn delivery gates and allowing an empty `end_turn` to complete without replying.

## Validation

- `cd crabot-agent && ./node_modules/.bin/vitest run tests/unified-agent-resume-task.test.ts tests/orchestration/scheduled-task-runner.test.ts tests/agent/agent-handler.test.ts tests/engine/query-loop.test.ts tests/engine/query-loop-end-turn-supplement.test.ts tests/mcp/crab-messaging-send-master-private.test.ts tests/mcp/crab-messaging-ask-human.test.ts tests/mcp/crab-messaging-system-session.test.ts` - 143 tests passed.
- `cd crabot-agent && ./node_modules/.bin/tsc --noEmit` - passed.
- `./dev.sh build` - exit 0 after installing missing worktree-local `crabot-shared` deps; backend modules including `crabot-agent` built and `crabot-agent/dist` contains the new substrate/messaging code. The worktree still printed an Admin Web `tsc: command not found` line because `crabot-admin/web/node_modules` was not installed.
- Final subagent code review approved the code/docs diff and found no generated files committed.

## Residual Risk

- No fresh live terminal-supplement trace was generated in this PR run; the regression is covered by focused unit tests matching the `humanInputEpoch != lastDeliveredInfoEpoch` + message-source + goal condition from trace `2ec19f5a`.
