### PR TITLE
fix(release): 打包补回 builtins skill 载荷，缺失不再静默 (#43)

### DIFF
--- a/.github/scripts/verify-release-payload.mjs
+++ b/.github/scripts/verify-release-payload.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+/**
+ * 校验 release staging 目录是否包含全部运行时载荷。
+ *
+ * 背景：打包脚本用 `--exclude='*.md'` 剔文档，只给 builtin-skills/ 开了 include 白名单，
+ * 结果 crabot-admin/builtins/skills/ 下的 SKILL.md 全被剔掉（issue #43）——目录还在、
+ * 内容没了，Admin 启动时一个内置 skill 都注册不上。这类"白名单漏一条"人眼 review 挡不住，
+ * 打包后直接比对源码与 staging。
+ *
+ * 用法：node .github/scripts/verify-release-payload.mjs <stagingDir>
+ * 退出码：0 = 完整，1 = 有缺失（打印缺失清单）
+ */
+import { existsSync, readdirSync, statSync } from 'node:fs'
+import { join, relative, sep } from 'node:path'
+
+const stagingDir = process.argv[2]
+if (!stagingDir) {
+  console.error('usage: verify-release-payload.mjs <stagingDir>')
+  process.exit(2)
+}
+
+const repoRoot = process.cwd()
+
+/** 递归列出目录下所有文件（返回相对 repoRoot 的路径，统一用 / 分隔） */
+function listFiles(dir) {
+  if (!existsSync(dir)) return []
+  const out = []
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name)
+    if (statSync(full).isDirectory()) out.push(...listFiles(full))
+    else out.push(relative(repoRoot, full).split(sep).join('/'))
+  }
+  return out
+}
+
+// 1. 两处 skill 载荷：源码里有多少个文件，包里就得有多少个（含 references/*.md）
+const skillPayload = [
+  ...listFiles(join(repoRoot, 'crabot-admin', 'builtin-skills')),
+  ...listFiles(join(repoRoot, 'crabot-admin', 'builtins')),
+]
+
+// 2. 其余运行时必需文件（有过漏打前科或缺了就起不来的）
+const required = [
+  'cli.mjs',
+  'package.json',
+  'install.sh',
+  'LICENSE',
+  'scripts/start.mjs',
+  'scripts/lib/registry.mjs',
+  'crabot-agent/crabot-module.yaml',
+  'crabot-memory/schema_version',
+  'crabot-memory/uv.lock',
+]
+
+const expected = [...new Set([...skillPayload, ...required])].sort()
+const missing = expected.filter((rel) => !existsSync(join(stagingDir, rel)))
+
+if (missing.length > 0) {
+  console.error(`[verify-release-payload] 缺少 ${missing.length} 个运行时文件：`)
+  for (const m of missing) console.error(`  - ${m}`)
+  process.exit(1)
+}
+
+console.log(`[verify-release-payload] OK：${expected.length} 个运行时文件齐全（其中 skill 载荷 ${skillPayload.length} 个）`)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,7 @@ jobs:
           mkdir -p "/tmp/${DIRNAME}"
 
           # 复制运行时文件
-          cp cli.mjs crabot.cmd package.json install.sh install.ps1 "/tmp/${DIRNAME}/"
+          cp cli.mjs crabot.cmd package.json install.sh install.ps1 LICENSE "/tmp/${DIRNAME}/"
           cp -r dist "/tmp/${DIRNAME}/"
 
           # rsync -H 保留 pnpm store 单模块内的 hardlink，避免每个文件被 inflate 成独立副本。
@@ -162,11 +162,16 @@ jobs:
           done
 
           # crabot-admin：额外排 web/（前端源码 + 构建依赖；构建产物已在 dist/web/）
-          # builtin-skills/*.md 是运行时 snapshot（readFileSync 同步加载），include 必须在 *.md exclude 之前
+          # 两处 skill 载荷的 *.md 都是运行时内容（SkillManager 读 SKILL.md 及 references/），
+          # include 必须在 *.md exclude 之前：
+          #   builtin-skills/   → seedBuiltinSkills 的 superpowers snapshot
+          #   builtins/skills/  → registerBuiltins 扫描的 Crabot 自有 skill（memory-curate 等）
           if [ -d "crabot-admin" ]; then
             rsync -aH \
                   --include='builtin-skills/' \
                   --include='builtin-skills/**' \
