### PR TITLE
feat(core): agent 专用 python venv（agent-venv）+ MM PATH 前置注入

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,6 +305,13 @@ node scripts/debug-agent.mjs modules  # 查看 MM 注册的模块
 - Vite 开发服务器（port 5173）代理 `/api` 和 `/ws` 到后端 port 3000
 - **改了前端代码不生效？** 检查是通过 port 5173（Vite）还是 port 3000（静态文件）访问的
 
+### Agent 专用 Python 环境（agent-venv）
+
+- agent shell（bash 工具 / bg-shell）里的 `python3` / `pip3` 解析到 **`$DATA_DIR/agent-venv`**——MM 启动时用 `uv venv --seed` 懒创建的实例级 venv（`crabot-core/src/agent-venv.ts`，缺失/损坏自愈）
+- MM 把 `<venv>/bin` 前置进 `process.env.PATH`（`crabot-core/src/main.ts`），经 spawn 的 `...process.env` 透传给所有子模块；uv 不可用或创建失败仅 warn 降级，不阻塞启动
+- agent 自行 `pip3 install` 的包落在该 venv，**不会污染系统 python**；memory 模块仍走 `uv run --frozen` 项目 venv，不受影响
+- spec：`crabot-docs/superpowers/specs/2026-07-19-agent-python-venv-design.md`
+
 ### 实例隔离（单实例约束）
 
 Crabot **强制单实例运行**。每个用户 / 每台机器（dev 模式）最多跑一个 Crabot MM。多用户场景请走 system mode（见下方）。

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,6 +1,14 @@
 # Crabot 项目进度
 
-> 最后更新：2026-07-19 — subagent 模型配置热生效（delegate 时实时解析）
+> 最后更新：2026-07-19 — Agent 专用 Python 环境（agent-venv）
+
+## 2026-07-19 — Agent 专用 Python 环境（agent-venv）
+
+- 背景：install.sh 装的 uv 只服务 memory 模块（`uv sync`），从未接入 agent shell 环境。trace 证实 agent 直接用系统 `python3` 并 `pip3 install` 污染系统 site-packages / user site；生产非登录 shell 下 uv 甚至不在 PATH。
+- 方案（spec 方案 B）：MM 启动时懒创建 `$DATA_DIR/agent-venv`（`uv venv --seed`，缺失/损坏自愈），并把 `<venv>/bin` 前置进 `process.env.PATH`，经 spawn 的 `...process.env` 透传给全部子模块。单一代码路径覆盖 dev / user / system 三模式；install.sh 零改动；uv 不可用或创建失败仅 warn 降级，不阻塞启动。
+- 实现：新增 `crabot-core/src/agent-venv.ts`（`ensureAgentVenv()`），`crabot-core/src/main.ts` 接入；`--seed` 必须带（uv venv 默认不装 pip）。
+- spec：`crabot-docs/superpowers/specs/2026-07-19-agent-python-venv-design.md`；AGENTS.md「开发环境」与 deployment/installation.md 已同步。
+- 验证：crabot-core 新增 5 个定向测试 + 全量 79 个通过；tsc build 通过；真实 uv 端到端验证（临时 DATA_DIR 建 venv、PATH 前置、venv 内 python3/pip3 可用）。生产/user mode 的完整验收（`which python3` 落到 venv）待实例下次重启后自然生效。
 
 ## 2026-07-19 — subagent 模型配置热生效（delegate 时实时解析）
 

