### PR TITLE
[codex] remove channel file path allowlists

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,6 +1,13 @@
 # Crabot 项目进度
 
-> 最后更新：2026-07-16 — 挂起/唤醒语义 + goal 生命周期闭环已实现（PR #31）
+> 最后更新：2026-07-16 — 移除 Channel 出站文件路径白名单
+
+## 2026-07-16 — 移除 Channel 出站文件路径白名单
+
+- 根因：`generate_image` 生成成功后返回 Agent 本地路径，但 Feishu Channel 额外维护静态路径白名单，导致后续 `send_message(file_path)` 被拒绝；Telegram、WeChat、DingTalk 的同名 capability 字段未参与运行时校验。
+- 修复：四个 Channel 删除 `allowed_file_paths`；Feishu 同时删除实际拦截，保留文件读取、30 MB 限制与平台上传流程，并新增旧白名单外 `generated-images` 路径的发送回归测试。
+- Follow-up：Admin 统一管理出站路径策略、Agent crab-messaging `send_message` 执行审核；本轮不修改 Agent 或 `generate_image` 存储位置。
+- 验证：四个 Channel TypeScript build 通过；Feishu 214、WeChat 56、DingTalk 58 个测试通过；Telegram capability 定向测试通过，全量套件唯一失败为既有 reaction emoji 断言漂移（与本次 diff 无关）。
 
 ## 2026-07-16 — 挂起/唤醒语义收紧 + Goal 生命周期闭环（已实现，PR #31）
 

