### PR TITLE
feat(agent): revive vs new_task 决策优化（上下文价值 + 体积双关）

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,6 +1,18 @@
 # Crabot 项目进度
 
-> 最后更新：2026-07-17 — 恢复飞书外部群 PRD 获取流程
+> 最后更新：2026-07-18 — 复活 vs new_task 决策优化（价值关 + 体积关）
+
+## 2026-07-18 — 复活 vs new_task 决策优化（价值关 + 体积关）
+
+- 背景：复活机制（06-29 上线）后出现"无限续杯"——续跑完成刷新 `completed_at`，24h 候选窗口滑动，候选资格永久续期。问题框定为"每条消息到来时该复活还是 new_task"的决策质量，而非候选出局规则；已排除次数上限、worker 自纠正、successor、复活时压缩等方案。
+- 价值关（dispatcher）：supplement 判据从"消息形态像补充"改为"处理新消息是否需要旧 task 上下文/结果"；拿不准偏向 new_task；failed 候选"继续/再跑一次"仍判 supplement。新增 recent terminal 候选段渲染，但只含处置信息（task_id+status+completed_at+失败原因），不含标题/进度——任务身份交给 07-12 设计的消息归因（task="..."）。
+- 上线后复盘追加（同日，经真实 LLM 重放验证）：归因优先规则（关联判断以 task= 归因消息内容为准，无归因词面重叠不构成依据）+ 活跃/terminal 两段列表降注（"只提供 id 与状态，不代表任务内容"）+ 旧工作指引（指代"很久以前"且可见 task 归因消息未涉及 → new_task）。复盘案例（alpha 词面冲突）经 6 次重放两轮规则均未改判，确认为可见信息下的边界案例；dispatcher 旧 task 检索留作后续方向。
+- 体积关（executor）：`canResumeTask` 预检查在 terminal_supplement 模式下估算 checkpoint messages，≥ 200k×0.8（复用现有常量，无新配置）→ `checkpoint_too_large(est≈…)` fallback，admin 状态不被触碰，直接降级 new_task；二元判定，不存在"压缩后复活"。restart 模式不受门禁影响。
+- trace：revive fallback span 新增 `fallback_reason`，体积降级可诊断。
+- spec：`crabot-docs/superpowers/specs/2026-07-18-revive-vs-new-task-decision-design.md`；plan：`crabot-docs/superpowers/plans/2026-07-18-revive-vs-new-task-decision.md`；协议 `protocol-agent-v2.md` §5.1 已同步。
+- Follow-up（暂缓）：context-overflow 韧性（错误不重试 + compaction 尾部治理 + 失败可诊断），spec 已写：`crabot-docs/superpowers/specs/2026-07-18-context-overflow-resilience-design.md`；候选"结果摘要"字段（若误判仍多再立项，涉及存储+协议）。
+- 顺手修复：context-assembler 既有 recent-terminal 测试写死 2026-07-12 时间戳掉出 24h 窗口，改为相对当前时间。
+- 验证：dispatcher/executor/resume 定向 89 个通过；crabot-agent 全量 1545 passed（2 skipped）；`tsc --noEmit` 通过。
 
 ## 2026-07-17 — 恢复飞书外部群 PRD 获取流程
 

--- a/crabot-agent/src/dispatcher/dispatcher-executor.ts
+++ b/crabot-agent/src/dispatcher/dispatcher-executor.ts
@@ -100,6 +100,9 @@ export async function executeDispatchActions(
               attempted_target_task_id: action.target_task_id,
               target_task_status: target.status,
               target_task_completed_at: target.completed_at,
+              // revive 拒绝原因（no_checkpoint / checkpoint_too_large(est≈…) 等）入 span，
+              // 让体积降级在 trace 可诊断。Spec: 2026-07-18-revive-vs-new-task-decision-design §决策 2
+              ...(revive.reason ? { fallback_reason: revive.reason } : {}),
             })
           }
           await fireReaction(ctx)

--- a/crabot-agent/src/dispatcher/dispatcher-prompt.ts
+++ b/crabot-agent/src/dispatcher/dispatcher-prompt.ts
@@ -79,7 +79,7 @@ function buildDispatchRules(
 }
 
 const SUPPLEMENT_WHITELIST_REMINDER =
