### PR TITLE
fix(agent): subagent 模型配置热生效（delegate 时实时解析）

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,6 +1,14 @@
 # Crabot 项目进度
 
-> 最后更新：2026-07-17 — 恢复飞书外部群 PRD 获取流程
+> 最后更新：2026-07-19 — subagent 模型配置热生效（delegate 时实时解析）
+
+## 2026-07-19 — subagent 模型配置热生效（delegate 时实时解析）
+
+- 起因：m2u 实例 cost_effective provider 余额耗尽（HTTP 402），Admin 改 slot 后"继续任务"仍用旧 provider，必须重启实例才生效。根因：worker loop 启动时固化 subAgentsSnapshot，delegate_task 闭包绑定快照里嵌入的 model 连接信息，热更只影响"下一个 loop"。
+- spec：`crabot-docs/superpowers/specs/2026-07-19-subagent-model-hot-reload-design.md`。方案：subagent **列表**保持 loop 级快照（工具 enum / prompt 一致性不变），列表内各项的 model 等配置在每次派发时从 live `this.subAgents` 按 id 重查；live 中已删除则回退快照。
+- 实现：`agent-handler.ts` 新增 `resolveLiveSubAgent`，接入 `makeRunSubAgent` 闭包（同步/异步 delegate 共用）与 goal_audit `buildSpawnDeps`；`runGoalAudit` 本就实时读 `this.subAgents` 无需改。主 adapter 与已 spawn 的持久 subagent 保持 loop/spawn 级快照（协议已写明，要立即生效则终止重派）。
+- 协议：protocol-agent-v2 §6.1 热更表把 model_config 拆成三种粒度（worker 主 adapter / subagent 派发 / 已 spawn subagent）；protocol-admin §3.19.6 补上"保存后触发 pushConfigToAgentModules"约定。
+- 验证：新增 `delegate-model-hot-reload.test.ts` 4 条（in-flight 派发用新 endpoint/apikey/model_id、enum 快照不变、删除回退、异步派发与 goal_audit 取 live）；agent 全量 1543/1544（另 2 skipped），唯一失败为 7-17 已记录的 context-assembler 固定时间漂移，stash 验证与本次 diff 无关。
 
 ## 2026-07-17 — 恢复飞书外部群 PRD 获取流程
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5,7 +5,7 @@
 ## 2026-07-19 — subagent 模型配置热生效（delegate 时实时解析）
 
 - 起因：m2u 实例 cost_effective provider 余额耗尽（HTTP 402），Admin 改 slot 后"继续任务"仍用旧 provider，必须重启实例才生效。根因：worker loop 启动时固化 subAgentsSnapshot，delegate_task 闭包绑定快照里嵌入的 model 连接信息，热更只影响"下一个 loop"。
-- spec：`crabot-docs/superpowers/specs/2026-07-19-subagent-model-hot-reload-design.md`。方案：subagent **列表**保持 loop 级快照（工具 enum / prompt 一致性不变），列表内各项的 model 等配置在每次派发时从 live `this.subAgents` 按 id 重查；live 中已删除则回退快照。
+- spec：`crabot-docs/superpowers/specs/2026-07-19-subagent-model-hot-reload-design.md`。方案：subagent **列表**保持 loop 级快照（工具 enum / prompt 一致性不变），列表内各项的 model 等配置在每次派发时从 live `this.subAgents` 按 name 重查；live 中已删除则回退快照。
 - 实现：`agent-handler.ts` 新增 `resolveLiveSubAgent`，接入 `makeRunSubAgent` 闭包（同步/异步 delegate 共用）与 goal_audit `buildSpawnDeps`；`runGoalAudit` 本就实时读 `this.subAgents` 无需改。主 adapter 与已 spawn 的持久 subagent 保持 loop/spawn 级快照（协议已写明，要立即生效则终止重派）。
 - 协议：protocol-agent-v2 §6.1 热更表把 model_config 拆成三种粒度（worker 主 adapter / subagent 派发 / 已 spawn subagent）；protocol-admin §3.19.6 补上"保存后触发 pushConfigToAgentModules"约定。
 - 验证：新增 `delegate-model-hot-reload.test.ts` 4 条（in-flight 派发用新 endpoint/apikey/model_id、enum 快照不变、删除回退、异步派发与 goal_audit 取 live）；agent 全量 1543/1544（另 2 skipped），唯一失败为 7-17 已记录的 context-assembler 固定时间漂移，stash 验证与本次 diff 无关。

