### PR TITLE
fix(wechat): 入站文件超时降级后凭 message_id 按需补取

### DIFF
--- a/crabot-channel-feishu/tests/feishu-drive-media.test.ts
+++ b/crabot-channel-feishu/tests/feishu-drive-media.test.ts
@@ -49,13 +49,18 @@ it('权限不足时返回带 remediation 的对象，scope 按 ref.kind 选', as
   expect(res.remediation.grant_url).not.toContain('im%3Amessage')
 })
 
-it('drive 下载失败（403）时抛出可读的权限原因，而非 null/通用失败', async () => {
+it('drive 下载失败（403）时返回 failed 且 error 为可读的权限原因，而非通用失败', async () => {
   channel.client.downloadDriveFile = vi.fn(async () => { throw new Error('request failed with HTTP status 403 Forbidden') })
   const handle = await channel.mediaHandleStore.put({ kind: 'file', filename: 'a.pptx', credential: { file_token: 'boxT' } })
-  await expect(channel.mediaFetch.fetch(handle)).rejects.toThrow(/权限|分享|drive:drive:readonly/)
+  // 同步下载路径的异常由 MediaFetchManager 捕获为 {status:'failed', error}，经 fetch_media 透给 agent
+  const res = await channel.mediaFetch.fetch(handle)
+  expect(res.status).toBe('failed')
+  expect(res.error).toMatch(/权限|分享|drive:drive:readonly/)
 })
-it('drive 下载非权限错误也带原始原因', async () => {
+it('drive 下载非权限错误 failed，error 带原始原因', async () => {
   channel.client.downloadDriveFile = vi.fn(async () => { throw new Error('socket hang up') })
   const handle = await channel.mediaHandleStore.put({ kind: 'file', filename: 'a.pptx', credential: { file_token: 'boxT' } })
-  await expect(channel.mediaFetch.fetch(handle)).rejects.toThrow(/socket hang up/)
+  const res = await channel.mediaFetch.fetch(handle)
+  expect(res.status).toBe('failed')
+  expect(res.error).toMatch(/socket hang up/)
 })

--- a/crabot-channel-wechat/src/wechat-channel.ts
+++ b/crabot-channel-wechat/src/wechat-channel.ts
@@ -107,7 +107,7 @@ export class WechatChannel extends ModuleBase {
     this.mediaFetch = new MediaFetchManager({
       store: this.mediaHandleStore,
       channelId: this.config.moduleId,
-      download: (rec) => this.downloadFromUrl(rec),
+      download: (rec) => this.downloadFile(rec),
       publishEvent: (event) => this.rpcClient.publishEvent(event, this.config.moduleId).then(() => undefined),
     })
 
@@ -288,7 +288,7 @@ export class WechatChannel extends ModuleBase {
     const { content: formattedContent, features: extraFeatures } = formatWechatContent(msgType, rawContent)
 
     // 文件（公开 URL）惰性化：登记 handle，图片保持原样
-    const content = await this.lazifyFileContent(formattedContent, session.id)
+    const content = await this.lazifyFileContent(formattedContent, session.id, event.message.id)
 
     // 检测 @Crabot
     const atString = (rawContent.at_string as string | undefined) ?? ''
@@ -539,18 +539,60 @@ export class WechatChannel extends ModuleBase {
    * 把"带公开 URL 的文件"改成惰性 handle 形态（图片不动，仍传 media_url 供 agent 注入）。
    * type=file 且有 media_url → 登记 handle、改 status=not_fetched、去掉 media_url。
    */
-  private async lazifyFileContent(content: MessageContent, sessionId: string): Promise<MessageContent> {
-    if (content.type !== 'file' || !content.media_url) return content
+  private async lazifyFileContent(content: MessageContent, sessionId: string, messageId?: string): Promise<MessageContent> {
+    if (content.type !== 'file') return content
+    // 超时降级消息（connector 60s 内没拿到 file_url）没有 media_url，但凭 message_id
+    // 仍可在 fetch_media 时重查 connector 拿迟到补上的 file_url，故同样登记 handle。
+    // 本地文件（file_path）或既无 URL 也无 message_id 的消息无从下载，跳过。
+    if (!content.media_url && (content.file_path || !messageId)) return content
     const handle = await this.mediaHandleStore.put({
       kind: 'file',
       ...(content.filename !== undefined ? { filename: content.filename } : {}),
       ...(content.mime_type !== undefined ? { mime_type: content.mime_type } : {}),
       ...(content.size !== undefined ? { size: content.size } : {}),
       session_id: sessionId,
-      credential: { url: content.media_url },
+      credential: {
+        ...(content.media_url !== undefined ? { url: content.media_url } : {}),
+        ...(messageId !== undefined ? { message_id: messageId } : {}),
+      },
     })
     const { media_url: _omit, ...rest } = content
     return { ...rest, handle, status: 'not_fetched' }
+  }
+
+  /**
+   * wechat 媒体下载适配：credential 无 url（入站时 connector 60s 超时降级）→ 先重查
+   * connector 消息记录拿迟到补上的 file_url。重查失败 throw，异常 message 经
+   * MediaFetchManager 作为 fetch_media 的 error 透给 agent。
+   */
+  private async downloadFile(rec: MediaHandleRecord): Promise<{ filePath: string; mimeType?: string; size: number } | null> {
+    if (rec.credential.url) return this.downloadFromUrl(rec)
+    const url = await this.refetchLateFileUrl(rec)
+    return this.downloadFromUrl({ ...rec, credential: { ...rec.credential, url } })
+  }
+
+  /** 凭 credential.message_id 重查 connector，返回迟到补上的 file_url 并写回 handle 记录。拿不到则 throw。 */
+  private async refetchLateFileUrl(rec: MediaHandleRecord): Promise<string> {
+    const messageId = rec.credential.message_id as string | undefined
+    if (!messageId) throw new Error('媒体记录缺少下载凭证（无 url 也无 message_id），无法下载')
+    const msg = await this.client.getMessageById(messageId)
+    if (!msg) throw new Error(`重查渠道消息 ${messageId} 失败，暂时拿不到文件下载地址，可稍后重试 fetch_media`)
+    const content = msg.content as Record<string, unknown> | undefined
+    const fileUrl = typeof content?.file_url === 'string' ? content.file_url : undefined
+    if (!fileUrl) {
+      throw new Error(
+        '文件在微信渠道侧尚未下载完成（入站时下载超时）。可稍等片刻后重试 fetch_media；若多次重试仍失败，说明渠道侧下载失败，请告知用户重新发送该文件'
+      )
+    }
+    const handle = this.mediaHandleStore.findByCredential(rec.credential)
+    if (handle) {
+      const fileSize = content?.file_size
+      await this.mediaHandleStore.update(handle, {
+        credential: { ...rec.credential, url: fileUrl },
+        ...(rec.size === undefined && typeof fileSize === 'number' ? { size: fileSize } : {}),
+      })
+    }
+    return fileUrl
   }
 
   /** wechat 媒体下载：HTTP GET 公开 URL（connector 已传图床，无需 token）落盘。 */

--- a/crabot-channel-wechat/tests/wechat-fetch-media.test.ts
+++ b/crabot-channel-wechat/tests/wechat-fetch-media.test.ts
@@ -70,6 +70,71 @@ describe('wechat fetch_media RPC', () => {
     expect(res.error).toBeTruthy()
   })
 
+  it('credential 无 url：重查 connector 拿迟到 file_url → ready，credential 写回 url 并补 size', async () => {
+    const fileContent = Buffer.from('late docx content')
+    const originalFetch = global.fetch
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      arrayBuffer: async () => fileContent.buffer,
+    })) as unknown as typeof fetch
+    const getMessageById = vi.fn(async () => ({
+      id: 'msg_conn_9',
+      content: { type: 9, file_url: 'http://cdn.example.com/late.docx', file_name: 'video1.docx', file_size: 2048 },
+    }))
+    ;(channel as any).client.getMessageById = getMessageById
+
+    const handle = await (channel as any).mediaHandleStore.put({
+      kind: 'file',
+      filename: 'video1.docx',
+      session_id: 'sess_1',
+      credential: { message_id: 'msg_conn_9' },
+    })
+
+    const res = await (channel as any).handleFetchMedia({ handle })
+    expect(res.status).toBe('ready')
+    expect(fs.existsSync(res.file_path)).toBe(true)
+    expect(getMessageById).toHaveBeenCalledWith('msg_conn_9')
+
+    const rec = (channel as any).mediaHandleStore.get(handle)
+    expect(rec.credential.url).toBe('http://cdn.example.com/late.docx')
+    expect(rec.credential.message_id).toBe('msg_conn_9')
+    expect(rec.size).toBe(2048)
+
+    global.fetch = originalFetch
+  })
+
+  it('重查后仍无 file_url → failed，error 含可行动指引', async () => {
+    ;(channel as any).client.getMessageById = vi.fn(async () => ({
+      id: 'msg_conn_10',
+      content: { type: 9, file_name: 'video1.docx', file_size: 52428800 },
+    }))
+
+    const handle = await (channel as any).mediaHandleStore.put({
+      kind: 'file',
+      filename: 'video1.docx',
+      credential: { message_id: 'msg_conn_10' },
+    })
+
+    const res = await (channel as any).handleFetchMedia({ handle })
+    expect(res.status).toBe('failed')
+    expect(res.error).toContain('尚未下载完成')
+    expect(res.error).toContain('fetch_media')
+  })
+
+  it('重查请求失败（getMessageById 返回 null）→ failed', async () => {
+    ;(channel as any).client.getMessageById = vi.fn(async () => null)
+
+    const handle = await (channel as any).mediaHandleStore.put({
+      kind: 'file',
+      filename: 'x.pdf',
+      credential: { message_id: 'msg_conn_11' },
+    })
+
+    const res = await (channel as any).handleFetchMedia({ handle })
+    expect(res.status).toBe('failed')
+    expect(res.error).toBeTruthy()
+  })
+
   it('HTTP 下载失败 → status=failed', async () => {
     const originalFetch = global.fetch
     global.fetch = vi.fn(async () => ({

--- a/crabot-channel-wechat/tests/wechat-inbound-lazy-media.test.ts
+++ b/crabot-channel-wechat/tests/wechat-inbound-lazy-media.test.ts
@@ -77,6 +77,45 @@ describe('wechat 入站惰性媒体', () => {
     expect(content.handle).toBeUndefined()
   })
 
+  it('有 media_url 且有 messageId：credential 同时存 url 与 message_id', async () => {
+    const content = await (channel as any).lazifyFileContent(
+      { type: 'file', media_url: 'http://cdn.example.com/doc.pdf', filename: 'doc.pdf', size: 456 },
+      'sess_xyz',
+      'msg_conn_001',
+    )
+
+    const rec = (channel as any).mediaHandleStore.get(content.handle)
+    expect(rec.credential.url).toBe('http://cdn.example.com/doc.pdf')
+    expect(rec.credential.message_id).toBe('msg_conn_001')
+  })
+
+  it('超时降级（无 media_url 有 messageId）：也登记 handle，credential 只存 message_id', async () => {
+    const content = await (channel as any).lazifyFileContent(
+      { type: 'file', text: 'video1.docx', filename: 'video1.docx', size: 52428800 },
+      'sess_deg',
+      'msg_conn_002',
+    )
+
+    expect(content.status).toBe('not_fetched')
+    expect(content.handle).toMatch(/^fm_[0-9a-f]{12}$/)
+    expect(content.media_url).toBeUndefined()
+
+    const rec = (channel as any).mediaHandleStore.get(content.handle)
+    expect(rec).toBeDefined()
+    expect(rec.credential.message_id).toBe('msg_conn_002')
+    expect(rec.credential.url).toBeUndefined()
+    expect(rec.session_id).toBe('sess_deg')
+    expect(rec.size).toBe(52428800)
+  })
+
+  it('无 media_url 也无 messageId：保持不变（无 handle 登记）', async () => {
+    const input = { type: 'file' as const, filename: 'orphan.pdf' }
+    const content = await (channel as any).lazifyFileContent(input, 'sess_1')
+
+    expect(content.handle).toBeUndefined()
+    expect(content.status).toBeUndefined()
+  })
+
   it('video（type=file, mime_type=video/mp4）：登记 handle，status=not_fetched', async () => {
     const content = await (channel as any).lazifyFileContent(
       { type: 'file', text: '视频', media_url: 'http://cdn.example.com/v.mp4', mime_type: 'video/mp4' },

--- a/crabot-shared/src/media-fetch/media-fetch-manager.test.ts
+++ b/crabot-shared/src/media-fetch/media-fetch-manager.test.ts
@@ -152,6 +152,25 @@ test('大文件（size >= asyncThreshold）立即返回 fetching，后台下载�
   assert.equal(payload['handle'], handle)
 })
 
+test('同步下载抛错 → 返回 failed，error 为异常 message，不向上抛', async () => {
+  const store = makeStore()
+  const pub = makePublisher()
+  const handle = await store.put({ kind: 'file', size: 1024, credential: {} })
+
+  const mgr = new MediaFetchManager({
+    store,
+    channelId: 'ch_test',
+    download: async (): Promise<DownloadResult | null> => {
+      throw new Error('文件在微信渠道侧尚未下载完成')
+    },
+    publishEvent: pub.fn,
+  })
+
+  const result = await mgr.fetch(handle)
+  assert.equal(result.status, 'failed')
+  assert.ok(result.error?.includes('文件在微信渠道侧尚未下载完成'))
+})
+
 test('后台下载抛错 → publishEvent 事件 status=failed', async () => {
   const dir = mkdtemp()
   const store = makeStore(dir)

--- a/crabot-shared/src/media-fetch/media-fetch-manager.ts
+++ b/crabot-shared/src/media-fetch/media-fetch-manager.ts
@@ -46,7 +46,12 @@ export class MediaFetchManager {
       }
       return { status: 'fetching' }
     }
-    const r = await this.deps.download(rec)
+    let r: Awaited<ReturnType<MediaDownloadFn>>
+    try {
+      r = await this.deps.download(rec)
+    } catch (err) {
+      return { status: 'failed', error: err instanceof Error ? err.message : String(err) }
+    }
     if (!r) return { status: 'failed', error: `download failed for handle ${handle}` }
     await this.deps.store.markDownloaded(handle, r.filePath)
     return {

--- a/crabot-shared/src/media-fetch/media-handle-store.test.ts
+++ b/crabot-shared/src/media-fetch/media-handle-store.test.ts
@@ -113,3 +113,29 @@ test('findByCredential 忽略顺序差异', async () => {
   const found = store.findByCredential({ platform_message_id: 'msg_001', file_key: 'fk_abc' })
   assert.equal(found, handle)
 })
+
+test('update 合并 credential 与 size 并持久化', async () => {
+  const dir = mkdtemp()
+  const store = new MediaHandleStore(dir)
+  const handle = await store.put({ kind: 'file', filename: 'a.pdf', session_id: 'sess_1', credential: { message_id: 'm1' } })
+
+  await store.update(handle, { credential: { message_id: 'm1', url: 'http://cdn/a.pdf' }, size: 2048 })
+
+  const rec = store.get(handle)
+  assert.equal(rec?.credential['url'], 'http://cdn/a.pdf')
+  assert.equal(rec?.credential['message_id'], 'm1')
+  assert.equal(rec?.size, 2048)
+  // 未动的字段保留
+  assert.equal(rec?.filename, 'a.pdf')
+  assert.equal(rec?.session_id, 'sess_1')
+
+  // 持久化：新实例 init 后仍可见
+  const store2 = new MediaHandleStore(dir)
+  await store2.init()
+  assert.equal(store2.get(handle)?.credential['url'], 'http://cdn/a.pdf')
+})
+
+test('update 未知 handle no-op 不抛错', async () => {
+  const store = new MediaHandleStore(mkdtemp())
+  await store.update('fm_nonexistent', { size: 1 })
+})

--- a/crabot-shared/src/media-fetch/media-handle-store.ts
+++ b/crabot-shared/src/media-fetch/media-handle-store.ts
@@ -78,6 +78,18 @@ export class MediaHandleStore {
     }
   }
 
+  /** 渠道侧补写 credential / size（如 wechat 重查拿到迟到的 file_url 后回写）。未知 handle no-op。 */
+  async update(handle: string, patch: Partial<Pick<MediaHandleRecord, 'credential' | 'size'>>): Promise<void> {
+    const rec = this.map.get(handle)
+    if (!rec) return
+    this.map = new Map(this.map).set(handle, { ...rec, ...patch })
+    try {
+      await this.persist()
+    } catch (err) {
+      console.warn('[MediaHandleStore] update persist failed:', err)
+    }
+  }
+
   /** 比较两个 credential 是否逻辑相等（按 key-value 逐项相等，忽略顺序）。 */
   private credentialMatch(a: Record<string, unknown>, b: Record<string, unknown>): boolean {
     const aKeys = Object.keys(a).sort()

--- a/crabot-shared/src/media-fetch/types.ts
+++ b/crabot-shared/src/media-fetch/types.ts
@@ -7,7 +7,7 @@ export interface MediaHandleRecord {
   session_id?: string
   /** 首次下载成功后写回的本地路径；再次 fetch 文件仍在则直接返回 */
   downloaded_file_path?: string
-  /** 渠道特定下载凭证（feishu: {platform_message_id, file_key}；telegram: {file_id}；wechat: {url}）。由该渠道的 download 适配函数解读。 */
+  /** 渠道特定下载凭证（feishu: {platform_message_id, file_key}；telegram: {file_id}；wechat: {url?, message_id}，url 缺失时凭 message_id 重查 connector 消息记录取迟到的 file_url）。由该渠道的 download 适配函数解读。 */
   credential: Record<string, unknown>
 }
 


### PR DESCRIPTION
## 问题

wechat 渠道大文件（如 video1.docx 这类改名视频）经常触发 connector 的 60s 下载超时降级：emit 给 bot 的消息只有 file_name/file_size、没有 file_url。此前这类消息不登记 media handle，agent 没有任何获取内容的途径，只能反复请用户重发；用户重发同一个大文件又再次超时，死循环。

而实际上超时后 down_file 任务并不取消，迟到的 ack 会把 file_url 写进 connector 的消息记录——bot 事后凭 \`GET /api/v1/bot/messages/:id\` 就能拿到，只是此前没有利用。

## 方案（拉模型，connector 零改动）

Spec（已确认）：[2026-07-26-wechat-inbound-file-timeout-refetch-design.md](https://github.com/smilefufu/crabot-docs/blob/main/superpowers/specs/2026-07-26-wechat-inbound-file-timeout-refetch-design.md)

- **lazifyFileContent**：降级文件消息（无 media_url、无 file_path）也登记 handle，credential 存 \`{message_id}\`；正常消息 credential 从 \`{url}\` 扩展为 \`{url, message_id}\`。旧存量 \`{url}\` 记录兼容，无迁移。
- **downloadFile**（原 downloadFromUrl 外包一层）：credential 无 url 时凭 message_id 重查 connector 拿迟到的 file_url，成功后写回 credential（并补 size），再走原下载落盘；仍无 file_url 时 throw 可行动指引（稍后重试 fetch_media / 请用户重发）。
- **MediaFetchManager**（shared）：同步下载路径 try/catch，异常 message 作为 \`{status:'failed', error}\` 返回，与后台慢档路径一致，指引文案经 fetch_media 透达 LLM。
- **MediaHandleStore**（shared）：新增 \`update(handle, patch)\` 供渠道回写 credential/size。
- **feishu 测试断言对齐**：feishu drive 下载路径此前用 throw 传可读错误（403 remediation），错误呈现从 RPC 异常变为 failed 结果 + error 字段，文案不变仍达 LLM，断言同步更新（spec §5.4 勘误已记录）。

agent 侧渲染与 fetch_media 工具零改动：降级消息登记 handle 后自动出现 \`[文件: …（未下载）— 调 fetch_media, handle=…]\` 指引。

## 测试

- crabot-shared：96 passed（新增同步 throw→failed、store.update 持久化/未知 handle no-op）
- crabot-channel-wechat：62 passed（新增降级登记 credential、重查成功写回+补 size、仍无 file_url 的指引文案、查询失败 failed；既有 media_url 链路回归）
- crabot-channel-feishu：239 passed（含断言对齐的 2 例）
- crabot-agent media-resolver 定向：7 passed
- crabot-channel-telegram：36 passed + 1 failed（reaction emoji 断言 \`✍\` vs \`🫡\`，main 既有失败，与本 PR 无关，本 PR 未触碰 telegram）

🤖 Generated with [Claude Code](https://claude.com/claude-code)