+                  --include='builtins/' \
+                  --include='builtins/**' \
                   "${COMMON_EXCLUDES[@]}" \
                   --exclude='/src/' --exclude='/test*/' --exclude='/web/' \
                   "crabot-admin/" "/tmp/${DIRNAME}/crabot-admin/"
@@ -183,6 +188,9 @@ jobs:
                   --exclude='*.md' --exclude='*.markdown' \
                   "crabot-memory/" "/tmp/${DIRNAME}/crabot-memory/"
           fi
+
+          # 打包前校验运行时载荷齐全（防止 exclude 规则漏掉 skill 等运行时文件）
+          node .github/scripts/verify-release-payload.mjs "/tmp/${DIRNAME}"
 
           # 打包（tar 默认保留 staging 目录内的 hardlink）
           cd /tmp
@@ -201,7 +209,7 @@ jobs:
           $TempDir = "$env:TEMP\$DirName"
           New-Item -ItemType Directory -Force -Path $TempDir
 
-          Copy-Item cli.mjs, crabot.cmd, package.json, install.sh, install.ps1 $TempDir
+          Copy-Item cli.mjs, crabot.cmd, package.json, install.sh, install.ps1, LICENSE $TempDir
           Copy-Item -Recurse dist, scripts, node_modules $TempDir
           # 清理 scripts/lib/__tests__ 等 dev-only 测试目录；scripts/lib/node_modules 是运行时依赖必须保留
           Get-ChildItem -Path "$TempDir\scripts" -Recurse -Directory -Filter '__tests__' -ErrorAction SilentlyContinue |
@@ -235,13 +243,15 @@ jobs:
           }
 
           # 清理无用文件（递归扫整个 staging 目录）
-          # crabot-admin/builtin-skills/*.md 是运行时 snapshot，必须保留
+          # crabot-admin 下两处 skill 载荷的 *.md 是运行时内容，必须保留：
+          #   builtin-skills/  → seedBuiltinSkills 的 superpowers snapshot
+          #   builtins/skills/ → registerBuiltins 扫描的 Crabot 自有 skill（memory-curate 等）
           $filePatterns = @('*.md','*.markdown','*.map','*.ts','tsconfig*.json',
                             '*.tsbuildinfo','.eslintrc*','.prettierrc*','.editorconfig',
                             '.gitignore','.npmignore')
           foreach ($pat in $filePatterns) {
             Get-ChildItem -Path $TempDir -Recurse -File -Filter $pat -ErrorAction SilentlyContinue |
-              Where-Object { $_.FullName -notmatch '[\\/]builtin-skills[\\/]' } |
+              Where-Object { $_.FullName -notmatch '[\\/](builtin-skills|builtins)[\\/]' } |
               Remove-Item -Force -ErrorAction SilentlyContinue
           }
           $dirPatterns = @('__tests__','.github')
@@ -252,6 +262,10 @@ jobs:
           # *.test.* / *.spec.* 用 -Include（多 pattern）
           Get-ChildItem -Path $TempDir -Recurse -File -Include '*.test.*','*.spec.*' -ErrorAction SilentlyContinue |
             Remove-Item -Force -ErrorAction SilentlyContinue
+
+          # 打包前校验运行时载荷齐全（防止清理规则漏掉 skill 等运行时文件）
+          node .github/scripts/verify-release-payload.mjs "$TempDir"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
           Compress-Archive -Path $TempDir -DestinationPath "$DirName.zip"
           (Get-FileHash "$DirName.zip" -Algorithm SHA256).Hash | Out-File "$DirName.zip.sha256"

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,6 +1,15 @@
 # Crabot 项目进度
 