--- a/crabot-core/src/agent-venv.test.ts
+++ b/crabot-core/src/agent-venv.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { ensureAgentVenv } from './agent-venv.js'
+
+const IS_WIN = process.platform === 'win32'
+const BIN_DIR = IS_WIN ? 'Scripts' : 'bin'
+const PY = IS_WIN ? 'python.exe' : 'python'
+
+let tmpDir: string
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-venv-test-'))
+})
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+})
+
+function createFakeVenvPython(dataDir: string) {
+  const binDir = path.join(dataDir, 'agent-venv', BIN_DIR)
+  fs.mkdirSync(binDir, { recursive: true })
+  fs.writeFileSync(path.join(binDir, PY), '')
+}
+
+describe('ensureAgentVenv', () => {
+  it('venv python 已存在时不调用 uv，PATH 以 venv bin 开头且保留原 PATH', () => {
+    createFakeVenvPython(tmpDir)
+    const spawn = vi.fn()
+
+    const result = ensureAgentVenv(tmpDir, spawn as never)
+
+    expect(spawn).not.toHaveBeenCalled()
+    const venvBin = path.join(tmpDir, 'agent-venv', BIN_DIR)
+    expect(result).toBe(venvBin + path.delimiter + (process.env.PATH ?? ''))
+  })
+
+  it('venv 缺失时调用 uv venv --seed 重建，成功后 PATH 前置', () => {
+    const spawn = vi.fn((...args: unknown[]) => {
+      // 模拟 uv venv：创建 venv python
+      createFakeVenvPython(tmpDir)
+      return { error: undefined, status: 0, stderr: '' }
+    })
+
+    const result = ensureAgentVenv(tmpDir, spawn as never)
+
+    expect(spawn).toHaveBeenCalledTimes(1)
+    const [cmd, args] = spawn.mock.calls[0] as [string, string[]]
+    expect(args).toEqual(['venv', '--seed', path.join(tmpDir, 'agent-venv')])
+    expect(path.basename(cmd)).toMatch(/^uv(\.exe)?$/)
+    const venvBin = path.join(tmpDir, 'agent-venv', BIN_DIR)
+    expect(result).toBe(venvBin + path.delimiter + (process.env.PATH ?? ''))
+  })
+
+  it('uv 不可用（spawn error）时返回 null，不抛异常', () => {
+    const spawn = vi.fn(() => ({ error: new Error('spawn uv ENOENT'), status: null, stderr: '' }))
+
+    const result = ensureAgentVenv(tmpDir, spawn as never)
+
+    expect(result).toBeNull()
+  })
+
+  it('uv venv 非零退出时返回 null，不抛异常', () => {
+    const spawn = vi.fn(() => ({ error: undefined, status: 1, stderr: 'network unreachable' }))
+
+    const result = ensureAgentVenv(tmpDir, spawn as never)
+
+    expect(result).toBeNull()
+  })
+
+  it('uv venv 成功但 python 仍缺失（损坏）时返回 null', () => {
+    const spawn = vi.fn(() => ({ error: undefined, status: 0, stderr: '' }))
+
+    const result = ensureAgentVenv(tmpDir, spawn as never)
+
+    expect(result).toBeNull()
+  })
+})

--- a/crabot-core/src/agent-venv.ts
+++ b/crabot-core/src/agent-venv.ts
@@ -1,0 +1,53 @@
+/**
+ * Agent 专用 Python 环境（$DATA_DIR/agent-venv）
+ *
+ * install.sh 装的 uv 原本只服务 memory 模块（uv sync），agent 的 bash 工具继承
+ * MM 进程 PATH，python3/pip3 会落到系统 python 并污染其 site-packages。
+ * 这里在 MM 启动时懒创建一个 uv 管理的实例级 venv，并把其 bin 前置到 PATH，
+ * 经 spawn 的 process.env 透传给所有子模块，agent shell 里的 python3/pip3
+ * 随之解析到该 venv。uv 不可用或创建失败时返回 null（降级为原 PATH，等价历史行为）。
+ *
+ * 详见 crabot-docs/superpowers/specs/2026-07-19-agent-python-venv-design.md
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { resolveExecutable } from './executable-resolver.js'
+
+const IS_WIN = process.platform === 'win32'
+
+type SpawnFn = typeof spawnSync
+
+/**
+ * 确保 $DATA_DIR/agent-venv 存在（缺失/损坏时用 uv 重建），返回前置了 venv bin
+ * 的新 PATH；失败返回 null（调用方保持原 PATH）。
+ *
+ * spawn 参数仅用于测试注入，生产走默认 spawnSync。
+ */
+export function ensureAgentVenv(dataDir: string, spawn: SpawnFn = spawnSync): string | null {
+  const venvDir = path.join(dataDir, 'agent-venv')
+  const venvBin = path.join(venvDir, IS_WIN ? 'Scripts' : 'bin')
+  const venvPython = path.join(venvBin, IS_WIN ? 'python.exe' : 'python')
+
+  if (!fs.existsSync(venvPython)) {
+    const uv = resolveExecutable('uv')
+    // --seed 必须带：uv venv 默认不装 pip，无 seed 时 venv 内没有 pip3。
+    const r = spawn(uv, ['venv', '--seed', venvDir], { encoding: 'utf-8' })
+    if (r.error || r.status !== 0) {
+      console.warn(
+        `[ModuleManager] agent venv 创建失败，跳过 PATH 注入（agent 将使用系统 python）: ${
+          r.error ? r.error.message : (r.stderr || `exit ${r.status}`).toString().trim()
+        }`
+      )
+      return null
+    }
+    if (!fs.existsSync(venvPython)) {
+      console.warn(`[ModuleManager] agent venv 创建后未找到 ${venvPython}，跳过 PATH 注入`)
+      return null
+    }
+  }
+
+  const current = process.env.PATH ?? ''
+  return venvBin + path.delimiter + current
+}