--- a/crabot-agent/src/agent/agent-handler.ts
+++ b/crabot-agent/src/agent/agent-handler.ts
@@ -3842,11 +3842,14 @@ export class AgentHandler {
   }
 
   /**
-   * 按 id 从 live this.subAgents 重查 subagent 配置，找不到（loop 运行期间被删）回退快照。
+   * 按 name 从 live this.subAgents 重查 subagent 配置，找不到（loop 运行期间被删）回退快照。
+   * 用 name 而非 id：delegate_task 本身就按 name 派发（工具 enum 即 name 列表），
+   * 且"name"承载语义身份——admin 删除再重建同名 subagent 视为同一 subagent 换了配置，
+   * 派发应用新配置而不是静默回退旧快照。
    * 见 makeRunSubAgent 闭包注释 / spec 2026-07-19-subagent-model-hot-reload-design.md。
    */
   private resolveLiveSubAgent(snapshot: SubAgentConfig): SubAgentConfig {
-    return this.subAgents.find((s) => s.id === snapshot.id) ?? snapshot
+    return this.subAgents.find((s) => s.name === snapshot.name) ?? snapshot
   }
 
   /** 异步派发 subagent：via spawnPersistentAgent，工具立即返回，完成时通知父 humanQueue。 */

--- a/crabot-agent/src/agent/agent-handler.ts
+++ b/crabot-agent/src/agent/agent-handler.ts
@@ -3688,10 +3688,13 @@ export class AgentHandler {
       buildSpawnDeps: (goal) => {
         // auditor 配置不存在 → spawn 抛错 → caller fail-open（console.warn）。
         // 用 throw 把"找不到 auditor"统一走 spawn 异常分支，避免在多处分散判断。
-        const auditor = opts.subAgents.find((s) => s.id === 'builtin-goal-auditor')
-        if (!auditor) {
+        const auditorSnapshot = opts.subAgents.find((s) => s.id === 'builtin-goal-auditor')
+        if (!auditorSnapshot) {
           throw new Error('builtin-goal-auditor subagent not configured')
         }
+        // 每次 spawn audit 时从 live this.subAgents 重解析 model —— 与 delegate_task 一致，
+        // model_config 热更新对 audit 派发 in-flight 生效（spec 2026-07-19）。
+        const auditor = handler.resolveLiveSubAgent(auditorSnapshot)
         const auditAdapter = adapterFromModel(auditor.model)
         const auditPermission = opts.getAuditPermissionConfig()
         return {
@@ -3820,15 +3823,30 @@ export class AgentHandler {
     return async (subagent, input, ctx) => {
       const typedInput = input as RunSubAgentInput & { sync?: boolean }
 
+      // 派发时从最新热更的 this.subAgents 重解析：loop 启动时的 snapshot 只保证
+      // subagent「列表」一致（工具 enum / prompt），列表内各项的 model 等配置在每次
+      // 派发时取 live 值 —— model_config 热更新对 subagent 派发 in-flight 生效。
+      // live 列表中已被删除时回退快照，不打断 in-flight 推理。
+      // spec: 2026-07-19-subagent-model-hot-reload-design.md
+      const effective = this.resolveLiveSubAgent(subagent)
+
       // 异步路径：asyncEnabled + 没有显式 sync=true
       if (deps.asyncEnabled && !typedInput.sync && deps.asyncCtx && deps.humanQueue) {
-        return this.runSubAgentAsync(subagent, typedInput, deps.asyncCtx, deps)
+        return this.runSubAgentAsync(effective, typedInput, deps.asyncCtx, deps)
       }
 
       // 同步路径（默认 fallback / 显式 sync=true）
-      const { traceId: _traceId, ...result } = await this.runSubAgentDirect(subagent, input, ctx, deps)
+      const { traceId: _traceId, ...result } = await this.runSubAgentDirect(effective, input, ctx, deps)
       return result
     }
+  }
+
+  /**
+   * 按 id 从 live this.subAgents 重查 subagent 配置，找不到（loop 运行期间被删）回退快照。
+   * 见 makeRunSubAgent 闭包注释 / spec 2026-07-19-subagent-model-hot-reload-design.md。
+   */
+  private resolveLiveSubAgent(snapshot: SubAgentConfig): SubAgentConfig {
+    return this.subAgents.find((s) => s.id === snapshot.id) ?? snapshot
   }
 
   /** 异步派发 subagent：via spawnPersistentAgent，工具立即返回，完成时通知父 humanQueue。 */

--- a/crabot-agent/tests/agent/delegate-model-hot-reload.test.ts
+++ b/crabot-agent/tests/agent/delegate-model-hot-reload.test.ts
@@ -1,0 +1,259 @@
+/**
+ * subagent model 热生效（delegate 时实时解析）测试。
+ *
+ * spec: 2026-07-19-subagent-model-hot-reload-design.md
+ *
+ * 语义不变量：
+ * 1. in-flight worker loop 内，updateSubagents（admin push model_config）后，
+ *    delegate_task 派发用 live 列表里的新 model 建 adapter —— 不重启、不等下个 loop。
+ * 2. delegate_task 的 enum（subagent 列表）仍是 loop 启动时快照 —— 列表一致性不受热更影响。
+ * 3. loop 运行期间 subagent 被从 live 列表删除 → 派发回退用快照，不报错。
+ * 4. 异步派发（spawnPersistentAgent）同样取 live model。
+ * 5. goal_audit 的 buildSpawnDeps 每次 spawn 时取 live auditor model。
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { AgentHandler } from '../../src/agent/agent-handler.js'
+import { HumanMessageQueue } from '../../src/engine/human-message-queue.js'
+import type { SubAgentConfig, ExecuteTaskParams, WorkerAgentContext } from '../../src/types.js'
+
+vi.mock('../../src/engine/index.js', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return { ...actual, runEngine: vi.fn() }
+})
+
+vi.mock('../../src/engine/sub-agent.js', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return { ...actual, forkEngine: vi.fn() }
+})
+
+vi.mock('../../src/engine/bg-entities/bg-agent.js', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return { ...actual, spawnPersistentAgent: vi.fn() }
+})
+
+vi.mock('../../src/agent/end-turn-gate.js', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return { ...actual, createAsyncAuditEndTurnGate: vi.fn() }
+})
+
+import { runEngine } from '../../src/engine/index.js'
+import { forkEngine } from '../../src/engine/sub-agent.js'
+import { spawnPersistentAgent } from '../../src/engine/bg-entities/bg-agent.js'
+import { createAsyncAuditEndTurnGate } from '../../src/agent/end-turn-gate.js'
+
+const mockRunEngine = vi.mocked(runEngine)
+const mockForkEngine = vi.mocked(forkEngine)
+const mockSpawnPersistentAgent = vi.mocked(spawnPersistentAgent)
+const mockCreateGate = vi.mocked(createAsyncAuditEndTurnGate)
+
+function makeSdkEnv() {
+  return {
+    modelId: 'test-model',
+    format: 'anthropic' as const,
+    env: { ANTHROPIC_BASE_URL: 'http://localhost:4000', ANTHROPIC_API_KEY: 'k' },
+  }
+}
+
+function makeSubAgent(name: string, modelTag: 'old' | 'new'): SubAgentConfig {
+  return {
+    id: `id-${name}`,
+    name,
+    description: `desc ${name}`,
+    when_to_use: `use ${name}`,
+    role: 'r',
+    workflow: 'w',
+    deliverables: 'd',
+    model: {
+      model_id: `${modelTag}-model`,
+      endpoint: `https://${modelTag}.example.com`,
+      apikey: `${modelTag}-key`,
+      format: 'anthropic',
+    } as never,
+    builtin_capabilities: { file_system: true, shell: false, task_intel: false, crab_memory: false, crab_messaging: false },
+    allowed_mcp_server_ids: [],
+    allowed_skill_ids: [],
+    max_turns: 10,
+  }
+}
+
+function makeTask(): ExecuteTaskParams['task'] {
+  return {
+    task_id: 't1', task_title: 'demo', task_description: 'demo', task_type: 'user_request', priority: 'normal',
+  }
+}
+
+function makeContext(): WorkerAgentContext {
+  return {
+    admin_endpoint: { module_id: 'admin', port: 1 },
+    memory_endpoint: { module_id: 'memory', port: 2 },
+    channel_endpoints: [{ module_id: 'channel', port: 3 }],
+    short_term_memories: [], long_term_memories: [], available_tools: [],
+    time_windows: { recent_messages_window_hours: 4, short_term_memory_window_hours: 12 },
+  }
+}
+
+function getDelegateTool(options: any) {
+  const tools = (options.tools as () => ReadonlyArray<any>)()
+  return tools.find((t) => t.name === 'delegate_task')
+}
+
+/** forkEngine 收到的 adapter 是 AnthropicAdapter，私有字段 config 存了 endpoint/apikey。 */
+function adapterEndpoint(call: any): { endpoint: string; apikey: string } {
+  const cfg = (call.adapter as any).config
+  return { endpoint: cfg.endpoint, apikey: cfg.apikey }
+}
+
+describe('subagent model 热生效（delegate 时实时解析）', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockForkEngine.mockImplementation(async () => ({
+      outcome: 'completed', output: 'ok', totalTurns: 1,
+    }) as never)
+  })
+
+  it('in-flight loop 内 updateSubagents 后，delegate_task 用新 model 建 adapter；enum 仍是快照', async () => {
+    const handler = new AgentHandler(makeSdkEnv(), { systemPrompt: 'sys' }, {
+      subAgents: [makeSubAgent('code_writer', 'old')],
+    })
+
+    mockRunEngine.mockImplementation(async (params: any) => {
+      const dt = getDelegateTool(params.options)
+      const enumBefore = dt.inputSchema.properties.subagent_type.enum
+
+      // 第一次派发：loop 快照里的旧 model
+      await dt.call({ subagent_type: 'code_writer', task: 'first' }, {})
+
+      // 模拟 admin push model_config 热更（同 id/name，换 provider）
+      handler.updateSubagents([makeSubAgent('code_writer', 'new')])
+
+      const enumAfter = getDelegateTool(params.options).inputSchema.properties.subagent_type.enum
+      // 列表不变量：enum 仍来自 loop 启动时快照
+      expect(enumBefore).toEqual(['code_writer'])
+      expect(enumAfter).toEqual(['code_writer'])
+
+      // 第二次派发：应取 live 的新 model
+      await dt.call({ subagent_type: 'code_writer', task: 'second' }, {})
+
+      return {
+        outcome: 'completed', finalText: 'ok', totalTurns: 1,
+        usage: { inputTokens: 1, outputTokens: 1 },
+        finalMessages: [],
+      } as never
+    })
+
+    await handler.executeTask({ task: makeTask(), context: makeContext() })
+
+    expect(mockForkEngine).toHaveBeenCalledTimes(2)
+    const first = mockForkEngine.mock.calls[0][0] as any
+    const second = mockForkEngine.mock.calls[1][0] as any
+    expect(first.model).toBe('old-model')
+    expect(adapterEndpoint(first)).toEqual({ endpoint: 'https://old.example.com', apikey: 'old-key' })
+    // 核心语义断言：第二次派发用新 provider 的 model/endpoint/apikey
+    expect(second.model).toBe('new-model')
+    expect(adapterEndpoint(second)).toEqual({ endpoint: 'https://new.example.com', apikey: 'new-key' })
+  })
+
+  it('loop 运行期间 subagent 被删除 → 派发回退用快照，不报错', async () => {
+    const handler = new AgentHandler(makeSdkEnv(), { systemPrompt: 'sys' }, {
+      subAgents: [makeSubAgent('code_writer', 'old')],
+    })
+
+    mockRunEngine.mockImplementation(async (params: any) => {
+      // admin 把 code_writer 从 subagents 里删了
+      handler.updateSubagents([])
+
+      const dt = getDelegateTool(params.options)
+      // enum 快照里还有 code_writer，LLM 仍可能派发它
+      const result = await dt.call({ subagent_type: 'code_writer', task: 'still works' }, {})
+      expect(result.isError).not.toBe(true)
+
+      return {
+        outcome: 'completed', finalText: 'ok', totalTurns: 1,
+        usage: { inputTokens: 1, outputTokens: 1 },
+        finalMessages: [],
+      } as never
+    })
+
+    await handler.executeTask({ task: makeTask(), context: makeContext() })
+
+    expect(mockForkEngine).toHaveBeenCalledTimes(1)
+    const call = mockForkEngine.mock.calls[0][0] as any
+    expect(call.model).toBe('old-model')
+    expect(adapterEndpoint(call).endpoint).toBe('https://old.example.com')
+  })
+
+  it('异步派发（spawnPersistentAgent）同样取 live model', async () => {
+    const snapshotEntry = makeSubAgent('code_writer', 'old')
+    const handler = new AgentHandler(makeSdkEnv(), { systemPrompt: 'sys' }, {
+      subAgents: [snapshotEntry],
+    })
+    handler.updateSubagents([makeSubAgent('code_writer', 'new')])
+
+    mockSpawnPersistentAgent.mockImplementation(async () => 'agent_test1' as never)
+
+    const runSubAgent = (handler as any).makeRunSubAgent({
+      parentTools: [],
+      parentTaskId: 't1',
+      callerLabel: 'test',
+      humanQueue: new HumanMessageQueue(),
+      asyncEnabled: true,
+      asyncCtx: { owner: { friend_id: 'f1', session_id: 's1' } },
+    })
+    // delegate_task 闭包传进来的是 loop 快照里的旧 entry
+    await runSubAgent(snapshotEntry, { task: 'async job' }, {})
+
+    expect(mockSpawnPersistentAgent).toHaveBeenCalledTimes(1)
+    const spawnOpts = mockSpawnPersistentAgent.mock.calls[0][0] as any
+    expect(spawnOpts.model).toBe('new-model')
+    expect((spawnOpts.adapter as any).config.endpoint).toBe('https://new.example.com')
+    expect((spawnOpts.adapter as any).config.apikey).toBe('new-key')
+  })
+
+  it('goal_audit buildSpawnDeps 每次 spawn 时取 live auditor model', async () => {
+    const auditorOld = { ...makeSubAgent('goal_auditor', 'old'), id: 'builtin-goal-auditor', system_only: true }
+    const auditorNew = { ...makeSubAgent('goal_auditor', 'new'), id: 'builtin-goal-auditor', system_only: true }
+
+    const handler = new AgentHandler(makeSdkEnv(), { systemPrompt: 'sys' }, {
+      subAgents: [auditorOld],
+      deps: {
+        rpcClient: {} as never,
+        moduleId: 'agent',
+        resolveChannelPort: async () => 1,
+        getMemoryPort: async () => 2,
+        getAdminPort: async () => 1,
+      },
+    })
+
+    let capturedDeps: any
+    mockCreateGate.mockImplementation(((deps: any) => {
+      capturedDeps = deps
+      return async () => null
+    }) as never)
+
+    ;(handler as any).buildAsyncAuditEndTurnGate({
+      goalModeEnabled: true,
+      goalSetCacheGetter: () => true,
+      taskId: 't1',
+      taskState: {} as never,
+      subAgents: [auditorOld], // loop 启动时快照
+      getAuditBaseTools: () => [],
+      getAuditPermissionConfig: () => undefined,
+      humanQueue: new HumanMessageQueue(),
+      cwd: '/tmp',
+      owner: { friend_id: 'f1', session_id: 's1' },
+      getConversationLog: () => [],
+    })
+
+    const goal = { objective: 'obj', acceptance_criteria: [] }
+
+    const firstSpawn = capturedDeps.buildSpawnDeps(goal)
+    expect((firstSpawn.adapter as any).config.endpoint).toBe('https://old.example.com')
+
+    // admin push 热更 auditor model 后再 spawn audit → 用新配置
+    handler.updateSubagents([auditorNew])
+    const secondSpawn = capturedDeps.buildSpawnDeps(goal)
+    expect((secondSpawn.adapter as any).config.endpoint).toBe('https://new.example.com')
+    expect((secondSpawn.adapter as any).config.apikey).toBe('new-key')
+    expect(secondSpawn.auditor.model.model_id).toBe('new-model')
+  })
+})

--- a/crabot-agent/tests/agent/delegate-model-hot-reload.test.ts
+++ b/crabot-agent/tests/agent/delegate-model-hot-reload.test.ts
@@ -182,6 +182,35 @@ describe('subagent model 热生效（delegate 时实时解析）', () => {
     expect(adapterEndpoint(call).endpoint).toBe('https://old.example.com')
   })
 
+  it('loop 运行期间同名 subagent 被删除再重建（新 id）→ 派发用重建后的新配置', async () => {
+    const handler = new AgentHandler(makeSdkEnv(), { systemPrompt: 'sys' }, {
+      subAgents: [makeSubAgent('code_writer', 'old')],
+    })
+
+    mockRunEngine.mockImplementation(async (params: any) => {
+      // admin 删除再重建同名 subagent：id 变了（重建），配置也换了
+      const recreated = { ...makeSubAgent('code_writer', 'new'), id: 'id-code_writer-recreated' }
+      handler.updateSubagents([recreated])
+
+      const dt = getDelegateTool(params.options)
+      await dt.call({ subagent_type: 'code_writer', task: 'after recreate' }, {})
+
+      return {
+        outcome: 'completed', finalText: 'ok', totalTurns: 1,
+        usage: { inputTokens: 1, outputTokens: 1 },
+        finalMessages: [],
+      } as never
+    })
+
+    await handler.executeTask({ task: makeTask(), context: makeContext() })
+
+    // name 匹配语义：同名重建视为同一 subagent 换配置，派发用新配置而非静默回退旧快照
+    expect(mockForkEngine).toHaveBeenCalledTimes(1)
+    const call = mockForkEngine.mock.calls[0][0] as any
+    expect(call.model).toBe('new-model')
+    expect(adapterEndpoint(call).endpoint).toBe('https://new.example.com')
+  })
+
   it('异步派发（spawnPersistentAgent）同样取 live model', async () => {
     const snapshotEntry = makeSubAgent('code_writer', 'old')
     const handler = new AgentHandler(makeSdkEnv(), { systemPrompt: 'sys' }, {


### PR DESCRIPTION
## 背景

m2u 实例 cost_effective provider 余额耗尽（HTTP 402），在 Admin 改 slot 后"继续任务"仍用旧 provider，必须重启实例才生效。

根因：`runWorkerLoop` 启动时固化 `subAgentsSnapshot`，`delegate_task` 闭包绑定快照中嵌入的 model 连接信息；热更只影响"下一个 loop"，而 loop 存活期间的继续执行永远等不到新 loop。

## 方案

spec：crabot-docs `superpowers/specs/2026-07-19-subagent-model-hot-reload-design.md`（已推到 docs main）

- subagent **列表**（delegate_task enum / description / system prompt）保持 loop 启动时快照——LLM 可见工具面不中途跳变（snapshot 设计的原始动机）。
- 列表内各项的 **model 等配置**在每次派发时从 live `this.subAgents` 按 name 重查（`resolveLiveSubAgent`）；live 中已删除则回退快照，不报错。
- 覆盖三条派发路径：同步 `runSubAgentDirect`、异步 `spawnPersistentAgent`、goal_audit `buildSpawnDeps`。`runGoalAudit` 本就实时读 live，无需改。
- 主 adapter 与已 spawn 的持久 subagent 保持 loop/spawn 级快照（protocol-agent-v2 §6.1 已写明三种粒度；要立即生效则终止重派）。

## 协议更新（crabot-docs，已合并）

- protocol-agent-v2 §6.1：model_config 热更拆为三种粒度（worker 主 adapter / subagent 派发 / 已 spawn subagent）。
- protocol-admin §3.19.6：补"保存后触发 pushConfigToAgentModules"约定。

## 测试

新增 `crabot-agent/tests/agent/delegate-model-hot-reload.test.ts` 4 条：

1. **故障场景复现**：in-flight loop 内 `updateSubagents` 换 provider 后，下一次 `delegate_task(code_writer)` 即用新 endpoint/apikey/model_id 建 adapter；enum 仍是快照。
2. loop 运行期间 subagent 被删 → 派发回退快照，不报错。
3. 异步派发（spawnPersistentAgent）取 live model。
4. goal_audit `buildSpawnDeps` 每次 spawn 取 live auditor model。

验证：`tsc --noEmit` 通过；新测试 4/4；相关既有测试 109/109；agent 全量 1543/1544（2 skipped），唯一失败为 context-assembler 固定时间漂移（7-17 已记录，stash 验证与本次 diff 无关）。