-> 最后更新：2026-07-26 — wechat 入站文件超时降级按需补取（PR #44）
+> 最后更新：2026-07-27 — release 包漏打 builtins skill 载荷（issue #43 上半）
+
+## 2026-07-27 — release 包漏打 builtins skill 载荷（issue #43 上半）
+
+- 现象（用户 v2026.7.14 system mode）：内置每小时 memory_curate 日程报 `Skill not found: memory-curate`，Available skills 只剩 4 个 superpowers；模型自行降级后每轮调 `send_master_private` 私聊 Master。
+- 根因：`release.yml` 打包 `--exclude='*.md'` 只给 `crabot-admin/builtin-skills/` 开了 include 白名单，`crabot-admin/builtins/skills/` 下 24 个 md（6 个 SKILL.md + crabot-cli/scrapling 的 references）全被剔掉——目录还在、内容没了，`SkillManager.registerBuiltins` 逐个 `continue` 且一条日志不打。Unix/Windows 两条打包路径同病。丢的不止 memory-curate：daily-reflection、memory-graph-linking、crabot-cli、tmp-page、scrapling 全缺（dev 跑源码永远复现不了）。
+- 审计：按 release.yml 规则本地重放打包并与源码求差集，除上述 24 个 md 外无第二处运行时资源被误删（dist 产物、memory 的 schema_version/uv.lock/config、各模块 crabot-module.yaml、panic-monitor 的 py/sh 均在包内）；顺带发现根 LICENSE 没进包（Apache-2.0 分发合规），一并补上。
+- 修复：① Unix rsync 加 `builtins/**` include，Windows 清理豁免改 `(builtin-skills|builtins)`；② 新增 `.github/scripts/verify-release-payload.mjs`，打包前比对源码 skill 载荷与 staging，缺任一文件即 fail（对旧规则重放确认能拦下这 24 个）；③ `registerBuiltins` 返回注册数并对"目录不可读 / 子目录缺 SKILL.md / 一个都没扫到"打 error，Admin 启动打印注册数量，不再静默。
+- 验证：新增 `crabot-admin/tests/builtin-skills-registration.test.ts` 4 条（正常注册 / 目录缺失 / 空壳目录 / 仓库载荷全量可注册）；admin 全量 1032 通过；agent skill 契约 21 条通过。升级路径无需迁移——`extractRelease` 整目录替换，老实例升级后 registerBuiltins 自动补注册。
+- **未做（issue #43 下半，需单开 spec）**：内部维护任务的外发边界（`external_output: forbidden` 之类系统级约束，而非靠 prompt）、skill 缺失时 fail closed、任务进终态后 worker 未取消仍发消息的生命周期竞态。
 
 ## 2026-07-26 — wechat 入站文件超时降级按需补取（PR #44）
 

