### PR TITLE
feat(admin): tmp-page 反代按需拉起 server，页面可用性归一到 expires_at

### DIFF
--- a/crabot-admin/src/core/data-paths.ts
+++ b/crabot-admin/src/core/data-paths.ts
@@ -20,3 +20,8 @@ export function getAdminDataDir(): string {
 export function getAdminLogsDir(): string {
   return path.resolve(getAdminDataDir(), '..', 'logs')
 }
+
+/** 顶层数据根目录（admin 数据目录的父级），与 agent 侧 getDataRootDir 语义一致。 */
+export function getDataRootDir(): string {
+  return path.resolve(getAdminDataDir(), '..')
+}

--- a/crabot-admin/src/index.ts
+++ b/crabot-admin/src/index.ts
@@ -192,7 +192,7 @@ import {
 import { ModuleInstaller } from './module-installer.js'
 import { ChatManager, buildChatTaskSnapshot } from './chat-manager.js'
 import { MediaStore } from './media-store.js'
-import { proxyTmpPage, resolveTmpPageBaseUrl, isManagePath } from './tmp-page-proxy.js'
+import { handleTmpPageRequest, resolveTmpPageBaseUrl } from './tmp-page-proxy.js'
 import {
   MCPServerManager,
   SkillManager,
@@ -245,7 +245,7 @@ import {
   formatMissingIdResponse,
 } from './goal-slash.js'
 import { readCredentials, verifyPassword, rotateCredentials, writeCredentials } from './credentials.js'
-import { getAdminLogsDir } from './core/data-paths.js'
+import { getAdminLogsDir, getDataRootDir } from './core/data-paths.js'
 
 // ============================================================================
 // JWT 工具函数
@@ -2344,19 +2344,17 @@ export class AdminModule extends ModuleBase {
         return
       }
 
-      // 临时交互页面反代（/tmp-pages/*）：纯透明转发到 agent 起的 server，不鉴权（匿名访问）
-      // 注意：/tmp-pages/ 不以 /api/ 开头，认证拦截本就不触发。
+      // 临时交互页面反代（/tmp-pages/*）：按需拉起 server 后透明转发，不鉴权（匿名访问）。
+      // 页面可用性以 meta.expires_at 为准；server 闲置退出由本入口与 agent 工具双侧复活
+      //（spec 2026-07-24-tmp-page-availability-design.md）。
+      // 注意：/tmp-pages/ 不以 /api/ 开头，认证拦截本就不触发。_manage 守卫在 handleTmpPageRequest 内。
       if (pathname.startsWith('/tmp-pages/')) {
-        // _manage 端点（列出/删除 page）仅供 agent 本机直连 127.0.0.1:<port> 使用，
-        // 不经公网反代暴露，否则匿名访问者可枚举/删除任意 page。
-        // isManagePath 归一化连续斜杠后再判，堵住 /tmp-pages//_manage 这类绕过。
-        if (isManagePath(pathname)) {
-          res.writeHead(404)
-          res.end(JSON.stringify({ error: 'Not found' }))
-          return
-        }
         const tmpPort = parseInt(process.env.CRABOT_TMP_PAGE_PORT ?? '19099', 10)
-        await proxyTmpPage(req, res, tmpPort)
+        await handleTmpPageRequest(req, res, pathname, {
+          serverScriptPath: path.join(CRABOT_HOME, 'crabot-admin', 'builtins', 'skills', 'tmp-page', 'scripts', 'server.cjs'),
+          dataDir: getDataRootDir(),
+          port: tmpPort,
+        })
         return
       }
 

--- a/crabot-admin/src/tmp-page-proxy.test.ts
+++ b/crabot-admin/src/tmp-page-proxy.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, afterAll, beforeAll } from 'vitest'
 import http from 'node:http'
-import { proxyTmpPage, isManagePath } from './tmp-page-proxy'
+import net from 'node:net'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { proxyTmpPage, isManagePath, ensureTmpPageServer } from './tmp-page-proxy'
 
 describe('isManagePath', () => {
   it('命中 _manage 端点', () => {
@@ -57,5 +61,79 @@ describe('proxyTmpPage', () => {
     const r = await fetch(`http://127.0.0.1:${frontPort}/dead`)
     expect(r.status).toBe(502)
     expect(await r.text()).toContain('失效')
+  })
+})
+
+async function getFreePort(): Promise<number> {
+  return new Promise((resolve) => {
+    const s = net.createServer()
+    s.listen(0, '127.0.0.1', () => {
+      const p = (s.address() as { port: number }).port
+      s.close(() => resolve(p))
+    })
+  })
+}
+
+/** 写一个自记录、自终结的假 server 脚本;spawn 时把 env 记到 spawn.log */
+function writeFakeServerScript(dir: string): string {
+  const script = `
+const fs = require('fs'); const http = require('http'); const path = require('path')
+const port = parseInt(process.env.CRABOT_TMP_PAGE_PORT, 10)
+fs.appendFileSync(path.join(__dirname, 'spawn.log'),
+  JSON.stringify({ data_dir: process.env.DATA_DIR, port: process.env.CRABOT_TMP_PAGE_PORT }) + '\\n')
+const server = http.createServer((req, res) => {
+  res.writeHead(200, { 'Content-Type': 'text/html' }); res.end('<h1>revived</h1>')
+})
+server.on('error', (e) => process.exit(e.code === 'EADDRINUSE' ? 0 : 1))
+server.listen(port, '127.0.0.1')
+setTimeout(() => process.exit(0), 8000)
+`
+  const p = path.join(dir, 'fake-server.cjs')
+  fs.writeFileSync(p, script)
+  return p
+}
+
+describe('ensureTmpPageServer', () => {
+  it('端口未开 → 拉起假 server 并等到就绪;再次调用走快路径不重复 spawn', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tmp-page-ensure-'))
+    const scriptPath = writeFakeServerScript(dir)
+    const port = await getFreePort()
+    const opts = { serverScriptPath: scriptPath, dataDir: dir, port }
+
+    await ensureTmpPageServer(opts)
+    const r = await fetch(`http://127.0.0.1:${port}/tmp-pages/x`)
+    expect(await r.text()).toContain('revived')
+
+    await ensureTmpPageServer(opts) // 端口已开,快路径
+    const lines = fs.readFileSync(path.join(dir, 'spawn.log'), 'utf8').trim().split('\n')
+    expect(lines.length).toBe(1)
+  })
+
+  it('spawn env 含一致的 DATA_DIR 与 CRABOT_TMP_PAGE_PORT', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tmp-page-env-'))
+    const scriptPath = writeFakeServerScript(dir)
+    const port = await getFreePort()
+    await ensureTmpPageServer({ serverScriptPath: scriptPath, dataDir: dir, port })
+    const rec = JSON.parse(fs.readFileSync(path.join(dir, 'spawn.log'), 'utf8').trim())
+    expect(rec.data_dir).toBe(dir)
+    expect(rec.port).toBe(String(port))
+  })
+
+  it('脚本缺失 → reject', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tmp-page-miss-'))
+    const port = await getFreePort()
+    await expect(ensureTmpPageServer({
+      serverScriptPath: path.join(dir, 'nope.cjs'), dataDir: dir, port,
+    })).rejects.toThrow()
+  })
+
+  it('并发调用共享同一次拉起,只 spawn 一次', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tmp-page-conc-'))
+    const scriptPath = writeFakeServerScript(dir)
+    const port = await getFreePort()
+    const opts = { serverScriptPath: scriptPath, dataDir: dir, port }
+    await Promise.all([1, 2, 3, 4, 5].map(() => ensureTmpPageServer(opts)))
+    const lines = fs.readFileSync(path.join(dir, 'spawn.log'), 'utf8').trim().split('\n')
+    expect(lines.length).toBe(1)
   })
 })

