### PR TITLE
fix(task): admin 判死前叫停 worker，对齐任务终态与 worker 生命周期 (#43)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,5 +1,22 @@
 # Crabot 项目进度
 
+> 最后更新：2026-07-27 — 任务终态与 worker 生命周期对齐（issue #43 下半）
+
+## 2026-07-27 — 任务终态与 worker 生命周期对齐（issue #43 下半）
+
+- 现象：任务被 admin 判 failed 后，worker 仍在发消息（"还在等你回复……"），随后 `failed → executing` / `failed → completed` 被状态机拒绝。
+- 根因：**admin 是 task 状态的 SSOT，但 worker loop 活在 agent 进程里，改 tasks.json 不会让挂起的 loop 消失**。worker 调 ask_human 后 park 在自己的 24h barrier 上；barrier 到点**自己醒来**继续跑，而 admin 的 24h 超时 + 5min 扫描最多晚 5 分钟才判死——两个独立计时器互不通知，且顺序恰好反了。`crab-messaging.ts` 的常量注释证明作者预见了这个竞态（"barrier 先 timeout 但 admin 还没切 failed，worker 假醒空跑"），但把两个 24h 设成相等、漏算了扫描周期，导致"假醒"稳定发生而非偶发。
+- 不变量（本次确立）：**task 非终态 ⟺ worker 活着**。本 bug 与 2026-06-05 orphan bug（worker 死了但 task 卡 waiting_human）是同一不变量的正反两个方向；当年选方案 C（24h 超时兜底）只堵反向，顺手制造了正向。
+- 决策（与 master 逐条确认，未写独立 spec）：
+  1. **abort 失败仍落 failed** + agent 侧自检兜底。理由：agent 不可达时不落终态 = orphan bug 复现，比窄窗口内多发一条消息更糟。
+  2. **只做正向**，反向不动。反向已有 24h 超时兜底，且修好正向后这条兜底自己也会走 abort（worker 已不存在，no-op），语义闭合；期间人类回复走 pushSupplement 失败 → 降级 new_task，不丢消息。
+  3. **三条判死路径统一入口**（超时扫描 / 重启 sweep / trace 对账），顺带接上人类 `cancel_task`——`handleCancelTask` 里"in-flight 取消应通知 worker"的旧 TODO 在此了结（agent 侧 `cancel_task` RPC 早就备好，admin 从来没调过，是半条链路）。
+  4. **spec 2026-05-14 §3.6 的"超时推 system supplement 让 worker 收尾"作废**。它自相矛盾（failed 是无出边终态，收尾写不回状态），且"抢救 24h 上下文"的价值已被 revive 机制取代——`revive_task_for_supplement` + checkpoint resume 能原样恢复 messages + prompt cache 前缀（checkpoint 是 per-turn 落盘的，parked worker 的上下文已在盘上）。
+  5. 复用审查：`cancelTask` 带取消语义，抽出无场景语义的 `abortWorker(taskId, reason)`，cancel / timeout / sweep / 对账各自组装状态语义后调它。
+- 三道防线：① admin 判死前主动 `abort_worker`；② `ASK_HUMAN_BARRIER_TIMEOUT_MS` 24h → 24h+15min（> admin 24h + 5min 扫描周期），保证 admin 必然先判死；③ barrier 真超时自醒时 `abortIfTaskTerminal` 查一次状态，已终态则静默 abort（admin 不可达时 fail-open，不误杀）。
+- 协议：protocol-agent-v2 新增 §3.6.1 `abort_worker`；protocol-admin 状态机段补「终态与 worker 生命周期」不变量；spec 2026-05-14 §3.6 加修订说明。
+- 验证：新增 admin 4 条（cancel/超时各自 abort、abort 失败仍落 failed、worker 自报终态不 abort）+ agent 8 条（abortWorker 返回值与委托、终态兜底三态、barrier onTimeout 触发与不误触发）；admin 全量 1036 通过，agent 全量 1640/1641（唯一失败是并行满载下的 bg shell flake——两次跑失败的是不同文件，干净树同样复现过 2 条，单跑 25 条全绿）。
+
 > 最后更新：2026-07-26 — wechat 入站文件超时降级按需补取（PR #44）
 
 ## 2026-07-26 — wechat 入站文件超时降级按需补取（PR #44）

--- a/crabot-admin/src/abort-worker-before-terminal.test.ts
+++ b/crabot-admin/src/abort-worker-before-terminal.test.ts
@@ -90,6 +90,19 @@ describe('admin 判死前 abort worker', () => {
     expect((admin as any).tasks.get(task.id).status).toBe('cancelled')
   })
 
+  it('cancel 一个 waiting 任务：worker 也活着（park 在 waitForPush），abort 后正常切 cancelled', async () => {
+    const task = await createTask()
+    const stored = (admin as any).tasks.get(task.id)
+    stored.status = 'waiting'
+    stored.started_at = new Date().toISOString()
+    stored.waiting_at = new Date().toISOString()
+
+    await (admin as any).handleCancelTask({ task_id: task.id, reason: 'user-canceled' })
+
+    expect(abortCalls()).toHaveLength(1)
+    expect((admin as any).tasks.get(task.id).status).toBe('cancelled')
+  })
+
   it('waiting_human 超时判死前叫停 worker', async () => {
     const task = await createTask()
     const stored = (admin as any).tasks.get(task.id)

--- a/crabot-admin/src/abort-worker-before-terminal.test.ts
+++ b/crabot-admin/src/abort-worker-before-terminal.test.ts
@@ -1,0 +1,132 @@
+/**
+ * 不变量：**task 非终态 ⟺ worker 活着**（决策 2026-07-27）。
+ *
+ * admin 是 task 状态的 SSOT，但 worker loop 活在 agent 进程里——改 tasks.json 不会让
+ * 挂起的 loop 消失。历史 bug（issue #43 现象二）：waiting_human 超时判死后 worker 仍
+ * parked 在 24h barrier 上，醒来继续发消息、再撞状态机拒绝。
+ *
+ * 这里锁三条 admin 主动判死路径都先叫停 worker，且 abort 失败不阻断判死。
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import fs from 'node:fs/promises'
+import AdminModule from './index.js'
+
+const TEST_PROTOCOL_PORT = 19824
+const TEST_WEB_PORT = 13024
+const TEST_DATA_DIR = './test-data/admin-abort-worker-test'
+
+type AgentCall = { method: string; params: unknown }
+
+describe('admin 判死前 abort worker', () => {
+  let admin: AdminModule
+  let agentCalls: AgentCall[]
+  let abortShouldFail: boolean
+
+  beforeAll(async () => {
+    await fs.rm(TEST_DATA_DIR, { recursive: true, force: true }).catch(() => {})
+
+    admin = new AdminModule(
+      {
+        moduleId: 'admin-abort-worker-test',
+        moduleType: 'admin',
+        version: '0.1.0',
+        protocolVersion: '0.1.0',
+        port: TEST_PROTOCOL_PORT,
+        subscriptions: [],
+      },
+      {
+        web_port: TEST_WEB_PORT,
+        data_dir: TEST_DATA_DIR,
+        password_env: 'TEST_ADMIN_PASSWORD_ABORT_WORKER',
+        jwt_secret_env: 'TEST_JWT_SECRET_ABORT_WORKER',
+        token_ttl: 3600,
+      }
+    )
+
+    process.env.TEST_ADMIN_PASSWORD_ABORT_WORKER = 'test_password_123'
+    process.env.TEST_JWT_SECRET_ABORT_WORKER = 'test_jwt_secret_at_least_32_chars'
+
+    await admin.start()
+  })
+
+  afterAll(async () => {
+    await admin.stop()
+    await fs.rm(TEST_DATA_DIR, { recursive: true, force: true }).catch(() => {})
+  })
+
+  beforeEach(() => {
+    agentCalls = []
+    abortShouldFail = false
+    // 拦截所有 agent RPC：记录调用，abort_worker 按开关决定成败，其余静默成功
+    ;(admin as any).callAgentRpc = async (method: string, params: unknown) => {
+      agentCalls.push({ method, params })
+      if (method === 'abort_worker') {
+        if (abortShouldFail) throw new Error('agent unreachable')
+        return { aborted: true }
+      }
+      return {}
+    }
+  })
+
+  async function createTask(): Promise<{ id: string }> {
+    const { task } = await (admin as any).handleCreateTask({
+      title: 't', priority: 'normal',
+      source: { trigger_type: 'manual', origin: 'human' },
+    })
+    return task
+  }
+
+  function abortCalls(): AgentCall[] {
+    return agentCalls.filter((c) => c.method === 'abort_worker')
+  }
+
+  it('cancel 前叫停 worker', async () => {
+    const task = await createTask()
+
+    await (admin as any).handleCancelTask({ task_id: task.id, reason: 'user-canceled' })
+
+    expect(abortCalls()).toHaveLength(1)
+    expect(abortCalls()[0].params).toMatchObject({ task_id: task.id, reason: 'user-canceled' })
+    expect((admin as any).tasks.get(task.id).status).toBe('cancelled')
+  })
+
+  it('waiting_human 超时判死前叫停 worker', async () => {
+    const task = await createTask()
+    const stored = (admin as any).tasks.get(task.id)
+    stored.status = 'waiting_human'
+    stored.started_at = new Date(Date.now() - 25 * 3600 * 1000).toISOString()
+    stored.waiting_human_at = new Date(Date.now() - 25 * 3600 * 1000).toISOString()
+
+    await admin.runWaitingHumanTimeoutScan()
+
+    expect(abortCalls()).toHaveLength(1)
+    expect(abortCalls()[0].params).toMatchObject({ task_id: task.id })
+    expect((admin as any).tasks.get(task.id).status).toBe('failed')
+  })
+
+  it('abort RPC 失败仍然落 failed（不因 agent 不可达把任务永久卡住）', async () => {
+    const task = await createTask()
+    const stored = (admin as any).tasks.get(task.id)
+    stored.status = 'waiting_human'
+    stored.started_at = new Date(Date.now() - 25 * 3600 * 1000).toISOString()
+    stored.waiting_human_at = new Date(Date.now() - 25 * 3600 * 1000).toISOString()
+    abortShouldFail = true
+
+    await admin.runWaitingHumanTimeoutScan()
+
+    expect(abortCalls()).toHaveLength(1)
+    expect((admin as any).tasks.get(task.id).status).toBe('failed')
+  })
+
+  it('worker 自己上报终态时不叫停（那是正常收尾，abort 会打断）', async () => {
+    const task = await createTask()
+    const stored = (admin as any).tasks.get(task.id)
+    stored.status = 'executing'
+    stored.started_at = new Date().toISOString()
+
+    await (admin as any).handleUpdateTaskStatus({ task_id: task.id, status: 'completed' })
+
+    expect(abortCalls()).toHaveLength(0)
+    expect((admin as any).tasks.get(task.id).status).toBe('completed')
+  })
+})

--- a/crabot-admin/src/index.ts
+++ b/crabot-admin/src/index.ts
@@ -5740,11 +5740,12 @@ export class AdminModule extends ModuleBase {
       throw new Error(AdminErrorCode.TASK_NOT_FOUND)
     }
 
-    // VALID_TRANSITIONS 已覆盖 pending/planning/executing/waiting_human → cancelled。
-    // applyStatusTransition 会抛 INVALID_STATUS_TRANSITION（含 waiting / 终态等不可取消的情况）。
+    // VALID_TRANSITIONS 覆盖全部四个 in-flight 态 → cancelled（pending / planning /
+    // executing / waiting_human / waiting）；只有终态会被 applyStatusTransition 拒。
     // 先叫停 worker 再切状态——取消一个还在跑的 worker 本来就是 cancel 的题中之义
-    // （旧 TODO"in-flight 取消应通知 worker"在此了结）。状态机拒绝时 abort 已经发出，
-    // 但那些场景（waiting / 终态）本就没有活着的 worker，abort 是 no-op。
+    // （旧 TODO"in-flight 取消应通知 worker"在此了结）。waiting 态的 worker 也是活着的
+    // （park 在 humanQueue.waitForPush 等 subagent / bg 通知），abort 唤醒它退出后
+    // waiting → cancelled 正常落地。只有对终态任务 abort 才是 no-op。
     await this.abortWorkerBeforeTerminal(task.id, params.reason ?? 'cancelled by human')
     try {
       this.applyStatusTransition(task, 'cancelled', { error: params.reason })

--- a/crabot-admin/src/index.ts
+++ b/crabot-admin/src/index.ts
@@ -4846,6 +4846,9 @@ export class AdminModule extends ModuleBase {
     // 2. 不能 resume 的（含 recovery 自身）→ 标 failed
     const toFail = [...needRecovery, ...inFlight.filter((t) => t.tags.includes('recovery'))]
     for (const t of toFail) {
+      // agent 刚重启，worker 通常已随进程消失，abort 多为 no-op；仍统一走判死入口，
+      // 覆盖"agent 没重启、只是 resume 失败"这类 worker 仍在的情形。
+      await this.abortWorkerBeforeTerminal(t.id, 'agent_restarted_during_execution')
       this.applyStatusTransition(t, 'failed', { error: 'agent_restarted_during_execution' })
     }
     if (toFail.length > 0) {
@@ -5147,6 +5150,34 @@ export class AdminModule extends ModuleBase {
    * 任何直接 mutate task.status 的新代码 = bug。如发现需要绕过本方法的场景，
    * 优先检查是不是 VALID_TRANSITIONS 缺一条；不是的话再考虑加 opt。
    */
+  /**
+   * admin 单方面把 task 判死前，先叫停对应的 worker loop。
+   *
+   * 不变量：**task 非终态 ⟺ worker 活着**。admin 是 task 状态的 SSOT，但 worker loop 的
+   * 生死在 agent 进程里——admin 改 tasks.json 不会让 agent 那边挂起的 loop 消失。三条
+   * 判死路径（waiting_human 超时 / 重启 sweep / trace 对账）+ 人类主动 cancel 都必须先
+   * 走这里，否则 worker 会带着已死的 task 继续跑（发消息、撞状态机拒绝）。
+   *
+   * **只用于 admin 主动判死**：worker 自己上报终态时不能调——那是它正常收尾，abort 会打断。
+   *
+   * 失败不阻断判死（决策 2026-07-27）：admin 不可达 agent 时若不落终态，任务会永久卡在
+   * 非终态——那正是 2026-06-05 orphan bug 的形态，比窄窗口内 worker 多说一句话更糟。
+   * abort 没送达的窄窗口由 agent 侧 barrier onTimeout 自检兜底。
+   */
+  private async abortWorkerBeforeTerminal(taskId: TaskId, reason: string): Promise<void> {
+    try {
+      await this.callAgentRpc<{ task_id: TaskId; reason: string }, { aborted: boolean }>(
+        'abort_worker',
+        { task_id: taskId, reason },
+      )
+    } catch (err) {
+      console.warn(
+        `[Admin] abort_worker failed for task ${taskId} (${reason}); ` +
+        `落终态继续，agent 侧 barrier 自检兜底: ${err instanceof Error ? err.message : String(err)}`,
+      )
+    }
+  }
+
   private applyStatusTransition(
     task: Task,
     newStatus: TaskStatus,
@@ -5644,6 +5675,9 @@ export class AdminModule extends ModuleBase {
       if (!task) continue  // race：扫描期间 task 被删了
 
       try {
+        // 判死前叫停 worker。对账的前提是"trace 已全终态"，worker 通常不在了（abort no-op），
+        // 但 trace 漏写 / worker 卡死等 drift 场景下它可能还活着，统一走判死入口。
+        await this.abortWorkerBeforeTerminal(patch.taskId, `reconciliation: ${patch.reason}`)
         // 智能恢复：current=waiting_human/waiting → 终态非法，需中转 executing
         if (task.status === 'waiting_human' || task.status === 'waiting') {
           this.applyStatusTransition(task, 'executing')
@@ -5681,10 +5715,12 @@ export class AdminModule extends ModuleBase {
     }
 
     for (const task of expiredTasks) {
-      // TODO(Phase 2 §3.6)：当 Phase 2 实现 humanQueue 注入路径后，超时切 failed 时还应
-      // 推一条 system supplement 给 worker（"超时未收到人类回复，请基于已掌握信息收尾"），
-      // 让 worker 优雅收尾而不是冷启动 recovery。当前 Phase 1 只切状态，supplement 留待
-      // Phase 2 完成 handleLocalSupplement + humanQueue 链路后补。
+      // 判死前先叫停 worker（它正 park 在 ask_human barrier 上，abort 会把它叫醒并退出）。
+      // spec 2026-05-14 §3.6 原设计是"切 failed + 推 system supplement 让 worker 收尾"，
+      // 已作废（决策 2026-07-27）：收尾要写回状态，而 failed 是无出边终态，语义自相矛盾；
+      // 且人类事后回复走 revive_task_for_supplement + checkpoint resume，上下文不会丢，
+      // 不需要临终抢救一份没人读的收尾报告。
+      await this.abortWorkerBeforeTerminal(task.id, 'waiting_human timeout')
       try {
         await this.handleUpdateTaskStatus({
           task_id: task.id,
@@ -5705,7 +5741,10 @@ export class AdminModule extends ModuleBase {
 
     // VALID_TRANSITIONS 已覆盖 pending/planning/executing/waiting_human → cancelled。
     // applyStatusTransition 会抛 INVALID_STATUS_TRANSITION（含 waiting / 终态等不可取消的情况）。
-    // TODO: pending 之外的 in-flight 取消应通知 worker，现在仍是直切。
+    // 先叫停 worker 再切状态——取消一个还在跑的 worker 本来就是 cancel 的题中之义
+    // （旧 TODO"in-flight 取消应通知 worker"在此了结）。状态机拒绝时 abort 已经发出，
+    // 但那些场景（waiting / 终态）本就没有活着的 worker，abort 是 no-op。
+    await this.abortWorkerBeforeTerminal(task.id, params.reason ?? 'cancelled by human')
     try {
       this.applyStatusTransition(task, 'cancelled', { error: params.reason })
     } catch (err) {

--- a/crabot-agent/src/agent/agent-handler.ts
+++ b/crabot-agent/src/agent/agent-handler.ts
@@ -3168,7 +3168,10 @@ export class AgentHandler {
    * 失败（agent 忙 / 网络抖动），此时 worker 会在 barrier 超时后自己醒来——若 task 已是
    * 终态，它继续跑就会发出用户看不懂的消息、再撞上状态机拒绝。这里静默 abort 收口。
    *
-   * admin 不可达时保持现状继续跑（fail-open）：查不到状态不代表任务已死。
+   * admin 不可达时保持现状继续跑（fail-open）：查不到状态不代表任务已死。但 admin 明确
+   * 答复 task 不存在是另一回事——`delete_task` 拒删活跃任务、按量清理只删终态任务，所以
+   * "查无此 task" ⟹ 它已经终态过并被删掉，此时同样要 abort（人类在 UI 看到 failed 任务
+   * 顺手删掉是很自然的操作，不能让 worker 借这条更窄的路继续跑）。
    */
   async abortWorkerIfTaskTerminal(taskId: TaskId): Promise<void> {
     if (!this.deps?.getAdminPort || !this.deps.rpcClient) return
@@ -3183,7 +3186,12 @@ export class AgentHandler {
         this.abortWorker(taskId, `task already ${resp.task.status} (barrier timeout guard)`)
       }
     } catch (err) {
-      log(`[abort-worker] terminal guard skipped task=${taskId}: ${err instanceof Error ? err.message : String(err)}`)
+      const msg = err instanceof Error ? err.message : String(err)
+      if (msg.includes('TASK_NOT_FOUND')) {
+        this.abortWorker(taskId, 'task no longer exists (barrier timeout guard)')
+        return
+      }
+      log(`[abort-worker] terminal guard skipped task=${taskId}: ${msg}`)
     }
   }
 

--- a/crabot-agent/src/agent/agent-handler.ts
+++ b/crabot-agent/src/agent/agent-handler.ts
@@ -224,6 +224,10 @@ const LOG_FILE = path.join(getAgentDataDir(), 'agent-handler-debug.log')
 /** subagent 完成通知里内联结果预览的字符上限；超过则截断并提示用 get_subagent_output 读全文。 */
 const SUBAGENT_RESULT_PREVIEW_MAX = 2000
 
+/** Task 终态集合。与 crabot-admin/src/task-state-machine.ts 的 TERMINAL_STATUSES 对齐
+ *  （同 goal-audit.ts TERMINAL_GOAL_STATUSES 的同步一份 + 注释指向源的做法）。 */
+const TERMINAL_TASK_STATUSES: ReadonlySet<string> = new Set(['completed', 'failed', 'cancelled'])
+
 export interface SubAgentExitInfo {
   readonly entity_id: string
   readonly task_description: string
@@ -1300,6 +1304,9 @@ export class AgentHandler {
           taskType: task.task_type,
           // 用 getter 形式封装本地 cache，worker 中途 set_task_goal 后下一轮工具调用立即生效。
           hasGoal: () => goalSetCache,
+          // ask_human barrier 超时自醒时的兜底：admin 判死时的 abort_worker 若没送达，
+          // 这里查一次 task 状态，已终态就静默 abort，不让 worker 带着死任务继续跑。
+          abortIfTaskTerminal: () => this.abortWorkerIfTaskTerminal(task.task_id),
           // Goal mode 缓冲：send_message handler 在工作态（无 activeAudit）把 info 消息推入 outboundBuffer；
           // 等审态（hasActiveAudit=true）下立即 flush。引用 taskState 持久数组，跨 iteration 一致。
           // spec: 2026-06-07-goal-audit-async-buffered-info-design.md Task 6
@@ -3130,12 +3137,53 @@ export class AgentHandler {
     }
   }
 
-  cancelTask(taskId: TaskId, _reason: string): void {
+  /**
+   * 中止某个 task 的 worker loop。**无场景语义**——只负责 abort，不碰 task 状态、
+   * 不假设调用方是取消 / 超时 / 对账中的哪一种。各场景的状态语义由 admin 侧组装。
+   *
+   * 不变量：admin 把 task 落终态前必须先调本方法（经 abort_worker RPC），保证
+   * 「task 非终态 ⟺ worker 活着」。parked 在 barrier 上的 worker 也能被叫醒——
+   * humanQueue.waitBarrier 监听 abortSignal，醒来后在下一轮 LLM 前退出。
+   *
+   * @returns 是否找到活着的 worker（false = 本来就没在跑，abort 是 no-op）
+   */
+  abortWorker(taskId: TaskId, reason: string): boolean {
+    const taskState = this.activeTasks.get(taskId)
+    if (!taskState) return false
+    log(`[abort-worker] task=${taskId} reason=${reason}`)
+    taskState.abortController.abort()
+    return true
+  }
+
+  cancelTask(taskId: TaskId, reason: string): void {
     // SSOT: 不再 mutate agent 内存里的 task status —— admin 那侧的 cancel_task RPC 已经
     // 把 tasks.json 改成 'cancelled'，本方法只负责 abort 当前 worker loop。
-    const taskState = this.activeTasks.get(taskId)
-    if (taskState) {
-      taskState.abortController.abort()
+    this.abortWorker(taskId, reason)
+  }
+
+  /**
+   * 兜底：barrier 超时自醒时，先确认 task 还没被 admin 判死。
+   *
+   * 正常路径下 admin 判死时会经 abort_worker 叫停 worker，走不到这里。但那条 RPC 可能
+   * 失败（agent 忙 / 网络抖动），此时 worker 会在 barrier 超时后自己醒来——若 task 已是
+   * 终态，它继续跑就会发出用户看不懂的消息、再撞上状态机拒绝。这里静默 abort 收口。
+   *
+   * admin 不可达时保持现状继续跑（fail-open）：查不到状态不代表任务已死。
+   */
+  async abortWorkerIfTaskTerminal(taskId: TaskId): Promise<void> {
+    if (!this.deps?.getAdminPort || !this.deps.rpcClient) return
+    if (!this.activeTasks.has(taskId)) return
+    try {
+      const adminPort = await this.deps.getAdminPort()
+      const resp = await this.deps.rpcClient.call<
+        { task_id: string },
+        { task: { status: string } }
+      >(adminPort, 'get_task', { task_id: taskId }, this.deps.moduleId)
+      if (TERMINAL_TASK_STATUSES.has(resp.task.status)) {
+        this.abortWorker(taskId, `task already ${resp.task.status} (barrier timeout guard)`)
+      }
+    } catch (err) {
+      log(`[abort-worker] terminal guard skipped task=${taskId}: ${err instanceof Error ? err.message : String(err)}`)
     }
   }
 

--- a/crabot-agent/src/mcp/crab-messaging.ts
+++ b/crabot-agent/src/mcp/crab-messaging.ts
@@ -66,6 +66,10 @@ export interface TaskContext {
    *
    *  spec: 2026-06-07-goal-audit-async-buffered-info-design.md §4.1 + Revision 第 1 段 */
   outboundBuffer?: Array<OutboundBufferEntry>
+  /** ask_human barrier 超时自醒时的兜底钩子：查一次 task 状态，已终态则 abort worker。
+   *  正常路径下 admin 判死会先经 abort_worker 叫停 worker，走不到这里；这条覆盖那次 RPC
+   *  失败的窄窗口。admin 不可达时 fail-open（继续跑）。 */
+  abortIfTaskTerminal?: () => Promise<void>
   /** 当前 task 是否处于"等审态"（activeAuditId 非空）。同步 getter，工具内每次调用现读。
    *  工作态（false）= 缓冲；等审态（true）= 立即 flush 给用户（过程响应）。
    *  spec: 2026-06-07-goal-audit-async-buffered-info-design.md Task 6 */
@@ -145,10 +149,16 @@ const ASK_HUMAN_PENDING_QUESTION_MAX_LEN = 2000
 
 /**
  * ask_human 设置 barrier 的超时。
- * 必须 >= admin WAITING_HUMAN_TIMEOUT_MS（24h），否则 barrier 先 timeout 但 admin 还没切 failed，worker 假醒空跑。
- * 注：admin 端常量在 crabot-admin/src/index.ts AdminModule.WAITING_HUMAN_TIMEOUT_MS。
+ *
+ * 必须 > admin 的 WAITING_HUMAN_TIMEOUT_MS(24h) + WAITING_HUMAN_SCAN_INTERVAL_MS(5min)：
+ * admin 判死发生在 [24h, 24h+5min] 区间（超时值 + 一个扫描周期），barrier 早于这个区间醒
+ * 就是 worker 假醒空跑。这里取 24h+15min 留足余量。
+ * 注：admin 端两个常量都在 crabot-admin/src/index.ts AdminModule 上。
+ *
+ * 顺序保证不只靠这个常量——admin 判死前会经 abort_worker 主动叫停 worker（维持
+ * 「task 非终态 ⟺ worker 活着」），本常量与 setBarrier 的 onTimeout 兜底是第二、三道防线。
  */
-const ASK_HUMAN_BARRIER_TIMEOUT_MS = 24 * 60 * 60 * 1000
+const ASK_HUMAN_BARRIER_TIMEOUT_MS = 24 * 60 * 60 * 1000 + 15 * 60 * 1000
 
 // ============================================================================
 // 工具类型定义
@@ -1026,7 +1036,10 @@ crabot 系统给你的所有信号——system prompt、supplement 注入、tool
           }
 
           // Step 3: setBarrier（本地内存操作，从不失败）
-          taskCtx.humanQueue.setBarrier(ASK_HUMAN_BARRIER_TIMEOUT_MS)
+          // onTimeout 兜底：barrier 自醒时先确认 admin 那边还没判死（见 abortIfTaskTerminal 注释）。
+          taskCtx.humanQueue.setBarrier(ASK_HUMAN_BARRIER_TIMEOUT_MS, () => {
+            void taskCtx.abortIfTaskTerminal?.()
+          })
         }
 
         return wrapText({

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -475,6 +475,7 @@ export class UnifiedAgent extends ModuleBase {
       this.registerMethod('deliver_human_response', this.handleDeliverHumanResponse.bind(this))
       this.registerMethod('deliver_page_feedback', this.handleDeliverPageFeedback.bind(this))
       this.registerMethod('cancel_task', this.handleCancelTask.bind(this))
+      this.registerMethod('abort_worker', this.handleAbortWorker.bind(this))
     }
 
     // Trace 接口
@@ -2382,6 +2383,18 @@ export class UnifiedAgent extends ModuleBase {
 
     this.agentHandler.cancelTask(params.task_id, params.reason)
     return { cancelled: true }
+  }
+
+  /**
+   * 中止 worker loop，不带场景语义。admin 把 task 落终态（cancelled / failed）前调用，
+   * 维持「task 非终态 ⟺ worker 活着」。worker 本来就不在跑时返回 aborted=false（no-op）。
+   */
+  private handleAbortWorker(params: { task_id: TaskId; reason: string }): { aborted: boolean } {
+    if (!this.agentHandler) {
+      throw new Error('Worker handler not configured')
+    }
+
+    return { aborted: this.agentHandler.abortWorker(params.task_id, params.reason) }
   }
 
   // ============================================================================

--- a/crabot-agent/tests/agent/agent-handler.test.ts
+++ b/crabot-agent/tests/agent/agent-handler.test.ts
@@ -798,6 +798,71 @@ describe('AgentHandler', () => {
     })
   })
 
+  // 不变量：task 非终态 ⟺ worker 活着（决策 2026-07-27，issue #43 现象二）。
+  // admin 判死前经 abort_worker RPC 调 abortWorker；abortWorkerIfTaskTerminal 是那条
+  // RPC 失败时、worker 从 barrier 超时自醒后的兜底。
+  describe('abortWorker / abortWorkerIfTaskTerminal', () => {
+    function withActiveTask(handler: AgentHandler, taskId: string): AbortController {
+      const abortController = new AbortController()
+      ;(handler as any).activeTasks.set(taskId, { abortController })
+      return abortController
+    }
+
+    it('abortWorker 中止活着的 worker 并返回 true', () => {
+      const handler = makeHandler()
+      const ac = withActiveTask(handler, 'task_1')
+
+      expect(handler.abortWorker('task_1', 'timeout')).toBe(true)
+      expect(ac.signal.aborted).toBe(true)
+    })
+
+    it('abortWorker 对不在跑的 task 返回 false（no-op）', () => {
+      const handler = makeHandler()
+      expect(handler.abortWorker('nonexistent_task', 'timeout')).toBe(false)
+    })
+
+    it('cancelTask 委托给 abortWorker', () => {
+      const handler = makeHandler()
+      const ac = withActiveTask(handler, 'task_1')
+
+      handler.cancelTask('task_1', 'user-canceled')
+      expect(ac.signal.aborted).toBe(true)
+    })
+
+    it('barrier 兜底：task 已终态 → abort', async () => {
+      const rpcCall = vi.fn().mockResolvedValue({ task: { id: 'task_1', status: 'failed' } })
+      const handler = makeMessagingHandler(rpcCall)
+      const ac = withActiveTask(handler, 'task_1')
+
+      await handler.abortWorkerIfTaskTerminal('task_1')
+
+      expect(ac.signal.aborted).toBe(true)
+      handler.dispose()
+    })
+
+    it('barrier 兜底：task 仍活跃 → 不动 worker', async () => {
+      const rpcCall = vi.fn().mockResolvedValue({ task: { id: 'task_1', status: 'waiting_human' } })
+      const handler = makeMessagingHandler(rpcCall)
+      const ac = withActiveTask(handler, 'task_1')
+
+      await handler.abortWorkerIfTaskTerminal('task_1')
+
+      expect(ac.signal.aborted).toBe(false)
+      handler.dispose()
+    })
+
+    it('barrier 兜底：admin 不可达 → fail-open，不误杀 worker', async () => {
+      const rpcCall = vi.fn().mockRejectedValue(new Error('admin unreachable'))
+      const handler = makeMessagingHandler(rpcCall)
+      const ac = withActiveTask(handler, 'task_1')
+
+      await expect(handler.abortWorkerIfTaskTerminal('task_1')).resolves.toBeUndefined()
+
+      expect(ac.signal.aborted).toBe(false)
+      handler.dispose()
+    })
+  })
+
   describe('getActiveTaskCount', () => {
     it('should be 0 after task completes', async () => {
       mockRunEngine.mockResolvedValue(makeEngineResult())

--- a/crabot-agent/tests/agent/agent-handler.test.ts
+++ b/crabot-agent/tests/agent/agent-handler.test.ts
@@ -851,6 +851,18 @@ describe('AgentHandler', () => {
       handler.dispose()
     })
 
+    it('barrier 兜底：task 已被删除（TASK_NOT_FOUND）→ abort', async () => {
+      // delete_task 拒删活跃任务、按量清理只删终态任务，所以"查无此 task" ⟹ 它已终态过。
+      const rpcCall = vi.fn().mockRejectedValue(new Error('ADMIN_TASK_NOT_FOUND'))
+      const handler = makeMessagingHandler(rpcCall)
+      const ac = withActiveTask(handler, 'task_1')
+
+      await handler.abortWorkerIfTaskTerminal('task_1')
+
+      expect(ac.signal.aborted).toBe(true)
+      handler.dispose()
+    })
+
     it('barrier 兜底：admin 不可达 → fail-open，不误杀 worker', async () => {
       const rpcCall = vi.fn().mockRejectedValue(new Error('admin unreachable'))
       const handler = makeMessagingHandler(rpcCall)

--- a/crabot-agent/tests/mcp/crab-messaging-ask-human-terminal-guard.test.ts
+++ b/crabot-agent/tests/mcp/crab-messaging-ask-human-terminal-guard.test.ts
@@ -1,0 +1,79 @@
+/**
+ * ask_human barrier 超时自醒时的终态兜底（决策 2026-07-27，issue #43 现象二第三道防线）。
+ *
+ * 正常路径：admin 判死前经 abort_worker 叫停 worker，barrier 根本等不到超时。
+ * 这条覆盖那次 RPC 失败的窄窗口——barrier 自己醒来时先查 task 状态，已终态就 abort，
+ * 不让 worker 带着死任务继续跑（历史上它会发出用户看不懂的进度消息，再撞状态机拒绝）。
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { buildMessagingTools } from '../../src/mcp/crab-messaging.js'
+import { HumanMessageQueue } from '../../src/engine/human-message-queue.js'
+
+function findTool(tools: ReturnType<typeof buildMessagingTools>, name: string) {
+  const t = tools.find((x) => x.name === name)
+  if (!t) throw new Error(`tool ${name} not found`)
+  return t
+}
+
+function buildTools(queue: HumanMessageQueue, abortIfTaskTerminal: () => Promise<void>) {
+  return buildMessagingTools({
+    rpcClient: {
+      call: vi.fn().mockResolvedValue({ platform_message_id: 'm', sent_at: '' }),
+    } as never,
+    moduleId: 'worker-test',
+    getAdminPort: async () => 19001,
+    resolveChannelPort: async () => 19009,
+    getTaskContext: () => ({
+      taskId: 't1',
+      humanQueue: queue,
+      triggerType: 'message' as const,
+      hasGoal: () => false,
+      abortIfTaskTerminal,
+    }),
+  })
+}
+
+describe('ask_human barrier 终态兜底', () => {
+  it('barrier 超时触发 abortIfTaskTerminal', async () => {
+    vi.useFakeTimers()
+    try {
+      const queue = new HumanMessageQueue()
+      const guard = vi.fn().mockResolvedValue(undefined)
+      const tools = buildTools(queue, guard)
+
+      await findTool(tools, 'send_message').handler({
+        channel_id: 'telegram-001', session_id: 's1', content: 'q', intent: 'ask_human',
+      })
+      expect(queue.hasBarrier).toBe(true)
+      expect(guard).not.toHaveBeenCalled()
+
+      // barrier 是 24h + 15min（> admin 24h 超时 + 5min 扫描周期）
+      vi.advanceTimersByTime(24 * 3600 * 1000)
+      expect(guard).not.toHaveBeenCalled()
+      vi.advanceTimersByTime(16 * 60 * 1000)
+      expect(guard).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('人类回复提前唤醒时不触发兜底（只有超时自醒才查）', async () => {
+    vi.useFakeTimers()
+    try {
+      const queue = new HumanMessageQueue()
+      const guard = vi.fn().mockResolvedValue(undefined)
+      const tools = buildTools(queue, guard)
+
+      await findTool(tools, 'send_message').handler({
+        channel_id: 'telegram-001', session_id: 's1', content: 'q', intent: 'ask_human',
+      })
+      queue.push('人类回复')
+
+      expect(queue.hasBarrier).toBe(false)
+      vi.advanceTimersByTime(25 * 3600 * 1000)
+      expect(guard).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})


### PR DESCRIPTION
修复 #43 现象二。与 #45（打包）主题独立，可分别 review。

## 不变量

**`task 非终态` ⟺ `worker 在 agent 的 activeTasks 里活着`**

admin 是 task 状态的 SSOT，但 worker loop 活在 agent 进程内——改 `tasks.json` 不会让挂起的 async 函数消失。两个方向的违反其实是同一个 bug：

| 方向 | 成因 | 症状 |
|---|---|---|
| 正向 | admin 单方面判死，agent 不知情 | failed + worker 还活着 → 本 issue |
| 反向 | worker 崩溃，admin 不知情 | waiting_human + worker 已死 → 2026-06-05 orphan bug |

当年 orphan bug 选了方案 C（24h 超时兜底）而不是方案 B（问 agent worker 死活），只堵了反向、顺手制造了正向。

## 具体机制

worker 调 `send_message(intent='ask_human')` 后 park 在自己的 24h barrier 上。到点 **barrier 自己把它叫醒**（agent 进程内计时器），它继续跑下一轮 LLM；admin 那边是另一个 24h 计时器 + 5 分钟扫描，判死落在 `[24h, 24h+5min]`。**worker 必然先醒**，醒来时不知道自己已被判死，照常发进度消息、最后撞 `failed → executing` 拒绝。

`crab-messaging.ts` 的常量注释证明作者预见了这个竞态——"barrier 先 timeout 但 admin 还没切 failed，worker 假醒空跑"——但把两个 24h 设成**相等**、漏算了 admin 的扫描周期，所以"假醒"是稳定发生而非偶发。

## 三道防线

1. **admin 判死前叫停 worker**（根治）。三条判死路径（`waiting_human` 超时扫描 / 重启 resume sweep / trace 对账）+ 人类 `cancel_task` 统一走新的 `abortWorkerBeforeTerminal`，经新增的 `abort_worker` RPC 叫停。abort 失败**不阻断判死**——agent 不可达时不落终态，任务就永久卡在非终态，那正是 orphan bug 的形态。
   顺带了结 `handleCancelTask` 的旧 TODO（"in-flight 取消应通知 worker"）：agent 侧 `cancel_task` RPC 早就备好，admin 从来没调过，是半条链路。
2. **常量对齐**：`ASK_HUMAN_BARRIER_TIMEOUT_MS` 24h → 24h+15min，越过 admin 判死区间。
3. **barrier 自醒兜底**：真超时醒来时 `abortIfTaskTerminal` 查一次 task 状态，已终态则静默 abort。admin 不可达时 fail-open，不误杀正常任务。

## 一并作废：spec 2026-05-14 §3.6 的收尾 supplement

原设计是"超时切 failed **+ 推 system supplement 让 worker 优雅收尾**"，代码里长期挂着 Phase 2 TODO 没实现。这次决定作废而不是补上：

- **自相矛盾**：`failed` 在 `VALID_TRANSITIONS` 里是无出边终态，worker 收尾后写不回任何状态，只会撞 `failed → completed` 拒绝——正是 issue 日志里那两条 rejected。
- **价值已被取代**：当年的理由是"抢救 worker 手里 24h 的上下文"。但 `revive_task_for_supplement` + checkpoint resume（spec 2026-06-29 / 2026-07-18）能原样恢复 messages 和 prompt cache 前缀，而 checkpoint 是 per-turn 落盘的——parked worker 的上下文已经在盘上。人类事后回复走 revive 即可，不需要临终产出一份没人读的收尾报告。

## 语义复用审查（CLAUDE.md 要求）

`cancelTask` 带明确的取消语义，不能直接当通用入口给超时/对账复用。抽出无场景语义的 `abortWorker(taskId, reason)`——只 abort，不碰状态、不假设场景；`cancelTask` 与三条判死路径各自组装自己的状态语义后调它。测试覆盖语义不变量而非参数透传：worker **自己**上报终态时不得 abort（那是正常收尾，打断它才是 bug）。

## 未采纳 issue 的建议方案

issue 建议"进终态立即取消 worker + 禁止后续 tool call + 丢弃 buffered outbound"。后两条会砍掉 `revive_task_for_supplement` 这条已投入的能力——"终态任务被人类追问后带着 checkpoint 继续办"是现行产品语义。真正缺的只是 admin 与 agent 之间的生命周期对齐。

## 验证

- admin 新增 4 条：cancel / 超时判死各自 abort、abort 失败仍落 failed、**worker 自报终态不 abort**
- agent 新增 8 条：`abortWorker` 返回值与 `cancelTask` 委托、终态兜底三态（终态 abort / 活跃不动 / admin 不可达 fail-open）、barrier `onTimeout` 触发与不误触发（人类回复提前唤醒时不查）
- admin 全量 1036 通过；agent 全量 1640/1641，唯一失败是并行满载下的 bg shell flake——两次跑失败的是**不同文件**，干净树同样复现过 2 条，两个文件单跑 25 条全绿
- `tsc --noEmit` 两模块干净

## 协议

已直推 crabot-docs main（`7a6fe1f`）：protocol-agent-v2 新增 §3.6.1 `abort_worker`、protocol-admin 状态机段补不变量、spec 2026-05-14 §3.6 加修订说明。本次实现先于协议落笔，事后补齐并对照复核过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)