--- a/crabot-admin/src/index.ts
+++ b/crabot-admin/src/index.ts
@@ -772,7 +772,8 @@ export class AdminModule extends ModuleBase {
 
     // 注册内置 Skill（幂等，仅首次启动时写入）
     const builtinSkillsPath = path.join(__dirname, '..', 'builtins', 'skills')
-    await this.skillManager.registerBuiltins(builtinSkillsPath)
+    const registeredBuiltins = await this.skillManager.registerBuiltins(builtinSkillsPath)
+    console.log(`[Admin] Registered ${registeredBuiltins} builtin skills from ${builtinSkillsPath}`)
 
     // Seed builtin skills（幂等）
     await this.skillManager.seedBuiltinSkills(getBuiltinSkills())

--- a/crabot-admin/src/mcp-skill-manager.ts
+++ b/crabot-admin/src/mcp-skill-manager.ts
@@ -910,18 +910,22 @@ export class SkillManager {
   /**
    * 注册内置 Skill（幂等：已存在同名的不会重复注册）
    * 在 Admin 初始化时调用，扫描 builtinsDir 下的子目录，每个子目录应包含 SKILL.md
+   *
+   * 返回本次扫到的可用 builtin skill 数量。扫不到任何一个是异常状态（历史上
+   * release 包漏打 SKILL.md 导致 memory-curate 等全部缺失且无声无息），必须报错。
    */
-  async registerBuiltins(builtinsDir: string): Promise<void> {
+  async registerBuiltins(builtinsDir: string): Promise<number> {
     let dirEntries: import('fs').Dirent[]
     try {
       dirEntries = await fs.readdir(builtinsDir, { withFileTypes: true })
     } catch {
-      // builtinsDir 不存在时静默跳过
-      return
+      console.error(`[SkillManager] builtin skills 目录不可读，内置 skill 全部缺失: ${builtinsDir}`)
+      return 0
     }
 
     const existingNames = new Set(this.list().map(s => s.name))
     let changed = false
+    let found = 0
 
     for (const dirent of dirEntries) {
       if (!dirent.isDirectory()) continue
@@ -932,11 +936,16 @@ export class SkillManager {
       try {
         content = await fs.readFile(skillMdPath, 'utf-8')
       } catch {
-        continue // 没有 SKILL.md 的子目录跳过
+        console.error(`[SkillManager] builtin skill "${dirent.name}" 缺 SKILL.md，已跳过: ${skillMdPath}`)
+        continue
       }
 
       const parsed = parseSkillMd(content)
-      if (!parsed.name) continue
+      if (!parsed.name) {
+        console.error(`[SkillManager] builtin skill "${dirent.name}" 的 SKILL.md 缺 frontmatter name，已跳过`)
+        continue
+      }
+      found++
 
       if (existingNames.has(parsed.name)) {
         // 已注册：用 SKILL.md 当前 frontmatter 同步条目
@@ -983,9 +992,15 @@ export class SkillManager {
       changed = true
     }
 
+    if (found === 0) {
+      console.error(`[SkillManager] builtin skills 目录下没扫到任何 SKILL.md，内置 skill 全部缺失: ${builtinsDir}`)
+    }
+
     if (changed) {
       await this.save()
     }
+
+    return found
   }
 
   /**

--- a/crabot-admin/tests/builtin-skills-registration.test.ts
+++ b/crabot-admin/tests/builtin-skills-registration.test.ts
@@ -1,0 +1,101 @@
+/**
+ * 回归：release 包漏打 crabot-admin/builtins/skills/**\/SKILL.md（issue #43）
+ *
+ * 打包脚本的 `--exclude='*.md'` 只给 builtin-skills/ 开了 include 白名单，
+ * builtins/skills/ 下的 SKILL.md 全被剔掉 → 目录还在、内容没了 →
+ * registerBuiltins 逐个 `continue`，一条日志都不打，运行时只剩 4 个 seed skill。
+ *
+ * 这里锁两件事：
+ *   1. 缺失形态（目录不存在 / 目录空壳）必须 fail loud，不能静默
+ *   2. 仓库里每个 builtins/skills 子目录都带可解析的 SKILL.md
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readdirSync, existsSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { SkillManager } from '../src/mcp-skill-manager.js'
+
+const REPO_BUILTINS_DIR = join(__dirname, '..', 'builtins', 'skills')
+
+function writeSkill(dir: string, name: string): void {
+  mkdirSync(join(dir, name), { recursive: true })
+  writeFileSync(
+    join(dir, name, 'SKILL.md'),
+    `---\nname: ${name}\ndescription: desc ${name}\nversion: 1.0.0\n---\nbody\n`,
+    'utf-8',
+  )
+}
+
+describe('SkillManager.registerBuiltins', () => {
+  let dataDir: string
+  let builtinsDir: string
+  let mgr: SkillManager
+  let errSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(async () => {
+    dataDir = mkdtempSync(join(tmpdir(), 'skill-builtins-data-'))
+    builtinsDir = mkdtempSync(join(tmpdir(), 'skill-builtins-src-'))
+    mgr = new SkillManager(dataDir)
+    await mgr.initialize()
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    errSpy.mockRestore()
+    rmSync(dataDir, { recursive: true, force: true })
+    rmSync(builtinsDir, { recursive: true, force: true })
+  })
+
+  it('注册所有含 SKILL.md 的子目录并返回数量', async () => {
+    writeSkill(builtinsDir, 'memory-curate')
+    writeSkill(builtinsDir, 'tmp-page')
+
+    const count = await mgr.registerBuiltins(builtinsDir)
+
+    expect(count).toBe(2)
+    expect(mgr.list().map((s) => s.name).sort()).toEqual(['memory-curate', 'tmp-page'])
+    expect(errSpy).not.toHaveBeenCalled()
+  })
+
+  it('目录不存在 → 返回 0 且报错，不静默', async () => {
+    const count = await mgr.registerBuiltins(join(builtinsDir, 'nope'))
+
+    expect(count).toBe(0)
+    expect(errSpy).toHaveBeenCalled()
+    expect(errSpy.mock.calls.flat().join(' ')).toContain('nope')
+  })
+
+  it('子目录在但 SKILL.md 被打包剔掉（issue #43 形态）→ 返回 0 且报错', async () => {
+    mkdirSync(join(builtinsDir, 'memory-curate'), { recursive: true })
+    mkdirSync(join(builtinsDir, 'tmp-page', 'scripts'), { recursive: true })
+    writeFileSync(join(builtinsDir, 'tmp-page', 'scripts', 'server.cjs'), '// kept', 'utf-8')
+
+    const count = await mgr.registerBuiltins(builtinsDir)
+
+    expect(count).toBe(0)
+    expect(mgr.list()).toHaveLength(0)
+    expect(errSpy).toHaveBeenCalled()
+  })
+})
+
+describe('仓库 builtins/skills 载荷', () => {
+  it('每个子目录都有可解析 SKILL.md，且能全量注册', async () => {
+    const dirs = readdirSync(REPO_BUILTINS_DIR, { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .map((d) => d.name)
+    expect(dirs.length).toBeGreaterThan(0)
+    for (const d of dirs) {
+      expect(existsSync(join(REPO_BUILTINS_DIR, d, 'SKILL.md')), `${d} 缺 SKILL.md`).toBe(true)
+    }
+
+    const dataDir = mkdtempSync(join(tmpdir(), 'skill-builtins-repo-'))
+    try {
+      const mgr = new SkillManager(dataDir)
+      await mgr.initialize()
+      const count = await mgr.registerBuiltins(REPO_BUILTINS_DIR)
+      expect(count).toBe(dirs.length)
+    } finally {
+      rmSync(dataDir, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
修复 #43 上半：内置 skill 在 release 包里整体缺失。

## 根因

`release.yml` 打包用 `--exclude='*.md'` 剔文档，只给 `crabot-admin/builtin-skills/` 开了 include 白名单，`crabot-admin/builtins/skills/` 下 24 个 md 全被剔掉（6 个 SKILL.md + crabot-cli / scrapling 的 references）。**目录还在、内容没了**，`SkillManager.registerBuiltins` 逐个 `continue` 且一条日志都不打，装机后只剩 `seedBuiltinSkills` 注入的 4 个 superpowers skill——与 issue 里报的 `Available skills` 逐字一致。

丢的不止 memory-curate：`daily-reflection`、`memory-graph-linking`、`crabot-cli`、`tmp-page`、`scrapling` 全缺（tmp-page 的 `server.cjs` 还在，agent 却不知道怎么用它）。Unix / Windows 两条打包路径同病。dev 跑源码目录完整，本地永远复现不了。

## 全量审计

按 `release.yml` 的规则本地重放打包，与源码求差集：除上述 24 个 md 外，**没有第二处运行时资源被误删**——dist 产物、crabot-memory 的 `schema_version` / `uv.lock` / config、各模块 `crabot-module.yaml`、panic-monitor 的 py/sh 都在包里，差集其余全是 tsconfig / README / dev.sh 这类开发文件。顺带发现根 `LICENSE` 没进包（Apache-2.0 分发合规问题），一并补上。

`crabot upgrade` 是整目录替换（`extractRelease` rm + rename），修好打包后老实例升级即自动补注册，无需迁移。

## 改动

1. **打包**：Unix rsync 加 `builtins/**` include；Windows 清理豁免 `[\\/]builtin-skills[\\/]` → `[\\/](builtin-skills|builtins)[\\/]`；两边补 `LICENSE`。
2. **CI 卡口**：新增 `.github/scripts/verify-release-payload.mjs`，打包前比对源码 skill 载荷与 staging，缺任一文件即 fail。这类"白名单漏一条"人眼 review 挡不住，只能端到端断言。
3. **fail loud**：`registerBuiltins` 返回注册数，对「目录不可读 / 子目录缺 SKILL.md / 一个都没扫到」三种情形打 error，Admin 启动打印注册数量。原来三条路径全是静默 `continue`/`return`。

## 验证

- 新增 `crabot-admin/tests/builtin-skills-registration.test.ts` 4 条：正常注册返回数量 / 目录不存在 fail loud / **子目录空壳（issue #43 形态）fail loud** / 仓库 builtins 载荷全量可注册。改实现前 4 条全红。
- 校验脚本双向验证：对**旧规则**重放的 staging → exit 1，精确列出这 24 个缺失文件；对**新规则** staging → OK（43 个运行时文件齐全）。
- `crabot-admin` 全量 1032 通过；`crabot-agent` skill 契约 21 条通过；`tsc --noEmit` 干净。

## 不在本 PR

issue #43 下半涉及语义改动，另开 spec：内部维护任务的外发边界（`external_output: forbidden` 这类系统级约束，而非靠 prompt）、skill 缺失时 fail closed、任务进终态后 worker 未取消仍发消息的生命周期竞态。

🤖 Generated with [Claude Code](https://claude.com/claude-code)