--- a/crabot-channel-dingtalk/src/dingtalk-channel.ts
+++ b/crabot-channel-dingtalk/src/dingtalk-channel.ts
@@ -482,7 +482,6 @@ export class DingtalkChannel extends ModuleBase {
       max_message_length: MAX_MESSAGE_LENGTH,
       max_file_size: null,
       supports_file_path: false,
-      allowed_file_paths: [],
       supports_list_contacts: false,
       supports_list_groups: false,
       supports_list_group_members: true,

--- a/crabot-channel-dingtalk/src/types.ts
+++ b/crabot-channel-dingtalk/src/types.ts
@@ -126,7 +126,6 @@ export interface ChannelCapabilities {
   max_message_length: number | null
   max_file_size: number | null
   supports_file_path: boolean
-  allowed_file_paths: string[]
   /** 是否支持 list_contacts */
   supports_list_contacts: boolean
   /** 是否支持 list_groups */

--- a/crabot-channel-feishu/src/feishu-channel.ts
+++ b/crabot-channel-feishu/src/feishu-channel.ts
@@ -789,11 +789,6 @@ export class FeishuChannel extends ModuleBase {
     const session = this.sessionManager.findById(params.session_id)
     if (!session) throwError('NOT_FOUND', `Session not found: ${params.session_id}`)
 
-    // file path 安全校验
-    if (params.content.file_path) {
-      this.assertFilePathAllowed(params.content.file_path)
-    }
-
     const receive: SendReceive = {
       type: session.type === 'group' ? 'chat_id' : 'open_id',
       id: session.platform_session_id,
@@ -890,7 +885,6 @@ export class FeishuChannel extends ModuleBase {
 
   private async loadContentBuffer(content: MessageContent): Promise<{ buf: Buffer; filename: string }> {
     if (content.file_path) {
-      this.assertFilePathAllowed(content.file_path)
       const buf = await readFileOrThrow(content.file_path)
       this.assertFileSize(buf.length)
       return { buf, filename: content.filename ?? path.basename(content.file_path) }
@@ -939,22 +933,10 @@ export class FeishuChannel extends ModuleBase {
     }
   }
 
-  private assertFilePathAllowed(filePath: string): void {
-    const allowed = this.allowedFilePaths()
-    const normalized = path.resolve(filePath)
-    if (!allowed.some((prefix) => normalized.startsWith(path.resolve(prefix)))) {
-      throwError('CHANNEL_FILE_PATH_NOT_ALLOWED', `file_path not allowed: ${filePath}`)
-    }
-  }
-
   private assertFileSize(size: number): void {
     if (size > MAX_FILE_SIZE) {
       throwError('CHANNEL_FILE_TOO_LARGE', `file size ${size} exceeds limit ${MAX_FILE_SIZE}`)
     }
-  }
-
-  private allowedFilePaths(): string[] {
-    return ['/tmp/', '/private/tmp/', path.join(this.dataDir, 'sessions'), path.join(this.dataDir, 'media')]
   }
 
   // ── capabilities ───────────────────────────────────────────────────────────
@@ -968,7 +950,6 @@ export class FeishuChannel extends ModuleBase {
       max_message_length: null,
       max_file_size: MAX_FILE_SIZE,
       supports_file_path: true,
-      allowed_file_paths: this.allowedFilePaths(),
       supports_list_contacts: true,
       supports_list_groups: true,
       supports_list_group_members: true,

--- a/crabot-channel-feishu/src/types.ts
+++ b/crabot-channel-feishu/src/types.ts
@@ -123,7 +123,6 @@ export interface ChannelCapabilities {
   max_message_length: number | null
   max_file_size: number | null
   supports_file_path: boolean
-  allowed_file_paths: string[]
   /** 是否支持 list_contacts */
   supports_list_contacts: boolean
   /** 是否支持 list_groups */

--- a/crabot-channel-feishu/tests/feishu-channel-send-media.test.ts
+++ b/crabot-channel-feishu/tests/feishu-channel-send-media.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+vi.mock('@larksuiteoapi/node-sdk', () => ({
+  Domain: { Feishu: 'feishu', Lark: 'lark' },
+  Client: class MockLarkClient {
+    request = vi.fn(async () => ({ code: 0 }))
+    im = {
+      message: { create: vi.fn(), reply: vi.fn(), get: vi.fn(), list: vi.fn() },
+      messageResource: { get: vi.fn() },
+      chat: { list: vi.fn(async () => ({ data: { items: [], has_more: false } })) },
+      chatMembers: { get: vi.fn() },
+      image: { create: vi.fn() },
+      file: { create: vi.fn() },
+    }
+    contact = { v3: { user: { get: vi.fn(), list: vi.fn() } } }
+  },
+  WSClient: class MockWSClient {
+    start() { return Promise.resolve() }
+    close() { return Promise.resolve() }
+  },
+  EventDispatcher: class MockEventDispatcher {
+    register() { return this }
+  },
+}))
+
+import { FeishuChannel } from '../src/feishu-channel'
+
+let dataDir: string
+let generatedDir: string
+let channel: FeishuChannel
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'feishu-send-media-'))
+  generatedDir = fs.mkdtempSync(path.join(process.cwd(), 'generated-images-test-'))
+  channel = new FeishuChannel({
+    module_id: 'channel-feishu-test',
+    module_type: 'channel',
+    version: '0.1.0',
+    protocol_version: '0.1.0',
+    port: 0,
+    data_dir: dataDir,
+    feishu: {
+      app_id: 'cli_x',
+      app_secret: 'sec',
+      domain: 'feishu',
+      only_respond_to_mentions: true,
+      markdown_format: 'auto',
+    },
+  })
+})
+
+afterEach(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true })
+  fs.rmSync(generatedDir, { recursive: true, force: true })
+})
+
+describe('FeishuChannel local media sending', () => {
+  it('uploads an image from a generated-images path outside the former channel allowlist', async () => {
+    const image = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x01, 0x02])
+    const imagePath = path.join(generatedDir, 'generated.png')
+    fs.writeFileSync(imagePath, image)
+
+    const session = (channel as any).sessionManager.upsert({
+      platform_session_id: 'oc_generated',
+      type: 'group',
+      title: 'Generated images',
+      sender_id: 'ou_user',
+      sender_name: 'User',
+    }).session
+    const uploadImage = vi.fn(async () => 'img_generated')
+    const sendImage = vi.fn(async () => ({ message_id: 'om_generated', create_time: '1710000000000' }))
+    ;(channel as any).client.uploadImage = uploadImage
+    ;(channel as any).client.sendImage = sendImage
+
+    const result = await (channel as any).handleSendMessage({
+      session_id: session.id,
+      content: { type: 'image', file_path: imagePath, filename: 'generated.png' },
+    })
+
+    expect(uploadImage).toHaveBeenCalledWith(image)
+    expect(sendImage).toHaveBeenCalledWith(
+      { type: 'chat_id', id: 'oc_generated' },
+      'img_generated',
+    )
+    expect(result.platform_message_id).toBe('om_generated')
+  })
+})

