### PR TITLE
feat(agent): wait_for_signal targets 准入校验 + goal 生命周期闭环

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,13 +1,12 @@
 # Crabot 项目进度
 
-> 最后更新：2026-07-16 — 挂起/唤醒语义 + goal 生命周期闭环 spec 定稿（待实现）
+> 最后更新：2026-07-16 — 挂起/唤醒语义 + goal 生命周期闭环已实现（PR #31）
 
-## 2026-07-16 — 待办：挂起/唤醒语义收紧 + Goal 生命周期闭环（spec 已定稿）
+## 2026-07-16 — 挂起/唤醒语义收紧 + Goal 生命周期闭环（已实现，PR #31）
 
 - 起因：m2u 生产 trace `ac9676e3` 复盘，暴露 4 个缺陷：A) 终态 goal 跨 epoch 重新武装 audit gate（幽灵 audit + 持久化报错丢结果，日志证实 ≥4 个任务命中）；B) Task-13 拦截文案教 agent 主动 wait audit → 空转 ≈14 分钟；C) set_task_goal 替换 goal 后新承诺从未被审计即完成任务；D) wait_for_signal 自由文本 + timeout_ms 旁路无准入校验。
-- spec：`crabot-docs/superpowers/specs/2026-07-16-wait-signal-targets-goal-lifecycle-design.md`（决策已与 master 确认）。
-- C 已简化（与 master 确认）：任务切终态时 still-active goal 无条件切 cleared + warn 日志；事后 audit 暂缓，升级触发条件见 spec §4.3。
-- 待实现，建议顺序 A → B → C → D+唤醒快照；受影响代码清单与测试不变量见 spec §8/§9。resume 两条路径（中断续跑 / 追问 re-pull）的 goal 语义交互见 spec §7，遗留脏数据（completed task + active goal）由收尾清理惰性消化，无需迁移。
+- spec：`crabot-docs/superpowers/specs/2026-07-16-wait-signal-targets-goal-lifecycle-design.md`。C 简化为收尾清理（cleared + warn），事后 audit 暂缓（升级触发条件见 spec §4.3）。
+- 实现（PR #31）：A/B/C/D 全部落地 + audit 等待兜底超时（10 分钟 → abort + fail-open，防 audit 卡死时 24h 挂起循环，review 发现补上）。resume 两条路径的 goal 语义交互见 spec §7，遗留脏数据（completed task + active goal）由收尾清理惰性消化，无需迁移。
 
 ## 2026-07-14 — 修复大型 Trace 执行树遗漏主 Worker
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,6 +1,13 @@
 # Crabot 项目进度
 
-> 最后更新：2026-07-14 — 修复大型 Trace 执行树遗漏主 Worker
+> 最后更新：2026-07-16 — 挂起/唤醒语义 + goal 生命周期闭环 spec 定稿（待实现）
+
+## 2026-07-16 — 待办：挂起/唤醒语义收紧 + Goal 生命周期闭环（spec 已定稿）
+
+- 起因：m2u 生产 trace `ac9676e3` 复盘，暴露 4 个缺陷：A) 终态 goal 跨 epoch 重新武装 audit gate（幽灵 audit + 持久化报错丢结果，日志证实 ≥4 个任务命中）；B) Task-13 拦截文案教 agent 主动 wait audit → 空转 ≈14 分钟；C) set_task_goal 替换 goal 后新承诺从未被审计即完成任务；D) wait_for_signal 自由文本 + timeout_ms 旁路无准入校验。
+- spec：`crabot-docs/superpowers/specs/2026-07-16-wait-signal-targets-goal-lifecycle-design.md`（决策已与 master 确认）。
+- C 已简化（与 master 确认）：任务切终态时 still-active goal 无条件切 cleared + warn 日志；事后 audit 暂缓，升级触发条件见 spec §4.3。
+- 待实现，建议顺序 A → B → C → D+唤醒快照；受影响代码清单与测试不变量见 spec §8/§9。resume 两条路径（中断续跑 / 追问 re-pull）的 goal 语义交互见 spec §7，遗留脏数据（completed task + active goal）由收尾清理惰性消化，无需迁移。
 
 ## 2026-07-14 — 修复大型 Trace 执行树遗漏主 Worker
 

--- a/crabot-admin/src/task-state-machine.test.ts
+++ b/crabot-admin/src/task-state-machine.test.ts
@@ -72,6 +72,53 @@ describe('applyDerivedFields', () => {
     }
   })
 