--- a/crabot-admin/src/tmp-page-proxy.test.ts
+++ b/crabot-admin/src/tmp-page-proxy.test.ts
@@ -4,7 +4,7 @@ import net from 'node:net'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import { proxyTmpPage, isManagePath, ensureTmpPageServer } from './tmp-page-proxy'
+import { proxyTmpPage, isManagePath, ensureTmpPageServer, handleTmpPageRequest } from './tmp-page-proxy'
 
 describe('isManagePath', () => {
   it('命中 _manage 端点', () => {
@@ -135,5 +135,67 @@ describe('ensureTmpPageServer', () => {
     await Promise.all([1, 2, 3, 4, 5].map(() => ensureTmpPageServer(opts)))
     const lines = fs.readFileSync(path.join(dir, 'spawn.log'), 'utf8').trim().split('\n')
     expect(lines.length).toBe(1)
+  })
+})
+
+describe('handleTmpPageRequest', () => {
+  async function makeFront(opts: Parameters<typeof handleTmpPageRequest>[3]): Promise<{ server: http.Server; port: number }> {
+    const server = http.createServer((req, res) => {
+      const pathname = new URL(req.url ?? '/', 'http://x').pathname
+      void handleTmpPageRequest(req, res, pathname, opts)
+    })
+    await new Promise<void>((r) => server.listen(0, '127.0.0.1', r))
+    return { server, port: (server.address() as { port: number }).port }
+  }
+
+  it('上游未运行 → 拉起后正常转发(复活主路径)', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tmp-page-revive-'))
+    const scriptPath = writeFakeServerScript(dir)
+    const upstreamPort2 = await getFreePort()
+    const { server, port } = await makeFront({ serverScriptPath: scriptPath, dataDir: dir, port: upstreamPort2 })
+    try {
+      const r = await fetch(`http://127.0.0.1:${port}/tmp-pages/abcdef0123456789`)
+      expect(r.status).toBe(200)
+      expect(await r.text()).toContain('revived')
+    } finally { server.close() }
+  })
+
+  it('脚本缺失 → 降级 502 现文案,不 crash', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tmp-page-degrade-'))
+    const upstreamPort2 = await getFreePort()
+    const { server, port } = await makeFront({
+      serverScriptPath: path.join(dir, 'nope.cjs'), dataDir: dir, port: upstreamPort2,
+    })
+    try {
+      const r = await fetch(`http://127.0.0.1:${port}/tmp-pages/abcdef0123456789`)
+      expect(r.status).toBe(502)
+      expect(await r.text()).toContain('失效')
+    } finally { server.close() }
+  })
+
+  it('_manage 路径在上游未运行时直接 404,不触发拉起', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tmp-page-guard-'))
+    const scriptPath = writeFakeServerScript(dir)
+    const upstreamPort2 = await getFreePort()
+    const { server, port } = await makeFront({ serverScriptPath: scriptPath, dataDir: dir, port: upstreamPort2 })
+    try {
+      const r = await fetch(`http://127.0.0.1:${port}/tmp-pages//_manage/list`)
+      expect(r.status).toBe(404)
+      expect(fs.existsSync(path.join(dir, 'spawn.log'))).toBe(false)
+    } finally { server.close() }
+  })
+
+  it('并发首访只 spawn 一次', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tmp-page-conc2-'))
+    const scriptPath = writeFakeServerScript(dir)
+    const upstreamPort2 = await getFreePort()
+    const { server, port } = await makeFront({ serverScriptPath: scriptPath, dataDir: dir, port: upstreamPort2 })
+    try {
+      const rs = await Promise.all([1, 2, 3, 4, 5].map(() =>
+        fetch(`http://127.0.0.1:${port}/tmp-pages/abcdef0123456789`)))
+      for (const r of rs) expect(r.status).toBe(200)
+      const lines = fs.readFileSync(path.join(dir, 'spawn.log'), 'utf8').trim().split('\n')
+      expect(lines.length).toBe(1)
+    } finally { server.close() }
   })
 })

