### PR TITLE
fix(agent): 对齐 subagent 后台命令等待契约

### DIFF
--- a/crabot-agent/src/agent/subagent-error-classifier.ts
+++ b/crabot-agent/src/agent/subagent-error-classifier.ts
@@ -89,7 +89,13 @@ const TIMEOUT_NEEDLES = ['etimedout', 'timed out', 'timeout', 'aborted', 'reques
 
 const NETWORK_NEEDLES = ['econnreset', 'econnrefused', 'enotfound', 'enetunreach', 'socket hang up', 'getaddrinfo']
 
-const MODEL_ERROR_NEEDLES = ['overloaded_error', 'overloaded', 'internal server error', 'service unavailable']
+const MODEL_ERROR_NEEDLES = [
+  'overloaded_error',
+  'overloaded',
+  'internal server error',
+  'service unavailable',
+  'temporarily unavailable',
+]
 
 export function classifySubAgentError(err: unknown): SubAgentErrorClassification {
   const text = `${getMessage(err)} ${getBodyText(err)}`
@@ -130,7 +136,11 @@ export function classifySubAgentError(err: unknown): SubAgentErrorClassification
   }
 
   // model_error: 5xx
-  if ((status !== undefined && status >= 500 && status < 600) || hasAny(text, MODEL_ERROR_NEEDLES)) {
+  if (
+    (status !== undefined && status >= 500 && status < 600) ||
+    /\bhttp\s+50[23]\b/i.test(text) ||
+    hasAny(text, MODEL_ERROR_NEEDLES)
+  ) {
     return {
       kind: 'model_error',
       retryable: true,
@@ -260,4 +270,3 @@ export function buildSubAgentFailureOutput(ctx: SubAgentFailureContext): SubAgen
   }
   return out as unknown as SubAgentFailureOutput
 }
-

--- a/crabot-agent/src/engine/tools/bash-tool.ts
+++ b/crabot-agent/src/engine/tools/bash-tool.ts
@@ -15,7 +15,8 @@ export const MAX_FOREGROUND_TIMEOUT_MS = 600_000
 /**
  * 前台宽限期：命令先前台运行这么久。
  * 期内退出 → 同步内联返回（等同普通同步调用）；超过仍在跑 → 转后台（命令不中断）+
- * 引导 agent 用 wait_for_signal 挂起等待。取代旧的「显式 timeout>60s 直接转 bg」破坏性逻辑。
+ * 按实际工具表引导 agent 用 wait_for_signal 或 blocking Output 等待。
+ * 取代旧的「显式 timeout>60s 直接转 bg」破坏性逻辑。
  */
 export const FOREGROUND_GRACE_PERIOD_MS = 10_000
 
@@ -164,7 +165,7 @@ function execCommand(
 /**
  * 默认前台执行：委托 runShellWithGrace（spawn 即 OS 直写磁盘日志，前台宽限 gracePeriodMs）。
  * - 宽限期内退出：读日志内联同步返回（不入 bgRegistry）。
- * - 超过宽限期仍在跑：转后台（注册 bgRegistry，命令**不中断**），返回 entity_id + 引导 wait_for_signal；
+ * - 超过宽限期仍在跑：转后台（注册 bgRegistry，命令**不中断**），返回 entity_id + 条件等待引导；
  *   其后退出经 onShellExit 唤醒挂起的 worker。
  * - 期间 abort：kill + 清文件，返回 aborted。
  */
@@ -197,8 +198,9 @@ async function runForegroundWithGrace(
       return {
         output:
           `命令运行已超过 ${sec}s，转入后台继续运行（entity_id: ${result.entity_id}）——命令未中断。\n` +
-          `若你还有别的事可做，现在就去做；若没有，调 wait_for_signal(reason="等 ${command.slice(0, 40)}") 挂起，` +
-          `该命令退出时会自动唤醒你，届时用 Output("${result.entity_id}") 读取完整输出。`,
+          `若你还有别的事可做，现在就去做。若工具列表中有 wait_for_signal，可调 ` +
+          `wait_for_signal(reason="等 ${command.slice(0, 40)}") 挂起，命令退出会唤醒主任务；` +
+          `若工具列表中没有 wait_for_signal，请调 Output("${result.entity_id}", block=true, timeout_ms=600000) 阻塞等待并读取输出。`,
         isError: false,
       }
     }
@@ -231,7 +233,7 @@ export function createBashTool(
     description:
       'Executes a bash command and returns its output. ' +
       `命令前台运行；若运行超过 ${Math.round(FOREGROUND_GRACE_PERIOD_MS / 1000)}s 仍未结束，自动转入后台并返回 entity_id（命令**继续运行、不中断**），` +
-      '随后你可继续做别的，或调 wait_for_signal 挂起等待其退出（退出会自动唤醒你），届时用 Output(entity_id) 读完整输出。',
+      '随后可继续做别的。工具列表中有 wait_for_signal 时可挂起等待主任务唤醒；没有该工具时用 Output(entity_id, block=true, timeout_ms=600000) 阻塞等待。',
     inputSchema: {
       type: 'object',
       properties: {
@@ -252,7 +254,7 @@ export function createBashTool(
         }
       }
 
-      // 默认路径：前台宽限期内完成则同步内联返回；超期仍在跑则转后台 + 引导 wait_for_signal。
+      // 默认路径：前台宽限期内完成则同步内联返回；超期仍在跑则转后台 + 条件等待引导。
       if (bgCtx) {
         return runForegroundWithGrace(command, bgCtx, getCwd(), context.abortSignal, gracePeriodMs)
       }

--- a/crabot-agent/src/engine/tools/output-tool.ts
+++ b/crabot-agent/src/engine/tools/output-tool.ts
@@ -22,7 +22,7 @@ export interface BgToolDeps {
 
 // block 模式参数（参 Claude Code BashOutput）
 const BLOCK_DEFAULT_TIMEOUT_MS = 30_000
-const BLOCK_MAX_TIMEOUT_MS = 120_000
+const BLOCK_MAX_TIMEOUT_MS = 600_000
 const BLOCK_POLL_INTERVAL_MS = 2_000
 const NO_NEW_OUTPUT_MARKER = '(no new output)'
 
@@ -116,8 +116,8 @@ export function createOutputTool(deps: BgToolDeps): ToolDefinition {
       '默认非阻塞 snapshot 读。' +
       '若 shell 还在 running 且想等下一段输出，**强烈建议**用 `block=true` 阻塞等到有新输出 / 状态变 terminal / 超时——' +
       '避免在 agent 主循环里反复短间隔 poll 污染上下文。' +
-      '注意：bg shell 的 exit 事件本身会通过 <bg-notification> 自动通知到 agent（且内联输出尾部），' +
-      '通常不需要主动 block 等终止——block 仅适用于"我要立刻拿到下一段输出再继续"的场景。' +
+      '工具列表中有 wait_for_signal 的主控 agent 通常可等待退出通知；' +
+      '没有 wait_for_signal 的 subagent 应用 block=true 等待，不依赖 <bg-notification>。' +
       '读 subagent 结果请用 get_subagent_output(agent_id)，不是本工具。',
     inputSchema: {
       type: 'object',

--- a/crabot-agent/tests/agent/subagent-error-classifier.test.ts
+++ b/crabot-agent/tests/agent/subagent-error-classifier.test.ts
@@ -77,6 +77,16 @@ describe('classifySubAgentError', () => {
       const c = classifySubAgentError(err)
       expect(c.kind).toBe('model_error')
     })
+
+    it.each([
+      'Subagent LLM 调用失败: HTTP 502: Bad Gateway',
+      'Subagent LLM 调用失败: HTTP 503: upstream connect error',
+      'Service temporarily unavailable. Please try again later.',
+    ])('字符串化上游错误 %s → model_error', (message) => {
+      const c = classifySubAgentError(new Error(message))
+      expect(c.kind).toBe('model_error')
+      expect(c.retryable).toBe(true)
+    })
   })
 
   describe('timeout / abort', () => {

--- a/crabot-agent/tests/agent/subagent-tool-filter.test.ts
+++ b/crabot-agent/tests/agent/subagent-tool-filter.test.ts
@@ -39,6 +39,7 @@ describe('classifyTool', () => {
     ['Skill', 'skill_loading'],
     ['mcp__user-mcp-x__some_tool', 'mcp_user'],
     ['delegate_task', 'delegate_task'],
+    ['wait_for_signal', 'unknown'],
     ['UnknownTool', 'unknown'],
   ])('classifyTool("%s") === %s', (name, expected) => {
     expect(classifyTool(name)).toBe(expected)
@@ -90,5 +91,11 @@ describe('filterToolsForSubAgent', () => {
     const tools = [fakeTool('Read'), fakeTool('SomeRandomTool')]
     const out = filterToolsForSubAgent(tools, ALL_ON, [], [])
     expect(out.map((t) => t.name)).toEqual(['Read'])
+  })
+
+  it('wait_for_signal 是 main-only，即使 shell capability 开启也不注入 subagent', () => {
+    const tools = [fakeTool('Bash'), fakeTool('Output'), fakeTool('wait_for_signal')]
+    const out = filterToolsForSubAgent(tools, ALL_ON, [], [])
+    expect(out.map((t) => t.name)).toEqual(['Bash', 'Output'])
   })
 })

--- a/crabot-agent/tests/engine/tools/bash-tool.test.ts
+++ b/crabot-agent/tests/engine/tools/bash-tool.test.ts
@@ -170,7 +170,7 @@ describe('createBashTool with bgCtx', () => {
     expect(result.output).toContain('stderr:\nbad')
   })
 
-  it('grace 慢路径：超期仍在跑 → 转后台注册 bgRegistry + 引导 wait_for_signal（命令不中断），退出触发 onShellExit', async () => {
+  it('grace 慢路径：共享文案按工具表区分 wait_for_signal 与 blocking Output', async () => {
     const pushed: ExitInfo[] = []
     // 注入 50ms 短 grace，命令 sleep 0.4s 必然超期
     const tool = createBashTool(() => cwd, undefined, makeBgCtx('task-grace-slow', (info) => pushed.push(info)), 50)
@@ -181,7 +181,11 @@ describe('createBashTool with bgCtx', () => {
     )
     expect(result.isError).toBe(false)
     expect(result.output).toContain('转入后台继续运行')
-    expect(result.output).toContain('wait_for_signal')
+    expect(result.output).toContain('工具列表中有 wait_for_signal')
+    expect(result.output).toContain('工具列表中没有 wait_for_signal')
+    expect(result.output).toContain('block=true')
+    expect(result.output).toContain('timeout_ms=600000')
+    expect(result.output).not.toContain('若没有，调 wait_for_signal')
     expect(result.output).not.toContain('exit_code:')
     const match = result.output.match(/shell_[0-9a-f]+/)
     expect(match).not.toBeNull()

--- a/crabot-agent/tests/engine/tools/bg-tools.test.ts
+++ b/crabot-agent/tests/engine/tools/bg-tools.test.ts
@@ -177,6 +177,14 @@ describe('Output tool', () => {
     expect(elapsed).toBeGreaterThan(2_000)
   }, 15_000)
 
+  it('block=true documents the 600s maximum used by timeout clamping', () => {
+    const tool = createOutputTool(deps)
+    const properties = (tool.inputSchema as {
+      properties: Record<string, { description?: string }>
+    }).properties
+    expect(properties.timeout_ms?.description).toContain('600000')
+  })
+
   it('runShellWithGrace promoted shell still feeds combined log output into Output', async () => {
     const result = await runShellWithGrace({
       command: 'sleep 0.15; printf "after-promotion-out\\n"; printf "after-promotion-err\\n" >&2',


### PR DESCRIPTION
## 根因

- wait_for_signal 绑定主任务 human queue、audit、异步 subagent 和后台实体状态，且会被 subagent 工具过滤器归为 unknown；它不应加入 subagent allowlist。
- 共享 Bash 文案却无条件要求 subagent 调用 wait_for_signal。
- subagent 唯一可用的 shell 等待路径 Output(block=true) 被硬限制为 120 秒。
- provider 错误字符串化后只剩 HTTP 502/503 或 temporarily unavailable，现有分类器将其记为 unknown。

## 变更

- 保持 wait_for_signal main-only，并增加显式过滤回归测试
- Bash / Output 共享文案按实际工具表说明主控与 subagent 两个等待分支
- Output 最大阻塞时间从 120000ms 调整为 600000ms
- 字符串化 HTTP 502/503 和 temporarily unavailable 归类为 model_error
- 不修改 vision slot 或任何 model 配置

## 验证

- crabot-agent: 1496 passed, 2 skipped
- ./dev.sh build
- git diff --check

## 文档

- smilefufu/crabot-docs#5