-  '\n\n**target_task_id 硬约束**：必须使用 prompt 中可见的 task_id（最近聊天历史 `<message task="...">` 或「当前正在运行的本 session task」里的 id）并字面完全一致——禁止编造、截断、模糊匹配或拼造前缀。找不到合理匹配的 → 用 new_task，不要用 supplement。系统会二次校验，不能补充的 task 会降级为 new_task。'
+  '\n\n**target_task_id 硬约束**：必须使用 prompt 中可见的 task_id（最近聊天历史 `<message task="...">`、`「当前正在运行的本 session task」或「近期结束的本 session task」里的 id）并字面完全一致——禁止编造、截断、模糊匹配或拼造前缀。找不到合理匹配的 → 用 new_task，不要用 supplement。系统会二次校验，不能补充的 task 会降级为 new_task。'
 
 /**
  * new_task 可选 immediate_reply 字段的字段说明。插在每个 dispatch rule
@@ -99,8 +99,8 @@ const PRIVATE_RULES_WITH_ACTIVE = `## 分诊规则（私聊 / admin chat）
 
 每个动作只能是以下两种之一：
 
-1. **supplement** — 这条消息是对某个已知 task 的补充 / 追问 / 修正 / 继续讨论。
-   - target_task_id 必须来自最近聊天历史消息的 task="..." 属性，或「当前正在运行的本 session task」列表
+1. **supplement** — 处理这条消息需要建立在某个已知 task 的已有上下文或结果之上（追问其结论、修正其产出、在其方案上追加条件、继续未完成的工作）。
+   - target_task_id 必须来自最近聊天历史消息的 task="..." 属性，或「当前正在运行的本 session task」/「近期结束的本 session task」列表
    - 不要输出补充正文；系统会把当前真实消息批次原样投递给 task
 
 2. **new_task** — 这条消息发起一个新任务。
@@ -108,10 +108,15 @@ const PRIVATE_RULES_WITH_ACTIVE = `## 分诊规则（私聊 / admin chat）
 ${NEW_TASK_IMMEDIATE_REPLY_HINT}
 
 判断要点：
+- supplement 的判据是**上下文价值**，不是消息形态：只有旧 task 的上下文/结果对处理这条新消息有复用价值时才 supplement；只是话题沾边、但旧上下文用不上的 → new_task
+- **判断与某 task 的关联时，以带该 task 「task="..."」归因的聊天消息内容为准**：归因消息在聊什么，这个 task 就是什么。归因内容与当前消息无关 → new_task；无归因消息里的词面重叠不构成关联依据
 - 用户明确指代历史中带 task="..." 的某个任务（"那个手机调研"、"再加一条"、"算了改成 X"等）→ supplement
-- 对已经完成/失败的历史 task，只有明确延续刚才任务时才 supplement；新话题或不确定时 new_task
+- 对已经完成的历史 task：明确延续其上下文才 supplement；开启新的工作事项（即使同主题领域）→ new_task
+- 对已失败的历史 task：用户表达"继续"/"再跑一次"→ supplement（失败重跑天然依赖原上下文）
 - 用户提出一个跟所有可见 task 都不相关的请求 → new_task
-- 不确定时优先 new_task（误判 new_task 后果较轻：开个新 agent 实例独立处理）
+- 上下文是否有复用价值拿不准时 → 优先 new_task（误判 new_task 后果较轻：开个新 agent 实例独立处理）
+- 用户指代「之前/以前/很久以前」的某项工作时：仅当某个可见 task 的归因消息**明确涉及同一项工作**才 supplement；可见 task 的归因消息均未涉及该项工作 → new_task（旧工作的上下文 worker 会自己检索找回，不要把指代旧工作的消息塞进正在运行的无关 task）
+- 「当前正在运行的本 session task」和「近期结束的本 session task」列表只提供 task_id 与状态，不代表任务内容；任务是什么，以它的归因消息为准
 
 **结合最近聊天历史判断**：用户当前消息常常引用历史上下文（"把这文件……"、"再加一条"），需要回看「最近聊天历史」段判断指代对象——尤其是文件 / 图片这类媒体消息（你能看到 \`[文件: xxx.pdf]\` / \`[图片: ...]\` 标记），它们就是用户当前指令要处理的素材。worker 启动后会拿到完整批次（含媒体），你只需把意图分诊清楚即可。
 
@@ -135,8 +140,8 @@ const GROUP_RULES_WITH_ACTIVE = `## 分诊规则（群聊）
 
 群聊批次（多消息多用户）的每个动作可以是以下三种之一：
 
-1. **supplement** — 某条消息是对某个已知 task 的补充 / 追问 / 修正 / 继续讨论。
-   - target_task_id 必须来自最近聊天历史消息的 task="..." 属性，或「当前正在运行的本 session task」列表
+1. **supplement** — 处理某条消息需要建立在某个已知 task 的已有上下文或结果之上（追问其结论、修正其产出、在其方案上追加条件、继续未完成的工作）。
+   - target_task_id 必须来自最近聊天历史消息的 task="..." 属性，或「当前正在运行的本 session task」/「近期结束的本 session task」列表
    - 不要输出补充正文；系统会把当前真实消息批次原样投递给 task
 
 2. **new_task** — 某条消息发起一个跟我相关的新任务。
@@ -150,7 +155,11 @@ ${NEW_TASK_IMMEDIATE_REPLY_HINT}
 - 被 [@Crabot] 标注、上下文只有发送者和我、我之前的消息被引用 → 必须 supplement 或 new_task，不允许 stay_silent
 - 群成员之间互相讨论（不是在叫我）/ 系统通知 / 分享链接 → stay_silent
 - 一批多条消息可拆分：比如其中一条 @我 走 new_task，另一条群成员讨论走 stay_silent
-- 如果历史 task 已经完成/失败，只有明确延续刚才任务时才 supplement；新话题或不确定时 new_task
+- supplement 的判据是**上下文价值**，不是消息形态：旧 task 的上下文/结果对处理这条消息有复用价值才 supplement；只是话题沾边 → new_task
+- **判断与某 task 的关联时，以带该 task 「task="..."」归因的聊天消息内容为准**：归因消息在聊什么，这个 task 就是什么。归因内容与当前消息无关 → new_task；无归因消息里的词面重叠不构成关联依据
+- 历史 task 已完成：明确延续其上下文才 supplement；开启新工作事项 → new_task。已失败：用户说"继续"/"再跑一次" → supplement。拿不准上下文价值 → new_task
+- 用户指代「之前/以前/很久以前」的某项工作时：仅当某个可见 task 的归因消息**明确涉及同一项工作**才 supplement；可见 task 的归因消息均未涉及该项工作 → new_task（旧工作的上下文 worker 会自己检索找回，不要把指代旧工作的消息塞进正在运行的无关 task）
+- 「当前正在运行的本 session task」和「近期结束的本 session task」列表只提供 task_id 与状态，不代表任务内容；任务是什么，以它的归因消息为准
 
 最多输出 ${MAX_ACTIONS_PER_DISPATCH} 个动作。
 

--- a/crabot-agent/src/dispatcher/dispatcher.ts
+++ b/crabot-agent/src/dispatcher/dispatcher.ts
@@ -176,6 +176,20 @@ export function buildUserPrompt(
       lines.push(`- [${t.task_id}] (status: ${t.status})`)
     }
   }
+  // recent terminal 候选显式渲染。只渲染消息归因承载不了的处置信息——status /
+  // completed_at / 失败原因；任务内容身份交给聊天历史的 task="..." 归因（07-12 设计：
+  // 归因消息即 task 身份，标题/进度摘要既陈旧又可能是噪声，不渲染）。
+  // Spec: 2026-07-18-revive-vs-new-task-decision-design §决策 1
+  const recentTerminalTasks = ctx.activeTasks.filter((t) => t.candidate_kind === 'recent_terminal')
+  if (recentTerminalTasks.length > 0) {
+    lines.push('\n## 近期结束的本 session task（可作为 supplement 候选）')
+    for (const t of recentTerminalTasks) {
+      const statusLabel = t.status === 'failed' ? 'failed_recently' : 'completed_recently'
+      const completedAt = t.completed_at ? `, completed_at: ${t.completed_at}` : ''
+      lines.push(`- [${t.task_id}] (status: ${statusLabel}${completedAt})`)
+      if (t.status === 'failed' && t.error) lines.push(`  失败原因: ${t.error}`)
+    }
+  }
   lines.push('\n按 system prompt 描述的 schema 输出 JSON。')
   return lines.join('\n')
 }

--- a/crabot-agent/src/dispatcher/dispatcher.ts
+++ b/crabot-agent/src/dispatcher/dispatcher.ts
@@ -187,7 +187,7 @@ export function buildUserPrompt(
       const statusLabel = t.status === 'failed' ? 'failed_recently' : 'completed_recently'
       const completedAt = t.completed_at ? `, completed_at: ${t.completed_at}` : ''
       lines.push(`- [${t.task_id}] (status: ${statusLabel}${completedAt})`)
-      if (t.status === 'failed' && t.error) lines.push(`  失败原因: ${t.error}`)
+      if (t.status === 'failed' && t.error) lines.push(`  失败原因: ${t.error.slice(0, 200)}`)
     }
   }
   lines.push('\n按 system prompt 描述的 schema 输出 JSON。')

--- a/crabot-agent/src/engine/context-manager.ts
+++ b/crabot-agent/src/engine/context-manager.ts
@@ -20,7 +20,7 @@ interface CumulativeUsage {
   readonly outputTokens: number
 }
 
-const DEFAULT_COMPACT_THRESHOLD = 0.8
+export const DEFAULT_COMPACT_THRESHOLD = 0.8
 const DEFAULT_KEEP_RECENT = 6
 const CHARS_PER_TOKEN = 4
 const MESSAGE_OVERHEAD_TOKENS = 4

--- a/crabot-agent/src/engine/query-loop.ts
+++ b/crabot-agent/src/engine/query-loop.ts
@@ -36,7 +36,7 @@ export interface RunEngineParams {
 }
 
 const DEFAULT_MAX_TURNS = 200
-const DEFAULT_MAX_CONTEXT_TOKENS = 200_000
+export const DEFAULT_MAX_CONTEXT_TOKENS = 200_000
 
 // 推理类模型偶尔以 end_turn 结束但只发 reasoning 不发 text。注入追问让其重说，
 // 超过上限仍空就老实返回空 finalText——绝不让另一个 LLM 替它编。

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -61,6 +61,8 @@ import type { BgEntityRecord, BgEntityStatus, BgEntityType } from './engine/bg-e
 import { redactSecrets } from './engine/redact-secrets.js'
 import { isResumable, redactCheckpoint } from './core/resume-checkpoint.js'
 import { AGENT_VERSION } from './constants.js'
+import { ContextManager, DEFAULT_COMPACT_THRESHOLD } from './engine/context-manager.js'
+import { DEFAULT_MAX_CONTEXT_TOKENS } from './engine/query-loop.js'
 
 const BARRIER_TIMEOUT_MS = 8_000
 
@@ -1947,6 +1949,19 @@ export class UnifiedAgent extends ModuleBase {
         this.traceStore.finalizeUnresumedCheckpoint(taskId)
       }
       return { ok: false, reason: guard.reason }
+    }
+    // 体积门禁（仅 terminal supplement revive）：checkpoint 超预算时不复活、不碰 admin 状态，
+    // 返回 fallback 由 dispatcher 降级 new_task。二元判定——要么原样复活，要么 new_task，
+    // 不存在"压缩后复活"（复活的价值就是原样 checkpoint + prompt cache 前缀）。
+    // restart 模式不加：重启恢复走 loop 内 compaction，不在本期范围。
+    // Spec: 2026-07-18-revive-vs-new-task-decision-design §决策 2
+    if (mode === 'terminal_supplement') {
+      const estimator = new ContextManager({ maxContextTokens: DEFAULT_MAX_CONTEXT_TOKENS })
+      const estimated = estimator.estimateTotalTokens(entry.checkpoint.messages)
+      const budget = DEFAULT_MAX_CONTEXT_TOKENS * DEFAULT_COMPACT_THRESHOLD
+      if (estimated >= budget) {
+        return { ok: false, reason: `checkpoint_too_large(est≈${Math.round(estimated / 1000)}k tokens)` }
+      }
     }
     return { ok: true }
   }

--- a/crabot-agent/tests/dispatcher/dispatcher-executor.test.ts
+++ b/crabot-agent/tests/dispatcher/dispatcher-executor.test.ts
@@ -290,6 +290,42 @@ describe('executeDispatchActions', () => {
     })
   })
 
+  it('terminal revive fallback span 带 fallback_reason（体积门禁等降级原因可诊断）', async () => {
+    const endSpan = vi.fn()
+    const trace = {
+      startSpan: vi.fn().mockReturnValue({ span_id: 'sp-1' }),
+      endSpan,
+    }
+    const base = makeExecCtx()
+    const ctx = makeExecCtx({
+      dispatchCtx: {
+        ...base.dispatchCtx,
+        activeTasks: [{
+          task_id: 'task-huge' as never,
+          title: 'huge',
+          status: 'completed',
+          priority: 'normal',
+          candidate_kind: 'recent_terminal',
+        } as never],
+      },
+      reviveTerminalSupplement: vi.fn().mockResolvedValue({
+        outcome: 'fallback' as const,
+        reason: 'checkpoint_too_large(est≈175k tokens)',
+      }),
+      spawnAgentInstance: vi.fn().mockResolvedValue({ spawnedTraceId: 'trace-new' }),
+      trace,
+    } as Partial<ExecuteContext>)
+    await executeDispatchActions([{ kind: 'supplement', target_task_id: 'task-huge' }], ctx)
+    const [, status, details] = endSpan.mock.calls[0]
+    expect(status).toBe('completed')
+    expect(details).toMatchObject({
+      outcome: 'supplement_fallback_recovered',
+      recovered_via: 'new_task',
+      attempted_target_task_id: 'task-huge',
+      fallback_reason: 'checkpoint_too_large(est≈175k tokens)',
+    })
+  })
+
   // ============================================================================
   // immediate_reply（spec: 2026-06-03-dispatcher-immediate-reply-and-overdue-removal-design.md）
   // ============================================================================

--- a/crabot-agent/tests/dispatcher/dispatcher-prompt.test.ts
+++ b/crabot-agent/tests/dispatcher/dispatcher-prompt.test.ts
@@ -52,6 +52,24 @@ describe('assembleDispatcherPrompt', () => {
     expect(p).not.toMatch(/stay_silent/)
   })
 
+  it('supplement 判据为上下文价值（2026-07-18 spec）：含价值判据 / failed 继续指引 / 拿不准偏向 new_task', () => {
+    for (const sessionType of ['private', 'group'] as const) {
+      const p = assembleDispatcherPrompt(ctx({ sessionType, activeTasks: [task('task-A')] }))
+      expect(p).toContain('上下文价值')
+      expect(p).toContain('再跑一次')
+      expect(p).toMatch(/拿不准.*new_task|拿不准时.*new_task/)
+    }
+  })
+
+  it('归因优先指引（2026-07-18 讨论）：关联判断以 task= 归因消息为准，列表不代表任务内容', () => {
+    for (const sessionType of ['private', 'group'] as const) {
+      const p = assembleDispatcherPrompt(ctx({ sessionType, activeTasks: [task('task-A')] }))
+      expect(p).toContain('归因')
+      expect(p).toContain('词面重叠不构成关联依据')
+      expect(p).toContain('不代表任务内容')
+    }
+  })
+
   it('包含 JSON 输出 schema 与软上限 5', () => {
     const p = assembleDispatcherPrompt(ctx())
     expect(p).toMatch(/actions/)
@@ -240,7 +258,9 @@ describe('buildUserPrompt task-aware context', () => {
     expect(p).toContain('已经按免费方案跑完一版')
   })
 
-  it('does not render recent terminal candidates in the task list by title', () => {
+  it('renders recent terminal candidates in a dedicated section with status/reason only', () => {
+    // 2026-07-18 讨论结论：候选段只渲染消息归因承载不了的处置信息
+    // （status/completed_at/失败原因）；任务身份交给归因消息，不渲染标题/进度
     const p = buildUserPrompt(ctx({
       messages: [msg('cur', '继续')],
       activeTasks: [{
@@ -251,10 +271,11 @@ describe('buildUserPrompt task-aware context', () => {
       }],
     }))
 
-    expect(p).not.toContain('## 当前正在运行的本 session task')
-    expect(p).not.toContain('（无）')
+    expect(p).toContain('## 近期结束的本 session task（可作为 supplement 候选）')
+    expect(p).toContain('[task-done] (status: completed_recently')
     expect(p).not.toContain('"t-task-done"')
-    expect(p).not.toContain('completed_recently')
+    // 不出现在运行中列表
+    expect(p).not.toContain('## 当前正在运行的本 session task')
   })
 
   it('renders only active session task id/status in the compact running task list', () => {
@@ -276,8 +297,11 @@ describe('buildUserPrompt task-aware context', () => {
     expect(p).toContain('status: waiting_human')
     expect(p).not.toContain('正在等回答')
     expect(p).not.toContain('请确认是否按免费版继续')
-    expect(p).not.toContain('最近进度')
     expect(p).not.toContain('这只是最后一条 task message，不是真进度')
-    expect(p).not.toContain('[task-done]')
+    // 运行中列表不含 recent terminal 候选；候选出现在独立段落
+    const runningSection = p.split('## 当前正在运行的本 session task')[1]?.split('##')[0] ?? ''
+    expect(runningSection).not.toContain('[task-done]')
+    expect(p).toContain('## 近期结束的本 session task（可作为 supplement 候选）')
+    expect(p).toContain('[task-done]')
   })
 })

--- a/crabot-agent/tests/dispatcher/dispatcher.test.ts
+++ b/crabot-agent/tests/dispatcher/dispatcher.test.ts
@@ -172,6 +172,7 @@ describe('dispatch', () => {
           status: 'completed',
           candidate_kind: 'recent_terminal',
           completed_at: '2026-06-29T10:00:00.000Z',
+          latest_progress: '已输出对比表格',
         }),
         makeTask('task-failed', {
           status: 'failed',
@@ -184,6 +185,22 @@ describe('dispatch', () => {
     const prompt = buildUserPrompt(ctx, { timezone: 'Asia/Shanghai' })
     expect(prompt).toMatch(/## 当前正在运行的本 session task/)
     expect(prompt).toMatch(/status: executing/)
+    // recent terminal 候选段只渲染处置信息（status/completed_at/失败原因），
+    // 不渲染标题/进度——任务身份交给归因消息（2026-07-18 讨论结论）
+    expect(prompt).toMatch(/## 近期结束的本 session task（可作为 supplement 候选）/)
+    expect(prompt).toMatch(/\[task-done\] \(status: completed_recently, completed_at: 2026-06-29T10:00:00\.000Z\)/)
+    expect(prompt).toMatch(/\[task-failed\] \(status: failed_recently/)
+    expect(prompt).toMatch(/失败原因: TypeError: terminated/)
+    expect(prompt).not.toMatch(/t-task-done/)
+    expect(prompt).not.toMatch(/最近进度/)
+    // 活跃 task 不出现在 recent terminal 段
+    expect(prompt).not.toMatch(/\[task-active\].*completed_recently/)
+  })
+
+  it('userPrompt 无 recent terminal 候选时不渲染候选段', () => {
+    const ctx = makeCtx({ activeTasks: [makeTask('task-active')] })
+    const prompt = buildUserPrompt(ctx)
+    expect(prompt).not.toMatch(/近期结束的本 session task/)
   })
 
   it('LLM can supplement a recent completed candidate because it is in the candidate whitelist', async () => {

--- a/crabot-agent/tests/dispatcher/dispatcher.test.ts
+++ b/crabot-agent/tests/dispatcher/dispatcher.test.ts
@@ -178,7 +178,7 @@ describe('dispatch', () => {
           status: 'failed',
           candidate_kind: 'recent_terminal',
           completed_at: '2026-06-29T10:05:00.000Z',
-          error: 'TypeError: terminated',
+          error: `${'E'.repeat(250)}TAIL_SENTINEL`,
         }),
       ],
     })
@@ -190,7 +190,8 @@ describe('dispatch', () => {
     expect(prompt).toMatch(/## 近期结束的本 session task（可作为 supplement 候选）/)
     expect(prompt).toMatch(/\[task-done\] \(status: completed_recently, completed_at: 2026-06-29T10:00:00\.000Z\)/)
     expect(prompt).toMatch(/\[task-failed\] \(status: failed_recently/)
-    expect(prompt).toMatch(/失败原因: TypeError: terminated/)
+    expect(prompt).toContain(`失败原因: ${'E'.repeat(200)}`)
+    expect(prompt).not.toContain('TAIL_SENTINEL')
     expect(prompt).not.toMatch(/t-task-done/)
     expect(prompt).not.toMatch(/最近进度/)
     // 活跃 task 不出现在 recent terminal 段

--- a/crabot-agent/tests/orchestration/context-assembler.test.ts
+++ b/crabot-agent/tests/orchestration/context-assembler.test.ts
@@ -323,6 +323,10 @@ describe('ContextAssembler', () => {
 
   it('keeps recent terminal out of active_tasks and hydrates its tagged history message', async () => {
     const platformTimestamp = '2026-07-12T09:58:44.000Z'
+    // 时间戳用相对当前时间：recent terminal 候选有 completed_at 24h 窗口过滤，
+    // 写死日期会随时间推移掉出窗口（2026-07-18 曾因此整测试失败）。
+    const createdAt = new Date(Date.now() - 31 * 60_000).toISOString()
+    const completedAt = new Date(Date.now() - 30 * 60_000).toISOString()
     assembler = new ContextAssembler({
       rpcClient: mockRpc as any,
       moduleId: 'flow-default',
@@ -341,11 +345,11 @@ describe('ContextAssembler', () => {
             status: 'completed',
             priority: 'normal',
             source: { channel_id: 'wechat-test', session_id: 'session-1', trigger_type: 'message' },
-            created_at: '2026-07-12T12:12:58.000Z',
-            completed_at: '2026-07-12T12:13:30.000Z',
+            created_at: createdAt,
+            completed_at: completedAt,
             messages: [{
               content: '[非文本]',
-              timestamp: '2026-07-12T12:12:58.000Z',
+              timestamp: createdAt,
               source: { platform_message_id: 'platform-image-1' },
             }],
           }],

--- a/crabot-agent/tests/unified-agent-resume-task.test.ts
+++ b/crabot-agent/tests/unified-agent-resume-task.test.ts
@@ -413,6 +413,7 @@ describe('UnifiedAgent.reviveTerminalSupplementTask', () => {
     cleanupError?: Error
     hasCheckpoint?: boolean
     checkpointVersion?: string
+    checkpointMessages?: Array<Record<string, unknown>>
     hasActiveTask?: boolean
   } = {}) {
     const agent = Object.create(UnifiedAgent.prototype) as Record<string, unknown>
@@ -435,16 +436,15 @@ describe('UnifiedAgent.reviveTerminalSupplementTask', () => {
     agent.agentHandler = { hasActiveTask: vi.fn().mockReturnValue(deps.hasActiveTask ?? false) }
     const checkpoint = {
       agent_version: deps.checkpointVersion ?? AGENT_VERSION,
-      messages: [{ id: 'm1', role: 'user', content: 'hi', timestamp: 1 }],
+      messages: deps.checkpointMessages ?? [{ id: 'm1', role: 'user', content: 'hi', timestamp: 1 }],
       worker_state: { todo_items: [] },
       system_prompt: 'SP',
     }
+    const entry = (deps.hasCheckpoint ?? true) ? { traceId: 'trace-completed', checkpoint } : undefined
     const finalizeUnresumedCheckpoint = vi.fn()
     agent.traceStore = {
-      getResumableCheckpoint: vi.fn().mockReturnValue(undefined),
-      findLatestResumeCheckpointByTaskId: vi
-        .fn()
-        .mockReturnValue((deps.hasCheckpoint ?? true) ? { traceId: 'trace-completed', checkpoint } : undefined),
+      getResumableCheckpoint: vi.fn().mockReturnValue(entry),
+      findLatestResumeCheckpointByTaskId: vi.fn().mockReturnValue(entry),
       finalizeUnresumedCheckpoint,
     }
 
@@ -545,6 +545,35 @@ describe('UnifiedAgent.reviveTerminalSupplementTask', () => {
     expect(result).toEqual({ outcome: 'fallback', reason: 'admin unavailable' })
     expect(agent.handleResumeTaskWithSupplement).not.toHaveBeenCalled()
     expect(agent.rpcClient.call).toHaveBeenCalledTimes(1)
+  })
+
+  // 体积门禁（2026-07-18 spec §决策 2）：checkpoint 估算 ≥ 200k×0.8 时判定不适合复活，
+  // 必须在 admin 改状态之前降级——不 revive、不标 failed、原 task 保持终态。
+  it('degrades to fallback WITHOUT touching admin when checkpoint exceeds size budget', async () => {
+    // 700k 字符 → 估算 ≈ 175k tokens，超 160k 阈值
+    const agent = buildReviveAgent({
+      checkpointMessages: [{ id: 'm1', role: 'user', content: 'x'.repeat(700_000), timestamp: 1 }],
+    })
+
+    const result = await agent.reviveTerminalSupplementTask('task-huge', '继续', 'wechat-x', 'sess-y')
+
+    expect(result.outcome).toBe('fallback')
+    expect((result as { reason?: string }).reason).toMatch(/^checkpoint_too_large\(est≈\d+k tokens\)$/)
+    expect(agent.rpcClient.call).not.toHaveBeenCalled()
+    expect(agent.handleResumeTaskWithSupplement).not.toHaveBeenCalled()
+  })
+
+  // 体积门禁只作用于 terminal_supplement 模式；restart 恢复不受门禁影响（走 loop 内 compaction）。
+  it('restart-mode pre-check ignores the size gate for the same oversized checkpoint', () => {
+    const agent = buildReviveAgent({
+      checkpointMessages: [{ id: 'm1', role: 'user', content: 'x'.repeat(700_000), timestamp: 1 }],
+    }) as unknown as {
+      canResumeTask: (taskId: string, mode?: 'restart' | 'terminal_supplement') => { ok: boolean; reason?: string }
+    }
+
+    expect(agent.canResumeTask('task-huge', 'restart')).toEqual({ ok: true })
+    const terminalCheck = agent.canResumeTask('task-huge', 'terminal_supplement')
+    expect(terminalCheck.ok).toBe(false)
   })
 })
 


### PR DESCRIPTION
## 背景

复活机制（06-29 上线）后出现"无限续杯"：续跑完成刷新 `completed_at`，24h 候选窗口滑动，候选资格永久续期。问题框定为"每条消息到来时该复活还是 new_task"的决策质量。

- spec: crabot-docs `superpowers/specs/2026-07-18-revive-vs-new-task-decision-design.md`（smilefufu/crabot-docs 配套 PR）
- plan: `superpowers/plans/2026-07-18-revive-vs-new-task-decision.md`

## 改动

**价值关（dispatcher）**
- supplement 判据从"消息形态像补充"改为"处理新消息是否需要旧 task 上下文/结果"；拿不准偏向 new_task
- 归因优先：关联判断以 `task="..."` 归因消息内容为准，无归因消息的词面重叠不构成依据（07-12 设计：归因消息即 task 身份）
- 旧工作指引：用户指代「之前/很久以前」的工作而可见 task 归因消息未涉及 → new_task
- recent terminal 候选段显式渲染：仅 task_id + status + completed_at + 失败原因（处置信息），不含标题/进度
- 活跃/terminal 两段列表降注："只提供 id 与状态，不代表任务内容"

**体积关（revive 准入）**
- `canResumeTask` 只读预检查（admin 改状态**之前**）估算 checkpoint messages，≥ 200k×0.8 → `checkpoint_too_large` fallback 降级 new_task，旧 task 终态不被触碰
- 二元判定：原样复活或 new_task，不存在压缩后复活；restart 模式不受影响
- revive fallback span 新增 `fallback_reason`，体积降级可诊断

**顺手修复**：context-assembler 测试写死 2026-07-12 时间戳掉出 24h 窗口的既有失败（改为相对时间）。

## 验证

- crabot-agent 全量 **1546 passed / 2 skipped / 0 failed**；`tsc --noEmit` 通过
- 上线后 12 次真实 dispatch 逐条复核：延续指令正确 supplement、新请求正确 new_task、群聊噪音正确 stay_silent，无误接/降级循环
- 一起边界误判（旧研究与应用中任务共享 "alpha" 命名）经真实 LLM 重放 6 次 + 探针推理分析，确认为可见信息下的合理边界案例；dispatcher 旧 task 检索留作后续方向

## 排除项

- 不改复活机制语义、不加配置/存储/RPC；context-overflow 韧性（错误不重试 + compaction 尾部治理）spec 已写，作为后续 follow-up