--- a/crabot-admin/src/tmp-page-proxy.ts
+++ b/crabot-admin/src/tmp-page-proxy.ts
@@ -149,6 +149,33 @@ function startTmpPageServer(opts: EnsureTmpPageServerOpts): Promise<void> {
   })
 }
 
+/**
+ * /tmp-pages/* 请求的完整处理：_manage 守卫 → 幂等拉起 server → 透明转发。
+ * 守卫必须在 ensure 之前（管理端点永不经反代，也不该为它拉起 server）。
+ * ensure 失败只记日志并继续转发——转发对不可达上游自会回 502 现文案。
+ */
+export async function handleTmpPageRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  pathname: string,
+  opts: EnsureTmpPageServerOpts,
+): Promise<void> {
+  if (isManagePath(pathname)) {
+    res.writeHead(404)
+    res.end(JSON.stringify({ error: 'Not found' }))
+    return
+  }
+  try {
+    await ensureTmpPageServer(opts)
+  } catch (err) {
+    console.error(JSON.stringify({
+      type: 'tmp-page-ensure-failed',
+      error: err instanceof Error ? err.message : String(err),
+    }))
+  }
+  return proxyTmpPage(req, res, opts.port)
+}
+
 /** 解析对外 base URL：优先用全局设置的 public_base_url，去尾斜杠；未配置退化为本地 web 地址 */
 export function resolveTmpPageBaseUrl(
   publicBaseUrl: string | undefined,

--- a/crabot-admin/src/tmp-page-proxy.ts
+++ b/crabot-admin/src/tmp-page-proxy.ts
@@ -1,4 +1,8 @@
 import http, { type IncomingMessage, type ServerResponse } from 'node:http'
+import { spawn } from 'node:child_process'
+import { existsSync, mkdirSync, openSync, closeSync } from 'node:fs'
+import net from 'node:net'
+import path from 'node:path'
 
 /**
  * 把 /tmp-pages/* 请求纯透明转发到 127.0.0.1:<port>（agent 起的 tmp-page server）。
@@ -47,6 +51,102 @@ export function proxyTmpPage(
  */
 export function isManagePath(pathname: string): boolean {
   return pathname.replace(/\/{2,}/g, '/').startsWith('/tmp-pages/_manage')
+}
+
+export interface EnsureTmpPageServerOpts {
+  serverScriptPath: string
+  dataDir: string
+  port: number
+  startupTimeoutMs?: number
+  probeIntervalMs?: number
+}
+
+const ensureInFlight = new Map<string, Promise<void>>()
+
+function probeLocalPort(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = net.connect({ host: '127.0.0.1', port })
+    const done = (open: boolean) => {
+      socket.removeAllListeners()
+      socket.destroy()
+      resolve(open)
+    }
+    socket.once('connect', () => done(true))
+    socket.once('error', () => done(false))
+    socket.setTimeout(500, () => done(false))
+  })
+}
+
+/**
+ * 幂等拉起 tmp-page server（spec 2026-07-24-tmp-page-availability-design.md §5.2）。
+ * 与 agent 侧 tmp-page-tools.ts 的 ensureTmpPageServer 同构——两包无共享依赖，有意重复。
+ * spawn env 的 DATA_DIR/CRABOT_TMP_PAGE_PORT 必须与反代目标一致（两侧拉起等价的不变量）。
+ */
+export async function ensureTmpPageServer(opts: EnsureTmpPageServerOpts): Promise<void> {
+  if (!existsSync(opts.serverScriptPath)) throw new Error('tmp-page server script unavailable')
+  if (await probeLocalPort(opts.port)) return
+  const key = `${opts.serverScriptPath}:${opts.dataDir}:${opts.port}`
+  const pending = ensureInFlight.get(key)
+  if (pending) return pending
+  const promise = startTmpPageServer(opts).finally(() => { ensureInFlight.delete(key) })
+  ensureInFlight.set(key, promise)
+  return promise
+}
+
+function startTmpPageServer(opts: EnsureTmpPageServerOpts): Promise<void> {
+  const timeoutMs = opts.startupTimeoutMs ?? 5_000
+  const probeIntervalMs = opts.probeIntervalMs ?? 50
+  const logDir = path.join(opts.dataDir, 'logs')
+  mkdirSync(logDir, { recursive: true })
+  const logFd = openSync(path.join(logDir, 'tmp-page-server.log'), 'a')
+
+  return new Promise((resolve, reject) => {
+    let settled = false
+    let childExited = false
+    const timer = setTimeout(() => finish(new Error('tmp-page server startup timed out')), timeoutMs)
+    const interval = setInterval(() => {
+      void probeLocalPort(opts.port).then((open) => {
+        if (open) finish()
+        else if (childExited) finish(new Error('tmp-page server exited before listening'))
+      })
+    }, probeIntervalMs)
+
+    const finish = (err?: Error) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      clearInterval(interval)
+      if (err) reject(err)
+      else resolve()
+    }
+
+    let child
+    try {
+      child = spawn(process.execPath, [opts.serverScriptPath], {
+        detached: true,
+        stdio: ['ignore', logFd, logFd],
+        env: {
+          ...process.env,
+          DATA_DIR: opts.dataDir,
+          CRABOT_TMP_PAGE_PORT: String(opts.port),
+        },
+      })
+    } catch (err) {
+      closeSync(logFd)
+      finish(err instanceof Error ? err : new Error(String(err)))
+      return
+    }
+    closeSync(logFd)
+
+    child.once('error', (err) => finish(err))
+    child.once('exit', () => {
+      childExited = true
+      void probeLocalPort(opts.port).then((open) => {
+        if (open) finish() // EADDRINUSE 幂等退出：别人已在跑
+      })
+    })
+    child.unref()
+  })
 }
 
 /** 解析对外 base URL：优先用全局设置的 public_base_url，去尾斜杠；未配置退化为本地 web 地址 */


