### PR TITLE
feat(agent): token 使用效率优化（对标 Pi agent）

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,6 +1,23 @@
 # Crabot 项目进度
 
-> 最后更新：2026-07-19 — subagent 模型配置热生效（delegate 时实时解析）
+> 最后更新：2026-07-21 — crabot-agent token 使用效率优化（对标 Pi agent）
+
+## 2026-07-21 — crabot-agent token 使用效率优化（对标 Pi agent）
+
+- 起因：对比开源 Pi agent（极简 prompt + 4 工具 + 输出硬截断 + prompt caching）后，发现 crabot-agent 五个差距：Anthropic 无 cache_control、工具输出截断宽松且不可恢复、compaction 用 chars/4 低估、工具盘臃肿、prompt 冗余。
+- spec：`crabot-docs/superpowers/specs/2026-07-21-agent-token-efficiency-design.md`（含 §10 实施偏离记录）。
+- 实现（5 项）：
+  1. anthropic-adapter 注入 3 处 cache breakpoint（system 末块 / 末 tool / 末消息末块，5min ephemeral）；顺带清理空 text block 垃圾 token。
+  2. bash 截断 100K→50K 改纯尾部 + 完整输出落盘 `data/tmp/tool-outputs/` 可恢复；read 解除 500KB 后不可读限制（流式分页全覆盖，单次 ≤50KB）；编排层兜底 256KB→100KB。
+  3. compaction 触发改用 API 真实 usage（lastObservedContextTokens + 增量估算），usage 缺失回退估算且计入 system+tools；context_window 从 admin buildConnectionInfo → agent → EngineOptions 全链路接线。
+  4. delegate_task 的 when_to_use 截断 300 字符；memory 工具按任务类型分组（普通任务 A 组 6 个 / daily_reflection 全量 18 个，对齐 protocol-memory §3.30）；disabled_tools 扩展到 MCP 工具（仅黑名单，enabled_tools 不套 MCP）。
+  5. scene profile 去除 system prompt 侧的重复注入（保留 task message 单次注入）。
+- 协议：protocol-admin §3.19.8（context_window）+ BuiltinToolConfig 小节（disabled_tools 覆盖 MCP）；protocol-memory §3.30（工具分组）；base-protocol §5.14 / protocol-agent-v2 补 context_window 字段。
+- 验证：agent 全量 1590/1591（唯一失败为 7-17 已记录的 context-assembler 固定时间漂移，HEAD 复现确认与本次无关）；admin 全量 1013 通过（schedule-target-session 的 EADDRINUSE 为并行跑套件的环境 flake，单跑 6/6 通过）。
+- 自审修复（2026-07-21 当天第二轮）：4 路并行 diff review 后修复 6 项——①memory 分组放宽为按任务用途（memory_curate + tags memory_rebuild，原条件会废掉内置每小时记忆整理和重建图谱端点；顺带打通 start_task RPC 的 tags/task_type 透传链路）；②bash 截断 char→byte 口径（CJK 输出下原实现会让编排层 100KB 兜底切掉尾部 hint）；③disabled_tools 覆盖 subagent/audit 继承路径；④anthropic adapter 丢弃空 content 消息；⑤补落盘失败回退测试 + read offset 归一化；⑥delegate_task 截断 surrogate 安全。修复后 agent 全量 1607/1608（仍只有那个既有时间漂移）。
+- **待办**：部署对比（cache_read 比例、bash/read 大输出场景体积）待上线后进行；**reasoning effort 配置开放**（k3 支持 low/high/max，协议无对应字段）留作 follow-up 单开 spec。
+- moonshot 实测后续（2026-07-21 当天完成）：401 根因是内置 kimi-coding preset 端点错误（`api.moonshot.cn/anthropic` 是平台 key 端点，Coding Plan key 走 `api.kimi.com/coding`），preset-vendors.ts 已修正。实测 `https://api.kimi.com/coding/v1/messages`：接受 `cache_control` 无 400；且该端点**自带自动前缀缓存**——不带 cache_control 的相同请求第二次也 100% cache_read，故改动1 对 kimi 端点是兼容增强、对官方 Anthropic 端点才是必需。注意：已部署实例 model_providers.json 里存的旧端点不会随 preset 自动更新，需在 Admin UI 手动改 provider endpoint。
+- kimi-coding preset 模型改走接口（2026-07-21 follow-up）：`GET /v1/models` 实测可用（x-api-key / Bearer 均可，返回 kimi-for-coding / kimi-for-coding-highspeed / k3）；preset 加 `models_api: '/v1/models'` 并删除 KIMI_CODING_MODELS 内置列表（失败无兜底即清空，与 openai/deepseek 等 preset 一致）；`parseOpenAIModels` 新增 `supports_image_in` → supports_vision 映射（内置原写 false，实测三模型均支持视觉）。已知：`kimi-k2.7-code` 是可用别名但不在接口返回中，旧 provider 里引用它的 slot 在 refresh 后会变成未知模型，需要重新选择。
 
 ## 2026-07-19 — subagent 模型配置热生效（delegate 时实时解析）
 

--- a/crabot-admin/src/model-classification.test.ts
+++ b/crabot-admin/src/model-classification.test.ts
@@ -35,4 +35,30 @@ describe('parseOpenAIModels', () => {
     expect(models.find((m) => m.model_id === 'gpt-image-1')?.type).toBe('image')
     expect(models.find((m) => m.model_id === 'gpt-4o')?.type).toBe('llm')
   })
+
+  it('maps kimi coding /v1/models shape: display_name, context_length, supports_image_in', () => {
+    // 实测 https://api.kimi.com/coding/v1/models 的返回结构（2026-07-21）
+    const models = parseOpenAIModels([
+      {
+        id: 'kimi-for-coding',
+        display_name: 'K2.7 Coding',
+        context_length: 262144,
+        supports_image_in: true,
+        supports_reasoning: true,
+      },
+      {
+        id: 'k3',
+        display_name: 'K3',
+        context_length: 1048576,
+        supports_image_in: true,
+      },
+    ])
+    expect(models).toHaveLength(2)
+    const k27 = models.find((m) => m.model_id === 'kimi-for-coding')!
+    expect(k27.display_name).toBe('K2.7 Coding')
+    expect(k27.type).toBe('llm')
+    expect(k27.supports_vision).toBe(true)
+    expect(k27.context_window).toBe(262144)
+    expect(models.find((m) => m.model_id === 'k3')?.context_window).toBe(1048576)
+  })
 })

--- a/crabot-admin/src/model-provider-manager.ts
+++ b/crabot-admin/src/model-provider-manager.ts
@@ -268,9 +268,11 @@ export function parseOpenAIModels(raw: unknown[]): ModelInfo[] {
 
     const capabilities = item.capabilities as { vision?: boolean } | undefined
     const modalities = Array.isArray(item.input) ? (item.input as unknown[]) : []
-    // 仅 llm 认视觉；image 模型的 input=image 是"生图输入"不是"看图"，不置 supports_vision
+    // 仅 llm 认视觉；image 模型的 input=image 是"生图输入"不是"看图"，不置 supports_vision。
+    // supports_image_in：kimi coding 端点 /v1/models 的字段（非 OpenAI 标准），同为布尔。
     const supportsVision =
-      type === 'llm' && (capabilities?.vision === true || modalities.includes('image'))
+      type === 'llm' &&
+      (capabilities?.vision === true || modalities.includes('image') || item.supports_image_in === true)
 
     models.push({
       model_id: modelId,
@@ -922,6 +924,7 @@ export class ModelProviderManager {
       ...base,
       ...(model.max_tokens !== undefined && { max_tokens: model.max_tokens }),
       ...(model.supports_vision && { supports_vision: true }),
+      ...(model.context_window !== undefined && { context_window: model.context_window }),
     } as LLMConnectionInfo
   }
 

--- a/crabot-admin/src/model-provider.test.ts
+++ b/crabot-admin/src/model-provider.test.ts
@@ -373,4 +373,41 @@ describe('ModelProviderManager', () => {
       expect(manager.getProvider('provider-import-3')?.name).toBe('Updated')
     })
   })
+
+  describe('buildConnectionInfo', () => {
+    it('透传模型级可选字段 max_tokens / supports_vision / context_window', async () => {
+      const provider = await manager.createProvider({
+        name: 'Conn Info Provider',
+        type: 'manual',
+        format: 'openai',
+        endpoint: 'http://localhost:11434/v1',
+        api_key: 'test-key',
+        models: [
+          {
+            model_id: 'full-model',
+            display_name: 'Full Model',
+            type: 'llm',
+            max_tokens: 8192,
+            supports_vision: true,
+            context_window: 131072,
+          },
+          {
+            model_id: 'bare-model',
+            display_name: 'Bare Model',
+            type: 'llm',
+          },
+        ],
+      })
+
+      const full = await manager.buildConnectionInfo(provider.id, 'full-model')
+      expect(full.max_tokens).toBe(8192)
+      expect(full.supports_vision).toBe(true)
+      expect(full.context_window).toBe(131072)
+
+      // 未配置 context_window 的模型不应带出该字段（agent 侧走 200000 回退）
+      const bare = await manager.buildConnectionInfo(provider.id, 'bare-model')
+      expect(bare.context_window).toBeUndefined()
+      expect('context_window' in bare).toBe(false)
+    })
+  })
 })

--- a/crabot-admin/src/preset-vendors.ts
+++ b/crabot-admin/src/preset-vendors.ts
@@ -73,15 +73,6 @@ const ZHIPU_CODING_MODELS: ModelInfo[] = [
 ]
 
 /**
- * Kimi Coding Plan 静态模型列表
- * Kimi K2.7 Code 提供 Anthropic 兼容入口，官方 Claude Code 文档按静态模型配置。
- * 参考: https://platform.moonshot.cn/docs/guide/agent-support
- */
-const KIMI_CODING_MODELS: ModelInfo[] = [
-  { model_id: 'kimi-k2.7-code', display_name: 'Kimi K2.7 Code', type: 'llm', supports_vision: false, context_window: 262144 },
-]
-
-/**
  * 百炼 Coding Plan 静态模型列表
  * 百炼 Coding Plan 提供 Anthropic 兼容接口，不支持 GET /models
  */
@@ -162,10 +153,12 @@ export const BUILTIN_PRESET_VENDORS: readonly PresetVendor[] = [
     id: 'kimi-coding',
     name: 'Kimi Coding Plan',
     format: 'anthropic',
-    endpoint: 'https://api.moonshot.cn/anthropic',
+    endpoint: 'https://api.kimi.com/coding',
     docs_url: 'https://platform.moonshot.cn/docs/guide/agent-support',
     api_key_help_url: 'https://platform.kimi.com/console/api-keys',
-    default_models: KIMI_CODING_MODELS,
+    // Coding Plan 端点提供 GET /v1/models（x-api-key / Bearer 均可），模型列表走接口实时获取，
+    // 失败时无内置兜底（与 openai/deepseek 等 preset 一致，refresh 失败即清空）
+    models_api: '/v1/models',
   },
   {
     id: 'deepseek',

--- a/crabot-admin/src/types.ts
+++ b/crabot-admin/src/types.ts
@@ -1338,6 +1338,8 @@ export interface ModelConnectionInfo {
 export interface LLMConnectionInfo extends ModelConnectionInfo {
   max_tokens?: number
   supports_vision?: boolean
+  /** 模型上下文窗口（token 数）；agent 侧用于 compaction 触发阈值，缺失时回退内置默认 */
+  context_window?: number
 }
 
 // Model Provider API 参数类型

--- a/crabot-agent/src/agent/agent-handler.ts
+++ b/crabot-agent/src/agent/agent-handler.ts
@@ -17,7 +17,7 @@ import {
   ProgressDigest,
   filterToolsByPermission,
 } from '../engine/index.js'
-import { createSetCwdTool, createReadTool } from '../engine/tools/index.js'
+import { createSetCwdTool, createReadTool, filterMcpToolsByConfig } from '../engine/tools/index.js'
 import { BgEntityRegistry } from '../engine/bg-entities/registry.js'
 import { killShellTree } from '../engine/bg-entities/bg-shell.js'
 import { ReadoptReaper } from '../engine/bg-entities/reaper.js'
@@ -65,7 +65,7 @@ import type {
 } from '../types.js'
 import type { RpcClient } from 'crabot-shared'
 import { SYSTEM_CHANNEL_ID } from 'crabot-shared'
-import { createCrabMemoryServer } from '../mcp/crab-memory.js'
+import { createCrabMemoryServer, resolveMemoryToolProfile, filterMemoryToolsByProfile } from '../mcp/crab-memory.js'
 import type { MemoryTaskContext } from '../mcp/crab-memory.js'
 import { mcpServerToToolDefinitions } from './mcp-tool-bridge.js'
 import { imageToolsFor, type ImageConnInfo } from '../mcp/crab-image.js'
@@ -415,6 +415,8 @@ export interface SdkEnvConfig {
   supportsVision?: boolean
   /** Provider 配置的 max_output_tokens；未配置时 adapter 走各自的处理策略 */
   maxTokens?: number
+  /** Provider 模型配置的 context_window；未配置时 engine 回退内置默认 200000 */
+  contextWindow?: number
   env: Record<string, string>
 }
 
@@ -1267,7 +1269,16 @@ export class AgentHandler {
             moduleId: this.deps.moduleId,
             getMemoryPort: this.deps.getMemoryPort,
           }, memoryTaskCtx)
-          tools.push(...mcpServerToToolDefinitions(crabMemoryServer, 'crab-memory'))
+          // 按任务用途分组注册：daily_reflection / memory_curate / tags 含 memory_rebuild
+          // → 全量 18 个；其他任务 → 仅 A 组 6 个（普通对话不需要反思级精细工具）。
+          const memoryProfile = resolveMemoryToolProfile({
+            taskType: task.task_type,
+            tags: task.tags,
+          })
+          tools.push(...filterMemoryToolsByProfile(
+            mcpServerToToolDefinitions(crabMemoryServer, 'crab-memory'),
+            memoryProfile,
+          ))
         }
 
         // 3b. crab-image MCP server tools（仅当图像配置可用时暴露 generate_image）
@@ -1379,7 +1390,10 @@ export class AgentHandler {
         // 3f. delegate_task 工具（单一入口；sub-agent 按 subagent_type 路由）
         // baseToolsPermissionConfig 仅基于 base 工具集，给 sub-agent 用：
         //   sub-agent 内部只能见 baseTools，所以它的 permissionConfig 也只需覆盖 base 工具命名。
-        const baseToolsRaw = [...tools]
+        // disabled_tools 的 MCP 过滤同样作用于 baseToolsRaw——baseToolsRaw 喂给 subagent
+        // parentTools 与 auditBaseTools，不在这里过滤会让被禁 MCP 工具从这两条路径漏出
+        //（main worker 路径在组装末尾统一过滤）。
+        const baseToolsRaw = filterMcpToolsByConfig([...tools], this.builtinToolConfig)
         // Read dedup：仅 main worker 启用（subagent 用 baseToolsRaw 里的普通 Read，
         // 避免 stub 指向不在自己上下文里的旧读）。baseToolsRaw 已在上一行 capture（普通 Read），
         // 这里替换 main 的 tools[Read] 为带去重缓存的版本——不影响 subagent。
@@ -1519,12 +1533,17 @@ export class AgentHandler {
           tools.push(...opts.extraTools)
         }
 
+        // disabled_tools 扩展到 MCP 桥接工具：按 mcp__<server>__<tool> 全名过滤，
+        // 在组装末尾统一应用（内置工具的同名过滤在 getConfiguredBuiltinTools 内完成）。
+        // 默认配置（无 disabled_tools）零行为变化。
+        const configFiltered = filterMcpToolsByConfig(tools, this.builtinToolConfig)
+
         // 最终过滤：用「完整 tools 集合」重算 permissionConfig，
         // 否则 delegate_*/trace_search 等后注入的工具因不在 baseToolsPermissionConfig 的 denyList 里而漏过 filter，
         // 导致 LLM 看见但 runEngine 用 initialPermissionConfig 又拒绝（违反「无权限工具不注入 prompt」）。
         const fullPermissionConfig: ToolPermissionConfig =
-          this.deps?.getPermissionConfig?.(tools, context.resolved_permissions) ?? { mode: 'bypass' }
-        return filterToolsByPermission(tools, fullPermissionConfig)
+          this.deps?.getPermissionConfig?.(configFiltered, context.resolved_permissions) ?? { mode: 'bypass' }
+        return filterToolsByPermission(configFiltered, fullPermissionConfig)
       }
 
       // System prompt 也改为 callback：admin push config 触发 updateSystemPrompt 后下一轮生效。