--- a/crabot-channel-telegram/src/telegram-channel.ts
+++ b/crabot-channel-telegram/src/telegram-channel.ts
@@ -648,7 +648,6 @@ export class TelegramChannel extends ModuleBase {
       max_message_length: MAX_MESSAGE_LENGTH,
       max_file_size: MAX_FILE_SIZE,
       supports_file_path: true,
-      allowed_file_paths: [path.join(this.dataDir, 'media')],
       supports_list_contacts: false,
       supports_list_groups: false,
       supports_list_group_members: true,

--- a/crabot-channel-telegram/src/types.ts
+++ b/crabot-channel-telegram/src/types.ts
@@ -218,7 +218,6 @@ export interface ChannelCapabilities {
   max_message_length: number | null
   max_file_size: number | null
   supports_file_path: boolean
-  allowed_file_paths: string[]
   /** 是否支持 list_contacts；telegram bot api 不支持 */
   supports_list_contacts: boolean
   /** 是否支持 list_groups；telegram bot api 不支持 */

--- a/crabot-channel-wechat/src/types.ts
+++ b/crabot-channel-wechat/src/types.ts
@@ -148,7 +148,6 @@ export interface ChannelCapabilities {
   max_message_length: number | null
   max_file_size: number | null
   supports_file_path: boolean
-  allowed_file_paths: string[]
   /** 是否支持 list_contacts */
   supports_list_contacts: boolean
   /** 是否支持 list_groups */

--- a/crabot-channel-wechat/src/wechat-channel.ts
+++ b/crabot-channel-wechat/src/wechat-channel.ts
@@ -524,7 +524,6 @@ export class WechatChannel extends ModuleBase {
       max_message_length: null,
       max_file_size: null,
       supports_file_path: true,
-      allowed_file_paths: ['/tmp/', '/private/tmp/'],
       supports_list_contacts: true,
       supports_list_groups: true,
       supports_list_group_members: true,


### PR DESCRIPTION
## Summary

- remove Feishu's runtime `file_path` allowlist so images produced under the Agent's `generated-images` directory can be uploaded and sent
- remove the unused `allowed_file_paths` capability field from Feishu, Telegram, WeChat, and DingTalk
- add a Feishu regression test covering a generated image path outside the former Channel-owned directories
- record the centralized Agent/Admin path-policy work as a follow-up in `PROGRESS.md`

## Root cause

`generate_image` returns a local path under the Agent data directory. Feishu independently restricted outbound local files to `/tmp` and its own Channel data directories, so the otherwise valid `generate_image -> send_message(file_path)` flow failed with `CHANNEL_FILE_PATH_NOT_ALLOWED`. The other built-in Channels advertised similar capability fields but did not enforce them.

## Scope

This PR intentionally does not change the Agent, the `generate_image` storage location, or add a centralized path policy. Those changes are deferred to a follow-up. Channels continue to enforce file existence/readability, platform size limits, and upload/send failures.

## Protocol

The matching protocol update was committed directly to `crabot-docs/main`:

- https://github.com/smilefufu/crabot-docs/commit/0f52554621c09d4886d5909a3e94f5a6bd0ac99e

## Validation

- Feishu: 214 tests passed
- WeChat: 56 tests passed
- DingTalk: 58 tests passed
- Telegram capability test passed
- all four Channel TypeScript builds passed
- `git diff --check` passed
- Telegram full suite remains 36/37 because an existing reaction test expects `🫡` while the unchanged implementation sends `✍`; neither file is touched by this PR