### PR TITLE
feat(agent): 任务权限热刷新（supplement/resume 按原身份重新解析）

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,6 +1,15 @@
 # Crabot 项目进度
 
-> 最后更新：2026-07-19 — Agent 专用 Python 环境（agent-venv）
+> 最后更新：2026-07-20 — 任务权限热刷新（supplement / resume 即时生效）
+
+## 2026-07-20 — 任务权限热刷新（supplement / resume 即时生效）
+
+- 起因：群任务内 agent 要求人类改 `cli_access.provider`，人类在 Admin 改完（落盘正确）并回复"改好了"，worker 仍持任务创建时的冻结快照报 `none`；重启也无效——resume 从 checkpoint `worker_context` 原样还原旧权限。只能开新任务才能拿到新权限。
+- 方案（spec 方案 A）：在两个"人类刚做过事"的边界用任务**原发起人身份**重新解析——① supplement 送达任务前（私聊/群聊/admin-chat/RPC 四个 `deliverHumanResponse` 入口）；② 从 checkpoint resume 时。每轮轮询与 admin 事件推送两个方案均否决（成本/故障面 vs 边际收益）。
+- 实现：`resolved_permissions` 从闭包冻结值改为 `taskState.resolvedPermissions` 活持有者（`agent-handler.ts`，同 `taskState.cwd` 模式）；engine/hook 链路新增 `getResolvedPermissions` getter（`engine/types.ts` → `query-loop.ts` → `hook-executor.ts` → cli-permission-gate），工具过滤与 CLI 闸每轮读活值；`updateTaskPermissions` 同步刷新 `resumeWorkerContext` 让 checkpoint 落"最近已知"。fail-soft：解析失败/admin 不可达保留任务当前权限，绝不降级 FAIL_CLOSED；放宽与收紧对称生效。
+- 协议：protocol-admin §3.2.7 语义新增第 4 条（任务级刷新时机 + 必须用原 `sender_friend_id`，防止群成员中途注入自己的权限）。
+- spec：`crabot-docs/superpowers/specs/2026-07-20-task-permission-hot-refresh-design.md`。
+- 验证：新增 `task-permission-hot-refresh.test.ts` 10 条（持有者初始化/热替换/原身份/隔离/resume 覆盖与回退）+ cli-permission-gate getter 优先级 4 条；agent 全量 1558/1559（另 2 skipped），唯一失败为 7-17 已记录的 context-assembler 固定时间漂移（主仓库同样失败，与本次 diff 无关）。
 
 ## 2026-07-19 — Agent 专用 Python 环境（agent-venv）
 