+  // spec 2026-07-16-wait-signal-targets-goal-lifecycle-design §4.2：
+  // task 切终态时 still-active goal 无条件切 cleared（收尾清理），goal 生命周期闭环。
+  describe('terminal transition 收尾清理 active goal（spec 2026-07-16 §4.2）', () => {
+    const activeGoal = () => ({
+      objective: '验证 X',
+      acceptance_criteria: [{ id: 'c1', kind: 'semantic' as const, spec: '完成 X' }],
+      status: 'active' as const,
+      tokens_used: 0,
+      audit_history: [],
+      created_at: NOW,
+      updated_at: NOW,
+    })
+
+    it('切终态（completed/failed/cancelled）时 active goal → cleared + completed_at', () => {
+      for (const s of ['completed', 'failed', 'cancelled'] as const) {
+        const next = applyDerivedFields(
+          fakeTask({ status: 'executing', started_at: NOW, goal: activeGoal() }),
+          s, NOW,
+        )
+        expect(next.goal?.status, `task→${s}`).toBe('cleared')
+        expect(next.goal?.completed_at, `task→${s}`).toBe(NOW)
+      }
+    })
+
+    it('goal 已终态（complete）→ 原样保留不动', () => {
+      const goal = { ...activeGoal(), status: 'complete' as const, completed_at: NOW }
+      const next = applyDerivedFields(
+        fakeTask({ status: 'executing', started_at: NOW, goal }),
+        'completed', NOW,
+      )
+      expect(next.goal?.status).toBe('complete')
+    })
+
+    it('非终态迁移不碰 goal', () => {
+      const next = applyDerivedFields(
+        fakeTask({ status: 'executing', started_at: NOW, goal: activeGoal() }),
+        'waiting', NOW,
+      )
+      expect(next.goal?.status).toBe('active')
+    })
+
+    it('无 goal 的 task 切终态不受影响', () => {
+      const next = applyDerivedFields(fakeTask({ status: 'executing', started_at: NOW }), 'completed', NOW)
+      expect(next.goal).toBeUndefined()
+    })
+  })
+
   it('sets waiting_human_at on enter, clears on leave', () => {
     const entering = applyDerivedFields(fakeTask({ status: 'executing' }), 'waiting_human', NOW)
     expect(entering.waiting_human_at).toBe(NOW)

--- a/crabot-admin/src/task-state-machine.ts
+++ b/crabot-admin/src/task-state-machine.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Task, TaskStatus } from './types.js'
+import { transitionGoalStatus } from './task-goal.js'
 
 // pending → failed 是合法转换（兜底/异常路径会用到）。
 export const VALID_TRANSITIONS: Readonly<Record<TaskStatus, ReadonlyArray<TaskStatus>>> = {
@@ -52,6 +53,17 @@ export function applyDerivedFields(
 
   if (isTerminalStatus(newStatus)) {
     next.completed_at = nowISO
+    // 收尾清理：task 进终态时 still-active goal 无条件切 cleared——goal 生命周期闭环，
+    // 防止"task 终态 + goal active"组合在后续 re-pull 时重新武装 audit gate（幽灵 audit）。
+    // warn 留统计口径："未审即收尾"的实际发生率，事后 audit 是否值得做以此为据（spec §4.3）。
+    // spec: 2026-07-16-wait-signal-targets-goal-lifecycle-design §4.2
+    if (next.goal && next.goal.status === 'active') {
+      console.warn(
+        `[TaskStateMachine] task ${task.id} 切 ${newStatus} 时 goal 仍 active，自动切 cleared`
+        + `（objective="${next.goal.objective.slice(0, 50)}", audit_history=${next.goal.audit_history.length} 条）`,
+      )
+      next.goal = transitionGoalStatus(next.goal, 'cleared', nowISO)
+    }
   }
 
   next.waiting_human_at = newStatus === 'waiting_human' ? nowISO : undefined

--- a/crabot-agent/src/agent/agent-handler.ts
+++ b/crabot-agent/src/agent/agent-handler.ts
@@ -108,6 +108,7 @@ import {
   buildHumanQueueReport,
   buildBlockedGuidance,
   resolveAuditJudgment,
+  shouldArmGoalGate,
   type AuditResult,
   type ConversationEntry,
   type GoalAuditTaskGoal,
@@ -115,7 +116,12 @@ import {
   type ParsedAuditReport,
 } from './goal-audit.js'
 import { createSubmitAuditResultTool } from './goal-auditor-tools.js'
-import { createWaitForSignalTool, type WaitForSignalDeps } from '../mcp/wait-for-signal.js'
+import {
+  createWaitForSignalTool,
+  formatStillRunningSnapshot,
+  type WaitForSignalDeps,
+  type RunningWaitTarget,
+} from '../mcp/wait-for-signal.js'
 import { createAsyncAuditEndTurnGate } from './end-turn-gate.js'
 import { buildAuditAbortedMarker } from './audit-result-marker.js'
 import {
@@ -262,6 +268,28 @@ export function formatSubAgentNotification(info: SubAgentExitInfo): string {
 function log(msg: string) {
   const ts = new Date().toISOString()
   try { fs.appendFileSync(LOG_FILE, `[${ts}] ${msg}\n`) } catch { /* ignore */ }
+}
+
+/**
+ * 从 bgRegistry running 记录中提取某 task 名下的在跑对象（唤醒快照数据源）。
+ * async subagent 与 bg shell 都是 registry 记录（type='agent'/'shell'），统一在此映射。
+ * excludeEntityId：正在退出的 entity 自身（registry 可能尚未更新为终态）。
+ * spec: 2026-07-16-wait-signal-targets-goal-lifecycle-design §6
+ */
+export function summarizeRunningEntities(
+  records: ReadonlyArray<import('../engine/bg-entities/types.js').BgEntityRecord>,
+  taskId: string,
+  excludeEntityId?: string,
+  nowMs: number = Date.now(),
+): RunningWaitTarget[] {
+  return records
+    .filter((r) => r.spawned_by_task_id === taskId && r.entity_id !== excludeEntityId && r.status === 'running')
+    .map((r) => ({
+      id: r.entity_id,
+      kind: r.type === 'agent' ? ('subagent' as const) : ('bg_entity' as const),
+      runtime_ms: Math.max(0, nowMs - new Date(r.spawned_at).getTime()),
+      description: r.type === 'shell' ? r.command : r.task_description,
+    }))
 }
 
 /**
@@ -696,9 +724,27 @@ export class AgentHandler {
     const message =
       `Background shell ${info.entity_id} 已退出 (status=${info.status}, exit_code=${info.exit_code}${runtimeStr})。\n` +
       `命令: ${command}${tailBlock}`
-    this.humanQueues.get(info.spawned_by_task_id)?.push(`[系统] ${message}`)
+    // 唤醒快照：只进本 task 的 humanQueue（friend 通知跨 task 场景下该清单无意义）。
+    // spec: 2026-07-16-wait-signal-targets-goal-lifecycle-design §6
+    const stillRunning = await this.buildStillRunningLine(info.spawned_by_task_id, info.entity_id)
+    this.humanQueues.get(info.spawned_by_task_id)?.push(
+      `[系统] ${message}${stillRunning ? `\n${stillRunning}` : ''}`,
+    )
     if (info.owner_friend_id) {
       this.enqueueBgNotification(`friend:${info.owner_friend_id}`, message)
+    }
+  }
+
+  /**
+   * 唤醒消息的"仍在运行"快照行——push 时刻现查现写，无新状态（spec 2026-07-16 §6）。
+   * 查询失败降级为空串（快照是增强信息，绝不阻塞通知投递）。
+   */
+  private async buildStillRunningLine(taskId: string, excludeEntityId?: string): Promise<string> {
+    try {
+      const running = await this.bgRegistry.list({ status: ['running'] })
+      return formatStillRunningSnapshot(summarizeRunningEntities(running, taskId, excludeEntityId))
+    } catch {
+      return ''
     }
   }
 
@@ -1122,7 +1168,9 @@ export class AgentHandler {
             { task_id: string },
             { task: { goal?: unknown } }
           >(adminPort, 'get_task', { task_id: task.task_id }, this.deps.moduleId)
-          goalSetCache = resp.task.goal !== undefined
+          // 终态 goal（complete/cleared/…）不武装 gate——承诺已兑现的任务被追问 re-pull 时
+          // 不再产生幽灵 audit（spec 2026-07-16 §2.2-1）。active goal 跨 epoch 继续生效不变。
+          goalSetCache = shouldArmGoalGate(resp.task.goal)
         } catch {
           // admin 不可用：保持 backward-compat，等同 no goal（audit gate 透明放行）
         }
@@ -1438,27 +1486,22 @@ export class AgentHandler {
         }
 
         // 3k2. wait_for_signal — 通用挂起原语，总是注入
-        // 合法性由工具内部预检判定（无 pending 事件且无 timeout_ms 时拒绝空挂起）。
-        // hasActiveAudit：taskState.activeAuditId 非空表示 task 处于"等审态"。
-        // hasActiveAsyncSubagent：跟全局 agentAbortControllers 取交集——bg-agent.ts 在 finally 清理 controller，
-        // 所以 "id 还在 Map 里" 等价于 "subagent 还没退出"。
-        // spec: 2026-06-07-goal-audit-async-buffered-info-design.md Task 3 / Task 5
+        // 合法性由工具内部 targets 准入校验判定（命名目标不存在 → 立即拒绝）。
+        // listActiveAsyncSubagentIds：跟全局 agentAbortControllers 取交集——bg-agent.ts 在
+        // finally 清理 controller，所以 "id 还在 Map 里" 等价于 "subagent 还没退出"。
+        // spec: 2026-07-16-wait-signal-targets-goal-lifecycle-design §5
         const waitForSignalTool = maybeCreateWaitForSignalTool(
           { goalModeEnabled, asyncEnabled: isMasterPrivate },
           {
             humanQueue,
-            hasActiveAudit: () => taskState.activeAuditId !== undefined,
-            hasActiveAsyncSubagent: () => {
-              for (const id of taskState.activeAsyncSubagentIds) {
-                if (this.agentAbortControllers.has(id)) return true
-              }
-              return false
-            },
-            // R2：本 task 名下 running 的（持久）bg shell——退出时 onShellExit push humanQueue 唤醒，
-            // 所以"等它退出"是合法裸挂起。可能永不退出的进程（服务/监控）仍建议带 timeout_ms。
-            hasRunningBgEntity: async () => {
+            listActiveAsyncSubagentIds: () =>
+              [...taskState.activeAsyncSubagentIds].filter((id) => this.agentAbortControllers.has(id)),
+            // 本 task 名下 running 的（持久）bg shell——退出时 onShellExit push humanQueue 唤醒。
+            // 可能永不退出的进程（服务/监控）仍建议带 timeout_ms。
+            listRunningBgEntities: async () => {
               const running = await this.bgRegistry.list({ status: ['running'] })
-              return running.some((s) => s.type === 'shell' && s.spawned_by_task_id === task.task_id)
+              return summarizeRunningEntities(running, task.task_id)
+                .filter((t) => t.kind === 'bg_entity')
             },
           },
         )
@@ -1792,15 +1835,10 @@ export class AgentHandler {
           clearActiveAuditId: () => {
             taskState.activeAuditId = undefined
           },
-          // Task 13 兜底：audit 跑中 LLM 直接 end_turn 时 engine 判定是否仍有活跃 audit。
+          // audit 跑中 LLM 直接 end_turn 时 engine 判定是否仍有活跃 audit → 直接挂起等结果。
           // taskState.activeAuditId 非空表示 audit 子进程还没完成。
-          // spec: 2026-06-07-goal-audit-async-buffered-info-design.md §4.6
+          // spec: 2026-07-16-wait-signal-targets-goal-lifecycle-design §3.2
           hasActiveAudit: () => taskState.activeAuditId !== undefined,
-          // Task 13 兜底拦截耗尽 3 次后，engine 调此 abort 当前 audit。
-          // 复用 set_task_goal 路径相同的 abortAudit closure——
-          // controller.abort + push audit_aborted marker + 清 outboundBuffer + activeAuditId。
-          // spec: 2026-06-07-goal-audit-async-buffered-info-design.md §4.6 / §4.7
-          abortActiveAudit: (reason: string) => abortAudit(reason),
           endTurnGate: this.buildAsyncAuditEndTurnGate({
             goalModeEnabled,
             goalSetCacheGetter: () => goalSetCache,
@@ -3688,8 +3726,19 @@ export class AgentHandler {
       return
     }
 
+    // append 与 complete 拆独立 try：append 失败（如 goal 已终态的竞态）不应连带跳过
+    // complete 调用（spec 2026-07-16 §2.2-3）。
+    let adminPort: number
     try {
-      const adminPort = await this.deps.getAdminPort()
+      adminPort = await this.deps.getAdminPort()
+    } catch (err) {
+      console.error(
+        `[goal-audit] persistAsyncAuditResult getAdminPort failed for ${params.taskId}/${params.auditId}:`,
+        err instanceof Error ? err.message : String(err),
+      )
+      return
+    }
+    try {
       await this.deps.rpcClient.call<unknown, { task?: { goal?: { status?: GoalStatus } } }>(
         adminPort,
         'append_task_goal_audit_entry',
@@ -3704,20 +3753,27 @@ export class AgentHandler {
         },
         this.deps.moduleId,
       )
+    } catch (err) {
+      console.warn(
+        `[goal-audit] persistAsyncAuditResult append failed for ${params.taskId}/${params.auditId}:`,
+        err instanceof Error ? err.message : String(err),
+      )
+    }
 
-      if (params.parsed.pass) {
+    if (params.parsed.pass) {
+      try {
         await this.deps.rpcClient.call<unknown, unknown>(
           adminPort,
           'complete_task_goal',
           { task_id: params.taskId },
           this.deps.moduleId,
         )
+      } catch (err) {
+        console.error(
+          `[goal-audit] persistAsyncAuditResult complete failed for ${params.taskId}/${params.auditId}:`,
+          err instanceof Error ? err.message : String(err),
+        )
       }
-    } catch (err) {
-      console.error(
-        `[goal-audit] persistAsyncAuditResult failed for ${params.taskId}/${params.auditId}:`,
-        err instanceof Error ? err.message : String(err),
-      )
     }
 
     try {
@@ -3831,8 +3887,17 @@ export class AgentHandler {
           }
         : {}),
       onExit: (info) => {
-        if (!deps.humanQueue) return
-        deps.humanQueue.push(formatSubAgentNotification(info))
+        const queue = deps.humanQueue
+        if (!queue) return
+        // 唤醒快照：附上还在跑的其他对象，agent 醒来即知是否要继续等（spec 2026-07-16 §6）。
+        // 快照查询失败降级为纯通知，绝不阻塞投递。
+        void this.buildStillRunningLine(deps.parentTaskId, info.entity_id)
+          .then((line) => {
+            queue.push(line ? `${formatSubAgentNotification(info)}\n${line}` : formatSubAgentNotification(info))
+          })
+          .catch(() => {
+            queue.push(formatSubAgentNotification(info))
+          })
       },
     })
 

--- a/crabot-agent/src/agent/agent-handler.ts
+++ b/crabot-agent/src/agent/agent-handler.ts
@@ -1839,6 +1839,9 @@ export class AgentHandler {
           // taskState.activeAuditId 非空表示 audit 子进程还没完成。
           // spec: 2026-07-16-wait-signal-targets-goal-lifecycle-design §3.2
           hasActiveAudit: () => taskState.activeAuditId !== undefined,
+          // audit 等待兜底超时触发时 abort 卡死的 audit（复用 set_task_goal 路径同款 closure：
+          // controller.abort + push audit_aborted marker + 清 outboundBuffer + activeAuditId）。
+          abortActiveAudit: (reason: string) => abortAudit(reason),
           endTurnGate: this.buildAsyncAuditEndTurnGate({
             goalModeEnabled,
             goalSetCacheGetter: () => goalSetCache,

--- a/crabot-agent/src/agent/agent-handler.ts
+++ b/crabot-agent/src/agent/agent-handler.ts
@@ -273,17 +273,19 @@ function log(msg: string) {
 /**
  * 从 bgRegistry running 记录中提取某 task 名下的在跑对象（唤醒快照数据源）。
  * async subagent 与 bg shell 都是 registry 记录（type='agent'/'shell'），统一在此映射。
- * excludeEntityId：正在退出的 entity 自身（registry 可能尚未更新为终态）。
+ * excludeEntityIds：正在退出的 entity 自身（registry 可能尚未更新为终态）+ 在跑的
+ * goal-audit subagent（它也以 parentTaskId 注册，但对 worker 必须不可见——快照泄漏它
+ * 会重新引入"教 agent 等 audit"污染，且与 wait_for_signal 的 targets 准入自相矛盾）。
  * spec: 2026-07-16-wait-signal-targets-goal-lifecycle-design §6
  */
 export function summarizeRunningEntities(
   records: ReadonlyArray<import('../engine/bg-entities/types.js').BgEntityRecord>,
   taskId: string,
-  excludeEntityId?: string,
+  excludeEntityIds: ReadonlyArray<string> = [],
   nowMs: number = Date.now(),
 ): RunningWaitTarget[] {
   return records
-    .filter((r) => r.spawned_by_task_id === taskId && r.entity_id !== excludeEntityId && r.status === 'running')
+    .filter((r) => r.spawned_by_task_id === taskId && !excludeEntityIds.includes(r.entity_id) && r.status === 'running')
     .map((r) => ({
       id: r.entity_id,
       kind: r.type === 'agent' ? ('subagent' as const) : ('bg_entity' as const),
@@ -737,12 +739,17 @@ export class AgentHandler {
 
   /**
    * 唤醒消息的"仍在运行"快照行——push 时刻现查现写，无新状态（spec 2026-07-16 §6）。
+   * 在跑的 goal-audit subagent 一并排除：它对 worker 必须不可见（B 修复的语义边界）。
    * 查询失败降级为空串（快照是增强信息，绝不阻塞通知投递）。
    */
   private async buildStillRunningLine(taskId: string, excludeEntityId?: string): Promise<string> {
     try {
       const running = await this.bgRegistry.list({ status: ['running'] })
-      return formatStillRunningSnapshot(summarizeRunningEntities(running, taskId, excludeEntityId))
+      const exclude: string[] = []
+      if (excludeEntityId) exclude.push(excludeEntityId)
+      const activeAuditId = this.activeTasks.get(taskId)?.activeAuditId
+      if (activeAuditId) exclude.push(activeAuditId)
+      return formatStillRunningSnapshot(summarizeRunningEntities(running, taskId, exclude))
     } catch {
       return ''
     }

--- a/crabot-agent/src/agent/end-turn-gate.ts
+++ b/crabot-agent/src/agent/end-turn-gate.ts
@@ -20,7 +20,7 @@
  */
 
 import { spawnAuditSubagent, type SpawnAuditSubagentDeps } from './audit-spawn.js'
-import type { GoalAuditTaskGoal } from './goal-audit.js'
+import { shouldArmGoalGate, type GoalAuditTaskGoal } from './goal-audit.js'
 import type { RpcClient } from 'crabot-shared'
 import type { WorkerTaskState } from '../types.js'
 import type { EndTurnGateResult } from '../engine/types.js'
@@ -96,6 +96,11 @@ export function createAsyncAuditEndTurnGate(
   const spawn = deps.spawnAuditSubagentFn ?? spawnAuditSubagent
 
   return async () => {
+    // 0. 已有 audit 在跑 → 绝不派第二个，交给 engine 的 hasActiveAudit 挂起路径接管。
+    //    防御性不变量：正常时序下 engine 在调 gate 前已按 hasActiveAudit 挂起，到不了这里；
+    //    显式挡住是防未来时序改动引入双 audit 并发（spec 2026-07-16 §4.2）。
+    if (deps.taskState.activeAuditId !== undefined) return null
+
     // 1. 工作态门控：worker 尚未 set_task_goal → 没东西要审 → 透明放行
     if (!deps.goalSetCacheGetter()) return null
 
@@ -132,12 +137,13 @@ export function createAsyncAuditEndTurnGate(
         { task_id: string },
         { task: { id: string; goal?: GoalAuditTaskGoal } }
       >(adminPort, 'get_task', { task_id: deps.taskId }, deps.moduleId)
-      if (!taskResp.task.goal) {
-        // goalModeEnabled + goalSetCache=true 才进得了这条 gate；理论上不该没 goal。
-        // 防御：缺失 → fail-open。
+      if (!shouldArmGoalGate(taskResp.task.goal)) {
+        // 缺失 → fail-open（goalModeEnabled + goalSetCache=true 才进得了这条 gate，理论上不该没 goal）。
+        // 终态（complete/cleared/…）→ 同样放行：承诺已兑现/已清除，不对终态 goal 派 audit
+        // （spec 2026-07-16 §2.2-2；防 set_task_goal 与 end_turn 并发竞态的第二道防线）。
         return null
       }
-      goal = taskResp.task.goal
+      goal = taskResp.task.goal!
     } catch (err) {
       console.warn(
         '[endTurnGate] get_task RPC failed open:',

--- a/crabot-agent/src/agent/goal-audit.ts
+++ b/crabot-agent/src/agent/goal-audit.ts
@@ -50,6 +50,35 @@ export interface ConversationEntry {
  */
 export type GoalStatus = 'active' | 'complete' | 'blocked' | 'budget_limited' | 'cleared'
 
+/**
+ * 终态集合。与 crabot-admin/src/task-goal.ts 的 TERMINAL_STATUSES 对齐
+ * （对齐由 tests/agent/goal-terminal.test.ts 跨包断言锁定）。
+ * spec: 2026-07-16-wait-signal-targets-goal-lifecycle-design §2.2
+ */
+export const TERMINAL_GOAL_STATUSES: ReadonlySet<GoalStatus> = new Set([
+  'complete',
+  'blocked',
+  'budget_limited',
+  'cleared',
+])
+
+export function isGoalTerminal(status: GoalStatus): boolean {
+  return TERMINAL_GOAL_STATUSES.has(status)
+}
+
+/**
+ * goal 是否应武装 audit gate：存在且非终态。
+ * 接受 admin get_task 返回的宽松 shape（status 缺失的旧数据按 active 防御处理）。
+ * worker 启动快照与 endTurnGate 第 3 步共用，保证两处判定不漂移。
+ * spec: 2026-07-16-wait-signal-targets-goal-lifecycle-design §2.2
+ */
+export function shouldArmGoalGate(goal: unknown): boolean {
+  if (goal === undefined || goal === null) return false
+  const status = (goal as { status?: unknown }).status
+  if (typeof status !== 'string') return true
+  return !TERMINAL_GOAL_STATUSES.has(status as GoalStatus)
+}
+
 /** Crab-messaging audit gate 拿到的结果；Task 8 会从这里 import */
 export interface AuditResult {
   readonly pass: boolean

--- a/crabot-agent/src/engine/query-loop.ts
+++ b/crabot-agent/src/engine/query-loop.ts
@@ -241,6 +241,14 @@ function formatAuditFailReport(result: AuditResultMarker): string {
 // 正常路径不依赖它：audit onExit 必然 push marker 唤醒。
 const GATE_WAIT_BARRIER_TIMEOUT_MS = 24 * 60 * 60 * 1000
 
+// audit 等待的有界兜底：audit subagent 只有 maxTurns 界、无墙钟界，若其 onExit push
+// marker 失败（audit-spawn catch 吞掉且不清 activeAuditId）或 adapter 悬挂，
+// activeAuditId 永不清除——不设界会退化成「24h 挂起 + 1 轮 LLM」的无限循环。
+// 超时 → abortActiveAudit（push audit_aborted marker 唤醒 + drain 清状态）→ fail-open
+// 放行后续 end_turn，保证前进性。audit 是有界审阅任务，实测秒到分钟级，10 分钟余量充足。
+// spec: 2026-07-16-wait-signal-targets-goal-lifecycle-design §3.2
+export const AUDIT_WAIT_FALLBACK_TIMEOUT_MS = 10 * 60 * 1000
+
 /**
  * endTurnGate 返回 { kind: 'wait' } 后的挂起处理：audit 已异步派出，engine 直接
  * setBarrier + waitBarrier 等 humanQueue push（audit 结果 / 用户 supplement），唤醒后
@@ -267,7 +275,16 @@ async function waitGateAuditAndDispatch(
   }
   // push 先于挂起到达（如 supplement 已 pending）→ 跳过 barrier 直接 drain，避免错过唤醒。
   if (!queue.hasPending) {
-    queue.setBarrier(GATE_WAIT_BARRIER_TIMEOUT_MS)
+    // audit 在跑且有 abort 能力时用有界兜底（见 AUDIT_WAIT_FALLBACK_TIMEOUT_MS 注释）；
+    // 否则退化为 24h 通用兜底（fail-open，行为同旧版）。
+    const abort = options.abortActiveAudit
+    if (options.hasActiveAudit?.() === true && abort) {
+      queue.setBarrier(AUDIT_WAIT_FALLBACK_TIMEOUT_MS, () => {
+        abort('audit_wait_timeout: audit 结果超时未到达，自动废弃本次 audit 以恢复任务前进')
+      })
+    } else {
+      queue.setBarrier(GATE_WAIT_BARRIER_TIMEOUT_MS)
+    }
     await queue.waitBarrier(abortSignal)
   }
   const drained = queue.drainPending()

--- a/crabot-agent/src/engine/query-loop.ts
+++ b/crabot-agent/src/engine/query-loop.ts
@@ -46,15 +46,6 @@ const MAX_SILENT_END_TURN_RETRIES = 3
 // reasoning 烧得更多，必须先压缩再重跑。
 const MAX_MAX_TOKENS_COMPACT_RETRIES = 2
 
-// audit 跑中 LLM 直接 end_turn 兜底拦截（Task 13）：drain 之后若仍有活跃 audit
-// + LLM 想 end_turn，engine 注入提示拦截续 loop，最多 3 次后 abort active audit
-// + 放行 end_turn。独立计数器，跟 silentEndTurnCount 不复用——前者是"没说话"
-// 后者是"audit 在跑你不能走"，语义不同。
-// spec: 2026-06-07-goal-audit-async-buffered-info-design.md §4.6
-const MAX_AUDIT_PENDING_END_TURN_RETRIES = 3
-const AUDIT_PENDING_END_TURN_PROMPT =
-  '你不能直接 end_turn——audit 仍在跑。请调 wait_for_signal 等审完成，或调其他工具响应当前任务。'
-
 // 规则细节由 agent 自己的 system prompt 维护（assembleAgentPrompt 的 end_turn
 // self-check + 收尾责任段），这里只做 engine 层的机制兜底钩子——告诉模型违反了
 // 哪条规则、要求重新汇报。把规则写两份会产生维护漂移。
@@ -331,9 +322,6 @@ export async function runEngine(params: RunEngineParams): Promise<EngineResult> 
   // 的静默完成（PR #8 review Finding 1）。
   let pendingDeliveryFailure: string | null = null
   let maxTokensCompactRetryCount = 0
-  // Task 13: audit 跑中 LLM 直接 end_turn 兜底拦截计数器，独立于 silentEndTurnCount。
-  // spec: 2026-06-07-goal-audit-async-buffered-info-design.md §4.6
-  let auditPendingEndTurnRetries = 0
   // 由上一轮追问设置、下一轮 onTurn 消费一次后清零。
   let pendingForcedSummaryAttempt: number | undefined = undefined
 
@@ -561,31 +549,27 @@ export async function runEngine(params: RunEngineParams): Promise<EngineResult> 
         }
       }
 
-      // Task 13: audit 跑中 LLM 直接 end_turn 兜底拦截。
+      // audit 跑中 LLM 直接 end_turn → engine 直接挂起等 audit 结果。
       // 顺序意义：在 drain（上方 humanMessageQueue?.hasPending 块）之后判断——
       // 让 audit_result.pass=true 优先 drained → clearActiveAuditId → 此处 hasActiveAudit=false
-      // 不会误拦截已完成的 audit。drain 没拿到 result 但 audit 仍在跑时（agent 跳过 wait_for_signal
-      // 直接 end_turn 的非法路径），注入拦截续 loop；3 次后 abort active audit + 放行 end_turn。
-      // spec: 2026-06-07-goal-audit-async-buffered-info-design.md §4.6
+      // 不会误挂起已完成的 audit。
+      // 旧版（2026-06-07 §4.6 Task 13）注入"请调 wait_for_signal 等审完成"续 loop——该文案会
+      // 教坏 agent 在无 audit 时也主动 wait（trace ac9676e3 空转实证），且每轮拦截烧一次全量
+      // context 的 LLM 调用。现直接复用 gate 'wait' 的挂起路径：零注入、零额外 LLM 轮，
+      // 挂起幂等可重入（人类追问唤醒 → 处理 → 再 end_turn → 再挂起）。
+      // spec: 2026-07-16-wait-signal-targets-goal-lifecycle-design §3.2
       if (options.hasActiveAudit?.() === true) {
-        if (auditPendingEndTurnRetries < MAX_AUDIT_PENDING_END_TURN_RETRIES) {
-          auditPendingEndTurnRetries++
-          fireOnTurn(buildSilentTurnEvent(
-            totalTurns, processed.text, stopReason, llmCallMs, llmStartedAtMs, undefined, response.usage,
-          ))
-          messages.push(createUserMessage(AUDIT_PENDING_END_TURN_PROMPT))
-          options.onSystemInjection?.({
-            type: 'audit_pending_intercept',
-            text: AUDIT_PENDING_END_TURN_PROMPT,
-            turnNumber: totalTurns,
-            injectedAtMs: Date.now(),
-          })
-          continue
+        fireOnTurn(buildSilentTurnEvent(
+          totalTurns, processed.text, stopReason, llmCallMs, llmStartedAtMs, undefined, response.usage,
+        ))
+        const outcome = await waitGateAuditAndDispatch(options, messages, totalTurns, abortSignal, flushAndTrackDelivery)
+        if (outcome === 'exit') {
+          return finishTask()
         }
-        // 兜底耗尽：abort active audit + fall through 让 end_turn 通过。
-        // abortActiveAudit 内部会清 activeAuditId / 推 audit_aborted marker / dropOutboundBuffer——
-        // 后续路径（max_tokens compact / silent forced_summary / endTurnGate）按正常 end_turn 收尾。
-        options.abortActiveAudit?.('end_turn_retries_exhausted')
+        if (typeof outcome === 'object') {
+          return buildResult('failed', finalText, totalTurns, contextManager, messages, exitToolCall, toolCallCount, wroteMemoryOrScene, outcome.failedReason)
+        }
+        continue
       }
 
       const isSilentText = processed.text.trim().length === 0

--- a/crabot-agent/src/engine/types.ts
+++ b/crabot-agent/src/engine/types.ts
@@ -405,6 +405,15 @@ export interface EngineOptions {
    */
   readonly hasActiveAudit?: () => boolean
   /**
+   * abort active audit。audit 等待兜底超时（AUDIT_WAIT_FALLBACK_TIMEOUT_MS）触发时调，
+   * 把卡死的 audit 标废 + push audit_aborted marker——唤醒挂起的 loop 并经 drain 清状态，
+   * 保证前进性（audit onExit push 失败 / adapter 悬挂时 activeAuditId 永不清除的兜底）。
+   * 注：set_task_goal 改 goal 触发的 abort 走 agent-handler 内 abortAudit closure 直接调，不走此回调。
+   * 不传时 engine 退化为 24h 通用兜底（fail-open）。
+   * spec: 2026-07-16-wait-signal-targets-goal-lifecycle-design §3.2
+   */
+  readonly abortActiveAudit?: (reason: string) => void
+  /**
    * 上下文压缩开始时触发（trace 可见性钩子）。
    * compaction 内部跑一次 LLM call 做摘要，可能耗时几秒——不接 trace 就是黑洞。
    */
@@ -433,8 +442,9 @@ export interface HumanMessageQueueLike {
   readonly drainPending: () => Array<string | ContentBlock[]>
   readonly hasPending: boolean
   readonly hasBarrier: boolean
-  /** endTurnGate 'wait' 路径用：engine 自行布防 barrier 再 waitBarrier（spec 2026-06-10 §4.7） */
-  readonly setBarrier: (timeoutMs: number) => void
+  /** endTurnGate 'wait' 路径用：engine 自行布防 barrier 再 waitBarrier（spec 2026-06-10 §4.7）。
+   *  onTimeout 仅真超时触发（push/clearBarrier 提前唤醒不触发）——audit 等待兜底 abort 用。 */
+  readonly setBarrier: (timeoutMs: number, onTimeout?: () => void) => void
   readonly waitBarrier: (signal?: AbortSignal) => Promise<void>
   readonly clearBarrier: () => void
 }

--- a/crabot-agent/src/engine/types.ts
+++ b/crabot-agent/src/engine/types.ts
@@ -324,7 +324,7 @@ export interface EngineOptions {
    * - `supplement` —— humanMessageQueue 实时纠偏注入
    * - `forced_summary` —— silent end_turn 兜底要求模型重说
    * - `stop_hook` —— Stop hook block 后注入的引导文本
-   * - `audit_pending_intercept` —— audit 跑中 LLM 直接 end_turn 兜底拦截（Task 13）
+   * - `assistant_text_end_turn` —— 非空 assistant text + end_turn 走错通道纠偏提醒
    *
    * caller 可把它接到 traceCallback / 日志 / metric——engine 自身不做任何 trace 写入。
    */
@@ -397,21 +397,13 @@ export interface EngineOptions {
    */
   readonly clearActiveAuditId?: () => void
   /**
-   * 检查当前是否有 active audit subagent 在跑（Task 13 兜底用）。
-   * 用于 audit 跑中 LLM 直接 end_turn 兜底拦截路径：drain 处理完 marker 后，若仍有活跃 audit
-   * + LLM 想 end_turn，engine 注入"你不能直接 end_turn" 拦截续 loop（最多 3 次后 abort）。
-   * 不传时 engine 跳过兜底拦截（caller 自己负责 audit 生命周期）。
-   * spec: 2026-06-07-goal-audit-async-buffered-info-design.md §4.6
+   * 检查当前是否有 active audit subagent 在跑。
+   * 用于 audit 跑中 LLM 直接 end_turn 路径：drain 处理完 marker 后，若仍有活跃 audit
+   * + LLM 想 end_turn，engine 直接挂起等 audit 结果（复用 gate 'wait' 路径，
+   * 零文案注入、幂等可重入）。不传时 engine 跳过（caller 自己负责 audit 生命周期）。
+   * spec: 2026-07-16-wait-signal-targets-goal-lifecycle-design §3.2
    */
   readonly hasActiveAudit?: () => boolean
-  /**
-   * abort active audit。Task 13 兜底拦截耗尽 3 次后调，强制把当前 audit 标废 + 推 audit_aborted
-   * marker 让 worker 看到提示后正常 end_turn。
-   * 注：set_task_goal 改 goal 触发的 abort 走 agent-handler 内 abortAudit closure 直接调，不走此回调。
-   * 不传时 engine 跳过 abort（兜底拦截耗尽仍会 fall through 让 end_turn 通过）。
-   * spec: 2026-06-07-goal-audit-async-buffered-info-design.md §4.6 / §4.7
-   */
-  readonly abortActiveAudit?: (reason: string) => void
   /**
    * 上下文压缩开始时触发（trace 可见性钩子）。
    * compaction 内部跑一次 LLM call 做摘要，可能耗时几秒——不接 trace 就是黑洞。
@@ -456,10 +448,9 @@ export interface SystemInjectionEvent {
    * - `supplement`：humanMessageQueue 实时纠偏注入
    * - `forced_summary`：silent end_turn 兜底要求模型重说
    * - `stop_hook`：Stop hook block 后注入的引导文本
-   * - `audit_pending_intercept`：audit 跑中 LLM 直接 end_turn 兜底拦截（Task 13）
    * - `assistant_text_end_turn`：非空 assistant text + end_turn 走错通道纠偏提醒
    */
-  readonly type: 'supplement' | 'forced_summary' | 'stop_hook' | 'audit_pending_intercept' | 'assistant_text_end_turn'
+  readonly type: 'supplement' | 'forced_summary' | 'stop_hook' | 'assistant_text_end_turn'
   /** 注入的文本内容（不含 ContentBlock[] 形态——supplement 的 ContentBlock 注入退化为 type 字符串描述） */
   readonly text: string
   /** 注入发生时的 turn 序号（与 EngineTurnEvent.turnNumber 同口径） */

--- a/crabot-agent/src/mcp/wait-for-signal.ts
+++ b/crabot-agent/src/mcp/wait-for-signal.ts
@@ -1,17 +1,24 @@
 /**
- * wait_for_signal 工具：通用挂起原语。
+ * wait_for_signal 工具：通用挂起原语（targets 结构化声明版）。
  *
  * 适用场景：
- * 1) worker 派出了 async subagent（delegate_task），此刻没有别的事可干；
- * 2) 系统注入 [audit_pending]，告知 worker 有审计正在跑；
- * 3) worker 起了会转后台的 bash（命令超 10s 自动转后台），等它退出再看结果；
- * 4) 定时等待：带 timeout_ms 挂起 N 毫秒后自动唤醒（如"10 分钟后复查长任务进度"）。
+ * 1) worker 派出了 async subagent（delegate_task），等它完成（target kind='subagent'）；
+ * 2) worker 起了会转后台的 bash（命令超 10s 自动转后台），等它退出（kind='bg_entity'）；
+ * 3) 等 crabot 系统之外的事件（PR review / 远端构建 / 页面状态），系统无法感知、
+ *    只能定时唤醒后由 agent 主动检查（kind='external'，timeout_ms 即轮询间隔）。
+ *
+ * 准入规则（spec 2026-07-16-wait-signal-targets-goal-lifecycle-design §5）：
+ * - targets 必填；subagent / bg_entity 目标不存在 → 立即拒绝（带不带 timeout_ms 都拒绝）
+ * - external 必须带 timeout_ms
+ * - audit / human_reply 不是合法等待对象（定向教育文案）
+ *
+ * 硬不变量（§5.2）：targets 只做准入校验，不做唤醒过滤——挂起后任何 humanQueue push
+ * （用户实时纠偏、无关 shell 退出、系统通知）都立即唤醒。严禁改成"只有目标事件才唤醒"，
+ * 否则实时纠偏注入链路会断。
  *
  * 实现：复用 humanQueue.setBarrier 机制（跟 ask_human 同一套 barrier 路径）。
- * 任何 humanQueue.push（subagent 完成 / bg shell 退出 / 用户补充 / 系统结果）会自动
- * clearBarrier 唤醒 worker；带 timeout_ms 时超时自动 push [wait_timeout] 标记唤醒。
- *
- * spec: 2026-06-07-goal-audit-async-buffered-info-design.md Task 2
+ * 超时消息用挂起时刻的快照——若期间有对象退出必然已 push 唤醒、超时不会触发，
+ * 所以挂起时快照在超时时仍准确，无需异步查询。
  */
 
 import { z } from 'zod'
@@ -27,30 +34,79 @@ export const WAIT_FOR_SIGNAL_TIMEOUT_MS = 24 * 60 * 60 * 1000
 /** timeout_ms 下限：防止 LLM 传毫秒级小值把挂起退化成空转 */
 export const WAIT_FOR_SIGNAL_MIN_TIMEOUT_MS = 1_000
 
+/** 连续 external 超时达到此次数后，超时文案追加"收尾 + schedule 复查"引导（spec §5.3） */
+export const EXTERNAL_TIMEOUT_GUIDANCE_THRESHOLD = 3
+
+/** 在跑对象快照条目——唤醒/超时消息的展示单元。 */
+export interface RunningWaitTarget {
+  readonly id: string
+  readonly kind: 'subagent' | 'bg_entity'
+  /** 已运行毫秒数（可选，快照展示用） */
+  readonly runtime_ms?: number
+  /** 命令 / 任务摘要（可选） */
+  readonly description?: string
+}
+
 export interface WaitForSignalDeps {
   readonly humanQueue: HumanMessageQueue
-  readonly hasActiveAudit: () => boolean
-  readonly hasActiveAsyncSubagent: () => boolean
-  /** 本 task 是否有 running 的 bg shell——它退出时会 push 唤醒。查 bgRegistry，故异步。 */
-  readonly hasRunningBgEntity: () => boolean | Promise<boolean>
+  /** 本 task 在跑的 async subagent id 列表（准入校验 + 快照）。 */
+  readonly listActiveAsyncSubagentIds: () => ReadonlyArray<string>
+  /** 本 task 名下 running 的 bg shell 列表。查 bgRegistry，故异步。 */
+  readonly listRunningBgEntities: () => Promise<ReadonlyArray<RunningWaitTarget>>
 }
+
+function formatRuntime(ms: number): string {
+  const sec = Math.round(ms / 1000)
+  if (sec < 60) return `${sec}s`
+  return `${Math.floor(sec / 60)}m${sec % 60 > 0 ? `${sec % 60}s` : ''}`
+}
+
+/**
+ * 把在跑对象列表格式化为唤醒消息里的"仍在运行"快照行。
+ * subagent 完成通知 / bg shell 退出通知 push 时由 harness 现查现写（无新状态）——
+ * agent 醒来即知还剩什么在跑，不依赖它对自身历史行为的记忆（spec §6）。
+ * 空列表返回空串（调用方直接拼接即可）。
+ */
+export function formatStillRunningSnapshot(items: ReadonlyArray<RunningWaitTarget>): string {
+  if (items.length === 0) return ''
+  const parts = items.map((i) => {
+    const details: string[] = []
+    if (i.description) details.push(i.description.slice(0, 60))
+    if (i.runtime_ms !== undefined) details.push(`已跑 ${formatRuntime(i.runtime_ms)}`)
+    return `${i.id}${details.length > 0 ? `（${details.join('，')}）` : ''}`
+  })
+  return `仍在运行：${parts.join('、')}。全部完成前如无其他工作，请继续 wait_for_signal。`
+}
+
+// zod 侧多收 audit / human_reply 两个非法 kind——不是为了放行，而是为了在 handler 里
+// 给出定向教育文案（比 schema 通用报错有效得多；schema 报错模型只会换个写法重试）。
+const targetSchema = z.object({
+  kind: z.enum(['subagent', 'bg_entity', 'external', 'audit', 'human_reply']),
+  id: z.string().optional(),
+})
 
 const inputSchema = z.object({
   reason: z.string().describe('挂起原因（trace 可读），如 "等 code_writer 完成"'),
-  timeout_ms: z.number().int().positive().optional()
-    .describe('最长等待毫秒数；超时自动唤醒并注入 [wait_timeout] 标记'),
+  targets: z.array(targetSchema).min(1),
+  timeout_ms: z.number().int().positive().optional(),
 })
 
 const TOOL_DESCRIPTION =
-  '挂起当前任务，等待外部异步事件唤醒。适用场景：' +
-  '1) 你派出了 async subagent（delegate_task）没有别的事可干；' +
-  '2) 你起了会转后台的 bash（命令超 10s 自动转后台），等它退出再处理结果——shell 退出会自动唤醒你；' +
-  '3) 定时等待：带 timeout_ms 最长挂起 N 毫秒（如周期性复查长任务：timeout_ms=600000 即最多等 10 分钟，' +
-  '期间 bg shell 退出等任何事件都会提前唤醒；醒来后可再次调用继续等）。' +
-  '注意：等待可能永不退出的进程（监控、服务）必须带 timeout_ms，否则会拒绝或挂到 24h 兜底。' +
-  '交付审计的等待不需要调本工具——系统在你 end_turn 时自动挂起。'
+  '挂起当前任务，等待外部异步事件唤醒。必须声明你在等什么（targets）：' +
+  "1) {kind:'subagent'}——等 delegate_task 派出的异步 subagent 完成（可选 id 精确指定）；" +
+  "2) {kind:'bg_entity'}——等后台 shell 退出（命令超 10s 自动转后台；可选 id）；" +
+  "3) {kind:'external'}——等 crabot 系统之外的事件（PR review / 远端构建 / 页面状态变化），" +
+  '必须带 timeout_ms 作为轮询间隔：系统无法感知外部事件，到点唤醒你后你必须自己主动检查外部状态，' +
+  '未到再挂下一轮。如有命令行 watcher 可用（如 gh pr checks --watch），优先起后台 shell 等它退出。' +
+  '注意：交付审计不需要也无法等待——系统在你 end_turn 时自动挂起等审；' +
+  '等人类回复用 send_message(intent=\'ask_human\')。' +
+  '挂起后任何事件（用户消息 / 其他 shell 退出）都会唤醒你，醒来先处理事件再决定是否继续等。'
 
 export function createWaitForSignalTool(deps: WaitForSignalDeps): ToolDefinition {
+  // 连续 external 超时计数（工具实例 = 单个 worker loop 生命周期）。
+  // 只增不减：无法观测"push 唤醒 vs 超时唤醒"，宁可多提示不漏提示。
+  let externalTimeoutStreak = 0
+
   return {
     name: 'wait_for_signal',
     description: TOOL_DESCRIPTION,
@@ -59,12 +115,30 @@ export function createWaitForSignalTool(deps: WaitForSignalDeps): ToolDefinition
       type: 'object',
       properties: {
         reason: { type: 'string', description: '挂起原因（trace 可读）' },
+        targets: {
+          type: 'array',
+          minItems: 1,
+          description: '你在等待的对象列表；每一项都必须真实存在，否则会被拒绝',
+          items: {
+            type: 'object',
+            properties: {
+              kind: {
+                type: 'string',
+                enum: ['subagent', 'bg_entity', 'external'],
+                description: 'subagent=异步子代理完成 | bg_entity=后台 shell 退出 | external=系统外部事件（必带 timeout_ms 定时自查）',
+              },
+              id: { type: 'string', description: '可选：精确指定 subagent/bg_entity 的 entity id' },
+            },
+            required: ['kind'],
+            additionalProperties: false,
+          },
+        },
         timeout_ms: {
           type: 'integer',
-          description: '可选：最长等待毫秒数，超时自动唤醒（注入 [wait_timeout] 标记）。定时复查场景必带。',
+          description: '最长等待毫秒数，超时自动唤醒（注入 [wait_timeout] 标记）。external 目标必带（作为轮询间隔）。',
         },
       },
-      required: ['reason'],
+      required: ['reason', 'targets'],
       additionalProperties: false,
     },
     call: async (rawInput: Record<string, unknown>, _context: ToolCallContext): Promise<ToolCallResult> => {
@@ -72,50 +146,133 @@ export function createWaitForSignalTool(deps: WaitForSignalDeps): ToolDefinition
       if (!parseResult.success) {
         return { isError: true, output: `invalid input: ${parseResult.error.message}` }
       }
-      const { reason, timeout_ms } = parseResult.data
+      const { reason, targets, timeout_ms } = parseResult.data
 
-      const hasPending = deps.humanQueue.hasPending
-      const hasAudit = deps.hasActiveAudit()
-      const hasSubagent = deps.hasActiveAsyncSubagent()
-      const hasBgEntity = await deps.hasRunningBgEntity()
-
-      if (hasPending) {
+      // 优先级最高：队列已有事件 → 不挂起，先处理
+      if (deps.humanQueue.hasPending) {
         return {
           isError: false,
           output: '已有 pending 唤醒事件，无需再次挂起；请继续处理队列中的事件。',
         }
       }
 
-      if (!hasPending && !hasAudit && !hasSubagent && !hasBgEntity && timeout_ms === undefined) {
-        return {
-          isError: true,
-          output:
-            '当前无 pending 异步事件（无 audit / async subagent / queue 消息 / 运行中的 bg entity），' +
-            '不带 timeout_ms 的挂起会被拒绝。' +
-            '若要定时等待（如 N 分钟后复查进度），带 timeout_ms 重新调用；' +
-            '若任务已全部完成，end_turn。',
+      // 准入校验：每个声明的目标都必须合法且存在（spec §5.1）
+      const subagentIds = deps.listActiveAsyncSubagentIds()
+      let bgEntities: ReadonlyArray<RunningWaitTarget> | undefined
+      for (const target of targets) {
+        switch (target.kind) {
+          case 'audit':
+            return {
+              isError: true,
+              output:
+                '交付审计由系统在你 end_turn 时自动触发并等待，你不需要、也无法主动等待它。'
+                + '请直接继续工作；都做完了就 end_turn，系统会自动挂起等审并唤醒你。',
+            }
+          case 'human_reply':
+            return {
+              isError: true,
+              output:
+                "等待人类回复请用 send_message(intent='ask_human')——它会正确挂起任务并等待回复送达；"
+                + 'wait_for_signal 不用于此场景。',
+            }
+          case 'subagent': {
+            if (target.id !== undefined) {
+              if (!subagentIds.includes(target.id)) {
+                return {
+                  isError: true,
+                  output:
+                    `目标 subagent ${target.id} 不存在或已完成——你可能在等一个不会到来的事件。`
+                    + `已完成的结果用 get_subagent_output("${target.id}") 读取；否则请继续其他工作或 end_turn。`,
+                }
+              }
+            } else if (subagentIds.length === 0) {
+              return {
+                isError: true,
+                output:
+                  '当前没有在跑的 async subagent，目标不存在——你可能在等一个不会到来的事件。'
+                  + '如已收到完成通知，用 get_subagent_output 读取结果；否则请继续其他工作或 end_turn。',
+              }
+            }
+            break
+          }
+          case 'bg_entity': {
+            bgEntities = bgEntities ?? await deps.listRunningBgEntities()
+            if (target.id !== undefined) {
+              if (!bgEntities.some((e) => e.id === target.id)) {
+                return {
+                  isError: true,
+                  output:
+                    `目标 bg entity ${target.id} 不存在或已退出——你可能在等一个不会到来的事件。`
+                    + `输出用 Output("${target.id}") 读取；在跑清单用 ListEntities 查看。`,
+                }
+              }
+            } else if (bgEntities.length === 0) {
+              return {
+                isError: true,
+                output:
+                  '当前没有运行中的后台 shell，目标不存在——你可能在等一个不会到来的事件。'
+                  + '如需查看已退出 shell 的输出用 Output(entity_id)；否则请继续其他工作或 end_turn。',
+              }
+            }
+            break
+          }
+          case 'external': {
+            if (timeout_ms === undefined) {
+              return {
+                isError: true,
+                output:
+                  'external 目标必须带 timeout_ms（作为轮询间隔）：系统无法感知外部事件，'
+                  + '只能定时唤醒你，由你主动检查外部状态（gh / curl 等），未到再挂下一轮。',
+              }
+            }
+            break
+          }
         }
+      }
+
+      // 挂起时刻快照——超时时若有对象退出必然已 push 唤醒（超时不会触发），
+      // 所以这份快照在超时消息里仍准确。
+      const hasExternal = targets.some((t) => t.kind === 'external')
+      const targetEcho = targets.map((t) => {
+        if (t.kind === 'external') return '外部事件（需你主动检查）'
+        return `${t.id ?? `任一 ${t.kind === 'subagent' ? 'async subagent' : '后台 shell'}`}`
+      }).join('、')
+
+      const buildTimeoutMessage = (waitedSec: number): string => {
+        if (hasExternal) externalTimeoutStreak++
+        const lines = [
+          `[wait_timeout] 等待超时（${reason}，已等 ${waitedSec}s），无外部事件到达。`,
+          `挂起时声明的等待对象：${targetEcho}——未推送退出事件的对象通常仍在运行。`,
+        ]
+        if (hasExternal) {
+          lines.push('external 目标请立即主动检查外部状态，未到再挂下一轮。')
+          if (externalTimeoutStreak >= EXTERNAL_TIMEOUT_GUIDANCE_THRESHOLD) {
+            lines.push(
+              '外部等待已连续多次超时——跨天级的等待不适合挂起轮询，'
+              + '考虑收尾本任务并创建 schedule 定时复查任务。',
+            )
+          }
+        }
+        lines.push('如需继续等，可再次调用 wait_for_signal。')
+        return lines.join('\n')
       }
 
       if (timeout_ms !== undefined) {
         const clamped = Math.min(Math.max(timeout_ms, WAIT_FOR_SIGNAL_MIN_TIMEOUT_MS), WAIT_FOR_SIGNAL_TIMEOUT_MS)
         const waitedSec = Math.round(clamped / 1000)
         deps.humanQueue.setBarrier(clamped, () => {
-          deps.humanQueue.push(
-            `[wait_timeout] 等待超时（${reason}，已等 ${waitedSec}s），无外部事件到达。` +
-            '请检查相关 bg entity 输出（Output 工具）或继续后续工作；如需继续等，可再次调用 wait_for_signal。',
-          )
+          deps.humanQueue.push(buildTimeoutMessage(waitedSec))
         })
         return {
           isError: false,
-          output: `已挂起等待 (${reason})；最长 ${waitedSec}s，期间任何事件 push 都会提前唤醒。`,
+          output: `已挂起等待 (${reason}，对象：${targetEcho})；最长 ${waitedSec}s，期间任何事件 push 都会提前唤醒。`,
         }
       }
 
       deps.humanQueue.setBarrier(WAIT_FOR_SIGNAL_TIMEOUT_MS)
       return {
         isError: false,
-        output: `已挂起等待 (${reason})；下次 push 唤醒后继续。`,
+        output: `已挂起等待 (${reason}，对象：${targetEcho})；下次 push 唤醒后继续。`,
       }
     },
   }

--- a/crabot-agent/src/prompts/agent-sections.ts
+++ b/crabot-agent/src/prompts/agent-sections.ts
@@ -539,7 +539,7 @@ list_groups / list_contacts 的返回是**分页结果**——看到 \`paginatio
 
 ### 长任务 / bg shell
 
-**Bash 有 10s 前台宽限期**：命令在 10s 内完成就正常同步返回；**超过 10s 仍在跑会自动转入后台（命令不中断）并返回 entity_id**——你不用预先判断时长、也没有什么"后台开关"要打开，长命令照常直接跑即可，不会堵住 agent loop。收到「已转入后台」后：有别的事就去做，没有就调 \`wait_for_signal({reason:"等 <命令>"})\` 挂起，该命令退出会自动唤醒你。**不要对转后台的命令反复裸 poll \`Output\`。**
+**Bash 有 10s 前台宽限期**：命令在 10s 内完成就正常同步返回；**超过 10s 仍在跑会自动转入后台（命令不中断）并返回 entity_id**——你不用预先判断时长、也没有什么"后台开关"要打开，长命令照常直接跑即可，不会堵住 agent loop。收到「已转入后台」后：有别的事就去做，没有就调 \`wait_for_signal({reason:"等 <命令>", targets:[{kind:"bg_entity"}]})\` 挂起，该命令退出会自动唤醒你。**不要对转后台的命令反复裸 poll \`Output\`。**
 
 **架构：bg entity 的 exit / 完成事件会自动 push 给你**——退出时 prompt 里会出现 \`<bg-notification>\` 块告诉你"shell_xxx 已退出，状态 X" **并内联输出尾部**，常见场景你无需再调 Output；只有要看完整 / 分页输出时才用 \`Output(entity_id)\`。你不需要主动确认 entity 是否结束。
 
@@ -738,12 +738,20 @@ set_task_goal 重写机会（你会在补充指示的接收提示里看到说明
 
 ## 异步等待原语：wait_for_signal
 
-派出 async subagent（delegate_task 异步路径）且没有别的事可干时，
-调 wait_for_signal({reason: "等 <subagent_name>"}) 把控制权交回 engine
-（任何 humanQueue push 都会唤醒你）。
+挂起时必须声明你在等什么（targets），harness 会校验目标真实存在：
+- 等 async subagent：wait_for_signal({reason: "等 <subagent_name>", targets: [{kind: "subagent"}]})
+- 等后台 shell 退出：targets: [{kind: "bg_entity"}]（可加 id 精确指定）
+- 等 crabot 之外的事件（PR review / 远端构建 / 页面状态）：targets: [{kind: "external"}]
+  且必须带 timeout_ms 作轮询间隔——系统感知不到外部事件，到点唤醒后你要自己主动检查
+  （gh / curl 等），未到再挂下一轮。有命令行 watcher（如 gh pr checks --watch）时
+  优先起后台 shell 等它退出。external 适合分钟到小时级；跨天级等待应收尾任务 + schedule 定时复查。
+
+任何 humanQueue push（用户消息 / 其他对象退出）都会唤醒你——醒来先处理事件，
+唤醒通知会附上"仍在运行"清单，据它决定继续等还是收尾。
 
 交付审计期间的等待不需要你做任何动作——系统在你 end_turn 时自动挂起、
-审完自动唤醒。不要 polling get_subagent_output 当 wait 用——那是 busy-wait 浪费 token。
+审完自动唤醒；审计不是 wait_for_signal 的合法等待对象。
+不要 polling get_subagent_output 当 wait 用——那是 busy-wait 浪费 token。
 
 ## 反复审计失败时怎么办
 

--- a/crabot-agent/tests/agent/agent-handler.goal-audit.test.ts
+++ b/crabot-agent/tests/agent/agent-handler.goal-audit.test.ts
@@ -322,6 +322,35 @@ describe('AgentHandler.persistAsyncAuditResult', () => {
     }
   })
 
+  it('append RPC 抛错（如终态竞态）→ pass 场景 complete_task_goal 仍被调用（spec 2026-07-16 §2.2-3）', async () => {
+    const rpcCall = vi.fn(async (_port: unknown, method: unknown) => {
+      if (method === 'append_task_goal_audit_entry') {
+        throw new Error('TaskGoal 当前 status=complete，非 active 不可追加 audit 历史')
+      }
+      return { task: { id: 't-async' } }
+    })
+    const appendTraceOutcome = vi.fn()
+    const handler = makeHandler({ rpcCall })
+    try {
+      await (handler as any).persistAsyncAuditResult({
+        taskId: 't-async',
+        auditId: 'audit-trace-3',
+        parsed: {
+          pass: true,
+          failedCriteria: [],
+          rawOutput: 'ok',
+        } satisfies ParsedAuditReport,
+        verdictSummary: { summary: '[audit PASS]' },
+        traceStore: { appendTraceOutcome },
+      })
+
+      expect(rpcCall.mock.calls.some((c) => c[1] === 'complete_task_goal')).toBe(true)
+      expect(appendTraceOutcome).toHaveBeenCalledWith('audit-trace-3', { summary: '[audit PASS]' })
+    } finally {
+      handler.dispose()
+    }
+  })
+
   it('async audit fail → 写 audit_history、不中断 complete，并 patch fail verdict', async () => {
     const rpcCall = vi.fn()
       .mockResolvedValueOnce({ task: { id: 't-async', goal: { ...sampleGoal(), status: 'active' } } })

--- a/crabot-agent/tests/agent/end-turn-gate-async.test.ts
+++ b/crabot-agent/tests/agent/end-turn-gate-async.test.ts
@@ -176,6 +176,60 @@ describe('createAsyncAuditEndTurnGate', () => {
     expect(h.spawnFn).not.toHaveBeenCalled()
   })
 
+  it('activeAuditId 非空（已有 audit 在跑）→ null，绝不派第二个 audit（spec 2026-07-16 §4.2）', async () => {
+    const h = makeHarness()
+    h.taskState.activeAuditId = 'audit-already-running'
+    const gate = createAsyncAuditEndTurnGate(h.deps)
+
+    const result = await gate()
+
+    expect(result).toBeNull()
+    expect(h.spawnFn).not.toHaveBeenCalled()
+    expect(h.rpcCall).not.toHaveBeenCalled()
+    // 原 audit 不受影响
+    expect(h.taskState.activeAuditId).toBe('audit-already-running')
+  })
+
+  it('goal 终态（status=complete）→ null fail-open，不 spawn（spec 2026-07-16 §2.2-2）', async () => {
+    const rpcCall = vi.fn(async () => ({
+      task: { id: 'task-1', goal: { ...makeGoal(), status: 'complete' } },
+    }))
+    const h = makeHarness({ rpcCallOverride: rpcCall })
+    const gate = createAsyncAuditEndTurnGate(h.deps)
+
+    const result = await gate()
+
+    expect(result).toBeNull()
+    expect(h.spawnFn).not.toHaveBeenCalled()
+    expect(h.taskState.activeAuditId).toBeUndefined()
+  })
+
+  it('goal 终态（status=cleared）→ null fail-open，不 spawn（spec 2026-07-16 §2.2-2）', async () => {
+    const rpcCall = vi.fn(async () => ({
+      task: { id: 'task-1', goal: { ...makeGoal(), status: 'cleared' } },
+    }))
+    const h = makeHarness({ rpcCallOverride: rpcCall })
+    const gate = createAsyncAuditEndTurnGate(h.deps)
+
+    const result = await gate()
+
+    expect(result).toBeNull()
+    expect(h.spawnFn).not.toHaveBeenCalled()
+  })
+
+  it('goal status=active → 照常 spawn（终态检查不误伤）', async () => {
+    const rpcCall = vi.fn(async () => ({
+      task: { id: 'task-1', goal: { ...makeGoal(), status: 'active' } },
+    }))
+    const h = makeHarness({ rpcCallOverride: rpcCall })
+    const gate = createAsyncAuditEndTurnGate(h.deps)
+
+    const result = await gate()
+
+    expect(result).toEqual({ kind: 'wait' })
+    expect(h.spawnFn).toHaveBeenCalledTimes(1)
+  })
+
   it('非空 buffer + goal 存在 → spawn audit + 设 activeAuditId + 返回 [audit_pending] marker', async () => {
     const h = makeHarness({ spawnReturn: 'audit-test-xyz' })
     const gate = createAsyncAuditEndTurnGate(h.deps)

--- a/crabot-agent/tests/agent/goal-terminal.test.ts
+++ b/crabot-agent/tests/agent/goal-terminal.test.ts
@@ -1,0 +1,51 @@
+/**
+ * goal 终态判定（spec 2026-07-16-wait-signal-targets-goal-lifecycle-design §2）：
+ *  - shouldArmGoalGate：goal 存在且非终态才武装 audit gate
+ *  - 终态集合与 crabot-admin/src/task-goal.ts 的 isTerminal 逐值对齐（防两边漂移）
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  TERMINAL_GOAL_STATUSES,
+  isGoalTerminal,
+  shouldArmGoalGate,
+  type GoalStatus,
+} from '../../src/agent/goal-audit'
+import { isTerminal as adminIsTerminal } from '../../../crabot-admin/src/task-goal'
+
+describe('isGoalTerminal / TERMINAL_GOAL_STATUSES', () => {
+  it('与 admin isTerminal 对每个 GoalStatus 取值一致（对齐测试）', () => {
+    const all: GoalStatus[] = ['active', 'complete', 'blocked', 'budget_limited', 'cleared']
+    for (const s of all) {
+      expect(isGoalTerminal(s), `status=${s}`).toBe(adminIsTerminal(s))
+    }
+  })
+
+  it('active 非终态，其余四态为终态', () => {
+    expect(isGoalTerminal('active')).toBe(false)
+    for (const s of ['complete', 'blocked', 'budget_limited', 'cleared'] as const) {
+      expect(TERMINAL_GOAL_STATUSES.has(s)).toBe(true)
+    }
+  })
+})
+
+describe('shouldArmGoalGate', () => {
+  it('goal undefined/null → false', () => {
+    expect(shouldArmGoalGate(undefined)).toBe(false)
+    expect(shouldArmGoalGate(null)).toBe(false)
+  })
+
+  it('goal active → true', () => {
+    expect(shouldArmGoalGate({ objective: 'x', status: 'active' })).toBe(true)
+  })
+
+  it('goal 终态（complete/blocked/budget_limited/cleared）→ false', () => {
+    for (const s of ['complete', 'blocked', 'budget_limited', 'cleared']) {
+      expect(shouldArmGoalGate({ objective: 'x', status: s }), `status=${s}`).toBe(false)
+    }
+  })
+
+  it('goal 无 status 字段（旧数据防御）→ true（视为 active）', () => {
+    expect(shouldArmGoalGate({ objective: 'x' })).toBe(true)
+  })
+})

--- a/crabot-agent/tests/agent/wait-for-signal-injection.test.ts
+++ b/crabot-agent/tests/agent/wait-for-signal-injection.test.ts
@@ -2,8 +2,10 @@ import { describe, it, expect } from 'vitest'
 import {
   extractLaunchedSubagentId,
   maybeCreateWaitForSignalTool,
+  summarizeRunningEntities,
 } from '../../src/agent/agent-handler.js'
 import { HumanMessageQueue } from '../../src/engine/human-message-queue.js'
+import type { BgEntityRecord } from '../../src/engine/bg-entities/types.js'
 
 describe('extractLaunchedSubagentId', () => {
   it('从 delegate_task 异步路径 JSON 输出抓 agent_id', () => {
@@ -42,9 +44,8 @@ describe('extractLaunchedSubagentId', () => {
 describe('maybeCreateWaitForSignalTool', () => {
   const stubDeps = {
     humanQueue: new HumanMessageQueue(),
-    hasActiveAudit: () => false,
-    hasActiveAsyncSubagent: () => false,
-    hasRunningBgEntity: () => false,
+    listActiveAsyncSubagentIds: () => [] as string[],
+    listRunningBgEntities: async () => [],
   }
 
   it('goalMode + async 都开 → 注入', () => {
@@ -83,23 +84,85 @@ describe('maybeCreateWaitForSignalTool', () => {
     expect(tool?.name).toBe('wait_for_signal')
   })
 
-  it('注入的工具透传 deps（hasActiveAsyncSubagent 真正被调）', async () => {
+  it('注入的工具透传 deps（listActiveAsyncSubagentIds 真正被调）', async () => {
     let callCount = 0
     const tool = maybeCreateWaitForSignalTool(
       { goalModeEnabled: false, asyncEnabled: true },
       {
         ...stubDeps,
-        hasActiveAsyncSubagent: () => {
+        listActiveAsyncSubagentIds: () => {
           callCount += 1
-          return true
+          return ['agent_x']
         },
       },
     )
     expect(tool).toBeDefined()
-    // 触发 tool.call —— 应该看到 hasActiveAsyncSubagent 被调用
-    await tool!.call({ reason: 'test' }, {} as never)
+    // 触发 tool.call —— 应该看到 listActiveAsyncSubagentIds 被调用
+    await tool!.call({ reason: 'test', targets: [{ kind: 'subagent' }] }, {} as never)
     expect(callCount).toBeGreaterThan(0)
-    // 清理 barrier（hasActiveAsyncSubagent=true 时 tool.call 会 setBarrier(24h)，否则会泄露 setTimeout）
+    // 清理 barrier（目标存在时 tool.call 会 setBarrier(24h)，否则会泄露 setTimeout）
     stubDeps.humanQueue.clearBarrier()
+  })
+})
+
+describe('summarizeRunningEntities（唤醒快照数据源，spec 2026-07-16 §6）', () => {
+  const NOW = Date.parse('2026-07-16T10:10:00.000Z')
+
+  function shellRec(id: string, taskId: string, spawnedAt: string): BgEntityRecord {
+    return {
+      entity_id: id,
+      type: 'shell',
+      status: 'running',
+      owner: { friend_id: 'f1' },
+      spawned_by_task_id: taskId,
+      spawned_at: spawnedAt,
+      exit_code: null,
+      ended_at: null,
+      last_activity_at: spawnedAt,
+      command: 'pnpm test --watch',
+      log_file: '/tmp/x.log',
+      pid: 1,
+      pgid: 1,
+      process_started_at: spawnedAt,
+    }
+  }
+
+  function agentRec(id: string, taskId: string, spawnedAt: string): BgEntityRecord {
+    return {
+      entity_id: id,
+      type: 'agent',
+      status: 'running',
+      owner: { friend_id: 'f1' },
+      spawned_by_task_id: taskId,
+      spawned_at: spawnedAt,
+      exit_code: null,
+      ended_at: null,
+      last_activity_at: spawnedAt,
+      task_description: 'research something',
+      messages_log_file: '/tmp/m.jsonl',
+      result_file: null,
+    }
+  }
+
+  it('按 task 过滤 + 排除指定 entity + kind 映射 + runtime 计算', () => {
+    const records = [
+      agentRec('agent_done', 'task-1', '2026-07-16T10:00:00.000Z'),   // 即将退出的（排除）
+      agentRec('agent_live', 'task-1', '2026-07-16T10:05:00.000Z'),
+      shellRec('shell_live', 'task-1', '2026-07-16T10:08:00.000Z'),
+      shellRec('shell_other_task', 'task-2', '2026-07-16T10:00:00.000Z'),
+    ]
+    const items = summarizeRunningEntities(records, 'task-1', 'agent_done', NOW)
+    expect(items.map((i) => i.id).sort()).toEqual(['agent_live', 'shell_live'])
+    const agent = items.find((i) => i.id === 'agent_live')!
+    expect(agent.kind).toBe('subagent')
+    expect(agent.runtime_ms).toBe(5 * 60_000)
+    expect(agent.description).toBe('research something')
+    const shell = items.find((i) => i.id === 'shell_live')!
+    expect(shell.kind).toBe('bg_entity')
+    expect(shell.description).toBe('pnpm test --watch')
+  })
+
+  it('无在跑对象 → 空数组', () => {
+    expect(summarizeRunningEntities([], 'task-1', undefined, NOW)).toEqual([])
   })
 })

--- a/crabot-agent/tests/agent/wait-for-signal-injection.test.ts
+++ b/crabot-agent/tests/agent/wait-for-signal-injection.test.ts
@@ -151,7 +151,7 @@ describe('summarizeRunningEntities（唤醒快照数据源，spec 2026-07-16 §6
       shellRec('shell_live', 'task-1', '2026-07-16T10:08:00.000Z'),
       shellRec('shell_other_task', 'task-2', '2026-07-16T10:00:00.000Z'),
     ]
-    const items = summarizeRunningEntities(records, 'task-1', 'agent_done', NOW)
+    const items = summarizeRunningEntities(records, 'task-1', ['agent_done'], NOW)
     expect(items.map((i) => i.id).sort()).toEqual(['agent_live', 'shell_live'])
     const agent = items.find((i) => i.id === 'agent_live')!
     expect(agent.kind).toBe('subagent')
@@ -162,7 +162,18 @@ describe('summarizeRunningEntities（唤醒快照数据源，spec 2026-07-16 §6
     expect(shell.description).toBe('pnpm test --watch')
   })
 
+  it('在跑的 goal-audit subagent 被排除——不向 agent 泄漏 audit 存在（PR #31 review）', () => {
+    // audit subagent 也以 spawned_by_task_id=parentTaskId 注册 registry（audit-spawn.ts），
+    // 快照若包含它 = 重新引入"教 agent 等 audit"的污染源 + 与 targets 准入自相矛盾。
+    const records = [
+      agentRec('agent_audit', 'task-1', '2026-07-16T10:09:00.000Z'),  // 在跑的 audit
+      shellRec('shell_live', 'task-1', '2026-07-16T10:08:00.000Z'),
+    ]
+    const items = summarizeRunningEntities(records, 'task-1', ['shell_exiting', 'agent_audit'], NOW)
+    expect(items.map((i) => i.id)).toEqual(['shell_live'])
+  })
+
   it('无在跑对象 → 空数组', () => {
-    expect(summarizeRunningEntities([], 'task-1', undefined, NOW)).toEqual([])
+    expect(summarizeRunningEntities([], 'task-1', [], NOW)).toEqual([])
   })
 })

--- a/crabot-agent/tests/engine/audit-pending-end-turn-fallback.test.ts
+++ b/crabot-agent/tests/engine/audit-pending-end-turn-fallback.test.ts
@@ -1,12 +1,15 @@
 /**
- * Task 13: audit 跑中 LLM 直接 end_turn 兜底拦截测试.
+ * audit 跑中 LLM 直接 end_turn → engine 直接挂起等 audit 结果（2026-07-16 重设计）.
  *
- * spec: 2026-06-07-goal-audit-async-buffered-info-design.md §4.6
+ * spec: 2026-07-16-wait-signal-targets-goal-lifecycle-design §3.2
+ * （取代 2026-06-07 §4.6 的"注入拦截文案 → LLM 调 wait_for_signal"路径——
+ *   那套文案会教坏 agent 主动 wait audit，见 trace ac9676e3 空转实证）
  *
- * 异常路径：
- *   - agent 看到 [audit_pending] 不调 wait_for_signal，直接 end_turn
- *   - engine 检测 hasActiveAudit=true + stop_reason 非 tool_use → 注入提示拦截续 loop
- *   - 最多 3 次后放弃：abort active audit + 让 end_turn 通过
+ * 新行为：
+ *   - end_turn + hasActiveAudit=true → engine setBarrier 挂起，零文案注入、零额外 LLM 轮
+ *   - audit pass marker 到达 → drain 分流 → flush + 退出 completed
+ *   - audit fail marker 到达 → drain 注入缺口报告 → 续 turn
+ *   - 挂起幂等可重入：人类追问唤醒 → 处理 → 再 end_turn → 再挂起（B-追问重入）
  */
 
 import { describe, it, expect, vi } from 'vitest'
@@ -43,70 +46,133 @@ function makeAdapter(steps: ReadonlyArray<AdapterStep>): LLMAdapter {
   } as unknown as LLMAdapter
 }
 
-describe('query-loop: audit pending end_turn fallback intercept (Task 13)', () => {
-  it('拦截前 3 次注入 forced prompt，第 4 次 abort + 放行 end_turn', async () => {
-    const abortSpy = vi.fn()
-    const injections: Array<{ type: string; text: string; turnNumber: number }> = []
-    // 模拟：abort 被调用之后 hasActiveAudit 转为 false，让 fall-through 端走正常 end_turn
-    let auditActive = true
-    const hasActiveAudit = vi.fn(() => auditActive)
-    const abortActiveAudit = (reason: string): void => {
-      abortSpy(reason)
-      auditActive = false
-    }
+function passMarker(auditId: string): string {
+  return buildAuditResultMarker({ auditId, pass: true, failedCriteria: [], detailedReport: '' })
+}
 
-    // LLM 反复 end_turn 不调 wait_for_signal
-    // turn 1: end_turn → intercept #1
-    // turn 2: end_turn → intercept #2
-    // turn 3: end_turn → intercept #3
-    // turn 4: end_turn → 兜底耗尽 → abort + 放行
-    const adapter = makeAdapter([
-      { kind: 'end_turn', text: '搞定' },
-      { kind: 'end_turn', text: '搞定' },
-      { kind: 'end_turn', text: '搞定' },
-      { kind: 'end_turn', text: '搞定' },
-    ])
+function failMarker(auditId: string): string {
+  return buildAuditResultMarker({
+    auditId,
+    pass: false,
+    failedCriteria: ['c1'],
+    detailedReport: '缺口：c1 未覆盖',
+  })
+}
+
+describe('query-loop: audit 跑中 end_turn → engine 直接挂起（spec 2026-07-16 §3.2）', () => {
+  it('end_turn + audit 在跑 → 挂起等 pass marker → 退出 completed；零拦截文案、零额外 LLM 轮', async () => {
+    const queue = new HumanMessageQueue()
+    const injections: Array<{ type: string }> = []
+    let auditActive = true
+    const clearActiveAuditId = vi.fn(() => { auditActive = false })
+    const flushSpy = vi.fn(async () => {})
+
+    const adapter = makeAdapter([{ kind: 'end_turn', text: '搞定' }])
+
+    // 挂起后再推 pass marker（模拟 audit 异步完成）
+    setTimeout(() => queue.push(passMarker('audit-1')), 30)
 
     const result = await runEngine({
       prompt: 'go',
       adapter,
       options: {
-        humanMessageQueue: new HumanMessageQueue(),
+        humanMessageQueue: queue,
         tools: [],
         systemPrompt: '',
         model: 'test-model',
-        hasActiveAudit,
-        abortActiveAudit,
-        onSystemInjection: (e) =>
-          injections.push({ type: e.type, text: e.text, turnNumber: e.turnNumber }),
+        hasActiveAudit: () => auditActive,
+        clearActiveAuditId,
+        flushOutboundBuffer: flushSpy,
+        dropOutboundBuffer: vi.fn(),
+        onSystemInjection: (e) => injections.push({ type: e.type }),
       },
     })
 
     expect(result.outcome).toBe('completed')
-
-    // 拦截注入：恰好 3 次 audit_pending_intercept
-    const intercepts = injections.filter((e) => e.type === 'audit_pending_intercept')
-    expect(intercepts).toHaveLength(3)
-    for (const intercept of intercepts) {
-      expect(intercept.text).toContain('你不能直接 end_turn')
-      expect(intercept.text).toContain('audit 仍在跑')
-    }
-
-    // abort 在第 4 次（兜底耗尽）调一次
-    expect(abortSpy).toHaveBeenCalledTimes(1)
-    expect(abortSpy).toHaveBeenCalledWith('end_turn_retries_exhausted')
-
-    // 总轮数：3 次拦截续 turn + 1 次放行 = 至少 4 轮
-    expect(result.totalTurns).toBeGreaterThanOrEqual(4)
+    expect(result.totalTurns).toBe(1)
+    expect(injections.filter((e) => e.type === 'audit_pending_intercept')).toHaveLength(0)
+    expect(clearActiveAuditId).toHaveBeenCalled()
+    expect(flushSpy).toHaveBeenCalled()
   })
 
-  it('hasActiveAudit=false 时不拦截，正常 end_turn', async () => {
-    const abortSpy = vi.fn()
+  it('挂起等到 fail marker → 注入缺口报告续 turn，第二轮正常收尾', async () => {
+    const queue = new HumanMessageQueue()
     const injections: Array<{ type: string; text: string }> = []
+    let auditActive = true
+    const clearActiveAuditId = vi.fn(() => { auditActive = false })
+    const dropSpy = vi.fn()
 
+    // turn 1 end_turn → 挂起 → fail → 续 turn 2 → audit 已清 → 正常 end_turn
     const adapter = makeAdapter([
       { kind: 'end_turn', text: '搞定' },
+      { kind: 'end_turn', text: '补完了' },
     ])
+    setTimeout(() => queue.push(failMarker('audit-2')), 30)
+
+    const result = await runEngine({
+      prompt: 'go',
+      adapter,
+      options: {
+        humanMessageQueue: queue,
+        tools: [],
+        systemPrompt: '',
+        model: 'test-model',
+        hasActiveAudit: () => auditActive,
+        clearActiveAuditId,
+        flushOutboundBuffer: vi.fn(async () => {}),
+        dropOutboundBuffer: dropSpy,
+        onSystemInjection: (e) => injections.push({ type: e.type, text: e.text }),
+      },
+    })
+
+    expect(result.outcome).toBe('completed')
+    expect(result.totalTurns).toBe(2)
+    expect(injections.filter((e) => e.type === 'audit_pending_intercept')).toHaveLength(0)
+    expect(dropSpy).toHaveBeenCalled()
+    expect(clearActiveAuditId).toHaveBeenCalled()
+  })
+
+  it('B-追问重入：挂起中人类消息唤醒 → 处理后再 end_turn → 再次挂起 → pass 后退出', async () => {
+    const queue = new HumanMessageQueue()
+    const injections: Array<{ type: string; text: string }> = []
+    let auditActive = true
+    const clearActiveAuditId = vi.fn(() => { auditActive = false })
+
+    // turn 1 end_turn → 挂起 → 人类追问唤醒续 turn 2 → end_turn → 再挂起 → pass → 退出
+    const adapter = makeAdapter([
+      { kind: 'end_turn', text: '搞定' },
+      { kind: 'end_turn', text: '回答了追问' },
+    ])
+    setTimeout(() => queue.push('顺便问一下，昨天那个也是这个原因吗？'), 30)
+    setTimeout(() => queue.push(passMarker('audit-3')), 120)
+
+    const result = await runEngine({
+      prompt: 'go',
+      adapter,
+      options: {
+        humanMessageQueue: queue,
+        tools: [],
+        systemPrompt: '',
+        model: 'test-model',
+        hasActiveAudit: () => auditActive,
+        clearActiveAuditId,
+        flushOutboundBuffer: vi.fn(async () => {}),
+        dropOutboundBuffer: vi.fn(),
+        onSystemInjection: (e) => injections.push({ type: e.type, text: e.text }),
+      },
+    })
+
+    expect(result.outcome).toBe('completed')
+    // 两轮 LLM：原始 end_turn + 追问处理轮；两次挂起都不烧额外轮次
+    expect(result.totalTurns).toBe(2)
+    expect(injections.filter((e) => e.type === 'audit_pending_intercept')).toHaveLength(0)
+    // 追问以 supplement 注入
+    expect(injections.some((e) => e.type === 'supplement' && e.text.includes('昨天那个'))).toBe(true)
+  })
+
+  it('hasActiveAudit=false 时不挂起，正常 end_turn', async () => {
+    const injections: Array<{ type: string }> = []
+    const adapter = makeAdapter([{ kind: 'end_turn', text: '搞定' }])
 
     const result = await runEngine({
       prompt: 'go',
@@ -117,48 +183,24 @@ describe('query-loop: audit pending end_turn fallback intercept (Task 13)', () =
         systemPrompt: '',
         model: 'test-model',
         hasActiveAudit: () => false,
-        abortActiveAudit: abortSpy,
-        onSystemInjection: (e) =>
-          injections.push({ type: e.type, text: e.text }),
+        onSystemInjection: (e) => injections.push({ type: e.type }),
       },
     })
 
     expect(result.outcome).toBe('completed')
-    // 没有拦截
-    expect(injections.filter((e) => e.type === 'audit_pending_intercept')).toHaveLength(0)
-    expect(abortSpy).not.toHaveBeenCalled()
     expect(result.totalTurns).toBe(1)
   })
 
-  it('drain 期间 audit_result(pass) 到达 → hasActiveAudit 转 false → 不拦截', async () => {
-    // 模拟 audit 在跑 → drain 拿到 pass result → clearActiveAuditId 让 hasActiveAudit=false
-    // engine 后续不拦截，走正常 end_turn 路径（buildResult completed）
+  it('drain 期间 audit_result(pass) 到达 → hasActiveAudit 转 false → 不挂起', async () => {
     const queue = new HumanMessageQueue()
-    const abortSpy = vi.fn()
     const flushSpy = vi.fn(async () => {})
-    const dropSpy = vi.fn()
-    const injections: Array<{ type: string; text: string }> = []
-
     let auditActive = true
-    // clearActiveAuditId 在 drain 路径里被调，模拟 audit 结束
-    const clearActiveAuditId = vi.fn(() => {
-      auditActive = false
-    })
-    const hasActiveAudit = vi.fn(() => auditActive)
+    const clearActiveAuditId = vi.fn(() => { auditActive = false })
 
-    // queue 预先 push 一条 pass marker —— end_turn drain 路径会拿到
-    queue.push(
-      buildAuditResultMarker({
-        auditId: 'audit-mid-1',
-        pass: true,
-        failedCriteria: [],
-        detailedReport: '',
-      }),
-    )
+    // queue 预先 push pass marker —— end_turn 前的 drain 拿到并清 audit
+    queue.push(passMarker('audit-mid-1'))
 
-    const adapter = makeAdapter([
-      { kind: 'end_turn', text: '搞定' },
-    ])
+    const adapter = makeAdapter([{ kind: 'end_turn', text: '搞定' }])
 
     const result = await runEngine({
       prompt: 'go',
@@ -168,83 +210,20 @@ describe('query-loop: audit pending end_turn fallback intercept (Task 13)', () =
         tools: [],
         systemPrompt: '',
         model: 'test-model',
-        hasActiveAudit,
-        abortActiveAudit: abortSpy,
-        flushOutboundBuffer: flushSpy,
-        dropOutboundBuffer: dropSpy,
+        hasActiveAudit: () => auditActive,
         clearActiveAuditId,
-        onSystemInjection: (e) =>
-          injections.push({ type: e.type, text: e.text }),
+        flushOutboundBuffer: flushSpy,
+        dropOutboundBuffer: vi.fn(),
       },
     })
 
     expect(result.outcome).toBe('completed')
-    // drain 调了 clearActiveAuditId（pass 路径）→ 之后 hasActiveAudit=false → 不拦截
     expect(clearActiveAuditId).toHaveBeenCalled()
     expect(flushSpy).toHaveBeenCalled()
-    expect(abortSpy).not.toHaveBeenCalled()
-    expect(injections.filter((e) => e.type === 'audit_pending_intercept')).toHaveLength(0)
-  })
-
-  it('counter 是 per-run 的，独立于其他 engine run', async () => {
-    // 跑两次独立的 engine —— 第二次的 counter 应该从 0 开始，能拦截 3 次
-    let auditActive1 = true
-    let auditActive2 = true
-    const injections1: Array<{ type: string }> = []
-    const injections2: Array<{ type: string }> = []
-
-    const makeOptions = (
-      hasAudit: () => boolean,
-      abortFn: (reason: string) => void,
-      injTarget: Array<{ type: string }>,
-    ) => ({
-      humanMessageQueue: new HumanMessageQueue(),
-      tools: [],
-      systemPrompt: '',
-      model: 'test-model',
-      hasActiveAudit: hasAudit,
-      abortActiveAudit: abortFn,
-      onSystemInjection: (e: { type: string }) => injTarget.push({ type: e.type }),
-    })
-
-    // Run 1: 4 个 end_turn，预期 3 次拦截 + abort
-    const adapter1 = makeAdapter([
-      { kind: 'end_turn', text: 'go' },
-      { kind: 'end_turn', text: 'go' },
-      { kind: 'end_turn', text: 'go' },
-      { kind: 'end_turn', text: 'go' },
-    ])
-    const abortSpy1 = vi.fn((_reason: string) => { auditActive1 = false })
-    await runEngine({
-      prompt: 'p1',
-      adapter: adapter1,
-      options: makeOptions(() => auditActive1, abortSpy1, injections1),
-    })
-    expect(injections1.filter((e) => e.type === 'audit_pending_intercept')).toHaveLength(3)
-    expect(abortSpy1).toHaveBeenCalledTimes(1)
-
-    // Run 2: 同样 4 个 end_turn，counter 应该重置 → 同样 3 次拦截 + abort
-    const adapter2 = makeAdapter([
-      { kind: 'end_turn', text: 'go' },
-      { kind: 'end_turn', text: 'go' },
-      { kind: 'end_turn', text: 'go' },
-      { kind: 'end_turn', text: 'go' },
-    ])
-    const abortSpy2 = vi.fn((_reason: string) => { auditActive2 = false })
-    await runEngine({
-      prompt: 'p2',
-      adapter: adapter2,
-      options: makeOptions(() => auditActive2, abortSpy2, injections2),
-    })
-    expect(injections2.filter((e) => e.type === 'audit_pending_intercept')).toHaveLength(3)
-    expect(abortSpy2).toHaveBeenCalledTimes(1)
   })
 
   it('callbacks not provided → 不抛错（backward compat）', async () => {
-    // hasActiveAudit / abortActiveAudit 都不传时，正常 end_turn 不受影响
-    const adapter = makeAdapter([
-      { kind: 'end_turn', text: '搞定' },
-    ])
+    const adapter = makeAdapter([{ kind: 'end_turn', text: '搞定' }])
 
     const result = await runEngine({
       prompt: 'go',
@@ -254,42 +233,10 @@ describe('query-loop: audit pending end_turn fallback intercept (Task 13)', () =
         tools: [],
         systemPrompt: '',
         model: 'test-model',
-        // hasActiveAudit / abortActiveAudit 都不传
       },
     })
 
     expect(result.outcome).toBe('completed')
     expect(result.totalTurns).toBe(1)
-  })
-
-  it('abortActiveAudit 缺失 → 兜底耗尽仍 fall-through 放行', async () => {
-    // hasActiveAudit 一直 true，没有 abortActiveAudit—— 3 次拦截后 fall-through
-    // 不能死循环（因为 hasActiveAudit 一直 true），但 retries 用尽就放行
-    const injections: Array<{ type: string }> = []
-    const adapter = makeAdapter([
-      { kind: 'end_turn', text: 'go' },
-      { kind: 'end_turn', text: 'go' },
-      { kind: 'end_turn', text: 'go' },
-      { kind: 'end_turn', text: 'go' },
-    ])
-
-    const result = await runEngine({
-      prompt: 'go',
-      adapter,
-      options: {
-        humanMessageQueue: new HumanMessageQueue(),
-        tools: [],
-        systemPrompt: '',
-        model: 'test-model',
-        hasActiveAudit: () => true,
-        // abortActiveAudit 不传——engine 跳过 abort 直接 fall-through
-        onSystemInjection: (e) => injections.push({ type: e.type }),
-      },
-    })
-
-    expect(result.outcome).toBe('completed')
-    expect(injections.filter((e) => e.type === 'audit_pending_intercept')).toHaveLength(3)
-    // retries 耗尽就 fall-through，不死循环
-    expect(result.totalTurns).toBeGreaterThanOrEqual(4)
   })
 })

--- a/crabot-agent/tests/engine/audit-pending-end-turn-fallback.test.ts
+++ b/crabot-agent/tests/engine/audit-pending-end-turn-fallback.test.ts
@@ -12,12 +12,16 @@
  *   - 挂起幂等可重入：人类追问唤醒 → 处理 → 再 end_turn → 再挂起（B-追问重入）
  */
 
-import { describe, it, expect, vi } from 'vitest'
-import { runEngine } from '../../src/engine/query-loop.js'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { runEngine, AUDIT_WAIT_FALLBACK_TIMEOUT_MS } from '../../src/engine/query-loop.js'
 import { HumanMessageQueue } from '../../src/engine/human-message-queue.js'
-import { buildAuditResultMarker } from '../../src/agent/audit-result-marker.js'
+import { buildAuditResultMarker, buildAuditAbortedMarker } from '../../src/agent/audit-result-marker.js'
 import type { LLMAdapter } from '../../src/engine/llm-adapter-types.js'
 import { chunksFromContent } from './helpers/mock-stream.js'
+
+afterEach(() => {
+  vi.useRealTimers()
+})
 
 type AdapterStep =
   | { kind: 'tool'; toolId: string; toolName: string; input?: Record<string, unknown> }
@@ -168,6 +172,52 @@ describe('query-loop: audit 跑中 end_turn → engine 直接挂起（spec 2026-
     expect(injections.filter((e) => e.type === 'audit_pending_intercept')).toHaveLength(0)
     // 追问以 supplement 注入
     expect(injections.some((e) => e.type === 'supplement' && e.text.includes('昨天那个'))).toBe(true)
+  })
+
+  it('audit 卡死（marker 永不到达）→ 兜底超时 abort + fail-open 放行（spec §3.2 前进性保证）', async () => {
+    vi.useFakeTimers()
+    const queue = new HumanMessageQueue()
+    const injections: Array<{ type: string; text: string }> = []
+    let auditActive = true
+    const clearActiveAuditId = vi.fn(() => { auditActive = false })
+    // 模拟 agent-handler 的 abortAudit closure：清状态 + push audit_aborted marker
+    const abortActiveAudit = vi.fn((reason: string) => {
+      auditActive = false
+      queue.push(buildAuditAbortedMarker({ auditId: 'audit-stuck', reason }))
+    })
+
+    // turn 1: end_turn → 挂起 → 无任何事件（audit 卡死）→ 兜底超时 → abort
+    // → audit_aborted marker 注入"已被取消"提示 → turn 2: end_turn → audit 已清 → 正常收尾
+    const adapter = makeAdapter([
+      { kind: 'end_turn', text: '搞定' },
+      { kind: 'end_turn', text: '收尾' },
+    ])
+
+    const resultPromise = runEngine({
+      prompt: 'go',
+      adapter,
+      options: {
+        humanMessageQueue: queue,
+        tools: [],
+        systemPrompt: '',
+        model: 'test-model',
+        hasActiveAudit: () => auditActive,
+        clearActiveAuditId,
+        abortActiveAudit,
+        flushOutboundBuffer: vi.fn(async () => {}),
+        dropOutboundBuffer: vi.fn(),
+        onSystemInjection: (e) => injections.push({ type: e.type, text: e.text }),
+      },
+    })
+    await vi.advanceTimersByTimeAsync(AUDIT_WAIT_FALLBACK_TIMEOUT_MS + 1000)
+    const result = await resultPromise
+
+    expect(result.outcome).toBe('completed')
+    expect(abortActiveAudit).toHaveBeenCalledTimes(1)
+    // 不再有旧式拦截文案
+    expect(injections.filter((e) => e.type === 'audit_pending_intercept')).toHaveLength(0)
+    // 前进性：不是 24h 死等——两轮 LLM 内收尾
+    expect(result.totalTurns).toBe(2)
   })
 
   it('hasActiveAudit=false 时不挂起，正常 end_turn', async () => {

--- a/crabot-agent/tests/integration/goal-audit-async-flow.test.ts
+++ b/crabot-agent/tests/integration/goal-audit-async-flow.test.ts
@@ -444,29 +444,19 @@ describe('E2E: goal-audit async flow', () => {
   // -------------------------------------------------------------------------
   // Case E: 等审态 + tool_use 续 turn 不 flush buffer
   // -------------------------------------------------------------------------
-  it('Case E: hasActiveAudit=true 时 tool_use 续 turn 不 flush + end_turn 3 次后 abort', async () => {
-    // 这个 case 直接验证 query-loop line 806 / 516 的等审态 guard:
-    // - hasActiveAudit 永远为 true（audit 不完成）
-    // - outboundBuffer 含 1 个 pre-audit final 候选
-    // - turn 1: Bash tool_use → 续 turn 时 line 806 guard 应拦截 flush
-    // - turn 2-4: end_turn → audit_pending_intercept 3 次注入
-    // - turn 5: end_turn → 配额耗尽 → abortActiveAudit('end_turn_retries_exhausted')
-    // 关键断言：channelSendSpy 全程 NOT called（pre-audit 内容绝不到 channel）
+  it('Case E: 等审态 tool_use 续 turn 不 flush + end_turn 直接挂起等 audit（spec 2026-07-16 §3.2）', async () => {
+    // 验证 query-loop 的等审态 guard + 新挂起路径:
+    // - outboundBuffer 含 1 个 pre-audit final 候选，activeAuditId 已设（等审态）
+    // - turn 1: Bash tool_use → 续 turn 时等审态 guard 拦截 flush（pre-audit 内容不泄漏）
+    // - turn 2: end_turn → engine 直接挂起（不注入拦截文案、不烧额外 LLM 轮）
+    // - audit pass marker 到达 → drain pass → clear + flush → completed
+    // 关键断言：pass 之前 channel 绝不收到 pre-audit 内容；pass 后恰好 flush 一次
     const wiring = makeWiring()
     const queue = new HumanMessageQueue()
     const injections: Array<{ type: string; text: string }> = []
-    const abortReasons: string[] = []
 
     wiring.outboundBuffer.push(makeBufferEntry('pre-audit 候选交付'))
-
-    // hasActiveAudit 永远 true——模拟 audit subagent 卡住不完成
-    const alwaysActiveAudit = (): boolean => true
-
-    // abortActiveAudit 只记录调用，不真改 state（让我们能验证它被调用且 buffer 仍非空——
-    // 这样可以单独验证 guard 行为，不被 abort 副作用混淆）
-    const abortActiveAuditSpy = vi.fn((reason: string) => {
-      abortReasons.push(reason)
-    })
+    wiring.setActiveAuditId('audit-E')
 
     // 简单的 Bash 工具——立即返回，不设 barrier
     const bashTool: ToolDefinition = {
@@ -478,17 +468,26 @@ describe('E2E: goal-audit async flow', () => {
     }
 
     // adapter:
-    //  turn 1: Bash tool_use → 续 turn 前 line 806 flush 被 guard 拦截
-    //  turn 2-4: end_turn → audit_pending_intercept 3 次
-    //  turn 5: end_turn → 配额耗尽 → abort 调用 + fall through 到 line 520 flush
-    //          line 520 flush 也被 guard 拦截（hasActiveAudit 仍为 true）→ 退出 completed
+    //  turn 1: Bash tool_use → 续 turn 前 flush 被等审态 guard 拦截
+    //  turn 2: end_turn → 等审态 → 直接挂起等 audit 结果
     const adapter = makeAdapter([
       { kind: 'tool', toolId: 't1', toolName: 'Bash' },
       { kind: 'end_turn', text: '完毕' },
-      { kind: 'end_turn', text: '完毕' },
-      { kind: 'end_turn', text: '完毕' },
-      { kind: 'end_turn', text: '完毕' },
     ])
+
+    // 挂起后 audit pass 到达；push 前采样 channel 调用数——验证 pass 前零泄漏
+    let sendCountBeforePass = -1
+    setTimeout(() => {
+      sendCountBeforePass = wiring.channelSendSpy.mock.calls.length
+      queue.push(
+        buildAuditResultMarker({
+          auditId: 'audit-E',
+          pass: true,
+          failedCriteria: [],
+          detailedReport: '',
+        }),
+      )
+    }, 50)
 
     const result = await runEngine({
       prompt: 'go',
@@ -498,29 +497,27 @@ describe('E2E: goal-audit async flow', () => {
         tools: [bashTool],
         systemPrompt: '',
         model: 'test-model',
-        // 不传 endTurnGate——确保 end_turn 路径直接走到 flush
+        // 不传 endTurnGate——聚焦 hasActiveAudit 挂起路径本身
         flushOutboundBuffer: wiring.flushOutboundBuffer,
         dropOutboundBuffer: wiring.dropOutboundBuffer,
         clearActiveAuditId: wiring.clearActiveAuditId,
-        hasActiveAudit: alwaysActiveAudit,
-        abortActiveAudit: abortActiveAuditSpy,
+        hasActiveAudit: wiring.hasActiveAudit,
         onSystemInjection: (e) =>
           injections.push({ type: e.type, text: e.text }),
       },
     })
 
     expect(result.outcome).toBe('completed')
-    // 核心断言 1: channel 全程未被调用——pre-audit 候选交付绝不到达用户
-    expect(wiring.channelSendSpy).not.toHaveBeenCalled()
-    // 核心断言 2: outboundBuffer 仍含 pre-audit 内容（guard 拦截两个 flush 点）
-    expect(wiring.outboundBuffer.length).toBe(1)
-    expect(wiring.outboundBuffer[0].content).toBe('pre-audit 候选交付')
-    // 核心断言 3: audit_pending_intercept 注入了 3 次（MAX_AUDIT_PENDING_END_TURN_RETRIES）
-    const intercepts = injections.filter((e) => e.type === 'audit_pending_intercept')
-    expect(intercepts.length).toBe(3)
-    // 核心断言 4: 配额耗尽时 abortActiveAudit 被调用 with 正确 reason
-    expect(abortActiveAuditSpy).toHaveBeenCalledTimes(1)
-    expect(abortReasons[0]).toBe('end_turn_retries_exhausted')
+    // 核心断言 1: audit pass 之前 channel 零调用——tool_use 续 turn 的 flush 被 guard 拦截
+    expect(sendCountBeforePass).toBe(0)
+    // 核心断言 2: pass 后 flush 恰好一次、buffer 清空
+    expect(wiring.channelSendSpy).toHaveBeenCalledTimes(1)
+    expect(wiring.outboundBuffer.length).toBe(0)
+    // 核心断言 3: 全程零拦截文案注入、零额外 LLM 轮（挂起不经过 LLM）
+    expect(injections.filter((e) => e.type === 'audit_pending_intercept')).toHaveLength(0)
+    expect(result.totalTurns).toBe(2)
+    // 核心断言 4: activeAuditId 已被 drain pass 路径清掉
+    expect(wiring.getActiveAuditId()).toBeUndefined()
   })
 
   // -------------------------------------------------------------------------

--- a/crabot-agent/tests/mcp/wait-for-signal.test.ts
+++ b/crabot-agent/tests/mcp/wait-for-signal.test.ts
@@ -1,132 +1,289 @@
-import { describe, it, expect, vi } from 'vitest'
-import { createWaitForSignalTool, type WaitForSignalDeps } from '../../src/mcp/wait-for-signal.js'
+/**
+ * wait_for_signal targets 准入校验 + 唤醒/超时快照。
+ * spec: 2026-07-16-wait-signal-targets-goal-lifecycle-design §5 / §6
+ *
+ * 关键语义：
+ *  - targets 必填；命名目标不存在 → 立即拒绝（带不带 timeout_ms 都拒绝）
+ *  - external 必须带 timeout_ms（轮询间隔——系统无法感知外部事件）
+ *  - audit / human_reply 不是合法等待对象 → 定向教育文案
+ *  - target 只做准入校验，不做唤醒过滤（任何 push 都唤醒——§5.2 硬不变量）
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import {
+  createWaitForSignalTool,
+  formatStillRunningSnapshot,
+  type WaitForSignalDeps,
+} from '../../src/mcp/wait-for-signal.js'
 import { HumanMessageQueue } from '../../src/engine/human-message-queue.js'
 import type { ToolCallContext } from '../../src/engine/types.js'
 
+const CTX = {} as ToolCallContext
+
 function makeDeps(overrides: Partial<WaitForSignalDeps> & { humanQueue: HumanMessageQueue }): WaitForSignalDeps {
   return {
-    hasActiveAudit: () => false,
-    hasActiveAsyncSubagent: () => false,
-    hasRunningBgEntity: () => false,
+    listActiveAsyncSubagentIds: () => [],
+    listRunningBgEntities: async () => [],
     ...overrides,
   }
 }
 
-describe('wait_for_signal', () => {
-  it('returns error when no pending event exists', async () => {
-    const humanQueue = new HumanMessageQueue()
-    const tool = createWaitForSignalTool(makeDeps({ humanQueue }))
-    const result = await tool.call({ reason: 'test' }, {} as ToolCallContext)
-    expect(result.isError).toBe(true)
-    expect(result.output).toContain('无 pending')
-    // 拒绝文案要引导 timeout_ms 路径，而不是只推 end_turn
-    expect(result.output).toContain('timeout_ms')
-    // assert observable: barrier NOT set
-    expect(humanQueue.hasBarrier).toBe(false)
-  })
+afterEach(() => {
+  vi.useRealTimers()
+})
 
-  it('sets barrier when audit is active', async () => {
+describe('wait_for_signal targets 准入校验', () => {
+  it('subagent 目标存在 → 挂起成功', async () => {
     const humanQueue = new HumanMessageQueue()
-    const tool = createWaitForSignalTool(makeDeps({ humanQueue, hasActiveAudit: () => true }))
-    const result = await tool.call({ reason: 'await audit' }, {} as ToolCallContext)
+    const tool = createWaitForSignalTool(makeDeps({
+      humanQueue,
+      listActiveAsyncSubagentIds: () => ['agent_1'],
+    }))
+    const result = await tool.call(
+      { reason: '等 research 完成', targets: [{ kind: 'subagent' }] }, CTX)
     expect(result.isError).toBe(false)
     expect(humanQueue.hasBarrier).toBe(true)
     humanQueue.clearBarrier()
   })
 
-  it('sets barrier when async subagent is active', async () => {
+  it('指定 id 的 subagent 在跑 → 挂起成功', async () => {
     const humanQueue = new HumanMessageQueue()
-    const tool = createWaitForSignalTool(makeDeps({ humanQueue, hasActiveAsyncSubagent: () => true }))
-    await tool.call({ reason: 'await subagent' }, {} as ToolCallContext)
+    const tool = createWaitForSignalTool(makeDeps({
+      humanQueue,
+      listActiveAsyncSubagentIds: () => ['agent_1', 'agent_2'],
+    }))
+    const result = await tool.call(
+      { reason: '等 agent_2', targets: [{ kind: 'subagent', id: 'agent_2' }] }, CTX)
+    expect(result.isError).toBe(false)
     expect(humanQueue.hasBarrier).toBe(true)
     humanQueue.clearBarrier()
   })
 
-  it('does not set barrier when humanQueue already has a pending push', async () => {
+  it('subagent 目标不存在 → 立即拒绝（带 timeout_ms 也拒绝——堵住旁路）', async () => {
+    const humanQueue = new HumanMessageQueue()
+    const tool = createWaitForSignalTool(makeDeps({ humanQueue }))
+    const result = await tool.call(
+      { reason: '等一个不存在的 subagent', targets: [{ kind: 'subagent' }], timeout_ms: 120_000 }, CTX)
+    expect(result.isError).toBe(true)
+    expect(result.output).toContain('不存在')
+    expect(humanQueue.hasBarrier).toBe(false)
+  })
+
+  it('指定 id 的 subagent 已完成 → 拒绝并指向 get_subagent_output', async () => {
+    const humanQueue = new HumanMessageQueue()
+    const tool = createWaitForSignalTool(makeDeps({
+      humanQueue,
+      listActiveAsyncSubagentIds: () => ['agent_other'],
+    }))
+    const result = await tool.call(
+      { reason: '等 agent_gone', targets: [{ kind: 'subagent', id: 'agent_gone' }] }, CTX)
+    expect(result.isError).toBe(true)
+    expect(result.output).toContain('agent_gone')
+    expect(result.output).toContain('get_subagent_output')
+    expect(humanQueue.hasBarrier).toBe(false)
+  })
+
+  it('bg_entity 目标存在 → 挂起成功', async () => {
+    const humanQueue = new HumanMessageQueue()
+    const tool = createWaitForSignalTool(makeDeps({
+      humanQueue,
+      listRunningBgEntities: async () => [{ id: 'shell_1', kind: 'bg_entity' }],
+    }))
+    const result = await tool.call(
+      { reason: '等构建', targets: [{ kind: 'bg_entity' }] }, CTX)
+    expect(result.isError).toBe(false)
+    expect(humanQueue.hasBarrier).toBe(true)
+    humanQueue.clearBarrier()
+  })
+
+  it('bg_entity 目标不存在 → 立即拒绝（带 timeout_ms 也拒绝）', async () => {
+    const humanQueue = new HumanMessageQueue()
+    const tool = createWaitForSignalTool(makeDeps({ humanQueue }))
+    const result = await tool.call(
+      { reason: '等 shell', targets: [{ kind: 'bg_entity', id: 'shell_gone' }], timeout_ms: 60_000 }, CTX)
+    expect(result.isError).toBe(true)
+    expect(result.output).toContain('shell_gone')
+    expect(humanQueue.hasBarrier).toBe(false)
+  })
+
+  it('external 不带 timeout_ms → 拒绝并解释轮询间隔语义', async () => {
+    const humanQueue = new HumanMessageQueue()
+    const tool = createWaitForSignalTool(makeDeps({ humanQueue }))
+    const result = await tool.call(
+      { reason: '等 PR review', targets: [{ kind: 'external' }] }, CTX)
+    expect(result.isError).toBe(true)
+    expect(result.output).toContain('timeout_ms')
+    expect(humanQueue.hasBarrier).toBe(false)
+  })
+
+  it('external + timeout_ms → 挂起成功', async () => {
+    const humanQueue = new HumanMessageQueue()
+    const tool = createWaitForSignalTool(makeDeps({ humanQueue }))
+    const result = await tool.call(
+      { reason: '等 PR review', targets: [{ kind: 'external' }], timeout_ms: 300_000 }, CTX)
+    expect(result.isError).toBe(false)
+    expect(humanQueue.hasBarrier).toBe(true)
+    humanQueue.clearBarrier()
+  })
+
+  it('audit 不是合法等待对象 → 定向教育：系统在 end_turn 时自动等待', async () => {
+    const humanQueue = new HumanMessageQueue()
+    const tool = createWaitForSignalTool(makeDeps({ humanQueue }))
+    const result = await tool.call(
+      { reason: '等待最终交付验证完成', targets: [{ kind: 'audit' }], timeout_ms: 120_000 }, CTX)
+    expect(result.isError).toBe(true)
+    expect(result.output).toContain('end_turn')
+    expect(result.output).toContain('自动')
+    expect(humanQueue.hasBarrier).toBe(false)
+  })
+
+  it('human_reply 不是合法等待对象 → 指向 ask_human', async () => {
+    const humanQueue = new HumanMessageQueue()
+    const tool = createWaitForSignalTool(makeDeps({ humanQueue }))
+    const result = await tool.call(
+      { reason: '等用户回复', targets: [{ kind: 'human_reply' }] }, CTX)
+    expect(result.isError).toBe(true)
+    expect(result.output).toContain('ask_human')
+    expect(humanQueue.hasBarrier).toBe(false)
+  })
+
+  it('targets 缺失 → schema 拒绝', async () => {
+    const humanQueue = new HumanMessageQueue()
+    const tool = createWaitForSignalTool(makeDeps({ humanQueue }))
+    const result = await tool.call({ reason: 'bare wait' }, CTX)
+    expect(result.isError).toBe(true)
+    expect(humanQueue.hasBarrier).toBe(false)
+  })
+
+  it('混合 targets：subagent 存在 + external 带 timeout → 挂起成功', async () => {
+    const humanQueue = new HumanMessageQueue()
+    const tool = createWaitForSignalTool(makeDeps({
+      humanQueue,
+      listActiveAsyncSubagentIds: () => ['agent_1'],
+    }))
+    const result = await tool.call(
+      { reason: '等 subagent 或 CI', targets: [{ kind: 'subagent' }, { kind: 'external' }], timeout_ms: 300_000 }, CTX)
+    expect(result.isError).toBe(false)
+    expect(humanQueue.hasBarrier).toBe(true)
+    humanQueue.clearBarrier()
+  })
+
+  it('已有 pending 唤醒事件 → 不挂起，提示先处理队列（优先级最高）', async () => {
     const humanQueue = new HumanMessageQueue()
     humanQueue.push('pending message')
     const tool = createWaitForSignalTool(makeDeps({ humanQueue }))
-    const result = await tool.call({ reason: 'await pending' }, {} as ToolCallContext)
+    const result = await tool.call(
+      { reason: '等', targets: [{ kind: 'subagent' }] }, CTX)
     expect(result.isError).toBe(false)
     expect(result.output).toContain('已有 pending')
     expect(humanQueue.hasBarrier).toBe(false)
     expect(humanQueue.drainPending()).toEqual(['pending message'])
   })
 
-  it('sets barrier when a bg entity is running', async () => {
+  it('§5.2 硬不变量：挂起后任何 push 都唤醒（target 不做唤醒过滤）', async () => {
     const humanQueue = new HumanMessageQueue()
-    const tool = createWaitForSignalTool(makeDeps({ humanQueue, hasRunningBgEntity: () => true }))
-    const result = await tool.call({ reason: 'await bg shell exit' }, {} as ToolCallContext)
-    expect(result.isError).toBe(false)
+    const tool = createWaitForSignalTool(makeDeps({
+      humanQueue,
+      listActiveAsyncSubagentIds: () => ['agent_1'],
+    }))
+    await tool.call({ reason: '等 subagent', targets: [{ kind: 'subagent', id: 'agent_1' }] }, CTX)
     expect(humanQueue.hasBarrier).toBe(true)
-    humanQueue.clearBarrier()
+    // 与 target 无关的用户消息 push → barrier 立即清除
+    humanQueue.push('用户实时纠偏')
+    expect(humanQueue.hasBarrier).toBe(false)
   })
 
-  describe('timeout_ms', () => {
-    it('allows timed wait with no pending event, pushes [wait_timeout] on expiry', async () => {
-      vi.useFakeTimers()
-      try {
-        const humanQueue = new HumanMessageQueue()
-        const tool = createWaitForSignalTool(makeDeps({ humanQueue }))
-        const result = await tool.call(
-          { reason: '10 分钟后复查导入进度', timeout_ms: 600_000 },
-          {} as ToolCallContext,
-        )
-        expect(result.isError).toBe(false)
-        expect(humanQueue.hasBarrier).toBe(true)
+  it('rejects non-integer timeout_ms', async () => {
+    const humanQueue = new HumanMessageQueue()
+    const tool = createWaitForSignalTool(makeDeps({ humanQueue }))
+    const result = await tool.call(
+      { reason: 'bad', targets: [{ kind: 'external' }], timeout_ms: 'soon' }, CTX)
+    expect(result.isError).toBe(true)
+    expect(humanQueue.hasBarrier).toBe(false)
+  })
 
-        vi.advanceTimersByTime(600_000)
-        expect(humanQueue.hasBarrier).toBe(false)
-        const drained = humanQueue.drainPending()
-        expect(drained).toHaveLength(1)
-        expect(String(drained[0])).toContain('[wait_timeout]')
-        expect(String(drained[0])).toContain('10 分钟后复查导入进度')
-      } finally {
-        vi.useRealTimers()
-      }
-    })
+  it('clamps timeout_ms below the minimum', async () => {
+    vi.useFakeTimers()
+    const humanQueue = new HumanMessageQueue()
+    const tool = createWaitForSignalTool(makeDeps({ humanQueue }))
+    await tool.call({ reason: 'tiny wait', targets: [{ kind: 'external' }], timeout_ms: 10 }, CTX)
+    // 10ms 被钳到最小值（1s）：10ms 后 barrier 仍在
+    vi.advanceTimersByTime(10)
+    expect(humanQueue.hasBarrier).toBe(true)
+    vi.advanceTimersByTime(1_000)
+    expect(humanQueue.hasBarrier).toBe(false)
+  })
+})
 
-    it('early push wakes barrier and suppresses the [wait_timeout] marker', async () => {
-      vi.useFakeTimers()
-      try {
-        const humanQueue = new HumanMessageQueue()
-        const tool = createWaitForSignalTool(makeDeps({ humanQueue }))
-        await tool.call({ reason: 'wait', timeout_ms: 600_000 }, {} as ToolCallContext)
+describe('wait_for_signal 超时消息', () => {
+  it('超时消息含 [wait_timeout] + 声明对象回显；external 提示主动检查', async () => {
+    vi.useFakeTimers()
+    const humanQueue = new HumanMessageQueue()
+    const tool = createWaitForSignalTool(makeDeps({
+      humanQueue,
+      listActiveAsyncSubagentIds: () => ['agent_1'],
+    }))
+    await tool.call(
+      { reason: '等 subagent 和 PR review', targets: [{ kind: 'subagent', id: 'agent_1' }, { kind: 'external' }], timeout_ms: 60_000 }, CTX)
+    vi.advanceTimersByTime(60_001)
+    const drained = humanQueue.drainPending()
+    expect(drained).toHaveLength(1)
+    const msg = String(drained[0])
+    expect(msg).toContain('[wait_timeout]')
+    expect(msg).toContain('agent_1')
+    expect(msg).toContain('主动检查')
+  })
 
-        humanQueue.push('[系统] Background shell shell_abc 已退出')
-        expect(humanQueue.hasBarrier).toBe(false)
+  it('early push 提前唤醒 → 不产生 [wait_timeout] 标记', async () => {
+    vi.useFakeTimers()
+    const humanQueue = new HumanMessageQueue()
+    const tool = createWaitForSignalTool(makeDeps({
+      humanQueue,
+      listRunningBgEntities: async () => [{ id: 'shell_abc', kind: 'bg_entity' }],
+    }))
+    await tool.call({ reason: 'wait', targets: [{ kind: 'bg_entity' }], timeout_ms: 600_000 }, CTX)
 
-        vi.advanceTimersByTime(600_000)
-        const drained = humanQueue.drainPending()
-        expect(drained).toHaveLength(1)
-        expect(String(drained[0])).not.toContain('[wait_timeout]')
-      } finally {
-        vi.useRealTimers()
-      }
-    })
+    humanQueue.push('[系统] Background shell shell_abc 已退出')
+    expect(humanQueue.hasBarrier).toBe(false)
 
-    it('clamps timeout_ms below the minimum', async () => {
-      vi.useFakeTimers()
-      try {
-        const humanQueue = new HumanMessageQueue()
-        const tool = createWaitForSignalTool(makeDeps({ humanQueue }))
-        await tool.call({ reason: 'tiny wait', timeout_ms: 10 }, {} as ToolCallContext)
-        // 10ms 被钳到最小值（1s）：10ms 后 barrier 仍在
-        vi.advanceTimersByTime(10)
-        expect(humanQueue.hasBarrier).toBe(true)
-        vi.advanceTimersByTime(1_000)
-        expect(humanQueue.hasBarrier).toBe(false)
-      } finally {
-        vi.useRealTimers()
-      }
-    })
+    vi.advanceTimersByTime(600_000)
+    const drained = humanQueue.drainPending()
+    expect(drained).toHaveLength(1)
+    expect(String(drained[0])).not.toContain('[wait_timeout]')
+  })
 
-    it('rejects non-integer timeout_ms', async () => {
-      const humanQueue = new HumanMessageQueue()
-      const tool = createWaitForSignalTool(makeDeps({ humanQueue }))
-      const result = await tool.call({ reason: 'bad', timeout_ms: 'soon' }, {} as ToolCallContext)
-      expect(result.isError).toBe(true)
-      expect(humanQueue.hasBarrier).toBe(false)
-    })
+  it('连续 3 次 external 超时 → 追加"收尾 + schedule 复查"引导', async () => {
+    vi.useFakeTimers()
+    const humanQueue = new HumanMessageQueue()
+    const tool = createWaitForSignalTool(makeDeps({ humanQueue }))
+    const messages: string[] = []
+    for (let i = 0; i < 3; i++) {
+      await tool.call(
+        { reason: '等外部事件', targets: [{ kind: 'external' }], timeout_ms: 60_000 }, CTX)
+      vi.advanceTimersByTime(60_001)
+      // 模拟 agent 醒来消费掉超时消息后再次挂起
+      messages.push(...humanQueue.drainPending().map(String))
+    }
+    expect(messages.length).toBe(3)
+    expect(messages[2]).toContain('schedule')
+    // 前两次不该有该引导
+    expect(messages[0]).not.toContain('schedule')
+  })
+})
+
+describe('formatStillRunningSnapshot', () => {
+  it('空列表 → 空串', () => {
+    expect(formatStillRunningSnapshot([])).toBe('')
+  })
+
+  it('列出每个在跑对象的 id，并引导继续等待', () => {
+    const line = formatStillRunningSnapshot([
+      { id: 'agent_7bc2', kind: 'subagent', runtime_ms: 192_000, description: 'research' },
+      { id: 'shell_a19a', kind: 'bg_entity', runtime_ms: 100_000 },
+    ])
+    expect(line).toContain('agent_7bc2')
+    expect(line).toContain('shell_a19a')
+    expect(line).toContain('仍在运行')
+    expect(line).toContain('wait_for_signal')
   })
 })


### PR DESCRIPTION
## 背景

m2u 生产 trace `ac9676e3`（wechat Codex API key 排查任务）复盘暴露四个缺陷。日志证实缺陷 A 非偶发（`persistAsyncAuditResult failed ... 非 active 不可追加` 至少命中 4 个任务）。

Spec：crabot-docs `superpowers/specs/2026-07-16-wait-signal-targets-goal-lifecycle-design.md`（决策已与 master 确认）。

## 修复内容

### A：goal 终态解除 audit gate
- `goalSetCache` 快照与 gate 取 goal 均改用 `shouldArmGoalGate`（存在且非终态才武装）；终态集合与 admin `isTerminal` 用跨包对齐测试锁定
- `persistAsyncAuditResult` 的 append 与 complete 拆独立 try——修复 "audit PASS 但 append 撞终态 → complete 一并被跳过 → 结果丢失"

### B：Task-13 拦截改 engine 直接挂起
- 删除 "请调 wait_for_signal 等审完成" 注入路径（教坏 agent 主动 wait audit 的污染源，epoch 3 空转 ≈14 分钟的根因）
- end_turn + `hasActiveAudit` → 复用 gate wait 挂起路径：零文案注入、零额外 LLM 轮、幂等可重入（人类追问唤醒 → 处理 → 再 end_turn → 再挂起）

### C：任务收尾清理 active goal
- `applyDerivedFields`：task 切终态时 still-active goal 自动切 `cleared` + warn 日志（单点覆盖正常完成 / 失败 / recovery 所有收尾路径；遗留脏数据惰性消化，无需迁移）
- gate 派 audit 前加 `activeAuditId` 前置检查（audit 在跑时永不派第二个）

### D：wait_for_signal targets 准入校验 + 唤醒快照
- 必须声明 `targets`（subagent / bg_entity / external）；命名目标不存在 → 立即拒绝（带 timeout_ms 也拒绝，堵住旁路）
- external 必带 timeout_ms（轮询间隔语义）；audit / human_reply 定向教育文案
- 硬不变量：targets 只做准入校验，不做唤醒过滤（用户实时纠偏永远穿透，单测锁定）
- subagent 完成 / bg 退出 / wait_timeout 三类唤醒消息附"仍在运行"快照（push 时现查现写，无新状态）；连续 3 次 external 超时追加"收尾 + schedule 复查"引导

## 测试

- 目标测试面：agent 9 文件 120/120，admin 3 文件 82/82；双包 `tsc --noEmit` 通过
- 全量：仅 3 个与本 PR 无关的既有失败（`context-assembler`（main 上同样失败）、`bg-tools` / `v1-cleanup`（并行负载 flaky，单独跑全绿））

🤖 Generated with [Claude Code](https://claude.com/claude-code)