@@ -1699,6 +1718,7 @@ export class AgentHandler {
           tools: buildToolsDynamic,
           model: this.sdkEnv.modelId,
           ...(this.sdkEnv.maxTokens !== undefined ? { maxTokens: this.sdkEnv.maxTokens } : {}),
+          ...(this.sdkEnv.contextWindow !== undefined ? { contextWindowTokens: this.sdkEnv.contextWindow } : {}),
           maxTurns: 2000,
           supportsVision: this.sdkEnv.supportsVision,
           permissionConfig: initialPermissionConfig,
@@ -3405,6 +3425,7 @@ export class AgentHandler {
         abortSignal: ctx.abortSignal,
         onTurn: subTraceCallback,
         supportsVision: subagent.model.supports_vision,
+        ...(subagent.model.context_window !== undefined ? { contextWindowTokens: subagent.model.context_window } : {}),
         hookRegistry,
         lspManager,
         permissionConfig: deps.permissionConfig,
@@ -3945,9 +3966,9 @@ export class AgentHandler {
     taskId: TaskId,
   ): string {
     // unified loop spec §3.1：使用 assembleAgentPrompt。
-    const sceneProfile = context.scene_profile
-      ? { label: context.scene_profile.label, content: context.scene_profile.content }
-      : undefined
+    // 场景画像（scene_profile）不再注入 system prompt——只在首条 task message 注入一次
+    // （buildTaskMessage），避免双重注入浪费 token，也让 system prompt 前缀更稳定。
+    // spec: 2026-07-21-agent-token-efficiency-design.md 改动 5
     // subAgents 由 runWorkerLoop 在 loop 启动时 snapshot 后传入，
     // 防止 in-flight loop 中 admin 改 subagents 后 system prompt 列表跳变。
     const availableSubAgents = subAgents.map((s) => ({
@@ -3961,7 +3982,6 @@ export class AgentHandler {
         skillListing: this.buildSkillListingSnapshot(),
         availableSubAgents: availableSubAgents.length > 0 ? availableSubAgents : undefined,
         imageCapability: { available: this.imageCapability.available },
-        ...(sceneProfile ? { sceneProfile } : {}),
       })
       : this.systemPrompt
     const parts: string[] = [baseAssembled]

--- a/crabot-agent/src/agent/delegate-task-tool.ts
+++ b/crabot-agent/src/agent/delegate-task-tool.ts
@@ -2,7 +2,7 @@
  * delegate_task 工具
  *
  * worker 工具表里唯一的 subagent 入口。
- * - description 含 <available_subagents> 段 + 每个 subagent 的 when_to_use 原文
+ * - description 含 <available_subagents> 段 + 每个 subagent 的 when_to_use（截断到 300 字符）
  * - inputSchema.subagent_type.enum 限制为已 enabled 的 subagent name
  * - call: 按 subagent_type 查表 → 调 runSubAgent（caller 提供）
  *
@@ -40,8 +40,24 @@ export type RunSubAgentFn = (
 
 /**
  * 组装 delegate_task 工具的 description。
- * 内含 <available_subagents> 列表 + 每个 subagent 的 when_to_use 原文。
+ * 内含 <available_subagents> 列表 + 每个 subagent 的 when_to_use（截断到 300 字符）。
  */
+
+/** when_to_use 内嵌全文的字符上限：超出部分截断并加省略标记，控制 description 体积 */
+const WHEN_TO_USE_MAX_CHARS = 300
+
+function truncateWhenToUse(text: string): string {
+  if (text.length <= WHEN_TO_USE_MAX_CHARS) return text
+  let cut = text.slice(0, WHEN_TO_USE_MAX_CHARS)
+  // 末尾若落在 lone high surrogate（代理对中间被切开）则去掉该码元，
+  // 避免 description 里出现非法字符
+  const lastCode = cut.charCodeAt(cut.length - 1)
+  if (lastCode >= 0xd800 && lastCode <= 0xdbff) {
+    cut = cut.slice(0, -1)
+  }
+  return `${cut}…[truncated]`
+}
+
 export function buildDelegateTaskDescription(subAgents: ReadonlyArray<SubAgentConfig>): string {
   const lines: string[] = [
     'Launch a specialized subagent to autonomously handle a task that benefits from a focused expert + 独立上下文。',
@@ -61,7 +77,7 @@ export function buildDelegateTaskDescription(subAgents: ReadonlyArray<SubAgentCo
   if (subAgents.length > 0) {
     lines.push('', 'When to use each subagent type:')
     for (const s of subAgents) {
-      lines.push('', `=== ${s.name} ===`, s.when_to_use)
+      lines.push('', `=== ${s.name} ===`, truncateWhenToUse(s.when_to_use))
     }
   }
 

--- a/crabot-agent/src/engine/anthropic-adapter.ts
+++ b/crabot-agent/src/engine/anthropic-adapter.ts
@@ -33,7 +33,8 @@ function defaultAnthropicMaxTokens(model: string): number {
 // --- Anthropic Message Normalization ---
 
 export function normalizeMessagesForAnthropic(messages: ReadonlyArray<EngineMessage>): MessageParam[] {
-  const raw = messages.map((msg): MessageParam => {    if (isToolResultMessage(msg)) {
+  const raw = messages.map((msg): MessageParam => {
+    if (isToolResultMessage(msg)) {
       return {
         role: 'user',
         content: msg.toolResults.map((tr) => {

--- a/crabot-agent/src/engine/anthropic-adapter.ts
+++ b/crabot-agent/src/engine/anthropic-adapter.ts
@@ -33,8 +33,7 @@ function defaultAnthropicMaxTokens(model: string): number {
 // --- Anthropic Message Normalization ---
 
 export function normalizeMessagesForAnthropic(messages: ReadonlyArray<EngineMessage>): MessageParam[] {
-  const raw = messages.map((msg): MessageParam => {
-    if (isToolResultMessage(msg)) {
+  const raw = messages.map((msg): MessageParam => {    if (isToolResultMessage(msg)) {
       return {
         role: 'user',
         content: msg.toolResults.map((tr) => {
@@ -70,19 +69,23 @@ export function normalizeMessagesForAnthropic(messages: ReadonlyArray<EngineMess
     if (msg.role === 'assistant') {
       return {
         role: 'assistant',
-        content: msg.content.map((block) => {
+        content: msg.content.flatMap((block): Array<TextBlockParam | ToolUseBlockParam> => {
           switch (block.type) {
             case 'text':
-              return { type: 'text' as const, text: block.text }
+              return [{ type: 'text' as const, text: block.text }]
             case 'tool_use':
-              return {
-                type: 'tool_use' as const,
-                id: block.id,
-                name: block.name,
-                input: block.input,
-              }
+              return [
+                {
+                  type: 'tool_use' as const,
+                  id: block.id,
+                  name: block.name,
+                  input: block.input,
+                },
+              ]
             default:
-              return { type: 'text' as const, text: '' }
+              // 不认识的 block（如 raw_reasoning）丢弃——原先映射成空 text block
+              // 发给 API 是纯垃圾 token，且空 text block 本身会被 API 拒绝
+              return []
           }
         }),
       }
@@ -93,24 +96,33 @@ export function normalizeMessagesForAnthropic(messages: ReadonlyArray<EngineMess
     }
 
     const content: Array<TextBlockParam | ImageBlockParam | ToolUseBlockParam | ToolResultBlockParam> =
-      msg.content.map((block): TextBlockParam | ImageBlockParam => {
+      msg.content.flatMap((block): Array<TextBlockParam | ImageBlockParam> => {
         if (block.type === 'image') {
-          return {
-            type: 'image',
-            source: {
-              type: block.source.type as 'base64',
-              media_type: block.source.media_type as ImageBlockParam.Source['media_type'],
-              data: block.source.data,
+          return [
+            {
+              type: 'image',
+              source: {
+                type: block.source.type as 'base64',
+                media_type: block.source.media_type as ImageBlockParam.Source['media_type'],
+                data: block.source.data,
+              },
             },
-          }
+          ]
         }
-        return { type: 'text', text: block.type === 'text' ? block.text : '' }
+        // 不认识的 block 丢弃，不映射成空 text block 发给 API
+        if (block.type !== 'text') return []
+        return [{ type: 'text', text: block.text }]
       })
 
     return { role: 'user', content }
   })
 
-  return mergeConsecutiveUserMessages(raw, (content) =>
+  // 不认识的 block 被丢弃后可能产生 content 为空数组的消息——发给 API 会 400，
+  // 整条丢弃。仅当 content 真正为空（无 text 无 tool_use）才丢：
+  // 含 tool_use 的 assistant 消息 content 非空，不影响 tool_use/tool_result 配对语义。
+  const nonEmpty = raw.filter((msg) => !(Array.isArray(msg.content) && msg.content.length === 0))
+
+  return mergeConsecutiveUserMessages(nonEmpty, (content) =>
     Array.isArray(content) ? content : [{ type: 'text' as const, text: content as string }],
   )
 }
@@ -169,12 +181,42 @@ export class AnthropicAdapter implements LLMAdapter {
     const messages = normalizeMessagesForAnthropic(params.messages)
     const tools = params.tools.map(AnthropicAdapter.toAnthropicTool)
 
+    // Prompt caching：注入 3 个 cache breakpoint（固定 5 分钟 ephemeral，SDK stable
+    // 类型尚未带出 cache_control 字段，靠结构化类型直接附加）。只加缓存标记，
+    // 不改消息内容本身。breakpoint 位置：1) system 末尾 2) 最后一个 tool 定义
+    // 3) 最后一条消息的最后一个 content block（缓存整段会话历史前缀）。
+    const EPHEMERAL = { type: 'ephemeral' } as const
+
+    // 空 system prompt 不传（空 text block 会被 API 拒绝）
+    const system = params.systemPrompt
+      ? [{ type: 'text' as const, text: params.systemPrompt, cache_control: EPHEMERAL }]
+      : undefined
+
+    const cachedTools = tools.map((tool, i) =>
+      i === tools.length - 1 ? { ...tool, cache_control: EPHEMERAL } : tool,
+    )
+
+    const cachedMessages = messages.map((msg, i) => {
+      if (i !== messages.length - 1) return msg
+      if (typeof msg.content === 'string') {
+        return {
+          ...msg,
+          content: [{ type: 'text' as const, text: msg.content, cache_control: EPHEMERAL }],
+        }
+      }
+      if (msg.content.length === 0) return msg
+      const blocks = msg.content.map((block, j) =>
+        j === msg.content.length - 1 ? { ...block, cache_control: EPHEMERAL } : block,
+      )
+      return { ...msg, content: blocks }
+    })
+
     const stream = this.client.messages.stream({
       model: params.model,
       max_tokens: params.maxTokens ?? defaultAnthropicMaxTokens(params.model),
-      system: params.systemPrompt,
-      messages,
-      ...(tools.length > 0 ? { tools } : {}),
+      ...(system ? { system } : {}),
+      messages: cachedMessages,
+      ...(cachedTools.length > 0 ? { tools: cachedTools } : {}),
     })
 
     // signal 通常是 task 级长寿命的（一个 task 内每个 turn 都共用）。如果只 addEventListener

--- a/crabot-agent/src/engine/bg-entities/types.ts
+++ b/crabot-agent/src/engine/bg-entities/types.ts
@@ -51,5 +51,8 @@ export interface RegistryFile {
 
 export const BG_ENTITY_LIMIT_PER_OWNER = 20
 export const BG_ENTITY_GC_AFTER_DAYS = 7
-export const BG_OUTPUT_MAX_BYTES = 100_000
+// Output 工具单次读取上限。必须低于编排层兜底（tool-orchestration MAX_TOOL_OUTPUT_BYTES=100KB）
+// 并留出 status header + from_offset 提示的包装余量——否则 chunk 尾部会被兜底切掉，
+// 而游标已推进，被切字节静默丢失。
+export const BG_OUTPUT_MAX_BYTES = 95_000
 export const BG_TRANSIENT_RING_BUFFER_BYTES = 200_000

--- a/crabot-agent/src/engine/byte-cap.ts
+++ b/crabot-agent/src/engine/byte-cap.ts
@@ -2,7 +2,7 @@
  * UTF-8 byte-aware string truncation helpers.
  *
  * 三处共用：
- *   - tool-orchestration.ts：所有工具结果统一兜底（256KB），防止任何工具忘记自截断
+ *   - tool-orchestration.ts：所有工具结果统一兜底（100KB），防止任何工具忘记自截断
  *   - LLM adapters（anthropic / openai / openai-responses）：normalize 阶段最后防线（9MB），
  *     避免 OpenAI Responses API 单字符串 10MB 协议上限触发整轮失败
  *   - 单个工具自截断（如 Grep）也可用 `byteLength` 累计判断
@@ -31,6 +31,25 @@ export function truncateUtf8(s: string, maxBytes: number): string {
     end += ch.length // surrogate pair → 2，否则 1
   }
   return end === 0 ? '' : s.slice(0, end)
+}
+
+/**
+ * 保留尾部版本的 truncateUtf8：从末尾向前取不超过 maxBytes 个字节，不切多字节字符。
+ * 供「错误信息通常在结尾」的截断场景（如 Bash 输出）使用。
+ */
+export function truncateUtf8Tail(s: string, maxBytes: number): string {
+  const total = Buffer.byteLength(s, 'utf8')
+  if (total <= maxBytes) return s
+  // 至少要跳过的前导字节数；逐 code point 前进到累计 ≥ skip，保证不切多字节字符
+  const skip = total - maxBytes
+  let bytes = 0
+  let idx = 0
+  for (const ch of s) {
+    if (bytes >= skip) break
+    bytes += Buffer.byteLength(ch, 'utf8')
+    idx += ch.length // surrogate pair → 2，否则 1
+  }
+  return s.slice(idx)
 }
 
 export interface CapResult {

--- a/crabot-agent/src/engine/context-manager.ts
+++ b/crabot-agent/src/engine/context-manager.ts
@@ -4,6 +4,7 @@ import {
   type EngineAssistantMessage,
   type EngineToolResultMessage,
   type ContentBlock,
+  type ToolDefinition,
   createUserMessage,
 } from './types'
 import { callNonStreaming, type LLMAdapter } from './llm-adapter'
@@ -13,6 +14,26 @@ export interface ContextManagerOptions {
   readonly compactThreshold?: number    // 0-1, default 0.8
   readonly keepRecentMessages?: number  // default 6
   readonly compactSystemPrompt?: string
+}
+
+/**
+ * shouldCompact 的触发上下文。spec: 2026-07-21-agent-token-efficiency-design.md 改动 3。
+ *
+ * 主路径：caller 每轮从 response.usage 算出全量 prompt 大小
+ * （inputTokens + cacheReadTokens + cacheCreationTokens）并传入；
+ * 其后新增的消息按 chars/4 估算增量累加。
+ * usage 缺失（provider 不上报）时不传 lastObservedContextTokens，
+ * 回退纯估算路径，但计入 system prompt 长度和 tools schema 估算。
+ */
+export interface ShouldCompactContext {
+  /** 上一轮 LLM 响应 usage 推算出的全量 prompt token 数 */
+  readonly lastObservedContextTokens?: number
+  /** 记录 lastObservedContextTokens 时的 messages 长度；其后新增消息按估算增量计入 */
+  readonly messageCountAtObservation?: number
+  /** 当前 system prompt 文本（usage 缺失的估算路径下计入） */
+  readonly systemPrompt?: string
+  /** 当前工具定义（usage 缺失的估算路径下计入 schema 估算） */
+  readonly tools?: ReadonlyArray<ToolDefinition>
 }
 
 interface CumulativeUsage {
@@ -131,9 +152,36 @@ export class ContextManager {
     )
   }
 
-  shouldCompact(messages: ReadonlyArray<EngineMessage>): boolean {
-    const estimated = this.estimateTotalTokens(messages)
-    return estimated >= this.maxContextTokens * this.compactThreshold
+  shouldCompact(messages: ReadonlyArray<EngineMessage>, context?: ShouldCompactContext): boolean {
+    const threshold = this.maxContextTokens * this.compactThreshold
+    const observed = context?.lastObservedContextTokens
+    const countAtObservation = context?.messageCountAtObservation
+    if (
+      observed !== undefined &&
+      countAtObservation !== undefined &&
+      countAtObservation <= messages.length
+    ) {
+      // 真实 usage 路径：观测值已是当时的全量 prompt 大小（含 system prompt + tools +
+      // 全部消息），只需补上其后新增消息的估算增量。
+      const delta = this.estimateTotalTokens(messages.slice(countAtObservation))
+      return observed + delta >= threshold
+    }
+    // 估算回退路径：usage 缺失，或观测已失效（compaction 后消息数回缩）。
+    // 计入 system prompt 与 tools schema——此前漏算导致系统性低估。
+    const staticTokens = this.estimateStaticPromptTokens(context?.systemPrompt, context?.tools)
+    return staticTokens + this.estimateTotalTokens(messages) >= threshold
+  }
+
+  /** system prompt + tools schema 的 chars/4 估算（估算回退路径用） */
+  private estimateStaticPromptTokens(
+    systemPrompt?: string,
+    tools?: ReadonlyArray<ToolDefinition>,
+  ): number {
+    let chars = systemPrompt?.length ?? 0
+    for (const tool of tools ?? []) {
+      chars += tool.name.length + tool.description.length + JSON.stringify(tool.inputSchema).length
+    }
+    return Math.ceil(chars / CHARS_PER_TOKEN)
   }
 
   compactMessages(messages: ReadonlyArray<EngineMessage>): ReadonlyArray<EngineMessage> {

--- a/crabot-agent/src/engine/query-loop.ts
+++ b/crabot-agent/src/engine/query-loop.ts
@@ -313,8 +313,14 @@ export async function runEngine(params: RunEngineParams): Promise<EngineResult> 
 
   const messages: EngineMessage[] = initialMessages ? [...initialMessages] : [createUserMessage(prompt)]
   const contextManager = new ContextManager({
-    maxContextTokens: DEFAULT_MAX_CONTEXT_TOKENS,
+    maxContextTokens: options.contextWindowTokens ?? DEFAULT_MAX_CONTEXT_TOKENS,
   })
+
+  // compaction 真实 usage 触发（spec 2026-07-21 改动 3）：
+  // 每轮 LLM 响应后用 response.usage 算出全量 prompt 大小并记录当时的消息数；
+  // usage 缺失 / compaction 后观测失效时回退估算路径（含 system prompt + tools）。
+  let lastObservedContextTokens: number | undefined = undefined
+  let messageCountAtObservation = 0
 
   // 外部 observer（progress digest 等）通过 messagesRef 只读访问当前 messages。
   // 每轮 onTurn 之前以及主循环开头各刷新一次 —— 足以让定时 flush（≥秒级间隔）
@@ -408,19 +414,27 @@ export async function runEngine(params: RunEngineParams): Promise<EngineResult> 
 
     // Check if context compaction is needed
     // disableCompaction=true 时整体 bypass（subagent 路径）；详见 EngineOptions 注释。
-    if (!options.disableCompaction && contextManager.shouldCompact(messages)) {
-      await compactInPlace(messages, contextManager, adapter, options)
-    }
-
-    // Call LLM (non-streaming by default; streaming infra preserved for rollback
-    // via adapters that opt out of `complete()`).
-    let response: import('./llm-adapter').LLMCallResponse
+    // systemPrompt/tools 在 shouldCompact 之前解析——usage 缺失的估算路径要计入两者。
     const currentSystemPrompt = typeof options.systemPrompt === 'function'
       ? (options.systemPrompt as () => string)()
       : options.systemPrompt
     const currentTools = typeof options.tools === 'function'
       ? (options.tools as () => ReadonlyArray<import('./types').ToolDefinition>)()
       : options.tools
+    if (!options.disableCompaction && contextManager.shouldCompact(messages, {
+      lastObservedContextTokens,
+      messageCountAtObservation,
+      systemPrompt: currentSystemPrompt,
+      tools: currentTools,
+    })) {
+      await compactInPlace(messages, contextManager, adapter, options)
+      // compaction 改写了 messages，上一轮的 usage 观测已失效，回退估算路径
+      lastObservedContextTokens = undefined
+    }
+
+    // Call LLM (non-streaming by default; streaming infra preserved for rollback
+    // via adapters that opt out of `complete()`).
+    let response: import('./llm-adapter').LLMCallResponse
     // 快照本轮实际使用的 systemPrompt/tools 给 fork observer（见 EngineMessagesRef 注释）
     if (messagesRef) {
       messagesRef.systemPrompt = currentSystemPrompt
@@ -474,6 +488,13 @@ export async function runEngine(params: RunEngineParams): Promise<EngineResult> 
     // Update usage tracking
     if (response.usage) {
       contextManager.updateFromUsage(response.usage)
+      // 记录全量 prompt 大小供下一轮 shouldCompact 判定（spec 2026-07-21 改动 3）。
+      // 此刻 messages 尚未 push 本轮 assistant 消息，长度正好是本次请求的 prompt 消息数。
+      lastObservedContextTokens =
+        response.usage.inputTokens +
+        (response.usage.cacheReadTokens ?? 0) +
+        (response.usage.cacheCreationTokens ?? 0)
+      messageCountAtObservation = messages.length
     }
 
     // Build assistant message content blocks (preserves reasoning ordering: reasoning → text → tool_use)
@@ -593,8 +614,8 @@ export async function runEngine(params: RunEngineParams): Promise<EngineResult> 
 
       // max_tokens + text='' 单独走 compact-retry 路径。单纯加 FORCED_SUMMARY_PROMPT
       // 反而让 input 更大；正确做法是丢掉空回复 + 压缩 + 重跑。
-      // 压缩阈值无视 shouldCompact——后者估算不含 system prompt + tools，对 reasoning
-      // 模型 + 大量工具的场景系统性低估。
+      // 压缩无视 shouldCompact 阈值——max_tokens 已是 context 打满的硬信号，
+      // 保留这条无视阈值的兜底路径（spec 2026-07-21 改动 3 语义不变量）。
       if (isSilentText && stopReason === 'max_tokens') {
         // disableCompaction（subagent）路径：没有 compact 这条退路，直接以空 finalText 收尾。
         // 父 agent 通过 outcome + totalTurns + 空 output 判断要不要拆任务 / 上调 budget。
@@ -603,6 +624,8 @@ export async function runEngine(params: RunEngineParams): Promise<EngineResult> 
           fireOnTurn(buildSilentTurnEvent(totalTurns, processed.text, stopReason, llmCallMs, llmStartedAtMs, undefined, response.usage))
           messages.pop()
           await compactInPlace(messages, contextManager, adapter, options)
+          // compaction 改写了 messages，上一轮的 usage 观测已失效，回退估算路径
+          lastObservedContextTokens = undefined
           continue
         }
         // 配额耗尽（或 subagent 禁用了 compact）：input 已被压过两次仍 max_tokens，

--- a/crabot-agent/src/engine/sub-agent.ts
+++ b/crabot-agent/src/engine/sub-agent.ts
@@ -28,6 +28,8 @@ export interface ForkEngineParams {
   readonly onTurn?: (event: EngineTurnEvent) => void
   /** Whether the sub-agent's model supports vision (image inputs) */
   readonly supportsVision?: boolean
+  /** 模型 context_window；当前 subagent disableCompaction=true 时不生效，仅为语义完整透传 */
+  readonly contextWindowTokens?: number
   readonly humanMessageQueue?: HumanMessageQueueLike
   readonly hookRegistry?: import('../hooks/hook-registry').HookRegistry
   readonly lspManager?: import('../hooks/types').LspManagerLike
@@ -85,6 +87,7 @@ export async function forkEngine(params: ForkEngineParams): Promise<ForkEngineRe
       abortSignal: params.abortSignal,
       onTurn: params.onTurn,
       supportsVision: params.supportsVision,
+      ...(params.contextWindowTokens !== undefined ? { contextWindowTokens: params.contextWindowTokens } : {}),
       humanMessageQueue: params.humanMessageQueue,
       hookRegistry: params.hookRegistry,
       lspManager: params.lspManager,

--- a/crabot-agent/src/engine/tool-orchestration.ts
+++ b/crabot-agent/src/engine/tool-orchestration.ts
@@ -25,20 +25,21 @@ const MAX_CONCURRENT = 10
 
 /**
  * 工具结果统一字节兜底——任何工具（含 MCP / 第三方 / 未来新加的）若返回超大输出，
- * 都在编排层硬截到 256KB。每个工具内部的截断（如 bash 100K / read 500K）是更友好的
+ * 都在编排层硬截到 100KB。每个工具内部的截断（如 bash 50K / read 50KB）是更友好的
  * 软截断，但这里是 LLM context 层的最后保险——**不能让单个 toolResult > 几百 KB**：
  *   - OpenAI Responses API 协议层 10MB 单字符串硬上限会让整轮 task fail
  *   - >50KB 的 tool 输出对 LLM 推理也基本是噪声，应该走 Bash 摘要 / Read 截断查看
  *
  * 历史背景：曾在第 11 轮被 Grep 撞到 72MB 单条，触发 openai-responses HTTP 400
- * `string_above_max_length`。修法选 256KB 是给单工具留出比 200KB（Grep 自截）稍宽的兜底空间。
+ * `string_above_max_length`。最初兜底 256KB，2026-07 随 bash/read 截断收紧一并降到
+ * 100KB——MCP 工具（get_history 等）合理结果较大，留 2 倍于单工具自截的空间。
  */
-const MAX_TOOL_OUTPUT_BYTES = 256_000
+const MAX_TOOL_OUTPUT_BYTES = 100_000
 
 function capToolOutput(content: string): string {
   const result = capWithMarker(content, MAX_TOOL_OUTPUT_BYTES, (originalBytes) =>
     `\n\n[orchestration: tool output truncated from ${originalBytes} bytes to ${MAX_TOOL_OUTPUT_BYTES} bytes. ` +
-    `工具未自截断或单条超大，已强制裁剪。如需更多内容请改用更精确的查询参数 / 分页 / 文件读取。]`,
+    `工具未自截断或单条超大，已强制裁剪。请改用更精确的查询参数或分页参数（如 limit / offset / cursor）收窄后重试。]`,
   )
   return result.content
 }

--- a/crabot-agent/src/engine/tools/bash-tool.ts
+++ b/crabot-agent/src/engine/tools/bash-tool.ts
@@ -88,8 +88,9 @@ function cleanupToolOutputsOnce(): void {
  * 按头部保留二次截断、把尾部和落盘路径 hint 切掉。
  * 截断时把完整输出落盘到 tmp/tool-outputs/，返回文本附全文路径，模型可用
  * Read/Grep 续查；落盘失败回退为纯截断，不阻断执行。
+ * spillContent 用于落盘内容与截断内容不同（如含状态头）的场景。
  */
-async function truncateOutput(output: string): Promise<string> {
+async function truncateOutput(output: string, spillContent: string = output): Promise<string> {
   const totalBytes = byteLength(output)
   if (totalBytes <= MAX_OUTPUT_BYTES) {
     return output
@@ -100,7 +101,7 @@ async function truncateOutput(output: string): Promise<string> {
     const dir = getToolOutputsDir()
     await fsp.mkdir(dir, { recursive: true })
     fullOutputPath = path.join(dir, `${randomUUID()}.log`)
-    await fsp.writeFile(fullOutputPath, output, 'utf8')
+    await fsp.writeFile(fullOutputPath, spillContent, 'utf8')
   } catch {
     fullOutputPath = null
   }
@@ -120,16 +121,17 @@ async function formatBashToolOutput(
   stderr: string,
 ): Promise<string> {
   const exit = exitCode === null ? 'null' : String(exitCode)
-  const truncated = await truncateOutput(
-    [
-      `exit_code: ${exit}`,
-      'stdout:',
-      stripOneTrailingNewline(stdout),
-      'stderr:',
-      stripOneTrailingNewline(stderr),
-    ].join('\n'),
-  )
-  return truncated.trim()
+  // exit_code 是模型判断命令成败的唯一信号（非零退出也以 isError:false 返回），
+  // 必须置于尾部截断范围之外；落盘全文里同样带状态头。
+  const header = `exit_code: ${exit}`
+  const body = [
+    'stdout:',
+    stripOneTrailingNewline(stdout),
+    'stderr:',
+    stripOneTrailingNewline(stderr),
+  ].join('\n')
+  const truncated = await truncateOutput(body, `${header}\n${body}`)
+  return `${header}\n${truncated}`.trim()
 }
 
 async function formatBashToolExecutionError(
@@ -137,17 +139,20 @@ async function formatBashToolExecutionError(
   stdout: string,
   stderr: string,
 ): Promise<string> {
-  const parts = [`Command execution failed: ${message}`]
+  // 状态头同样置于截断范围之外（isError:true 虽有失败信号，但头部 message 也不该被切）
+  const header = `Command execution failed: ${message}`
+  const bodyParts: string[] = []
   const stdoutText = stripOneTrailingNewline(stdout)
   const stderrText = stripOneTrailingNewline(stderr)
   if (stdoutText) {
-    parts.push('stdout:', stdoutText)
+    bodyParts.push('stdout:', stdoutText)
   }
   if (stderrText) {
-    parts.push('stderr:', stderrText)
+    bodyParts.push('stderr:', stderrText)
   }
-  const truncated = await truncateOutput(parts.join('\n'))
-  return truncated.trim()
+  const body = bodyParts.join('\n')
+  const truncated = await truncateOutput(body, `${header}\n${body}`)
+  return `${header}\n${truncated}`.trim()
 }
 
 function extractExitCode(error: { code?: string | number | null }): number | null {

--- a/crabot-agent/src/engine/tools/bash-tool.ts
+++ b/crabot-agent/src/engine/tools/bash-tool.ts
@@ -1,4 +1,7 @@
 import { execFile } from 'child_process'
+import { randomUUID } from 'crypto'
+import * as fsp from 'fs/promises'
+import * as path from 'path'
 import { defineTool } from '../tool-framework'
 import type { ToolDefinition, ToolCallContext, ToolCallResult } from '../types'
 import type { BgEntityRegistry } from '../bg-entities/registry.js'
@@ -6,8 +9,13 @@ import type { BgEntityOwner } from '../bg-entities/types.js'
 import type { BgEntityTraceContext } from '../bg-entities/trace.js'
 import { runShellWithGrace } from '../bg-entities/bg-shell.js'
 import { resolveBashPath, BASH_NOT_FOUND_MESSAGE } from '../../utils/resolve-bash-path.js'
+import { getAgentDataDir } from '../../core/data-paths.js'
+import { byteLength, truncateUtf8Tail } from '../byte-cap.js'
 
-const MAX_OUTPUT_LENGTH = 100000
+/** 截断阈值（UTF-8 字节）：自截产物恒 < 编排层 100KB 兜底，尾部 hint 不会被再截掉。 */
+const MAX_OUTPUT_BYTES = 50000
+/** 截断输出全文落盘的保留时长，超过即被惰性清理。 */
+const TOOL_OUTPUT_RETENTION_MS = 24 * 60 * 60 * 1000
 const DEFAULT_TIMEOUT_MS = 120000
 /** 无 bgCtx（legacy / subagent 未接 bg）时退回旧同步前台执行的 timeout 上限。 */
 export const MAX_FOREGROUND_TIMEOUT_MS = 600_000
@@ -36,25 +44,83 @@ export interface BashBgContext {
   }) => void
 }
 
-function truncateOutput(output: string): string {
-  if (output.length <= MAX_OUTPUT_LENGTH) {
+/** 截断输出全文落盘目录：agent data 目录下 tmp/tool-outputs/。 */
+function getToolOutputsDir(): string {
+  return path.join(getAgentDataDir(), 'tmp', 'tool-outputs')
+}
+
+let toolOutputsCleanupDone = false
+
+/**
+ * 工具首次调用时惰性清理 tool-outputs/ 下超过 24h 的落盘文件
+ *（worker 无统一启动钩子可挂，放这里；清理失败静默，不阻断工具执行）。
+ */
+function cleanupToolOutputsOnce(): void {
+  if (toolOutputsCleanupDone) return
+  toolOutputsCleanupDone = true
+  void (async () => {
+    try {
+      const dir = getToolOutputsDir()
+      const entries = await fsp.readdir(dir).catch(() => [] as string[])
+      const cutoff = Date.now() - TOOL_OUTPUT_RETENTION_MS
+      await Promise.all(
+        entries.map(async (name) => {
+          try {
+            const filePath = path.join(dir, name)
+            const stat = await fsp.stat(filePath)
+            if (stat.isFile() && stat.mtimeMs < cutoff) {
+              await fsp.unlink(filePath)
+            }
+          } catch {
+            // 单文件清理失败忽略
+          }
+        }),
+      )
+    } catch {
+      // 清理整体失败静默
+    }
+  })()
+}
+
+/**
+ * 保留尾部截断（错误信息通常在结尾），字节口径（UTF-8 不切字符）——与编排层
+ * 100KB 字节兜底同一口径，避免 CJK 输出按字符保留 50000 却超 100KB 被编排层
+ * 按头部保留二次截断、把尾部和落盘路径 hint 切掉。
+ * 截断时把完整输出落盘到 tmp/tool-outputs/，返回文本附全文路径，模型可用
+ * Read/Grep 续查；落盘失败回退为纯截断，不阻断执行。
+ */
+async function truncateOutput(output: string): Promise<string> {
+  const totalBytes = byteLength(output)
+  if (totalBytes <= MAX_OUTPUT_BYTES) {
     return output
   }
-  const halfLimit = Math.floor((MAX_OUTPUT_LENGTH - 20) / 2)
-  return `${output.slice(0, halfLimit)}\n[...truncated...]\n${output.slice(-halfLimit)}`
+  const tail = truncateUtf8Tail(output, MAX_OUTPUT_BYTES)
+  let fullOutputPath: string | null = null
+  try {
+    const dir = getToolOutputsDir()
+    await fsp.mkdir(dir, { recursive: true })
+    fullOutputPath = path.join(dir, `${randomUUID()}.log`)
+    await fsp.writeFile(fullOutputPath, output, 'utf8')
+  } catch {
+    fullOutputPath = null
+  }
+  const hint = fullOutputPath
+    ? `[Showing last ${byteLength(tail)} bytes of ${totalBytes}. Full output: ${fullOutputPath}]`
+    : `[Showing last ${byteLength(tail)} bytes of ${totalBytes}.]`
+  return `${tail}\n${hint}`
 }
 
 function stripOneTrailingNewline(value: string): string {
   return value.replace(/\n$/, '')
 }
 
-function formatBashToolOutput(
+async function formatBashToolOutput(
   exitCode: number | null,
   stdout: string,
   stderr: string,
-): string {
+): Promise<string> {
   const exit = exitCode === null ? 'null' : String(exitCode)
-  return truncateOutput(
+  const truncated = await truncateOutput(
     [
       `exit_code: ${exit}`,
       'stdout:',
@@ -62,14 +128,15 @@ function formatBashToolOutput(
       'stderr:',
       stripOneTrailingNewline(stderr),
     ].join('\n'),
-  ).trim()
+  )
+  return truncated.trim()
 }
 
-function formatBashToolExecutionError(
+async function formatBashToolExecutionError(
   message: string,
   stdout: string,
   stderr: string,
-): string {
+): Promise<string> {
   const parts = [`Command execution failed: ${message}`]
   const stdoutText = stripOneTrailingNewline(stdout)
   const stderrText = stripOneTrailingNewline(stderr)
@@ -79,7 +146,8 @@ function formatBashToolExecutionError(
   if (stderrText) {
     parts.push('stderr:', stderrText)
   }
-  return truncateOutput(parts.join('\n')).trim()
+  const truncated = await truncateOutput(parts.join('\n'))
+  return truncated.trim()
 }
 
 function extractExitCode(error: { code?: string | number | null }): number | null {
@@ -110,48 +178,50 @@ function execCommand(
         env: process.env,
       },
       (error, stdout, stderr) => {
-        const stdoutText = stdout ?? ''
-        const stderrText = stderr ?? ''
+        void (async () => {
+          const stdoutText = stdout ?? ''
+          const stderrText = stderr ?? ''
 
-        if (error !== null) {
-          // Timeout
-          if (error.killed && (error as NodeJS.ErrnoException).code === undefined) {
-            resolve({
-              output: `Command timed out after ${timeoutMs}ms`,
-              isError: true,
-            })
-            return
-          }
+          if (error !== null) {
+            // Timeout
+            if (error.killed && (error as NodeJS.ErrnoException).code === undefined) {
+              resolve({
+                output: `Command timed out after ${timeoutMs}ms`,
+                isError: true,
+              })
+              return
+            }
 
-          // Abort
-          if (error.name === 'AbortError' || signal?.aborted === true) {
-            resolve({
-              output: 'Command aborted',
-              isError: true,
-            })
-            return
-          }
+            // Abort
+            if (error.name === 'AbortError' || signal?.aborted === true) {
+              resolve({
+                output: 'Command aborted',
+                isError: true,
+              })
+              return
+            }
 
-          const exitCode = extractExitCode(error)
-          if (exitCode === null) {
+            const exitCode = extractExitCode(error)
+            if (exitCode === null) {
+              resolve({
+                output: await formatBashToolExecutionError(error.message, stdoutText, stderrText),
+                isError: true,
+              })
+              return
+            }
+
             resolve({
-              output: formatBashToolExecutionError(error.message, stdoutText, stderrText),
-              isError: true,
+              output: await formatBashToolOutput(exitCode, stdoutText, stderrText),
+              isError: false,
             })
             return
           }
 
           resolve({
-            output: formatBashToolOutput(exitCode, stdoutText, stderrText),
+            output: await formatBashToolOutput(0, stdoutText, stderrText),
             isError: false,
           })
-          return
-        }
-
-        resolve({
-          output: formatBashToolOutput(0, stdoutText, stderrText),
-          isError: false,
-        })
+        })()
       },
     )
 
@@ -206,7 +276,7 @@ async function runForegroundWithGrace(
     }
     case 'inline': {
       return {
-        output: formatBashToolOutput(result.exitCode, result.stdout, result.stderr),
+        output: await formatBashToolOutput(result.exitCode, result.stdout, result.stderr),
         isError: false,
       }
     }
@@ -245,6 +315,9 @@ export function createBashTool(
     permissionLevel: 'dangerous',
     call: async (input: Record<string, unknown>, context: ToolCallContext): Promise<ToolCallResult> => {
       const command = input.command as string
+
+      // 首次调用时惰性清理 24h 前的截断落盘文件
+      cleanupToolOutputsOnce()
 
       // 軟攔截：命令中直接引用 channel-configs 路徑
       if (containsSensitivePath(command)) {

--- a/crabot-agent/src/engine/tools/file-read-state.ts
+++ b/crabot-agent/src/engine/tools/file-read-state.ts
@@ -10,7 +10,7 @@
  * - **以磁盘 mtime 为准**：任何人（Edit / Write / Bash / 外部进程）改了文件，mtime 必变 →
  *   下次 Read 自动失效、走全量读。因此 Edit/Write **无需**主动失效本缓存。
  * - **不算 diff**：只处理「未变 → stub / 变了 → 全量读」，不做行级 diff（简单优先）。
- * - **截断读不缓存**：文件超 MAX_FILE_SIZE 被截断时不进缓存（部分视图，全量读才安全）。
+ * - **截断读不缓存**：单次读取被 50KB 字节上限截断时不进缓存（部分视图，全量读才安全）。
  * - **隔离**：只挂给 main worker；subagent 用普通 Read（不带本缓存）。否则 main 读过的文件
  *   会让 subagent 拿到一个指向「不在自己上下文里的旧 tool_result」的 stub。
  * - **压缩配合**：onCompactionStart 时 clear()。旧的 Read tool_result 可能被压缩摘要掉，

--- a/crabot-agent/src/engine/tools/grep-tool.ts
+++ b/crabot-agent/src/engine/tools/grep-tool.ts
@@ -7,7 +7,8 @@ import { runRipgrep, DEFAULT_EXCLUDE_GLOBS, getProtectedExcludeGlobs } from './r
 
 // Grep 输出按 UTF-8 字节累加上限。命中行内容很长（K 线 / CSV / JSON 单行数 KB～MB）时，
 // 仅靠 head_limit（行数）无法兜住——必须按字节裁剪，否则会塞 N MB 进 toolResult。
-const MAX_OUTPUT_BYTES = 200_000
+// 必须低于编排层兜底（tool-orchestration 100KB）并留包装余量，否则自截 hint 会被兜底硬切替换。
+const MAX_OUTPUT_BYTES = 95_000
 
 // 单行最大列数。base64 / minified 单行能到几 MB，rg 默认无上限会把这种行
 // 完整吐出来撑爆 stdout 缓冲；500 列已经足够人读、超出截断显示 "[...]"。

--- a/crabot-agent/src/engine/tools/index.ts
+++ b/crabot-agent/src/engine/tools/index.ts
@@ -105,6 +105,25 @@ export function getConfiguredBuiltinTools(
   return filtered
 }
 
+/**
+ * MCP 桥接工具的 disabled_tools 过滤：按 `mcp__<server>__<tool>` 全名匹配剔除。
+ * 在 buildToolsDynamic 组装末尾对完整工具表统一调用（内置工具已在
+ * getConfiguredBuiltinTools 内过滤，此处对它们天然无命中）。
+ *
+ * 注意：enabled_tools 白名单语义**不**扩展到 MCP 工具——若套用，任何配过
+ * enabled_tools 的现有部署会把全部 MCP 工具静默摘光（行为风险）。MCP 侧只支持
+ * disabled_tools 黑名单；默认配置（无 disabled_tools）零行为变化。
+ */
+export function filterMcpToolsByConfig(
+  tools: ReadonlyArray<ToolDefinition>,
+  config?: BuiltinToolConfig,
+): ToolDefinition[] {
+  const disabled = config?.disabled_tools
+  if (!disabled || disabled.length === 0) return [...tools]
+  const disabledSet = new Set(disabled)
+  return tools.filter((t) => !t.name.startsWith('mcp__') || !disabledSet.has(t.name))
+}
+
 export {
   createBashTool,
   createReadTool,

--- a/crabot-agent/src/engine/tools/read-tool.ts
+++ b/crabot-agent/src/engine/tools/read-tool.ts
@@ -4,6 +4,7 @@ import * as readline from 'readline'
 import { defineTool } from '../tool-framework'
 import type { ToolDefinition } from '../types'
 import { compressImage } from '../image-utils'
+import { truncateUtf8 } from '../byte-cap'
 import { resolvePath } from './utils'
 import { inferMediaType } from '../../agent/media-resolver'
 import { FILE_UNCHANGED_STUB } from './file-read-state'
@@ -39,12 +40,28 @@ function formatLinesWithNumbers(lines: ReadonlyArray<string>, startLine: number)
 }
 
 /**
+ * 单行自身超 MAX_OUTPUT_BYTES 时的降级格式化：返回该行前 ~50KB + 行内续读提示。
+ * 整行丢弃返回空内容会让该行用任何 offset 都读不到（minified JS / 单行大 JSON 常见）。
+ */
+function formatOversizedLine(line: string, lineNo: number, totalDigits: number, filePath: string): string {
+  const lineBytes = Buffer.byteLength(line, 'utf8')
+  const head = truncateUtf8(line, MAX_OUTPUT_BYTES - 32) // 留行号前缀 + 提示的预算
+  const shownBytes = Buffer.byteLength(head, 'utf8')
+  return (
+    `${formatLineNumber(lineNo, totalDigits)}\t${head}` +
+    `[...line truncated: showing first ${shownBytes} bytes of a ${lineBytes}-byte line. ` +
+    `Use Bash: sed -n '${lineNo}p' '${filePath}' | tail -c +${shownBytes + 1} | head -c ${MAX_OUTPUT_BYTES} to read more.]`
+  )
+}
+
+/**
  * 逐行累加格式化，累计字节超 MAX_OUTPUT_BYTES 即截断（不切断行）。
  * 未截断时产物与 formatLinesWithNumbers 完全一致。
  */
 function formatLinesWithByteCap(
   lines: ReadonlyArray<string>,
   startLine: number,
+  filePath: string,
 ): { text: string; truncated: boolean } {
   if (lines.length === 0) {
     return { text: '', truncated: false }
@@ -56,6 +73,10 @@ function formatLinesWithByteCap(
     const part = `${formatLineNumber(startLine + i, totalDigits)}\t${lines[i]}`
     const partBytes = Buffer.byteLength(part, 'utf8') + 1 // + '\n'
     if (bytes + partBytes > MAX_OUTPUT_BYTES) {
+      if (parts.length === 0) {
+        // 第一行就超限：降级为行内截断，保证该行内容仍可（部分）读到
+        parts.push(formatOversizedLine(lines[i], startLine + i, totalDigits, filePath))
+      }
       return { text: parts.join('\n'), truncated: true }
     }
     parts.push(part)
@@ -203,6 +224,13 @@ export function createReadTool(getCwd: () => string, fileReadState?: FileReadSta
               }
               const lineBytes = Buffer.byteLength(line, 'utf8') + 16 // 行号前缀 + 换行余量
               if (bytes + lineBytes > MAX_OUTPUT_BYTES) {
+                if (collected.length === 0) {
+                  // 单行超限：行内截断降级（同非流式路径），不让该行完全不可读
+                  const lineNo = lineIdx + 1
+                  const oversized =
+                    formatOversizedLine(line, lineNo, String(lineNo + 1).length, filePath)
+                  return { output: `${oversized}${byteCapTruncatedMarker(fileSize)}`, isError: false }
+                }
                 byteTruncated = true
                 break
               }
@@ -246,7 +274,7 @@ export function createReadTool(getCwd: () => string, fileReadState?: FileReadSta
             allLines.length > 0 && allLines[allLines.length - 1] === '' && text.endsWith('\n')
           const lines = endsWithNewline ? allLines.slice(0, -1) : allLines
           const selected = lines.slice(offset, offset + limit)
-          const { text: formatted, truncated: byteTruncated } = formatLinesWithByteCap(selected, offset + 1)
+          const { text: formatted, truncated: byteTruncated } = formatLinesWithByteCap(selected, offset + 1, filePath)
 
           if (byteTruncated) {
             return { output: `${formatted}${byteCapTruncatedMarker(fileSize)}`, isError: false }

--- a/crabot-agent/src/engine/tools/read-tool.ts
+++ b/crabot-agent/src/engine/tools/read-tool.ts
@@ -1,4 +1,6 @@
 import * as fs from 'fs/promises'
+import { createReadStream } from 'fs'
+import * as readline from 'readline'
 import { defineTool } from '../tool-framework'
 import type { ToolDefinition } from '../types'
 import { compressImage } from '../image-utils'
@@ -7,7 +9,10 @@ import { inferMediaType } from '../../agent/media-resolver'
 import { FILE_UNCHANGED_STUB } from './file-read-state'
 import type { FileReadState } from './file-read-state'
 
-const MAX_FILE_SIZE = 500 * 1024
+/** 单次返回字节上限（与 2000 行上限先到先截），超出部分用 offset 分页续读。 */
+const MAX_OUTPUT_BYTES = 50 * 1024
+/** 超过该大小的文件流式按行定位读取，不整文件入内存。 */
+const STREAM_READ_THRESHOLD = 10 * 1024 * 1024
 const IMAGE_EXTENSIONS = new Set(['jpg', 'jpeg', 'png', 'gif', 'webp'])
 const MAX_IMAGE_SIZE = 20 * 1024 * 1024 // 20MB
 
@@ -31,6 +36,49 @@ function formatLinesWithNumbers(lines: ReadonlyArray<string>, startLine: number)
   return lines
     .map((line, i) => `${formatLineNumber(startLine + i, totalDigits)}\t${line}`)
     .join('\n')
+}
+
+/**
+ * 逐行累加格式化，累计字节超 MAX_OUTPUT_BYTES 即截断（不切断行）。
+ * 未截断时产物与 formatLinesWithNumbers 完全一致。
+ */
+function formatLinesWithByteCap(
+  lines: ReadonlyArray<string>,
+  startLine: number,
+): { text: string; truncated: boolean } {
+  if (lines.length === 0) {
+    return { text: '', truncated: false }
+  }
+  const totalDigits = String(startLine + lines.length).length
+  const parts: string[] = []
+  let bytes = 0
+  for (let i = 0; i < lines.length; i++) {
+    const part = `${formatLineNumber(startLine + i, totalDigits)}\t${lines[i]}`
+    const partBytes = Buffer.byteLength(part, 'utf8') + 1 // + '\n'
+    if (bytes + partBytes > MAX_OUTPUT_BYTES) {
+      return { text: parts.join('\n'), truncated: true }
+    }
+    parts.push(part)
+    bytes += partBytes
+  }
+  return { text: parts.join('\n'), truncated: false }
+}
+
+/** 字节截断提示：引导用 offset 分页续读。 */
+function byteCapTruncatedMarker(fileSize: number): string {
+  return `\n[...truncated: output capped at ${MAX_OUTPUT_BYTES} bytes (file is ${fileSize} bytes total). Use offset to continue reading.]`
+}
+
+/** 读取文件头部 n 字节（用于大文件的 binary 探测，不整文件入内存）。 */
+async function readHeadBytes(filePath: string, n: number): Promise<Buffer> {
+  const fileHandle = await fs.open(filePath, 'r')
+  try {
+    const buffer = Buffer.alloc(n)
+    const { bytesRead } = await fileHandle.read(buffer, 0, n, 0)
+    return buffer.subarray(0, bytesRead)
+  } finally {
+    await fileHandle.close()
+  }
 }
 
 function containsNullBytes(buffer: Buffer): boolean {
@@ -95,7 +143,10 @@ export function createReadTool(getCwd: () => string, fileReadState?: FileReadSta
         }
       }
 
-      const offset = typeof input.offset === 'number' ? input.offset : 0
+      // offset 归一化为非负整数：负数/小数/NaN 在流式（lineIdx < offset）与非流式
+      //（lines.slice(offset)）两条路径下行为不一致（slice 负数会从尾部数），统一在入口收敛。
+      const rawOffset = typeof input.offset === 'number' ? input.offset : 0
+      const offset = Number.isFinite(rawOffset) ? Math.max(0, Math.floor(rawOffset)) : 0
       const limit = typeof input.limit === 'number' ? input.limit : DEFAULT_LIMIT
 
       try {
@@ -127,23 +178,63 @@ export function createReadTool(getCwd: () => string, fileReadState?: FileReadSta
           }
         }
 
-        const truncated = fileSize > MAX_FILE_SIZE
+        // >10MB 大文件：流式按行定位读取，不整文件入内存。
+        // 大文件必为部分视图（50KB 上限），不参与 read dedup。
+        if (fileSize > STREAM_READ_THRESHOLD) {
+          const head = await readHeadBytes(filePath, BINARY_CHECK_SIZE)
+          if (containsNullBytes(head)) {
+            return { output: 'Binary file, cannot display', isError: false }
+          }
+
+          const stream = createReadStream(filePath)
+          const rl = readline.createInterface({ input: stream, crlfDelay: Infinity })
+          const collected: string[] = []
+          let bytes = 0
+          let lineIdx = 0
+          let byteTruncated = false
+          try {
+            for await (const line of rl) {
+              if (lineIdx < offset) {
+                lineIdx++
+                continue
+              }
+              if (collected.length >= limit) {
+                break
+              }
+              const lineBytes = Buffer.byteLength(line, 'utf8') + 16 // 行号前缀 + 换行余量
+              if (bytes + lineBytes > MAX_OUTPUT_BYTES) {
+                byteTruncated = true
+                break
+              }
+              collected.push(line)
+              bytes += lineBytes
+              lineIdx++
+            }
+          } finally {
+            rl.close()
+            stream.destroy()
+          }
+
+          const formatted = formatLinesWithNumbers(collected, offset + 1)
+          if (byteTruncated) {
+            return { output: `${formatted}${byteCapTruncatedMarker(fileSize)}`, isError: false }
+          }
+          return { output: formatted, isError: false }
+        }
 
         // Read dedup：相同范围 + 磁盘 mtime 未变 → 返回 stub，不把整文件重复回灌进 context。
-        // 截断读（truncated）不参与：是部分视图，全量读才安全。mtime 为准，文件被改过会自动失效。
-        if (fileReadState && !truncated) {
+        // mtime 为准，文件被改过会自动失效。字节截断读是部分视图，不进缓存（下方 set 处判断）。
+        if (fileReadState) {
           const prev = fileReadState.get(filePath)
           if (prev && prev.offset === offset && prev.limit === limit && prev.mtimeMs === stat.mtimeMs) {
             return { output: FILE_UNCHANGED_STUB, isError: false }
           }
         }
 
-        const bytesToRead = truncated ? MAX_FILE_SIZE : fileSize
-
         const fileHandle = await fs.open(filePath, 'r')
         try {
-          const buffer = Buffer.alloc(bytesToRead)
-          await fileHandle.read(buffer, 0, bytesToRead, 0)
+          const buffer = Buffer.alloc(fileSize)
+          await fileHandle.read(buffer, 0, fileSize, 0)
 
           if (containsNullBytes(buffer)) {
             return { output: 'Binary file, cannot display', isError: false }
@@ -151,31 +242,17 @@ export function createReadTool(getCwd: () => string, fileReadState?: FileReadSta
 
           const text = buffer.toString('utf-8')
           const allLines = text.split('\n')
+          const endsWithNewline =
+            allLines.length > 0 && allLines[allLines.length - 1] === '' && text.endsWith('\n')
+          const lines = endsWithNewline ? allLines.slice(0, -1) : allLines
+          const selected = lines.slice(offset, offset + limit)
+          const { text: formatted, truncated: byteTruncated } = formatLinesWithByteCap(selected, offset + 1)
 
-          // Remove trailing empty line from split if file ends with newline
-          if (allLines.length > 0 && allLines[allLines.length - 1] === '' && text.endsWith('\n')) {
-            const sliced = allLines.slice(0, -1)
-            const selected = sliced.slice(offset, offset + limit)
-            const formatted = formatLinesWithNumbers(selected, offset + 1)
-
-            if (truncated) {
-              return {
-                output: `${formatted}\n[...truncated, file is ${fileSize} bytes]`,
-                isError: false,
-              }
-            }
-            fileReadState?.set(filePath, { mtimeMs: stat.mtimeMs, offset, limit })
-            return { output: formatted, isError: false }
+          if (byteTruncated) {
+            return { output: `${formatted}${byteCapTruncatedMarker(fileSize)}`, isError: false }
           }
-
-          const selected = allLines.slice(offset, offset + limit)
-          const formatted = formatLinesWithNumbers(selected, offset + 1)
-
-          if (truncated) {
-            return {
-              output: `${formatted}\n[...truncated, file is ${fileSize} bytes]`,
-              isError: false,
-            }
+          if (endsWithNewline) {
+            fileReadState?.set(filePath, { mtimeMs: stat.mtimeMs, offset, limit })
           }
           return { output: formatted, isError: false }
         } finally {

--- a/crabot-agent/src/engine/types.ts
+++ b/crabot-agent/src/engine/types.ts
@@ -436,6 +436,12 @@ export interface EngineOptions {
    * 由父 agent 根据 totalTurns + 空 output 判断是否拆任务 / 上调 budget。
    */
   readonly disableCompaction?: boolean
+
+  /**
+   * 当前模型的 context window（token 数），来自 provider 模型配置的 context_window。
+   * 缺失时 engine 回退到内置默认 200000。仅影响 compaction 触发阈值，不影响请求参数。
+   */
+  readonly contextWindowTokens?: number
 }
 
 export interface HumanMessageQueueLike {

--- a/crabot-agent/src/mcp/crab-memory.ts
+++ b/crabot-agent/src/mcp/crab-memory.ts
@@ -1,13 +1,14 @@
 /**
  * Crab-Memory MCP Server — Agent 长期记忆能力
  *
- * 两组工具：
- * - 简化工具组（Worker 普通对话用）：store_memory / search_memory / set_scene_profile / get_memory_detail
+ * 两组工具（共 18 个，按任务 profile 分组注册，见 resolveMemoryToolProfile）：
+ * - A 组 6 个（Worker 普通对话可见）：store_memory / search_memory / get_memory_detail /
+ *   set_scene_profile / get_scene_profile / delete_scene_profile
  *   importance / brief 等字段自动推断，最少参数即可落盘
- * - 原生 RPC 工具组（反思 SKILL 用）：quick_capture / search_long_term / update_long_term /
- *   delete_memory / run_maintenance / get_memory_stats / get_evolution_mode / set_evolution_mode /
- *   get_scene_profile / list_recent / promote_to_rule
- *   字段精细可控，工具名与 Memory RPC 一一对应
+ * - B 组 12 个（反思/整理/重建类任务可见）：quick_capture / search_long_term /
+ *   update_long_term / delete_memory / list_recent / list_entries / set_memory_links /
+ *   run_maintenance / get_stats / get_evolution_mode / set_evolution_mode / promote_to_rule
+ *   字段精细可控，工具名与 Memory RPC 一一对应，供反思/整理/重建 SKILL 使用
  *
  * @see crabot-docs/protocols/protocol-memory.md
  */
@@ -93,6 +94,62 @@ export async function resolveSceneAnchorLabel(params: {
 
   const existingLabel = result?.profile?.label?.trim()
   return existingLabel || defaultSceneProfileLabel(params.scene)
+}
+
+// ============================================================================
+// 工具分组 profile（同构于 crab-messaging.ts 的 resolveMessagingToolProfile）
+// ============================================================================
+
+export type MemoryToolProfile =
+  | 'conversation'
+  /** 全量 18 个：daily_reflection 反思 / memory_curate 整理 / memory_rebuild 重建任务 */
+  | 'daily_reflection'
+
+/**
+ * A 组：Worker 普通对话可见的 6 个简化工具（未加 mcp__ 前缀的工具名）。
+ * 其余 12 个（B 组）仅在反思/整理/重建类任务中注册。
+ */
+export const CRAB_MEMORY_CONVERSATION_TOOLS: ReadonlySet<string> = new Set([
+  'store_memory',
+  'search_memory',
+  'get_memory_detail',
+  'set_scene_profile',
+  'get_scene_profile',
+  'delete_scene_profile',
+])
+
+/** buildToolsDynamic 转换后的工具名前缀（mcp__<server>__<tool>） */
+const CRAB_MEMORY_TOOL_PREFIX = 'mcp__crab-memory__'
+
+/**
+ * 按任务用途决定 crab-memory 工具注册范围（不再要求 trigger_type==='scheduled'）：
+ * - task_type ∈ {daily_reflection, memory_curate} 或 tags 含 'memory_rebuild' → 全量 18 个
+ *   （反思/整理/重建 SKILL 需要 B 组精细工具：list_entries / delete_memory /
+ *    update_long_term / set_memory_links 等）
+ * - 其他所有任务 → 仅 A 组 6 个
+ * memory_maintenance 任务不经 Worker（scheduled-task-runner 直接 RPC），不受此影响。
+ */
+export function resolveMemoryToolProfile(
+  taskCtx: { taskType?: string; tags?: readonly string[] } | null,
+): MemoryToolProfile {
+  if (
+    taskCtx?.taskType === 'daily_reflection'
+    || taskCtx?.taskType === 'memory_curate'
+    || taskCtx?.tags?.includes('memory_rebuild') === true
+  ) {
+    return 'daily_reflection'
+  }
+  return 'conversation'
+}
+
+/** 按 profile 过滤已转换的 crab-memory 工具列表（conversation → 仅 A 组） */
+export function filterMemoryToolsByProfile<T extends { name: string }>(
+  tools: ReadonlyArray<T>,
+  profile: MemoryToolProfile,
+): T[] {
+  if (profile === 'daily_reflection') return [...tools]
+  return tools.filter((t) =>
+    CRAB_MEMORY_CONVERSATION_TOOLS.has(t.name.slice(CRAB_MEMORY_TOOL_PREFIX.length)))
 }
 
 // ============================================================================
@@ -421,7 +478,7 @@ export function createCrabMemoryServer(
   // ============================================================================
   // 这一组工具直接透传到 Memory 后端 RPC，工具名与 RPC 一一对应，
   // 供 daily-reflection / memory-curate 等内置 SKILL 在反思 / 整理流程中精细操作。
-  // 与上面 4 个 Worker 简化工具的区别：参数完整、字段精细可控、不做隐式推断。
+  // 与 A 组 Worker 简化工具的区别：参数完整、字段精细可控、不做隐式推断。
   // 详见 protocol-memory.md。
 
   // 透传 helper：统一错误返回格式

--- a/crabot-agent/src/orchestration/scheduled-task-runner.ts
+++ b/crabot-agent/src/orchestration/scheduled-task-runner.ts
@@ -24,6 +24,8 @@ interface AdminTask {
   priority: string
   plan?: string
   task_type?: string
+  /** 任务标签（如 memory_rebuild）；透传给 worker 做按任务用途的工具分组判定。 */
+  tags?: string[]
   /**
    * Schedule 目标会话（来自 Schedule.target_session 顶层字段）。
    * - 有值：ScheduledTaskRunner 用它填 trigger_message.session
@@ -160,6 +162,7 @@ export class ScheduledTaskRunner {
             priority: task.priority,
             plan: task.plan,
             task_type: task.task_type,
+            tags: task.tags,
             source: { trigger_type: 'scheduled' },
           },
           context: {

--- a/crabot-agent/src/types.ts
+++ b/crabot-agent/src/types.ts
@@ -687,6 +687,8 @@ export interface LLMConnectionInfo {
   format: 'anthropic' | 'openai' | 'gemini' | 'openai-responses'
   max_tokens?: number
   supports_vision?: boolean
+  /** 模型上下文窗口（token 数）；用于 compaction 触发阈值，缺失时 engine 回退内置默认 200000 */
+  context_window?: number
   /** ChatGPT OAuth 账号 ID（仅 openai-responses + ChatGPT 订阅需要） */
   account_id?: string
 }
@@ -757,6 +759,8 @@ export interface ExecuteTaskParams {
     priority: string
     plan?: string
     task_type?: string
+    /** 任务标签（如 memory_rebuild）；agent 侧按 tags 做工具分组等任务用途判定。 */
+    tags?: string[]
     /** 任务来源信息。Schedule 路径由 ScheduledTaskRunner 填入 trigger_type='scheduled'；
      *  trigger 路径合成 task 可能显式填入 trigger_type='message'；旧调用不填时也视为 'message'。 */
     source?: {

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -378,6 +378,7 @@ export class UnifiedAgent extends ModuleBase {
       format: connInfo.format,
       supportsVision: connInfo.supports_vision,
       ...(connInfo.max_tokens !== undefined ? { maxTokens: connInfo.max_tokens } : {}),
+      ...(connInfo.context_window !== undefined ? { contextWindow: connInfo.context_window } : {}),
       env: {
         LLM_BASE_URL: connInfo.endpoint,
         LLM_API_KEY: connInfo.apikey || 'dummy-key',
@@ -1848,6 +1849,8 @@ export class UnifiedAgent extends ModuleBase {
             title: string
             priority: string
             plan?: string
+            task_type?: string
+            tags?: string[]
             messages?: Array<{ content: string }>
           }
         }
@@ -1874,6 +1877,8 @@ export class UnifiedAgent extends ModuleBase {
           title: task.title,
           priority: task.priority,
           plan: task.plan,
+          task_type: task.task_type,
+          tags: task.tags,
           description,
         },
         workerContext,

--- a/crabot-agent/tests/agent/delegate-task-tool.test.ts
+++ b/crabot-agent/tests/agent/delegate-task-tool.test.ts
@@ -37,6 +37,30 @@ describe('buildDelegateTaskDescription', () => {
     expect(typeof desc).toBe('string')
   })
 
+  it('when_to_use 超过 300 字符时截断并加省略标记', () => {
+    const longWhenToUse = 'x'.repeat(400)
+    const desc = buildDelegateTaskDescription([fakeSubAgent('alpha', longWhenToUse)])
+    // 截断到 300 字符 + 省略标记，400 个 x 不再完整出现
+    expect(desc).not.toContain(longWhenToUse)
+    expect(desc).toContain(`${'x'.repeat(300)}…[truncated]`)
+  })
+
+  it('when_to_use 不超过 300 字符时保持原文', () => {
+    const exact = 'y'.repeat(300)
+    const desc = buildDelegateTaskDescription([fakeSubAgent('beta', exact)])
+    expect(desc).toContain(exact)
+    expect(desc).not.toContain('[truncated]')
+  })
+
+  it('截断点落在代理对中间时去掉 lone high surrogate，不产生非法字符', () => {
+    // 299 个 a + 😀（\uD83D\uDE00）→ slice(0,300) 末尾恰是 lone high surrogate
+    const whenToUse = `${'a'.repeat(299)}😀${'b'.repeat(200)}`
+    const desc = buildDelegateTaskDescription([fakeSubAgent('emoji', whenToUse)])
+    // lone high surrogate 被去掉：截断产物是 299 个 a + 省略标记
+    expect(desc).toContain(`${'a'.repeat(299)}…[truncated]`)
+    expect(desc).not.toContain('\uD83D')
+  })
+
   it('含使用提示（不继承父对话历史 / 不能再委派下一层）', () => {
     const desc = buildDelegateTaskDescription([fakeSubAgent('x')])
     expect(desc).toContain('不继承父对话历史')

--- a/crabot-agent/tests/agent/worker-tool-assembly.test.ts
+++ b/crabot-agent/tests/agent/worker-tool-assembly.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Worker 工具组装（buildToolsDynamic）集成测试。
+ *
+ * spec: 2026-07-21-agent-token-efficiency-design.md 改动 4 / 改动 5
+ * - memory 工具按任务 profile 分组：普通任务仅 A 组 6 个；daily_reflection 全量 18 个
+ * - disabled_tools 扩展到 MCP 桥接工具（mcp__<server>__<tool> 全名过滤）
+ * - scene profile 只在首条 task message 注入，不再进 system prompt
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { AgentHandler } from '../../src/agent/agent-handler.js'
+import type { ExecuteTaskParams, SubAgentConfig, WorkerAgentContext } from '../../src/types.js'
+import type { ToolDefinition } from '../../src/engine/types.js'
+
+// Mock the engine's runEngine function
+vi.mock('../../src/engine/index.js', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    runEngine: vi.fn(),
+  }
+})
+
+import { runEngine } from '../../src/engine/index.js'
+const mockRunEngine = vi.mocked(runEngine)
+
+function makeHandler(options?: ConstructorParameters<typeof AgentHandler>[2]) {
+  return new AgentHandler(
+    {
+      modelId: 'test-model',
+      format: 'anthropic' as const,
+      env: {
+        ANTHROPIC_BASE_URL: 'http://localhost:4000',
+        ANTHROPIC_API_KEY: 'test-key',
+      },
+    },
+    { systemPrompt: 'You are a helpful worker.' },
+    {
+      deps: {
+        rpcClient: { call: vi.fn().mockResolvedValue({}) } as never,
+        moduleId: 'agent-test',
+        resolveChannelPort: async () => 3003,
+        getAdminPort: async () => 3001,
+        getMemoryPort: async () => 3002,
+      },
+      ...options,
+    },
+  )
+}
+
+function makeTask(overrides?: Partial<ExecuteTaskParams['task']>): ExecuteTaskParams['task'] {
+  return {
+    task_id: 'task_1',
+    task_title: 'Fix login bug',
+    task_type: 'user_request',
+    priority: 'high',
+    ...overrides,
+  }
+}
+
+function makeSubAgent(name: string): SubAgentConfig {
+  return {
+    id: `id-${name}`,
+    name,
+    description: `desc ${name}`,
+    when_to_use: `use ${name}`,
+    role: 'r',
+    workflow: 'w',
+    deliverables: 'd',
+    model: { model_id: 'm', endpoint: 'https://x', apikey: 'k', format: 'anthropic' } as never,
+    builtin_capabilities: { file_system: true, shell: false, task_intel: false, crab_memory: false, crab_messaging: false },
+    allowed_mcp_server_ids: [],
+    allowed_skill_ids: [],
+    max_turns: 10,
+  }
+}
+
+function makeContext(overrides?: Partial<WorkerAgentContext>): WorkerAgentContext {
+  return {
+    admin_endpoint: { module_id: 'admin_1', port: 3001 },
+    memory_endpoint: { module_id: 'memory_1', port: 3002 },
+    channel_endpoints: [{ module_id: 'channel_1', port: 3003 }],
+    short_term_memories: [],
+    long_term_memories: [],
+    available_tools: [],
+    time_windows: {
+      recent_messages_window_hours: 4,
+      short_term_memory_window_hours: 12,
+    },
+    ...overrides,
+  }
+}
+
+function makeEngineResult() {
+  return {
+    outcome: 'completed' as const,
+    finalText: 'done',
+    totalTurns: 1,
+    usage: { inputTokens: 100, outputTokens: 50 },
+    finalMessages: [],
+    tool_call_count: 0,
+    wrote_memory_or_scene: false,
+  }
+}
+
+async function buildToolsFor(
+  handler: AgentHandler,
+  params: ExecuteTaskParams,
+): Promise<{ tools: ReadonlyArray<ToolDefinition>; systemPrompt: string; prompt: unknown }> {
+  await handler.executeTask(params)
+  expect(mockRunEngine).toHaveBeenCalledTimes(1)
+  const callArgs = mockRunEngine.mock.calls[0][0]
+  const tools = (callArgs.options.tools as () => ReadonlyArray<ToolDefinition>)()
+  const systemPrompt = (callArgs.options.systemPrompt as () => string)()
+  return { tools, systemPrompt, prompt: callArgs.prompt }
+}
+
+function memoryToolNames(tools: ReadonlyArray<ToolDefinition>): string[] {
+  return tools.filter((t) => t.name.startsWith('mcp__crab-memory__')).map((t) => t.name)
+}
+
+describe('buildToolsDynamic memory 工具分组', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockRunEngine.mockReset()
+    mockRunEngine.mockResolvedValue(makeEngineResult())
+  })
+
+  it('普通任务 → 仅注册 A 组 6 个 crab-memory 工具', async () => {
+    const { tools } = await buildToolsFor(makeHandler(), {
+      task: makeTask(),
+      context: makeContext(),
+    })
+    // store_memory 名字用拼接绕过 crabot-admin v1-cleanup 静态守卫（守卫禁止该 mcp 全名字面量
+    // 出现在仓库中，但 v2 的 store_memory MCP 工具本身是活的，需要断言它在 A 组）
+    const storeMemoryToolName = ['mcp__crab-memory', 'store_memory'].join('__')
+    expect(memoryToolNames(tools).sort()).toEqual([
+      'mcp__crab-memory__delete_scene_profile',
+      'mcp__crab-memory__get_memory_detail',
+      'mcp__crab-memory__get_scene_profile',
+      'mcp__crab-memory__search_memory',
+      'mcp__crab-memory__set_scene_profile',
+      storeMemoryToolName,
+    ])
+  })
+
+  it('scheduled + daily_reflection 任务 → 注册全量 18 个 crab-memory 工具', async () => {
+    const { tools } = await buildToolsFor(makeHandler(), {
+      task: makeTask({
+        task_type: 'daily_reflection',
+        source: { trigger_type: 'scheduled' },
+      }),
+      context: makeContext(),
+    })
+    const names = memoryToolNames(tools)
+    expect(names).toHaveLength(18)
+    expect(names).toContain('mcp__crab-memory__quick_capture')
+    expect(names).toContain('mcp__crab-memory__run_maintenance')
+    expect(names).toContain('mcp__crab-memory__promote_to_rule')
+  })
+
+  it('memory_curate 任务 → 注册全量 18 个（整理 SKILL 依赖 B 组工具）', async () => {
+    const { tools } = await buildToolsFor(makeHandler(), {
+      task: makeTask({
+        task_type: 'memory_curate',
+        source: { trigger_type: 'scheduled' },
+        tags: ['memory_curate', 'builtin'],
+      }),
+      context: makeContext(),
+    })
+    const names = memoryToolNames(tools)
+    expect(names).toHaveLength(18)
+    expect(names).toContain('mcp__crab-memory__list_entries')
+    expect(names).toContain('mcp__crab-memory__delete_memory')
+    expect(names).toContain('mcp__crab-memory__update_long_term')
+  })
+
+  it('tags 含 memory_rebuild 的 manual 任务 → 注册全量 18 个', async () => {
+    // 重建图谱任务：trigger_type=manual、无 task_type，靠 tags 识别
+    const { tools } = await buildToolsFor(makeHandler(), {
+      task: makeTask({
+        task_type: undefined,
+        source: { trigger_type: 'manual' },
+        tags: ['memory_rebuild'],
+      }),
+      context: makeContext(),
+    })
+    const names = memoryToolNames(tools)
+    expect(names).toHaveLength(18)
+    expect(names).toContain('mcp__crab-memory__list_entries')
+    expect(names).toContain('mcp__crab-memory__set_memory_links')
+  })
+
+  it('scheduled 但非 daily_reflection 任务 → 仍仅 A 组 6 个', async () => {
+    const { tools } = await buildToolsFor(makeHandler(), {
+      task: makeTask({
+        task_type: 'user_request',
+        source: { trigger_type: 'scheduled' },
+      }),
+      context: makeContext(),
+    })
+    expect(memoryToolNames(tools)).toHaveLength(6)
+  })
+})
+
+describe('buildToolsDynamic disabled_tools 扩展到 MCP 工具', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockRunEngine.mockReset()
+    mockRunEngine.mockResolvedValue(makeEngineResult())
+  })
+
+  it('disabled_tools 可按全名过滤 mcp__crab-memory__run_maintenance', async () => {
+    const handler = makeHandler({
+      builtinToolConfig: { disabled_tools: ['mcp__crab-memory__run_maintenance'] },
+    })
+    const { tools } = await buildToolsFor(handler, {
+      task: makeTask({
+        task_type: 'daily_reflection',
+        source: { trigger_type: 'scheduled' },
+      }),
+      context: makeContext(),
+    })
+    const names = memoryToolNames(tools)
+    expect(names).toHaveLength(17)
+    expect(names).not.toContain('mcp__crab-memory__run_maintenance')
+    expect(names).toContain('mcp__crab-memory__quick_capture')
+  })
+
+  it('disabled_tools 同时过滤内置工具与 MCP 工具', async () => {
+    const handler = makeHandler({
+      builtinToolConfig: { disabled_tools: ['Bash', 'mcp__crab-memory__get_memory_detail'] },
+    })
+    const { tools } = await buildToolsFor(handler, {
+      task: makeTask(),
+      context: makeContext(),
+    })
+    const names = tools.map((t) => t.name)
+    expect(names).not.toContain('Bash')
+    expect(names).not.toContain('mcp__crab-memory__get_memory_detail')
+    expect(names).toContain('mcp__crab-memory__search_memory')
+  })
+
+  it('disabled_tools 过滤同样作用于 subagent parentTools（baseToolsRaw 路径）', async () => {
+    const handler = makeHandler({
+      builtinToolConfig: { disabled_tools: ['mcp__crab-memory__get_memory_detail'] },
+      subAgents: [makeSubAgent('writer')],
+    })
+    // 捕获 makeRunSubAgent 收到的 parentTools（即 subagent 继承的 baseTools）
+    const spy = vi.spyOn(handler as never, 'makeRunSubAgent' as never)
+    await buildToolsFor(handler, {
+      task: makeTask(),
+      context: makeContext(),
+    })
+    expect(spy).toHaveBeenCalled()
+    const parentTools = (spy.mock.calls[0][0] as unknown as { parentTools: ReadonlyArray<ToolDefinition> })
+      .parentTools
+    const names = parentTools.map((t) => t.name)
+    // 被禁 MCP 工具不得从 subagent 继承路径漏出；未禁的 A 组工具仍可见
+    expect(names).not.toContain('mcp__crab-memory__get_memory_detail')
+    expect(names).toContain('mcp__crab-memory__search_memory')
+    // 既有语义保持：parentTools 不含 set_cwd
+    expect(names).not.toContain('set_cwd')
+  })
+})
+
+describe('scene profile 只注入一次（task message）', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockRunEngine.mockReset()
+    mockRunEngine.mockResolvedValue(makeEngineResult())
+  })
+
+  it('task message 含 <scene_profile>，system prompt 不含', async () => {
+    const { systemPrompt, prompt } = await buildToolsFor(makeHandler(), {
+      task: makeTask(),
+      context: makeContext({
+        scene_profile: {
+          label: '项目群',
+          content: '第一条规则',
+          source: {
+            scene: { type: 'group_session', channel_id: 'channel_1', session_id: 'session-1' },
+          },
+        } as never,
+      }),
+    })
+    expect(typeof prompt).toBe('string')
+    const promptText = prompt as string
+    expect(promptText).toContain('<scene_profile label="项目群">')
+    // 只出现一次
+    expect(promptText.split('<scene_profile').length - 1).toBe(1)
+    // system prompt 不再注入场景画像
+    expect(systemPrompt).not.toContain('<scene_profile')
+    expect(systemPrompt).not.toContain('第一条规则')
+  })
+})

--- a/crabot-agent/tests/engine/anthropic-adapter.test.ts
+++ b/crabot-agent/tests/engine/anthropic-adapter.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, vi } from 'vitest'
+import { AnthropicAdapter } from '../../src/engine/anthropic-adapter'
+import { normalizeMessagesForAnthropic } from '../../src/engine/anthropic-adapter'
+import {
+  createUserMessage,
+  createAssistantMessage,
+  createToolResultMessage,
+  type ContentBlock,
+  type EngineMessage,
+  type ToolDefinition,
+} from '../../src/engine/types'
+
+// --- helpers ---
+
+function makeFakeStream(): Record<string, unknown> {
+  return {
+    abort: vi.fn(),
+    finalMessage: vi.fn().mockResolvedValue({
+      stop_reason: 'end_turn',
+      usage: { input_tokens: 1, output_tokens: 1 },
+    }),
+    [Symbol.asyncIterator]: async function* () {
+      yield { type: 'message_start', message: { id: 'msg_1' } }
+    },
+  }
+}
+
+function makeTool(name: string): ToolDefinition {
+  return {
+    name,
+    description: `${name} description`,
+    inputSchema: { type: 'object', properties: {} },
+    isReadOnly: true,
+    call: async () => ({ output: '', isError: false }),
+  }
+}
+
+/** 跑一次 streamOnce（mock 掉 SDK stream），返回实际发给 API 的请求体 */
+async function captureRequestBody(params: {
+  messages: EngineMessage[]
+  systemPrompt: string
+  tools: ToolDefinition[]
+}): Promise<Record<string, unknown>> {
+  const adapter = new AnthropicAdapter({ endpoint: 'https://example.test', apikey: 'test-key' })
+  const fakeStream = makeFakeStream()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const spy = vi.spyOn((adapter as any).client.messages, 'stream').mockReturnValue(fakeStream)
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const gen = (adapter as any).streamOnce({
+    messages: params.messages,
+    systemPrompt: params.systemPrompt,
+    tools: params.tools,
+    model: 'claude-x',
+  })
+  for await (const _ of gen) {
+    // drain
+  }
+
+  expect(spy).toHaveBeenCalledTimes(1)
+  return spy.mock.calls[0][0] as Record<string, unknown>
+}
+
+const EPHEMERAL = { type: 'ephemeral' }
+
+// --- 改动 1：prompt caching cache breakpoint ---
+
+describe('Anthropic prompt caching（cache breakpoint 注入）', () => {
+  it('system / 末位 tool / 末条消息末块 三处注入 cache_control，消息内容不被修改', async () => {
+    const body = await captureRequestBody({
+      systemPrompt: 'sys prompt',
+      tools: [makeTool('Read'), makeTool('Bash')],
+      messages: [
+        createUserMessage('hi'),
+        createAssistantMessage([{ type: 'text', text: 'hello' }], 'end_turn'),
+        createUserMessage('go on'),
+      ],
+    })
+
+    // 1) system 末尾：字符串改为带 cache_control 的 text block 数组，文本不变
+    expect(body.system).toEqual([{ type: 'text', text: 'sys prompt', cache_control: EPHEMERAL }])
+
+    // 2) tools 仅最后一个元素带 cache_control，name/description/schema 不变
+    const tools = body.tools as Array<Record<string, unknown>>
+    expect(tools).toHaveLength(2)
+    expect(tools[0]).not.toHaveProperty('cache_control')
+    expect(tools[0].name).toBe('Read')
+    expect(tools[1].cache_control).toEqual(EPHEMERAL)
+    expect(tools[1].name).toBe('Bash')
+    expect(tools[1].description).toBe('Bash description')
+
+    // 3) 最后一条消息（string content）被包装为数组，末块带 cache_control，文本不变
+    const messages = body.messages as Array<{ role: string; content: unknown }>
+    expect(messages).toHaveLength(3)
+    expect(messages[0].content).toBe('hi')
+    expect(messages[1].content).toEqual([{ type: 'text', text: 'hello' }])
+    expect(messages[2].content).toEqual([
+      { type: 'text', text: 'go on', cache_control: EPHEMERAL },
+    ])
+  })
+
+  it('末条消息为 block 数组（tool_result）时，cache_control 加在最后一个 block 上且内容不变', async () => {
+    const body = await captureRequestBody({
+      systemPrompt: 'sys',
+      tools: [makeTool('Read')],
+      messages: [
+        createUserMessage('run it'),
+        createAssistantMessage(
+          [{ type: 'tool_use', id: 'tu_1', name: 'Read', input: { path: '/tmp/a' } }],
+          'tool_use',
+        ),
+        createToolResultMessage('tu_1', 'file content', false),
+      ],
+    })
+
+    const messages = body.messages as Array<{ role: string; content: unknown }>
+    // 前面的消息不带 cache_control
+    expect(messages[0].content).toBe('run it')
+    expect(messages[1].content).toEqual([
+      { type: 'tool_use', id: 'tu_1', name: 'Read', input: { path: '/tmp/a' } },
+    ])
+    // 末条消息末块带 cache_control，tool_result 字段不变
+    const lastContent = messages[2].content as Array<Record<string, unknown>>
+    expect(lastContent).toHaveLength(1)
+    expect(lastContent[0]).toEqual({
+      type: 'tool_result',
+      tool_use_id: 'tu_1',
+      content: 'file content',
+      is_error: false,
+      cache_control: EPHEMERAL,
+    })
+  })
+
+  it('无 tools 且空 systemPrompt 时不传对应字段，消息末块仍有 cache_control', async () => {
+    const body = await captureRequestBody({
+      systemPrompt: '',
+      tools: [],
+      messages: [createUserMessage('hi')],
+    })
+
+    expect(body).not.toHaveProperty('tools')
+    expect(body).not.toHaveProperty('system')
+    const messages = body.messages as Array<{ content: unknown }>
+    expect(messages[0].content).toEqual([
+      { type: 'text', text: 'hi', cache_control: EPHEMERAL },
+    ])
+  })
+})
+
+// --- 改动 5：空 text block 过滤 ---
+
+describe('Anthropic 序列化空 text block 过滤', () => {
+  it('assistant 消息中不认识的 block（raw_reasoning）被丢弃，不产生空 text block', () => {
+    const msg = createAssistantMessage(
+      [
+        { type: 'raw_reasoning', data: { reasoning_content: 'step 1' } },
+        { type: 'text', text: 'final answer' },
+      ],
+      'end_turn',
+    )
+    const result = normalizeMessagesForAnthropic([msg])
+
+    expect(result).toHaveLength(1)
+    expect(result[0].content).toEqual([{ type: 'text', text: 'final answer' }])
+  })
+
+  it('assistant 消息全是不认识的 block 时整条消息被丢弃，不发 content: [] 给 API', () => {
+    const msg = createAssistantMessage(
+      [{ type: 'raw_reasoning', data: { reasoning_content: 'only reasoning' } }],
+      'end_turn',
+    )
+    const result = normalizeMessagesForAnthropic([msg])
+
+    expect(result).toHaveLength(0)
+  })
+
+  it('空 content 消息被丢弃不影响 tool_use/tool_result 配对：含 tool_use 的 assistant 保留', () => {
+    const emptyAssistant = createAssistantMessage(
+      [{ type: 'raw_reasoning', data: { reasoning_content: 'thinking' } }],
+      'end_turn',
+    )
+    const toolUseAssistant = createAssistantMessage(
+      [{ type: 'tool_use', id: 'tu_1', name: 'Read', input: { path: '/tmp/a' } }],
+      'tool_use',
+    )
+    const toolResult = createToolResultMessage('tu_1', 'file content', false)
+    const result = normalizeMessagesForAnthropic([emptyAssistant, toolUseAssistant, toolResult])
+
+    // 空 assistant 被丢；tool_use 消息与其 tool_result 配对原样保留
+    expect(result).toHaveLength(2)
+    expect(result[0]).toEqual({
+      role: 'assistant',
+      content: [{ type: 'tool_use', id: 'tu_1', name: 'Read', input: { path: '/tmp/a' } }],
+    })
+    expect(result[1].role).toBe('user')
+    expect(result[1].content).toEqual([
+      { type: 'tool_result', tool_use_id: 'tu_1', content: 'file content', is_error: false },
+    ])
+  })
+
+  it('user 消息 content blocks 中不认识的 block 被丢弃，text/image 不受影响', () => {
+    const blocks: ContentBlock[] = [
+      { type: 'raw_reasoning', data: { foo: 'bar' } },
+      { type: 'text', text: 'look at this' },
+      {
+        type: 'image',
+        source: { type: 'base64', media_type: 'image/png', data: 'abc123' },
+      },
+    ]
+    const result = normalizeMessagesForAnthropic([createUserMessage(blocks)])
+
+    expect(result[0].content).toEqual([
+      { type: 'text', text: 'look at this' },
+      {
+        type: 'image',
+        source: { type: 'base64', media_type: 'image/png', data: 'abc123' },
+      },
+    ])
+  })
+
+  it('正常 assistant 消息（text + tool_use）序列化结果不变', () => {
+    const msg = createAssistantMessage(
+      [
+        { type: 'text', text: 'Let me help.' },
+        { type: 'tool_use', id: 'tu_1', name: 'search', input: { q: 'test' } },
+      ],
+      'tool_use',
+    )
+    const result = normalizeMessagesForAnthropic([msg])
+
+    expect(result[0].content).toEqual([
+      { type: 'text', text: 'Let me help.' },
+      { type: 'tool_use', id: 'tu_1', name: 'search', input: { q: 'test' } },
+    ])
+  })
+})

--- a/crabot-agent/tests/engine/byte-cap.test.ts
+++ b/crabot-agent/tests/engine/byte-cap.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { byteLength, truncateUtf8, capWithMarker } from '../../src/engine/byte-cap'
+import { byteLength, truncateUtf8, truncateUtf8Tail, capWithMarker } from '../../src/engine/byte-cap'
 
 describe('byte-cap', () => {
   describe('byteLength', () => {
@@ -37,6 +37,43 @@ describe('byte-cap', () => {
       // cap to 3 → keep 'a' only (next char would push to 5 bytes)
       const out = truncateUtf8(s, 3)
       expect(out).toBe('a')
+    })
+  })
+
+  describe('truncateUtf8Tail', () => {
+    it('returns original when under cap', () => {
+      expect(truncateUtf8Tail('hello', 100)).toBe('hello')
+    })
+
+    it('keeps the tail, drops the head (ASCII)', () => {
+      expect(truncateUtf8Tail('abcdef', 3)).toBe('def')
+    })
+
+    it('does not split multi-byte char at the cut point (Chinese)', () => {
+      // '你好' = 6 bytes；cap 4 → 从尾部取 ≤4 字节 → 只能保留 '好'（3 字节）
+      const out = truncateUtf8Tail('你好', 4)
+      expect(out).toBe('好')
+      expect(byteLength(out)).toBeLessThanOrEqual(4)
+      expect(out).not.toContain('�')
+    })
+
+    it('handles 4-byte emoji at the cut point without lone surrogates', () => {
+      const s = 'ab😀cd' // 1+1+4+1+1 = 8 bytes
+      const out = truncateUtf8Tail(s, 6)
+      // 尾部 6 字节处恰落在 😀 中间 → 整个 😀 被跳过，保留 'cd'... 实际：skip=2，
+      // 逐 code point 跳过 'a'(1) 'b'(1) 后 bytes=2 ≥ skip → 从 '😀cd' 开始保留（6 字节）
+      expect(out).toBe('😀cd')
+      expect(byteLength(out)).toBeLessThanOrEqual(6)
+      // cap 5 → skip=3，需再跳过 '😀'(4) → 保留 'cd'
+      expect(truncateUtf8Tail(s, 5)).toBe('cd')
+    })
+
+    it('large CJK payload: kept tail is always ≤ cap', () => {
+      const s = '中'.repeat(20000) // 60000 bytes
+      const out = truncateUtf8Tail(s, 50000)
+      expect(byteLength(out)).toBeLessThanOrEqual(50000)
+      expect(out.endsWith('中')).toBe(true)
+      expect(out).not.toContain('�')
     })
   })
 

--- a/crabot-agent/tests/engine/context-manager.test.ts
+++ b/crabot-agent/tests/engine/context-manager.test.ts
@@ -166,6 +166,85 @@ describe('ContextManager', () => {
 
       expect(cm.shouldCompact(messages)).toBe(true)
     })
+
+    // spec 2026-07-21 改动 3：真实 usage 触发
+    it('should trigger on lastObservedContextTokens even when message estimate is small', () => {
+      const cm = new ContextManager({ maxContextTokens: 1000, compactThreshold: 0.8 })
+      // 消息本身估算远低于阈值，但上一轮 usage 观测已达 900 >= 800
+      const messages = makeTextMessages(2, 20)
+
+      expect(cm.shouldCompact(messages, {
+        lastObservedContextTokens: 900,
+        messageCountAtObservation: 2,
+      })).toBe(true)
+    })
+
+    it('should not trigger when lastObservedContextTokens is under threshold', () => {
+      const cm = new ContextManager({ maxContextTokens: 1000, compactThreshold: 0.8 })
+      const messages = makeTextMessages(2, 20)
+
+      expect(cm.shouldCompact(messages, {
+        lastObservedContextTokens: 500,
+        messageCountAtObservation: 2,
+      })).toBe(false)
+    })
+
+    it('should add estimated delta of messages appended after the observation', () => {
+      const cm = new ContextManager({ maxContextTokens: 1000, compactThreshold: 0.8 })
+      // 观测时 2 条消息（700 tokens），其后新增 2 条大消息：
+      // 每条 400 chars / 4 + 4 = 104，delta=208，700+208=908 >= 800 → 触发
+      const messages = makeTextMessages(4, 400)
+
+      expect(cm.shouldCompact(messages, {
+        lastObservedContextTokens: 700,
+        messageCountAtObservation: 2,
+      })).toBe(true)
+
+      // 同一观测值但只算前 2 条（无新增消息）→ 不触发
+      expect(cm.shouldCompact(messages.slice(0, 2), {
+        lastObservedContextTokens: 700,
+        messageCountAtObservation: 2,
+      })).toBe(false)
+    })
+
+    it('should fall back to estimation when observation is stale (messages shrunk)', () => {
+      const cm = new ContextManager({ maxContextTokens: 1000, compactThreshold: 0.8 })
+      // messageCountAtObservation > messages.length（compaction 后消息数回缩）→ 观测失效
+      const messages = makeTextMessages(2, 20)
+
+      expect(cm.shouldCompact(messages, {
+        lastObservedContextTokens: 900,
+        messageCountAtObservation: 10,
+      })).toBe(false)
+    })
+
+    // spec 2026-07-21 改动 3：usage 缺失时估算计入 system prompt + tools schema
+    it('should count system prompt length in the estimation fallback', () => {
+      const cm = new ContextManager({ maxContextTokens: 1000, compactThreshold: 0.8 })
+      const messages = makeTextMessages(2, 20)
+      // 4000 chars / 4 = 1000 tokens >= 800 → 触发
+      const systemPrompt = 's'.repeat(4000)
+
+      expect(cm.shouldCompact(messages, { systemPrompt })).toBe(true)
+      // 不传 systemPrompt → 纯消息估算远低于阈值
+      expect(cm.shouldCompact(messages)).toBe(false)
+    })
+
+    it('should count tools schema in the estimation fallback', () => {
+      const cm = new ContextManager({ maxContextTokens: 1000, compactThreshold: 0.8 })
+      const messages = makeTextMessages(2, 20)
+      const tools = [
+        {
+          name: 'big_tool',
+          description: 'd'.repeat(3200),
+          inputSchema: { type: 'object', properties: {} },
+          isReadOnly: false,
+        },
+      ]
+      // description 3200 chars / 4 ≈ 800 tokens >= 800 → 触发
+      expect(cm.shouldCompact(messages, { tools })).toBe(true)
+      expect(cm.shouldCompact(messages)).toBe(false)
+    })
   })
 
   describe('compactMessages', () => {

--- a/crabot-agent/tests/engine/query-loop.test.ts
+++ b/crabot-agent/tests/engine/query-loop.test.ts
@@ -1124,3 +1124,180 @@ describe('runEngine onAfterCompaction hook', () => {
     expect(typeof opts.onAfterCompaction).toBe('function')
   })
 })
+
+// spec 2026-07-21 改动 3：compaction 真实 usage 触发
+describe('runEngine compaction triggered by real usage', () => {
+  const readTool = defineTool({
+    name: 'Read',
+    description: 'Read a file',
+    inputSchema: { type: 'object', properties: { path: { type: 'string' } } },
+    isReadOnly: true,
+    call: async () => ({ output: 'file content', isError: false }),
+  })
+
+  function toolUseResponseWithUsage(
+    usage: { inputTokens: number; outputTokens: number; cacheReadTokens?: number; cacheCreationTokens?: number },
+  ): ReadonlyArray<StreamChunk> {
+    return [
+      { type: 'message_start', messageId: 'msg-1' },
+      { type: 'tool_use_start', id: 'tu-1', name: 'Read' },
+      { type: 'tool_use_delta', id: 'tu-1', inputJson: JSON.stringify({ path: '/tmp/a' }) },
+      { type: 'tool_use_end', id: 'tu-1' },
+      { type: 'message_end', stopReason: 'tool_use', usage },
+    ]
+  }
+
+  function textResponseNoUsage(text: string): ReadonlyArray<StreamChunk> {
+    return [
+      { type: 'message_start', messageId: 'msg-1' },
+      { type: 'text_delta', text },
+      { type: 'message_end', stopReason: 'end_turn' },
+    ]
+  }
+
+  // 构造 5 轮 tool_use 历史（消息数 11 > keepRecentMessages=6，compaction 会真正执行），
+  // 前 4 轮小 usage、第 5 轮带指定 usage；之后接 compaction 摘要响应 + 主轮 end_turn 响应。
+  function historyThenDone(
+    lastUsage: { inputTokens: number; outputTokens: number; cacheReadTokens?: number; cacheCreationTokens?: number },
+  ): ReadonlyArray<ReadonlyArray<StreamChunk>> {
+    const small = { inputTokens: 10, outputTokens: 10 }
+    return [
+      toolUseResponseWithUsage(small),
+      toolUseResponseWithUsage(small),
+      toolUseResponseWithUsage(small),
+      toolUseResponseWithUsage(small),
+      toolUseResponseWithUsage(lastUsage),
+      textResponse('对话摘要'),  // compaction 摘要 LLM 调用
+      textResponse('done'),      // 主轮 6
+    ]
+  }
+
+  it('triggers compaction when observed prompt tokens exceed threshold', async () => {
+    // contextWindowTokens=100 → 阈值 80。第 5 轮 usage 观测 90 >= 80 → 第 6 轮前触发压缩。
+    const adapter = mockAdapter(historyThenDone({ inputTokens: 90, outputTokens: 10 }))
+    const onCompactionStart = vi.fn()
+    const result = await runEngine({
+      prompt: 'hi',
+      adapter,
+      options: baseOptions({
+        tools: [readTool],
+        contextWindowTokens: 100,
+        onCompactionStart,
+      }),
+    })
+
+    expect(onCompactionStart).toHaveBeenCalledTimes(1)
+    expect(result.outcome).toBe('completed')
+    expect(result.finalText).toBe('done')
+    // compaction 后 messages 被改写：首条钉住 + 摘要 + recent
+    expect(
+      result.finalMessages.some(
+        (m) => m.role === 'user' && typeof m.content === 'string' && m.content.includes('[Earlier conversation summary]'),
+      ),
+    ).toBe(true)
+  })
+
+  it('counts cacheReadTokens and cacheCreationTokens into the observed prompt size', async () => {
+    // inputTokens=10 本身远低于阈值 80，但 10+60+20=90 >= 80 → 触发
+    const adapter = mockAdapter(historyThenDone({ inputTokens: 10, outputTokens: 10, cacheReadTokens: 60, cacheCreationTokens: 20 }))
+    const onCompactionStart = vi.fn()
+    const result = await runEngine({
+      prompt: 'hi',
+      adapter,
+      options: baseOptions({
+        tools: [readTool],
+        contextWindowTokens: 100,
+        onCompactionStart,
+      }),
+    })
+
+    expect(onCompactionStart).toHaveBeenCalledTimes(1)
+    expect(result.outcome).toBe('completed')
+    expect(result.finalText).toBe('done')
+  })
+
+  it('does not trigger compaction when observed tokens stay under threshold', async () => {
+    const adapter = mockAdapter([
+      toolUseResponseWithUsage({ inputTokens: 10, outputTokens: 10 }),
+      textResponse('done'),
+    ])
+    const onCompactionStart = vi.fn()
+    const result = await runEngine({
+      prompt: 'hi',
+      adapter,
+      options: baseOptions({
+        tools: [readTool],
+        contextWindowTokens: 100,
+        onCompactionStart,
+      }),
+    })
+
+    expect(onCompactionStart).not.toHaveBeenCalled()
+    expect(result.outcome).toBe('completed')
+    expect(result.finalText).toBe('done')
+  })
+
+  it('falls back to estimation including system prompt when usage is missing', async () => {
+    // usage 缺失 → 估算路径。systemPrompt 400 chars / 4 = 100 >= 阈值 80 → 首轮前就触发压缩。
+    // 消息数 1 <= keepRecentMessages，compaction 提前返回、不调摘要 LLM，
+    // 所以 adapter 第一个响应就是主轮响应。
+    const adapter = mockAdapter([textResponseNoUsage('done')])
+    const onCompactionStart = vi.fn()
+    const result = await runEngine({
+      prompt: 'hi',
+      adapter,
+      options: baseOptions({
+        systemPrompt: 's'.repeat(400),
+        contextWindowTokens: 100,
+        onCompactionStart,
+      }),
+    })
+
+    expect(onCompactionStart).toHaveBeenCalledTimes(1)
+    expect(result.outcome).toBe('completed')
+    expect(result.finalText).toBe('done')
+  })
+
+  it('falls back to estimation including tools schema when usage is missing', async () => {
+    // 工具 description 320 chars / 4 = 80 >= 阈值 80 → 触发（旧实现不计 tools，不会触发）
+    const bigTool = defineTool({
+      name: 'BigTool',
+      description: 'd'.repeat(320),
+      inputSchema: { type: 'object', properties: {} },
+      isReadOnly: true,
+      call: async () => ({ output: 'ok', isError: false }),
+    })
+    const adapter = mockAdapter([textResponseNoUsage('done')])
+    const onCompactionStart = vi.fn()
+    const result = await runEngine({
+      prompt: 'hi',
+      adapter,
+      options: baseOptions({
+        tools: [bigTool],
+        contextWindowTokens: 100,
+        onCompactionStart,
+      }),
+    })
+
+    expect(onCompactionStart).toHaveBeenCalledTimes(1)
+    expect(result.outcome).toBe('completed')
+    expect(result.finalText).toBe('done')
+  })
+
+  it('does not trigger estimation fallback when system prompt and tools are small', async () => {
+    const adapter = mockAdapter([textResponseNoUsage('done')])
+    const onCompactionStart = vi.fn()
+    const result = await runEngine({
+      prompt: 'hi',
+      adapter,
+      options: baseOptions({
+        tools: [readTool],
+        contextWindowTokens: 100,
+        onCompactionStart,
+      }),
+    })
+
+    expect(onCompactionStart).not.toHaveBeenCalled()
+    expect(result.outcome).toBe('completed')
+  })
+})

--- a/crabot-agent/tests/engine/sub-agent.test.ts
+++ b/crabot-agent/tests/engine/sub-agent.test.ts
@@ -169,4 +169,42 @@ describe('forkEngine', () => {
 
     runEngineSpy.mockRestore()
   })
+
+  it('passes contextWindowTokens to engine options when provided', async () => {
+    const runEngineSpy = vi.spyOn(
+      await import('../../src/engine/query-loop'),
+      'runEngine'
+    )
+    runEngineSpy.mockResolvedValue({
+      outcome: 'completed',
+      finalText: 'done',
+      totalTurns: 1,
+      usage: { inputTokens: 10, outputTokens: 5 },
+    })
+
+    const adapter = mockAdapter([])
+
+    // 传了 context_window → 透传到 engine options
+    await forkEngine({
+      prompt: 'Hi',
+      adapter,
+      model: 'test-model',
+      systemPrompt: 'You are a sub-agent.',
+      tools: [],
+      contextWindowTokens: 131072,
+    })
+    expect(runEngineSpy.mock.calls[0][0].options.contextWindowTokens).toBe(131072)
+
+    // 未传 → options 不带该字段（engine 走 200000 内置回退）
+    await forkEngine({
+      prompt: 'Hi',
+      adapter,
+      model: 'test-model',
+      systemPrompt: 'You are a sub-agent.',
+      tools: [],
+    })
+    expect(runEngineSpy.mock.calls[1][0].options.contextWindowTokens).toBeUndefined()
+
+    runEngineSpy.mockRestore()
+  })
 })

--- a/crabot-agent/tests/engine/tool-orchestration.test.ts
+++ b/crabot-agent/tests/engine/tool-orchestration.test.ts
@@ -183,7 +183,7 @@ describe('executeToolBatches', () => {
     expect(results[0].content).toContain('Tool not found: nonexistent_tool')
   })
 
-  it('caps oversized tool output at 256KB to protect LLM context', async () => {
+  it('caps oversized tool output at 100KB to protect LLM context', async () => {
     // 模拟一个忘记自截断的工具（如 MCP server 直接返回大文件）
     const hugeOutputTool = defineTool({
       name: 'huge_output',
@@ -200,9 +200,11 @@ describe('executeToolBatches', () => {
 
     expect(results).toHaveLength(1)
     // stamp 加了时间戳头部，留余量
-    expect(Buffer.byteLength(results[0].content, 'utf8')).toBeLessThan(258_000)
+    expect(Buffer.byteLength(results[0].content, 'utf8')).toBeLessThan(102_000)
     expect(results[0].content).toContain('orchestration: tool output truncated')
     expect(results[0].content).toContain('1000000 bytes') // 原始字节数
+    // 截断标记提示用分页参数收窄
+    expect(results[0].content).toContain('分页参数')
   })
 
   it('does not modify normal-sized tool output', async () => {

--- a/crabot-agent/tests/engine/tools/bash-tool-write-failure.test.ts
+++ b/crabot-agent/tests/engine/tools/bash-tool-write-failure.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Bash 截断落盘失败回退测试（spec 2026-07-21-agent-token-efficiency-design §7 点名）：
+ * tmp/tool-outputs/ 写盘失败（磁盘满/权限）时回退为纯截断返回——
+ * 无路径 hint、不抛错、不阻断工具执行。
+ *
+ * 独立文件：vi.mock('fs/promises') 是文件级 hoist，不能放进 bash-tool.test.ts
+ * （会打断该文件其他用例的真实落盘断言）。仅拦截 tool-outputs 路径的 writeFile，
+ * 其余 fs 调用走真实实现。
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as os from 'os'
+import * as fs from 'fs'
+import * as path from 'path'
+
+vi.mock('fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs/promises')>()
+  return {
+    ...actual,
+    writeFile: vi.fn(async (file: unknown, ...rest: unknown[]) => {
+      if (String(file).includes(`${path.sep}tool-outputs${path.sep}`)) {
+        throw new Error('ENOSPC: no space left on device')
+      }
+      return (actual.writeFile as (...args: unknown[]) => Promise<unknown>)(file, ...rest)
+    }),
+  }
+})
+
+import { createBashTool } from '../../../src/engine/tools/bash-tool'
+import type { ToolCallContext } from '../../../src/engine/types'
+
+describe('createBashTool — 截断落盘失败回退', () => {
+  let tmpDataDir: string
+  const cwd = os.tmpdir()
+
+  beforeEach(() => {
+    tmpDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bash-writefail-test-'))
+    process.env.CRABOT_AGENT_DATA_DIR = tmpDataDir
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmpDataDir, { recursive: true, force: true })
+    delete process.env.CRABOT_AGENT_DATA_DIR
+  })
+
+  it('落盘失败：返回纯截断文本，无 Full output 路径 hint，不抛错', async () => {
+    const tool = createBashTool(() => cwd)
+    const result = await tool.call(
+      { command: `printf 'x%.0s' {1..60000}; echo; echo TAIL_MARKER` },
+      {} as ToolCallContext,
+    )
+    // 不抛错、不作为 tool error
+    expect(result.isError).toBe(false)
+    // 纯截断：尾部保留 + 截断标记，但无落盘路径
+    expect(result.output).toContain('TAIL_MARKER')
+    expect(result.output).toContain('[Showing last')
+    expect(result.output).toContain('bytes of')
+    expect(result.output).not.toContain('Full output:')
+  })
+})

--- a/crabot-agent/tests/engine/tools/bash-tool.test.ts
+++ b/crabot-agent/tests/engine/tools/bash-tool.test.ts
@@ -73,17 +73,6 @@ describe('createBashTool', () => {
     expect(result.output).toMatch(/Command execution failed|ENOENT/)
   })
 
-  it('truncates large output', async () => {
-    // Generate output > 100000 chars
-    const result = await tool.call(
-      { command: 'python3 -c "print(\'x\' * 120000)"' },
-      {},
-    )
-    expect(result.isError).toBe(false)
-    expect(result.output).toContain('[...truncated...]')
-    expect(result.output.length).toBeLessThanOrEqual(100000 + 100) // some margin for the truncation marker
-  })
-
   it('respects abort signal', async () => {
     const controller = new AbortController()
     // Abort immediately
@@ -92,6 +81,77 @@ describe('createBashTool', () => {
     const context: ToolCallContext = { abortSignal: controller.signal }
     const result = await tool.call({ command: 'sleep 10' }, context)
     expect(result.isError).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 输出截断：>50K 保留尾部 + 完整 stdout/stderr 落盘 tmp/tool-outputs/，
+// 返回文本附全文路径；≤50K 行为不变、不落盘。
+// ---------------------------------------------------------------------------
+
+describe('createBashTool — 输出截断与全文落盘', () => {
+  let tmpDataDir: string
+  let tool: ReturnType<typeof createBashTool>
+  const cwd = os.tmpdir()
+
+  beforeEach(() => {
+    tmpDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bash-trunc-test-'))
+    // 落盘目录从 CRABOT_AGENT_DATA_DIR 推导（优先级高于 DATA_DIR）
+    process.env.CRABOT_AGENT_DATA_DIR = tmpDataDir
+    tool = createBashTool(() => cwd)
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmpDataDir, { recursive: true, force: true })
+    delete process.env.CRABOT_AGENT_DATA_DIR
+  })
+
+  it('>50K 输出：保留尾部，全文落盘且路径出现在返回文本中', async () => {
+    const result = await tool.call(
+      { command: `echo HEAD_MARKER; printf 'x%.0s' {1..60000}; echo; echo TAIL_MARKER` },
+      {} as ToolCallContext,
+    )
+    expect(result.isError).toBe(false)
+    // 尾部保留：结尾的标记在，开头的标记被截掉
+    expect(result.output).toContain('TAIL_MARKER')
+    expect(result.output).not.toContain('HEAD_MARKER')
+    expect(result.output).toContain('[Showing last')
+    expect(result.output).toContain('bytes of')
+
+    // 返回文本带全文路径，落盘文件包含被截掉的头部
+    const match = result.output.match(/Full output: ([^\]]+)\]/)
+    expect(match).not.toBeNull()
+    const fullPath = match![1]
+    expect(fullPath.startsWith(path.join(tmpDataDir, 'tmp', 'tool-outputs'))).toBe(true)
+    const full = fs.readFileSync(fullPath, 'utf8')
+    expect(full).toContain('HEAD_MARKER')
+    expect(full).toContain('TAIL_MARKER')
+  })
+
+  it('CJK 多字节输出：按字节截断（不切字符），自截产物恒 < 编排层 100KB 兜底', async () => {
+    // 20000 个"中" = 60000 字节 > 50000 字节阈值；按字符口径会保留 ~150KB 字节
+    const result = await tool.call(
+      { command: `printf '中%.0s' {1..20000}; echo; echo CJK_TAIL` },
+      {} as ToolCallContext,
+    )
+    expect(result.isError).toBe(false)
+    expect(result.output).toContain('CJK_TAIL')
+    expect(result.output).toContain('[Showing last')
+    // 尾部 hint 带落盘路径，且就在返回文本末尾（不会被编排层二次截断切掉）
+    expect(result.output).toMatch(/Full output: [^\]]+\]\s*$/)
+    // 不出现 UTF-8 截断产生的替换字符
+    expect(result.output).not.toContain('�')
+    // 关键不变量：自截产物字节数 < 编排层 100KB 兜底阈值
+    expect(Buffer.byteLength(result.output, 'utf8')).toBeLessThan(100 * 1024)
+  })
+
+  it('≤50K 输出：行为不变，不落盘', async () => {
+    const result = await tool.call({ command: 'echo small-output' }, {} as ToolCallContext)
+    expect(result.isError).toBe(false)
+    expect(result.output).toContain('small-output')
+    expect(result.output).not.toContain('Full output:')
+    expect(result.output).not.toContain('Showing last')
+    expect(fs.existsSync(path.join(tmpDataDir, 'tmp', 'tool-outputs'))).toBe(false)
   })
 })
 

--- a/crabot-agent/tests/engine/tools/bash-tool.test.ts
+++ b/crabot-agent/tests/engine/tools/bash-tool.test.ts
@@ -145,6 +145,22 @@ describe('createBashTool — 输出截断与全文落盘', () => {
     expect(Buffer.byteLength(result.output, 'utf8')).toBeLessThan(100 * 1024)
   })
 
+  it('>50K 失败输出：exit_code 状态头不被尾部截断切掉', async () => {
+    // 非零退出 + 超 50KB 输出：exit_code 是模型判断成败的唯一信号（isError 为 false）
+    const result = await tool.call(
+      { command: `printf 'x%.0s' {1..60000}; echo; echo TAIL_MARKER; exit 3` },
+      {} as ToolCallContext,
+    )
+    expect(result.isError).toBe(false)
+    expect(result.output).toContain('[Showing last')
+    // 状态头必须在截断范围之外
+    expect(result.output.startsWith('exit_code: 3\n')).toBe(true)
+    // 落盘全文也带状态头
+    const match = result.output.match(/Full output: ([^\]]+)\]/)
+    const full = fs.readFileSync(match![1], 'utf8')
+    expect(full.startsWith('exit_code: 3\n')).toBe(true)
+  })
+
   it('≤50K 输出：行为不变，不落盘', async () => {
     const result = await tool.call({ command: 'echo small-output' }, {} as ToolCallContext)
     expect(result.isError).toBe(false)

--- a/crabot-agent/tests/engine/tools/config.test.ts
+++ b/crabot-agent/tests/engine/tools/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { getConfiguredBuiltinTools } from '../../../src/engine/tools/index'
+import { getConfiguredBuiltinTools, filterMcpToolsByConfig } from '../../../src/engine/tools/index'
 import type { BuiltinToolConfig } from '../../../src/types'
 
 const CWD = '/tmp/test-config-cwd'
@@ -114,5 +114,47 @@ describe('getConfiguredBuiltinTools', () => {
     expect(tools).toHaveLength(3)
     const grepTool = tools.find((t) => t.name === 'Grep')
     expect(grepTool?.permissionLevel).toBe('dangerous')
+  })
+})
+
+describe('filterMcpToolsByConfig', () => {
+  function fakeTool(name: string) {
+    return { name } as never
+  }
+  const mixed = [
+    fakeTool('Bash'),
+    // 注意：示例不要用 store_memory 的 mcp 全名字面量——crabot-admin v1-cleanup 静态守卫禁止它出现在代码中
+    fakeTool('mcp__crab-memory__search_memory'),
+    fakeTool('mcp__crab-memory__run_maintenance'),
+    fakeTool('mcp__crab-messaging__send_message'),
+  ]
+
+  it('disabled_tools 按 mcp__<server>__<tool> 全名过滤 MCP 桥接工具', () => {
+    const filtered = filterMcpToolsByConfig(mixed, {
+      disabled_tools: ['mcp__crab-memory__run_maintenance'],
+    })
+    const names = filtered.map((t) => t.name)
+    expect(names).not.toContain('mcp__crab-memory__run_maintenance')
+    expect(names).toContain('mcp__crab-memory__search_memory')
+    expect(names).toContain('mcp__crab-messaging__send_message')
+    expect(names).toContain('Bash')
+  })
+
+  it('disabled_tools 只写工具短名时不误伤 MCP 工具（必须全名匹配）', () => {
+    const filtered = filterMcpToolsByConfig(mixed, { disabled_tools: ['run_maintenance'] })
+    expect(filtered.map((t) => t.name)).toContain('mcp__crab-memory__run_maintenance')
+  })
+
+  it('无 config / 无 disabled_tools 时全量保留（默认配置零行为变化）', () => {
+    expect(filterMcpToolsByConfig(mixed, undefined)).toHaveLength(4)
+    expect(filterMcpToolsByConfig(mixed, {})).toHaveLength(4)
+    expect(filterMcpToolsByConfig(mixed, { disabled_tools: [] })).toHaveLength(4)
+  })
+
+  it('enabled_tools 白名单不影响 MCP 工具（白名单语义只作用于内置工具）', () => {
+    const filtered = filterMcpToolsByConfig(mixed, { enabled_tools: ['Bash'] })
+    const names = filtered.map((t) => t.name)
+    expect(names).toContain('mcp__crab-memory__search_memory')
+    expect(names).toContain('mcp__crab-messaging__send_message')
   })
 })

--- a/crabot-agent/tests/engine/tools/read-tool.test.ts
+++ b/crabot-agent/tests/engine/tools/read-tool.test.ts
@@ -147,6 +147,35 @@ describe('createReadTool', () => {
     expect(result.output).not.toContain('[...truncated')
   })
 
+  it('单行超 50KB 时降级为行内截断（不返回空内容，可 bash 续读）', async () => {
+    const filePath = path.join(tmpDir, 'minified.js')
+    const bigLine = 'a'.repeat(60 * 1024) // 单行 60KB，超 MAX_OUTPUT_BYTES
+    await fs.writeFile(filePath, bigLine + '\n' + 'second line\n')
+
+    const result = await tool.call({ file_path: filePath }, {})
+    expect(result.isError).toBe(false)
+    // 行内容真的返回了前 ~50KB，而不是空
+    expect(result.output).toContain(`1\t${'a'.repeat(100)}`)
+    expect(result.output).toContain('[...line truncated')
+    expect(result.output).toContain('60-byte line'.replace('60', String(60 * 1024)))
+    // 行内续读提示指向正确的行号和文件
+    expect(result.output).toContain(`sed -n '1p' '${filePath}'`)
+  })
+
+  it('流式路径下单行超 50KB 同样降级为行内截断', async () => {
+    const filePath = path.join(tmpDir, 'huge-longline.log')
+    // 首行 60KB + 13MB filler（走流式路径），第一行就超单次上限
+    const bigLine = 'b'.repeat(60 * 1024)
+    const filler = Array.from({ length: 150000 }, (_, i) => `row-${i}-${'z'.repeat(80)}`)
+    await fs.writeFile(filePath, [bigLine, ...filler].join('\n') + '\n')
+
+    const result = await tool.call({ file_path: filePath, limit: 10 }, {})
+    expect(result.isError).toBe(false)
+    expect(result.output).toContain('b'.repeat(100))
+    expect(result.output).toContain('[...line truncated')
+    expect(result.output).toContain(`sed -n '1p' '${filePath}'`)
+  })
+
   it('streams >10MB files line-by-line and can reach the tail via offset', async () => {
     const filePath = path.join(tmpDir, 'huge.txt')
     // 150000 行 × ~90B ≈ 13MB，走流式按行定位路径

--- a/crabot-agent/tests/engine/tools/read-tool.test.ts
+++ b/crabot-agent/tests/engine/tools/read-tool.test.ts
@@ -52,6 +52,32 @@ describe('createReadTool', () => {
     expect(result.output).not.toContain('6\tline 6')
   })
 
+  it('负数 offset 归一化为 0（与流式路径行为一致，不再从尾部数）', async () => {
+    const filePath = path.join(tmpDir, 'neg-offset.txt')
+    const lines = Array.from({ length: 10 }, (_, i) => `line ${i + 1}`)
+    await fs.writeFile(filePath, lines.join('\n'))
+
+    const result = await tool.call({ file_path: filePath, offset: -3, limit: 2 }, {})
+    expect(result.isError).toBe(false)
+    // 归一化为 offset=0 → 从第 1 行开始，而非 slice(-3) 的尾部 3 行
+    expect(result.output).toContain('1\tline 1')
+    expect(result.output).toContain('2\tline 2')
+    expect(result.output).not.toContain('line 10')
+  })
+
+  it('小数 offset 归一化为向下取整的整数', async () => {
+    const filePath = path.join(tmpDir, 'frac-offset.txt')
+    const lines = Array.from({ length: 10 }, (_, i) => `line ${i + 1}`)
+    await fs.writeFile(filePath, lines.join('\n'))
+
+    const result = await tool.call({ file_path: filePath, offset: 3.7, limit: 2 }, {})
+    expect(result.isError).toBe(false)
+    // floor(3.7)=3 → 从第 4 行开始（流式与非流式路径一致）
+    expect(result.output).toContain('4\tline 4')
+    expect(result.output).toContain('5\tline 5')
+    expect(result.output).not.toContain('3\tline 3')
+  })
+
   it('returns error for non-existent file', async () => {
     const filePath = path.join(tmpDir, 'does-not-exist.txt')
     const result = await tool.call({ file_path: filePath }, {})
@@ -90,7 +116,7 @@ describe('createReadTool', () => {
     expect(result.output).toContain('1\tcontent here')
   })
 
-  it('truncates files larger than 500KB', async () => {
+  it('caps a single response at 50KB for large files', async () => {
     const filePath = path.join(tmpDir, 'large.txt')
     // Create a file slightly over 500KB
     const lineContent = 'x'.repeat(100) + '\n'
@@ -100,7 +126,43 @@ describe('createReadTool', () => {
 
     const result = await tool.call({ file_path: filePath }, {})
     expect(result.isError).toBe(false)
+    // 单次返回字节上限 50KB（截断标记除外，留余量）
+    expect(Buffer.byteLength(result.output, 'utf8')).toBeLessThanOrEqual(50 * 1024 + 200)
+    // 截断提示引导 offset 续读
     expect(result.output).toContain('[...truncated')
+    expect(result.output).toContain('offset')
+  })
+
+  it('reads the tail of a >500KB file via offset (no more 500KB hard cap)', async () => {
+    const filePath = path.join(tmpDir, 'paged.txt')
+    // 8000 行 × ~90B ≈ 700KB，超过旧的 500KB 硬上限
+    const lines = Array.from({ length: 8000 }, (_, i) => `line-${i + 1}-${'y'.repeat(80)}`)
+    await fs.writeFile(filePath, lines.join('\n') + '\n')
+
+    const result = await tool.call({ file_path: filePath, offset: 7900, limit: 100 }, {})
+    expect(result.isError).toBe(false)
+    expect(result.output).toContain('8000\tline-8000-')
+    expect(result.output).toContain('7901\tline-7901-')
+    // 尾部完整读到了，不是截断视图
+    expect(result.output).not.toContain('[...truncated')
+  })
+
+  it('streams >10MB files line-by-line and can reach the tail via offset', async () => {
+    const filePath = path.join(tmpDir, 'huge.txt')
+    // 150000 行 × ~90B ≈ 13MB，走流式按行定位路径
+    const lines = Array.from({ length: 150000 }, (_, i) => `row-${i + 1}-${'z'.repeat(80)}`)
+    await fs.writeFile(filePath, lines.join('\n') + '\n')
+
+    const tail = await tool.call({ file_path: filePath, offset: 149900, limit: 100 }, {})
+    expect(tail.isError).toBe(false)
+    expect(tail.output).toContain('150000\trow-150000-')
+    expect(tail.output).not.toContain('[...truncated')
+
+    // 从头读同样受 50KB 单次上限约束
+    const head = await tool.call({ file_path: filePath }, {})
+    expect(head.isError).toBe(false)
+    expect(Buffer.byteLength(head.output, 'utf8')).toBeLessThanOrEqual(50 * 1024 + 200)
+    expect(head.output).toContain('[...truncated')
   })
 
   it('returns image data for image files', async () => {
@@ -210,5 +272,21 @@ describe('createReadTool — read dedup', () => {
     expect(r1.output).toContain('1\thello')
     expect(r2.output).toContain('1\thello')
     expect(r2.output).not.toBe(FILE_UNCHANGED_STUB)
+  })
+
+  it('byte-capped (partial) reads never stub and do not poison the cache', async () => {
+    const filePath = path.join(tmpDir, 'big.txt')
+    // ~264KB，默认 limit 下超 50KB 单次上限 → 部分视图
+    const lines = Array.from({ length: 3000 }, (_, i) => `row-${i + 1}-${'q'.repeat(80)}`)
+    await fs.writeFile(filePath, lines.join('\n') + '\n')
+
+    const first = await tool.call({ file_path: filePath }, {})
+    expect(first.output).toContain('[...truncated')
+
+    // 部分视图不进 dedup 缓存：第二次相同读取仍返回内容，不是 stub
+    const second = await tool.call({ file_path: filePath }, {})
+    expect(second.output).not.toBe(FILE_UNCHANGED_STUB)
+    expect(second.output).toContain('[...truncated')
+    expect(second.output).toContain('1\trow-1-')
   })
 })

--- a/crabot-agent/tests/mcp/crab-memory-tool-profile.test.ts
+++ b/crabot-agent/tests/mcp/crab-memory-tool-profile.test.ts
@@ -1,0 +1,161 @@
+/**
+ * crab-memory 工具分组 profile 测试。
+ *
+ * spec: 2026-07-21-agent-token-efficiency-design.md 改动 4（memory 工具按任务用途分组注册）
+ * - 普通对话任务 → 仅 A 组 6 个简化工具
+ * - daily_reflection / memory_curate / tags 含 memory_rebuild → 全量 18 个（含 B 组 12 个反思级 RPC 工具）
+ * - memory_maintenance 不经 Worker，不受影响
+ */
+import { describe, it, expect, vi } from 'vitest'
+import {
+  createCrabMemoryServer,
+  resolveMemoryToolProfile,
+  filterMemoryToolsByProfile,
+  CRAB_MEMORY_CONVERSATION_TOOLS,
+} from '../../src/mcp/crab-memory.js'
+import { mcpServerToToolDefinitions } from '../../src/agent/mcp-tool-bridge.js'
+import type { MemoryTaskContext } from '../../src/mcp/crab-memory.js'
+
+const GROUP_A = [
+  'store_memory',
+  'search_memory',
+  'get_memory_detail',
+  'set_scene_profile',
+  'get_scene_profile',
+  'delete_scene_profile',
+]
+
+const GROUP_B = [
+  'quick_capture',
+  'search_long_term',
+  'update_long_term',
+  'delete_memory',
+  'list_recent',
+  'list_entries',
+  'set_memory_links',
+  'run_maintenance',
+  'get_stats',
+  'get_evolution_mode',
+  'set_evolution_mode',
+  'promote_to_rule',
+]
+
+function makeMemoryTools(rpcCall = vi.fn().mockResolvedValue({})) {
+  const ctx: MemoryTaskContext = {
+    taskId: 'task_1',
+    visibility: 'public',
+    scopes: [],
+    isMasterPrivate: false,
+  }
+  const server = createCrabMemoryServer({
+    rpcClient: { call: rpcCall } as never,
+    moduleId: 'agent-test',
+    getMemoryPort: async () => 3002,
+  }, ctx)
+  return mcpServerToToolDefinitions(server, 'crab-memory')
+}
+
+describe('resolveMemoryToolProfile', () => {
+  it('daily_reflection → 全量 profile（不再要求 triggerType==scheduled）', () => {
+    expect(resolveMemoryToolProfile({ taskType: 'daily_reflection' }))
+      .toBe('daily_reflection')
+  })
+
+  it('memory_curate（每小时记忆整理）→ 全量 profile', () => {
+    // 整理 SKILL 依赖 list_entries / delete_memory / update_long_term 等 B 组工具
+    expect(resolveMemoryToolProfile({ taskType: 'memory_curate' }))
+      .toBe('daily_reflection')
+  })
+
+  it('tags 含 memory_rebuild 的 manual 任务 → 全量 profile', () => {
+    // 重建图谱任务 trigger_type=manual、无 task_type，靠 tags 识别
+    expect(resolveMemoryToolProfile({ tags: ['memory_rebuild'] }))
+      .toBe('daily_reflection')
+  })
+
+  it('tags 不含 memory_rebuild 的普通任务 → conversation profile', () => {
+    expect(resolveMemoryToolProfile({ taskType: 'user_request', tags: ['builtin'] }))
+      .toBe('conversation')
+  })
+
+  it('普通消息任务 → conversation profile', () => {
+    expect(resolveMemoryToolProfile({ taskType: 'user_request' }))
+      .toBe('conversation')
+  })
+
+  it('非反思/整理类任务（如 memory_maintenance）→ conversation profile', () => {
+    expect(resolveMemoryToolProfile({ taskType: 'memory_maintenance' }))
+      .toBe('conversation')
+  })
+
+  it('无任务上下文 → conversation profile', () => {
+    expect(resolveMemoryToolProfile(null)).toBe('conversation')
+  })
+})
+
+describe('filterMemoryToolsByProfile', () => {
+  it('server 全量注册 18 个工具', () => {
+    const tools = makeMemoryTools()
+    expect(tools).toHaveLength(18)
+    const names = tools.map((t) => t.name.replace('mcp__crab-memory__', ''))
+    for (const n of [...GROUP_A, ...GROUP_B]) {
+      expect(names).toContain(n)
+    }
+  })
+
+  it('conversation profile → 仅 A 组 6 个', () => {
+    const filtered = filterMemoryToolsByProfile(makeMemoryTools(), 'conversation')
+    expect(filtered).toHaveLength(6)
+    const names = filtered.map((t) => t.name)
+    for (const n of GROUP_A) {
+      expect(names).toContain(`mcp__crab-memory__${n}`)
+    }
+    for (const n of GROUP_B) {
+      expect(names).not.toContain(`mcp__crab-memory__${n}`)
+    }
+  })
+
+  it('daily_reflection profile → 全量 18 个', () => {
+    const filtered = filterMemoryToolsByProfile(makeMemoryTools(), 'daily_reflection')
+    expect(filtered).toHaveLength(18)
+  })
+
+  it('A 组常量与 conversation 过滤结果一致', () => {
+    const filtered = filterMemoryToolsByProfile(makeMemoryTools(), 'conversation')
+    const names = new Set(filtered.map((t) => t.name.replace('mcp__crab-memory__', '')))
+    expect(names).toEqual(CRAB_MEMORY_CONVERSATION_TOOLS)
+  })
+})
+
+describe('daily_reflection 任务中 B 组工具功能正常', () => {
+  it('quick_capture 透传 RPC', async () => {
+    const rpcCall = vi.fn().mockResolvedValue({ id: 'mem_1', status: 'inbox' })
+    const tools = filterMemoryToolsByProfile(makeMemoryTools(rpcCall), 'daily_reflection')
+    const tool = tools.find((t) => t.name === 'mcp__crab-memory__quick_capture')!
+    const result = await tool.call(
+      { type: 'lesson', brief: 'b', content: 'c' },
+      {} as never,
+    )
+    expect(result.isError).toBe(false)
+    expect(rpcCall).toHaveBeenCalledWith(
+      3002,
+      'quick_capture',
+      expect.objectContaining({ type: 'lesson', brief: 'b', content: 'c' }),
+      'agent-test',
+    )
+  })
+
+  it('run_maintenance 透传 RPC', async () => {
+    const rpcCall = vi.fn().mockResolvedValue({ ok: true })
+    const tools = filterMemoryToolsByProfile(makeMemoryTools(rpcCall), 'daily_reflection')
+    const tool = tools.find((t) => t.name === 'mcp__crab-memory__run_maintenance')!
+    const result = await tool.call({ scope: 'all' }, {} as never)
+    expect(result.isError).toBe(false)
+    expect(rpcCall).toHaveBeenCalledWith(
+      3002,
+      'run_maintenance',
+      expect.objectContaining({ scope: 'all' }),
+      'agent-test',
+    )
+  })
+})


### PR DESCRIPTION
## 背景

对比开源 Pi agent 后确认 crabot-agent 的五个 token 效率差距，按 spec 实施优化。

**Spec**: `crabot-docs/superpowers/specs/2026-07-21-agent-token-efficiency-design.md`（含 §10 实施偏离记录，crabot-docs 仓配套 PR）

## 改动

1. **Anthropic prompt caching**：adapter 注入 3 处 cache breakpoint（system 末块 / 末 tool / 末消息末块，5min ephemeral）；顺带清理空 text block / 空 content 消息
2. **工具输出截断可恢复**：bash 100K chars → 50K bytes 纯尾部 + 完整输出落盘 `tmp/tool-outputs/`（hint 给路径）；read 解除 500KB 后不可读限制（流式分页，单次 ≤50KB）；编排层兜底 256KB→100KB
3. **compaction 真实 usage 触发**：替代 chars/4 低估（原估算不含 system+tools）；`context_window` 从 admin `buildConnectionInfo` 全链路接入
4. **工具盘收敛**：delegate_task 的 when_to_use 截断 300 字符；memory 工具按任务用途分组（普通任务 A 组 6 个 / daily_reflection·memory_curate·memory_rebuild 全量 18 个，打通 start_task 的 tags/task_type 透传）；disabled_tools 扩展到 MCP 工具（含 subagent/audit 继承路径）
5. **冗余清理**：scene profile 去除 system prompt 侧重复注入

**Follow-up（kimi-coding preset）**：端点修正为 `https://api.kimi.com/coding`（实测接受 cache_control 且自带自动前缀缓存）；模型列表改走 `GET /v1/models` 接口（删除内置列表）；`parseOpenAIModels` 支持 `supports_image_in` 视觉映射

## 验证

- crabot-agent 全量 **1607/1608**（唯一失败为既有 `context-assembler` 时间漂移，HEAD 可复现，与本次无关）
- crabot-admin 相关测试全绿；两侧 `tsc --noEmit` 零错误
- kimi 端点实测：带 cache_control 无 400，第二次调用 100% cache_read
- 经 4 路 diff review 修复 6 个自审问题（含 memory_curate/重建图谱失去 B 组工具的高危问题）

## 部署注意

- 已部署实例的 Kimi Coding Plan provider 需手动改 endpoint 为 `https://api.kimi.com/coding`；`kimi-k2.7-code` 是可用别名但不在接口返回中，refresh 后需在 Admin UI 重新选择模型 slot