### PR TITLE
fix(ci): discuss job 的 PR head 检出改为 --detach

### DIFF
--- a/.github/workflows/claude-discuss.yml
+++ b/.github/workflows/claude-discuss.yml
@@ -28,10 +28,12 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
 
       # issue_comment 事件默认 checkout 到默认分支，需切到 PR head 才能读到 PR 的实际代码
+      # --detach：action 自身也会把 PR 检出为同名本地分支（fork PR 走 git fetch pull/N/head:分支名），
+      # 若这里占住分支名，该 fetch 会被 git 拒绝导致整个 job 失败（2026-07-13 crabot PR #26 实测）
       - name: Checkout PR head
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr checkout "${{ github.event.issue.number || github.event.pull_request.number }}"
+        run: gh pr checkout --detach "${{ github.event.issue.number || github.event.pull_request.number }}"
 
       # 不提供 prompt → 交互（tag）模式：action 自带触发短语与写权限校验
       - uses: anthropics/claude-code-action@v1


### PR DESCRIPTION
## 问题

fork PR 上评论 `@claude` 触发 discuss workflow 时，job 必定失败（crabot PR #26 实测，run 29241958940）：

```
fatal: refusing to fetch into branch 'refs/heads/feat/image-generation' checked out at ...
Action failed with error: Command failed: git fetch origin --depth=20 pull/26/head:feat/image-generation
```

前置步骤 `gh pr checkout N` 把 PR 分支检出为同名本地分支后，claude-code-action 自身对 fork PR 执行 `git fetch origin pull/N/head:<branch>`，git 拒绝 fetch 到已检出的分支，整个 job 挂掉。同仓库 PR 走的是另一条检出路径，所以此前冒烟未暴露。

## 修复

`gh pr checkout --detach`：以 detached HEAD 检出 PR 代码，不占用分支名。action 自身的 fetch/checkout 不再冲突；即使某些事件路径 action 不做检出，工作区也已在 PR head 上。

🤖 Generated with [Claude Code](https://claude.com/claude-code)