### PR TITLE
feat(workers): Manager/Worker 拆分 P1——worker 契约与内置 adapter

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,6 +1,13 @@
 # Crabot 项目进度
 
-> 最后更新：2026-07-27 — 任务终态与 worker 生命周期对齐（issue #43 下半）
+> 最后更新：2026-07-29 — Manager/Worker 拆分 P1：worker 契约与内置 adapter（PR 待合并）
+
+## 2026-07-29 — Manager/Worker 拆分 P1：worker 契约与内置 adapter
+
+- 背景：manager/worker 双 agent 拆分立项。总体架构 spec `crabot-docs/superpowers/specs/2026-07-28-manager-worker-agent-split-design.md` 已确认；协议落地 protocol-agent-v3（v2 标记 Superseded，admin task 域退役为读模型，TaskStatus 精简，crab-messaging 收窄为 manager 持有）；实施路线图 P1–P8 见 `crabot-docs/superpowers/plans/2026-07-28-manager-worker-split-roadmap.md`。
+- P1 交付（本 PR，纯新增未激活，现网零影响）：`crabot-agent/src/workers/` —— 契约类型（与 protocol-agent-v3 §3/§6.1 逐字对齐）、append-only session 树（任意节点分支，取代 ResumeCheckpoint 的方向）、OutputLog 游标增量读（UTF-8 边界安全）、builtin adapter（burst 状态机：spawn/sendInput/resume/fork/kill/scanOrphans，per-worker 互斥）、可复用契约一致性套件（P2 的 claude-code/codex adapter 直接复跑）。tests/workers 47 用例。
+- 评审沉淀：四轮并发竞态修复（sendInput 双发、收尾窗口、catch 锁外判死、kill 交接窗口 killRequested 闭环）；burst 显式 disableCompaction（压缩与 session 树协同留 P7）；resume 幂等提交次序（append→writeMeta→注册+标记）。
+- 待办：P2（tmux 驱动 + claude-code/codex adapter）起手前先写细化 plan；终审裁决"留"的 Minor 清单见 roadmap 同目录执行记录。
 
 ## 2026-07-27 — 任务终态与 worker 生命周期对齐（issue #43 下半）
 

--- a/crabot-agent/src/workers/async-mutex.ts
+++ b/crabot-agent/src/workers/async-mutex.ts
@@ -1,0 +1,23 @@
+/**
+ * AsyncMutex — minimal in-process mutex for serializing async operations.
+ * Extracted from BgEntityRegistry for general use.
+ */
+
+export class AsyncMutex {
+  private queue: Promise<void> = Promise.resolve()
+
+  async run<T>(fn: () => Promise<T>): Promise<T> {
+    let release!: () => void
+    const next = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const previous = this.queue
+    this.queue = previous.then(() => next)
+    await previous
+    try {
+      return await fn()
+    } finally {
+      release()
+    }
+  }
+}

--- a/crabot-agent/src/workers/builtin/adapter.ts
+++ b/crabot-agent/src/workers/builtin/adapter.ts
@@ -800,7 +800,13 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
   private async transitionState(instance: WorkerInstance, handle: IncarnationHandle, state: WorkerContractState): Promise<void> {
     await this.writeMeta(instance, { state })
     instance.state = state
-    this.deps.onStateChange?.(handle, state)
+    // 观察者（onStateChange）的异常永远不能中断状态机的推进。任何回调错误都被捕获
+    // 并仅作 console.error 记录，防止阻塞状态转移或导致后续 burst/sendInput 卡死。
+    try {
+      this.deps.onStateChange?.(handle, state)
+    } catch (err) {
+      console.error(`[BuiltinWorkerAdapter] onStateChange callback error for ${handle.worker_id}#${handle.seq}:`, err)
+    }
   }
 
   private async transitionExited(
@@ -817,7 +823,13 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     instance.state = 'exited'
     instance.ended_reason = ended_reason
     if (outcome !== undefined) instance.outcome = outcome
-    this.deps.onStateChange?.(handle, 'exited')
+    // 观察者（onStateChange）的异常永远不能中断状态机的推进。任何回调错误都被捕获
+    // 并仅作 console.error 记录，防止阻塞状态转移或导致后续 burst/sendInput 卡死。
+    try {
+      this.deps.onStateChange?.(handle, 'exited')
+    } catch (err) {
+      console.error(`[BuiltinWorkerAdapter] onStateChange callback error for ${handle.worker_id}#${handle.seq}:`, err)
+    }
   }
 
   private async writeMeta(

--- a/crabot-agent/src/workers/builtin/adapter.ts
+++ b/crabot-agent/src/workers/builtin/adapter.ts
@@ -11,10 +11,16 @@
  * 当前 burst 结束若判定为 idle 且队列非空则原地续 burst（不经过可见的 idle 态）；
  * exited 态抛 WorkerExitedError，交给上层 harness 做透明接续（P3）。
  *
- * resume：从已 exited 的化身的 session_ref（tip node_id）派生 seq+1 新化身，
+ * resume：从已 exited 的化身的 session_ref（tip node_id）派生新化身（seq 见 nextSeq），
  * append wakeInput 后起新 burst。
  *
- * fork/kill 留给后续 task（Task 7-8）。
+ * fork：侧问分支。不要求 prev 处于任何特定状态——主线 running/idle/exited 都能 fork。
+ * 从 prev.session_ref 节点 append forkInput 为分支（不动主线 tip，树因此分叉，这是
+ * fork 的合法用法）。新化身独立 meta/output，跑一次性 burst（不含 finish_task 工具，
+ * 结束即 exited，没有 idle 态）。newSeq 与 resume 共用 nextSeq()，在同一把互斥锁内
+ * 计算，避免二者撞号。
+ *
+ * kill 留给后续 task（Task 8）。
  */
 import { promises as fs } from 'fs'
 import { join } from 'path'
@@ -39,7 +45,10 @@ import type {
   Workspace,
 } from '../types.js'
 
-const NOT_IMPLEMENTED = 'not implemented until Task 7-8'
+const NOT_IMPLEMENTED = 'not implemented until Task 8'
+
+/** fork 是一次性侧问，maxTurns 取小值，避免侧问跑成一次完整任务。 */
+const FORK_MAX_TURNS = 8
 
 /**
  * sendInput 打到已 exited 的化身时抛出。透明接续（自动 resume 并重投）是 harness（P3）
@@ -80,11 +89,21 @@ interface WorkerInstance {
   readonly dir: string
   readonly sessionTree: SessionTree
   readonly outputLog: OutputLog
+  /**
+   * 本化身自己的当前 tip node_id（不是 sessionTree.latestTip()）。sessionTree 是跨化身
+   * 共享的同一个对象，其内部 tip 是"整个文件最后一次 append"的全局游标——fork 分支往
+   * 任意历史节点 append 时会把这个全局游标带偏。若主线继续依赖 sessionTree.latestTip()
+   * 判断自己的续接点，fork 期间/之后会读到 fork 分支的节点，把新一轮消息误挂在 fork
+   * 分支下面。每个化身必须维护自己的 tip，只在自己 append 时更新。
+   */
+  tip: string
   state: WorkerContractState
   ended_reason?: IncarnationEndReason
   outcome?: 'completed' | 'failed'
   /** running 态下经 sendInput 排队、等下一次 burst 间隙统一 append 的用户消息（P1：内存，不跨重启持久）。 */
   pendingInputs: string[]
+  /** 是否已经被 resume 过一次。用于在 resume() 里检测"对同一 prev 的重复 resume"（先到先得，后来者报错）。 */
+  resumed?: boolean
 }
 
 function instanceKey(worker_id: string, seq: number): string {
@@ -134,7 +153,7 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
 
     const sessionTree = new SessionTree(join(dir, 'session.jsonl'))
     const outputLog = new OutputLog(join(dir, `output-${seq}.log`))
-    await sessionTree.append(null, createUserMessage(spec.prompt))
+    const rootId = await sessionTree.append(null, createUserMessage(spec.prompt))
 
     const instance: WorkerInstance = {
       worker_id: spec.worker_id,
@@ -142,6 +161,7 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
       dir,
       sessionTree,
       outputLog,
+      tip: rootId,
       state: 'running',
       pendingInputs: [],
     }
@@ -170,27 +190,30 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
       throw new Error(`BuiltinWorkerAdapter.resume: no builtin config resident in memory for worker ${prev.worker_id} (P1: worker must have been spawned in this process)`)
     }
 