--- a/crabot-core/src/main.ts
+++ b/crabot-core/src/main.ts
@@ -7,6 +7,7 @@ import path from 'node:path'
 import fs from 'node:fs'
 import { homedir } from 'node:os'
 import { buildCoreModules } from './core-modules.js'
+import { ensureAgentVenv } from './agent-venv.js'
 
 // 获取模块路径
 const CRABOT_ROOT = path.resolve(process.cwd(), '..')
@@ -25,6 +26,14 @@ const DATA_DIR = process.env.DATA_DIR
 const WORKSPACE_DIR = process.env.WORKSPACE_DIR || homedir()
 // 写回 process.env 确保子进程通过 process.env spread 时能继承此值
 process.env.WORKSPACE_DIR = WORKSPACE_DIR
+
+// Agent 专用 python 环境：确保 $DATA_DIR/agent-venv 存在（uv 懒创建），把其 bin
+// 前置到 PATH，让 agent shell 的 python3/pip3 落到实例 venv 而非系统 python。
+// uv 不可用或创建失败时返回 null，保持原 PATH（等价历史行为）。
+const agentVenvPath = ensureAgentVenv(DATA_DIR)
+if (agentVenvPath) {
+  process.env.PATH = agentVenvPath
+}
 
 // 加载环境变量文件（统一从根目录 .env 读取）
 const envFiles = [


### PR DESCRIPTION
## 背景

install.sh 安装的 uv 只服务 memory 模块（`uv sync`），从未接入 agent 的 shell 执行环境。本机 trace 证实：agent 直接使用系统 `python3`，并大量 `pip3 install` 污染系统 Python.framework site-packages 和 user site；生产非登录 shell 场景下 `~/.local/bin` 不在 PATH，uv 甚至不可见。

## 方案（spec 方案 B）

MM 启动时懒创建 `$DATA_DIR/agent-venv`（`uv venv --seed`，缺失/损坏自愈），把 `<venv>/bin` 前置进 `process.env.PATH`，经 spawn 的 `...process.env` 透传给全部子模块，agent 的 bash/bg-shell 随之解析到实例 venv。

- 单一代码路径覆盖 dev / 生产 user mode / system mode，install.sh 零改动
- `--seed` 必须带：uv venv 默认不装 pip（已在 uv 0.10.1 验证）
- uv 不可用或创建失败仅 warn 降级，不阻塞 MM 启动（等价历史行为）
- 只做 PATH 前置，不重排用户原有 PATH；memory 模块 `uv run --frozen` 不受影响

spec: crabot-docs/superpowers/specs/2026-07-19-agent-python-venv-design.md（已随 crabot-docs@94c231f 提交）

## 改动

- `crabot-core/src/agent-venv.ts`（新增）：`ensureAgentVenv(dataDir)`
- `crabot-core/src/main.ts`：接入并写回 `process.env.PATH`（跟随 WORKSPACE_DIR 既有先例）
- `crabot-core/src/agent-venv.test.ts`（新增）：5 个定向用例
- CLAUDE.md（AGENTS.md）/ PROGRESS.md 同步

## 验证

- crabot-core 全量 79 个测试通过（含新增 5 个）；`tsc` build 通过
- 真实 uv 端到端：临时 DATA_DIR 建 venv（Python 3.11.14 + pip 26.1.2），PATH 正确前置，venv 内 `python3`/`pip3` 可用
- 完整验收（agent bash 里 `which python3` 落到 venv）待实例重启后生效