### PR TITLE
[codex] 修复 Task/Trace 状态对账误判

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,6 +1,6 @@
 # Crabot 项目进度
 
-> 最后更新：2026-07-16 — 移除 Channel 出站文件路径白名单
+> 最后更新：2026-07-17 — 修复 Task/Trace 状态对账误判
 
 ## 2026-07-16 — 移除 Channel 出站文件路径白名单
 
@@ -15,12 +15,12 @@
 - spec：`crabot-docs/superpowers/specs/2026-07-16-wait-signal-targets-goal-lifecycle-design.md`。C 简化为收尾清理（cleared + warn），事后 audit 暂缓（升级触发条件见 spec §4.3）。
 - 实现（PR #31）：A/B/C/D 全部落地 + audit 等待兜底超时（10 分钟 → abort + fail-open，防 audit 卡死时 24h 挂起循环，review 发现补上）。resume 两条路径的 goal 语义交互见 spec §7，遗留脏数据（completed task + active goal）由收尾清理惰性消化，无需迁移。
 
-## 2026-07-14 — 修复大型 Trace 执行树遗漏主 Worker
+## 2026-07-17 — 修复大型 Trace 执行树与 Task 状态对账
 
 - `get_trace_tree` 不再只读取最新 100 条关联 trace；现在同步分页取回同一 task 的全部 trace 后再按 dispatcher / worker / sub-agent 分组。
-- 修复长任务产生超过 100 条 sub-agent trace 后，最早启动且仍运行中的主 Worker 被截断、Trace 页面只显示 Dispatch 和 Subagent 的问题。
-- 回归覆盖 1 条旧 Worker + 1000 条后续 Sub-agent，强制跨页并确保完整执行树仍包含 Worker。
-- 验证：TraceStore 定向测试 43/43 通过，Agent TypeScript `--noEmit` 检查通过。
+- Admin reconciliation 改用完整 `get_trace_tree`，只按 `workers` 判定任务状态：任一 Worker 仍运行则不收口；全部终态时以后启动的 Worker 为准，front/sub-agent 失败不再直接把 task 判成 failed。
+- 回归覆盖旧 Worker + 1000 条后续 Sub-agent 的跨页执行树，以及旧 Worker failed、后续 Worker completed 的状态收口。
+- 验证：Admin reconciliation 定向测试、Agent TraceStore 跨页回归与两个模块 TypeScript build 通过。
 
 ## 2026-07-12 — 修复终态任务误入活跃列表与 WeChat 原始时间戳丢失
 