--- a/crabot-agent/src/agent/agent-handler.ts
+++ b/crabot-agent/src/agent/agent-handler.ts
@@ -2996,7 +2996,7 @@ export class AgentHandler {
   /**
    * 取任务的权限主体（原发起人身份 + 会话），供 unified-agent 在 supplement/resume 时
    * 重新解析权限（spec 2026-07-20-task-permission-hot-refresh §方案A）。
-   * 返回 null = 任务不存在或不是消息触发任务（scheduled / 系统任务无 task_origin，不刷新）。
+   * 返回 null = 任务不存在或不是消息触发任务（scheduled / 系统任务不刷新）。
    */
   getTaskPrincipal(taskId: TaskId): {
     senderFriend?: Friend
@@ -3004,8 +3004,11 @@ export class AgentHandler {
     sessionType: 'private' | 'group'
   } | null {
     const taskState = this.activeTasks.get(taskId)
-    const origin = taskState?.resumeWorkerContext?.task_origin
-    if (!taskState || !origin?.session_id || !origin.session_type) return null
+    // scheduled 任务带 target_session 时也有 task_origin（但无 sender_friend）——
+    // 其权限由 Admin 按 creator（含 master_private）解析下发，严禁按匿名会话身份重解析。
+    if (!taskState || taskState.triggerType !== 'message') return null
+    const origin = taskState.resumeWorkerContext?.task_origin
+    if (!origin?.session_id || !origin.session_type) return null
     return {
       ...(taskState.resumeWorkerContext?.sender_friend
         ? { senderFriend: taskState.resumeWorkerContext.sender_friend }

--- a/crabot-agent/src/agent/agent-handler.ts
+++ b/crabot-agent/src/agent/agent-handler.ts
@@ -1079,6 +1079,11 @@ export class AgentHandler {
       this.activeTasks.set(task.task_id, taskState)
     }
 
+    // 任务权限活持有者：loop 启动时由 context 初始化（已有值说明是 supplement 刷新过的
+    // in-flight 任务，不被旧 context 回盖；spec 2026-07-20-task-permission-hot-refresh）。
+    // buildToolsDynamic / cli-permission-gate 每轮经此读取，不再用冻结快照。
+    taskState.resolvedPermissions = taskState.resolvedPermissions ?? context.resolved_permissions
+
     // Init live snapshot（query-loop 的 onLiveProgress 会逐步填充）
     this.liveSnapshots.set(task.task_id, {
       task_id: task.task_id,
@@ -1396,7 +1401,7 @@ export class AgentHandler {
         // set_cwd 工具单独 push（仅 main worker 用；子 subagent 严格继承 parent cwd 不允许改）
         tools.push(createSetCwdTool({ getCwd, setCwd }))
         const baseToolsPermissionConfig: ToolPermissionConfig =
-          this.deps?.getPermissionConfig?.(baseToolsRaw, context.resolved_permissions) ?? { mode: 'bypass' }
+          this.deps?.getPermissionConfig?.(baseToolsRaw, taskState.resolvedPermissions) ?? { mode: 'bypass' }
         // baseTools 构造后立刻把 outer auditBaseTools 接上，给 audit gate 的 getter 用。
         // 见 mcpConfigFactory 上方的 outer let 声明。
         const baseTools = filterToolsByPermission(baseToolsRaw, baseToolsPermissionConfig)
@@ -1523,7 +1528,7 @@ export class AgentHandler {
         // 否则 delegate_*/trace_search 等后注入的工具因不在 baseToolsPermissionConfig 的 denyList 里而漏过 filter，
         // 导致 LLM 看见但 runEngine 用 initialPermissionConfig 又拒绝（违反「无权限工具不注入 prompt」）。
         const fullPermissionConfig: ToolPermissionConfig =
-          this.deps?.getPermissionConfig?.(tools, context.resolved_permissions) ?? { mode: 'bypass' }
+          this.deps?.getPermissionConfig?.(tools, taskState.resolvedPermissions) ?? { mode: 'bypass' }
         return filterToolsByPermission(tools, fullPermissionConfig)
       }
 
@@ -1566,7 +1571,7 @@ export class AgentHandler {
       // runEngine 内部会在每轮调用 buildToolsDynamic 重新拿最新工具列表。
       const initialTools = buildToolsDynamic()
       const initialPermissionConfig: ToolPermissionConfig =
-        this.deps?.getPermissionConfig?.(initialTools, context.resolved_permissions) ?? { mode: 'bypass' }
+        this.deps?.getPermissionConfig?.(initialTools, taskState.resolvedPermissions) ?? { mode: 'bypass' }
 
       log(`Starting worker engine: model=${this.sdkEnv.modelId}, task=${task.task_title}, tools=${initialTools.length}`)
 
@@ -1587,11 +1592,13 @@ export class AgentHandler {
       taskState.messagesRef = messagesRef
       // 快照 worker 执行上下文子集（权限/身份/场景）——resumed worker 据此复原工具集 + 投递
       // 目标 + report mode。缺了它 resumed worker 会落进 FAIL_CLOSED（几乎无工具）。
+      // 注：resolved_permissions 初始取任务权限持有者的当前值；后续 updateTaskPermissions
+      // 热刷新时会同步更新这里，checkpoint 始终落"最近已知"权限。
       taskState.resumeWorkerContext = {
         task_origin: context.task_origin,
         sender_friend: context.sender_friend,
         memory_permissions: context.memory_permissions,
-        resolved_permissions: context.resolved_permissions,
+        resolved_permissions: taskState.resolvedPermissions,
         scene_profile: context.scene_profile,
       }
       // traceId 存 taskState + traceStore 存 Map，供 flushActiveCheckpoints（onStop 路径）补 flush。
@@ -1714,6 +1721,9 @@ export class AgentHandler {
           hookRegistry: workerHookRegistry,
           senderIsMaster,
           ...(context.resolved_permissions ? { resolvedPermissions: context.resolved_permissions } : {}),
+          // 任务权限活值：cli-permission-gate 每轮经 getter 读 taskState 持有者，
+          // supplement/resume 刷新后下一轮即生效（spec 2026-07-20-task-permission-hot-refresh）。
+          getResolvedPermissions: () => taskState.resolvedPermissions,
           contentReviewer: this.buildContentReviewer(),
           sessionType: context.task_origin?.session_type ?? 'private',
           // 一旦有 info 送达，就允许后续 silent end_turn 作为正常收口：系统无法可靠判断
@@ -2981,6 +2991,43 @@ export class AgentHandler {
         log(`[onDispatched] append_message admin RPC failed (non-fatal) task=${taskId}: ${err instanceof Error ? err.message : String(err)}`)
       }
     })()
+  }
+
+  /**
+   * 取任务的权限主体（原发起人身份 + 会话），供 unified-agent 在 supplement/resume 时
+   * 重新解析权限（spec 2026-07-20-task-permission-hot-refresh §方案A）。
+   * 返回 null = 任务不存在或不是消息触发任务（scheduled / 系统任务无 task_origin，不刷新）。
+   */
+  getTaskPrincipal(taskId: TaskId): {
+    senderFriend?: Friend
+    sessionId: string
+    sessionType: 'private' | 'group'
+  } | null {
+    const taskState = this.activeTasks.get(taskId)
+    const origin = taskState?.resumeWorkerContext?.task_origin
+    if (!taskState || !origin?.session_id || !origin.session_type) return null
+    return {
+      ...(taskState.resumeWorkerContext?.sender_friend
+        ? { senderFriend: taskState.resumeWorkerContext.sender_friend }
+        : {}),
+      sessionId: origin.session_id,
+      sessionType: origin.session_type,
+    }
+  }
+
+  /**
+   * 热替换任务当前生效的 ResolvedPermissions（仅本任务持有者 + checkpoint 快照，
+   * 不碰任何跨任务共享状态）。替换是原子引用交换：进行中的 turn 用它开始时的
+   * 权限跑完，下一 turn（buildToolsDynamic / cli gate 经 getter 重读）用新权限。
+   */
+  updateTaskPermissions(taskId: TaskId, perms: ResolvedPermissions): void {
+    const taskState = this.activeTasks.get(taskId)
+    if (!taskState) return
+    taskState.resolvedPermissions = perms
+    if (taskState.resumeWorkerContext) {
+      taskState.resumeWorkerContext = { ...taskState.resumeWorkerContext, resolved_permissions: perms }
+    }
+    log(`[permissions] task ${taskId} permissions hot-refreshed`)
   }
 
   deliverHumanResponse(taskId: TaskId, messages: ChannelMessage[]): void {

--- a/crabot-agent/src/engine/query-loop.ts
+++ b/crabot-agent/src/engine/query-loop.ts
@@ -395,6 +395,7 @@ export async function runEngine(params: RunEngineParams): Promise<EngineResult> 
       lspManager: options.lspManager,
       senderIsMaster: options.senderIsMaster,
       resolvedPermissions: options.resolvedPermissions,
+      ...(options.getResolvedPermissions ? { getResolvedPermissions: options.getResolvedPermissions } : {}),
       contentReviewer: options.contentReviewer,
       sessionType: options.sessionType,
     },

--- a/crabot-agent/src/engine/types.ts
+++ b/crabot-agent/src/engine/types.ts
@@ -295,8 +295,13 @@ export interface EngineOptions {
   readonly timezone?: string
   /** 当前消息发起人是否 master——CLI permission gate hook 的 master 短路依据 */
   readonly senderIsMaster?: boolean
-  /** 发起人 effective permissions（friend ∪ session 并集）——CLI permission gate hook 用 */
+  /** 发起人 effective permissions（friend ∪ session 并集）——CLI permission gate hook 用（静态兜底） */
   readonly resolvedPermissions?: import('../types.js').ResolvedPermissions
+  /**
+   * 任务权限活值 getter（存在时 hook 优先读它）。由 worker loop 注入 taskState 持有者，
+   * supplement/resume 刷新后下一轮 hook 即生效（spec: 2026-07-20-task-permission-hot-refresh-design.md）。
+   */
+  readonly getResolvedPermissions?: () => import('../types.js').ResolvedPermissions | undefined
   /** 内容审核器——CLI permission gate 在 schedule add 时调用 */
   readonly contentReviewer?: import('../hooks/types.js').ContentReviewer
   /** 当前会话场景，用于拒绝指引文案区分群/私聊 */

--- a/crabot-agent/src/hooks/hook-executor.ts
+++ b/crabot-agent/src/hooks/hook-executor.ts
@@ -31,6 +31,7 @@ async function executeSingleHook(
         lspManager: context.lspManager,
         senderIsMaster: context.senderIsMaster,
         resolvedPermissions: context.resolvedPermissions,
+        ...(context.getResolvedPermissions ? { getResolvedPermissions: context.getResolvedPermissions } : {}),
         contentReviewer: context.contentReviewer,
         sessionType: context.sessionType,
       })

--- a/crabot-agent/src/hooks/internal-handlers.ts
+++ b/crabot-agent/src/hooks/internal-handlers.ts
@@ -84,7 +84,10 @@ registerInternalHandler('cli-permission-gate', async (input, context) => {
   }
 
   // 4. 硬闸：cli_access[domain]
-  const cliAccess = context.resolvedPermissions?.cli_access
+  // 活值优先：getResolvedPermissions 读 taskState 持有者（supplement/resume 刷新即生效），
+  // 静态 resolvedPermissions 仅作兜底（无 getter 的调用方）。
+  const effectivePerms = context.getResolvedPermissions?.() ?? context.resolvedPermissions
+  const cliAccess = effectivePerms?.cli_access
   if (!cliAccess) {
     return {
       action: 'block',
@@ -113,7 +116,7 @@ registerInternalHandler('cli-permission-gate', async (input, context) => {
 
   // 5. 软闸：内容审核（仅 schedule add）
   if (REQUIRES_CONTENT_REVIEW.has(parsed.subcommand)) {
-    if (!context.contentReviewer || !context.resolvedPermissions) {
+    if (!context.contentReviewer || !effectivePerms) {
       return {
         action: 'block',
         message: 'PERMISSION_DENIED: 内容审核器未配置（fail-closed）。',
@@ -125,7 +128,7 @@ registerInternalHandler('cli-permission-gate', async (input, context) => {
     let review
     try {
       review = await context.contentReviewer({
-        effectivePermissions: context.resolvedPermissions,
+        effectivePermissions: effectivePerms,
         commandText: cmdStr,
       })
     } catch (err) {

--- a/crabot-agent/src/hooks/types.ts
+++ b/crabot-agent/src/hooks/types.ts
@@ -53,8 +53,14 @@ export interface InternalHandlerContext {
   readonly lspManager?: LspManagerLike
   /** 当前消息发起人是否 master（master 短路免审核） */
   readonly senderIsMaster?: boolean
-  /** 发起人 effective permissions（friend ∪ session）*/
+  /** 发起人 effective permissions（friend ∪ session）——静态兜底值 */
   readonly resolvedPermissions?: ResolvedPermissions
+  /**
+   * 任务权限活值 getter（存在时优先于 resolvedPermissions）。
+   * 由 worker loop 注入，读 taskState 持有者——supplement/resume 刷新后下一轮 hook 即生效
+   * （spec: 2026-07-20-task-permission-hot-refresh-design.md）。
+   */
+  readonly getResolvedPermissions?: () => ResolvedPermissions | undefined
   /** 内容审核器（schedule add 等需要审核的命令使用） */
   readonly contentReviewer?: ContentReviewer
   /** 当前会话场景，用于拒绝指引文案区分群/私聊 */
@@ -74,6 +80,8 @@ export interface HookExecutorContext {
   /** ↓ Task 8 新增：CLI 权限闸需要的上下文 */
   readonly senderIsMaster?: boolean
   readonly resolvedPermissions?: ResolvedPermissions
+  /** 任务权限活值 getter（存在时优先于 resolvedPermissions；spec: 2026-07-20-task-permission-hot-refresh-design.md） */
+  readonly getResolvedPermissions?: () => ResolvedPermissions | undefined
   readonly contentReviewer?: ContentReviewer
   /** 当前会话场景，用于拒绝指引文案区分群/私聊 */
   readonly sessionType?: 'private' | 'group'

--- a/crabot-agent/src/types.ts
+++ b/crabot-agent/src/types.ts
@@ -557,7 +557,10 @@ export interface WorkerAgentContext {
    * 2. Schedule 触发：Admin 端按 `creator_friend_id` 解析（系统内置走 master_private）后随 RPC 下发
    * 3. 都没有：worker 兜底回 FAIL_CLOSED_TOOL_ACCESS（仅 messaging）
    *
-   * 每个任务都带自己的快照，避免共享字段在并发任务间被串改。
+   * 每个任务都带自己的副本，避免共享字段在并发任务间被串改。
+   * 生命周期：loop 启动时以此初始化 taskState.resolvedPermissions；此后任务内活值以
+   * taskState 持有者为准（supplement / resume 时按原发起人身份重新解析并热替换，
+   * spec: 2026-07-20-task-permission-hot-refresh-design.md）。
    */
   resolved_permissions?: ResolvedPermissions
   /** 当前场景画像，由 Memory 模块直接返回并映射为运行时格式 */
@@ -834,6 +837,14 @@ export interface WorkerTaskState {
    * 拿回原工具集 + 投递目标 + report mode。runWorkerLoop 开始后从 context 快照写入。
    */
   resumeWorkerContext?: ResumeWorkerContext
+  /**
+   * 任务当前生效的 ResolvedPermissions（tool_access / cli_access 的活持有人）。
+   * runWorkerLoop 启动时由 context.resolved_permissions 初始化；之后可由
+   * updateTaskPermissions 热替换（supplement / resume 时按原身份重新解析，
+   * spec: 2026-07-20-task-permission-hot-refresh-design.md）。
+   * buildToolsDynamic 与 cli-permission-gate 每轮经 getter 读它，不再读冻结快照。
+   */
+  resolvedPermissions?: ResolvedPermissions
   /**
    * "改目标券"：人类 supplement 到达时置 true（上限 1，不叠加）。
    * set_task_goal 重设已有 goal 时消费它——没券不许 worker 自改目标（反 specification-gaming）。

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -2076,10 +2076,13 @@ export class UnifiedAgent extends ModuleBase {
       //
       // 权限例外（spec 2026-07-20-task-permission-hot-refresh）：resolved_permissions 不直接
       // 还原 checkpoint 冻结值，而是用任务原发起人身份重新解析——agent 停机期间人类改的权限
-      // 对 resume 任务即时生效。解析失败 / 无会话主体（scheduled 等）→ 回退 checkpoint 快照。
+      // 对 resume 任务即时生效。解析失败 / 无会话主体 → 回退 checkpoint 快照。
+      // scheduled 任务（含带 target_session 的）不刷新：其权限由 Admin 按 creator
+      // （含 master_private）解析下发，按匿名会话身份重解析会造成降级/抬升（review #38）。
+      const triggerType = normalizeResumeTriggerType(task.source?.trigger_type)
       const wc = entry.checkpoint.worker_context
       let resumeResolvedPerms = wc?.resolved_permissions
-      if (wc?.task_origin?.session_id && wc.task_origin.session_type) {
+      if (triggerType !== 'scheduled' && wc?.task_origin?.session_id && wc.task_origin.session_type) {
         const freshPerms = await this.resolvePrincipalPermissions(
           wc.sender_friend,
           wc.task_origin.session_id,
@@ -2107,7 +2110,6 @@ export class UnifiedAgent extends ModuleBase {
         ...(wc?.scene_profile ? { scene_profile: wc.scene_profile } : {}),
       }
 
-      const triggerType = normalizeResumeTriggerType(task.source?.trigger_type)
       const taskSource = {
         ...(task.source ?? {}),
         trigger_type: triggerType,

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -698,6 +698,8 @@ export class UnifiedAgent extends ModuleBase {
         pushSupplement: async (taskId: string): Promise<'delivered' | 'fallback'> => {
           if (!this.agentHandler!.hasActiveTask(taskId)) return 'fallback'
           try {
+            // 权限热刷新：supplement 进任务前按原发起人身份重新解析（spec 2026-07-20）
+            await this.refreshTaskPermissions(taskId)
             // 传整批 ChannelMessage（保留媒体，Task 3 已让 deliverHumanResponse 渲染媒体）
             this.agentHandler!.deliverHumanResponse(taskId, messages)
             return 'delivered'
@@ -917,6 +919,8 @@ export class UnifiedAgent extends ModuleBase {
         pushSupplement: async (taskId: string): Promise<'delivered' | 'fallback'> => {
           if (!this.agentHandler!.hasActiveTask(taskId)) return 'fallback'
           try {
+            // 权限热刷新：supplement 进任务前按原发起人身份重新解析（spec 2026-07-20）
+            await this.refreshTaskPermissions(taskId)
             // 传整批 ChannelMessage（保留媒体，Task 3 已让 deliverHumanResponse 渲染媒体）
             this.agentHandler!.deliverHumanResponse(taskId, messages)
             return 'delivered'
@@ -1054,6 +1058,24 @@ export class UnifiedAgent extends ModuleBase {
       console.warn(`[Agent] resolvePrincipalPermissions failed for session ${sessionId}:`, err)
       return null
     }
+  }
+
+  /**
+   * 权限热刷新（spec 2026-07-20-task-permission-hot-refresh）：supplement 送达任务前调用，
+   * 用任务**原发起人**身份重新解析权限并热替换该任务的持有者——Admin 侧权限变更因此对
+   * in-flight 任务即时生效，无需新任务。
+   * fail-soft：解析失败 / 非消息触发任务（无 principal）→ 保留任务当前权限，不抛错。
+   */
+  private async refreshTaskPermissions(taskId: TaskId): Promise<void> {
+    if (!this.agentHandler) return
+    const principal = this.agentHandler.getTaskPrincipal(taskId)
+    if (!principal) return
+    const perms = await this.resolvePrincipalPermissions(
+      principal.senderFriend,
+      principal.sessionId,
+      principal.sessionType,
+    )
+    if (perms) this.agentHandler.updateTaskPermissions(taskId, perms)
   }
 
   /**
@@ -1589,6 +1611,8 @@ export class UnifiedAgent extends ModuleBase {
             }
 
             // 投递纠偏消息（deliverHumanResponse 内部会调 transitionTaskStatus('executing')）
+            // 权限热刷新：supplement 进任务前按原发起人身份重新解析（spec 2026-07-20）
+            await this.refreshTaskPermissions(taskId)
             const syntheticMessage: ChannelMessage = {
               platform_message_id: `supplement-${Date.now()}`,
               session: { channel_id: 'admin-web', session_id: sessionId, type: 'private' as const },
@@ -2046,10 +2070,23 @@ export class UnifiedAgent extends ModuleBase {
       // assembleScheduledTaskContext 现装配（不存进 checkpoint，避免过期）。
       const baseContext = await this.contextAssembler.assembleScheduledTaskContext()
 
-      // 关键：用 checkpoint 里存的「worker 执行上下文子集」覆盖回执行身份/权限/场景，
+      // 关键：用 checkpoint 里存的「worker 执行上下文子集」覆盖回执行身份/场景，
       // 让 resumed worker 拿回和原任务一样的工具集 + 投递目标 + report mode。
       // 缺失（旧 checkpoint）时回退到从 task.source 重建 task_origin（仅修投递，工具仍可能受限）。
+      //
+      // 权限例外（spec 2026-07-20-task-permission-hot-refresh）：resolved_permissions 不直接
+      // 还原 checkpoint 冻结值，而是用任务原发起人身份重新解析——agent 停机期间人类改的权限
+      // 对 resume 任务即时生效。解析失败 / 无会话主体（scheduled 等）→ 回退 checkpoint 快照。
       const wc = entry.checkpoint.worker_context
+      let resumeResolvedPerms = wc?.resolved_permissions
+      if (wc?.task_origin?.session_id && wc.task_origin.session_type) {
+        const freshPerms = await this.resolvePrincipalPermissions(
+          wc.sender_friend,
+          wc.task_origin.session_id,
+          wc.task_origin.session_type,
+        )
+        if (freshPerms) resumeResolvedPerms = freshPerms
+      }
       const fallbackOrigin: TaskOrigin | undefined =
         task.source?.channel_id && task.source?.session_id
           ? {
@@ -2066,7 +2103,7 @@ export class UnifiedAgent extends ModuleBase {
         ...(wc?.task_origin ?? fallbackOrigin ? { task_origin: wc?.task_origin ?? fallbackOrigin } : {}),
         ...(wc?.sender_friend ? { sender_friend: wc.sender_friend } : {}),
         ...(wc?.memory_permissions ? { memory_permissions: wc.memory_permissions } : {}),
-        ...(wc?.resolved_permissions ? { resolved_permissions: wc.resolved_permissions } : {}),
+        ...(resumeResolvedPerms ? { resolved_permissions: resumeResolvedPerms } : {}),
         ...(wc?.scene_profile ? { scene_profile: wc.scene_profile } : {}),
       }
 
@@ -2274,14 +2311,16 @@ export class UnifiedAgent extends ModuleBase {
     }
   }
 
-  private handleDeliverHumanResponse(params: {
+  private async handleDeliverHumanResponse(params: {
     task_id: TaskId
     messages: ChannelMessage[]
-  }): DeliverHumanResponseResult {
+  }): Promise<DeliverHumanResponseResult> {
     if (!this.agentHandler) {
       throw new Error('Worker handler not configured')
     }
 
+    // 权限热刷新：supplement 进任务前按原发起人身份重新解析（spec 2026-07-20）
+    await this.refreshTaskPermissions(params.task_id)
     this.agentHandler.deliverHumanResponse(params.task_id, params.messages)
     return { received: true, task_status: 'executing' }
   }

--- a/crabot-agent/tests/agent/task-permission-hot-refresh.test.ts
+++ b/crabot-agent/tests/agent/task-permission-hot-refresh.test.ts
@@ -217,6 +217,22 @@ describe('AgentHandler 任务权限持有者', () => {
     expect(() => h.updateTaskPermissions('nope', FRESH_PERMS)).not.toThrow()
     h.dispose()
   })
+
+  it('scheduled 任务（带 target_session、无 sender_friend）不返回 principal（review #38 回归）', () => {
+    const h = makeHandler()
+    internalsOf(h).activeTasks.set('sched-1', {
+      resolvedPermissions: OLD_PERMS,
+      resumeWorkerContext: {
+        resolved_permissions: OLD_PERMS,
+        // 带 target_session 的 scheduled 任务也有 task_origin —— 只判 session 会误判
+        task_origin: { channel_id: 'c1', session_id: 'group-s1', session_type: 'group' },
+      },
+      triggerType: 'scheduled',
+    } as never)
+
+    expect(h.getTaskPrincipal('sched-1')).toBeNull()
+    h.dispose()
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -364,5 +380,34 @@ describe('UnifiedAgent resumeTaskInternal（resume 触发点）', () => {
       context: { resolved_permissions?: ResolvedPermissions }
     }
     expect(payload.context.resolved_permissions).toEqual(OLD_PERMS)
+  })
+
+  it('scheduled 任务（带 target_session）resume 不重新解析，保留 creator 下发的 checkpoint 权限（review #38 回归）', async () => {
+    const rpcCall = vi.fn().mockImplementation(async (_port: unknown, method: string) => {
+      if (method === 'get_task') {
+        return {
+          task: {
+            id: 'task-1',
+            title: 't',
+            priority: 'normal',
+            source: { trigger_type: 'scheduled', channel_id: 'c1', session_id: 's1' },
+          },
+        }
+      }
+      return {}
+    })
+    const { agent, executeAgentLoopInBackground } = buildResumeAgent(rpcCall)
+
+    const result = await (agent as { resumeTaskInternal: ResumeFn }).resumeTaskInternal({ task_id: 'task-1' })
+
+    expect(result.resumed).toBe(true)
+    const payload = executeAgentLoopInBackground.mock.calls[0][0] as {
+      context: { resolved_permissions?: ResolvedPermissions }
+    }
+    expect(payload.context.resolved_permissions).toEqual(OLD_PERMS)
+    // 不得发起匿名会话重解析
+    expect(
+      rpcCall.mock.calls.some((c) => c[1] === 'resolve_principal_permissions'),
+    ).toBe(false)
   })
 })

--- a/crabot-agent/tests/agent/task-permission-hot-refresh.test.ts
+++ b/crabot-agent/tests/agent/task-permission-hot-refresh.test.ts
@@ -1,0 +1,368 @@
+/**
+ * 任务权限热刷新回归测试
+ *
+ * Spec: 2026-07-20-task-permission-hot-refresh-design.md
+ *
+ * 覆盖：
+ * 1. AgentHandler：taskState 权限持有者初始化 / updateTaskPermissions 热替换 /
+ *    getTaskPrincipal 原发起人身份 / per-task 隔离 / runEngine getResolvedPermissions 接线
+ * 2. UnifiedAgent.refreshTaskPermissions（supplement 触发点）：原身份重新解析 + fail-soft
+ * 3. UnifiedAgent resumeTaskInternal（resume 触发点）：新解析覆盖 checkpoint 快照 + 失败回退
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { AgentHandler } from '../../src/agent/agent-handler.js'
+import type { ExecuteTriggerMessageParams } from '../../src/agent/agent-handler.js'
+import { UnifiedAgent } from '../../src/unified-agent.js'
+import { AGENT_VERSION } from '../../src/constants.js'
+import type { Friend, FrontAgentContext, ResolvedPermissions } from '../../src/types.js'
+
+// Mock the engine so tests don't actually run the worker loop
+vi.mock('../../src/engine/index.js', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    runEngine: vi.fn(),
+  }
+})
+import { runEngine } from '../../src/engine/index.js'
+
+const FULL_TOOL_ACCESS = {
+  memory: true, messaging: true, task: true,
+  mcp_skill: true, file_io: true, browser: true,
+  shell: true, remote_exec: true, desktop: true,
+}
+const NONE_CLI_ACCESS = {
+  provider: 'none' as const, agent: 'none' as const, mcp: 'none' as const,
+  skill: 'none' as const, schedule: 'none' as const, channel: 'none' as const,
+  friend: 'none' as const, permission: 'none' as const, config: 'none' as const,
+  undo: 'none' as const,
+}
+
+const OLD_PERMS: ResolvedPermissions = {
+  tool_access: { ...FULL_TOOL_ACCESS },
+  cli_access: { ...NONE_CLI_ACCESS },
+  storage: null,
+  memory_scopes: ['s1'],
+}
+const FRESH_PERMS: ResolvedPermissions = {
+  tool_access: { ...FULL_TOOL_ACCESS },
+  cli_access: { ...NONE_CLI_ACCESS, provider: 'read' },
+  storage: null,
+  memory_scopes: ['s1'],
+}
+
+function makeFriend(id: string): Friend {
+  return {
+    id,
+    display_name: id,
+    permission: 'normal',
+    channel_identities: [],
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  }
+}
+
+function makeSdkEnv() {
+  return {
+    modelId: 'test-model',
+    format: 'anthropic' as const,
+    env: {
+      ANTHROPIC_BASE_URL: 'http://localhost:4000',
+      ANTHROPIC_API_KEY: 'test-key',
+    },
+  }
+}
+
+function makeFrontContext(): FrontAgentContext {
+  return {
+    sender_friend: makeFriend('f1'),
+    recent_messages: [],
+    short_term_memories: [],
+    active_tasks: [],
+    available_tools: [],
+    time_windows: {
+      recent_messages_window_hours: 4,
+      short_term_memory_window_hours: 12,
+    },
+  } as unknown as FrontAgentContext
+}
+
+function makeParams(sessionId = 's1'): ExecuteTriggerMessageParams {
+  return {
+    messages: [{
+      platform_message_id: 'm-1',
+      session: { session_id: sessionId, channel_id: 'c1', type: 'private' },
+      sender: { friend_id: 'f1', platform_user_id: 'u1', platform_display_name: 'tester' },
+      content: { type: 'text', text: 'hello' },
+      features: { is_mention_crab: false },
+      platform_timestamp: '2026-07-20T00:00:00Z',
+    }],
+    activeTasks: [],
+    isGroup: false,
+    senderFriend: makeFriend('f1'),
+    triggerArrivedAtMs: Date.now(),
+    memoryPermissions: {
+      write_visibility: 'internal',
+      write_scopes: [sessionId],
+      read_min_visibility: 'internal',
+      read_accessible_scopes: [sessionId],
+    } as never,
+    resolvedPermissions: OLD_PERMS,
+    channelId: 'c1',
+    sessionId,
+    frontContext: makeFrontContext(),
+  }
+}
+
+function makeHandler(): AgentHandler {
+  return new AgentHandler(
+    makeSdkEnv(),
+    { systemPrompt: 'test agent' },
+    {
+      deps: {
+        rpcClient: { call: vi.fn().mockResolvedValue({}) } as never,
+        moduleId: 'test-agent',
+        resolveChannelPort: async () => 3003,
+        getMemoryPort: async () => 3002,
+        getAdminPort: async () => 0,
+      },
+    },
+  )
+}
+
+type HandlerInternals = {
+  activeTasks: Map<string, {
+    resolvedPermissions?: ResolvedPermissions
+    resumeWorkerContext?: { resolved_permissions?: ResolvedPermissions }
+  }>
+}
+
+function internalsOf(handler: AgentHandler): HandlerInternals {
+  return handler as unknown as HandlerInternals
+}
+
+/** 启动一个 runEngine 永不返回的 in-flight worker loop，返回 taskId 与 engine options */
+async function startPendingLoop(handler: AgentHandler, sessionId = 's1') {
+  ;(runEngine as ReturnType<typeof vi.fn>).mockImplementation(
+    () => new Promise(() => { /* never resolves: keep task in-flight */ }),
+  )
+  const params = makeParams(sessionId)
+  const pre = await handler.registerTriggerAndActivate(params)
+  void handler.runTriggerWorkerLoop(params, pre).catch(() => {})
+  await vi.waitFor(() => {
+    expect(runEngine as ReturnType<typeof vi.fn>).toHaveBeenCalled()
+  })
+  const engineOptions = (runEngine as ReturnType<typeof vi.fn>).mock.calls.at(-1)![0].options as {
+    getResolvedPermissions?: () => ResolvedPermissions | undefined
+  }
+  return { taskId: pre.taskId, engineOptions }
+}
+
+describe('AgentHandler 任务权限持有者', () => {
+  const handler = makeHandler()
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('loop 启动后持有者初始化为 context 权限，engine 收到 getResolvedPermissions', async () => {
+    const h = makeHandler()
+    const { engineOptions } = await startPendingLoop(h)
+    expect(engineOptions.getResolvedPermissions).toBeTypeOf('function')
+    expect(engineOptions.getResolvedPermissions!()).toEqual(OLD_PERMS)
+    h.dispose()
+  })
+
+  it('updateTaskPermissions 热替换持有者 + resumeWorkerContext 快照，engine getter 立即读到新值', async () => {
+    const h = makeHandler()
+    const { taskId, engineOptions } = await startPendingLoop(h)
+
+    h.updateTaskPermissions(taskId, FRESH_PERMS)
+
+    expect(engineOptions.getResolvedPermissions!()).toEqual(FRESH_PERMS)
+    const ts = internalsOf(h).activeTasks.get(taskId)
+    expect(ts?.resolvedPermissions).toEqual(FRESH_PERMS)
+    expect(ts?.resumeWorkerContext?.resolved_permissions).toEqual(FRESH_PERMS)
+    h.dispose()
+  })
+
+  it('getTaskPrincipal 返回任务原发起人身份（用于按原身份重新解析）', async () => {
+    const h = makeHandler()
+    const { taskId } = await startPendingLoop(h)
+
+    const principal = h.getTaskPrincipal(taskId)
+    expect(principal).toEqual({
+      senderFriend: expect.objectContaining({ id: 'f1' }),
+      sessionId: 's1',
+      sessionType: 'private',
+    })
+    expect(h.getTaskPrincipal('task-not-exist')).toBeNull()
+    h.dispose()
+  })
+
+  it('per-task 隔离：刷新 A 任务不影响 B 任务', async () => {
+    const h = makeHandler()
+    const a = await startPendingLoop(h, 'sa')
+    const b = await startPendingLoop(h, 'sb')
+
+    h.updateTaskPermissions(a.taskId, FRESH_PERMS)
+
+    expect(internalsOf(h).activeTasks.get(a.taskId)?.resolvedPermissions).toEqual(FRESH_PERMS)
+    expect(internalsOf(h).activeTasks.get(b.taskId)?.resolvedPermissions).toEqual(OLD_PERMS)
+    h.dispose()
+  })
+
+  it('对不存在的任务调用 updateTaskPermissions 静默 no-op', () => {
+    const h = makeHandler()
+    expect(() => h.updateTaskPermissions('nope', FRESH_PERMS)).not.toThrow()
+    h.dispose()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// UnifiedAgent 触发点（Object.create 轻量 harness，同 resolve-principal.test.ts）
+// ---------------------------------------------------------------------------
+
+type RefreshFn = (taskId: string) => Promise<void>
+type ResumeFn = (params: { task_id: string }) => Promise<{ resumed: boolean; reason?: string }>
+
+function buildAgentStub(rpcCall: ReturnType<typeof vi.fn>) {
+  const agent = Object.create(UnifiedAgent.prototype) as Record<string, unknown>
+  agent.config = { moduleId: 'test-agent' }
+  agent.rpcClient = { call: rpcCall }
+  agent.getAdminPort = async () => 19001
+  return agent
+}
+
+describe('UnifiedAgent.refreshTaskPermissions（supplement 触发点）', () => {
+  it('用任务原发起人身份重新解析并热替换', async () => {
+    const rpcCall = vi.fn().mockResolvedValue({ resolved: FRESH_PERMS, sources: {} })
+    const agent = buildAgentStub(rpcCall)
+    const updateTaskPermissions = vi.fn()
+    agent.agentHandler = {
+      getTaskPrincipal: () => ({
+        senderFriend: makeFriend('original-sender'),
+        sessionId: 'group-s1',
+        sessionType: 'group',
+      }),
+      updateTaskPermissions,
+    }
+
+    await (agent as { refreshTaskPermissions: RefreshFn }).refreshTaskPermissions('task-1')
+
+    expect(rpcCall).toHaveBeenCalledWith(
+      19001,
+      'resolve_principal_permissions',
+      { sender_friend_id: 'original-sender', session_id: 'group-s1', session_type: 'group' },
+      'test-agent',
+    )
+    expect(updateTaskPermissions).toHaveBeenCalledWith('task-1', FRESH_PERMS)
+  })
+
+  it('解析失败（admin 不可达）→ 保留当前权限，不抛错', async () => {
+    const rpcCall = vi.fn().mockRejectedValue(new Error('admin down'))
+    const agent = buildAgentStub(rpcCall)
+    const updateTaskPermissions = vi.fn()
+    agent.agentHandler = {
+      getTaskPrincipal: () => ({ senderFriend: makeFriend('f1'), sessionId: 's1', sessionType: 'private' }),
+      updateTaskPermissions,
+    }
+
+    await expect(
+      (agent as { refreshTaskPermissions: RefreshFn }).refreshTaskPermissions('task-1'),
+    ).resolves.toBeUndefined()
+    expect(updateTaskPermissions).not.toHaveBeenCalled()
+  })
+
+  it('非消息触发任务（无 principal）→ 不发起解析', async () => {
+    const rpcCall = vi.fn()
+    const agent = buildAgentStub(rpcCall)
+    agent.agentHandler = {
+      getTaskPrincipal: () => null,
+      updateTaskPermissions: vi.fn(),
+    }
+
+    await (agent as { refreshTaskPermissions: RefreshFn }).refreshTaskPermissions('task-1')
+    expect(rpcCall).not.toHaveBeenCalled()
+  })
+})
+
+describe('UnifiedAgent resumeTaskInternal（resume 触发点）', () => {
+  function buildResumeAgent(rpcCall: ReturnType<typeof vi.fn>) {
+    const agent = buildAgentStub(rpcCall)
+    agent.agentHandler = { hasActiveTask: () => false }
+    agent.getCheckpointForResume = () => ({
+      traceId: 'trace-1',
+      checkpoint: {
+        agent_version: AGENT_VERSION,
+        system_prompt: '',
+        messages: [{ role: 'user', content: 'hi' }],
+        worker_state: {
+          todo_items: [],
+          goal_revision_unlocked: false,
+          human_input_epoch: 0,
+          last_delivered_info_epoch: 0,
+        },
+        worker_context: {
+          task_origin: { channel_id: 'c1', session_id: 's1', session_type: 'group' },
+          sender_friend: makeFriend('original-sender'),
+          resolved_permissions: OLD_PERMS,
+        },
+      },
+    })
+    agent.contextAssembler = { assembleScheduledTaskContext: async () => ({}) }
+    const executeAgentLoopInBackground = vi.fn()
+    agent.agentLoopSubstrate = { executeAgentLoopInBackground }
+    return { agent, executeAgentLoopInBackground }
+  }
+
+  const GET_TASK_RESULT = {
+    task: {
+      id: 'task-1',
+      title: 't',
+      priority: 'normal',
+      source: { trigger_type: 'message', channel_id: 'c1', session_id: 's1' },
+    },
+  }
+
+  it('resume 用原发起人身份重新解析，覆盖 checkpoint 冻结快照', async () => {
+    const rpcCall = vi.fn().mockImplementation(async (_port: unknown, method: string) => {
+      if (method === 'get_task') return GET_TASK_RESULT
+      if (method === 'resolve_principal_permissions') return { resolved: FRESH_PERMS, sources: {} }
+      return {}
+    })
+    const { agent, executeAgentLoopInBackground } = buildResumeAgent(rpcCall)
+
+    const result = await (agent as { resumeTaskInternal: ResumeFn }).resumeTaskInternal({ task_id: 'task-1' })
+
+    expect(result.resumed).toBe(true)
+    const payload = executeAgentLoopInBackground.mock.calls[0][0] as {
+      context: { resolved_permissions?: ResolvedPermissions }
+    }
+    expect(payload.context.resolved_permissions).toEqual(FRESH_PERMS)
+    // 解析用原发起人身份
+    expect(rpcCall).toHaveBeenCalledWith(
+      19001,
+      'resolve_principal_permissions',
+      { sender_friend_id: 'original-sender', session_id: 's1', session_type: 'group' },
+      'test-agent',
+    )
+  })
+
+  it('resume 时解析失败 → 回退 checkpoint 快照', async () => {
+    const rpcCall = vi.fn().mockImplementation(async (_port: unknown, method: string) => {
+      if (method === 'get_task') return GET_TASK_RESULT
+      if (method === 'resolve_principal_permissions') throw new Error('admin down')
+      return {}
+    })
+    const { agent, executeAgentLoopInBackground } = buildResumeAgent(rpcCall)
+
+    const result = await (agent as { resumeTaskInternal: ResumeFn }).resumeTaskInternal({ task_id: 'task-1' })
+
+    expect(result.resumed).toBe(true)
+    const payload = executeAgentLoopInBackground.mock.calls[0][0] as {
+      context: { resolved_permissions?: ResolvedPermissions }
+    }
+    expect(payload.context.resolved_permissions).toEqual(OLD_PERMS)
+  })
+})

--- a/crabot-agent/tests/hooks/cli-permission-gate.test.ts
+++ b/crabot-agent/tests/hooks/cli-permission-gate.test.ts
@@ -96,6 +96,58 @@ describe('cli-permission-gate hook', () => {
     expect(r.action).toBe('continue')
   })
 
+  // 任务权限热刷新（spec 2026-07-20-task-permission-hot-refresh）：
+  // getResolvedPermissions 活值优先于静态 resolvedPermissions
+  it('getResolvedPermissions 活值优先：静态 none + 活值 read → 放行 read 命令', async () => {
+    const handler = getInternalHandler('cli-permission-gate')!
+    const ctx = makeCtx({
+      resolvedPermissions: minimalPerms, // 静态快照仍是 none
+      getResolvedPermissions: () => ({
+        ...minimalPerms,
+        cli_access: { ...NONE_CLI_ACCESS, provider: 'read' },
+      }),
+    })
+    const r = await handler({ event: 'PreToolUse', toolInput: { command: 'crabot provider list' } }, ctx)
+    expect(r.action).toBe('continue')
+  })
+
+  it('getResolvedPermissions 活值优先：静态 read + 活值 none → block（收紧也即时生效）', async () => {
+    const handler = getInternalHandler('cli-permission-gate')!
+    const ctx = makeCtx({
+      resolvedPermissions: {
+        ...minimalPerms,
+        cli_access: { ...NONE_CLI_ACCESS, provider: 'read' },
+      },
+      getResolvedPermissions: () => minimalPerms,
+    })
+    const r = await handler({ event: 'PreToolUse', toolInput: { command: 'crabot provider list' } }, ctx)
+    expect(r.action).toBe('block')
+  })
+
+  it('getResolvedPermissions 返回 undefined → 回退静态 resolvedPermissions', async () => {
+    const handler = getInternalHandler('cli-permission-gate')!
+    const ctx = makeCtx({
+      resolvedPermissions: {
+        ...minimalPerms,
+        cli_access: { ...NONE_CLI_ACCESS, provider: 'read' },
+      },
+      getResolvedPermissions: () => undefined,
+    })
+    const r = await handler({ event: 'PreToolUse', toolInput: { command: 'crabot provider list' } }, ctx)
+    expect(r.action).toBe('continue')
+  })
+
+  it('getResolvedPermissions 活值每次调用重读（同 ctx 中途变更立即生效）', async () => {
+    const handler = getInternalHandler('cli-permission-gate')!
+    let live = minimalPerms
+    const ctx = makeCtx({ getResolvedPermissions: () => live })
+    const cmd = { event: 'PreToolUse' as const, toolInput: { command: 'crabot provider list' } }
+
+    expect((await handler(cmd, ctx)).action).toBe('block')
+    live = { ...minimalPerms, cli_access: { ...NONE_CLI_ACCESS, provider: 'read' } }
+    expect((await handler(cmd, ctx)).action).toBe('continue')
+  })
+
   it('--reveal 永远 block', async () => {
     const handler = getInternalHandler('cli-permission-gate')!
     const ctx = makeCtx({ senderIsMaster: true, resolvedPermissions: masterPerms })


### PR DESCRIPTION
## 背景

群任务内 agent 要求人类改 `cli_access.provider`，人类在 Admin 改完（已正确落盘）并回复改好了，worker 仍持任务创建时的冻结快照报 `none`；重启也无效——resume 从 checkpoint `worker_context` 原样还原旧权限。只能开新任务才能拿到新权限。

## 方案（spec 方案 A）

在两个人类刚做过事的边界用任务**原发起人身份**重新解析权限：
1. **supplement 送达任务前**（私聊 / 群聊 / admin-chat / RPC `deliver_human_response` 四个入口）
2. **从 checkpoint resume 时**

否决方案：每轮 LLM 调用轮询（RPC 成本 + admin 故障面）、admin 事件推送（管道复杂且不能覆盖 resume）。

spec：`crabot-docs/superpowers/specs/2026-07-20-task-permission-hot-refresh-design.md`
协议：protocol-admin.md §3.2.7 语义第 4 条（crabot-docs 同步提交）

## 实现

- `taskState.resolvedPermissions` 活持有者（同 `taskState.cwd` 模式）；`buildToolsDynamic` / `initialPermissionConfig` 每轮读活值
- engine → hook 链路新增 `getResolvedPermissions` getter：cli-permission-gate 活值优先、静态兜底，放宽与收紧对称即时生效
- `AgentHandler.getTaskPrincipal` / `updateTaskPermissions`；后者同步刷新 `resumeWorkerContext`，checkpoint 始终落最近已知权限
- fail-soft：解析失败 / admin 不可达 → 保留任务当前权限，运行中任务绝不降级 FAIL_CLOSED
- 重新解析必须用任务创建时记录的原 `sender_friend_id`，不用 supplement 发送者（防群成员中途注入权限）

## 验证

- 新增 `task-permission-hot-refresh.test.ts` 10 条（持有者初始化 / 热替换 / 原身份 / per-task 隔离 / resume 覆盖与回退）+ cli-permission-gate getter 优先级 4 条
- agent 全量 1558/1559 通过，唯一失败为既有 context-assembler 固定时间漂移（主仓库同样失败，与本 diff 无关）
- `tsc --noEmit` 通过