### PR DESCRIPTION
## 背景

tmp-page 存在两套打架的失效机制:页面 TTL 默认 24h(`meta.expires_at`),但 server.cjs 闲置 30 分钟自动退出,退出后外部访客经 admin 反代访问只会得到 502"页面已失效或服务未启动"——复活路径(`ensureTmpPageServer`)只挂在 agent 的 `tmp_page_create`/`tmp_page_update` 上,访客访问无法拉起 server。对访客而言"最后一次活动后 30 分钟"成了事实 TTL,工具返回的 `expires_at` 是假承诺。

Spec(已确认):`crabot-docs/superpowers/specs/2026-07-24-tmp-page-availability-design.md`
协议更新:protocol-agent-v2.md §5.4.4 已补可用性契约(crabot-docs@112ddce)

## 改动

- `tmp-page-proxy.ts` 新增 `ensureTmpPageServer`(探测 → in-flight 去抖 → detached spawn → 轮询探活,与 agent 侧同构;两包无共享依赖,~60 行有意重复)
- 新增组合入口 `handleTmpPageRequest`(`_manage` 守卫 → ensure → 透明转发),ensure 失败仅记日志、降级为现有 502 文案
- `index.ts` 的 `/tmp-pages/` 分支改调组合入口;`core/data-paths.ts` 新增 `getDataRootDir()`(守卫测试禁止裸读 `process.env.DATA_DIR`)

## 语义不变量

- `_manage` 守卫在 ensure 之前判定,管理端点不经反代、不为其拉起 server(有测试)
- 反代仍匿名不鉴权;404/过期判定仍归 server.cjs;agent 侧工具与 SKILL.md 零改动
- spawn env 的 `DATA_DIR`/`CRABOT_TMP_PAGE_PORT` 与反代目标一致(两侧拉起等价,有测试)

## 验证

- 新增 8 个测试用例(ensure 快路径/env 不变量/脚本缺失/并发去抖;组合入口复活主路径/降级 502/守卫/并发首访单 spawn),admin 全量 1028 用例通过,tsc 零错误
- dev 环境手工验证:杀掉 server 后经 `localhost:3000/tmp-pages/<id>` 访问,页面正常返回且注入 helper,`tmp-page-server.log` 出现新 `server-started`;POST submit 落盘 `events.jsonl`;`/tmp-pages//_manage/list` 仍 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)