-    // assertExited + newSeq 计算 + append + 实例注册整体在锁内原子完成：两次并发 resume
-    // 同一 prev 若不串行化，会各自算出相同的 newSeq、各自往 prev.session_ref 上挂一个孩子
-    // ——树分叉。这里选择"先到先得，后来者报错"的语义：newSeq 对应的实例位一旦被占用，
-    // 后来者视为对同一 prev 的重复 resume，直接失败，而不是静默产出第二个化身。
+    // assertExited + 重复 resume 检测 + newSeq 计算 + append + 实例注册整体在锁内原子完成：
+    // 两次并发 resume 同一 prev 若不串行化，会各自往 prev.session_ref 上挂一个孩子——树分叉。
+    // 这里选择"先到先得，后来者报错"的语义：prevInstance.resumed 标记一旦被占用，后来者
+    // 视为对同一 prev 的重复 resume，直接失败，而不是静默产出第二个化身。newSeq 用 nextSeq()
+    // 而非 prev.seq+1——fork 可能已经消耗掉 prev.seq+1 这个号位（fork 分支和主线共享同一
+    // seq 序列），继续用 prev.seq+1 会在这种情况下误判"并发 resume"或直接撞号覆盖。
     const mutex = this.getMutex(prev.worker_id)
     const { instance, handle } = await mutex.run(async () => {
       await this.assertExited(prev.worker_id, prev.seq)
 
-      const newSeq = prev.seq + 1
-      const newKey = instanceKey(prev.worker_id, newSeq)
-      if (this.instances.has(newKey)) {
-        throw new Error(`BuiltinWorkerAdapter.resume: incarnation ${newKey} already exists (concurrent resume of the same prev incarnation?)`)
+      const prevInstance = this.instances.get(instanceKey(prev.worker_id, prev.seq))
+      if (prevInstance?.resumed) {
+        throw new Error(`BuiltinWorkerAdapter.resume: incarnation ${prev.worker_id}#${prev.seq} already resumed (concurrent resume of the same prev incarnation?)`)
       }
+      if (prevInstance) prevInstance.resumed = true
 
+      const newSeq = this.nextSeq(prev.worker_id)
       const dir = join(this.deps.dataDir, prev.worker_id)
       let sessionTree = this.findSessionTreeForWorker(prev.worker_id)
       if (!sessionTree) {
         sessionTree = await SessionTree.load(join(dir, 'session.jsonl'))
       }
       const outputLog = new OutputLog(join(dir, `output-${newSeq}.log`))
-      await sessionTree.append(prev.session_ref, createUserMessage(wakeInput))
+      const wakeId = await sessionTree.append(prev.session_ref, createUserMessage(wakeInput))
 
       const newInstance: WorkerInstance = {
         worker_id: prev.worker_id,
@@ -198,10 +221,11 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
         dir,
         sessionTree,
         outputLog,
+        tip: wakeId,
         state: 'running',
         pendingInputs: [],
       }
-      this.instances.set(newKey, newInstance)
+      this.instances.set(instanceKey(prev.worker_id, newSeq), newInstance)
 
       const newHandle: IncarnationHandle = { worker_id: prev.worker_id, seq: newSeq, impl: 'builtin' }
       await this.writeMeta(newInstance)
@@ -218,8 +242,55 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     return handle
   }
 
-  async fork(_prev: IncarnationRef, _forkInput: string): Promise<IncarnationHandle> {
-    throw new Error(NOT_IMPLEMENTED)
+  async fork(prev: IncarnationRef, forkInput: string): Promise<IncarnationHandle> {
+    const builtin = this.builtinConfigs.get(prev.worker_id)
+    if (!builtin) {
+      throw new Error(`BuiltinWorkerAdapter.fork: no builtin config resident in memory for worker ${prev.worker_id} (P1: worker must have been spawned in this process)`)
+    }
+
+    // fork 不要求 prev 处于任何特定状态——这就是侧问的意义：主线跑着的时候也能问。不像
+    // resume 那样校验 assertExited。newSeq 用 nextSeq()，与 resume 共用同一分配逻辑、
+    // 在同一把互斥锁内计算，避免二者撞号。append 挂在 prev.session_ref 上是分支，不动
+    // 主线 tip——session 树因此分叉，这是 fork 的合法用法（resume/sendInput 的"禁止分叉"
+    // 不变量是它们各自场景下的语义，不适用于 fork）。
+    const mutex = this.getMutex(prev.worker_id)
+    const { instance, handle } = await mutex.run(async () => {
+      const dir = join(this.deps.dataDir, prev.worker_id)
+      let sessionTree = this.findSessionTreeForWorker(prev.worker_id)
+      if (!sessionTree) {
+        sessionTree = await SessionTree.load(join(dir, 'session.jsonl'))
+      }
+
+      const newSeq = this.nextSeq(prev.worker_id)
+      const outputLog = new OutputLog(join(dir, `output-${newSeq}.log`))
+      const forkId = await sessionTree.append(prev.session_ref, createUserMessage(forkInput))
+
+      const newInstance: WorkerInstance = {
+        worker_id: prev.worker_id,
+        seq: newSeq,
+        dir,
+        sessionTree,
+        outputLog,
+        tip: forkId,
+        state: 'running',
+        pendingInputs: [],
+      }
+      this.instances.set(instanceKey(prev.worker_id, newSeq), newInstance)
+
+      const newHandle: IncarnationHandle = { worker_id: prev.worker_id, seq: newSeq, impl: 'builtin' }
+      await this.writeMeta(newInstance)
+      return { instance: newInstance, handle: newHandle }
+    })
+
+    // fire-and-forget：一次性 burst 在后台跑，fork 立刻以 running 态返回。
+    this.runForkBurst(instance, handle, builtin).catch(async (err) => {
+      console.error('[builtin-adapter] runForkBurst threw unexpectedly:', err)
+      await this.getMutex(instance.worker_id).run(async () => {
+        await this.transitionExited(instance, handle, 'crashed')
+      })
+    })
+
+    return handle
   }
 
   async sendInput(h: IncarnationHandle, text: string, _opts?: { raw?: boolean }): Promise<void> {
@@ -246,9 +317,7 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
       if (!builtin) {
         throw new Error(`BuiltinWorkerAdapter.sendInput: no builtin config resident in memory for worker ${h.worker_id}`)
       }
-      const tip = instance.sessionTree.latestTip()
-      if (tip === null) throw new Error(`BuiltinWorkerAdapter: worker ${instance.worker_id} has empty session tree`)
-      await instance.sessionTree.append(tip, createUserMessage(text))
+      instance.tip = await instance.sessionTree.append(instance.tip, createUserMessage(text))
       await this.transitionState(instance, h, 'running')
       return true
     })
@@ -297,8 +366,7 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     handle: IncarnationHandle,
     builtin: NonNullable<SpawnSpec['builtin']>,
   ): Promise<void> {
-    const tip = instance.sessionTree.latestTip()
-    if (tip === null) throw new Error(`BuiltinWorkerAdapter: worker ${instance.worker_id} has empty session tree`)
+    const tip = instance.tip
     const initialMessages = instance.sessionTree.pathTo(tip)
 
     const pendingWrites: Promise<void>[] = []
@@ -345,6 +413,7 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
       for (const msg of newMessages as EngineMessage[]) {
         parent = await instance.sessionTree.append(parent, msg)
       }
+      instance.tip = parent
 
       if (result.outcome === 'failed' || result.outcome === 'aborted') {
         await this.transitionExited(instance, handle, result.outcome === 'aborted' ? 'killed' : 'crashed')
@@ -362,11 +431,11 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
       // （不经过可见的 idle 态）；否则转 idle，等待下一次 resume/sendInput 唤醒。
       if (instance.pendingInputs.length > 0) {
         const queued = instance.pendingInputs.splice(0, instance.pendingInputs.length)
-        let queueParent = instance.sessionTree.latestTip()
-        if (queueParent === null) throw new Error(`BuiltinWorkerAdapter: worker ${instance.worker_id} has empty session tree`)
+        let queueParent = instance.tip
         for (const text of queued) {
           queueParent = await instance.sessionTree.append(queueParent, createUserMessage(text))
         }
+        instance.tip = queueParent
         return true
       }
 
@@ -377,6 +446,69 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     if (continueBurst) {
       await this.runBurst(instance, handle, builtin)
     }
+  }
+
+  /**
+   * fork 专用的一次性 burst：不含 finish_task 工具（工具表用 spec 注入的原样），没有
+   * "提前退出"这回事——end_turn 或 maxTurns 耗尽都视为侧问正常收尾，直接 exited(completed)，
+   * 不经过 idle、不支持续 burst（没有 pendingInputs 排队逻辑）。engine 抛错/aborted 才是
+   * exited(crashed)。收尾在该 worker 的互斥锁内完成，append 只作用于 fork 自己的分支链路，
+   * 不触碰主线 tip。
+   */
+  private async runForkBurst(
+    instance: WorkerInstance,
+    handle: IncarnationHandle,
+    builtin: NonNullable<SpawnSpec['builtin']>,
+  ): Promise<void> {
+    const tip = instance.tip
+    const initialMessages = instance.sessionTree.pathTo(tip)
+
+    const pendingWrites: Promise<void>[] = []
+    const result: EngineResult = await runEngine({
+      prompt: '',
+      adapter: builtin.adapter,
+      initialMessages,
+      options: {
+        systemPrompt: builtin.systemPrompt,
+        tools: builtin.tools,
+        model: builtin.model,
+        maxTurns: FORK_MAX_TURNS,
+        disableCompaction: true,
+        onTurn: (event) => {
+          if (event.assistantText) {
+            pendingWrites.push(instance.outputLog.append(event.assistantText + '\n'))
+          }
+        },
+      },
+    })
+    await Promise.all(pendingWrites)
+
+    const mutex = this.getMutex(instance.worker_id)
+    await mutex.run(async () => {
+      if (result.finalMessages.length < initialMessages.length) {
+        console.error(
+          `[builtin-adapter] runForkBurst compaction guard triggered for worker ${instance.worker_id}: ` +
+          `finalMessages.length (${result.finalMessages.length}) < initialMessages.length (${initialMessages.length}). ` +
+          `Compaction was unexpectedly enabled; marking incarnation as crashed.`,
+        )
+        await this.transitionExited(instance, handle, 'crashed')
+        return
+      }
+      const newMessages = result.finalMessages.slice(initialMessages.length)
+      let parent = tip
+      for (const msg of newMessages as EngineMessage[]) {
+        parent = await instance.sessionTree.append(parent, msg)
+      }
+      instance.tip = parent
+
+      if (result.outcome === 'failed' || result.outcome === 'aborted') {
+        await this.transitionExited(instance, handle, 'crashed')
+        return
+      }
+
+      // 'completed'（end_turn）与 'max_turns' 都视为一次性侧问正常收尾。
+      await this.transitionExited(instance, handle, 'completed', 'completed')
+    })
   }
 
   /** worker_id 对应的互斥锁，惰性创建（见 workerMutexes 字段注释）。 */
@@ -394,6 +526,19 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
       if (instance.worker_id === worker_id) return instance.sessionTree
     }
     return undefined
+  }
+
+  /**
+   * worker_id 对应下一个可用的化身序号：该 worker 现存所有化身（主线 + fork 分支）里
+   * 最大 seq + 1。resume 和 fork 共用这一个分配逻辑，且都在各自的 mutex.run 内调用，
+   * 保证两者不会分配出相同的 seq。
+   */
+  private nextSeq(worker_id: string): number {
+    let max = 0
+    for (const instance of this.instances.values()) {
+      if (instance.worker_id === worker_id && instance.seq > max) max = instance.seq
+    }
+    return max + 1
   }
 
   private async assertExited(worker_id: string, seq: number): Promise<void> {
@@ -456,7 +601,7 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     const meta = {
       seq: instance.seq,
       state,
-      tip_node_id: instance.sessionTree.latestTip(),
+      tip_node_id: instance.tip,
       ...(ended_reason !== undefined ? { ended_reason } : {}),
       ...(outcome !== undefined ? { outcome } : {}),
     }

--- a/crabot-agent/src/workers/builtin/adapter.ts
+++ b/crabot-agent/src/workers/builtin/adapter.ts
@@ -196,6 +196,8 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     // 视为对同一 prev 的重复 resume，直接失败，而不是静默产出第二个化身。newSeq 用 nextSeq()
     // 而非 prev.seq+1——fork 可能已经消耗掉 prev.seq+1 这个号位（fork 分支和主线共享同一
     // seq 序列），继续用 prev.seq+1 会在这种情况下误判"并发 resume"或直接撞号覆盖。
+    // resumed 标记必须在 append 及实例注册成功之后才能提交（同一时刻），以确保失败路径
+    // 幂等可重试：若 append 抛错，resumed 仍未被设置，后续重试不会被"重复 resume"检查拒绝。
     const mutex = this.getMutex(prev.worker_id)
     const { instance, handle } = await mutex.run(async () => {
       await this.assertExited(prev.worker_id, prev.seq)
@@ -204,7 +206,6 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
       if (prevInstance?.resumed) {
         throw new Error(`BuiltinWorkerAdapter.resume: incarnation ${prev.worker_id}#${prev.seq} already resumed (concurrent resume of the same prev incarnation?)`)
       }
-      if (prevInstance) prevInstance.resumed = true
 
       const newSeq = this.nextSeq(prev.worker_id)
       const dir = join(this.deps.dataDir, prev.worker_id)
@@ -226,6 +227,9 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
         pendingInputs: [],
       }
       this.instances.set(instanceKey(prev.worker_id, newSeq), newInstance)
+      // 成功注册新实例之后、writeMeta 之前提交 resumed 标记：同一临界区内原子完成，
+      // 失败路径不会留下回滚不了的副作用。
+      if (prevInstance) prevInstance.resumed = true
 
       const newHandle: IncarnationHandle = { worker_id: prev.worker_id, seq: newSeq, impl: 'builtin' }
       await this.writeMeta(newInstance)

--- a/crabot-agent/src/workers/builtin/adapter.ts
+++ b/crabot-agent/src/workers/builtin/adapter.ts
@@ -24,6 +24,7 @@ import type { EngineMessage, EngineResult, ToolDefinition } from '../../engine/i
 import type { Resolvable } from '../../engine/types.js'
 import { SessionTree } from '../session-tree.js'
 import { OutputLog } from '../output-log.js'
+import { AsyncMutex } from '../async-mutex.js'
 import type {
   AdapterCapabilities,
   CapabilityBundle,
@@ -100,6 +101,13 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
   private readonly instances = new Map<string, WorkerInstance>()
   /** worker_id → spawn 时注入的 builtin 执行配置（adapter/model/tools），resume 与续 burst 复用。P1：仅内存，不跨重启持久。 */
   private readonly builtinConfigs = new Map<string, NonNullable<SpawnSpec['builtin']>>()
+  /**
+   * worker_id → 互斥锁，惰性创建。sendInput 全程、resume 全程、runBurst 的收尾段（判定
+   * pendingInputs 到状态落定）都在同一把锁内串行执行——同一化身任意时刻至多一个 burst
+   * 在跑是该 adapter 的不变量。runEngine 本身的调用留在锁外，避免并发 sendInput(running)
+   * 的入队被一整次 burst 的执行时长堵死。
+   */
+  private readonly workerMutexes = new Map<string, AsyncMutex>()
 
   constructor(
     private readonly deps: {
@@ -155,34 +163,48 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
   }
 
   async resume(prev: IncarnationRef, wakeInput: string): Promise<IncarnationHandle> {
-    await this.assertExited(prev.worker_id, prev.seq)
     const builtin = this.builtinConfigs.get(prev.worker_id)
     if (!builtin) {
       throw new Error(`BuiltinWorkerAdapter.resume: no builtin config resident in memory for worker ${prev.worker_id} (P1: worker must have been spawned in this process)`)
     }
 
-    const newSeq = prev.seq + 1
-    const dir = join(this.deps.dataDir, prev.worker_id)
-    let sessionTree = this.findSessionTreeForWorker(prev.worker_id)
-    if (!sessionTree) {
-      sessionTree = await SessionTree.load(join(dir, 'session.jsonl'))
-    }
-    const outputLog = new OutputLog(join(dir, `output-${newSeq}.log`))
-    await sessionTree.append(prev.session_ref, createUserMessage(wakeInput))
+    // assertExited + newSeq 计算 + append + 实例注册整体在锁内原子完成：两次并发 resume
+    // 同一 prev 若不串行化，会各自算出相同的 newSeq、各自往 prev.session_ref 上挂一个孩子
+    // ——树分叉。这里选择"先到先得，后来者报错"的语义：newSeq 对应的实例位一旦被占用，
+    // 后来者视为对同一 prev 的重复 resume，直接失败，而不是静默产出第二个化身。
+    const mutex = this.getMutex(prev.worker_id)
+    const { instance, handle } = await mutex.run(async () => {
+      await this.assertExited(prev.worker_id, prev.seq)
 
-    const instance: WorkerInstance = {
-      worker_id: prev.worker_id,
-      seq: newSeq,
-      dir,
-      sessionTree,
-      outputLog,
-      state: 'running',
-      pendingInputs: [],
-    }
-    this.instances.set(instanceKey(prev.worker_id, newSeq), instance)
+      const newSeq = prev.seq + 1
+      const newKey = instanceKey(prev.worker_id, newSeq)
+      if (this.instances.has(newKey)) {
+        throw new Error(`BuiltinWorkerAdapter.resume: incarnation ${newKey} already exists (concurrent resume of the same prev incarnation?)`)
+      }
 
-    const handle: IncarnationHandle = { worker_id: prev.worker_id, seq: newSeq, impl: 'builtin' }
-    await this.writeMeta(instance)
+      const dir = join(this.deps.dataDir, prev.worker_id)
+      let sessionTree = this.findSessionTreeForWorker(prev.worker_id)
+      if (!sessionTree) {
+        sessionTree = await SessionTree.load(join(dir, 'session.jsonl'))
+      }
+      const outputLog = new OutputLog(join(dir, `output-${newSeq}.log`))
+      await sessionTree.append(prev.session_ref, createUserMessage(wakeInput))
+
+      const newInstance: WorkerInstance = {
+        worker_id: prev.worker_id,
+        seq: newSeq,
+        dir,
+        sessionTree,
+        outputLog,
+        state: 'running',
+        pendingInputs: [],
+      }
+      this.instances.set(newKey, newInstance)
+
+      const newHandle: IncarnationHandle = { worker_id: prev.worker_id, seq: newSeq, impl: 'builtin' }
+      await this.writeMeta(newInstance)
+      return { instance: newInstance, handle: newHandle }
+    })
 
     this.runBurst(instance, handle, builtin).catch(async (err) => {
       console.error('[builtin-adapter] runBurst threw unexpectedly (resume):', err)
@@ -197,30 +219,42 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
   }
 
   async sendInput(h: IncarnationHandle, text: string, _opts?: { raw?: boolean }): Promise<void> {
-    const instance = this.instances.get(instanceKey(h.worker_id, h.seq))
-    if (!instance) {
-      throw new Error(`BuiltinWorkerAdapter.sendInput: no such incarnation ${h.worker_id}#${h.seq} resident in this process`)
-    }
+    // 状态检查 + 相应动作（入队 / append+转running）整体在该 worker 的互斥锁内完成，消除
+    // "两次背靠背 sendInput 都读到 idle、拿同一 tip"的 check-then-act 竞态（跨 await 边界）。
+    const mutex = this.getMutex(h.worker_id)
+    const startBurst = await mutex.run(async () => {
+      const instance = this.instances.get(instanceKey(h.worker_id, h.seq))
+      if (!instance) {
+        throw new Error(`BuiltinWorkerAdapter.sendInput: no such incarnation ${h.worker_id}#${h.seq} resident in this process`)
+      }
 
-    if (instance.state === 'exited') {
-      throw new WorkerExitedError(h.worker_id, h.seq)
-    }
+      if (instance.state === 'exited') {
+        throw new WorkerExitedError(h.worker_id, h.seq)
+      }
 
-    if (instance.state === 'running') {
-      instance.pendingInputs.push(text)
-      return
-    }
+      if (instance.state === 'running') {
+        instance.pendingInputs.push(text)
+        return false
+      }
 
-    // idle → 追加新一轮用户消息，续 burst，转 running。
-    const builtin = this.builtinConfigs.get(h.worker_id)
-    if (!builtin) {
-      throw new Error(`BuiltinWorkerAdapter.sendInput: no builtin config resident in memory for worker ${h.worker_id}`)
-    }
-    const tip = instance.sessionTree.latestTip()
-    if (tip === null) throw new Error(`BuiltinWorkerAdapter: worker ${instance.worker_id} has empty session tree`)
-    await instance.sessionTree.append(tip, createUserMessage(text))
-    await this.transitionState(instance, h, 'running')
+      // idle → 追加新一轮用户消息，转 running。起 burst 留到锁外（见下）。
+      const builtin = this.builtinConfigs.get(h.worker_id)
+      if (!builtin) {
+        throw new Error(`BuiltinWorkerAdapter.sendInput: no builtin config resident in memory for worker ${h.worker_id}`)
+      }
+      const tip = instance.sessionTree.latestTip()
+      if (tip === null) throw new Error(`BuiltinWorkerAdapter: worker ${instance.worker_id} has empty session tree`)
+      await instance.sessionTree.append(tip, createUserMessage(text))
+      await this.transitionState(instance, h, 'running')
+      return true
+    })
 
+    if (!startBurst) return
+
+    // burst 的 runEngine 调用本身在锁外：否则并发 sendInput(running) 的入队会被这次
+    // burst 的整个执行时长堵死。
+    const instance = this.instances.get(instanceKey(h.worker_id, h.seq))!
+    const builtin = this.builtinConfigs.get(h.worker_id)!
     this.runBurst(instance, h, builtin).catch(async (err) => {
       console.error('[builtin-adapter] runBurst threw unexpectedly (sendInput continuation):', err)
       await this.transitionExited(instance, h, 'crashed')
@@ -282,50 +316,71 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     })
     await Promise.all(pendingWrites)
 
-    // burst 结束：把新增消息（finalMessages 相对 initialMessages 的后缀）逐条 append 进 session 树。
-    // 防御断言：若压缩被意外启用，finalMessages.length 会小于 initialMessages.length，
-    // 此时不回写新消息，标化身为 exited(crashed) 并记日志。
-    if (result.finalMessages.length < initialMessages.length) {
-      console.error(
-        `[builtin-adapter] runBurst compaction guard triggered for worker ${instance.worker_id}: ` +
-        `finalMessages.length (${result.finalMessages.length}) < initialMessages.length (${initialMessages.length}). ` +
-        `Compaction was unexpectedly enabled; marking incarnation as crashed.`,
-      )
-      await this.transitionExited(instance, handle, 'crashed')
-      return
-    }
-    const newMessages = result.finalMessages.slice(initialMessages.length)
-    let parent = tip
-    for (const msg of newMessages as EngineMessage[]) {
-      parent = await instance.sessionTree.append(parent, msg)
-    }
-
-    if (result.outcome === 'failed' || result.outcome === 'aborted') {
-      await this.transitionExited(instance, handle, result.outcome === 'aborted' ? 'killed' : 'crashed')
-      return
-    }
-
-    if (result.exitToolCall?.name === 'finish_task') {
-      const rawOutcome = result.exitToolCall.input.outcome
-      const outcome: 'completed' | 'failed' = rawOutcome === 'failed' ? 'failed' : 'completed'
-      await this.transitionExited(instance, handle, outcome, outcome)
-      return
-    }
-
-    // end_turn（或 max_turns 耗尽）→ 若 sendInput 排了队，逐条 append 后原地续 burst
-    // （不经过可见的 idle 态）；否则转 idle，等待下一次 resume/sendInput 唤醒。
-    if (instance.pendingInputs.length > 0) {
-      const queued = instance.pendingInputs.splice(0, instance.pendingInputs.length)
-      let queueParent = instance.sessionTree.latestTip()
-      if (queueParent === null) throw new Error(`BuiltinWorkerAdapter: worker ${instance.worker_id} has empty session tree`)
-      for (const text of queued) {
-        queueParent = await instance.sessionTree.append(queueParent, createUserMessage(text))
+    // 收尾段（压缩防御 → append 新消息 → 判 outcome → 判队列 → 落 idle/续 burst）整体在该
+    // worker 的互斥锁内原子完成：消除"同步判定 pendingInputs 为空后 await transitionState
+    // 期间新 sendInput 插队"的窗口——判定与状态落定必须是同一个不可分割的临界区。
+    // 续 burst 的递归调用放在锁外触发（见下），不然会把 runEngine 的执行时长堵在锁里。
+    const mutex = this.getMutex(instance.worker_id)
+    const continueBurst = await mutex.run(async () => {
+      // burst 结束：把新增消息（finalMessages 相对 initialMessages 的后缀）逐条 append 进 session 树。
+      // 防御断言：若压缩被意外启用，finalMessages.length 会小于 initialMessages.length，
+      // 此时不回写新消息，标化身为 exited(crashed) 并记日志。
+      if (result.finalMessages.length < initialMessages.length) {
+        console.error(
+          `[builtin-adapter] runBurst compaction guard triggered for worker ${instance.worker_id}: ` +
+          `finalMessages.length (${result.finalMessages.length}) < initialMessages.length (${initialMessages.length}). ` +
+          `Compaction was unexpectedly enabled; marking incarnation as crashed.`,
+        )
+        await this.transitionExited(instance, handle, 'crashed')
+        return false
       }
-      await this.runBurst(instance, handle, builtin)
-      return
-    }
+      const newMessages = result.finalMessages.slice(initialMessages.length)
+      let parent = tip
+      for (const msg of newMessages as EngineMessage[]) {
+        parent = await instance.sessionTree.append(parent, msg)
+      }
 
-    await this.transitionState(instance, handle, 'idle')
+      if (result.outcome === 'failed' || result.outcome === 'aborted') {
+        await this.transitionExited(instance, handle, result.outcome === 'aborted' ? 'killed' : 'crashed')
+        return false
+      }
+
+      if (result.exitToolCall?.name === 'finish_task') {
+        const rawOutcome = result.exitToolCall.input.outcome
+        const outcome: 'completed' | 'failed' = rawOutcome === 'failed' ? 'failed' : 'completed'
+        await this.transitionExited(instance, handle, outcome, outcome)
+        return false
+      }
+
+      // end_turn（或 max_turns 耗尽）→ 若 sendInput 排了队，逐条 append 后原地续 burst
+      // （不经过可见的 idle 态）；否则转 idle，等待下一次 resume/sendInput 唤醒。
+      if (instance.pendingInputs.length > 0) {
+        const queued = instance.pendingInputs.splice(0, instance.pendingInputs.length)
+        let queueParent = instance.sessionTree.latestTip()
+        if (queueParent === null) throw new Error(`BuiltinWorkerAdapter: worker ${instance.worker_id} has empty session tree`)
+        for (const text of queued) {
+          queueParent = await instance.sessionTree.append(queueParent, createUserMessage(text))
+        }
+        return true
+      }
+
+      await this.transitionState(instance, handle, 'idle')
+      return false
+    })
+
+    if (continueBurst) {
+      await this.runBurst(instance, handle, builtin)
+    }
+  }
+
+  /** worker_id 对应的互斥锁，惰性创建（见 workerMutexes 字段注释）。 */
+  private getMutex(worker_id: string): AsyncMutex {
+    let mutex = this.workerMutexes.get(worker_id)
+    if (!mutex) {
+      mutex = new AsyncMutex()
+      this.workerMutexes.set(worker_id, mutex)
+    }
+    return mutex
   }
 
   private findSessionTreeForWorker(worker_id: string): SessionTree | undefined {

--- a/crabot-agent/src/workers/builtin/adapter.ts
+++ b/crabot-agent/src/workers/builtin/adapter.ts
@@ -21,9 +21,15 @@
  * 计算，避免二者撞号。
  *
  * kill：每化身持有一个 AbortController，burst 启动时创建、其 signal 传给 runEngine。
- * running 态 kill 只是 abort() 当前 burst——burst 自己以 outcome='aborted' 收尾时既有
- * 分流会落 exited(killed)（见 runBurst/runForkBurst 收尾段）；idle 态（没有 burst 在跑）
- * kill 直接在互斥锁内落 exited(killed)；已 exited 幂等返回，不覆盖原 ended_reason。
+ * running 态 kill 在互斥锁内先置 instance.killRequested = true，再 abort() 当前 burst——
+ * 单纯 abort 不够：sendInput(idle→running) 转态后到续 burst 安装新 controller 之间、以及
+ * runBurst 续 burst 路径锁释放到递归调用之间都有窗口，其间 instance.abortController 还
+ * 指向旧 burst，abort 旧 controller 对即将起的新 burst 无效。runBurst/runForkBurst 因此
+ * 在安装新 controller 时、以及收尾段判定是否续 burst/正常收尾前，各在锁内核对一次
+ * killRequested：已置位则不启动/不续 burst，直接落 exited(killed)，与 kill() 的置位+abort
+ * 共享同一把锁，消除上述窗口。burst 正常被 abort 命中时仍以 outcome='aborted' 收尾落
+ * exited(killed)（见 runBurst/runForkBurst 收尾段）；idle 态（没有 burst 在跑）kill 直接
+ * 在互斥锁内落 exited(killed)；已 exited 幂等返回，不覆盖原 ended_reason。
  *
  * scanOrphans：进程重启后，内存 instances 已丢失，只能凭磁盘 meta 文件识别"重启前还
  * 没来得及收尾的化身"——把 state==='running' 的原子改写为 exited(crashed)。调用方须
@@ -112,10 +118,17 @@ interface WorkerInstance {
   resumed?: boolean
   /**
    * 当前（或最近一次）burst 的 AbortController，在 runBurst/runForkBurst 每次调用 runEngine
-   * 前创建，其 signal 传给 runEngine。kill() 在 running 态下只是 abort() 它——不直接改状态，
+   * 前创建，其 signal 传给 runEngine。kill() 在 running 态下 abort() 它——不直接改状态，
    * 状态迁移仍由 burst 自己收尾时的 outcome==='aborted' 分流完成。
    */
   abortController?: AbortController
+  /**
+   * kill() 在 running 态下于互斥锁内置位，一旦置位永不复位（化身终将落 exited）。
+   * runBurst/runForkBurst 在安装新 controller 时、以及收尾段判定是否续 burst/正常收尾前，
+   * 各在同一把锁内核对它——用于兜住 abortController 指向旧 burst 而 abort 落空的窗口
+   * （见 kill() 顶部注释）。
+   */
+  killRequested?: boolean
 }
 
 function instanceKey(worker_id: string, seq: number): string {
@@ -384,9 +397,13 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
         return
       }
 
-      // running：只 abort 当前 burst 的 signal。burst 的 runEngine 调用本身在锁外跑（见
-      // runBurst 注释），abort() 后由它自己以 outcome='aborted' 收尾时落 exited(killed)——
-      // 这里不代为转态，避免和 burst 收尾段的互斥锁临界区打架。
+      // running：先置位 killRequested，再 abort 当前 burst 的 signal。置位在 abort 之前，
+      // 确保 runBurst/runForkBurst 在同一把锁内做的 killRequested 核对不会漏判。burst 的
+      // runEngine 调用本身在锁外跑（见 runBurst 注释），abort() 后由它自己以
+      // outcome='aborted' 收尾时落 exited(killed)——这里不代为转态，避免和 burst 收尾段的
+      // 互斥锁临界区打架；abortController 若恰好指向已经跑完的旧 burst（交接窗口内），
+      // abort 对它是空操作，届时由 killRequested 兜底。
+      instance.killRequested = true
       instance.abortController?.abort()
     })
   }
@@ -453,10 +470,24 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
   ): Promise<void> {
     const tip = instance.tip
     const initialMessages = instance.sessionTree.pathTo(tip)
+    const mutex = this.getMutex(instance.worker_id)
 
     // 每次进入 runBurst（含续 burst 的递归调用）都换一个新 AbortController，供 kill() abort。
-    const abortController = new AbortController()
-    instance.abortController = abortController
+    // 安装与 killRequested 核对必须在同一把锁内原子完成，和 kill() 的"置位+abort"共享该锁：
+    // 否则会有窗口——kill 已经决定要杀这个（还没起的）新 burst，但读到的 abortController
+    // 还是上一个已经跑完的 burst 的，abort 它没有任何效果，新 burst 照样起来（P1 全分支
+    // 终审 Important，见 kill() 顶部注释）。已置位则不装 controller、不起 runEngine，直接
+    // 在锁内落 exited(killed)。
+    const abortController = await mutex.run(async () => {
+      if (instance.killRequested) {
+        await this.transitionExited(instance, handle, 'killed')
+        return undefined
+      }
+      const ac = new AbortController()
+      instance.abortController = ac
+      return ac
+    })
+    if (!abortController) return
 
     const pendingWrites: Promise<void>[] = []
     const result: EngineResult = await runEngine({
@@ -484,7 +515,6 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     // worker 的互斥锁内原子完成：消除"同步判定 pendingInputs 为空后 await transitionState
     // 期间新 sendInput 插队"的窗口——判定与状态落定必须是同一个不可分割的临界区。
     // 续 burst 的递归调用放在锁外触发（见下），不然会把 runEngine 的执行时长堵在锁里。
-    const mutex = this.getMutex(instance.worker_id)
     const continueBurst = await mutex.run(async () => {
       // burst 结束：把新增消息（finalMessages 相对 initialMessages 的后缀）逐条 append 进 session 树。
       // 防御断言：若压缩被意外启用，finalMessages.length 会小于 initialMessages.length，
@@ -514,6 +544,15 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
         const rawOutcome = result.exitToolCall.input.outcome
         const outcome: 'completed' | 'failed' = rawOutcome === 'failed' ? 'failed' : 'completed'
         await this.transitionExited(instance, handle, outcome, outcome)
+        return false
+      }
+
+      // burst 正常收尾（非 aborted/failed/finish_task）但期间 killRequested 已被置位：
+      // abort 大概率是打在了这次 burst 身上（下面 outcome==='aborted' 分支已经处理），但也
+      // 可能是打晚了——engine 已经决定 end_turn，abort 信号没赶上（P1 全分支终审 Important
+      // 收尾段检查点）。无论如何都不能继续/续 burst，直接落 exited(killed)。
+      if (instance.killRequested) {
+        await this.transitionExited(instance, handle, 'killed')
         return false
       }
 
@@ -552,10 +591,21 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
   ): Promise<void> {
     const tip = instance.tip
     const initialMessages = instance.sessionTree.pathTo(tip)
+    const mutex = this.getMutex(instance.worker_id)
 
-    // fork 化身同样支持被 kill() abort——见 runBurst 里对应注释。
-    const abortController = new AbortController()
-    instance.abortController = abortController
+    // fork 化身同样支持被 kill() abort——见 runBurst 里对应注释，同样的窗口①在 fork 的
+    // 一次性 burst 上也存在：fork() 把新化身以 running 态注册、锁外 fire-and-forget 起
+    // runForkBurst，安装 controller 前先在锁内核对 killRequested。
+    const abortController = await mutex.run(async () => {
+      if (instance.killRequested) {
+        await this.transitionExited(instance, handle, 'killed')
+        return undefined
+      }
+      const ac = new AbortController()
+      instance.abortController = ac
+      return ac
+    })
+    if (!abortController) return
 
     const pendingWrites: Promise<void>[] = []
     const result: EngineResult = await runEngine({
@@ -578,7 +628,6 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     })
     await Promise.all(pendingWrites)
 
-    const mutex = this.getMutex(instance.worker_id)
     await mutex.run(async () => {
       if (result.finalMessages.length < initialMessages.length) {
         console.error(
@@ -598,6 +647,13 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
 
       if (result.outcome === 'failed' || result.outcome === 'aborted') {
         await this.transitionExited(instance, handle, result.outcome === 'aborted' ? 'killed' : 'crashed')
+        return
+      }
+
+      // outcome 是正常收尾但 killRequested 已置位：abort 打晚了，engine 已经决定收尾，
+      // 但用户明确要求过 kill，不该落 completed（P1 全分支终审 Important 收尾段检查点）。
+      if (instance.killRequested) {
+        await this.transitionExited(instance, handle, 'killed')
         return
       }
 

--- a/crabot-agent/src/workers/builtin/adapter.ts
+++ b/crabot-agent/src/workers/builtin/adapter.ts
@@ -214,22 +214,16 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
 
     const handle: IncarnationHandle = { worker_id: spec.worker_id, seq, impl: 'builtin' }
     // writeMeta 成功之后才注册到 instances/builtinConfigs，跟 resume 保持一致的提交次序：
-    // 磁盘失败时不留孤儿实例（此时 session.jsonl 已经有 root 节点，重试会撞上面新加的
-    // "已 spawn"检查——与 resume/fork 的幂等重试语义不同，P1 范围内 spawn 失败要求调用方
-    // 换一个 worker_id 重试，不在本次修复范围内展开）。
+    // 磁盘失败时不留孤儿实例。注意此时上面的"已 spawn"三重守卫（builtinConfigs 命中 /
+    // instances 命中 / 磁盘 meta-${seq}.json 存在）全部落空——writeMeta 还没成功过，没有
+    // 一个会命中。调用方重试 spawn 因此不会被拦住，只会在 session.jsonl 里再 append 一个
+    // 孤儿根节点（不被任何化身的 tip 引用，是良性的，不影响 pathTo）。
     await this.writeMeta(instance)
     this.instances.set(instanceKey(spec.worker_id, seq), instance)
     this.builtinConfigs.set(spec.worker_id, spec.builtin)
 
     // fire-and-forget：burst 在后台跑，spawn 立刻以 running 态返回。
-    this.runBurst(instance, handle, spec.builtin).catch(async (err) => {
-      // 安全网：runBurst 内部已经把 runEngine 的失败路径处理成 exited(crashed)，
-      // 这里只兜住真正意外的同步/异步抛错（比如 append 磁盘写失败）。
-      console.error('[builtin-adapter] runBurst threw unexpectedly:', err)
-      await this.getMutex(instance.worker_id).run(async () => {
-        await this.transitionExited(instance, handle, 'crashed')
-      })
-    })
+    this.runBurst(instance, handle, spec.builtin).catch((err) => this.safetyNetExit(instance, handle, err, 'runBurst'))
 
     return handle
   }
@@ -286,12 +280,7 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
       return { instance: newInstance, handle: newHandle }
     })
 
-    this.runBurst(instance, handle, builtin).catch(async (err) => {
-      console.error('[builtin-adapter] runBurst threw unexpectedly (resume):', err)
-      await this.getMutex(instance.worker_id).run(async () => {
-        await this.transitionExited(instance, handle, 'crashed')
-      })
-    })
+    this.runBurst(instance, handle, builtin).catch((err) => this.safetyNetExit(instance, handle, err, 'runBurst (resume)'))
 
     return handle
   }
@@ -339,12 +328,7 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     })
 
     // fire-and-forget：一次性 burst 在后台跑，fork 立刻以 running 态返回。
-    this.runForkBurst(instance, handle, builtin).catch(async (err) => {
-      console.error('[builtin-adapter] runForkBurst threw unexpectedly:', err)
-      await this.getMutex(instance.worker_id).run(async () => {
-        await this.transitionExited(instance, handle, 'crashed')
-      })
-    })
+    this.runForkBurst(instance, handle, builtin).catch((err) => this.safetyNetExit(instance, handle, err, 'runForkBurst'))
 
     return handle
   }
@@ -384,12 +368,7 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     // burst 的整个执行时长堵死。
     const instance = this.instances.get(instanceKey(h.worker_id, h.seq))!
     const builtin = this.builtinConfigs.get(h.worker_id)!
-    this.runBurst(instance, h, builtin).catch(async (err) => {
-      console.error('[builtin-adapter] runBurst threw unexpectedly (sendInput continuation):', err)
-      await this.getMutex(instance.worker_id).run(async () => {
-        await this.transitionExited(instance, h, 'crashed')
-      })
-    })
+    this.runBurst(instance, h, builtin).catch((err) => this.safetyNetExit(instance, h, err, 'runBurst (sendInput continuation)'))
   }
 
   async readOutput(h: IncarnationHandle, cursor: OutputCursor): Promise<{ chunk: string; nextCursor: OutputCursor }> {
@@ -486,6 +465,32 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
 
   capabilities(): AdapterCapabilities {
     return { fork: true, revive: true, goalMode: true, subagent: true, structuredTrace: true }
+  }
+
+  /**
+   * fire-and-forget 起 burst（spawn/resume/fork/sendInput 四处）后统一 .catch 到这里。
+   * runBurst/runForkBurst 内部已经把 runEngine 的失败路径处理成 exited(crashed)，能落到
+   * 这里的都是真正意外的同步/异步抛错（比如 pendingWrites 落盘失败后的兜底 throw）。
+   * transitionExited 自己还要再摸一次磁盘（writeMeta，pendingInputs 非空时还有 dead-letter
+   * append）——若它这次也抛错（ENOSPC/EIO 之类最容易撞上），这层 catch 回调本身就是一个
+   * 没人再接的 async 函数，rejection 会直接命中 main.ts 的 process.on('unhandledRejection')
+   * → process.exit(1)，把整个 agent 进程一起打崩。因此再包一层 try/catch 兜底：兜不住就
+   * 只能 console.error 记录——此时化身状态已经不可靠（内存/磁盘可能没落到 exited），但至少
+   * 保证不崩进程。
+   */
+  private async safetyNetExit(instance: WorkerInstance, handle: IncarnationHandle, err: unknown, context: string): Promise<void> {
+    console.error(`[builtin-adapter] ${context} threw unexpectedly:`, err)
+    try {
+      await this.getMutex(instance.worker_id).run(async () => {
+        await this.transitionExited(instance, handle, 'crashed')
+      })
+    } catch (innerErr) {
+      console.error(
+        `[builtin-adapter] safety net itself failed while exiting incarnation ${instance.worker_id}#${instance.seq} ` +
+        '(incarnation state may now be unreliable; process kept alive):',
+        innerErr,
+      )
+    }
   }
 
   // --- Internal: burst execution ---

--- a/crabot-agent/src/workers/builtin/adapter.ts
+++ b/crabot-agent/src/workers/builtin/adapter.ts
@@ -182,48 +182,60 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     if (!spec.builtin) {
       throw new Error(`BuiltinWorkerAdapter.spawn: spec.builtin missing for worker ${spec.worker_id}`)
     }
+    const builtin = spec.builtin
 
-    // fail-fast：拒绝对同一个 worker_id 重复 spawn。builtinConfigs/instances 命中说明本
-    // 进程已经 spawn 过；磁盘已有 meta-1.json 覆盖跨进程场景（上一进程 spawn 过、本进程
-    // 刚启动，内存态是空的但磁盘还留着旧化身）。不拦住的话，重复 spawn 会把新的根节点
-    // append 进同一个 session.jsonl，跟旧化身的节点混进一棵树，是脏数据源头。
-    if (this.builtinConfigs.has(spec.worker_id) || this.findSessionTreeForWorker(spec.worker_id)) {
-      throw new Error(`BuiltinWorkerAdapter.spawn: worker_id ${spec.worker_id} already spawned in this process`)
-    }
-    const seq = 1
-    const dir = join(this.deps.dataDir, spec.worker_id)
-    if (await fileExists(join(dir, `meta-${seq}.json`))) {
-      throw new Error(`BuiltinWorkerAdapter.spawn: worker_id ${spec.worker_id} already has meta-${seq}.json on disk`)
-    }
-    await fs.mkdir(dir, { recursive: true })
+    // 守卫（三重 fail-fast 检查）到提交（writeMeta→instances.set→builtinConfigs.set）整体
+    // 在该 worker 的互斥锁内原子完成，与 resume/fork 对齐：不然两次并发 spawn 同一
+    // worker_id 会双双穿过守卫（builtinConfigs/instances 命中检查、磁盘 meta-1.json 检查
+    // 之间隔着多个 await），各自建根节点、各自 writeMeta、各自注册，产出双根节点、meta
+    // 互相覆盖、两个 burst 各持不同 abortController 交错写同一 output/meta。锁内排队后，
+    // 后到的那次会命中"已 spawn"守卫被拒——先到先得，语义与 resume 的重复检测一致。
+    const mutex = this.getMutex(spec.worker_id)
+    const { instance, handle } = await mutex.run(async () => {
+      // fail-fast：拒绝对同一个 worker_id 重复 spawn。builtinConfigs/instances 命中说明本
+      // 进程已经 spawn 过；磁盘已有 meta-1.json 覆盖跨进程场景（上一进程 spawn 过、本进程
+      // 刚启动，内存态是空的但磁盘还留着旧化身）。不拦住的话，重复 spawn 会把新的根节点
+      // append 进同一个 session.jsonl，跟旧化身的节点混进一棵树，是脏数据源头。
+      if (this.builtinConfigs.has(spec.worker_id) || this.findSessionTreeForWorker(spec.worker_id)) {
+        throw new Error(`BuiltinWorkerAdapter.spawn: worker_id ${spec.worker_id} already spawned in this process`)
+      }
+      const seq = 1
+      const dir = join(this.deps.dataDir, spec.worker_id)
+      if (await fileExists(join(dir, `meta-${seq}.json`))) {
+        throw new Error(`BuiltinWorkerAdapter.spawn: worker_id ${spec.worker_id} already has meta-${seq}.json on disk`)
+      }
+      await fs.mkdir(dir, { recursive: true })
 
-    const sessionTree = new SessionTree(join(dir, 'session.jsonl'))
-    const outputLog = new OutputLog(join(dir, `output-${seq}.log`))
-    const rootId = await sessionTree.append(null, createUserMessage(spec.prompt))
+      const sessionTree = new SessionTree(join(dir, 'session.jsonl'))
+      const outputLog = new OutputLog(join(dir, `output-${seq}.log`))
+      const rootId = await sessionTree.append(null, createUserMessage(spec.prompt))
 
-    const instance: WorkerInstance = {
-      worker_id: spec.worker_id,
-      seq,
-      dir,
-      sessionTree,
-      outputLog,
-      tip: rootId,
-      state: 'running',
-      pendingInputs: [],
-    }
+      const newInstance: WorkerInstance = {
+        worker_id: spec.worker_id,
+        seq,
+        dir,
+        sessionTree,
+        outputLog,
+        tip: rootId,
+        state: 'running',
+        pendingInputs: [],
+      }
 
-    const handle: IncarnationHandle = { worker_id: spec.worker_id, seq, impl: 'builtin' }
-    // writeMeta 成功之后才注册到 instances/builtinConfigs，跟 resume 保持一致的提交次序：
-    // 磁盘失败时不留孤儿实例。注意此时上面的"已 spawn"三重守卫（builtinConfigs 命中 /
-    // instances 命中 / 磁盘 meta-${seq}.json 存在）全部落空——writeMeta 还没成功过，没有
-    // 一个会命中。调用方重试 spawn 因此不会被拦住，只会在 session.jsonl 里再 append 一个
-    // 孤儿根节点（不被任何化身的 tip 引用，是良性的，不影响 pathTo）。
-    await this.writeMeta(instance)
-    this.instances.set(instanceKey(spec.worker_id, seq), instance)
-    this.builtinConfigs.set(spec.worker_id, spec.builtin)
+      const newHandle: IncarnationHandle = { worker_id: spec.worker_id, seq, impl: 'builtin' }
+      // writeMeta 成功之后才注册到 instances/builtinConfigs，跟 resume 保持一致的提交次序：
+      // 磁盘失败时不留孤儿实例。注意此时上面的"已 spawn"三重守卫（builtinConfigs 命中 /
+      // instances 命中 / 磁盘 meta-${seq}.json 存在）全部落空——writeMeta 还没成功过，没有
+      // 一个会命中。调用方重试 spawn 因此不会被拦住，只会在 session.jsonl 里再 append 一个
+      // 孤儿根节点（不被任何化身的 tip 引用，是良性的，不影响 pathTo）。
+      await this.writeMeta(newInstance)
+      this.instances.set(instanceKey(spec.worker_id, seq), newInstance)
+      this.builtinConfigs.set(spec.worker_id, builtin)
+      return { instance: newInstance, handle: newHandle }
+    })
 
-    // fire-and-forget：burst 在后台跑，spawn 立刻以 running 态返回。
-    this.runBurst(instance, handle, spec.builtin).catch((err) => this.safetyNetExit(instance, handle, err, 'runBurst'))
+    // fire-and-forget：burst 在后台跑，spawn 立刻以 running 态返回。留在锁外，不然会把
+    // runEngine 的整个执行时长堵在锁里，挡住排队的其他 worker_id 无关操作。
+    this.runBurst(instance, handle, builtin).catch((err) => this.safetyNetExit(instance, handle, err, 'runBurst'))
 
     return handle
   }

--- a/crabot-agent/src/workers/builtin/adapter.ts
+++ b/crabot-agent/src/workers/builtin/adapter.ts
@@ -196,8 +196,9 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     // 视为对同一 prev 的重复 resume，直接失败，而不是静默产出第二个化身。newSeq 用 nextSeq()
     // 而非 prev.seq+1——fork 可能已经消耗掉 prev.seq+1 这个号位（fork 分支和主线共享同一
     // seq 序列），继续用 prev.seq+1 会在这种情况下误判"并发 resume"或直接撞号覆盖。
-    // resumed 标记必须在 append 及实例注册成功之后才能提交（同一时刻），以确保失败路径
-    // 幂等可重试：若 append 抛错，resumed 仍未被设置，后续重试不会被"重复 resume"检查拒绝。
+    // resumed 标记必须在 writeMeta 成功之后才能提交，以确保失败路径幂等可重试：若 writeMeta
+    // 抛错，resumed 仍未被设置，后续重试不会被"重复 resume"检查拒绝。instances.set 与
+    // resumed 标记同时提交，整体在锁内原子完成。
     const mutex = this.getMutex(prev.worker_id)
     const { instance, handle } = await mutex.run(async () => {
       await this.assertExited(prev.worker_id, prev.seq)
@@ -226,13 +227,12 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
         state: 'running',
         pendingInputs: [],
       }
-      this.instances.set(instanceKey(prev.worker_id, newSeq), newInstance)
-      // 成功注册新实例之后、writeMeta 之前提交 resumed 标记：同一临界区内原子完成，
-      // 失败路径不会留下回滚不了的副作用。
-      if (prevInstance) prevInstance.resumed = true
 
       const newHandle: IncarnationHandle = { worker_id: prev.worker_id, seq: newSeq, impl: 'builtin' }
+      // writeMeta 成功之后才注册到 instances 并标记 resumed，确保磁盘失败时不留孤儿实例。
       await this.writeMeta(newInstance)
+      this.instances.set(instanceKey(prev.worker_id, newSeq), newInstance)
+      if (prevInstance) prevInstance.resumed = true
       return { instance: newInstance, handle: newHandle }
     })
 

--- a/crabot-agent/src/workers/builtin/adapter.ts
+++ b/crabot-agent/src/workers/builtin/adapter.ts
@@ -1,12 +1,20 @@
 /**
- * BuiltinWorkerAdapter — worker 契约的 builtin 实现（P1：spawn + burst 状态机）。
+ * BuiltinWorkerAdapter — worker 契约的 builtin 实现（P1：spawn + burst 状态机 + sendInput/resume）。
  *
- * 每个 worker 落 <dataDir>/<worker_id>/{session.jsonl,output.log,meta.json}。
- * spawn 建目录、把 prompt 作为根节点 append 进 session 树、fire-and-forget 起一个
- * "burst"（一次 runEngine 调用），随即以 running 态返回。burst 结束后按 engine
- * outcome / exitToolCall 迁移到 idle 或 exited，meta.json 原子写。
+ * 每个 worker 落 <dataDir>/<worker_id>/session.jsonl（跨化身共享的 session 树）+
+ * 每个化身独立的 output-<seq>.log / meta-<seq>.json。spawn 建目录、把 prompt 作为根
+ * 节点 append 进 session 树、fire-and-forget 起一个 "burst"（一次 runEngine 调用），
+ * 随即以 running 态返回。burst 结束后按 engine outcome / exitToolCall 迁移到 idle 或
+ * exited，meta-<seq>.json 原子写。
  *
- * resume/fork/sendInput/kill 留给后续 task（Task 6-8）。
+ * sendInput：idle 态追加新一轮用户消息并续 burst；running 态进入本化身的待注入队列，
+ * 当前 burst 结束若判定为 idle 且队列非空则原地续 burst（不经过可见的 idle 态）；
+ * exited 态抛 WorkerExitedError，交给上层 harness 做透明接续（P3）。
+ *
+ * resume：从已 exited 的化身的 session_ref（tip node_id）派生 seq+1 新化身，
+ * append wakeInput 后起新 burst。
+ *
+ * fork/kill 留给后续 task（Task 7-8）。
  */
 import { promises as fs } from 'fs'
 import { join } from 'path'
@@ -30,7 +38,21 @@ import type {
   Workspace,
 } from '../types.js'
 
-const NOT_IMPLEMENTED = 'not implemented until Task 6-8'
+const NOT_IMPLEMENTED = 'not implemented until Task 7-8'
+
+/**
+ * sendInput 打到已 exited 的化身时抛出。透明接续（自动 resume 并重投）是 harness（P3）
+ * 的职责，adapter 层保持窄语义，只负责如实报告"这个化身已经结束了"。
+ */
+export class WorkerExitedError extends Error {
+  constructor(
+    readonly worker_id: string,
+    readonly seq: number,
+  ) {
+    super(`BuiltinWorkerAdapter: incarnation ${worker_id}#${seq} has exited`)
+    this.name = 'WorkerExitedError'
+  }
+}
 
 const FINISH_TASK_TOOL: ToolDefinition = {
   ...defineTool({
@@ -60,6 +82,8 @@ interface WorkerInstance {
   state: WorkerContractState
   ended_reason?: IncarnationEndReason
   outcome?: 'completed' | 'failed'
+  /** running 态下经 sendInput 排队、等下一次 burst 间隙统一 append 的用户消息（P1：内存，不跨重启持久）。 */
+  pendingInputs: string[]
 }
 
 function instanceKey(worker_id: string, seq: number): string {
@@ -74,6 +98,8 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
   readonly implId = 'builtin' as const
 
   private readonly instances = new Map<string, WorkerInstance>()
+  /** worker_id → spawn 时注入的 builtin 执行配置（adapter/model/tools），resume 与续 burst 复用。P1：仅内存，不跨重启持久。 */
+  private readonly builtinConfigs = new Map<string, NonNullable<SpawnSpec['builtin']>>()
 
   constructor(
     private readonly deps: {
@@ -99,7 +125,7 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     await fs.mkdir(dir, { recursive: true })
 
     const sessionTree = new SessionTree(join(dir, 'session.jsonl'))
-    const outputLog = new OutputLog(join(dir, 'output.log'))
+    const outputLog = new OutputLog(join(dir, `output-${seq}.log`))
     await sessionTree.append(null, createUserMessage(spec.prompt))
 
     const instance: WorkerInstance = {
@@ -109,8 +135,10 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
       sessionTree,
       outputLog,
       state: 'running',
+      pendingInputs: [],
     }
     this.instances.set(instanceKey(spec.worker_id, seq), instance)
+    this.builtinConfigs.set(spec.worker_id, spec.builtin)
 
     const handle: IncarnationHandle = { worker_id: spec.worker_id, seq, impl: 'builtin' }
     await this.writeMeta(instance)
@@ -126,28 +154,89 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     return handle
   }
 
-  async resume(_prev: IncarnationRef, _wakeInput: string): Promise<IncarnationHandle> {
-    throw new Error(NOT_IMPLEMENTED)
+  async resume(prev: IncarnationRef, wakeInput: string): Promise<IncarnationHandle> {
+    await this.assertExited(prev.worker_id, prev.seq)
+    const builtin = this.builtinConfigs.get(prev.worker_id)
+    if (!builtin) {
+      throw new Error(`BuiltinWorkerAdapter.resume: no builtin config resident in memory for worker ${prev.worker_id} (P1: worker must have been spawned in this process)`)
+    }
+
+    const newSeq = prev.seq + 1
+    const dir = join(this.deps.dataDir, prev.worker_id)
+    let sessionTree = this.findSessionTreeForWorker(prev.worker_id)
+    if (!sessionTree) {
+      sessionTree = await SessionTree.load(join(dir, 'session.jsonl'))
+    }
+    const outputLog = new OutputLog(join(dir, `output-${newSeq}.log`))
+    await sessionTree.append(prev.session_ref, createUserMessage(wakeInput))
+
+    const instance: WorkerInstance = {
+      worker_id: prev.worker_id,
+      seq: newSeq,
+      dir,
+      sessionTree,
+      outputLog,
+      state: 'running',
+      pendingInputs: [],
+    }
+    this.instances.set(instanceKey(prev.worker_id, newSeq), instance)
+
+    const handle: IncarnationHandle = { worker_id: prev.worker_id, seq: newSeq, impl: 'builtin' }
+    await this.writeMeta(instance)
+
+    this.runBurst(instance, handle, builtin).catch(async (err) => {
+      console.error('[builtin-adapter] runBurst threw unexpectedly (resume):', err)
+      await this.transitionExited(instance, handle, 'crashed')
+    })
+
+    return handle
   }
 
   async fork(_prev: IncarnationRef, _forkInput: string): Promise<IncarnationHandle> {
     throw new Error(NOT_IMPLEMENTED)
   }
 
-  async sendInput(_h: IncarnationHandle, _text: string, _opts?: { raw?: boolean }): Promise<void> {
-    throw new Error(NOT_IMPLEMENTED)
+  async sendInput(h: IncarnationHandle, text: string, _opts?: { raw?: boolean }): Promise<void> {
+    const instance = this.instances.get(instanceKey(h.worker_id, h.seq))
+    if (!instance) {
+      throw new Error(`BuiltinWorkerAdapter.sendInput: no such incarnation ${h.worker_id}#${h.seq} resident in this process`)
+    }
+
+    if (instance.state === 'exited') {
+      throw new WorkerExitedError(h.worker_id, h.seq)
+    }
+
+    if (instance.state === 'running') {
+      instance.pendingInputs.push(text)
+      return
+    }
+
+    // idle → 追加新一轮用户消息，续 burst，转 running。
+    const builtin = this.builtinConfigs.get(h.worker_id)
+    if (!builtin) {
+      throw new Error(`BuiltinWorkerAdapter.sendInput: no builtin config resident in memory for worker ${h.worker_id}`)
+    }
+    const tip = instance.sessionTree.latestTip()
+    if (tip === null) throw new Error(`BuiltinWorkerAdapter: worker ${instance.worker_id} has empty session tree`)
+    await instance.sessionTree.append(tip, createUserMessage(text))
+    await this.transitionState(instance, h, 'running')
+
+    this.runBurst(instance, h, builtin).catch(async (err) => {
+      console.error('[builtin-adapter] runBurst threw unexpectedly (sendInput continuation):', err)
+      await this.transitionExited(instance, h, 'crashed')
+    })
   }
 
   async readOutput(h: IncarnationHandle, cursor: OutputCursor): Promise<{ chunk: string; nextCursor: OutputCursor }> {
     const instance = this.instances.get(instanceKey(h.worker_id, h.seq))
-    const outputLog = instance ? instance.outputLog : new OutputLog(join(this.deps.dataDir, h.worker_id, 'output.log'))
+    const outputLog = instance ? instance.outputLog : new OutputLog(join(this.deps.dataDir, h.worker_id, `output-${h.seq}.log`))
     return outputLog.read(cursor)
   }
 
   async state(h: IncarnationHandle): Promise<WorkerContractState> {
     const instance = this.instances.get(instanceKey(h.worker_id, h.seq))
     if (instance) return instance.state
-    const metaPath = join(this.deps.dataDir, h.worker_id, 'meta.json')
+    const metaPath = join(this.deps.dataDir, h.worker_id, `meta-${h.seq}.json`)
     const raw = await fs.readFile(metaPath, 'utf-8')
     const meta = JSON.parse(raw) as { state: WorkerContractState }
     return meta.state
@@ -223,8 +312,48 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
       return
     }
 
-    // end_turn（或 max_turns 耗尽）→ idle，等待下一次 resume/sendInput 唤醒。
+    // end_turn（或 max_turns 耗尽）→ 若 sendInput 排了队，逐条 append 后原地续 burst
+    // （不经过可见的 idle 态）；否则转 idle，等待下一次 resume/sendInput 唤醒。
+    if (instance.pendingInputs.length > 0) {
+      const queued = instance.pendingInputs.splice(0, instance.pendingInputs.length)
+      let queueParent = instance.sessionTree.latestTip()
+      if (queueParent === null) throw new Error(`BuiltinWorkerAdapter: worker ${instance.worker_id} has empty session tree`)
+      for (const text of queued) {
+        queueParent = await instance.sessionTree.append(queueParent, createUserMessage(text))
+      }
+      await this.runBurst(instance, handle, builtin)
+      return
+    }
+
     await this.transitionState(instance, handle, 'idle')
+  }
+
+  private findSessionTreeForWorker(worker_id: string): SessionTree | undefined {
+    for (const instance of this.instances.values()) {
+      if (instance.worker_id === worker_id) return instance.sessionTree
+    }
+    return undefined
+  }
+
+  private async assertExited(worker_id: string, seq: number): Promise<void> {
+    const existing = this.instances.get(instanceKey(worker_id, seq))
+    if (existing) {
+      if (existing.state !== 'exited') {
+        throw new Error(`BuiltinWorkerAdapter.resume: incarnation ${worker_id}#${seq} is not exited (state=${existing.state})`)
+      }
+      return
+    }
+    const metaPath = join(this.deps.dataDir, worker_id, `meta-${seq}.json`)
+    let raw: string
+    try {
+      raw = await fs.readFile(metaPath, 'utf-8')
+    } catch {
+      throw new Error(`BuiltinWorkerAdapter.resume: no such incarnation ${worker_id}#${seq}`)
+    }
+    const meta = JSON.parse(raw) as { state: WorkerContractState }
+    if (meta.state !== 'exited') {
+      throw new Error(`BuiltinWorkerAdapter.resume: incarnation ${worker_id}#${seq} is not exited (state=${meta.state})`)
+    }
   }
 
   private combineTools(tools: Resolvable<ReadonlyArray<ToolDefinition>>): Resolvable<ReadonlyArray<ToolDefinition>> {
@@ -266,8 +395,8 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
       ...(ended_reason !== undefined ? { ended_reason } : {}),
       ...(outcome !== undefined ? { outcome } : {}),
     }
-    const metaPath = join(instance.dir, 'meta.json')
-    const tmpPath = join(instance.dir, `.meta.json.tmp-${randomUUID()}`)
+    const metaPath = join(instance.dir, `meta-${instance.seq}.json`)
+    const tmpPath = join(instance.dir, `.meta-${instance.seq}.json.tmp-${randomUUID()}`)
     await fs.writeFile(tmpPath, JSON.stringify(meta), 'utf-8')
     await fs.rename(tmpPath, metaPath)
   }

--- a/crabot-agent/src/workers/builtin/adapter.ts
+++ b/crabot-agent/src/workers/builtin/adapter.ts
@@ -156,7 +156,9 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
       // 安全网：runBurst 内部已经把 runEngine 的失败路径处理成 exited(crashed)，
       // 这里只兜住真正意外的同步/异步抛错（比如 append 磁盘写失败）。
       console.error('[builtin-adapter] runBurst threw unexpectedly:', err)
-      await this.transitionExited(instance, handle, 'crashed')
+      await this.getMutex(instance.worker_id).run(async () => {
+        await this.transitionExited(instance, handle, 'crashed')
+      })
     })
 
     return handle
@@ -208,7 +210,9 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
 
     this.runBurst(instance, handle, builtin).catch(async (err) => {
       console.error('[builtin-adapter] runBurst threw unexpectedly (resume):', err)
-      await this.transitionExited(instance, handle, 'crashed')
+      await this.getMutex(instance.worker_id).run(async () => {
+        await this.transitionExited(instance, handle, 'crashed')
+      })
     })
 
     return handle
@@ -257,7 +261,9 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     const builtin = this.builtinConfigs.get(h.worker_id)!
     this.runBurst(instance, h, builtin).catch(async (err) => {
       console.error('[builtin-adapter] runBurst threw unexpectedly (sendInput continuation):', err)
-      await this.transitionExited(instance, h, 'crashed')
+      await this.getMutex(instance.worker_id).run(async () => {
+        await this.transitionExited(instance, h, 'crashed')
+      })
     })
   }
 
@@ -429,6 +435,9 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     ended_reason: IncarnationEndReason,
     outcome?: 'completed' | 'failed',
   ): Promise<void> {
+    if (instance.pendingInputs.length > 0) {
+      console.log(`[dead-letter] incarnation ${instance.worker_id}#${instance.seq} exited with ${instance.pendingInputs.length} unsent message(s)`)
+    }
     await this.writeMeta(instance, { state: 'exited', ended_reason, outcome })
     instance.state = 'exited'
     instance.ended_reason = ended_reason

--- a/crabot-agent/src/workers/builtin/adapter.ts
+++ b/crabot-agent/src/workers/builtin/adapter.ts
@@ -1,0 +1,261 @@
+/**
+ * BuiltinWorkerAdapter — worker 契约的 builtin 实现（P1：spawn + burst 状态机）。
+ *
+ * 每个 worker 落 <dataDir>/<worker_id>/{session.jsonl,output.log,meta.json}。
+ * spawn 建目录、把 prompt 作为根节点 append 进 session 树、fire-and-forget 起一个
+ * "burst"（一次 runEngine 调用），随即以 running 态返回。burst 结束后按 engine
+ * outcome / exitToolCall 迁移到 idle 或 exited，meta.json 原子写。
+ *
+ * resume/fork/sendInput/kill 留给后续 task（Task 6-8）。
+ */
+import { promises as fs } from 'fs'
+import { join } from 'path'
+import { randomUUID } from 'crypto'
+import { runEngine, defineTool, createUserMessage } from '../../engine/index.js'
+import type { EngineMessage, EngineResult, ToolDefinition } from '../../engine/index.js'
+import type { Resolvable } from '../../engine/types.js'
+import { SessionTree } from '../session-tree.js'
+import { OutputLog } from '../output-log.js'
+import type {
+  AdapterCapabilities,
+  CapabilityBundle,
+  DetectResult,
+  IncarnationHandle,
+  IncarnationRef,
+  IncarnationEndReason,
+  OutputCursor,
+  SpawnSpec,
+  WorkerAdapter,
+  WorkerContractState,
+  Workspace,
+} from '../types.js'
+
+const NOT_IMPLEMENTED = 'not implemented until Task 6-8'
+
+const FINISH_TASK_TOOL: ToolDefinition = {
+  ...defineTool({
+    name: 'finish_task',
+    description: '结束当前 burst：任务完成或确认失败时调用，附一句话总结。',
+    isReadOnly: true,
+    inputSchema: {
+      type: 'object',
+      properties: {
+        outcome: { type: 'string', enum: ['completed', 'failed'], description: '任务终态' },
+        summary: { type: 'string', description: '一句话总结' },
+      },
+      required: ['outcome', 'summary'],
+    },
+    // exitsLoop=true 时引擎不会真的执行 call，直接把 input 写进 EngineResult.exitToolCall。
+    call: async () => ({ output: '', isError: false }),
+  }),
+  exitsLoop: true,
+}
+
+interface WorkerInstance {
+  readonly worker_id: string
+  readonly seq: number
+  readonly dir: string
+  readonly sessionTree: SessionTree
+  readonly outputLog: OutputLog
+  state: WorkerContractState
+  ended_reason?: IncarnationEndReason
+  outcome?: 'completed' | 'failed'
+}
+
+function instanceKey(worker_id: string, seq: number): string {
+  return `${worker_id}#${seq}`
+}
+
+function resolve<T>(value: Resolvable<T>): T {
+  return typeof value === 'function' ? (value as () => T)() : value
+}
+
+export class BuiltinWorkerAdapter implements WorkerAdapter {
+  readonly implId = 'builtin' as const
+
+  private readonly instances = new Map<string, WorkerInstance>()
+
+  constructor(
+    private readonly deps: {
+      readonly dataDir: string
+      readonly onStateChange?: (h: IncarnationHandle, state: WorkerContractState) => void
+    },
+  ) {}
+
+  async detect(): Promise<DetectResult> {
+    return { installed: true, activated: true }
+  }
+
+  async provision(_ws: Workspace, _caps: CapabilityBundle): Promise<void> {
+    // P1 空实现：builtin 走现有下发通道，无需单独 provision。
+  }
+
+  async spawn(spec: SpawnSpec): Promise<IncarnationHandle> {
+    if (!spec.builtin) {
+      throw new Error(`BuiltinWorkerAdapter.spawn: spec.builtin missing for worker ${spec.worker_id}`)
+    }
+    const seq = 1
+    const dir = join(this.deps.dataDir, spec.worker_id)
+    await fs.mkdir(dir, { recursive: true })
+
+    const sessionTree = new SessionTree(join(dir, 'session.jsonl'))
+    const outputLog = new OutputLog(join(dir, 'output.log'))
+    await sessionTree.append(null, createUserMessage(spec.prompt))
+
+    const instance: WorkerInstance = {
+      worker_id: spec.worker_id,
+      seq,
+      dir,
+      sessionTree,
+      outputLog,
+      state: 'running',
+    }
+    this.instances.set(instanceKey(spec.worker_id, seq), instance)
+
+    const handle: IncarnationHandle = { worker_id: spec.worker_id, seq, impl: 'builtin' }
+    await this.writeMeta(instance)
+
+    // fire-and-forget：burst 在后台跑，spawn 立刻以 running 态返回。
+    this.runBurst(instance, handle, spec.builtin).catch(async (err) => {
+      // 安全网：runBurst 内部已经把 runEngine 的失败路径处理成 exited(crashed)，
+      // 这里只兜住真正意外的同步/异步抛错（比如 append 磁盘写失败）。
+      console.error('[builtin-adapter] runBurst threw unexpectedly:', err)
+      await this.transitionExited(instance, handle, 'crashed')
+    })
+
+    return handle
+  }
+
+  async resume(_prev: IncarnationRef, _wakeInput: string): Promise<IncarnationHandle> {
+    throw new Error(NOT_IMPLEMENTED)
+  }
+
+  async fork(_prev: IncarnationRef, _forkInput: string): Promise<IncarnationHandle> {
+    throw new Error(NOT_IMPLEMENTED)
+  }
+
+  async sendInput(_h: IncarnationHandle, _text: string, _opts?: { raw?: boolean }): Promise<void> {
+    throw new Error(NOT_IMPLEMENTED)
+  }
+
+  async readOutput(h: IncarnationHandle, cursor: OutputCursor): Promise<{ chunk: string; nextCursor: OutputCursor }> {
+    const instance = this.instances.get(instanceKey(h.worker_id, h.seq))
+    const outputLog = instance ? instance.outputLog : new OutputLog(join(this.deps.dataDir, h.worker_id, 'output.log'))
+    return outputLog.read(cursor)
+  }
+
+  async state(h: IncarnationHandle): Promise<WorkerContractState> {
+    const instance = this.instances.get(instanceKey(h.worker_id, h.seq))
+    if (instance) return instance.state
+    const metaPath = join(this.deps.dataDir, h.worker_id, 'meta.json')
+    const raw = await fs.readFile(metaPath, 'utf-8')
+    const meta = JSON.parse(raw) as { state: WorkerContractState }
+    return meta.state
+  }
+
+  async kill(_h: IncarnationHandle): Promise<void> {
+    throw new Error(NOT_IMPLEMENTED)
+  }
+
+  capabilities(): AdapterCapabilities {
+    return { fork: true, revive: true, goalMode: true, subagent: true, structuredTrace: true }
+  }
+
+  // --- Internal: burst execution ---
+
+  private async runBurst(
+    instance: WorkerInstance,
+    handle: IncarnationHandle,
+    builtin: NonNullable<SpawnSpec['builtin']>,
+  ): Promise<void> {
+    const tip = instance.sessionTree.latestTip()
+    if (tip === null) throw new Error(`BuiltinWorkerAdapter: worker ${instance.worker_id} has empty session tree`)
+    const initialMessages = instance.sessionTree.pathTo(tip)
+
+    const pendingWrites: Promise<void>[] = []
+    const result: EngineResult = await runEngine({
+      prompt: '',
+      adapter: builtin.adapter,
+      initialMessages,
+      options: {
+        systemPrompt: builtin.systemPrompt,
+        tools: this.combineTools(builtin.tools),
+        model: builtin.model,
+        ...(builtin.maxTurnsPerBurst !== undefined ? { maxTurns: builtin.maxTurnsPerBurst } : {}),
+        onTurn: (event) => {
+          if (event.assistantText) {
+            pendingWrites.push(instance.outputLog.append(event.assistantText + '\n'))
+          }
+        },
+      },
+    })
+    await Promise.all(pendingWrites)
+
+    // burst 结束：把新增消息（finalMessages 相对 initialMessages 的后缀）逐条 append 进 session 树。
+    const newMessages = result.finalMessages.slice(initialMessages.length)
+    let parent = tip
+    for (const msg of newMessages as EngineMessage[]) {
+      parent = await instance.sessionTree.append(parent, msg)
+    }
+
+    if (result.outcome === 'failed' || result.outcome === 'aborted') {
+      await this.transitionExited(instance, handle, result.outcome === 'aborted' ? 'killed' : 'crashed')
+      return
+    }
+
+    if (result.exitToolCall?.name === 'finish_task') {
+      const rawOutcome = result.exitToolCall.input.outcome
+      const outcome: 'completed' | 'failed' = rawOutcome === 'failed' ? 'failed' : 'completed'
+      await this.transitionExited(instance, handle, outcome, outcome)
+      return
+    }
+
+    // end_turn（或 max_turns 耗尽）→ idle，等待下一次 resume/sendInput 唤醒。
+    await this.transitionState(instance, handle, 'idle')
+  }
+
+  private combineTools(tools: Resolvable<ReadonlyArray<ToolDefinition>>): Resolvable<ReadonlyArray<ToolDefinition>> {
+    return () => [...resolve(tools), FINISH_TASK_TOOL]
+  }
+
+  // 先落盘、再切内存态：state() 优先读内存，若顺序反过来，外部在 writeMeta 的
+  // await 期间读 state() 会看到"内存已切但磁盘还是旧值"的窗口。
+  private async transitionState(instance: WorkerInstance, handle: IncarnationHandle, state: WorkerContractState): Promise<void> {
+    await this.writeMeta(instance, { state })
+    instance.state = state
+    this.deps.onStateChange?.(handle, state)
+  }
+
+  private async transitionExited(
+    instance: WorkerInstance,
+    handle: IncarnationHandle,
+    ended_reason: IncarnationEndReason,
+    outcome?: 'completed' | 'failed',
+  ): Promise<void> {
+    await this.writeMeta(instance, { state: 'exited', ended_reason, outcome })
+    instance.state = 'exited'
+    instance.ended_reason = ended_reason
+    if (outcome !== undefined) instance.outcome = outcome
+    this.deps.onStateChange?.(handle, 'exited')
+  }
+
+  private async writeMeta(
+    instance: WorkerInstance,
+    overrides: { state?: WorkerContractState; ended_reason?: IncarnationEndReason; outcome?: 'completed' | 'failed' } = {},
+  ): Promise<void> {
+    const state = overrides.state ?? instance.state
+    const ended_reason = overrides.ended_reason ?? instance.ended_reason
+    const outcome = overrides.outcome ?? instance.outcome
+    const meta = {
+      seq: instance.seq,
+      state,
+      tip_node_id: instance.sessionTree.latestTip(),
+      ...(ended_reason !== undefined ? { ended_reason } : {}),
+      ...(outcome !== undefined ? { outcome } : {}),
+    }
+    const metaPath = join(instance.dir, 'meta.json')
+    const tmpPath = join(instance.dir, `.meta.json.tmp-${randomUUID()}`)
+    await fs.writeFile(tmpPath, JSON.stringify(meta), 'utf-8')
+    await fs.rename(tmpPath, metaPath)
+  }
+}

--- a/crabot-agent/src/workers/builtin/adapter.ts
+++ b/crabot-agent/src/workers/builtin/adapter.ts
@@ -182,6 +182,8 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
         tools: this.combineTools(builtin.tools),
         model: builtin.model,
         ...(builtin.maxTurnsPerBurst !== undefined ? { maxTurns: builtin.maxTurnsPerBurst } : {}),
+        // session 树以原始消息为真相源，burst 内禁用压缩。压缩与树的协同（折叠节点）是 P7 集成议题。
+        disableCompaction: true,
         onTurn: (event) => {
           if (event.assistantText) {
             pendingWrites.push(instance.outputLog.append(event.assistantText + '\n'))
@@ -192,6 +194,17 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     await Promise.all(pendingWrites)
 
     // burst 结束：把新增消息（finalMessages 相对 initialMessages 的后缀）逐条 append 进 session 树。
+    // 防御断言：若压缩被意外启用，finalMessages.length 会小于 initialMessages.length，
+    // 此时不回写新消息，标化身为 exited(crashed) 并记日志。
+    if (result.finalMessages.length < initialMessages.length) {
+      console.error(
+        `[builtin-adapter] runBurst compaction guard triggered for worker ${instance.worker_id}: ` +
+        `finalMessages.length (${result.finalMessages.length}) < initialMessages.length (${initialMessages.length}). ` +
+        `Compaction was unexpectedly enabled; marking incarnation as crashed.`,
+      )
+      await this.transitionExited(instance, handle, 'crashed')
+      return
+    }
     const newMessages = result.finalMessages.slice(initialMessages.length)
     let parent = tip
     for (const msg of newMessages as EngineMessage[]) {

--- a/crabot-agent/src/workers/builtin/adapter.ts
+++ b/crabot-agent/src/workers/builtin/adapter.ts
@@ -20,7 +20,15 @@
  * 结束即 exited，没有 idle 态）。newSeq 与 resume 共用 nextSeq()，在同一把互斥锁内
  * 计算，避免二者撞号。
  *
- * kill 留给后续 task（Task 8）。
+ * kill：每化身持有一个 AbortController，burst 启动时创建、其 signal 传给 runEngine。
+ * running 态 kill 只是 abort() 当前 burst——burst 自己以 outcome='aborted' 收尾时既有
+ * 分流会落 exited(killed)（见 runBurst/runForkBurst 收尾段）；idle 态（没有 burst 在跑）
+ * kill 直接在互斥锁内落 exited(killed)；已 exited 幂等返回，不覆盖原 ended_reason。
+ *
+ * scanOrphans：进程重启后，内存 instances 已丢失，只能凭磁盘 meta 文件识别"重启前还
+ * 没来得及收尾的化身"——把 state==='running' 的原子改写为 exited(crashed)。调用方须
+ * 在本进程任何 adapter 实例开始活动前调用一次，之后的 spawn/resume/fork 才读到一致
+ * 的磁盘状态。
  */
 import { promises as fs } from 'fs'
 import { join } from 'path'
@@ -44,8 +52,6 @@ import type {
   WorkerContractState,
   Workspace,
 } from '../types.js'
-
-const NOT_IMPLEMENTED = 'not implemented until Task 8'
 
 /** fork 是一次性侧问，maxTurns 取小值，避免侧问跑成一次完整任务。 */
 const FORK_MAX_TURNS = 8
@@ -104,6 +110,12 @@ interface WorkerInstance {
   pendingInputs: string[]
   /** 是否已经被 resume 过一次。用于在 resume() 里检测"对同一 prev 的重复 resume"（先到先得，后来者报错）。 */
   resumed?: boolean
+  /**
+   * 当前（或最近一次）burst 的 AbortController，在 runBurst/runForkBurst 每次调用 runEngine
+   * 前创建，其 signal 传给 runEngine。kill() 在 running 态下只是 abort() 它——不直接改状态，
+   * 状态迁移仍由 burst 自己收尾时的 outcome==='aborted' 分流完成。
+   */
+  abortController?: AbortController
 }
 
 function instanceKey(worker_id: string, seq: number): string {
@@ -355,8 +367,77 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     return meta.state
   }
 
-  async kill(_h: IncarnationHandle): Promise<void> {
-    throw new Error(NOT_IMPLEMENTED)
+  async kill(h: IncarnationHandle): Promise<void> {
+    const mutex = this.getMutex(h.worker_id)
+    await mutex.run(async () => {
+      const instance = this.instances.get(instanceKey(h.worker_id, h.seq))
+      if (!instance) {
+        throw new Error(`BuiltinWorkerAdapter.kill: no such incarnation ${h.worker_id}#${h.seq} resident in this process`)
+      }
+
+      // 已 exited：幂等返回，不覆盖原 ended_reason（kill 打晚了不该篡改真实终态原因）。
+      if (instance.state === 'exited') return
+
+      // idle：没有 burst 在跑，没有什么可 abort 的，直接落终态。
+      if (instance.state === 'idle') {
+        await this.transitionExited(instance, h, 'killed')
+        return
+      }
+
+      // running：只 abort 当前 burst 的 signal。burst 的 runEngine 调用本身在锁外跑（见
+      // runBurst 注释），abort() 后由它自己以 outcome='aborted' 收尾时落 exited(killed)——
+      // 这里不代为转态，避免和 burst 收尾段的互斥锁临界区打架。
+      instance.abortController?.abort()
+    })
+  }
+
+  /**
+   * 崩溃恢复扫描：遍历 dataDir 下所有 worker 目录的 meta-<seq>.json，把 state==='running'
+   * 的原子改写为 exited(crashed) 并收集返回。直接读写文件、不经过内存 instances、不加锁——
+   * 调用方必须保证在本进程任何 adapter 实例开始活动（spawn/resume/fork）之前调用一次，
+   * 此时不存在与运行中 burst 的并发写冲突。坏 meta 文件（读取或 JSON.parse 失败）原样跳过。
+   */
+  static async scanOrphans(dataDir: string): Promise<IncarnationHandle[]> {
+    const orphans: IncarnationHandle[] = []
+    let workerIds: string[]
+    try {
+      workerIds = await fs.readdir(dataDir)
+    } catch {
+      return orphans
+    }
+
+    for (const worker_id of workerIds) {
+      const dir = join(dataDir, worker_id)
+      let entries: string[]
+      try {
+        entries = await fs.readdir(dir)
+      } catch {
+        continue
+      }
+
+      for (const entry of entries) {
+        const match = /^meta-(\d+)\.json$/.exec(entry)
+        if (!match) continue
+        const seq = Number(match[1])
+        const metaPath = join(dir, entry)
+
+        let meta: { state?: WorkerContractState; [key: string]: unknown }
+        try {
+          meta = JSON.parse(await fs.readFile(metaPath, 'utf-8'))
+        } catch {
+          continue
+        }
+        if (meta.state !== 'running') continue
+
+        const updated = { ...meta, state: 'exited', ended_reason: 'crashed' }
+        const tmpPath = join(dir, `.meta-${seq}.json.tmp-${randomUUID()}`)
+        await fs.writeFile(tmpPath, JSON.stringify(updated), 'utf-8')
+        await fs.rename(tmpPath, metaPath)
+        orphans.push({ worker_id, seq, impl: 'builtin' })
+      }
+    }
+
+    return orphans
   }
 
   capabilities(): AdapterCapabilities {
@@ -373,6 +454,10 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     const tip = instance.tip
     const initialMessages = instance.sessionTree.pathTo(tip)
 
+    // 每次进入 runBurst（含续 burst 的递归调用）都换一个新 AbortController，供 kill() abort。
+    const abortController = new AbortController()
+    instance.abortController = abortController
+
     const pendingWrites: Promise<void>[] = []
     const result: EngineResult = await runEngine({
       prompt: '',
@@ -385,6 +470,7 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
         ...(builtin.maxTurnsPerBurst !== undefined ? { maxTurns: builtin.maxTurnsPerBurst } : {}),
         // session 树以原始消息为真相源，burst 内禁用压缩。压缩与树的协同（折叠节点）是 P7 集成议题。
         disableCompaction: true,
+        abortSignal: abortController.signal,
         onTurn: (event) => {
           if (event.assistantText) {
             pendingWrites.push(instance.outputLog.append(event.assistantText + '\n'))
@@ -467,6 +553,10 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     const tip = instance.tip
     const initialMessages = instance.sessionTree.pathTo(tip)
 
+    // fork 化身同样支持被 kill() abort——见 runBurst 里对应注释。
+    const abortController = new AbortController()
+    instance.abortController = abortController
+
     const pendingWrites: Promise<void>[] = []
     const result: EngineResult = await runEngine({
       prompt: '',
@@ -478,6 +568,7 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
         model: builtin.model,
         maxTurns: FORK_MAX_TURNS,
         disableCompaction: true,
+        abortSignal: abortController.signal,
         onTurn: (event) => {
           if (event.assistantText) {
             pendingWrites.push(instance.outputLog.append(event.assistantText + '\n'))

--- a/crabot-agent/src/workers/builtin/adapter.ts
+++ b/crabot-agent/src/workers/builtin/adapter.ts
@@ -139,6 +139,16 @@ function resolve<T>(value: Resolvable<T>): T {
   return typeof value === 'function' ? (value as () => T)() : value
 }
 
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await fs.access(path)
+    return true
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return false
+    throw err
+  }
+}
+
 export class BuiltinWorkerAdapter implements WorkerAdapter {
   readonly implId = 'builtin' as const
 
@@ -172,8 +182,19 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     if (!spec.builtin) {
       throw new Error(`BuiltinWorkerAdapter.spawn: spec.builtin missing for worker ${spec.worker_id}`)
     }
+
+    // fail-fast：拒绝对同一个 worker_id 重复 spawn。builtinConfigs/instances 命中说明本
+    // 进程已经 spawn 过；磁盘已有 meta-1.json 覆盖跨进程场景（上一进程 spawn 过、本进程
+    // 刚启动，内存态是空的但磁盘还留着旧化身）。不拦住的话，重复 spawn 会把新的根节点
+    // append 进同一个 session.jsonl，跟旧化身的节点混进一棵树，是脏数据源头。
+    if (this.builtinConfigs.has(spec.worker_id) || this.findSessionTreeForWorker(spec.worker_id)) {
+      throw new Error(`BuiltinWorkerAdapter.spawn: worker_id ${spec.worker_id} already spawned in this process`)
+    }
     const seq = 1
     const dir = join(this.deps.dataDir, spec.worker_id)
+    if (await fileExists(join(dir, `meta-${seq}.json`))) {
+      throw new Error(`BuiltinWorkerAdapter.spawn: worker_id ${spec.worker_id} already has meta-${seq}.json on disk`)
+    }
     await fs.mkdir(dir, { recursive: true })
 
     const sessionTree = new SessionTree(join(dir, 'session.jsonl'))
@@ -190,11 +211,15 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
       state: 'running',
       pendingInputs: [],
     }
-    this.instances.set(instanceKey(spec.worker_id, seq), instance)
-    this.builtinConfigs.set(spec.worker_id, spec.builtin)
 
     const handle: IncarnationHandle = { worker_id: spec.worker_id, seq, impl: 'builtin' }
+    // writeMeta 成功之后才注册到 instances/builtinConfigs，跟 resume 保持一致的提交次序：
+    // 磁盘失败时不留孤儿实例（此时 session.jsonl 已经有 root 节点，重试会撞上面新加的
+    // "已 spawn"检查——与 resume/fork 的幂等重试语义不同，P1 范围内 spawn 失败要求调用方
+    // 换一个 worker_id 重试，不在本次修复范围内展开）。
     await this.writeMeta(instance)
+    this.instances.set(instanceKey(spec.worker_id, seq), instance)
+    this.builtinConfigs.set(spec.worker_id, spec.builtin)
 
     // fire-and-forget：burst 在后台跑，spawn 立刻以 running 态返回。
     this.runBurst(instance, handle, spec.builtin).catch(async (err) => {
@@ -304,10 +329,12 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
         state: 'running',
         pendingInputs: [],
       }
-      this.instances.set(instanceKey(prev.worker_id, newSeq), newInstance)
 
       const newHandle: IncarnationHandle = { worker_id: prev.worker_id, seq: newSeq, impl: 'builtin' }
+      // writeMeta 成功之后才注册到 instances，和 resume 保持一致的提交次序：磁盘失败时
+      // 不留孤儿实例。
       await this.writeMeta(newInstance)
+      this.instances.set(instanceKey(prev.worker_id, newSeq), newInstance)
       return { instance: newInstance, handle: newHandle }
     })
 
@@ -489,7 +516,16 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     })
     if (!abortController) return
 
+    // pendingWrites 里的 promise 必须在 push 的同一刻就挂上 catch：burst 可能跑几分钟，
+    // onTurn 到下面 await Promise.all(pendingWrites) 之间跨度很长，若 append 提前 reject
+    // 却没有 handler，Node 会在本轮微任务结束时就判定为 unhandledRejection——命中
+    // main.ts 的 process.on('unhandledRejection') 兜底，直接 process.exit(1) 打崩整个
+    // agent 进程。这里改成收集错误到 writeErrors，Promise.all 结束后统一判定：与
+    // spawn/resume/fork/sendInput 处包给 this.runBurst(...) 的安全网 catch（跑到
+    // transitionExited(..., 'crashed')）走同一条错误路径——不在这里代为转态，避免
+    // 和下面的收尾段互斥锁临界区重复处理。
     const pendingWrites: Promise<void>[] = []
+    const writeErrors: unknown[] = []
     const result: EngineResult = await runEngine({
       prompt: '',
       adapter: builtin.adapter,
@@ -504,12 +540,22 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
         abortSignal: abortController.signal,
         onTurn: (event) => {
           if (event.assistantText) {
-            pendingWrites.push(instance.outputLog.append(event.assistantText + '\n'))
+            pendingWrites.push(
+              instance.outputLog.append(event.assistantText + '\n').catch((err) => {
+                writeErrors.push(err)
+              }),
+            )
           }
         },
       },
     })
     await Promise.all(pendingWrites)
+    if (writeErrors.length > 0) {
+      throw new Error(
+        `[builtin-adapter] runBurst: ${writeErrors.length} outputLog.append write(s) failed for worker ${instance.worker_id}: ` +
+        writeErrors.map((e) => (e instanceof Error ? e.message : String(e))).join('; '),
+      )
+    }
 
     // 收尾段（压缩防御 → append 新消息 → 判 outcome → 判队列 → 落 idle/续 burst）整体在该
     // worker 的互斥锁内原子完成：消除"同步判定 pendingInputs 为空后 await transitionState
@@ -607,7 +653,12 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     })
     if (!abortController) return
 
+    // 同 runBurst：push 时立即挂 catch，避免 append 在长时间跑的 burst 期间 reject 却
+    // 没有 handler，触发 unhandledRejection 打崩进程。错误收集到 writeErrors，
+    // Promise.all 后统一抛出，走 fork() 处包给 this.runForkBurst(...) 的安全网 catch
+    // （crashed 收尾），与 runBurst 保持一致的错误语义。
     const pendingWrites: Promise<void>[] = []
+    const writeErrors: unknown[] = []
     const result: EngineResult = await runEngine({
       prompt: '',
       adapter: builtin.adapter,
@@ -621,12 +672,22 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
         abortSignal: abortController.signal,
         onTurn: (event) => {
           if (event.assistantText) {
-            pendingWrites.push(instance.outputLog.append(event.assistantText + '\n'))
+            pendingWrites.push(
+              instance.outputLog.append(event.assistantText + '\n').catch((err) => {
+                writeErrors.push(err)
+              }),
+            )
           }
         },
       },
     })
     await Promise.all(pendingWrites)
+    if (writeErrors.length > 0) {
+      throw new Error(
+        `[builtin-adapter] runForkBurst: ${writeErrors.length} outputLog.append write(s) failed for worker ${instance.worker_id}: ` +
+        writeErrors.map((e) => (e instanceof Error ? e.message : String(e))).join('; '),
+      )
+    }
 
     await mutex.run(async () => {
       if (result.finalMessages.length < initialMessages.length) {

--- a/crabot-agent/src/workers/builtin/adapter.ts
+++ b/crabot-agent/src/workers/builtin/adapter.ts
@@ -597,7 +597,7 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
       instance.tip = parent
 
       if (result.outcome === 'failed' || result.outcome === 'aborted') {
-        await this.transitionExited(instance, handle, 'crashed')
+        await this.transitionExited(instance, handle, result.outcome === 'aborted' ? 'killed' : 'crashed')
         return
       }
 

--- a/crabot-agent/src/workers/builtin/adapter.ts
+++ b/crabot-agent/src/workers/builtin/adapter.ts
@@ -436,7 +436,8 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     outcome?: 'completed' | 'failed',
   ): Promise<void> {
     if (instance.pendingInputs.length > 0) {
-      console.log(`[dead-letter] incarnation ${instance.worker_id}#${instance.seq} exited with ${instance.pendingInputs.length} unsent message(s)`)
+      const deadLetterMsg = `[dead-letter] incarnation ${instance.worker_id}#${instance.seq} exited with ${instance.pendingInputs.length} unsent message(s): ${instance.pendingInputs.join(' | ')}\n`
+      await instance.outputLog.append(deadLetterMsg)
     }
     await this.writeMeta(instance, { state: 'exited', ended_reason, outcome })
     instance.state = 'exited'

--- a/crabot-agent/src/workers/output-log.ts
+++ b/crabot-agent/src/workers/output-log.ts
@@ -1,0 +1,60 @@
+import * as fs from 'fs/promises'
+import { AsyncMutex } from './async-mutex'
+import type { OutputCursor } from './types'
+
+export class OutputLog {
+  private mutex = new AsyncMutex()
+
+  constructor(private filePath: string) {}
+
+  async append(text: string): Promise<void> {
+    return this.mutex.run(async () => {
+      await fs.appendFile(this.filePath, text, 'utf-8')
+    })
+  }
+
+  async read(cursor: OutputCursor, cap: number = 50_000): Promise<{ chunk: string; nextCursor: OutputCursor }> {
+    return this.mutex.run(async () => {
+      try {
+        const stat = await fs.stat(this.filePath)
+        const fileSize = stat.size
+
+        // If cursor is already at or past end of file, return empty chunk
+        if (cursor.offset >= fileSize) {
+          return { chunk: '', nextCursor: cursor }
+        }
+
+        // Calculate bytes to read: up to cap, but not beyond file size
+        const bytesToRead = Math.min(cap, fileSize - cursor.offset)
+        const buffer = Buffer.alloc(bytesToRead)
+
+        const fd = await fs.open(this.filePath, 'r')
+        try {
+          await fd.read(buffer, 0, bytesToRead, cursor.offset)
+          let chunk = buffer.toString('utf-8')
+
+          // Truncation occurs only if we hit the cap limit and there's more content
+          const isTruncated = bytesToRead === cap && cursor.offset + bytesToRead < fileSize
+
+          if (isTruncated) {
+            // Add truncation marker
+            chunk += `\n[output truncated at ${bytesToRead} bytes, continue reading from cursor]`
+          }
+
+          return {
+            chunk,
+            nextCursor: { offset: cursor.offset + bytesToRead },
+          }
+        } finally {
+          await fd.close()
+        }
+      } catch (error) {
+        // File not found: return empty chunk with same cursor
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+          return { chunk: '', nextCursor: cursor }
+        }
+        throw error
+      }
+    })
+  }
+}

--- a/crabot-agent/src/workers/output-log.ts
+++ b/crabot-agent/src/workers/output-log.ts
@@ -2,6 +2,32 @@ import * as fs from 'fs/promises'
 import { AsyncMutex } from './async-mutex'
 import type { OutputCursor } from './types'
 
+// A cap-truncated read can land in the middle of a multi-byte UTF-8 character.
+// Given the number of valid bytes in `buffer[0, len)`, return the largest prefix
+// length that does not split a UTF-8 character, by dropping an incomplete
+// trailing sequence (if any). Only relevant when the read was cut off by `cap`;
+// a read that reaches EOF is already a complete, valid UTF-8 file and needs no trimming.
+function trimIncompleteUtf8Tail(buffer: Buffer, len: number): number {
+  const maxLookback = Math.min(3, len)
+  for (let i = 1; i <= maxLookback; i++) {
+    const byte = buffer[len - i]
+    if ((byte & 0xc0) !== 0x80) {
+      // Found the lead byte of the last character in the buffer.
+      let seqLen: number
+      if ((byte & 0x80) === 0x00) seqLen = 1
+      else if ((byte & 0xe0) === 0xc0) seqLen = 2
+      else if ((byte & 0xf0) === 0xe0) seqLen = 3
+      else if ((byte & 0xf8) === 0xf0) seqLen = 4
+      else seqLen = 1 // not a valid lead byte; treat as standalone
+
+      return i < seqLen ? len - i : len
+    }
+  }
+  // Last `maxLookback` bytes are all continuation bytes with no lead byte found
+  // in range: the lead byte is further back, meaning the sequence is complete.
+  return len
+}
+
 export class OutputLog {
   private mutex = new AsyncMutex()
 
@@ -31,19 +57,27 @@ export class OutputLog {
         const fd = await fs.open(this.filePath, 'r')
         try {
           await fd.read(buffer, 0, bytesToRead, cursor.offset)
-          let chunk = buffer.toString('utf-8')
 
           // Truncation occurs only if we hit the cap limit and there's more content
           const isTruncated = bytesToRead === cap && cursor.offset + bytesToRead < fileSize
 
+          // Only cap-truncated reads risk splitting a multi-byte UTF-8 character
+          // mid-sequence; a read that reaches EOF is complete and needs no trimming.
+          let usedBytes = bytesToRead
+          if (isTruncated) {
+            usedBytes = trimIncompleteUtf8Tail(buffer, bytesToRead)
+          }
+
+          let chunk = buffer.toString('utf-8', 0, usedBytes)
+
           if (isTruncated) {
             // Add truncation marker
-            chunk += `\n[output truncated at ${bytesToRead} bytes, continue reading from cursor]`
+            chunk += `\n[output truncated at ${usedBytes} bytes, continue reading from cursor]`
           }
 
           return {
             chunk,
-            nextCursor: { offset: cursor.offset + bytesToRead },
+            nextCursor: { offset: cursor.offset + usedBytes },
           }
         } finally {
           await fd.close()

--- a/crabot-agent/src/workers/output-log.ts
+++ b/crabot-agent/src/workers/output-log.ts
@@ -28,6 +28,15 @@ function trimIncompleteUtf8Tail(buffer: Buffer, len: number): number {
   return len
 }
 
+// Determine the byte length of a UTF-8 character given its lead byte.
+function utf8CharLength(leadByte: number): number {
+  if ((leadByte & 0x80) === 0x00) return 1
+  else if ((leadByte & 0xe0) === 0xc0) return 2
+  else if ((leadByte & 0xf0) === 0xe0) return 3
+  else if ((leadByte & 0xf8) === 0xf0) return 4
+  else return 1 // invalid lead byte; treat as standalone
+}
+
 export class OutputLog {
   private mutex = new AsyncMutex()
 
@@ -51,21 +60,39 @@ export class OutputLog {
         }
 
         // Calculate bytes to read: up to cap, but not beyond file size
-        const bytesToRead = Math.min(cap, fileSize - cursor.offset)
-        const buffer = Buffer.alloc(bytesToRead)
+        let bytesToRead = Math.min(cap, fileSize - cursor.offset)
+        let buffer = Buffer.alloc(bytesToRead)
 
         const fd = await fs.open(this.filePath, 'r')
         try {
           await fd.read(buffer, 0, bytesToRead, cursor.offset)
 
           // Truncation occurs only if we hit the cap limit and there's more content
-          const isTruncated = bytesToRead === cap && cursor.offset + bytesToRead < fileSize
+          let isTruncated = bytesToRead === cap && cursor.offset + bytesToRead < fileSize
 
           // Only cap-truncated reads risk splitting a multi-byte UTF-8 character
           // mid-sequence; a read that reaches EOF is complete and needs no trimming.
           let usedBytes = bytesToRead
           if (isTruncated) {
             usedBytes = trimIncompleteUtf8Tail(buffer, bytesToRead)
+          }
+
+          // If trimming left us with zero bytes (first character was incomplete) and
+          // there's more content in the file, we must guarantee progress by reading
+          // at least one complete character. cap is a soft limit; progress is a hard requirement.
+          if (usedBytes === 0 && cursor.offset + bytesToRead < fileSize) {
+            // Determine how many bytes the first character needs
+            const firstByte = buffer[0]
+            const charBytesNeeded = utf8CharLength(firstByte)
+
+            // Re-read with enough capacity for the complete character
+            const newBytesToRead = charBytesNeeded
+            buffer = Buffer.alloc(newBytesToRead)
+            await fd.read(buffer, 0, newBytesToRead, cursor.offset)
+
+            // Since we're reading the full character without truncation, no trimming needed
+            usedBytes = newBytesToRead
+            isTruncated = false
           }
 
           let chunk = buffer.toString('utf-8', 0, usedBytes)

--- a/crabot-agent/src/workers/session-tree.ts
+++ b/crabot-agent/src/workers/session-tree.ts
@@ -1,0 +1,82 @@
+/**
+ * SessionTree — append-only session 树,JSONL 持久化。
+ * 内存 Map<node_id, SessionNode> + 追加写文件,append 由 AsyncMutex 串行化保证原子有序。
+ */
+import { randomUUID } from 'crypto'
+import { promises as fs } from 'fs'
+import type { EngineMessage } from '../engine/index.js'
+import { AsyncMutex } from './async-mutex.js'
+
+export interface SessionNode {
+  readonly node_id: string // uuid
+  readonly parent_id: string | null // null = 根
+  readonly message: EngineMessage
+}
+
+export class SessionTree {
+  private readonly nodes = new Map<string, SessionNode>()
+  private readonly mutex = new AsyncMutex()
+  private tip: string | null = null
+
+  constructor(private readonly filePath: string) {}
+
+  static async load(filePath: string): Promise<SessionTree> {
+    const tree = new SessionTree(filePath)
+    let raw: string
+    try {
+      raw = await fs.readFile(filePath, 'utf-8')
+    } catch (err: unknown) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return tree
+      throw err
+    }
+    for (const line of raw.split('\n')) {
+      if (!line.trim()) continue
+      let node: SessionNode
+      try {
+        node = JSON.parse(line) as SessionNode
+      } catch {
+        // 崩溃截断导致的坏行,跳过
+        continue
+      }
+      tree.nodes.set(node.node_id, node)
+      tree.tip = node.node_id
+    }
+    return tree
+  }
+
+  /** 追加一条消息为 parentId 的子节点,返回新 node_id;写盘为 append+fsync */
+  async append(parentId: string | null, message: EngineMessage): Promise<string> {
+    return this.mutex.run(async () => {
+      const node: SessionNode = { node_id: randomUUID(), parent_id: parentId, message }
+      const line = JSON.stringify(node) + '\n'
+      const handle = await fs.open(this.filePath, 'a')
+      try {
+        await handle.appendFile(line)
+        await handle.sync()
+      } finally {
+        await handle.close()
+      }
+      this.nodes.set(node.node_id, node)
+      this.tip = node.node_id
+      return node.node_id
+    })
+  }
+
+  /** 从某节点回溯到根,返回正序 EngineMessage[](喂给 RunEngineParams.initialMessages) */
+  pathTo(nodeId: string): EngineMessage[] {
+    const messages: EngineMessage[] = []
+    let current: string | null = nodeId
+    while (current !== null) {
+      const node: SessionNode | undefined = this.nodes.get(current)
+      if (!node) throw new Error(`SessionTree: unknown node_id ${current}`)
+      messages.push(node.message)
+      current = node.parent_id
+    }
+    return messages.reverse()
+  }
+
+  /** 最后 append 的 node_id */
+  latestTip(): string | null {
+    return this.tip
+  }
+}

--- a/crabot-agent/src/workers/session-tree.ts
+++ b/crabot-agent/src/workers/session-tree.ts
@@ -47,6 +47,11 @@ export class SessionTree {
   /** 追加一条消息为 parentId 的子节点,返回新 node_id;写盘为 append+fsync */
   async append(parentId: string | null, message: EngineMessage): Promise<string> {
     return this.mutex.run(async () => {
+      // parentId 校验必须在锁内、写盘之前完成：fork/resume 传入的 session_ref 若是非法
+      // 节点(不存在于树中),必须同步抛错直达调用方,不能先落一行脏数据再让上层发现不一致。
+      if (parentId !== null && !this.nodes.has(parentId)) {
+        throw new Error(`SessionTree: unknown parent_id ${parentId}`)
+      }
       const node: SessionNode = { node_id: randomUUID(), parent_id: parentId, message }
       const line = JSON.stringify(node) + '\n'
       const handle = await fs.open(this.filePath, 'a')

--- a/crabot-agent/src/workers/types.ts
+++ b/crabot-agent/src/workers/types.ts
@@ -1,0 +1,72 @@
+import type { ToolDefinition, LLMAdapter, EngineMessage } from '../engine/index.js'
+import type { Resolvable } from '../engine/types.js'
+
+export type WorkerImplId = 'builtin' | 'claude-code' | 'codex'
+export type WorkerContractState = 'running' | 'idle' | 'exited'
+export type IncarnationEndReason =
+  | 'completed' | 'failed' | 'killed' | 'superseded' | 'crashed' | 'pre_migration'
+
+export interface Workspace { readonly root: string }
+export interface OutputCursor { readonly offset: number }
+export interface TraceCursor { readonly offset: number }
+
+export interface NormalizedTraceEvent {
+  readonly ts: string
+  readonly kind: 'message' | 'tool_call' | 'tool_result' | 'thinking' | 'lifecycle'
+  readonly role?: 'assistant' | 'user' | 'system'
+  readonly summary: string
+  readonly detail?: unknown
+}
+
+export interface CapabilityBundle {
+  readonly skills: ReadonlyArray<{ id: string; name: string; skill_dir: string }>
+  readonly mcp_servers: ReadonlyArray<Record<string, unknown>>
+}
+
+export interface SpawnSpec {
+  readonly worker_id: string
+  readonly prompt: string
+  readonly workspace: Workspace
+  readonly goal?: string
+  /** builtin 专用注入(外部 CLI adapter 忽略) */
+  readonly builtin?: {
+    readonly adapter: LLMAdapter
+    readonly model: string
+    readonly systemPrompt: Resolvable<string>
+    readonly tools: Resolvable<ReadonlyArray<ToolDefinition>>
+    readonly maxTurnsPerBurst?: number
+  }
+}
+
+export interface IncarnationHandle {
+  readonly worker_id: string
+  readonly seq: number
+  readonly impl: WorkerImplId
+}
+export interface IncarnationRef {
+  readonly worker_id: string
+  readonly seq: number
+  /** builtin: session 树 node_id;CLI: 原生 session id */
+  readonly session_ref: string
+}
+
+export interface DetectResult { installed: boolean; activated: boolean; detail?: string }
+export interface AdapterCapabilities {
+  readonly fork: boolean; readonly revive: boolean; readonly goalMode: boolean
+  readonly subagent: boolean; readonly structuredTrace: boolean
+}
+
+export interface WorkerAdapter {
+  readonly implId: WorkerImplId
+  detect(): Promise<DetectResult>
+  provision(ws: Workspace, caps: CapabilityBundle): Promise<void>
+  spawn(spec: SpawnSpec): Promise<IncarnationHandle>
+  resume(prev: IncarnationRef, wakeInput: string): Promise<IncarnationHandle>
+  fork(prev: IncarnationRef, forkInput: string): Promise<IncarnationHandle>
+  sendInput(h: IncarnationHandle, text: string, opts?: { raw?: boolean }): Promise<void>
+  readOutput(h: IncarnationHandle, cursor: OutputCursor): Promise<{ chunk: string; nextCursor: OutputCursor }>
+  state(h: IncarnationHandle): Promise<WorkerContractState>
+  readTrace?(h: IncarnationHandle, cursor?: TraceCursor): Promise<NormalizedTraceEvent[]>
+  kill(h: IncarnationHandle): Promise<void>
+  capabilities(): AdapterCapabilities
+}

--- a/crabot-agent/src/workers/types.ts
+++ b/crabot-agent/src/workers/types.ts
@@ -1,4 +1,4 @@
-import type { ToolDefinition, LLMAdapter, EngineMessage } from '../engine/index.js'
+import type { ToolDefinition, LLMAdapter } from '../engine/index.js'
 import type { Resolvable } from '../engine/types.js'
 
 export type WorkerImplId = 'builtin' | 'claude-code' | 'codex'

--- a/crabot-agent/tests/workers/async-mutex.test.ts
+++ b/crabot-agent/tests/workers/async-mutex.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest'
+import { AsyncMutex } from '../../src/workers/async-mutex'
+
+describe('AsyncMutex', () => {
+  it('should serialize two concurrent run() calls', async () => {
+    const mutex = new AsyncMutex()
+    const order: string[] = []
+
+    const fn1 = async () => {
+      order.push('fn1-enter')
+      await new Promise((resolve) => setTimeout(resolve, 50))
+      order.push('fn1-exit')
+      return 'result1'
+    }
+
+    const fn2 = async () => {
+      order.push('fn2-enter')
+      await new Promise((resolve) => setTimeout(resolve, 50))
+      order.push('fn2-exit')
+      return 'result2'
+    }
+
+    // Start both concurrently
+    const [result1, result2] = await Promise.all([
+      mutex.run(fn1),
+      mutex.run(fn2),
+    ])
+
+    expect(result1).toBe('result1')
+    expect(result2).toBe('result2')
+
+    // Verify serialization: no interleaving
+    // fn1 should complete before fn2 starts
+    expect(order).toEqual([
+      'fn1-enter',
+      'fn1-exit',
+      'fn2-enter',
+      'fn2-exit',
+    ])
+  })
+
+  it('should not deadlock and allow retry after error', async () => {
+    const mutex = new AsyncMutex()
+    const order: string[] = []
+
+    const failingFn = async () => {
+      order.push('failing-enter')
+      await new Promise((resolve) => setTimeout(resolve, 20))
+      order.push('failing-exit')
+      throw new Error('intentional error')
+    }
+
+    const successFn = async () => {
+      order.push('success-enter')
+      order.push('success-exit')
+      return 'success'
+    }
+
+    // First call throws error
+    let error: Error | null = null
+    try {
+      await mutex.run(failingFn)
+    } catch (e) {
+      error = e as Error
+    }
+
+    expect(error).not.toBeNull()
+    expect(error?.message).toBe('intentional error')
+
+    // Second call should still execute (not deadlocked)
+    const result = await mutex.run(successFn)
+    expect(result).toBe('success')
+
+    // Verify order: failing function completes (even with error),
+    // then success function executes
+    expect(order).toEqual([
+      'failing-enter',
+      'failing-exit',
+      'success-enter',
+      'success-exit',
+    ])
+  })
+})

--- a/crabot-agent/tests/workers/builtin-adapter.test.ts
+++ b/crabot-agent/tests/workers/builtin-adapter.test.ts
@@ -787,4 +787,121 @@ describe('BuiltinWorkerAdapter', () => {
     const thirdError = (thirdResumeResult[0] as PromiseRejectedResult).reason
     expect(thirdError instanceof Error ? thirdError.message : String(thirdError)).toMatch(/already resumed/)
   })
+
+  // --- kill / 崩溃恢复扫描 ---
+
+  it('kill running 化身：burst 的 abortSignal 被触发，终态 exited(killed)', async () => {
+    const runEngineSpy = vi.spyOn(engineModule, 'runEngine')
+    const gate = deferred<void>()
+    const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+    const s = spec({
+      adapter: makeGatedAdapter(gate.promise, [{ text: '不会被看到的回复', stopReason: 'end_turn' }]),
+    })
+
+    const h = await adapter.spawn(s)
+    expect(await adapter.state(h)).toBe('running')
+
+    await adapter.kill(h)
+
+    // abortSignal 已经被触发——burst 还卡在 gate 里，尚未来得及跑完。
+    const callArgs = runEngineSpy.mock.calls[0]?.[0]
+    const abortSignal = callArgs?.options?.abortSignal
+    expect(abortSignal).toBeDefined()
+    expect(abortSignal?.aborted).toBe(true)
+    expect(await adapter.state(h)).toBe('running') // burst 还没真正收尾
+
+    // 放行 gate：stream 恢复，query-loop 在检测到 abortSignal.aborted 后以 outcome='aborted' 收尾。
+    gate.resolve()
+    await waitState(adapter, h, 'exited')
+
+    const metaRaw = await fs.readFile(join(tmp, s.worker_id, 'meta-1.json'), 'utf-8')
+    const meta = JSON.parse(metaRaw)
+    expect(meta.state).toBe('exited')
+    expect(meta.ended_reason).toBe('killed')
+  })
+
+  it('kill idle 化身 → 直接 exited(killed)，不经过 burst', async () => {
+    const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+    const s = spec({
+      adapter: makeAdapter([{ text: '首轮回复', stopReason: 'end_turn' }]),
+    })
+
+    const h = await adapter.spawn(s)
+    await waitState(adapter, h, 'idle')
+
+    await adapter.kill(h)
+    expect(await adapter.state(h)).toBe('exited')
+
+    const metaRaw = await fs.readFile(join(tmp, s.worker_id, 'meta-1.json'), 'utf-8')
+    const meta = JSON.parse(metaRaw)
+    expect(meta.state).toBe('exited')
+    expect(meta.ended_reason).toBe('killed')
+  })
+
+  it('kill 已 exited 的化身 → 幂等返回，不抛错、不覆盖原 ended_reason', async () => {
+    const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+    const s = spec({
+      adapter: makeAdapter([
+        { toolCalls: [{ name: 'finish_task', id: 'call_1', input: { outcome: 'completed', summary: '搞定了' } }], stopReason: 'tool_use' },
+      ]),
+    })
+
+    const h = await adapter.spawn(s)
+    await waitState(adapter, h, 'exited')
+
+    await expect(adapter.kill(h)).resolves.toBeUndefined()
+    await expect(adapter.kill(h)).resolves.toBeUndefined()
+
+    const metaRaw = await fs.readFile(join(tmp, s.worker_id, 'meta-1.json'), 'utf-8')
+    const meta = JSON.parse(metaRaw)
+    expect(meta.state).toBe('exited')
+    expect(meta.ended_reason).toBe('completed') // kill 没有覆盖掉原本的终态原因
+  })
+
+  // --- scanOrphans（崩溃恢复扫描）---
+
+  describe('BuiltinWorkerAdapter.scanOrphans', () => {
+    it('把 state=running 的 meta 原子改写为 exited(crashed) 并返回；坏 JSON 文件跳过', async () => {
+      const runningDir = join(tmp, 'worker-running')
+      await fs.mkdir(runningDir, { recursive: true })
+      await fs.writeFile(
+        join(runningDir, 'meta-1.json'),
+        JSON.stringify({ seq: 1, state: 'running', tip_node_id: 'node-1' }),
+        'utf-8',
+      )
+
+      const idleDir = join(tmp, 'worker-idle')
+      await fs.mkdir(idleDir, { recursive: true })
+      await fs.writeFile(
+        join(idleDir, 'meta-1.json'),
+        JSON.stringify({ seq: 1, state: 'idle', tip_node_id: 'node-2' }),
+        'utf-8',
+      )
+
+      const corruptDir = join(tmp, 'worker-corrupt')
+      await fs.mkdir(corruptDir, { recursive: true })
+      await fs.writeFile(join(corruptDir, 'meta-1.json'), '{ not valid json', 'utf-8')
+
+      const orphans = await BuiltinWorkerAdapter.scanOrphans(tmp)
+
+      expect(orphans).toEqual([{ worker_id: 'worker-running', seq: 1, impl: 'builtin' }])
+
+      const runningMeta = JSON.parse(await fs.readFile(join(runningDir, 'meta-1.json'), 'utf-8'))
+      expect(runningMeta.state).toBe('exited')
+      expect(runningMeta.ended_reason).toBe('crashed')
+      expect(runningMeta.tip_node_id).toBe('node-1') // 其余字段保留
+
+      const idleMeta = JSON.parse(await fs.readFile(join(idleDir, 'meta-1.json'), 'utf-8'))
+      expect(idleMeta.state).toBe('idle') // 未被扫描器改动
+
+      const corruptRaw = await fs.readFile(join(corruptDir, 'meta-1.json'), 'utf-8')
+      expect(corruptRaw).toBe('{ not valid json') // 坏文件原样保留，未被改写
+    })
+
+    it('空 dataDir 或不存在时返回空数组', async () => {
+      const emptyDir = join(tmp, 'does-not-exist')
+      const orphans = await BuiltinWorkerAdapter.scanOrphans(emptyDir)
+      expect(orphans).toEqual([])
+    })
+  })
 })

--- a/crabot-agent/tests/workers/builtin-adapter.test.ts
+++ b/crabot-agent/tests/workers/builtin-adapter.test.ts
@@ -49,6 +49,33 @@ function deferred<T = void>(): { promise: Promise<T>; resolve: (v: T) => void } 
   return { promise, resolve }
 }
 
+/** 第一个 stream 调用返回给定响应，第二个及后续调用抛错——用于测试续 burst 崩溃场景。 */
+function makeAdapterWithSecondBurstError(
+  firstBurstResponse: {
+    text?: string
+    toolCalls?: Array<{ name: string; id: string; input: Record<string, unknown> }>
+    stopReason: 'end_turn' | 'tool_use'
+  },
+): LLMAdapter {
+  let callCount = 0
+  return {
+    stream: vi.fn(async function* () {
+      if (callCount > 0) {
+        throw new Error('second burst error')
+      }
+      callCount++
+      const r = firstBurstResponse
+      const content: unknown[] = []
+      if (r.text) content.push({ type: 'text', text: r.text })
+      for (const tc of r.toolCalls ?? []) {
+        content.push({ type: 'tool_use', id: tc.id, name: tc.name, input: tc.input })
+      }
+      yield* chunksFromContent(content, r.stopReason, { inputTokens: 100, outputTokens: 50 })
+    }),
+    updateConfig: () => {},
+  } as unknown as LLMAdapter
+}
+
 /** 像 makeAdapter，但每次 stream() 先 await gate——用于制造"burst 仍在跑"的可控窗口。 */
 function makeGatedAdapter(
   gate: Promise<void>,
@@ -395,6 +422,34 @@ describe('BuiltinWorkerAdapter', () => {
     assertNoFork(nodes)
     const serialized = nodes.map((n) => JSON.stringify(n.message))
     expect(serialized.some((c) => c.includes('窗口期消息'))).toBe(true)
+  })
+
+  it('transitionExited 时 pendingInputs 非空 → readOutput 能读到 dead-letter 消息', async () => {
+    const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+    const s = spec({
+      adapter: makeAdapter([{ text: '测试', stopReason: 'end_turn' }]),
+    })
+
+    const h = await adapter.spawn(s)
+    await waitState(adapter, h, 'idle')
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const instance = (adapter as any).instances.get(`${s.worker_id}#1`)
+    expect(instance).toBeTruthy()
+
+    // 手动向 pendingInputs 添加消息，模拟"化身被外部中止前有待处理消息"的场景
+    instance.pendingInputs.push('待处理消息1', '待处理消息2')
+
+    // 调用 transitionExited，应该记录 dead-letter
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (adapter as any).transitionExited(instance, h, 'crashed')
+
+    // 验证 readOutput 包含 dead-letter 消息
+    const { chunk } = await adapter.readOutput(h, { offset: 0 })
+    expect(chunk).toContain('[dead-letter]')
+    expect(chunk).toContain('2')  // 未发送消息数
+    expect(chunk).toContain('待处理消息1')
+    expect(chunk).toContain('待处理消息2')
   })
 
   it('并发 resume 同一 prev：仅一次成功，无树分叉', async () => {

--- a/crabot-agent/tests/workers/builtin-adapter.test.ts
+++ b/crabot-agent/tests/workers/builtin-adapter.test.ts
@@ -1135,6 +1135,61 @@ describe('BuiltinWorkerAdapter', () => {
     }
   })
 
+  // --- 安全网自身兜底：transitionExited 二次抛错不触发 unhandledRejection ---
+
+  it('safetyNetExit: runBurst 意外抛错后，安全网自己的 transitionExited(writeMeta) 再抛错也不触发 unhandledRejection、不崩进程', async () => {
+    const capture = captureUnhandledRejections()
+    try {
+      const gate = deferred<void>()
+      const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+      const s = spec({
+        adapter: makeGatedAdapter(gate.promise, [{ text: '首轮输出(落盘会失败)', stopReason: 'end_turn' }]),
+      })
+
+      const h = await adapter.spawn(s)
+      expect(await adapter.state(h)).toBe('running')
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const adapterAny = adapter as any
+      const instance = (adapterAny.instances as Map<string, { outputLog: { append: (t: string) => Promise<void> } }>).get(
+        `${s.worker_id}#1`,
+      )
+      expect(instance).toBeDefined()
+      // onTurn 里的落盘失败 → runBurst 走 writeErrors 分支，向外抛错，命中 spawn() 里
+      // this.runBurst(...).catch(...) 这层安全网。
+      instance!.outputLog.append = vi.fn(async () => {
+        throw new Error('simulated output-log disk error')
+      })
+
+      // 安全网内部会调 transitionExited → writeMeta：这里让它也抛错，模拟 ENOSPC/EIO 之类
+      // "安全网自己也救不回来"的场景——修复前这个 rejection 没人接，会成为 unhandledRejection。
+      let writeMetaCalled: () => void = () => {}
+      const writeMetaCalledPromise = new Promise<void>((resolve) => {
+        writeMetaCalled = resolve
+      })
+      const originalWriteMeta = adapterAny.writeMeta.bind(adapter)
+      adapterAny.writeMeta = vi.fn(async (...args: unknown[]) => {
+        writeMetaCalled()
+        throw new Error('simulated writeMeta disk error (safety net)')
+      })
+
+      gate.resolve()
+      await writeMetaCalledPromise
+      // writeMeta 抛错发生在微任务链路更深处，给事件循环留出真实的宏任务间隔，让
+      // Node 有机会把"没人接住的 rejection"判定为 unhandledRejection（修复前会命中）。
+      await new Promise((r) => setTimeout(r, 50))
+      await new Promise((r) => setTimeout(r, 50))
+
+      expect(capture.reasons).toEqual([])
+
+      // 化身状态不可靠是预期的（writeMeta 一直失败，磁盘/内存都没能落到 exited），
+      // 这里只关心"没有崩进程"，不对 instance.state 做强断言。
+      adapterAny.writeMeta = originalWriteMeta
+    } finally {
+      capture.restore()
+    }
+  })
+
   // --- spawn: 重复 worker_id fail-fast ---
 
   it('spawn 同一 worker_id 两次(本进程内存已有化身) → 第二次 fail-fast 抛错，不影响第一个化身', async () => {

--- a/crabot-agent/tests/workers/builtin-adapter.test.ts
+++ b/crabot-agent/tests/workers/builtin-adapter.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { promises as fs } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { randomUUID } from 'crypto'
+import { BuiltinWorkerAdapter } from '../../src/workers/builtin/adapter.js'
+import type { SpawnSpec, IncarnationHandle, WorkerContractState } from '../../src/workers/types.js'
+import type { LLMAdapter } from '../../src/engine/llm-adapter-types.js'
+import { chunksFromContent } from '../engine/helpers/mock-stream.js'
+
+function makeAdapter(
+  responses: Array<{
+    text?: string
+    toolCalls?: Array<{ name: string; id: string; input: Record<string, unknown> }>
+    stopReason: 'end_turn' | 'tool_use'
+  }>,
+): LLMAdapter {
+  let i = 0
+  return {
+    stream: vi.fn(async function* () {
+      const r = responses[i++] ?? responses[responses.length - 1]
+      const content: unknown[] = []
+      if (r.text) content.push({ type: 'text', text: r.text })
+      for (const tc of r.toolCalls ?? []) {
+        content.push({ type: 'tool_use', id: tc.id, name: tc.name, input: tc.input })
+      }
+      yield* chunksFromContent(content, r.stopReason, { inputTokens: 100, outputTokens: 50 })
+    }),
+    updateConfig: () => {},
+  } as unknown as LLMAdapter
+}
+
+function throwingAdapter(): LLMAdapter {
+  return {
+    stream: vi.fn(async function* () {
+      throw new Error('boom')
+    }),
+    updateConfig: () => {},
+  } as unknown as LLMAdapter
+}
+
+function spec(opts: { adapter: LLMAdapter; worker_id?: string }): SpawnSpec {
+  return {
+    worker_id: opts.worker_id ?? randomUUID(),
+    prompt: '测试任务',
+    workspace: { root: '/tmp/ws' },
+    builtin: {
+      adapter: opts.adapter,
+      model: 'test',
+      systemPrompt: '',
+      tools: [],
+    },
+  }
+}
+
+async function waitState(
+  adapter: BuiltinWorkerAdapter,
+  h: IncarnationHandle,
+  target: WorkerContractState,
+): Promise<void> {
+  const deadline = Date.now() + 2000
+  let last: WorkerContractState | undefined
+  while (Date.now() < deadline) {
+    last = await adapter.state(h)
+    if (last === target) return
+    await new Promise((r) => setTimeout(r, 10))
+  }
+  throw new Error(`waitState timeout: expected '${target}', last seen '${last}'`)
+}
+
+describe('BuiltinWorkerAdapter', () => {
+  let tmp: string
+
+  beforeEach(async () => {
+    tmp = await fs.mkdtemp(join(tmpdir(), 'builtin-adapter-'))
+  })
+
+  afterEach(async () => {
+    await fs.rm(tmp, { recursive: true, force: true })
+  })
+
+  it('spawn → burst end_turn → idle，输出可增量读', async () => {
+    const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+    const s = spec({
+      adapter: makeAdapter([{ text: '想了想，先问你：A 还是 B？', stopReason: 'end_turn' }]),
+    })
+
+    const h = await adapter.spawn(s)
+    await waitState(adapter, h, 'idle')
+
+    const { chunk } = await adapter.readOutput(h, { offset: 0 })
+    expect(chunk).toContain('A 还是 B')
+  })
+
+  it('finish_task → exited(completed)', async () => {
+    const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+    const s = spec({
+      adapter: makeAdapter([
+        {
+          toolCalls: [{ name: 'finish_task', id: 'call_1', input: { outcome: 'completed', summary: '搞定了' } }],
+          stopReason: 'tool_use',
+        },
+      ]),
+    })
+
+    const h = await adapter.spawn(s)
+    await waitState(adapter, h, 'exited')
+
+    const metaRaw = await fs.readFile(join(tmp, s.worker_id, 'meta.json'), 'utf-8')
+    const meta = JSON.parse(metaRaw)
+    expect(meta.state).toBe('exited')
+    expect(meta.ended_reason).toBe('completed')
+    expect(meta.outcome).toBe('completed')
+  })
+
+  it('engine 抛错 → exited(crashed)', async () => {
+    const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+    const s = spec({ adapter: throwingAdapter() })
+
+    const h = await adapter.spawn(s)
+    await waitState(adapter, h, 'exited')
+
+    const metaRaw = await fs.readFile(join(tmp, s.worker_id, 'meta.json'), 'utf-8')
+    const meta = JSON.parse(metaRaw)
+    expect(meta.state).toBe('exited')
+    expect(meta.ended_reason).toBe('crashed')
+  })
+})

--- a/crabot-agent/tests/workers/builtin-adapter.test.ts
+++ b/crabot-agent/tests/workers/builtin-adapter.test.ts
@@ -1249,6 +1249,58 @@ describe('BuiltinWorkerAdapter', () => {
     expect(runEngineSpy).toHaveBeenCalledTimes(1)
   })
 
+  // --- onStateChange 异常隔离：观察者永不阻断状态机 ---
+
+  it('onStateChange 回调同步抛错 → 状态机继续运行，终态正确，错误仅 console.error', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const onStateChangeErrors: Error[] = []
+
+    const adapter = new BuiltinWorkerAdapter({
+      dataDir: tmp,
+      onStateChange: () => {
+        const err = new Error('onStateChange observer error')
+        onStateChangeErrors.push(err)
+        throw err
+      },
+    })
+
+    const s = spec({
+      adapter: makeAdapter([
+        { text: '首轮回复', stopReason: 'end_turn' },
+        { text: '第二轮回复', stopReason: 'end_turn' },
+      ]),
+    })
+
+    // spawn 触发 transitionState(running→idle)，其中 onStateChange 会抛错。
+    // 状态机应该继续运转，不被回调错误打断。
+    const h = await adapter.spawn(s)
+    await waitState(adapter, h, 'idle')
+
+    // 第一次 transitionState 调用（spawn→idle）抛错被捕获
+    expect(onStateChangeErrors.length).toBeGreaterThan(0)
+    expect(consoleErrorSpy).toHaveBeenCalled()
+
+    // sendInput(idle→running)：状态机从 idle 正常转到 running，再回 idle，
+    // 第二次和第三次 onStateChange 调用都会抛错。
+    const errorCountBefore = onStateChangeErrors.length
+    await adapter.sendInput(h, '后续问题')
+    await waitState(adapter, h, 'idle')
+
+    // 状态机应该跑到底，终态正确，onStateChange 又被调用多次且每次都抛错
+    expect(await adapter.state(h)).toBe('idle')
+    expect(onStateChangeErrors.length).toBeGreaterThan(errorCountBefore)
+
+    // console.error 应该被多次调用（每次 onStateChange 抛错一次）
+    expect(consoleErrorSpy.mock.calls.length).toBeGreaterThan(1)
+
+    // 验证 meta 文件的最终状态正确（不被 onStateChange 抛错覆盖）
+    const metaRaw = await fs.readFile(join(tmp, s.worker_id, 'meta-1.json'), 'utf-8')
+    const meta = JSON.parse(metaRaw)
+    expect(meta.state).toBe('idle')
+
+    consoleErrorSpy.mockRestore()
+  })
+
   // --- fork: 提交次序对齐 resume(writeMeta 成功后才 instances.set) ---
 
   it('fork: writeMeta 抛错 → instances 无残留(提交次序与 resume 对齐)', async () => {

--- a/crabot-agent/tests/workers/builtin-adapter.test.ts
+++ b/crabot-agent/tests/workers/builtin-adapter.test.ts
@@ -997,4 +997,206 @@ describe('BuiltinWorkerAdapter', () => {
       expect(orphans).toEqual([])
     })
   })
+
+  // --- runBurst/runForkBurst: outputLog.append 失败不触发 unhandledRejection ---
+
+  /** 临时挂一个 unhandledRejection 监听，收集 reason，测试结束时摘掉。 */
+  function captureUnhandledRejections(): { reasons: unknown[]; restore: () => void } {
+    const reasons: unknown[] = []
+    const listener = (reason: unknown) => {
+      reasons.push(reason)
+    }
+    process.on('unhandledRejection', listener)
+    return { reasons, restore: () => process.removeListener('unhandledRejection', listener) }
+  }
+
+  /**
+   * 第一轮受 gate 控制（放行前装好 outputLog.append 的 reject mock）；第二轮起插入一段
+   * *真实*的宏任务延迟（setTimeout，不是受测试代码控制的 deferred）——复现"burst 跨越
+   * 多个真实事件循环 tick"的场景，让第一轮 onTurn 里 push 的 rejecting promise 在真正被
+   * Promise.all 接住之前，有机会先被 Node 判定为 unhandledRejection（这正是线上"burst
+   * 跑几分钟"场景的加速版：用一次真实 setTimeout 制造出同等性质的事件循环间隔，而不是
+   * 单纯堆微任务——否则 Promise.all 的 .then 几乎在同一轮微任务里就把 handler 接上，
+   * 复现不出 bug）。第一轮工具调一个不存在的工具名，让 engine 走"tool not found”错误
+   * 结果分支后继续下一轮，而不是直接 end_turn 收尾。
+   */
+  function makeAdapterGatedThenRealDelay(
+    gate: Promise<void>,
+    delayMs: number,
+    responses: Array<{
+      text?: string
+      toolCalls?: Array<{ name: string; id: string; input: Record<string, unknown> }>
+      stopReason: 'end_turn' | 'tool_use'
+    }>,
+  ): LLMAdapter {
+    let i = 0
+    return {
+      stream: vi.fn(async function* () {
+        if (i === 0) {
+          await gate
+        } else {
+          await new Promise((r) => setTimeout(r, delayMs))
+        }
+        const r = responses[i++] ?? responses[responses.length - 1]
+        const content: unknown[] = []
+        if (r.text) content.push({ type: 'text', text: r.text })
+        for (const tc of r.toolCalls ?? []) {
+          content.push({ type: 'tool_use', id: tc.id, name: tc.name, input: tc.input })
+        }
+        yield* chunksFromContent(content, r.stopReason, { inputTokens: 100, outputTokens: 50 })
+      }),
+      updateConfig: () => {},
+    } as unknown as LLMAdapter
+  }
+
+  it('runBurst: onTurn 里 outputLog.append reject 不触发 unhandledRejection，化身按 crashed 收尾', async () => {
+    const capture = captureUnhandledRejections()
+    try {
+      const gate = deferred<void>()
+      const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+      const s = spec({
+        adapter: makeAdapterGatedThenRealDelay(gate.promise, 50, [
+          { text: '第一轮输出(落盘会失败)', toolCalls: [{ name: 'no_such_tool', id: 'call_1', input: {} }], stopReason: 'tool_use' },
+          { text: '第二轮输出', stopReason: 'end_turn' },
+        ]),
+      })
+
+      const h = await adapter.spawn(s)
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const adapterAny = adapter as any
+      const instance = (adapterAny.instances as Map<string, { outputLog: { append: (t: string) => Promise<void> } }>).get(
+        `${s.worker_id}#1`,
+      )
+      expect(instance).toBeDefined()
+      // 顶替掉 outputLog.append，让 onTurn 里的落盘调用 reject——模拟磁盘写失败。
+      instance!.outputLog.append = vi.fn(async () => {
+        throw new Error('simulated output-log disk error')
+      })
+
+      gate.resolve()
+      await waitState(adapter, h, 'exited')
+
+      expect(capture.reasons).toEqual([])
+
+      const metaRaw = await fs.readFile(join(tmp, s.worker_id, 'meta-1.json'), 'utf-8')
+      const meta = JSON.parse(metaRaw)
+      expect(meta.state).toBe('exited')
+      expect(meta.ended_reason).toBe('crashed')
+    } finally {
+      capture.restore()
+    }
+  })
+
+  it('runForkBurst: onTurn 里 outputLog.append reject 不触发 unhandledRejection，fork 化身按 crashed 收尾', async () => {
+    const capture = captureUnhandledRejections()
+    try {
+      const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+      const s = spec({
+        adapter: makeAdapter([{ text: '主线首轮', stopReason: 'end_turn' }]),
+      })
+
+      const h = await adapter.spawn(s)
+      await waitState(adapter, h, 'idle')
+
+      const metaRaw = await fs.readFile(join(tmp, s.worker_id, 'meta-1.json'), 'utf-8')
+      const meta = JSON.parse(metaRaw) as { tip_node_id: string }
+      const prevRef: IncarnationRef = { worker_id: s.worker_id, seq: 1, session_ref: meta.tip_node_id }
+
+      const forkGate = deferred<void>()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const adapterAny = adapter as any
+      const builtinConfig = (adapterAny.builtinConfigs as Map<string, { adapter: unknown }>).get(s.worker_id)!
+      builtinConfig.adapter = makeAdapterGatedThenRealDelay(forkGate.promise, 50, [
+        { text: '侧问第一轮(落盘会失败)', toolCalls: [{ name: 'no_such_tool', id: 'call_1', input: {} }], stopReason: 'tool_use' },
+        { text: '侧问第二轮', stopReason: 'end_turn' },
+      ])
+
+      const forkHandle = await adapter.fork(prevRef, '侧问一下')
+      const forkInstance = (adapterAny.instances as Map<string, { outputLog: { append: (t: string) => Promise<void> } }>).get(
+        `${s.worker_id}#${forkHandle.seq}`,
+      )
+      expect(forkInstance).toBeDefined()
+      forkInstance!.outputLog.append = vi.fn(async () => {
+        throw new Error('simulated output-log disk error (fork)')
+      })
+
+      forkGate.resolve()
+      await waitState(adapter, forkHandle, 'exited')
+
+      expect(capture.reasons).toEqual([])
+
+      const forkMetaRaw = await fs.readFile(join(tmp, s.worker_id, `meta-${forkHandle.seq}.json`), 'utf-8')
+      const forkMeta = JSON.parse(forkMetaRaw)
+      expect(forkMeta.state).toBe('exited')
+      expect(forkMeta.ended_reason).toBe('crashed')
+    } finally {
+      capture.restore()
+    }
+  })
+
+  // --- spawn: 重复 worker_id fail-fast ---
+
+  it('spawn 同一 worker_id 两次(本进程内存已有化身) → 第二次 fail-fast 抛错，不影响第一个化身', async () => {
+    const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+    const workerId = randomUUID()
+    const s1 = spec({ adapter: makeAdapter([{ text: '第一次', stopReason: 'end_turn' }]), worker_id: workerId })
+    const h1 = await adapter.spawn(s1)
+    await waitState(adapter, h1, 'idle')
+
+    const s2 = spec({ adapter: makeAdapter([{ text: '第二次', stopReason: 'end_turn' }]), worker_id: workerId })
+    await expect(adapter.spawn(s2)).rejects.toThrow(/already spawned/)
+
+    // 第一个化身状态未被破坏。
+    expect(await adapter.state(h1)).toBe('idle')
+  })
+
+  it('spawn 跨进程重复:磁盘已有 meta-1.json 但新 adapter 实例内存为空 → fail-fast 抛错', async () => {
+    const workerId = randomUUID()
+    const adapter1 = new BuiltinWorkerAdapter({ dataDir: tmp })
+    const s1 = spec({ adapter: makeAdapter([{ text: '第一次', stopReason: 'end_turn' }]), worker_id: workerId })
+    const h1 = await adapter1.spawn(s1)
+    await waitState(adapter1, h1, 'idle')
+
+    // 模拟新进程重启：全新 adapter 实例，instances/builtinConfigs 都是空的，只有磁盘留着旧化身。
+    const adapter2 = new BuiltinWorkerAdapter({ dataDir: tmp })
+    const s2 = spec({ adapter: makeAdapter([{ text: '第二次', stopReason: 'end_turn' }]), worker_id: workerId })
+    await expect(adapter2.spawn(s2)).rejects.toThrow(/already has meta-1\.json on disk/)
+  })
+
+  // --- fork: 提交次序对齐 resume(writeMeta 成功后才 instances.set) ---
+
+  it('fork: writeMeta 抛错 → instances 无残留(提交次序与 resume 对齐)', async () => {
+    const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+    const s = spec({ adapter: makeAdapter([{ text: '主线首轮', stopReason: 'end_turn' }]) })
+    const h = await adapter.spawn(s)
+    await waitState(adapter, h, 'idle')
+
+    const metaRaw = await fs.readFile(join(tmp, s.worker_id, 'meta-1.json'), 'utf-8')
+    const meta = JSON.parse(metaRaw) as { tip_node_id: string }
+    const prevRef: IncarnationRef = { worker_id: s.worker_id, seq: 1, session_ref: meta.tip_node_id }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const adapterAny = adapter as any
+    const originalWriteMeta = adapterAny.writeMeta.bind(adapter)
+    let writeMetaCallCount = 0
+    adapterAny.writeMeta = vi.fn(async (...args: unknown[]) => {
+      writeMetaCallCount++
+      if (writeMetaCallCount === 1) {
+        throw new Error('simulated writeMeta disk error (fork)')
+      }
+      return originalWriteMeta(...args)
+    })
+
+    await expect(adapter.fork(prevRef, '侧问')).rejects.toThrow(/simulated writeMeta disk error \(fork\)/)
+
+    // writeMeta 失败了，instances 里不应该有 seq=2 的孤儿条目。
+    const key2 = `${s.worker_id}#2`
+    expect((adapterAny.instances as Map<string, unknown>).has(key2)).toBe(false)
+
+    // 重试应该能成功（fork 没有像 resume 那样的"重复"标记，重试是无副作用的）。
+    const retryHandle = await adapter.fork(prevRef, '侧问-重试')
+    expect(retryHandle.seq).toBe(2)
+    await waitState(adapter, retryHandle, 'exited')
+  })
 })

--- a/crabot-agent/tests/workers/builtin-adapter.test.ts
+++ b/crabot-agent/tests/workers/builtin-adapter.test.ts
@@ -3,8 +3,9 @@ import { promises as fs } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { randomUUID } from 'crypto'
-import { BuiltinWorkerAdapter } from '../../src/workers/builtin/adapter.js'
-import type { SpawnSpec, IncarnationHandle, WorkerContractState } from '../../src/workers/types.js'
+import { BuiltinWorkerAdapter, WorkerExitedError } from '../../src/workers/builtin/adapter.js'
+import { SessionTree } from '../../src/workers/session-tree.js'
+import type { SpawnSpec, IncarnationHandle, IncarnationRef, WorkerContractState } from '../../src/workers/types.js'
 import type { LLMAdapter } from '../../src/engine/llm-adapter-types.js'
 import * as engineModule from '../../src/engine/query-loop.js'
 import { chunksFromContent } from '../engine/helpers/mock-stream.js'
@@ -35,6 +36,39 @@ function throwingAdapter(): LLMAdapter {
   return {
     stream: vi.fn(async function* () {
       throw new Error('boom')
+    }),
+    updateConfig: () => {},
+  } as unknown as LLMAdapter
+}
+
+function deferred<T = void>(): { promise: Promise<T>; resolve: (v: T) => void } {
+  let resolve!: (v: T) => void
+  const promise = new Promise<T>((r) => {
+    resolve = r
+  })
+  return { promise, resolve }
+}
+
+/** 像 makeAdapter，但每次 stream() 先 await gate——用于制造"burst 仍在跑"的可控窗口。 */
+function makeGatedAdapter(
+  gate: Promise<void>,
+  responses: Array<{
+    text?: string
+    toolCalls?: Array<{ name: string; id: string; input: Record<string, unknown> }>
+    stopReason: 'end_turn' | 'tool_use'
+  }>,
+): LLMAdapter {
+  let i = 0
+  return {
+    stream: vi.fn(async function* () {
+      await gate
+      const r = responses[i++] ?? responses[responses.length - 1]
+      const content: unknown[] = []
+      if (r.text) content.push({ type: 'text', text: r.text })
+      for (const tc of r.toolCalls ?? []) {
+        content.push({ type: 'tool_use', id: tc.id, name: tc.name, input: tc.input })
+      }
+      yield* chunksFromContent(content, r.stopReason, { inputTokens: 100, outputTokens: 50 })
     }),
     updateConfig: () => {},
   } as unknown as LLMAdapter
@@ -107,7 +141,7 @@ describe('BuiltinWorkerAdapter', () => {
     const h = await adapter.spawn(s)
     await waitState(adapter, h, 'exited')
 
-    const metaRaw = await fs.readFile(join(tmp, s.worker_id, 'meta.json'), 'utf-8')
+    const metaRaw = await fs.readFile(join(tmp, s.worker_id, 'meta-1.json'), 'utf-8')
     const meta = JSON.parse(metaRaw)
     expect(meta.state).toBe('exited')
     expect(meta.ended_reason).toBe('completed')
@@ -121,7 +155,7 @@ describe('BuiltinWorkerAdapter', () => {
     const h = await adapter.spawn(s)
     await waitState(adapter, h, 'exited')
 
-    const metaRaw = await fs.readFile(join(tmp, s.worker_id, 'meta.json'), 'utf-8')
+    const metaRaw = await fs.readFile(join(tmp, s.worker_id, 'meta-1.json'), 'utf-8')
     const meta = JSON.parse(metaRaw)
     expect(meta.state).toBe('exited')
     expect(meta.ended_reason).toBe('crashed')
@@ -140,5 +174,129 @@ describe('BuiltinWorkerAdapter', () => {
     expect(runEngineSpy).toHaveBeenCalled()
     const callArgs = runEngineSpy.mock.calls[0]?.[0]
     expect(callArgs?.options?.disableCompaction).toBe(true)
+  })
+
+  it('sendInput(idle) → 追加新一轮用户消息并起新 burst，新 burst 可见旧上下文', async () => {
+    const runEngineSpy = vi.spyOn(engineModule, 'runEngine')
+    const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+    const s = spec({
+      adapter: makeAdapter([
+        { text: '第一轮回复', stopReason: 'end_turn' },
+        { text: '第二轮回复', stopReason: 'end_turn' },
+      ]),
+    })
+
+    const h = await adapter.spawn(s)
+    await waitState(adapter, h, 'idle')
+
+    await adapter.sendInput(h, '追加的问题')
+    expect(await adapter.state(h)).toBe('running')
+    await waitState(adapter, h, 'idle')
+
+    expect(runEngineSpy).toHaveBeenCalledTimes(2)
+    const secondCallArgs = runEngineSpy.mock.calls[1]?.[0]
+    const serialized = JSON.stringify(secondCallArgs?.initialMessages ?? [])
+    expect(serialized).toContain('测试任务') // 首轮 prompt 仍在上下文里
+    expect(serialized).toContain('第一轮回复') // 首轮 assistant 回复仍在上下文里
+    expect(serialized).toContain('追加的问题') // 新注入的用户消息
+
+    const { chunk } = await adapter.readOutput(h, { offset: 0 })
+    expect(chunk).toContain('第二轮回复')
+  })
+
+  it('sendInput(running) → 进入待注入队列，burst 间隙自动续 burst，消息不丢', async () => {
+    const runEngineSpy = vi.spyOn(engineModule, 'runEngine')
+    const gate = deferred<void>()
+    const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+    const s = spec({
+      adapter: makeGatedAdapter(gate.promise, [
+        { text: '第一轮回复', stopReason: 'end_turn' },
+        { text: '处理完排队消息', stopReason: 'end_turn' },
+      ]),
+    })
+
+    const h = await adapter.spawn(s)
+    expect(await adapter.state(h)).toBe('running')
+
+    await adapter.sendInput(h, '排队消息1')
+    await adapter.sendInput(h, '排队消息2')
+    // 仍在同一个 burst 内，两条注入都进了队列，没有触发新 burst。
+    expect(await adapter.state(h)).toBe('running')
+
+    gate.resolve()
+    await waitState(adapter, h, 'idle')
+
+    // 第一个 burst 结束发现队列非空 → 原地续了第二个 burst。
+    expect(runEngineSpy).toHaveBeenCalledTimes(2)
+
+    const tree = await SessionTree.load(join(tmp, s.worker_id, 'session.jsonl'))
+    const tip = tree.latestTip()
+    expect(tip).not.toBeNull()
+    const serialized = tree.pathTo(tip!).map((m) => JSON.stringify(m))
+    const idxQ1 = serialized.findIndex((c) => c.includes('排队消息1'))
+    const idxQ2 = serialized.findIndex((c) => c.includes('排队消息2'))
+    const idxFinal = serialized.findIndex((c) => c.includes('处理完排队消息'))
+    expect(idxQ1).toBeGreaterThan(-1)
+    expect(idxQ2).toBeGreaterThan(idxQ1)
+    expect(idxFinal).toBeGreaterThan(idxQ2)
+  })
+
+  it('sendInput(exited) → 抛 WorkerExitedError', async () => {
+    const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+    const s = spec({
+      adapter: makeAdapter([
+        { toolCalls: [{ name: 'finish_task', id: 'call_1', input: { outcome: 'completed', summary: '搞定了' } }], stopReason: 'tool_use' },
+      ]),
+    })
+
+    const h = await adapter.spawn(s)
+    await waitState(adapter, h, 'exited')
+
+    await expect(adapter.sendInput(h, '还有件事')).rejects.toThrow(WorkerExitedError)
+    try {
+      await adapter.sendInput(h, '还有件事')
+      expect.unreachable('sendInput 应该在 exited 态抛出 WorkerExitedError')
+    } catch (err) {
+      expect(err).toBeInstanceOf(WorkerExitedError)
+      expect((err as WorkerExitedError).worker_id).toBe(s.worker_id)
+      expect((err as WorkerExitedError).seq).toBe(1)
+    }
+  })
+
+  it('resume(prev, wakeInput) → 派生 seq+1 新化身，pathTo 连续含 wakeInput', async () => {
+    const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+    const s = spec({
+      adapter: makeAdapter([
+        { toolCalls: [{ name: 'finish_task', id: 'call_1', input: { outcome: 'completed', summary: '第一段完成' } }], stopReason: 'tool_use' },
+        { text: '欢迎回来', stopReason: 'end_turn' },
+      ]),
+    })
+
+    const h1 = await adapter.spawn(s)
+    await waitState(adapter, h1, 'exited')
+
+    const metaRaw = await fs.readFile(join(tmp, s.worker_id, 'meta-1.json'), 'utf-8')
+    const meta = JSON.parse(metaRaw) as { tip_node_id: string }
+    const prevRef: IncarnationRef = { worker_id: s.worker_id, seq: 1, session_ref: meta.tip_node_id }
+
+    const h2 = await adapter.resume(prevRef, '我回来了')
+    expect(h2.seq).toBe(2)
+    await waitState(adapter, h2, 'idle')
+
+    const tree = await SessionTree.load(join(tmp, s.worker_id, 'session.jsonl'))
+    const tip = tree.latestTip()
+    expect(tip).not.toBeNull()
+    const serialized = tree.pathTo(tip!).map((m) => JSON.stringify(m))
+    const idxPrompt = serialized.findIndex((c) => c.includes('测试任务'))
+    const idxWake = serialized.findIndex((c) => c.includes('我回来了'))
+    const idxReply = serialized.findIndex((c) => c.includes('欢迎回来'))
+    expect(idxPrompt).toBe(0)
+    expect(idxWake).toBeGreaterThan(idxPrompt)
+    expect(idxReply).toBeGreaterThan(idxWake)
+
+    // resume 之后新化身独立落盘，读老 seq 的 meta 不受影响。
+    const meta2Raw = await fs.readFile(join(tmp, s.worker_id, 'meta-2.json'), 'utf-8')
+    const meta2 = JSON.parse(meta2Raw)
+    expect(meta2.state).toBe('idle')
   })
 })

--- a/crabot-agent/tests/workers/builtin-adapter.test.ts
+++ b/crabot-agent/tests/workers/builtin-adapter.test.ts
@@ -6,6 +6,7 @@ import { randomUUID } from 'crypto'
 import { BuiltinWorkerAdapter } from '../../src/workers/builtin/adapter.js'
 import type { SpawnSpec, IncarnationHandle, WorkerContractState } from '../../src/workers/types.js'
 import type { LLMAdapter } from '../../src/engine/llm-adapter-types.js'
+import * as engineModule from '../../src/engine/query-loop.js'
 import { chunksFromContent } from '../engine/helpers/mock-stream.js'
 
 function makeAdapter(
@@ -124,5 +125,20 @@ describe('BuiltinWorkerAdapter', () => {
     const meta = JSON.parse(metaRaw)
     expect(meta.state).toBe('exited')
     expect(meta.ended_reason).toBe('crashed')
+  })
+
+  it('runBurst 传递 disableCompaction: true 到 runEngine', async () => {
+    const runEngineSpy = vi.spyOn(engineModule, 'runEngine')
+    const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+    const s = spec({
+      adapter: makeAdapter([{ text: '测试输出', stopReason: 'end_turn' }]),
+    })
+
+    const h = await adapter.spawn(s)
+    await waitState(adapter, h, 'idle')
+
+    expect(runEngineSpy).toHaveBeenCalled()
+    const callArgs = runEngineSpy.mock.calls[0]?.[0]
+    expect(callArgs?.options?.disableCompaction).toBe(true)
   })
 })

--- a/crabot-agent/tests/workers/builtin-adapter.test.ts
+++ b/crabot-agent/tests/workers/builtin-adapter.test.ts
@@ -1219,6 +1219,36 @@ describe('BuiltinWorkerAdapter', () => {
     await expect(adapter2.spawn(s2)).rejects.toThrow(/already has meta-1\.json on disk/)
   })
 
+  it('spawn 背靠背并发不 await 同一 worker_id：恰一个成功一个被拒，session.jsonl 单根，仅一个 burst 起跑', async () => {
+    const runEngineSpy = vi.spyOn(engineModule, 'runEngine')
+    const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+    const workerId = randomUUID()
+    const s1 = spec({ adapter: makeAdapter([{ text: '第一个 spawn 的回复', stopReason: 'end_turn' }]), worker_id: workerId })
+    const s2 = spec({ adapter: makeAdapter([{ text: '第二个 spawn 的回复', stopReason: 'end_turn' }]), worker_id: workerId })
+
+    // 关键：两次调用之间不 await——复现"两次并发 spawn 同一 worker_id 都穿过三重守卫"的
+    // 竞态场景（守卫检查与提交之间隔着多个 await，不加锁的话两次调用都会读到守卫落空）。
+    const results = await Promise.allSettled([adapter.spawn(s1), adapter.spawn(s2)])
+
+    const fulfilled = results.filter((r): r is PromiseFulfilledResult<IncarnationHandle> => r.status === 'fulfilled')
+    const rejected = results.filter((r) => r.status === 'rejected')
+    expect(fulfilled.length).toBe(1)
+    expect(rejected.length).toBe(1)
+    const rejectedReason = (rejected[0] as PromiseRejectedResult).reason
+    expect(rejectedReason instanceof Error ? rejectedReason.message : String(rejectedReason)).toMatch(/already spawned/)
+
+    const winner = fulfilled[0]!.value
+    await waitState(adapter, winner, 'idle')
+
+    // session.jsonl 单根：被拒的那次从未建根节点/写 meta，不会跟赢家的根节点混进同一棵树。
+    const nodes = await loadRawNodes(workerId)
+    const roots = nodes.filter((n) => n.parent_id === null)
+    expect(roots.length).toBe(1)
+
+    // 仅一个 burst 起跑：被拒的那次从未提交，自然也不会 fire-and-forget 起 runBurst。
+    expect(runEngineSpy).toHaveBeenCalledTimes(1)
+  })
+
   // --- fork: 提交次序对齐 resume(writeMeta 成功后才 instances.set) ---
 
   it('fork: writeMeta 抛错 → instances 无残留(提交次序与 resume 对齐)', async () => {

--- a/crabot-agent/tests/workers/builtin-adapter.test.ts
+++ b/crabot-agent/tests/workers/builtin-adapter.test.ts
@@ -868,6 +868,51 @@ describe('BuiltinWorkerAdapter', () => {
     expect(meta.ended_reason).toBe('killed')
   })
 
+  it('kill 打在 sendInput(idle→running) 转态后、续 burst 安装新 controller 前的窗口 → 终态 exited(killed)，不起新 burst（P1 全分支终审回归）', async () => {
+    const runEngineSpy = vi.spyOn(engineModule, 'runEngine')
+    const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+    const s = spec({
+      adapter: makeAdapter([
+        { text: '第一轮回复', stopReason: 'end_turn' },
+        { text: '不应该被看到的第二轮回复', stopReason: 'end_turn' },
+      ]),
+    })
+
+    const h = await adapter.spawn(s)
+    await waitState(adapter, h, 'idle')
+    expect(runEngineSpy).toHaveBeenCalledTimes(1)
+
+    // 精确命中窗口①：覆写 transitionState，在 sendInput 的 idle→running 转态落定后（仍在
+    // sendInput 那次 mutex.run 的临界区内、锁释放前）插入一次 kill 调用——kill 因此在锁
+    // 队列里排在"续 burst 安装新 controller"的 continuation 之前获锁，复现终审描述的
+    // "kill abort 了旧 controller、新 burst 照跑"竞态。覆写手法与既有窗口②测试一致。
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const adapterAny = adapter as any
+    const originalTransitionState = adapterAny.transitionState.bind(adapter)
+    let killPromise: Promise<void> | undefined
+    adapterAny.transitionState = async (instanceArg: unknown, handleArg: unknown, state: string) => {
+      const result = await originalTransitionState(instanceArg, handleArg, state)
+      if (state === 'running' && !killPromise) {
+        killPromise = adapter.kill(h)
+      }
+      return result
+    }
+
+    await adapter.sendInput(h, '追加的问题')
+    await killPromise
+    await waitState(adapter, h, 'exited')
+
+    const metaRaw = await fs.readFile(join(tmp, s.worker_id, 'meta-1.json'), 'utf-8')
+    const meta = JSON.parse(metaRaw)
+    expect(meta.state).toBe('exited')
+    expect(meta.ended_reason).toBe('killed')
+
+    // 续 burst 没有真正起来：runEngine 调用次数仍停在 spawn 那一次，第二轮回复没被消费。
+    expect(runEngineSpy).toHaveBeenCalledTimes(1)
+    const { chunk } = await adapter.readOutput(h, { offset: 0 })
+    expect(chunk).not.toContain('不应该被看到的第二轮回复')
+  })
+
   it('kill idle 化身 → 直接 exited(killed)，不经过 burst', async () => {
     const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
     const s = spec({

--- a/crabot-agent/tests/workers/builtin-adapter.test.ts
+++ b/crabot-agent/tests/workers/builtin-adapter.test.ts
@@ -49,8 +49,13 @@ function deferred<T = void>(): { promise: Promise<T>; resolve: (v: T) => void } 
   return { promise, resolve }
 }
 
-/** 第一个 stream 调用返回给定响应，第二个及后续调用抛错——用于测试续 burst 崩溃场景。 */
+/**
+ * 第一个 stream 调用返回给定响应，第二个及后续调用先 await gate 再抛错——用于测试续 burst
+ * 崩溃场景。gate 让调用方能精确控制"第二个 burst 已经进入 running、但还没抛错"这个窗口，
+ * 便于在其间 sendInput 制造待处理消息。
+ */
 function makeAdapterWithSecondBurstError(
+  gate: Promise<void>,
   firstBurstResponse: {
     text?: string
     toolCalls?: Array<{ name: string; id: string; input: Record<string, unknown> }>
@@ -61,6 +66,7 @@ function makeAdapterWithSecondBurstError(
   return {
     stream: vi.fn(async function* () {
       if (callCount > 0) {
+        await gate
         throw new Error('second burst error')
       }
       callCount++
@@ -424,30 +430,35 @@ describe('BuiltinWorkerAdapter', () => {
     expect(serialized.some((c) => c.includes('窗口期消息'))).toBe(true)
   })
 
-  it('transitionExited 时 pendingInputs 非空 → readOutput 能读到 dead-letter 消息', async () => {
+  it('续 burst 途中崩溃且 pendingInputs 非空 → readOutput 能读到 dead-letter 消息（真实调用链）', async () => {
     const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+    const gate = deferred<void>()
     const s = spec({
-      adapter: makeAdapter([{ text: '测试', stopReason: 'end_turn' }]),
+      adapter: makeAdapterWithSecondBurstError(gate.promise, { text: '首轮回复', stopReason: 'end_turn' }),
     })
 
     const h = await adapter.spawn(s)
     await waitState(adapter, h, 'idle')
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const instance = (adapter as any).instances.get(`${s.worker_id}#1`)
-    expect(instance).toBeTruthy()
+    // sendInput(idle) 起第二个 burst：mutex.run 内先把消息 append 进树、转 running，
+    // 返回时 state 已经是 running——第二个 burst 的 stream() 此刻正卡在 gate 里。
+    await adapter.sendInput(h, '触发续 burst')
+    expect(await adapter.state(h)).toBe('running')
 
-    // 手动向 pendingInputs 添加消息，模拟"化身被外部中止前有待处理消息"的场景
-    instance.pendingInputs.push('待处理消息1', '待处理消息2')
+    // 第二个 burst 仍在跑（未抛错），此刻 sendInput 走的是 running 分支：入队而不起新 burst。
+    await adapter.sendInput(h, '待处理消息1')
+    await adapter.sendInput(h, '待处理消息2')
+    expect(await adapter.state(h)).toBe('running')
 
-    // 调用 transitionExited，应该记录 dead-letter
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await (adapter as any).transitionExited(instance, h, 'crashed')
+    // 放行 gate：第二个 burst 的 stream() 抛错 → runEngine 内部 catch 收敛为
+    // outcome='failed'（finalMessages 未变短，不会误触发压缩防御）→ runBurst 收尾段
+    // 判定 failed → transitionExited('crashed')，此时 pendingInputs 仍是那两条排队消息。
+    gate.resolve()
+    await waitState(adapter, h, 'exited')
 
-    // 验证 readOutput 包含 dead-letter 消息
     const { chunk } = await adapter.readOutput(h, { offset: 0 })
     expect(chunk).toContain('[dead-letter]')
-    expect(chunk).toContain('2')  // 未发送消息数
+    expect(chunk).toContain('2 unsent message(s)')
     expect(chunk).toContain('待处理消息1')
     expect(chunk).toContain('待处理消息2')
   })

--- a/crabot-agent/tests/workers/builtin-adapter.test.ts
+++ b/crabot-agent/tests/workers/builtin-adapter.test.ts
@@ -669,4 +669,63 @@ describe('BuiltinWorkerAdapter', () => {
     expect(winner.seq).toBe(2)
     await waitState(adapter, winner, 'idle')
   })
+
+  it('resume 失败后可重试：append 抛错不阻断后续重试（幂等性）', async () => {
+    const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+    const s = spec({
+      adapter: makeAdapter([
+        { toolCalls: [{ name: 'finish_task', id: 'call_1', input: { outcome: 'completed', summary: '第一段完成' } }], stopReason: 'tool_use' },
+        { text: '欢迎回来', stopReason: 'end_turn' },
+      ]),
+    })
+
+    const h1 = await adapter.spawn(s)
+    await waitState(adapter, h1, 'exited')
+
+    const metaRaw = await fs.readFile(join(tmp, s.worker_id, 'meta-1.json'), 'utf-8')
+    const meta = JSON.parse(metaRaw) as { tip_node_id: string }
+    const prevRef: IncarnationRef = { worker_id: s.worker_id, seq: 1, session_ref: meta.tip_node_id }
+
+    // 首次 resume 时 sessionTree.append 会抛错，模拟磁盘瞬时故障。
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const adapterAny = adapter as any
+    let appendCallCount = 0
+    // 找到 worker 的 sessionTree（从任意 instance 中取出）
+    let sessionTreeInstance: SessionTree | undefined
+    for (const inst of (adapterAny.instances as Map<string, any>).values()) {
+      if (inst.worker_id === s.worker_id) {
+        sessionTreeInstance = inst.sessionTree
+        break
+      }
+    }
+    expect(sessionTreeInstance).toBeDefined()
+
+    const originalAppend = sessionTreeInstance!.append.bind(sessionTreeInstance)
+    sessionTreeInstance!.append = vi.fn(async (...args) => {
+      appendCallCount++
+      if (appendCallCount === 1) {
+        throw new Error('simulated transient disk error')
+      }
+      return originalAppend(...args)
+    })
+
+    // 第一次 resume 失败
+    const firstResumeResult = await Promise.allSettled([adapter.resume(prevRef, '尝试1')])
+    expect(firstResumeResult[0]!.status).toBe('rejected')
+    const firstError = (firstResumeResult[0] as PromiseRejectedResult).reason
+    expect(firstError instanceof Error ? firstError.message : String(firstError)).toMatch(/transient disk error/)
+
+    // 第二次 resume 应该成功（不被"重复 resume"拒绝）
+    const secondResumeResult = await Promise.allSettled([adapter.resume(prevRef, '尝试2')])
+    expect(secondResumeResult[0]!.status).toBe('fulfilled')
+    const successfulHandle = (secondResumeResult[0] as PromiseFulfilledResult<IncarnationHandle>).value
+    expect(successfulHandle.seq).toBe(2)
+    await waitState(adapter, successfulHandle, 'idle')
+
+    // 第三次 resume 才应该被拒（真正的重复 resume）
+    const thirdResumeResult = await Promise.allSettled([adapter.resume(prevRef, '尝试3')])
+    expect(thirdResumeResult[0]!.status).toBe('rejected')
+    const thirdError = (thirdResumeResult[0] as PromiseRejectedResult).reason
+    expect(thirdError instanceof Error ? thirdError.message : String(thirdError)).toMatch(/already resumed/)
+  })
 })

--- a/crabot-agent/tests/workers/builtin-adapter.test.ts
+++ b/crabot-agent/tests/workers/builtin-adapter.test.ts
@@ -728,4 +728,63 @@ describe('BuiltinWorkerAdapter', () => {
     const thirdError = (thirdResumeResult[0] as PromiseRejectedResult).reason
     expect(thirdError instanceof Error ? thirdError.message : String(thirdError)).toMatch(/already resumed/)
   })
+
+  it('resume 失败后可重试：writeMeta 抛错后重试成功（不留孤儿实例）', async () => {
+    const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+    const s = spec({
+      adapter: makeAdapter([
+        { toolCalls: [{ name: 'finish_task', id: 'call_1', input: { outcome: 'completed', summary: '第一段完成' } }], stopReason: 'tool_use' },
+        { text: '欢迎回来', stopReason: 'end_turn' },
+      ]),
+    })
+
+    const h1 = await adapter.spawn(s)
+    await waitState(adapter, h1, 'exited')
+
+    const metaRaw = await fs.readFile(join(tmp, s.worker_id, 'meta-1.json'), 'utf-8')
+    const meta = JSON.parse(metaRaw) as { tip_node_id: string }
+    const prevRef: IncarnationRef = { worker_id: s.worker_id, seq: 1, session_ref: meta.tip_node_id }
+
+    // 首次 resume 时 writeMeta 会抛错，模拟磁盘写入瞬时故障。
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const adapterAny = adapter as any
+    let writeMetaCallCount = 0
+    const originalWriteMeta = adapterAny.writeMeta.bind(adapter)
+    adapterAny.writeMeta = vi.fn(async (...args) => {
+      writeMetaCallCount++
+      if (writeMetaCallCount === 1) {
+        throw new Error('simulated writeMeta disk error')
+      }
+      return originalWriteMeta(...args)
+    })
+
+    // 第一次 resume 失败（writeMeta 抛错）
+    const firstResumeResult = await Promise.allSettled([adapter.resume(prevRef, '尝试1')])
+    expect(firstResumeResult[0]!.status).toBe('rejected')
+    const firstError = (firstResumeResult[0] as PromiseRejectedResult).reason
+    expect(firstError instanceof Error ? firstError.message : String(firstError)).toMatch(/writeMeta disk error/)
+
+    // 验证没有留下孤儿实例：instances 里不应该有 seq=2 的条目
+    // （因为 writeMeta 失败了，instances.set 还没执行）
+    const key2Before = `${s.worker_id}#2`
+    expect((adapterAny.instances as Map<string, any>).has(key2Before)).toBe(false)
+
+    // 第二次 resume 应该成功（不被"重复 resume"拒绝）
+    const secondResumeResult = await Promise.allSettled([adapter.resume(prevRef, '尝试2')])
+    expect(secondResumeResult[0]!.status).toBe('fulfilled')
+    const successfulHandle = (secondResumeResult[0] as PromiseFulfilledResult<IncarnationHandle>).value
+    expect(successfulHandle.seq).toBe(2)
+    await waitState(adapter, successfulHandle, 'idle')
+
+    // 验证元数据确实被写入磁盘
+    const meta2Raw = await fs.readFile(join(tmp, s.worker_id, 'meta-2.json'), 'utf-8')
+    const meta2 = JSON.parse(meta2Raw)
+    expect(meta2.state).toBe('idle')
+
+    // 第三次 resume 才应该被拒（真正的重复 resume）
+    const thirdResumeResult = await Promise.allSettled([adapter.resume(prevRef, '尝试3')])
+    expect(thirdResumeResult[0]!.status).toBe('rejected')
+    const thirdError = (thirdResumeResult[0] as PromiseRejectedResult).reason
+    expect(thirdError instanceof Error ? thirdError.message : String(thirdError)).toMatch(/already resumed/)
+  })
 })

--- a/crabot-agent/tests/workers/builtin-adapter.test.ts
+++ b/crabot-agent/tests/workers/builtin-adapter.test.ts
@@ -503,6 +503,54 @@ describe('BuiltinWorkerAdapter', () => {
     await waitState(adapter, resumedHandle, 'idle')
   })
 
+  it('kill running fork 化身：fork burst 的 abortSignal 被触发，终态 exited(killed) 而不是 crashed', async () => {
+    const runEngineSpy = vi.spyOn(engineModule, 'runEngine')
+    const gate = deferred<void>()
+    const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+    const s = spec({
+      adapter: makeAdapterGatedFromSecondCall(gate.promise, [
+        { text: '首轮回复', stopReason: 'end_turn' },
+        { text: '侧问回复', stopReason: 'end_turn' },
+      ]),
+    })
+
+    const h = await adapter.spawn(s)
+    await waitState(adapter, h, 'idle')
+
+    const tree = await SessionTree.load(join(tmp, s.worker_id, 'session.jsonl'))
+    const mainTip = tree.latestTip()!
+    const prevRef: IncarnationRef = { worker_id: s.worker_id, seq: 1, session_ref: mainTip }
+
+    // fork 调用会触发 fork burst，其中会卡在 gate（因为是第二次调用）
+    const forkHandle = await adapter.fork(prevRef, '侧问问题')
+    expect(forkHandle.seq).toBe(2)
+
+    // 等待足够长的时间让 fork burst 进入卡在 gate 的状态
+    await new Promise((r) => setTimeout(r, 100))
+
+    // 确认 fork burst 的 abortSignal 已被创建（第二次 runEngine 调用是 fork 的）
+    expect(runEngineSpy.mock.calls.length).toBeGreaterThanOrEqual(2)
+    const forkCallArgs = runEngineSpy.mock.calls[1]?.[0]
+    expect(forkCallArgs?.options?.abortSignal).toBeDefined()
+    expect(forkCallArgs?.options?.abortSignal?.aborted).toBe(false) // 还没被 abort
+
+    // kill fork 化身
+    await adapter.kill(forkHandle)
+
+    // 确认 kill 后 abortSignal 被触发
+    expect(forkCallArgs?.options?.abortSignal?.aborted).toBe(true)
+
+    // 放行 gate 让 fork burst 继续，会检测到 abortSignal 被触发
+    gate.resolve()
+    await waitState(adapter, forkHandle, 'exited')
+
+    // 验证 fork 化身的终态：应该是 exited(killed)，不能是 crashed
+    const forkMetaRaw = await fs.readFile(join(tmp, s.worker_id, 'meta-2.json'), 'utf-8')
+    const forkMeta = JSON.parse(forkMetaRaw)
+    expect(forkMeta.state).toBe('exited')
+    expect(forkMeta.ended_reason).toBe('killed') // 这是关键断言，当前代码会返回 'crashed'
+  })
+
   // --- 并发竞态回归（per-worker 互斥）---
 
   /** 从 session.jsonl 读出全部节点，用于检测树是否分叉（同一 parent_id 出现多个孩子）。 */

--- a/crabot-agent/tests/workers/builtin-adapter.test.ts
+++ b/crabot-agent/tests/workers/builtin-adapter.test.ts
@@ -299,4 +299,138 @@ describe('BuiltinWorkerAdapter', () => {
     const meta2 = JSON.parse(meta2Raw)
     expect(meta2.state).toBe('idle')
   })
+
+  // --- 并发竞态回归（per-worker 互斥）---
+
+  /** 从 session.jsonl 读出全部节点，用于检测树是否分叉（同一 parent_id 出现多个孩子）。 */
+  async function loadRawNodes(worker_id: string): Promise<Array<{ node_id: string; parent_id: string | null; message: unknown }>> {
+    const raw = await fs.readFile(join(tmp, worker_id, 'session.jsonl'), 'utf-8')
+    return raw
+      .split('\n')
+      .filter((l) => l.trim())
+      .map((l) => JSON.parse(l))
+  }
+
+  function assertNoFork(nodes: Array<{ node_id: string; parent_id: string | null }>): void {
+    const childCount = new Map<string, number>()
+    for (const n of nodes) {
+      if (n.parent_id === null) continue
+      childCount.set(n.parent_id, (childCount.get(n.parent_id) ?? 0) + 1)
+    }
+    for (const [parent, count] of childCount) {
+      expect(count, `node ${parent} 有 ${count} 个孩子——树分叉了`).toBe(1)
+    }
+  }
+
+  it('sendInput(idle) 背靠背并发不 await：两条消息都不丢且树无分叉', async () => {
+    const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+    const s = spec({
+      adapter: makeAdapter([
+        { text: '首轮回复', stopReason: 'end_turn' },
+        { text: '第二轮回复', stopReason: 'end_turn' },
+        { text: '第三轮回复', stopReason: 'end_turn' },
+      ]),
+    })
+
+    const h = await adapter.spawn(s)
+    await waitState(adapter, h, 'idle')
+
+    // 关键：两次调用之间不 await——复现"都读到 idle、拿同一 tip"的竞态场景。
+    const p1 = adapter.sendInput(h, '并发消息A')
+    const p2 = adapter.sendInput(h, '并发消息B')
+    await Promise.all([p1, p2])
+
+    await waitState(adapter, h, 'idle')
+
+    const nodes = await loadRawNodes(s.worker_id)
+    assertNoFork(nodes)
+
+    const serialized = nodes.map((n) => JSON.stringify(n.message))
+    expect(serialized.some((c) => c.includes('并发消息A'))).toBe(true)
+    expect(serialized.some((c) => c.includes('并发消息B'))).toBe(true)
+  })
+
+  it('burst 收尾"判定队列为空→落 idle"窗口期注入的 sendInput 不丢', async () => {
+    const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+    const gate = deferred<void>()
+    const s = spec({
+      adapter: makeGatedAdapter(gate.promise, [
+        { text: '首轮回复', stopReason: 'end_turn' },
+        { text: '窗口期消息的回复', stopReason: 'end_turn' },
+      ]),
+    })
+
+    const h = await adapter.spawn(s)
+    expect(await adapter.state(h)).toBe('running')
+
+    // burst 被 gate 卡住时装好拦截：一旦收尾段判定要落 idle，就在"判定完成、状态还没
+    // 真正落定"这个当口抢发 sendInput，复现窗口期竞态（transitionState 是私有方法，
+    // 用实例属性覆盖原型方法来精确命中这个窗口——比纯靠时序凑巧命中更可靠）。
+    // 用 deferred 而非轮询 state() 等收敛：instance.state 在 transitionState 内部落 idle
+    // 后、mutex 真正释放前就已可见，轮询可能逮到这个转瞬即逝的中间态就提前判定"已收敛"，
+    // 而注入的续 burst 其实还没跑完——那样断言会读到写了一半的树，是测试自身的假竞态，
+    // 不是被测代码的问题；等第二次 transitionState('idle') 真正落盘完成才是可靠的收敛信号。
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const adapterAny = adapter as any
+    const originalTransitionState = adapterAny.transitionState.bind(adapter)
+    let idleCount = 0
+    const secondIdle = deferred<void>()
+    adapterAny.transitionState = async (instanceArg: unknown, handleArg: unknown, state: string) => {
+      const result = await originalTransitionState(instanceArg, handleArg, state)
+      if (state === 'idle') {
+        idleCount++
+        if (idleCount === 1) {
+          void adapter.sendInput(h, '窗口期消息')
+        } else {
+          secondIdle.resolve()
+        }
+      }
+      return result
+    }
+
+    gate.resolve()
+    await secondIdle.promise
+
+    const nodes = await loadRawNodes(s.worker_id)
+    assertNoFork(nodes)
+    const serialized = nodes.map((n) => JSON.stringify(n.message))
+    expect(serialized.some((c) => c.includes('窗口期消息'))).toBe(true)
+  })
+
+  it('并发 resume 同一 prev：仅一次成功，无树分叉', async () => {
+    const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+    const s = spec({
+      adapter: makeAdapter([
+        { toolCalls: [{ name: 'finish_task', id: 'call_1', input: { outcome: 'completed', summary: '第一段完成' } }], stopReason: 'tool_use' },
+        { text: '欢迎回来A', stopReason: 'end_turn' },
+        { text: '欢迎回来B', stopReason: 'end_turn' },
+      ]),
+    })
+
+    const h1 = await adapter.spawn(s)
+    await waitState(adapter, h1, 'exited')
+
+    const metaRaw = await fs.readFile(join(tmp, s.worker_id, 'meta-1.json'), 'utf-8')
+    const meta = JSON.parse(metaRaw) as { tip_node_id: string }
+    const prevRef: IncarnationRef = { worker_id: s.worker_id, seq: 1, session_ref: meta.tip_node_id }
+
+    const results = await Promise.allSettled([
+      adapter.resume(prevRef, '我回来了-A'),
+      adapter.resume(prevRef, '我回来了-B'),
+    ])
+
+    const fulfilled = results.filter((r): r is PromiseFulfilledResult<IncarnationHandle> => r.status === 'fulfilled')
+    const rejected = results.filter((r) => r.status === 'rejected')
+    expect(fulfilled.length).toBe(1)
+    expect(rejected.length).toBe(1)
+
+    const nodes = await loadRawNodes(s.worker_id)
+    assertNoFork(nodes)
+    const childrenOfPrevTip = nodes.filter((n) => n.parent_id === prevRef.session_ref)
+    expect(childrenOfPrevTip.length).toBe(1)
+
+    const winner = fulfilled[0]!.value
+    expect(winner.seq).toBe(2)
+    await waitState(adapter, winner, 'idle')
+  })
 })

--- a/crabot-agent/tests/workers/builtin-adapter.test.ts
+++ b/crabot-agent/tests/workers/builtin-adapter.test.ts
@@ -107,6 +107,35 @@ function makeGatedAdapter(
   } as unknown as LLMAdapter
 }
 
+/**
+ * 像 makeAdapter，但从第二次 stream() 调用起先 await gate——用于制造"主线 burst 已经
+ * idle 落定、fork 的 burst 还卡着没跑完"这个可控窗口，同一个 mock adapter 被主线和
+ * fork 共用（贴合 builtinConfigs 按 worker_id 缓存、fork 复用同一 builtin.adapter 的实现）。
+ */
+function makeAdapterGatedFromSecondCall(
+  gate: Promise<void>,
+  responses: Array<{
+    text?: string
+    toolCalls?: Array<{ name: string; id: string; input: Record<string, unknown> }>
+    stopReason: 'end_turn' | 'tool_use'
+  }>,
+): LLMAdapter {
+  let i = 0
+  return {
+    stream: vi.fn(async function* () {
+      if (i > 0) await gate
+      const r = responses[i++] ?? responses[responses.length - 1]
+      const content: unknown[] = []
+      if (r.text) content.push({ type: 'text', text: r.text })
+      for (const tc of r.toolCalls ?? []) {
+        content.push({ type: 'tool_use', id: tc.id, name: tc.name, input: tc.input })
+      }
+      yield* chunksFromContent(content, r.stopReason, { inputTokens: 100, outputTokens: 50 })
+    }),
+    updateConfig: () => {},
+  } as unknown as LLMAdapter
+}
+
 function spec(opts: { adapter: LLMAdapter; worker_id?: string }): SpawnSpec {
   return {
     worker_id: opts.worker_id ?? randomUUID(),
@@ -331,6 +360,147 @@ describe('BuiltinWorkerAdapter', () => {
     const meta2Raw = await fs.readFile(join(tmp, s.worker_id, 'meta-2.json'), 'utf-8')
     const meta2 = JSON.parse(meta2Raw)
     expect(meta2.state).toBe('idle')
+  })
+
+  // --- fork（侧问分支）---
+
+  it('fork(prev, forkInput) → 主线 idle 状态和 tip 不受影响，fork 有独立输出，fork 能看到主线历史', async () => {
+    const runEngineSpy = vi.spyOn(engineModule, 'runEngine')
+    const gate = deferred<void>()
+    const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+    const s = spec({
+      adapter: makeAdapterGatedFromSecondCall(gate.promise, [
+        { text: '首轮回复', stopReason: 'end_turn' },
+        { text: '侧问回复', stopReason: 'end_turn' },
+      ]),
+    })
+
+    const h = await adapter.spawn(s)
+    await waitState(adapter, h, 'idle')
+
+    const treeBeforeFork = await SessionTree.load(join(tmp, s.worker_id, 'session.jsonl'))
+    const mainTip = treeBeforeFork.latestTip()
+    expect(mainTip).not.toBeNull()
+
+    const prevRef: IncarnationRef = { worker_id: s.worker_id, seq: 1, session_ref: mainTip! }
+    const forkHandle = await adapter.fork(prevRef, '侧问问题')
+    expect(forkHandle.seq).toBe(2)
+
+    // fork 的 burst 还卡在 gate 里没跑完：此时主线状态/tip 必须完全不受影响。注意：不能
+    // 用 SessionTree.load(...).latestTip() 判断——那是整个共享文件"最后一次 append"的
+    // 全局游标，fork 往 prev.session_ref 上分支追加后，这个全局游标必然指向 fork 的新
+    // 节点。真正代表"主线自己的续接点"的是主线化身自己维护的 tip（落在 meta-1.json 的
+    // tip_node_id 里），必须仍然等于 fork 之前的 mainTip。
+    expect(await adapter.state(h)).toBe('idle')
+    let mainMeta = JSON.parse(await fs.readFile(join(tmp, s.worker_id, 'meta-1.json'), 'utf-8')) as { tip_node_id: string }
+    expect(mainMeta.tip_node_id).toBe(mainTip)
+
+    gate.resolve()
+    await waitState(adapter, forkHandle, 'exited')
+
+    // fork 结束后主线依旧不受影响。
+    expect(await adapter.state(h)).toBe('idle')
+    mainMeta = JSON.parse(await fs.readFile(join(tmp, s.worker_id, 'meta-1.json'), 'utf-8')) as { tip_node_id: string }
+    expect(mainMeta.tip_node_id).toBe(mainTip)
+
+    // fork 化身独立 meta：exited(completed)。
+    const forkMetaRaw = await fs.readFile(join(tmp, s.worker_id, 'meta-2.json'), 'utf-8')
+    const forkMeta = JSON.parse(forkMetaRaw)
+    expect(forkMeta.state).toBe('exited')
+    expect(forkMeta.ended_reason).toBe('completed')
+    expect(forkMeta.outcome).toBe('completed')
+
+    // fork 输出独立可读，且与主线输出互不串。
+    const forkOutput = await adapter.readOutput(forkHandle, { offset: 0 })
+    expect(forkOutput.chunk).toContain('侧问回复')
+    const mainOutput = await adapter.readOutput(h, { offset: 0 })
+    expect(mainOutput.chunk).toContain('首轮回复')
+    expect(mainOutput.chunk).not.toContain('侧问回复')
+
+    // fork 看得到主线历史：第二次 runEngine 调用（fork 的 burst）的 initialMessages 里
+    // 含首轮 prompt、首轮 assistant 回复、以及 forkInput 本身。
+    expect(runEngineSpy).toHaveBeenCalledTimes(2)
+    const forkCallArgs = runEngineSpy.mock.calls[1]?.[0]
+    const serialized = JSON.stringify(forkCallArgs?.initialMessages ?? [])
+    expect(serialized).toContain('测试任务')
+    expect(serialized).toContain('首轮回复')
+    expect(serialized).toContain('侧问问题')
+
+    // session 树分叉：mainTip 现在有且仅有一个孩子（fork 的分支节点），主线没有继续。
+    const raw = await fs.readFile(join(tmp, s.worker_id, 'session.jsonl'), 'utf-8')
+    const rawNodes = raw
+      .split('\n')
+      .filter((l) => l.trim())
+      .map((l) => JSON.parse(l) as { node_id: string; parent_id: string | null })
+    const childrenOfMainTip = rawNodes.filter((n) => n.parent_id === mainTip)
+    expect(childrenOfMainTip.length).toBe(1)
+  })
+
+  it('fork 不要求 prev 处于任何特定状态：主线仍 running 时也能 fork', async () => {
+    const gate = deferred<void>()
+    const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+    const s = spec({
+      adapter: makeGatedAdapter(gate.promise, [
+        { text: '主线回复', stopReason: 'end_turn' },
+        { text: '侧问回复', stopReason: 'end_turn' },
+      ]),
+    })
+
+    const h = await adapter.spawn(s)
+    expect(await adapter.state(h)).toBe('running')
+
+    // 主线首个 burst 还没跑完（卡在 gate），此时 fork：session_ref 用根节点（prompt 节点）。
+    const tree = await SessionTree.load(join(tmp, s.worker_id, 'session.jsonl'))
+    const rootTip = tree.latestTip()
+    expect(rootTip).not.toBeNull()
+    const prevRef: IncarnationRef = { worker_id: s.worker_id, seq: 1, session_ref: rootTip! }
+
+    const forkHandle = await adapter.fork(prevRef, '侧问问题')
+    expect(forkHandle.seq).toBe(2)
+
+    gate.resolve()
+    await waitState(adapter, h, 'idle')
+    await waitState(adapter, forkHandle, 'exited')
+
+    expect(await adapter.state(h)).toBe('idle')
+    const forkMetaRaw = await fs.readFile(join(tmp, s.worker_id, 'meta-2.json'), 'utf-8')
+    const forkMeta = JSON.parse(forkMetaRaw)
+    expect(forkMeta.state).toBe('exited')
+    expect(forkMeta.outcome).toBe('completed')
+  })
+
+  it('fork 之后 resume 主线：seq 分配不与 fork 撞号（fork 消耗 seq 2，resume 应得 seq 3）', async () => {
+    const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+    const s = spec({
+      adapter: makeAdapter([
+        { text: '首轮回复', stopReason: 'end_turn' },
+        { text: '侧问回复', stopReason: 'end_turn' },
+        { toolCalls: [{ name: 'finish_task', id: 'call_1', input: { outcome: 'completed', summary: '主线完成' } }], stopReason: 'tool_use' },
+        { text: '欢迎回来', stopReason: 'end_turn' },
+      ]),
+    })
+
+    const h = await adapter.spawn(s)
+    await waitState(adapter, h, 'idle')
+
+    const tree1 = await SessionTree.load(join(tmp, s.worker_id, 'session.jsonl'))
+    const mainTip = tree1.latestTip()!
+    const forkRef: IncarnationRef = { worker_id: s.worker_id, seq: 1, session_ref: mainTip }
+    const forkHandle = await adapter.fork(forkRef, '侧问问题')
+    expect(forkHandle.seq).toBe(2)
+    await waitState(adapter, forkHandle, 'exited')
+
+    // 主线继续跑到 finish_task → exited。
+    await adapter.sendInput(h, '继续')
+    await waitState(adapter, h, 'exited')
+
+    const mainMetaRaw = await fs.readFile(join(tmp, s.worker_id, 'meta-1.json'), 'utf-8')
+    const mainMeta = JSON.parse(mainMetaRaw) as { tip_node_id: string }
+    const resumeRef: IncarnationRef = { worker_id: s.worker_id, seq: 1, session_ref: mainMeta.tip_node_id }
+
+    const resumedHandle = await adapter.resume(resumeRef, '我回来了')
+    expect(resumedHandle.seq).toBe(3)
+    await waitState(adapter, resumedHandle, 'idle')
   })
 
   // --- 并发竞态回归（per-worker 互斥）---

--- a/crabot-agent/tests/workers/contract-builtin.test.ts
+++ b/crabot-agent/tests/workers/contract-builtin.test.ts
@@ -1,0 +1,74 @@
+/**
+ * builtin 接入可复用契约套件（见 contract-suite.ts 文件头注释）。mock LLM adapter 按
+ * script 顺序回放：'idle' → 纯文本 end_turn；'exit_success'/'exit_failure' → 文本 + 调用
+ * builtin 内置的 finish_task 工具（outcome 对应 completed/failed）——与
+ * builtin-adapter.test.ts 现有的 mock 模式（makeAdapter + chunksFromContent）同构。
+ */
+import { promises as fs } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { vi } from 'vitest'
+import { BuiltinWorkerAdapter } from '../../src/workers/builtin/adapter.js'
+import type { SpawnSpec, IncarnationHandle, IncarnationRef } from '../../src/workers/types.js'
+import type { LLMAdapter } from '../../src/engine/llm-adapter-types.js'
+import { chunksFromContent } from '../engine/helpers/mock-stream.js'
+import { runContractSuite, type ScriptStep, type ContractFixture } from './contract-suite.js'
+
+/** 每次 stream() 调用消费 script 里的下一个 step；越界后重放最后一个 step。 */
+function scriptedLLMAdapter(script: ScriptStep[]): LLMAdapter {
+  let i = 0
+  return {
+    stream: vi.fn(async function* () {
+      const step = script[i] ?? script[script.length - 1]
+      const callIndex = i
+      i++
+      const content: unknown[] = [{ type: 'text', text: step.output }]
+      let stopReason: 'end_turn' | 'tool_use' = 'end_turn'
+      if (step.then !== 'idle') {
+        stopReason = 'tool_use'
+        content.push({
+          type: 'tool_use',
+          id: `call_${callIndex}`,
+          name: 'finish_task',
+          input: {
+            outcome: step.then === 'exit_success' ? 'completed' : 'failed',
+            summary: step.output,
+          },
+        })
+      }
+      yield* chunksFromContent(content, stopReason, { inputTokens: 10, outputTokens: 10 })
+    }),
+    updateConfig: () => {},
+  } as unknown as LLMAdapter
+}
+
+async function makeBuiltinFixture(): Promise<ContractFixture> {
+  const tmp = await fs.mkdtemp(join(tmpdir(), 'contract-builtin-'))
+  const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+
+  const makeSpec = (workerId: string, script: ScriptStep[]): SpawnSpec => ({
+    worker_id: workerId,
+    prompt: '契约测试任务',
+    workspace: { root: '/tmp/ws' },
+    builtin: {
+      adapter: scriptedLLMAdapter(script),
+      model: 'test',
+      systemPrompt: '',
+      tools: [],
+    },
+  })
+
+  const refFor = async (h: IncarnationHandle): Promise<IncarnationRef> => {
+    const metaRaw = await fs.readFile(join(tmp, h.worker_id, `meta-${h.seq}.json`), 'utf-8')
+    const meta = JSON.parse(metaRaw) as { tip_node_id: string }
+    return { worker_id: h.worker_id, seq: h.seq, session_ref: meta.tip_node_id }
+  }
+
+  const cleanup = async (): Promise<void> => {
+    await fs.rm(tmp, { recursive: true, force: true })
+  }
+
+  return { adapter, makeSpec, refFor, cleanup }
+}
+
+runContractSuite('builtin', makeBuiltinFixture)

--- a/crabot-agent/tests/workers/contract-suite.ts
+++ b/crabot-agent/tests/workers/contract-suite.ts
@@ -1,0 +1,236 @@
+/**
+ * 可复用的 WorkerAdapter 契约一致性套件——与实现无关的行为断言，供 builtin（本文件的
+ * contract-builtin.test.ts）以及 P2 的 claude-code / codex tmux adapter 复跑同一套。
+ *
+ * 每个 fixture 提供一个 makeSpec(workerId, script)：script 是一串 ScriptStep，第一个
+ * step 由 spawn 触发的初始 burst 消费，此后每次 sendInput 依次消费下一个 step——具体怎么
+ * 让底层实现（builtin 用 mock LLMAdapter；P2 用 mock CLI）按这个顺序吐输出，是 fixture 的
+ * 职责，契约套件本身不关心。
+ *
+ * session_ref（IncarnationRef 里喂给 fork/resume 的字段）是逐 impl 不透明的格式（builtin：
+ * session 树 node_id；CLI：原生 session id），WorkerAdapter 接口没有从 handle 反查它的方法，
+ * 所以 fixture 必须额外提供 refFor(handle) 这条通路——这是相对任务简报里给的三字段接口
+ * （adapter/makeSpec/cleanup）的一个必要补充，否则 fork/revive 两条契约断言根本没法在
+ * impl-agnostic 的前提下发起调用。
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { randomUUID } from 'crypto'
+import type {
+  WorkerAdapter,
+  IncarnationHandle,
+  IncarnationRef,
+  SpawnSpec,
+  WorkerContractState,
+} from '../../src/workers/types.js'
+
+export interface ScriptStep {
+  readonly output: string
+  readonly then: 'idle' | 'exit_success' | 'exit_failure'
+}
+
+export interface ContractFixture {
+  readonly adapter: WorkerAdapter
+  /** 每次 sendInput 消费下一个 script step；第一个 step 由 spawn 的初始 burst 消费。 */
+  readonly makeSpec: (workerId: string, script: ScriptStep[]) => SpawnSpec
+  /** 把一个已知 handle 转成可喂给 fork/resume 的 IncarnationRef（session_ref 格式不透明，见文件头注释）。 */
+  readonly refFor: (h: IncarnationHandle) => Promise<IncarnationRef>
+  readonly cleanup: () => Promise<void>
+}
+
+export type MakeFixture = () => Promise<ContractFixture>
+
+/**
+ * 状态收敛轮询：100ms 间隔、5s 超时——给未来 tmux 实现（拉起真实进程）留够裕量。
+ * `targets` 允许传多个可接受的终态（例如"idle 或 exited 皆可"），单个轮询循环里判定，
+ * 不用 Promise.race 叠两个独立循环——否则赢家 resolve 后，输家那个循环仍在后台继续跑
+ * 到自己的超时才抛错，变成没人 await 的 unhandled rejection。
+ */
+async function waitForState(
+  adapter: WorkerAdapter,
+  h: IncarnationHandle,
+  targets: WorkerContractState | ReadonlyArray<WorkerContractState>,
+): Promise<void> {
+  const targetList = Array.isArray(targets) ? targets : [targets as WorkerContractState]
+  const intervalMs = 100
+  const deadline = Date.now() + 5000
+  let last: WorkerContractState | undefined
+  while (Date.now() < deadline) {
+    last = await adapter.state(h)
+    if ((targetList as WorkerContractState[]).includes(last)) return
+    await new Promise((r) => setTimeout(r, intervalMs))
+  }
+  throw new Error(`waitForState timeout: expected one of [${targetList.join(', ')}], last seen '${last}'`)
+}
+
+/** 每个 it 单独起一个 worker，靠随机 worker_id 隔离，不依赖 fixture 内部如何划分数据目录。 */
+function freshWorkerId(): string {
+  return `contract-${randomUUID()}`
+}
+
+export function runContractSuite(name: string, makeFixture: MakeFixture): void {
+  describe(`WorkerAdapter contract: ${name}`, () => {
+    let fx: ContractFixture
+
+    beforeEach(async () => {
+      fx = await makeFixture()
+    })
+
+    afterEach(async () => {
+      await fx.cleanup()
+    })
+
+    it(
+      '① spawn → burst(idle) → state 收敛 idle，readOutput 含该 step 输出',
+      async () => {
+        const spec = fx.makeSpec(freshWorkerId(), [{ output: '第一段输出', then: 'idle' }])
+        const h = await fx.adapter.spawn(spec)
+        await waitForState(fx.adapter, h, 'idle')
+
+        const { chunk } = await fx.adapter.readOutput(h, { offset: 0 })
+        expect(chunk).toContain('第一段输出')
+      },
+      15000,
+    )
+
+    it(
+      '② readOutput 游标增量：同一游标二次读为空，不重复吐旧内容',
+      async () => {
+        const spec = fx.makeSpec(freshWorkerId(), [{ output: '第一段输出', then: 'idle' }])
+        const h = await fx.adapter.spawn(spec)
+        await waitForState(fx.adapter, h, 'idle')
+
+        const first = await fx.adapter.readOutput(h, { offset: 0 })
+        expect(first.chunk).toContain('第一段输出')
+
+        const second = await fx.adapter.readOutput(h, first.nextCursor)
+        expect(second.chunk).not.toContain('第一段输出')
+      },
+      15000,
+    )
+
+    it(
+      '③ sendInput(idle) → 消费下一个 step，输出追加而非覆盖',
+      async () => {
+        const spec = fx.makeSpec(freshWorkerId(), [
+          { output: '第一段输出', then: 'idle' },
+          { output: '第二段输出', then: 'idle' },
+        ])
+        const h = await fx.adapter.spawn(spec)
+        await waitForState(fx.adapter, h, 'idle')
+
+        const before = await fx.adapter.readOutput(h, { offset: 0 })
+        expect(before.chunk).toContain('第一段输出')
+
+        await fx.adapter.sendInput(h, '继续')
+        await waitForState(fx.adapter, h, 'idle')
+
+        const after = await fx.adapter.readOutput(h, { offset: 0 })
+        expect(after.chunk).toContain('第一段输出')
+        expect(after.chunk).toContain('第二段输出')
+
+        const incremental = await fx.adapter.readOutput(h, before.nextCursor)
+        expect(incremental.chunk).toContain('第二段输出')
+        expect(incremental.chunk).not.toContain('第一段输出')
+      },
+      15000,
+    )
+
+    it.each(['exit_success', 'exit_failure'] as const)(
+      '④ %s step → 收敛 exited',
+      async (then) => {
+        const spec = fx.makeSpec(freshWorkerId(), [{ output: '收尾输出', then }])
+        const h = await fx.adapter.spawn(spec)
+        await waitForState(fx.adapter, h, 'exited')
+        expect(await fx.adapter.state(h)).toBe('exited')
+      },
+      15000,
+    )
+
+    it(
+      '⑤ 对 exited 化身 sendInput 必须拒绝（错误类型不限定）',
+      async () => {
+        const spec = fx.makeSpec(freshWorkerId(), [{ output: '收尾输出', then: 'exit_success' }])
+        const h = await fx.adapter.spawn(spec)
+        await waitForState(fx.adapter, h, 'exited')
+
+        let rejected = false
+        try {
+          await fx.adapter.sendInput(h, '还有件事')
+        } catch {
+          rejected = true
+        }
+        expect(rejected).toBe(true)
+      },
+      15000,
+    )
+
+    it(
+      '⑥ kill：spawn 后立即 kill → 最终 exited，再次 kill 幂等',
+      async () => {
+        const spec = fx.makeSpec(freshWorkerId(), [{ output: '不一定会被读到的输出', then: 'idle' }])
+        const h = await fx.adapter.spawn(spec)
+
+        await fx.adapter.kill(h)
+        await waitForState(fx.adapter, h, 'exited')
+
+        await expect(fx.adapter.kill(h)).resolves.toBeUndefined()
+      },
+      15000,
+    )
+
+    it(
+      '⑦a capabilities.fork 声明与实际行为一致',
+      async () => {
+        const spec = fx.makeSpec(freshWorkerId(), [{ output: '主线输出', then: 'idle' }])
+        const h = await fx.adapter.spawn(spec)
+        await waitForState(fx.adapter, h, 'idle')
+        const ref = await fx.refFor(h)
+        const caps = fx.adapter.capabilities()
+
+        if (caps.fork) {
+          const forkHandle = await fx.adapter.fork(ref, '侧问问题')
+          expect(forkHandle.worker_id).toBe(h.worker_id)
+          await waitForState(fx.adapter, forkHandle, 'exited')
+          const output = await fx.adapter.readOutput(forkHandle, { offset: 0 })
+          expect(typeof output.chunk).toBe('string')
+        } else {
+          await expect(fx.adapter.fork(ref, '侧问问题')).rejects.toBeTruthy()
+        }
+      },
+      15000,
+    )
+
+    it(
+      '⑦b capabilities.revive 声明与实际行为一致',
+      async () => {
+        const spec = fx.makeSpec(freshWorkerId(), [{ output: '主线输出', then: 'exit_success' }])
+        const h = await fx.adapter.spawn(spec)
+        await waitForState(fx.adapter, h, 'exited')
+        const ref = await fx.refFor(h)
+        const caps = fx.adapter.capabilities()
+
+        if (caps.revive) {
+          const revivedHandle = await fx.adapter.resume(ref, '唤醒输入')
+          expect(revivedHandle.worker_id).toBe(h.worker_id)
+          // 不同实现续跑后的落定状态语义可能不同（idle / exited 都合法），只要求最终不再是
+          // 一直卡着——两者之一即可，同时验证输出通路可用。
+          await waitForState(fx.adapter, revivedHandle, ['idle', 'exited'])
+          const output = await fx.adapter.readOutput(revivedHandle, { offset: 0 })
+          expect(typeof output.chunk).toBe('string')
+        } else {
+          await expect(fx.adapter.resume(ref, '唤醒输入')).rejects.toBeTruthy()
+        }
+      },
+      15000,
+    )
+
+    it('⑧ detect() 返回结构合法', async () => {
+      const result = await fx.adapter.detect()
+      expect(typeof result.installed).toBe('boolean')
+      expect(typeof result.activated).toBe('boolean')
+      if (result.detail !== undefined) {
+        expect(typeof result.detail).toBe('string')
+      }
+    })
+  })
+}

--- a/crabot-agent/tests/workers/output-log.test.ts
+++ b/crabot-agent/tests/workers/output-log.test.ts
@@ -133,4 +133,82 @@ describe('OutputLog', () => {
     expect(assembled).not.toContain('�')
     expect(cursor.offset).toBe(Buffer.byteLength(original, 'utf-8'))
   })
+
+  it('should guarantee progress with extremely small cap=1 when encountering 3-byte UTF-8 character', async () => {
+    const log = new OutputLog(logPath)
+
+    // File: 'A' (1 byte) + '中' (3 bytes) + 'B' (1 byte) = 5 bytes total
+    const original = 'A中B'
+    await log.append(original)
+
+    const cap = 1 // Extremely small cap, smaller than any multi-byte character
+    let cursor = { offset: 0 }
+    let assembled = ''
+    const offsets: number[] = []
+    let guard = 0
+
+    while (true) {
+      offsets.push(cursor.offset)
+      const { chunk, nextCursor } = await log.read(cursor, cap)
+      const contentBeforeTruncation = chunk.split('\n[output truncated')[0]
+      assembled += contentBeforeTruncation
+
+      // Check for progress: nextCursor.offset must strictly increase or we're done
+      if (nextCursor.offset === cursor.offset) {
+        break
+      }
+      expect(nextCursor.offset).toBeGreaterThan(cursor.offset)
+      cursor = nextCursor
+      guard += 1
+      if (guard > 20) throw new Error('read loop did not terminate')
+    }
+
+    // Verify the assembled content matches original
+    expect(assembled).toBe(original)
+    expect(assembled).not.toContain('�') // No broken characters
+    expect(cursor.offset).toBe(Buffer.byteLength(original, 'utf-8'))
+
+    // Verify offsets are strictly increasing
+    for (let i = 1; i < offsets.length; i++) {
+      expect(offsets[i]).toBeGreaterThan(offsets[i - 1])
+    }
+  })
+
+  it('should guarantee progress with cap=3 when encountering 4-byte emoji', async () => {
+    const log = new OutputLog(logPath)
+
+    // File: 'AB' (2 bytes) + '🎉' (4 bytes) + 'C' (1 byte) = 7 bytes total
+    const original = 'AB🎉C'
+    await log.append(original)
+
+    const cap = 3 // cap < emoji's 4-byte size
+    let cursor = { offset: 0 }
+    let assembled = ''
+    const offsets: number[] = []
+    let guard = 0
+
+    while (true) {
+      offsets.push(cursor.offset)
+      const { chunk, nextCursor } = await log.read(cursor, cap)
+      const contentBeforeTruncation = chunk.split('\n[output truncated')[0]
+      assembled += contentBeforeTruncation
+
+      if (nextCursor.offset === cursor.offset) {
+        break
+      }
+      expect(nextCursor.offset).toBeGreaterThan(cursor.offset)
+      cursor = nextCursor
+      guard += 1
+      if (guard > 20) throw new Error('read loop did not terminate')
+    }
+
+    expect(assembled).toBe(original)
+    expect(assembled).not.toContain('�')
+    expect(cursor.offset).toBe(Buffer.byteLength(original, 'utf-8'))
+
+    // Verify offsets are strictly increasing
+    for (let i = 1; i < offsets.length; i++) {
+      expect(offsets[i]).toBeGreaterThan(offsets[i - 1])
+    }
+  })
 })

--- a/crabot-agent/tests/workers/output-log.test.ts
+++ b/crabot-agent/tests/workers/output-log.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { OutputLog } from '../../src/workers/output-log'
+import * as fs from 'fs/promises'
+import * as path from 'path'
+import * as os from 'os'
+
+describe('OutputLog', () => {
+  let tempDir: string
+  let logPath: string
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'output-log-test-'))
+    logPath = path.join(tempDir, 'output.log')
+  })
+
+  afterEach(async () => {
+    try {
+      await fs.rm(tempDir, { recursive: true, force: true })
+    } catch {
+      // ignore cleanup errors
+    }
+  })
+
+  it('should support incremental reads without duplication or loss', async () => {
+    const log = new OutputLog(logPath)
+
+    // Write content
+    await log.append('Hello')
+    await log.append(' ')
+    await log.append('World')
+
+    // First read: get first 5 bytes ("Hello"), use large cap to avoid truncation
+    const read1 = await log.read({ offset: 0 }, 1000)
+    expect(read1.chunk).toBe('Hello World')
+    expect(read1.nextCursor.offset).toBe(11)
+
+    // Second read: continue from offset 11 (end), should get empty chunk
+    const read2 = await log.read(read1.nextCursor)
+    expect(read2.chunk).toBe('')
+    expect(read2.nextCursor.offset).toBe(11)
+  })
+
+  it('should truncate at cap and continue reading with nextCursor', async () => {
+    const log = new OutputLog(logPath)
+
+    // Write content that exceeds cap
+    const largeContent = 'x'.repeat(100) // 100 bytes
+    await log.append(largeContent)
+
+    // First read with cap of 50 bytes
+    const cap = 50
+    const read1 = await log.read({ offset: 0 }, cap)
+
+    // Check that chunk is truncated and includes the truncation marker
+    expect(read1.chunk).toContain('[output truncated at')
+    expect(read1.chunk).toContain('continue reading from cursor]')
+
+    // Extract actual content (before the truncation marker)
+    const contentBeforeTruncation = read1.chunk.split('\n[output truncated')[0]
+    expect(contentBeforeTruncation).toBe('x'.repeat(50))
+
+    // nextCursor should point to actual consumed bytes (50, not including marker)
+    expect(read1.nextCursor.offset).toBe(50)
+
+    // Second read: continue from nextCursor, should get remaining content
+    const read2 = await log.read(read1.nextCursor)
+    expect(read2.chunk).toBe('x'.repeat(50))
+    expect(read2.nextCursor.offset).toBe(100)
+
+    // Third read: already at end
+    const read3 = await log.read(read2.nextCursor)
+    expect(read3.chunk).toBe('')
+    expect(read3.nextCursor.offset).toBe(100)
+  })
+
+  it('should return empty chunk for non-existent file', async () => {
+    const nonExistentPath = path.join(tempDir, 'does-not-exist.log')
+    const log = new OutputLog(nonExistentPath)
+
+    const result = await log.read({ offset: 0 })
+    expect(result.chunk).toBe('')
+    expect(result.nextCursor.offset).toBe(0)
+  })
+})

--- a/crabot-agent/tests/workers/output-log.test.ts
+++ b/crabot-agent/tests/workers/output-log.test.ts
@@ -81,4 +81,56 @@ describe('OutputLog', () => {
     expect(result.chunk).toBe('')
     expect(result.nextCursor.offset).toBe(0)
   })
+
+  it('should not split a multi-byte UTF-8 character when cap boundary falls mid-character', async () => {
+    const log = new OutputLog(logPath)
+
+    // 49 'A' + '中' (3-byte UTF-8) + 'BBBB'; cap=50 lands right in the middle of '中'
+    const original = 'A'.repeat(49) + '中' + 'BBBB'
+    await log.append(original)
+
+    const cap = 50
+    let cursor = { offset: 0 }
+    let assembled = ''
+    let guard = 0
+    while (true) {
+      const { chunk, nextCursor } = await log.read(cursor, cap)
+      const contentBeforeTruncation = chunk.split('\n[output truncated')[0]
+      assembled += contentBeforeTruncation
+      if (nextCursor.offset === cursor.offset) break // no progress => done
+      cursor = nextCursor
+      guard += 1
+      if (guard > 20) throw new Error('read loop did not terminate')
+    }
+
+    expect(assembled).toBe(original)
+    expect(assembled).not.toContain('�')
+    expect(cursor.offset).toBe(Buffer.byteLength(original, 'utf-8'))
+  })
+
+  it('should not split a 4-byte emoji when cap boundary falls mid-character', async () => {
+    const log = new OutputLog(logPath)
+
+    // emoji '🎉' is 4 bytes in UTF-8; place cap boundary inside it
+    const original = 'A'.repeat(48) + '🎉' + 'BBBB'
+    await log.append(original)
+
+    const cap = 50 // 48 'A' bytes + 2 of the 4 emoji bytes = boundary mid-character
+    let cursor = { offset: 0 }
+    let assembled = ''
+    let guard = 0
+    while (true) {
+      const { chunk, nextCursor } = await log.read(cursor, cap)
+      const contentBeforeTruncation = chunk.split('\n[output truncated')[0]
+      assembled += contentBeforeTruncation
+      if (nextCursor.offset === cursor.offset) break
+      cursor = nextCursor
+      guard += 1
+      if (guard > 20) throw new Error('read loop did not terminate')
+    }
+
+    expect(assembled).toBe(original)
+    expect(assembled).not.toContain('�')
+    expect(cursor.offset).toBe(Buffer.byteLength(original, 'utf-8'))
+  })
 })

--- a/crabot-agent/tests/workers/session-tree.test.ts
+++ b/crabot-agent/tests/workers/session-tree.test.ts
@@ -89,4 +89,22 @@ describe('SessionTree', () => {
     const lines = raw.split('\n').filter((l) => l.trim().length > 0)
     expect(lines).toHaveLength(11)
   })
+
+  it('append 非法 parentId(树中不存在的节点) 在锁内同步抛错,不落脏数据', async () => {
+    const filePath = join(tmp, 's.jsonl')
+    const tree = new SessionTree(filePath)
+    await tree.append(null, u('root'))
+
+    await expect(tree.append('不存在的node-id', asst('侧问'))).rejects.toThrow(/unknown parent_id/)
+
+    // 非法 append 没有落盘：文件里仍然只有 root 这一行。
+    const raw = await fs.readFile(filePath, 'utf-8')
+    const lines = raw.split('\n').filter((l) => l.trim().length > 0)
+    expect(lines).toHaveLength(1)
+
+    // 校验没有把 mutex 卡死：后续合法 append 仍然可用。
+    const rootId = tree.latestTip()!
+    const childId = await tree.append(rootId, asst('合法子节点'))
+    expect(tree.pathTo(childId)).toHaveLength(2)
+  })
 })

--- a/crabot-agent/tests/workers/session-tree.test.ts
+++ b/crabot-agent/tests/workers/session-tree.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { promises as fs } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { SessionTree } from '../../src/workers/session-tree'
+import { createUserMessage, createAssistantMessage } from '../../src/engine/types'
+import type { EngineMessage } from '../../src/engine/types'
+
+// 本地 helper：构造 EngineMessage
+function u(text: string): EngineMessage {
+  return createUserMessage(text)
+}
+function asst(text: string): EngineMessage {
+  return createAssistantMessage([{ type: 'text', text }], 'end_turn')
+}
+
+describe('SessionTree', () => {
+  let tmp: string
+
+  beforeEach(async () => {
+    tmp = await fs.mkdtemp(join(tmpdir(), 'session-tree-'))
+  })
+
+  afterEach(async () => {
+    await fs.rm(tmp, { recursive: true, force: true })
+  })
+
+  it('append 链 + pathTo 还原正序消息', async () => {
+    const tree = new SessionTree(join(tmp, 's.jsonl'))
+    const a = await tree.append(null, u('hi'))
+    const b = await tree.append(a, asst('yo'))
+    expect(tree.pathTo(b).map((m) => m.role)).toEqual(['user', 'assistant'])
+    expect(tree.latestTip()).toBe(b)
+  })
+
+  it('分支:同一父节点两个子,两条 pathTo 互不污染', async () => {
+    const tree = new SessionTree(join(tmp, 's.jsonl'))
+    const root = await tree.append(null, u('root'))
+    const branchA = await tree.append(root, asst('branch-a'))
+    const branchB = await tree.append(root, asst('branch-b'))
+
+    const pathA = tree.pathTo(branchA)
+    const pathB = tree.pathTo(branchB)
+
+    expect(pathA).toHaveLength(2)
+    expect(pathB).toHaveLength(2)
+    expect(pathA[1].id).not.toBe(pathB[1].id)
+
+    const lastA = pathA[1]
+    const lastB = pathB[1]
+    expect(lastA.role).toBe('assistant')
+    expect(lastB.role).toBe('assistant')
+    if (lastA.role === 'assistant' && lastB.role === 'assistant') {
+      expect((lastA.content[0] as { type: 'text'; text: string }).text).toBe('branch-a')
+      expect((lastB.content[0] as { type: 'text'; text: string }).text).toBe('branch-b')
+    }
+  })
+
+  it('load 重建:进程重启后 pathTo/latestTip 一致', async () => {
+    const filePath = join(tmp, 's.jsonl')
+    const tree = new SessionTree(filePath)
+    const a = await tree.append(null, u('hi'))
+    const b = await tree.append(a, asst('yo'))
+
+    const reloaded = await SessionTree.load(filePath)
+    expect(reloaded.latestTip()).toBe(b)
+    expect(reloaded.pathTo(b).map((m) => m.role)).toEqual(['user', 'assistant'])
+    expect(reloaded.pathTo(b).map((m) => m.id)).toEqual(tree.pathTo(b).map((m) => m.id))
+  })
+
+  it('append 并发安全(AsyncMutex):10 个并发 append 不丢行', async () => {
+    const filePath = join(tmp, 's.jsonl')
+    const tree = new SessionTree(filePath)
+    const root = await tree.append(null, u('root'))
+
+    const results = await Promise.all(
+      Array.from({ length: 10 }, (_, i) => tree.append(root, asst(`child-${i}`)))
+    )
+
+    // 全部 node_id 唯一
+    expect(new Set(results).size).toBe(10)
+
+    // 重新 load,文件里应有 11 行(root + 10 children),且都能从 tree 里查到
+    const reloaded = await SessionTree.load(filePath)
+    for (const nodeId of results) {
+      expect(reloaded.pathTo(nodeId)).toHaveLength(2)
+    }
+    const raw = await fs.readFile(filePath, 'utf-8')
+    const lines = raw.split('\n').filter((l) => l.trim().length > 0)
+    expect(lines).toHaveLength(11)
+  })
+})


### PR DESCRIPTION
## 概述

Manager/Worker 双 agent 拆分的第一个落地 PR(P1/P8)。**纯新增、未激活**:`src/workers/` 不被任何现网路径 import,engine/ 与 agent-handler.ts 零改动,cutover 前现网行为不变。

- 总体架构 spec:`crabot-docs/superpowers/specs/2026-07-28-manager-worker-agent-split-design.md`
- 协议:`crabot-docs/protocols/protocol-agent-v3.md`(§3/§5/§6,类型逐字对齐)
- 路线图:`crabot-docs/superpowers/plans/2026-07-28-manager-worker-split-roadmap.md`(本 PR = P1)
- 细化 plan:`crabot-docs/superpowers/plans/2026-07-28-mw-p1-worker-contract.md`

## 交付内容

- `src/workers/types.ts`:worker 类终端契约(WorkerAdapter/Incarnation/SpawnSpec 等,protocol-agent-v3 逐字段对齐)
- `src/workers/session-tree.ts`:append-only JSONL session 树,任意节点分支;`pathTo(node)` 直接产出 `RunEngineParams.initialMessages`
- `src/workers/output-log.ts`:输出落盘 + 游标增量读(UTF-8 边界安全,cap 软上限/进展硬保证)
- `src/workers/builtin/adapter.ts`:builtin adapter——burst 状态机(spawn/sendInput/resume/fork/kill/scanOrphans),per-worker AsyncMutex 串行化全部状态迁移,burst 显式 disableCompaction 守护树前缀
- `tests/workers/contract-suite.ts`:实现无关的契约一致性套件,P2 的 claude-code/codex adapter 直接复跑
- 47 个测试用例;全量回归零变红

## 评审过程沉淀(逐 task 独立评审 + 全分支终审)

修复了四类并发竞态(sendInput 双发、burst 收尾窗口、catch 锁外判死、kill 交接窗口 killRequested 闭环)与 resume 幂等提交次序;终审裁决"留"的 Minor 清单(runBurst/runForkBurst 重复、fork 化身 sendInput 排队不消费等)记录在案,P2/P3 按裁决处理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)