--- a/crabot-admin/src/index.ts
+++ b/crabot-admin/src/index.ts
@@ -5613,10 +5613,10 @@ export class AdminModule extends ModuleBase {
     const fetchTracesByTaskId = async (taskId: string) => {
       try {
         const result = await this.callAgentRpc<
-          { task_id: string; limit: number },
-          { traces: Array<{ trace_id: string; related_task_id?: string; status: 'running' | 'completed' | 'failed'; outcome?: { summary?: string } }>; total: number }
-        >('search_traces', { task_id: taskId, limit: 100 })
-        return result.traces
+          { task_id: string },
+          { tree: { workers: Array<{ trace_id: string; status: 'running' | 'completed' | 'failed' }> } }
+        >('get_trace_tree', { task_id: taskId })
+        return result.tree.workers
       } catch (err) {
         throw err instanceof Error ? err : new Error(String(err))
       }

--- a/crabot-admin/src/reconcile-tasks-against-traces.test.ts
+++ b/crabot-admin/src/reconcile-tasks-against-traces.test.ts
@@ -48,7 +48,7 @@ describe('reconcileTasksAgainstTraces', () => {
     expect(patches[0].newStatus).toBe('completed')
   })
 
-  it('task=executing + 任一 trace=failed → 修成 failed', async () => {
+  it('task=executing + 最后 worker=failed → 修成 failed', async () => {
     const tasks = [makeTask({ id: 't-2', status: 'executing', updated_at: '2026-06-09T18:00:00.000Z' })]
     const patches = await reconcileTasksAgainstTraces({
       tasks,
@@ -64,6 +64,23 @@ describe('reconcileTasksAgainstTraces', () => {
     expect(patches[0].newStatus).toBe('failed')
   })
 
+  it('最后启动的 worker completed 时忽略旧 worker failed', async () => {
+    const tasks = [makeTask({ id: 't-latest-completed', status: 'executing', updated_at: '2026-06-09T18:00:00.000Z' })]
+    const patches = await reconcileTasksAgainstTraces({
+      tasks,
+      fetchTracesByTaskId: mockFetchTraces({
+        't-latest-completed': [
+          { trace_id: 'worker-old', status: 'failed' },
+          { trace_id: 'worker-new', status: 'completed' },
+        ],
+      }),
+      now: FIXED_NOW,
+    })
+
+    expect(patches).toHaveLength(1)
+    expect(patches[0].newStatus).toBe('completed')
+  })
+
   it('任一 trace 仍 running → 不修', async () => {
     const tasks = [makeTask({ id: 't-3', status: 'waiting_human', updated_at: '2026-06-09T18:00:00.000Z' })]
     const patches = await reconcileTasksAgainstTraces({
@@ -76,6 +93,26 @@ describe('reconcileTasksAgainstTraces', () => {
       }),
       now: FIXED_NOW,
     })
+    expect(patches).toHaveLength(0)
+  })
+
+  it('早期 worker running 且后续有超过 100 条终态 worker 时不收口', async () => {
+    const tasks = [makeTask({ id: 't-running-oldest', status: 'executing', updated_at: '2026-06-09T18:00:00.000Z' })]
+    const terminalWorkers = Array.from({ length: 101 }, (_, index) => ({
+      trace_id: `worker-${index}`,
+      status: 'completed' as const,
+    }))
+    const patches = await reconcileTasksAgainstTraces({
+      tasks,
+      fetchTracesByTaskId: mockFetchTraces({
+        't-running-oldest': [
+          { trace_id: 'worker-running', status: 'running' },
+          ...terminalWorkers,
+        ],
+      }),
+      now: FIXED_NOW,
+    })
+
     expect(patches).toHaveLength(0)
   })
 

--- a/crabot-admin/src/reconcile-tasks-against-traces.ts
+++ b/crabot-admin/src/reconcile-tasks-against-traces.ts
@@ -12,14 +12,14 @@
  * - admin 状态机判定 waiting_human → completed 非法，拒绝
  * - bestEffortRpc 吞错，task 永远卡在 waiting_human
  *
- * 修复策略：检测到"task 仍活跃 + 所有 trace 终态 + 距上次更新 > minStaleAgeMs"时，
- * 按 trace.outcome 决定切 completed/failed。reconciliation 不修 status=pending 的 task
+ * 修复策略：检测到"task 仍活跃 + 所有 worker trace 终态 + 距上次更新 > minStaleAgeMs"时，
+ * 按最后启动的 worker 状态切 completed/failed。reconciliation 不修 status=pending 的 task
  * （刚创建还没起 worker 的，留给 dispatcher 重新调度）。
  */
 
 import type { Task, TaskStatus } from './types.js'
 
-/** Trace 索引子集，对账只关心这几个字段 */
+/** Worker trace 索引子集，对账只关心这几个字段 */
 export interface TraceIndexLite {
   trace_id: string
   related_task_id?: string
@@ -30,7 +30,7 @@ export interface TraceIndexLite {
 export interface ReconcileInput {
   /** admin 全部 task（pure function 不读磁盘） */
   readonly tasks: ReadonlyArray<Task>
-  /** 拉单个 task 关联的所有 trace（注入式，便于 mock） */
+  /** 拉单个 task 按 started_at 升序排列的所有 worker trace（注入式，便于 mock） */
   readonly fetchTracesByTaskId: (taskId: string) => Promise<ReadonlyArray<TraceIndexLite>>
   /**
    * task 多久没更新才纳入对账（防止刚 spawn 还没写 trace 的 task 被误判 stale）。
@@ -77,35 +77,34 @@ export async function reconcileTasksAgainstTraces(input: ReconcileInput): Promis
       continue
     }
 
-    // 拉 task 关联的所有 trace
-    let traces: ReadonlyArray<TraceIndexLite>
+    // 拉 task 关联的所有 worker trace
+    let workers: ReadonlyArray<TraceIndexLite>
     try {
-      traces = await fetchTracesByTaskId(task.id)
+      workers = await fetchTracesByTaskId(task.id)
     } catch {
       // 拉失败（agent 不可达 / RPC 错）就跳过本轮 —— 下轮再试
       continue
     }
 
-    // 无 trace：可能是 task 刚建还没 spawn 第一条 trace。保守跳过。
-    if (traces.length === 0) continue
+    // 无 worker：可能是 task 刚建还没 spawn。保守跳过。
+    if (workers.length === 0) continue
 
-    // 任一 trace 仍 running → task 真在跑，不对账
-    const anyRunning = traces.some(t => t.status === 'running')
+    // 任一 worker 仍 running → task 真在跑，不对账
+    const anyRunning = workers.some(t => t.status === 'running')
     if (anyRunning) continue
 
-    // 所有 trace 都终态 + task 仍活跃 → drift，需修复
-    // 决策：任一 trace=failed → task 标 failed；全 completed → task 标 completed
-    const anyFailed = traces.some(t => t.status === 'failed')
-    const newStatus: 'completed' | 'failed' = anyFailed ? 'failed' : 'completed'
+    // 所有 worker 都终态 + task 仍活跃 → 以后启动的 worker 为权威。
+    const latestWorker = workers.at(-1)
+    if (!latestWorker || latestWorker.status === 'running') continue
+    const newStatus = latestWorker.status
 
     patches.push({
       taskId: task.id,
       oldStatus: task.status,
       newStatus,
-      reason: `task ${task.status} but all ${traces.length} trace(s) terminal (${
-        anyFailed ? 'has failed trace' : 'all completed'
-      })`,
-      traces: traces.map(t => ({ trace_id: t.trace_id, status: t.status })),
+      reason: `task ${task.status} but all ${workers.length} worker trace(s) terminal ` +
+        `(latest worker ${latestWorker.trace_id.slice(0, 8)}=${latestWorker.status})`,
+      traces: workers.map(t => ({ trace_id: t.trace_id, status: t.status })),
     })
   }
 


### PR DESCRIPTION
## 变更

- Admin reconciliation 改用现有 `get_trace_tree` 获取完整 task trace tree
- 仅以 `tree.workers` 判断 task 终态，忽略 front/dispatcher/subagent 的失败
- 任一 worker 仍在运行时跳过对账；全部终态时以后启动的 worker 为准
- 增加旧 worker 失败但新 worker 完成，以及超过 100 条 worker trace 的回归覆盖
- 压缩更新 `PROGRESS.md` 中对应记录

## 根因

原实现调用 `search_traces({ task_id, limit: 100 })`，并按“任意 trace 失败则 task 失败”收口。长任务的早期主 worker 可能被分页截断，同时旧 subagent 失败会被错误当作 task 的权威终态。

## 影响

修复只影响超过 stale 阈值的非终态 task 对账。正常 worker 状态写入、状态机、resume、dispatcher、goal、audit 和 delivery 语义保持不变。

## 验证

- Admin reconciliation 定向测试：10/10 通过
- Admin TypeScript build：通过
- Agent 超过 100 条 trace 的执行树回归：通过
- Agent TypeScript build：通过
- MM / Admin / Agent 运行时健康检查：通过