### PR TITLE
feat(workers): Manager/Worker 拆分 P2——tmux 驱动与外部 CLI adapter

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,6 +1,12 @@
 # Crabot 项目进度
 
-> 最后更新：2026-07-29 — Manager/Worker 拆分 P1：worker 契约与内置 adapter（PR 待合并）
+> 最后更新：2026-07-29 — Manager/Worker 拆分 P2：tmux 驱动与外部 CLI adapter（PR 待合并）
+
+## 2026-07-29 — Manager/Worker 拆分 P2：tmux 驱动与外部 CLI adapter
+
+- P1（PR #47）当日四轮 auto review 后合并。P2 交付（纯新增未激活）：tmux 驱动层（new-session+pipe-pane 批处理防首输出竞态、send-keys -l 防键名解释）、CLI hook 事件文件通道（纯 POSIX printf 追加 + fs.watch/轮询,无 HTTP 端点）、provision 物化基建（skill 复制/mcp 双格式渲染含 TOML quoted-key/自述文件）、claude-code adapter（--session-id 预知 session_ref、Stop hook 通知、无头 -p --fork-session 侧问、readTrace 解析 projects JSONL）、codex adapter（文档语义实现：CODEX_HOME 隔离、rollout 文件名 session 发现、fork 定案不支持 [openai/codex#11750/#17568]）、契约套件复跑（cc/codex 各 10 例,mock CLI 走真实 tmux）。tests/workers 163 用例。
+- 评审沉淀：P1 锁纪律在 cc adapter 的两处回归被抓（syncState 全段入锁、spawn 提交后置）；安全审查修 session_ref 注入（UUID 边界校验+shQuote 双层）；codex auth.json 0600+gitignore。
+- 已知限制：本机无 codex,其 adapter 待真机校准（8 项清单见执行记录）；协议已同步修正（codex fork=false、通知为事件文件通道,crabot-docs 5e95b20）。
 
 ## 2026-07-29 — Manager/Worker 拆分 P1：worker 契约与内置 adapter
 

--- a/crabot-agent/src/workers/claude-code/adapter.ts
+++ b/crabot-agent/src/workers/claude-code/adapter.ts
@@ -12,6 +12,11 @@
  * CliEventChannel.hookCommand,permissions 预配置 acceptEdits 降弹窗)、.claude/skills/(复用
  * Task 3 的 materializeSkills)、.mcp.json(renderMcpJson)、CLAUDE.md(renderContextMd)。
  *
+ * spawn 提交纪律:tmux newSession 成功之后才落 meta(running)+注册 runtime——newSession 失败
+ * 时不留任何持久痕迹(session_id 可重生成,workspace 内 provision 产物残留可接受),同 worker_id
+ * 可安全重试 spawn。首条输入(sendText)失败:此时已注册的化身按 kill 路径清理 tmux 会话后落
+ * exited(crashed)(不是 killed——这不是用户发起的 kill),不放任 running;spawn 仍然 reject。
+ *
  * state 三源合成,按优先级依次判定(前一源给出确定结果就不再看后一源):
  *   1. 事件文件:自上一次 sendInput(或 spawn)以来出现过新的 'stop' 事件 → idle;
  *   2. tmux isAlive() 为 false → exited(是否 killed 由本地 killed 标记区分 killed/completed);
@@ -20,8 +25,11 @@
  * cc 每答完一轮都会再触发一次 Stop——sendInput 时必须把 baseline 推到当前计数,否则上一轮
  * 遗留的 stop 事件会让新一轮还没答完就被误判成 idle。
  *
- * 每次状态判定若与内存态不同,在该 worker 的互斥锁内原子完成"改内存 + 写 meta"(沿用 P1
- * builtin adapter 的锁纪律),避免并发 state()/sendInput()/kill() 交错写出不一致的 meta。
+ * 状态判定(读事件基线/isAlive)与提交(改内存 + 写 meta)整体在该 worker 的互斥锁内原子完成
+ * (锁按 worker 粒度,不阻塞其他 worker;isAlive 是 tmux 子进程调用,锁内执行可接受)——避免
+ * "判定用的是过期快照,提交时才发现已被另一次并发调用改写"的窗口:两次并发 state() 若只在
+ * 提交这一步加锁,后完成判定的那次会拿着过期快照无条件覆盖先完成的那次刚落的新鲜结果。
+ * 判定与提交现在是同一个不可分割的临界区,保证 exited 终态不可覆盖、也不丢并发更新。
  *
  * sendInput:活会话直接 tmux sendText(cc 自带 steering 队列,不需要我们排队);raw 选项走
  * tmux sendKeys(text 按空白切分成按键名数组,如 "y Enter" → ['y','Enter']);exited 态抛
@@ -163,6 +171,11 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
     const sessionId = randomUUID()
     const sessionName = `crabot-w-${spec.worker_id}-${seq}`
     const outputFile = join(dir, `output-${seq}.log`)
+    const command = `${this.claudeBin} --session-id ${sessionId} --permission-mode acceptEdits`
+
+    // newSession 成功之后才落 meta(running)+注册 runtime:tmux 失败时不留任何持久痕迹
+    // (session_id 可重生成,workspace 内 provision 产物残留可接受),同 worker_id 可安全重试。
+    await this.tmux.newSession({ name: sessionName, cwd: spec.workspace.root, command, outputFile })
 
     const runtime: Runtime = {
       worker_id: spec.worker_id,
@@ -180,11 +193,19 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
     await writeMetaAtomic(dir, seq, { seq, state: 'running', session_id: sessionId })
     this.runtimes.set(instanceKey(handle), runtime)
 
-    const command = `${this.claudeBin} --session-id ${sessionId} --permission-mode acceptEdits`
-    await this.tmux.newSession({ name: sessionName, cwd: spec.workspace.root, command, outputFile })
-
-    // 首条任务输入经 sendText 注入,cc 把它当第一条用户消息。
-    await this.tmux.sendText(sessionName, spec.prompt)
+    // 首条任务输入经 sendText 注入,cc 把它当第一条用户消息。注入失败:session 可能已经起来
+    // 但没喂到任务,不能放任 running——按 kill 路径清理 tmux 会话后落 exited(crashed)(不是
+    // killed,这不是用户发起的 kill),spawn 仍然 reject 把失败如实报给调用方。
+    try {
+      await this.tmux.sendText(sessionName, spec.prompt)
+    } catch (err) {
+      await this.getMutex(handle.worker_id).run(async () => {
+        if (runtime.state === 'exited') return
+        await this.tmux.killSession(sessionName)
+        await this.transitionExited(runtime, handle, 'crashed')
+      })
+      throw err
+    }
 
     return handle
   }
@@ -269,30 +290,33 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
   private async syncState(runtime: Runtime, h: IncarnationHandle): Promise<{ state: WorkerContractState; stopCount: number }> {
     if (runtime.state === 'exited') return { state: 'exited', stopCount: runtime.stopBaseline }
 
-    const events = await runtime.eventChannel.readAll()
-    const stopCount = events.filter((e) => e.kind === 'stop').length
+    return this.getMutex(h.worker_id).run(async () => {
+      // 锁内重读:进锁前 runtime.state 可能已被并发操作(如 kill,或排在前面的另一次
+      // syncState)抢先落定为 exited——终态不可覆盖。
+      if (runtime.state === 'exited') return { state: 'exited', stopCount: runtime.stopBaseline }
 
-    let computed: WorkerContractState
-    if (stopCount > runtime.stopBaseline) {
-      computed = 'idle'
-    } else if (!(await this.tmux.isAlive(runtime.sessionName))) {
-      computed = 'exited'
-    } else {
-      computed = 'running'
-    }
+      const events = await runtime.eventChannel.readAll()
+      const stopCount = events.filter((e) => e.kind === 'stop').length
 
-    if (computed !== runtime.state) {
-      await this.getMutex(h.worker_id).run(async () => {
-        if (runtime.state === 'exited') return // 已被并发操作(如 kill)抢先落定,不覆盖
+      let computed: WorkerContractState
+      if (stopCount > runtime.stopBaseline) {
+        computed = 'idle'
+      } else if (!(await this.tmux.isAlive(runtime.sessionName))) {
+        computed = 'exited'
+      } else {
+        computed = 'running'
+      }
+
+      if (computed !== runtime.state) {
         if (computed === 'exited') {
           await this.transitionExited(runtime, h, runtime.killed ? 'killed' : 'completed')
         } else {
           await this.transitionState(runtime, h, computed)
         }
-      })
-    }
+      }
 
-    return { state: runtime.state, stopCount }
+      return { state: runtime.state, stopCount }
+    })
   }
 
   private getMutex(worker_id: string): AsyncMutex {

--- a/crabot-agent/src/workers/claude-code/adapter.ts
+++ b/crabot-agent/src/workers/claude-code/adapter.ts
@@ -17,8 +17,10 @@
  * exited(crashed)(不是 killed——这不是用户发起的 kill),不放任 running;spawn 仍然 reject。
  *
  * state 三源合成,按优先级依次判定(前一源给出确定结果就不再看后一源):
- *   1. 事件文件:自上一次 sendInput(或 spawn)以来出现过新的 'stop' 事件 → idle;
- *   2. tmux isAlive() 为 false → exited(是否 killed 由本地 killed 标记区分 killed/completed);
+ *   1. tmux isAlive() 为 false → exited(终态优先,是否 killed 由本地 killed 标记区分
+ *      killed/completed)——进程可能在发过 stop 事件之后自退(崩溃/OOM/自敲 exit),必须先判
+ *      isAlive,否则 stop 计数恒大于 baseline 会一直判成 idle,永远走不到这条分支;
+ *   2. 会话还活着时,事件文件:自上一次 sendInput(或 spawn)以来出现过新的 'stop' 事件 → idle;
  *   3. 默认 running。
  * 用"自上次输入以来的 stop 计数"(stopBaseline)而非"是否曾经见过 stop"来判定,是因为
  * cc 每答完一轮都会再触发一次 Stop——sendInput 时必须把 baseline 推到当前计数,否则上一轮
@@ -495,7 +497,8 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
     // nextCursor.offset 是"实际消费到的行号",不是 start + events.length——归一化失败/不认识
     // 的 type(mode/summary/queue-operation 等)不产事件但仍然消费了一行,调用方若用
     // offset += events.length 来推进游标,会在这些被跳过的行上重复读或漏读(P2 review #4,
-    // protocol-agent-v3 §10.3 要求 next_cursor)。
+    // 契约见 protocol-agent-v3 §6.1 WorkerAdapter.readTrace;RPC 层 §8.3 GetWorkerTraceResult
+    // 的 next_cursor 由这个 offset 序列化而来)。
     let consumed = start
     for (let i = start; i < lines.length; i++) {
       const event = normalizeTraceLine(lines[i])
@@ -525,9 +528,9 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
   // --- Internal ---
 
   /**
-   * 三源合成状态判定:事件文件(新 stop → idle) > tmux isAlive(false → exited) > 默认 running。
-   * 与内存态不同则在互斥锁内原子迁移(改内存 + 写 meta)。返回判定结果与本次读到的 stop 计数
-   * (供 sendInput 复用,避免重复读一遍事件文件)。
+   * 三源合成状态判定:tmux isAlive(false → exited,终态优先) > 事件文件(会话还活着时,新
+   * stop → idle) > 默认 running。与内存态不同则在互斥锁内原子迁移(改内存 + 写 meta)。
+   * 返回判定结果与本次读到的 stop 计数(供 sendInput 复用,避免重复读一遍事件文件)。
    */
   private async syncState(runtime: Runtime, h: IncarnationHandle): Promise<{ state: WorkerContractState; stopCount: number }> {
     if (runtime.state === 'exited') return { state: 'exited', stopCount: runtime.stopBaseline }

--- a/crabot-agent/src/workers/claude-code/adapter.ts
+++ b/crabot-agent/src/workers/claude-code/adapter.ts
@@ -149,6 +149,9 @@ interface Runtime {
   /** 自上一次 sendInput(或 spawn)以来"已计入"的 stop 事件数;新 stop 数超过它才判定本轮 idle。 */
   stopBaseline: number
   killed: boolean
+  /** 是否已经被 resume 过一次。resume() 锁内检测"对同一 prev 的重复 resume"(先到先得,
+   * 后来者报错),对齐 builtin 同款语义(P2 review #2)。fork 不受此限制。 */
+  resumed?: boolean
 }
 
 function instanceKey(h: { worker_id: string; seq: number }): string {
@@ -303,15 +306,25 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
 
     const dir = prevRuntime.dir
 
-    // seq 分配(nextSeq(),该 worker 现存所有化身 max seq + 1)+ tmux newSession + 提交
-    // (meta+runtime)整体在该 worker 的互斥锁内原子完成——不能再用 prev.seq+1 这种固定公式:
-    // fork 化身常驻 runtimes 不删,prev.seq+1 可能早被更早一次 fork/resume 占用,继续用它会
-    // 在"已存在"检查上假死(见文件头注释、P2 review #1)。newSession 只是起一个 tmux pane
-    // (不等待 CLI 完整应答),放进锁内不违反"耗时较长操作留在锁外"的纪律——那条纪律是专门
-    // 针对 fork() 的无头子进程调用(等一整轮 CLI 应答,可能耗时较长)定的,见 fork() 注释。
+    // 重复 resume 检测(先到先得)+ seq 分配(nextSeq(),该 worker 现存所有化身 max seq + 1)+
+    // tmux newSession + 提交(meta+runtime+resumed 标记)整体在该 worker 的互斥锁内原子完成:
+    // - nextSeq() 不能再用 prev.seq+1 这种固定公式:fork 化身常驻 runtimes 不删,prev.seq+1
+    //   可能早被更早一次 fork/resume 占用,继续用它会在"已存在"检查上假死(见文件头注释、
+    //   P2 review #1)。newSession 只是起一个 tmux pane(不等待 CLI 完整应答),放进锁内不
+    //   违反"耗时较长操作留在锁外"的纪律——那条纪律是专门针对 fork() 的无头子进程调用
+    //   (等一整轮 CLI 应答,可能耗时较长)定的,见 fork() 注释。
+    // - nextSeq() 修好撞号之后,并发/连续对同一 exited prev 的 resume 各自都能分到不撞号
+    //   的 seq、各起一个 tmux 会话跑 --resume 同一 session_ref——语义上变成了对同一个 cc
+    //   会话的并行续接,不是 resume 想要的语义。对齐 builtin 的 resumed 标记:prev 一旦被
+    //   某次 resume 占用就不能再被 resume,后来者直接报错(不产出第二个化身)。resumed 标记
+    //   必须在 writeMeta 成功之后才提交,保证失败路径(newSession 抛错)幂等可重试:若在
+    //   此之前失败,resumed 仍未被设置,后续重试不会被"已 resume"拒绝(P2 review #2)。
     let handle!: IncarnationHandle
     let runtime!: Runtime
     await this.getMutex(prev.worker_id).run(async () => {
+      if (prevRuntime.resumed) {
+        throw new Error(`ClaudeCodeAdapter.resume: incarnation ${prev.worker_id}#${prev.seq} already resumed (concurrent resume of the same prev incarnation?)`)
+      }
       const seq = this.nextSeq(prev.worker_id)
       handle = { worker_id: prev.worker_id, seq, impl: 'claude-code' }
       const sessionName = `crabot-w-${prev.worker_id}-${seq}`
@@ -341,6 +354,7 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
 
       await writeMetaAtomic(dir, seq, { seq, state: 'running', session_id: prev.session_ref })
       this.runtimes.set(instanceKey(handle), runtime)
+      prevRuntime.resumed = true
     })
 
     // 首条 wakeInput 注入失败:按 spawn 同款纪律处理——已注册的化身清理 tmux 会话后落

--- a/crabot-agent/src/workers/claude-code/adapter.ts
+++ b/crabot-agent/src/workers/claude-code/adapter.ts
@@ -299,49 +299,56 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
       throw new Error(`ClaudeCodeAdapter.resume: incarnation ${prev.worker_id}#${prev.seq} has not exited yet (state=${prevState})`)
     }
 
-    const seq = prev.seq + 1
-    const handle: IncarnationHandle = { worker_id: prev.worker_id, seq, impl: 'claude-code' }
-    if (this.runtimes.has(instanceKey(handle))) {
-      throw new Error(`ClaudeCodeAdapter.resume: worker_id ${prev.worker_id} seq ${seq} already exists in this process`)
-    }
-
     const dir = prevRuntime.dir
-    const sessionName = `crabot-w-${prev.worker_id}-${seq}`
-    const outputFile = join(dir, `output-${seq}.log`)
-    // 不重复传 --permission-mode:provision 阶段已把 acceptEdits 写进 settings.json,覆盖
-    // 命令行没有重复声明的场景(resume 正是这样的场景)。session_ref 是 cc 侧的会话 uuid,
-    // 沿用不变。拼接时用 shQuote 转义 session_ref,防止 shell 注入(双层防御:
-    // 入口已校验 UUID 格式,拼接时再加引号转义,提高防御深度)。
-    const command = `${this.claudeBin} --resume ${shQuote(prev.session_ref)}`
 
-    // 锁纪律与 spawn 一致:tmux newSession 成功之后才落 meta(running)+注册 runtime。
-    await this.tmux.newSession({ name: sessionName, cwd: prevRuntime.workspaceRoot, command, outputFile })
+    // seq 分配(nextSeq(),该 worker 现存所有化身 max seq + 1)+ tmux newSession + 提交
+    // (meta+runtime)整体在该 worker 的互斥锁内原子完成——不能再用 prev.seq+1 这种固定公式:
+    // fork 化身常驻 runtimes 不删,prev.seq+1 可能早被更早一次 fork/resume 占用,继续用它会
+    // 在"已存在"检查上假死(见文件头注释、P2 review #1)。newSession 只是起一个 tmux pane
+    // (不等待 CLI 完整应答),放进锁内不违反"耗时较长操作留在锁外"的纪律——那条纪律是专门
+    // 针对 fork() 的无头子进程调用(等一整轮 CLI 应答,可能耗时较长)定的,见 fork() 注释。
+    let handle!: IncarnationHandle
+    let runtime!: Runtime
+    await this.getMutex(prev.worker_id).run(async () => {
+      const seq = this.nextSeq(prev.worker_id)
+      handle = { worker_id: prev.worker_id, seq, impl: 'claude-code' }
+      const sessionName = `crabot-w-${prev.worker_id}-${seq}`
+      const outputFile = join(dir, `output-${seq}.log`)
+      // 不重复传 --permission-mode:provision 阶段已把 acceptEdits 写进 settings.json,覆盖
+      // 命令行没有重复声明的场景(resume 正是这样的场景)。session_ref 是 cc 侧的会话 uuid,
+      // 沿用不变。拼接时用 shQuote 转义 session_ref,防止 shell 注入(双层防御:
+      // 入口已校验 UUID 格式,拼接时再加引号转义,提高防御深度)。
+      const command = `${this.claudeBin} --resume ${shQuote(prev.session_ref)}`
 
-    const runtime: Runtime = {
-      worker_id: prev.worker_id,
-      seq,
-      dir,
-      workspaceRoot: prevRuntime.workspaceRoot,
-      sessionName,
-      sessionId: prev.session_ref,
-      outputLog: new OutputLog(outputFile),
-      eventChannel: new CliEventChannel(eventsFilePath({ root: prevRuntime.workspaceRoot })),
-      state: 'running',
-      stopBaseline: 0,
-      killed: false,
-    }
+      // 锁纪律与 spawn 一致:tmux newSession 成功之后才落 meta(running)+注册 runtime。
+      await this.tmux.newSession({ name: sessionName, cwd: prevRuntime.workspaceRoot, command, outputFile })
 
-    await writeMetaAtomic(dir, seq, { seq, state: 'running', session_id: prev.session_ref })
-    this.runtimes.set(instanceKey(handle), runtime)
+      runtime = {
+        worker_id: prev.worker_id,
+        seq,
+        dir,
+        workspaceRoot: prevRuntime.workspaceRoot,
+        sessionName,
+        sessionId: prev.session_ref,
+        outputLog: new OutputLog(outputFile),
+        eventChannel: new CliEventChannel(eventsFilePath({ root: prevRuntime.workspaceRoot })),
+        state: 'running',
+        stopBaseline: 0,
+        killed: false,
+      }
+
+      await writeMetaAtomic(dir, seq, { seq, state: 'running', session_id: prev.session_ref })
+      this.runtimes.set(instanceKey(handle), runtime)
+    })
 
     // 首条 wakeInput 注入失败:按 spawn 同款纪律处理——已注册的化身清理 tmux 会话后落
     // exited(crashed)(不是 killed,不是用户发起的 kill),resume 仍然 reject。
     try {
-      await this.tmux.sendText(sessionName, wakeInput)
+      await this.tmux.sendText(runtime.sessionName, wakeInput)
     } catch (err) {
       await this.getMutex(handle.worker_id).run(async () => {
         if (runtime.state === 'exited') return
-        await this.tmux.killSession(sessionName)
+        await this.tmux.killSession(runtime.sessionName)
         await this.transitionExited(runtime, handle, 'crashed')
       })
       throw err
@@ -359,38 +366,35 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
       throw new Error(`ClaudeCodeAdapter.fork: no such incarnation ${prev.worker_id}#${prev.seq} resident in this process`)
     }
 
-    const seq = prev.seq + 1
-    const handle: IncarnationHandle = { worker_id: prev.worker_id, seq, impl: 'claude-code' }
-    if (this.runtimes.has(instanceKey(handle))) {
-      throw new Error(`ClaudeCodeAdapter.fork: worker_id ${prev.worker_id} seq ${seq} already exists in this process`)
-    }
-
     const dir = prevRuntime.dir
-    const outputFile = join(dir, `output-${seq}.log`)
     // cc 的 --fork-session 在其内部生成一个新会话 id,--output-format text 的 stdout 不
     // 携带它,拿不到就拿不到:这里落一个本地占位 uuid,不对应真实 cc 会话文件(已知限制)。
     const sessionId = randomUUID()
 
-    const runtime: Runtime = {
-      worker_id: prev.worker_id,
-      seq,
-      dir,
-      workspaceRoot: prevRuntime.workspaceRoot,
-      sessionName: '',
-      sessionId,
-      outputLog: new OutputLog(outputFile),
-      eventChannel: new CliEventChannel(eventsFilePath({ root: prevRuntime.workspaceRoot })),
-      state: 'running',
-      stopBaseline: 0,
-      killed: false,
-    }
-
-    // 为可观测起见,先提交一段 meta(running)+注册 runtime——与最终提交 exited 一样,都在
-    // per-worker 互斥锁内完成(两次并发 fork 同一 prev 时,后到者会在锁内重新撞见"已存在"
-    // 而拒绝,不会双写同一个 seq)。
+    // seq 分配(nextSeq(),该 worker 现存所有化身 max seq + 1)+ 提交一段 meta(running)+
+    // 注册 runtime 整体在 per-worker 互斥锁内完成——不能再用 prev.seq+1 这种固定公式:fork
+    // 化身常驻 runtimes 不删,对同一个 prev 连续 fork 两次,prev.seq+1 算出来的号位第二次会
+    // 撞上第一次已经占用的那个,而不是真正分配到空位(见文件头注释、P2 review #1)。nextSeq()
+    // 与锁内的注册在同一次 mutex.run 内完成,保证分配即生效,不会被并发的另一次
+    // fork/resume 抢到同一个号位。
+    let handle!: IncarnationHandle
+    let runtime!: Runtime
     await this.getMutex(prev.worker_id).run(async () => {
-      if (this.runtimes.has(instanceKey(handle))) {
-        throw new Error(`ClaudeCodeAdapter.fork: worker_id ${prev.worker_id} seq ${seq} already exists in this process`)
+      const seq = this.nextSeq(prev.worker_id)
+      handle = { worker_id: prev.worker_id, seq, impl: 'claude-code' }
+      const outputFile = join(dir, `output-${seq}.log`)
+      runtime = {
+        worker_id: prev.worker_id,
+        seq,
+        dir,
+        workspaceRoot: prevRuntime.workspaceRoot,
+        sessionName: '',
+        sessionId,
+        outputLog: new OutputLog(outputFile),
+        eventChannel: new CliEventChannel(eventsFilePath({ root: prevRuntime.workspaceRoot })),
+        state: 'running',
+        stopBaseline: 0,
+        killed: false,
       }
       await writeMetaAtomic(dir, seq, { seq, state: 'running', session_id: sessionId })
       this.runtimes.set(instanceKey(handle), runtime)
@@ -559,6 +563,20 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
       this.mutexes.set(worker_id, mutex)
     }
     return mutex
+  }
+
+  /**
+   * worker_id 对应下一个可用的化身序号:该 worker 现存所有化身(主线 + fork 分支 + resume
+   * 链)里最大 seq + 1。resume() 和 fork() 共用这一个分配逻辑,且都在各自的 mutex.run 内
+   * 调用,保证互不撞号(fork 化身常驻不删,不能用 prev.seq+1 这种固定公式——见 fork()/
+   * resume() 注释)。与 builtin adapter 的同名方法同一思路。
+   */
+  private nextSeq(worker_id: string): number {
+    let max = 0
+    for (const runtime of this.runtimes.values()) {
+      if (runtime.worker_id === worker_id && runtime.seq > max) max = runtime.seq
+    }
+    return max + 1
   }
 
   private async transitionState(runtime: Runtime, h: IncarnationHandle, state: WorkerContractState): Promise<void> {

--- a/crabot-agent/src/workers/claude-code/adapter.ts
+++ b/crabot-agent/src/workers/claude-code/adapter.ts
@@ -505,7 +505,13 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
       throw err
     }
 
-    const lines = raw.split('\n').filter((line) => line.length > 0)
+    // 半行纪律(对齐 cli-events.ts watch()):trace 文件由 cc 持续追加、这里懒解析式轮询读取,
+    // 读到写入中途是常态。split 末尾要么是空串(文本以 \n 结尾)要么是尚未写完的半行,两种
+    // 情况都不能当"已消费的完整行"处理——统一 pop 掉,不产事件也不推进 nextCursor,保证
+    // 下次连同补全后的内容重新完整读取该行,不会永久丢事件。
+    const rawLines = raw.split('\n')
+    rawLines.pop()
+    const lines = rawLines.filter((line) => line.length > 0)
     const start = cursor?.offset ?? 0
     const events: NormalizedTraceEvent[] = []
     // nextCursor.offset 是"实际消费到的行号",不是 start + events.length——归一化失败/不认识

--- a/crabot-agent/src/workers/claude-code/adapter.ts
+++ b/crabot-agent/src/workers/claude-code/adapter.ts
@@ -105,6 +105,17 @@ function shQuote(s: string): string {
   return `'${s.replace(/'/g, `'\\''`)}'`
 }
 
+/** UUID 格式校验:标准 UUID 格式(8-4-4-4-12 十六进制段,由连字符分隔)。*/
+function validateSessionRef(sessionRef: string): void {
+  const uuidPattern = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/
+  if (!uuidPattern.test(sessionRef)) {
+    throw new Error(
+      `ClaudeCodeAdapter: invalid session_ref format (expected UUID, got '${sessionRef.slice(0, 50)}'). ` +
+        `session_ref must be a valid UUID and cannot contain shell metacharacters.`,
+    )
+  }
+}
+
 /** sendInput 打到已 exited 的化身时抛出。与 builtin 的同名类语义一致,各自独立定义(不共享 import)。 */
 export class WorkerExitedError extends Error {
   constructor(
@@ -275,6 +286,9 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
   }
 
   async resume(prev: IncarnationRef, wakeInput: string): Promise<IncarnationHandle> {
+    // API 边界校验:session_ref 必须是有效 UUID 格式,防止 shell 注入
+    validateSessionRef(prev.session_ref)
+
     const prevRuntime = this.runtimes.get(instanceKey(prev))
     if (!prevRuntime) {
       throw new Error(`ClaudeCodeAdapter.resume: no such incarnation ${prev.worker_id}#${prev.seq} resident in this process`)
@@ -296,8 +310,9 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
     const outputFile = join(dir, `output-${seq}.log`)
     // 不重复传 --permission-mode:provision 阶段已把 acceptEdits 写进 settings.json,覆盖
     // 命令行没有重复声明的场景(resume 正是这样的场景)。session_ref 是 cc 侧的会话 uuid,
-    // 沿用不变。
-    const command = `${this.claudeBin} --resume ${prev.session_ref}`
+    // 沿用不变。拼接时用 shQuote 转义 session_ref,防止 shell 注入(双层防御:
+    // 入口已校验 UUID 格式,拼接时再加引号转义,提高防御深度)。
+    const command = `${this.claudeBin} --resume ${shQuote(prev.session_ref)}`
 
     // 锁纪律与 spawn 一致:tmux newSession 成功之后才落 meta(running)+注册 runtime。
     await this.tmux.newSession({ name: sessionName, cwd: prevRuntime.workspaceRoot, command, outputFile })
@@ -336,6 +351,9 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
   }
 
   async fork(prev: IncarnationRef, forkInput: string): Promise<IncarnationHandle> {
+    // API 边界校验:session_ref 必须是有效 UUID 格式,防止 shell 注入
+    validateSessionRef(prev.session_ref)
+
     const prevRuntime = this.runtimes.get(instanceKey(prev))
     if (!prevRuntime) {
       throw new Error(`ClaudeCodeAdapter.fork: no such incarnation ${prev.worker_id}#${prev.seq} resident in this process`)

--- a/crabot-agent/src/workers/claude-code/adapter.ts
+++ b/crabot-agent/src/workers/claude-code/adapter.ts
@@ -1,6 +1,5 @@
 /**
- * ClaudeCodeAdapter — WorkerAdapter 契约的 claude-code 实现(spawn/sendInput/state/kill 的
- * 核心生命周期)。resume/fork/readTrace 留给 Task 5,本文件里抛 not-implemented。
+ * ClaudeCodeAdapter — WorkerAdapter 契约的 claude-code 实现。
  *
  * spawn:session_id = randomUUID() 出生即定(即 session_ref);建 <dataDir>/<worker_id>/ 目录;
  * tmux newSession 拉起 `<claudeBin> --session-id <uuid> --permission-mode acceptEdits`,交互态
@@ -39,10 +38,44 @@
  *
  * meta-<seq>.json 布局沿用 P1:{ seq, state, session_id, ended_reason? },写法抽到
  * src/workers/meta-store.ts 共享(不改 builtin 自己的 writeMeta)。
+ *
+ * detect:`<claudeBin> --version`(经 `sh -c` 跑,claudeBin 本就是一段 shell 命令片段——
+ * 与 spawn 把它塞进 tmux pane 命令是同一语义)成功 → installed;activated 看
+ * `dirname(claudeProjectsDir)`(即约定的 `~/.claude/`)下是否有 settings.json 或
+ * .credentials.json,不做任何网络调用。
+ *
+ * resume:先取 prev 化身常驻 runtime(未常驻则报错,P1 同款约束:只能 resume 本进程 spawn 过
+ * 的化身),校验其已 exited(未 exited 直接拒绝)→ 新 tmux 会话跑
+ * `<claudeBin> --resume <prev.session_ref>`(不重复传 --permission-mode,provision 阶段已把
+ * acceptEdits 写进 settings.json 兜底命令行之外的场景)→ seq+1 化身、独立 meta/output、
+ * session_ref 原样透传(cc 侧同一个会话 id)。锁纪律与 spawn 一致:tmux newSession 成功后才
+ * 提交 meta+runtime,首条 wakeInput(sendText)失败按 kill 路径清理并落 exited(crashed)。
+ *
+ * fork(侧问,query_worker 的底座):无头一击,不进 tmux——
+ * `<claudeBin> -p <forkInput> --resume <prev.session_ref> --fork-session --output-format text`
+ * (经 `sh -c` 跑,forkInput/参数逐个 shQuote 转义)子进程 stdout 落到 fork 化身自己的
+ * output-<seq>.log;退出码 0 → exited(completed),非 0 → exited(crashed)。为可观测起见,
+ * 先在 per-worker 互斥锁内提交一段 meta(running)+注册 runtime,子进程本身(可能耗时较长)在
+ * 锁外跑不阻塞同 worker_id 上的其它操作(主线不受影响),跑完后再在锁内提交终态。cc 的
+ * --fork-session 在其内部生成一个新会话 id,但 `--output-format text` 的 stdout 不携带它,
+ * 拿不到就拿不到——fork 化身的 session_id 落一个本地生成的占位 UUID,不对应真实 cc 会话
+ * 文件,该化身自己的 readTrace 会优雅退化为空数组(已知限制,见 Task 5 报告)。
+ *
+ * readTrace:workspace root 经 cc 的 slug 规则(`/`与`.`都替换成`-`)映射到
+ * `<claudeProjectsDir>/<slug>/<session_id>.jsonl`,按行增量解析并归一化——
+ * type=user/assistant → kind message(role 对应,summary 取消息文本截 200);assistant 内的
+ * tool_use content block → kind tool_call;user 记录带 toolUseResult 字段 → kind
+ * tool_result;type=system → kind lifecycle;其余 type(mode/summary/queue-operation 等)跳过。
+ * cursor.offset 是行号(非字节偏移);文件不存在时返回空数组(见下方"与 brief 的偏差")。
+ * 只能对本进程内常驻 runtime 的化身调用——trace 文件路径依赖 workspace root,而这个信息
+ * 只存在于内存 runtime 里,meta.json 不落它。
  */
 import { promises as fs } from 'fs'
-import { join } from 'path'
+import { join, dirname } from 'path'
 import { randomUUID } from 'crypto'
+import { homedir } from 'os'
+import { execFile } from 'child_process'
+import { promisify } from 'util'
 import { TmuxDriver } from '../tmux/driver.js'
 import { CliEventChannel } from '../cli-events.js'
 import { OutputLog } from '../output-log.js'
@@ -65,6 +98,13 @@ import type {
   Workspace,
 } from '../types.js'
 
+const execFileAsync = promisify(execFile)
+
+/** POSIX shell 单引号转义,与 tmux/driver.ts 的私有 shQuote 同款用法(独立复制一份)。 */
+function shQuote(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`
+}
+
 /** sendInput 打到已 exited 的化身时抛出。与 builtin 的同名类语义一致,各自独立定义(不共享 import)。 */
 export class WorkerExitedError extends Error {
   constructor(
@@ -85,6 +125,8 @@ interface Runtime {
   readonly worker_id: string
   readonly seq: number
   readonly dir: string
+  readonly workspaceRoot: string
+  /** tmux 会话名;fork 化身不进 tmux,恒为空串。 */
   readonly sessionName: string
   readonly sessionId: string
   readonly outputLog: OutputLog
@@ -105,6 +147,7 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
 
   private readonly tmux: TmuxDriver
   private readonly claudeBin: string
+  private readonly claudeProjectsDir: string
   private readonly runtimes = new Map<string, Runtime>()
   private readonly mutexes = new Map<string, AsyncMutex>()
 
@@ -113,16 +156,36 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
       readonly dataDir: string
       readonly claudeBin?: string
       readonly tmux?: TmuxDriver
+      /** cc trace 文件根目录,默认 ~/.claude/projects;detect() 的 activated 检查也复用它
+       *(取 dirname 得到 ~/.claude/)。测试用可注入 fixture 目录,不依赖开发机真实 home。 */
+      readonly claudeProjectsDir?: string
       readonly onStateChange?: (h: IncarnationHandle, state: WorkerContractState) => void
     },
   ) {
     this.tmux = deps.tmux ?? new TmuxDriver()
     this.claudeBin = deps.claudeBin ?? 'claude'
+    this.claudeProjectsDir = deps.claudeProjectsDir ?? join(homedir(), '.claude', 'projects')
   }
 
   async detect(): Promise<DetectResult> {
-    // 占位:真实探测(claude 二进制是否存在/是否已登录)留给 Task 5。
-    return { installed: false, activated: false, detail: 'ClaudeCodeAdapter.detect: not implemented until Task 5' }
+    let versionOutput: string
+    try {
+      const { stdout } = await execFileAsync('/bin/sh', ['-c', `${this.claudeBin} --version`])
+      versionOutput = stdout.trim()
+    } catch (err) {
+      return { installed: false, activated: false, detail: `claude binary not found or failed to run: ${(err as Error).message}` }
+    }
+
+    const claudeHomeDir = dirname(this.claudeProjectsDir)
+    let activated = false
+    try {
+      const entries = await fs.readdir(claudeHomeDir)
+      activated = entries.includes('settings.json') || entries.includes('.credentials.json')
+    } catch {
+      activated = false
+    }
+
+    return { installed: true, activated, detail: versionOutput }
   }
 
   async provision(ws: Workspace, caps: CapabilityBundle): Promise<void> {
@@ -181,6 +244,7 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
       worker_id: spec.worker_id,
       seq,
       dir,
+      workspaceRoot: spec.workspace.root,
       sessionName,
       sessionId,
       outputLog: new OutputLog(outputFile),
@@ -210,12 +274,135 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
     return handle
   }
 
-  async resume(_prev: IncarnationRef, _wakeInput: string): Promise<IncarnationHandle> {
-    throw new Error('ClaudeCodeAdapter.resume: not implemented until Task 5')
+  async resume(prev: IncarnationRef, wakeInput: string): Promise<IncarnationHandle> {
+    const prevRuntime = this.runtimes.get(instanceKey(prev))
+    if (!prevRuntime) {
+      throw new Error(`ClaudeCodeAdapter.resume: no such incarnation ${prev.worker_id}#${prev.seq} resident in this process`)
+    }
+    const prevHandle: IncarnationHandle = { worker_id: prev.worker_id, seq: prev.seq, impl: 'claude-code' }
+    const { state: prevState } = await this.syncState(prevRuntime, prevHandle)
+    if (prevState !== 'exited') {
+      throw new Error(`ClaudeCodeAdapter.resume: incarnation ${prev.worker_id}#${prev.seq} has not exited yet (state=${prevState})`)
+    }
+
+    const seq = prev.seq + 1
+    const handle: IncarnationHandle = { worker_id: prev.worker_id, seq, impl: 'claude-code' }
+    if (this.runtimes.has(instanceKey(handle))) {
+      throw new Error(`ClaudeCodeAdapter.resume: worker_id ${prev.worker_id} seq ${seq} already exists in this process`)
+    }
+
+    const dir = prevRuntime.dir
+    const sessionName = `crabot-w-${prev.worker_id}-${seq}`
+    const outputFile = join(dir, `output-${seq}.log`)
+    // 不重复传 --permission-mode:provision 阶段已把 acceptEdits 写进 settings.json,覆盖
+    // 命令行没有重复声明的场景(resume 正是这样的场景)。session_ref 是 cc 侧的会话 uuid,
+    // 沿用不变。
+    const command = `${this.claudeBin} --resume ${prev.session_ref}`
+
+    // 锁纪律与 spawn 一致:tmux newSession 成功之后才落 meta(running)+注册 runtime。
+    await this.tmux.newSession({ name: sessionName, cwd: prevRuntime.workspaceRoot, command, outputFile })
+
+    const runtime: Runtime = {
+      worker_id: prev.worker_id,
+      seq,
+      dir,
+      workspaceRoot: prevRuntime.workspaceRoot,
+      sessionName,
+      sessionId: prev.session_ref,
+      outputLog: new OutputLog(outputFile),
+      eventChannel: new CliEventChannel(eventsFilePath({ root: prevRuntime.workspaceRoot })),
+      state: 'running',
+      stopBaseline: 0,
+      killed: false,
+    }
+
+    await writeMetaAtomic(dir, seq, { seq, state: 'running', session_id: prev.session_ref })
+    this.runtimes.set(instanceKey(handle), runtime)
+
+    // 首条 wakeInput 注入失败:按 spawn 同款纪律处理——已注册的化身清理 tmux 会话后落
+    // exited(crashed)(不是 killed,不是用户发起的 kill),resume 仍然 reject。
+    try {
+      await this.tmux.sendText(sessionName, wakeInput)
+    } catch (err) {
+      await this.getMutex(handle.worker_id).run(async () => {
+        if (runtime.state === 'exited') return
+        await this.tmux.killSession(sessionName)
+        await this.transitionExited(runtime, handle, 'crashed')
+      })
+      throw err
+    }
+
+    return handle
   }
 
-  async fork(_prev: IncarnationRef, _forkInput: string): Promise<IncarnationHandle> {
-    throw new Error('ClaudeCodeAdapter.fork: not implemented until Task 5')
+  async fork(prev: IncarnationRef, forkInput: string): Promise<IncarnationHandle> {
+    const prevRuntime = this.runtimes.get(instanceKey(prev))
+    if (!prevRuntime) {
+      throw new Error(`ClaudeCodeAdapter.fork: no such incarnation ${prev.worker_id}#${prev.seq} resident in this process`)
+    }
+
+    const seq = prev.seq + 1
+    const handle: IncarnationHandle = { worker_id: prev.worker_id, seq, impl: 'claude-code' }
+    if (this.runtimes.has(instanceKey(handle))) {
+      throw new Error(`ClaudeCodeAdapter.fork: worker_id ${prev.worker_id} seq ${seq} already exists in this process`)
+    }
+
+    const dir = prevRuntime.dir
+    const outputFile = join(dir, `output-${seq}.log`)
+    // cc 的 --fork-session 在其内部生成一个新会话 id,--output-format text 的 stdout 不
+    // 携带它,拿不到就拿不到:这里落一个本地占位 uuid,不对应真实 cc 会话文件(已知限制)。
+    const sessionId = randomUUID()
+
+    const runtime: Runtime = {
+      worker_id: prev.worker_id,
+      seq,
+      dir,
+      workspaceRoot: prevRuntime.workspaceRoot,
+      sessionName: '',
+      sessionId,
+      outputLog: new OutputLog(outputFile),
+      eventChannel: new CliEventChannel(eventsFilePath({ root: prevRuntime.workspaceRoot })),
+      state: 'running',
+      stopBaseline: 0,
+      killed: false,
+    }
+
+    // 为可观测起见,先提交一段 meta(running)+注册 runtime——与最终提交 exited 一样,都在
+    // per-worker 互斥锁内完成(两次并发 fork 同一 prev 时,后到者会在锁内重新撞见"已存在"
+    // 而拒绝,不会双写同一个 seq)。
+    await this.getMutex(prev.worker_id).run(async () => {
+      if (this.runtimes.has(instanceKey(handle))) {
+        throw new Error(`ClaudeCodeAdapter.fork: worker_id ${prev.worker_id} seq ${seq} already exists in this process`)
+      }
+      await writeMetaAtomic(dir, seq, { seq, state: 'running', session_id: sessionId })
+      this.runtimes.set(instanceKey(handle), runtime)
+    })
+
+    // 无头一击,不进 tmux:子进程在锁外跑(可能耗时较长),不阻塞同 worker_id 上其它操作
+    // (主线不受影响)。claudeBin 与 spawn/resume 同款语义——一段 shell 命令片段,经 sh -c
+    // 跑;forkInput 与其它参数逐个 shQuote 转义,防止内容里的 shell 元字符注入。
+    const args = ['-p', forkInput, '--resume', prev.session_ref, '--fork-session', '--output-format', 'text']
+    const shellCommand = `${this.claudeBin} ${args.map(shQuote).join(' ')}`
+
+    let stdout = ''
+    let endedReason: IncarnationEndReason
+    try {
+      const result = await execFileAsync('/bin/sh', ['-c', shellCommand], { cwd: prevRuntime.workspaceRoot })
+      stdout = result.stdout
+      endedReason = 'completed'
+    } catch (err) {
+      stdout = (err as { stdout?: string }).stdout ?? ''
+      endedReason = 'crashed'
+    }
+
+    if (stdout) await runtime.outputLog.append(stdout)
+
+    await this.getMutex(prev.worker_id).run(async () => {
+      if (runtime.state === 'exited') return // 幂等兜底
+      await this.transitionExited(runtime, handle, endedReason)
+    })
+
+    return handle
   }
 
   async sendInput(h: IncarnationHandle, text: string, opts?: { raw?: boolean }): Promise<void> {
@@ -259,8 +446,36 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
     return (await this.syncState(runtime, h)).state
   }
 
-  async readTrace(_h: IncarnationHandle, _cursor?: TraceCursor): Promise<NormalizedTraceEvent[]> {
-    throw new Error('ClaudeCodeAdapter.readTrace: not implemented until Task 5')
+  async readTrace(h: IncarnationHandle, cursor?: TraceCursor): Promise<NormalizedTraceEvent[]> {
+    const runtime = this.runtimes.get(instanceKey(h))
+    if (!runtime) {
+      // trace 文件路径依赖 workspace root,这个信息只存在于内存 runtime 里(meta.json 不落
+      // 它),不像 readOutput 那样有约定路径可以脱离内存重建。
+      throw new Error(`ClaudeCodeAdapter.readTrace: no such incarnation ${h.worker_id}#${h.seq} resident in this process`)
+    }
+
+    const slug = projectSlug(runtime.workspaceRoot)
+    const filePath = join(this.claudeProjectsDir, slug, `${runtime.sessionId}.jsonl`)
+
+    let raw: string
+    try {
+      raw = await fs.readFile(filePath, 'utf-8')
+    } catch (err) {
+      // 契约(types.ts)里 readTrace 只返回 NormalizedTraceEvent[],没有 unavailable_reason
+      // 的位置——文件缺失(化身还没写过 trace,或 fork 化身的占位 session_id 本就对不上真实
+      // 文件)退化为空数组。
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return []
+      throw err
+    }
+
+    const lines = raw.split('\n').filter((line) => line.length > 0)
+    const start = cursor?.offset ?? 0
+    const events: NormalizedTraceEvent[] = []
+    for (let i = start; i < lines.length; i++) {
+      const event = normalizeTraceLine(lines[i])
+      if (event) events.push(event)
+    }
+    return events
   }
 
   async kill(h: IncarnationHandle): Promise<void> {
@@ -360,4 +575,75 @@ function workerIdLabelFromWorkspace(ws: Workspace): string {
   const trimmed = ws.root.replace(/\/+$/, '')
   const idx = trimmed.lastIndexOf('/')
   return idx >= 0 ? trimmed.slice(idx + 1) : trimmed
+}
+
+/** cc 的 project 目录 slug 规则:cwd 路径里的 `/` 与 `.` 都替换成 `-`(已用真实 ~/.claude/projects/ 核实)。 */
+function projectSlug(cwd: string): string {
+  return cwd.replace(/[/.]/g, '-')
+}
+
+function truncate(text: string, max: number): string {
+  return text.length > max ? text.slice(0, max) : text
+}
+
+/** message.content 既可能是纯字符串,也可能是 content block 数组;后者只取 text 块拼接,跳过 thinking/tool_use/tool_result。 */
+function extractMessageText(content: unknown): string {
+  if (typeof content === 'string') return content
+  if (Array.isArray(content)) {
+    return content
+      .filter((block): block is { type: string; text?: string } => !!block && typeof block === 'object' && (block as { type?: unknown }).type === 'text')
+      .map((block) => block.text ?? '')
+      .join('\n')
+  }
+  return ''
+}
+
+/**
+ * 归一化单行 cc trace JSONL 为 NormalizedTraceEvent;不认识的行(JSON 解析失败、或
+ * type 不在 user/assistant/system 之内,如 mode/summary/queue-operation 等)返回 null 跳过。
+ */
+function normalizeTraceLine(line: string): NormalizedTraceEvent | null {
+  let parsed: Record<string, unknown>
+  try {
+    parsed = JSON.parse(line)
+  } catch {
+    return null
+  }
+  if (!parsed || typeof parsed !== 'object') return null
+  const ts = typeof parsed.timestamp === 'string' ? parsed.timestamp : ''
+
+  if (parsed.type === 'system') {
+    const summary = typeof parsed.content === 'string' ? truncate(parsed.content, 200) : String(parsed.subtype ?? 'system')
+    return { ts, kind: 'lifecycle', role: 'system', summary, detail: parsed }
+  }
+
+  if (parsed.type === 'user') {
+    if ('toolUseResult' in parsed) {
+      const result = parsed.toolUseResult
+      const summary = truncate(typeof result === 'string' ? result : JSON.stringify(result ?? {}), 200)
+      return { ts, kind: 'tool_result', role: 'user', summary, detail: result }
+    }
+    const message = parsed.message as { content?: unknown } | undefined
+    const text = extractMessageText(message?.content)
+    return { ts, kind: 'message', role: 'user', summary: truncate(text, 200), detail: message }
+  }
+
+  if (parsed.type === 'assistant') {
+    const message = parsed.message as { content?: unknown } | undefined
+    const content = message?.content
+    if (Array.isArray(content)) {
+      const toolUse = content.find(
+        (block): block is { type: 'tool_use'; name: string; input?: unknown } =>
+          !!block && typeof block === 'object' && (block as { type?: unknown }).type === 'tool_use',
+      )
+      if (toolUse) {
+        const summary = truncate(`${toolUse.name}(${JSON.stringify(toolUse.input ?? {})})`, 200)
+        return { ts, kind: 'tool_call', role: 'assistant', summary, detail: toolUse }
+      }
+    }
+    const text = extractMessageText(content)
+    return { ts, kind: 'message', role: 'assistant', summary: truncate(text, 200), detail: message }
+  }
+
+  return null
 }

--- a/crabot-agent/src/workers/claude-code/adapter.ts
+++ b/crabot-agent/src/workers/claude-code/adapter.ts
@@ -1,0 +1,339 @@
+/**
+ * ClaudeCodeAdapter — WorkerAdapter 契约的 claude-code 实现(spawn/sendInput/state/kill 的
+ * 核心生命周期)。resume/fork/readTrace 留给 Task 5,本文件里抛 not-implemented。
+ *
+ * spawn:session_id = randomUUID() 出生即定(即 session_ref);建 <dataDir>/<worker_id>/ 目录;
+ * tmux newSession 拉起 `<claudeBin> --session-id <uuid> --permission-mode acceptEdits`,交互态
+ * 跑在 tmux pane 里,cwd=workspace,pane 输出经 tmux pipe-pane 落 output-<seq>.log;meta 落盘为
+ * running;首条任务输入(spec.prompt)经 tmux sendText 注入(cc 把它当第一条用户消息)。
+ *
+ * provision:与 spawn 分离的独立步骤(WorkerAdapter 契约本就是两个方法),由调用方在 spawn 前
+ * 调用一次,把 workspace 布好——.claude/settings.json(Stop/Notification hook 接到
+ * CliEventChannel.hookCommand,permissions 预配置 acceptEdits 降弹窗)、.claude/skills/(复用
+ * Task 3 的 materializeSkills)、.mcp.json(renderMcpJson)、CLAUDE.md(renderContextMd)。
+ *
+ * state 三源合成,按优先级依次判定(前一源给出确定结果就不再看后一源):
+ *   1. 事件文件:自上一次 sendInput(或 spawn)以来出现过新的 'stop' 事件 → idle;
+ *   2. tmux isAlive() 为 false → exited(是否 killed 由本地 killed 标记区分 killed/completed);
+ *   3. 默认 running。
+ * 用"自上次输入以来的 stop 计数"(stopBaseline)而非"是否曾经见过 stop"来判定,是因为
+ * cc 每答完一轮都会再触发一次 Stop——sendInput 时必须把 baseline 推到当前计数,否则上一轮
+ * 遗留的 stop 事件会让新一轮还没答完就被误判成 idle。
+ *
+ * 每次状态判定若与内存态不同,在该 worker 的互斥锁内原子完成"改内存 + 写 meta"(沿用 P1
+ * builtin adapter 的锁纪律),避免并发 state()/sendInput()/kill() 交错写出不一致的 meta。
+ *
+ * sendInput:活会话直接 tmux sendText(cc 自带 steering 队列,不需要我们排队);raw 选项走
+ * tmux sendKeys(text 按空白切分成按键名数组,如 "y Enter" → ['y','Enter']);exited 态抛
+ * WorkerExitedError(与 builtin 同名同语义的独立类,不 import builtin)。
+ *
+ * kill:tmux killSession → exited(killed),幂等(已 exited 直接返回,不覆盖原 ended_reason)。
+ *
+ * meta-<seq>.json 布局沿用 P1:{ seq, state, session_id, ended_reason? },写法抽到
+ * src/workers/meta-store.ts 共享(不改 builtin 自己的 writeMeta)。
+ */
+import { promises as fs } from 'fs'
+import { join } from 'path'
+import { randomUUID } from 'crypto'
+import { TmuxDriver } from '../tmux/driver.js'
+import { CliEventChannel } from '../cli-events.js'
+import { OutputLog } from '../output-log.js'
+import { AsyncMutex } from '../async-mutex.js'
+import { writeMetaAtomic } from '../meta-store.js'
+import { materializeSkills, renderMcpJson, renderContextMd, type ProvisionSources } from '../provision/materialize.js'
+import type {
+  AdapterCapabilities,
+  CapabilityBundle,
+  DetectResult,
+  IncarnationEndReason,
+  IncarnationHandle,
+  IncarnationRef,
+  NormalizedTraceEvent,
+  OutputCursor,
+  SpawnSpec,
+  TraceCursor,
+  WorkerAdapter,
+  WorkerContractState,
+  Workspace,
+} from '../types.js'
+
+/** sendInput 打到已 exited 的化身时抛出。与 builtin 的同名类语义一致,各自独立定义(不共享 import)。 */
+export class WorkerExitedError extends Error {
+  constructor(
+    readonly worker_id: string,
+    readonly seq: number,
+  ) {
+    super(`ClaudeCodeAdapter: incarnation ${worker_id}#${seq} has exited`)
+    this.name = 'WorkerExitedError'
+  }
+}
+
+/** hook 事件文件路径约定:workspace 内 .claude/events-cli.jsonl。provision 与 spawn 都按此约定定位,保持一致。 */
+export function eventsFilePath(ws: Workspace): string {
+  return join(ws.root, '.claude', 'events-cli.jsonl')
+}
+
+interface Runtime {
+  readonly worker_id: string
+  readonly seq: number
+  readonly dir: string
+  readonly sessionName: string
+  readonly sessionId: string
+  readonly outputLog: OutputLog
+  readonly eventChannel: CliEventChannel
+  state: WorkerContractState
+  ended_reason?: IncarnationEndReason
+  /** 自上一次 sendInput(或 spawn)以来"已计入"的 stop 事件数;新 stop 数超过它才判定本轮 idle。 */
+  stopBaseline: number
+  killed: boolean
+}
+
+function instanceKey(h: { worker_id: string; seq: number }): string {
+  return `${h.worker_id}#${h.seq}`
+}
+
+export class ClaudeCodeAdapter implements WorkerAdapter {
+  readonly implId = 'claude-code' as const
+
+  private readonly tmux: TmuxDriver
+  private readonly claudeBin: string
+  private readonly runtimes = new Map<string, Runtime>()
+  private readonly mutexes = new Map<string, AsyncMutex>()
+
+  constructor(
+    private readonly deps: {
+      readonly dataDir: string
+      readonly claudeBin?: string
+      readonly tmux?: TmuxDriver
+      readonly onStateChange?: (h: IncarnationHandle, state: WorkerContractState) => void
+    },
+  ) {
+    this.tmux = deps.tmux ?? new TmuxDriver()
+    this.claudeBin = deps.claudeBin ?? 'claude'
+  }
+
+  async detect(): Promise<DetectResult> {
+    // 占位:真实探测(claude 二进制是否存在/是否已登录)留给 Task 5。
+    return { installed: false, activated: false, detail: 'ClaudeCodeAdapter.detect: not implemented until Task 5' }
+  }
+
+  async provision(ws: Workspace, caps: CapabilityBundle): Promise<void> {
+    const claudeDir = join(ws.root, '.claude')
+    // hook 写入目录必须先 mkdir——printf >> 对缺目录静默失败(Task 2 评审裁决)。
+    await fs.mkdir(claudeDir, { recursive: true })
+
+    const channel = new CliEventChannel(eventsFilePath(ws))
+    const settings = {
+      hooks: {
+        Stop: [{ hooks: [{ type: 'command', command: channel.hookCommand('stop') }] }],
+        Notification: [{ hooks: [{ type: 'command', command: channel.hookCommand('notification') }] }],
+      },
+      // --permission-mode acceptEdits 已在命令行传了,这里在 settings.json 里重复声明一份,
+      // 覆盖命令行参数之外(如未来 --resume)也走同一降弹窗策略的场景。
+      permissions: { defaultMode: 'acceptEdits' },
+    }
+    await fs.writeFile(join(claudeDir, 'settings.json'), JSON.stringify(settings, null, 2) + '\n', 'utf-8')
+
+    await materializeSkills(ws.root, caps.skills, '.claude/skills')
+
+    const mcpServers = caps.mcp_servers as unknown as ProvisionSources['mcpServers']
+    await fs.writeFile(join(ws.root, '.mcp.json'), renderMcpJson(mcpServers), 'utf-8')
+
+    await fs.writeFile(
+      join(ws.root, 'CLAUDE.md'),
+      renderContextMd({
+        workerId: workerIdLabelFromWorkspace(ws),
+        taskTitle: 'Crabot Worker Task',
+        disciplines: '中间产物统一写入工作区内,不要写到工作区之外的路径。',
+      }),
+      'utf-8',
+    )
+  }
+
+  async spawn(spec: SpawnSpec): Promise<IncarnationHandle> {
+    const seq = 1
+    const handle: IncarnationHandle = { worker_id: spec.worker_id, seq, impl: 'claude-code' }
+    if (this.runtimes.has(instanceKey(handle))) {
+      throw new Error(`ClaudeCodeAdapter.spawn: worker_id ${spec.worker_id} already spawned in this process`)
+    }
+
+    const dir = join(this.deps.dataDir, spec.worker_id)
+    await fs.mkdir(dir, { recursive: true })
+
+    const sessionId = randomUUID()
+    const sessionName = `crabot-w-${spec.worker_id}-${seq}`
+    const outputFile = join(dir, `output-${seq}.log`)
+
+    const runtime: Runtime = {
+      worker_id: spec.worker_id,
+      seq,
+      dir,
+      sessionName,
+      sessionId,
+      outputLog: new OutputLog(outputFile),
+      eventChannel: new CliEventChannel(eventsFilePath(spec.workspace)),
+      state: 'running',
+      stopBaseline: 0,
+      killed: false,
+    }
+
+    await writeMetaAtomic(dir, seq, { seq, state: 'running', session_id: sessionId })
+    this.runtimes.set(instanceKey(handle), runtime)
+
+    const command = `${this.claudeBin} --session-id ${sessionId} --permission-mode acceptEdits`
+    await this.tmux.newSession({ name: sessionName, cwd: spec.workspace.root, command, outputFile })
+
+    // 首条任务输入经 sendText 注入,cc 把它当第一条用户消息。
+    await this.tmux.sendText(sessionName, spec.prompt)
+
+    return handle
+  }
+
+  async resume(_prev: IncarnationRef, _wakeInput: string): Promise<IncarnationHandle> {
+    throw new Error('ClaudeCodeAdapter.resume: not implemented until Task 5')
+  }
+
+  async fork(_prev: IncarnationRef, _forkInput: string): Promise<IncarnationHandle> {
+    throw new Error('ClaudeCodeAdapter.fork: not implemented until Task 5')
+  }
+
+  async sendInput(h: IncarnationHandle, text: string, opts?: { raw?: boolean }): Promise<void> {
+    const runtime = this.runtimes.get(instanceKey(h))
+    if (!runtime) {
+      throw new Error(`ClaudeCodeAdapter.sendInput: no such incarnation ${h.worker_id}#${h.seq} resident in this process`)
+    }
+
+    const { state: current, stopCount } = await this.syncState(runtime, h)
+    if (current === 'exited') throw new WorkerExitedError(h.worker_id, h.seq)
+
+    // 新一轮开始:把 baseline 推到当前 stop 计数,上一轮遗留的 stop 事件不会被误算进新一轮。
+    runtime.stopBaseline = stopCount
+
+    if (opts?.raw) {
+      const keys = text.split(/\s+/).filter((k) => k.length > 0)
+      await this.tmux.sendKeys(runtime.sessionName, keys)
+    } else {
+      await this.tmux.sendText(runtime.sessionName, text)
+    }
+
+    await this.getMutex(h.worker_id).run(async () => {
+      if (runtime.state !== 'exited') await this.transitionState(runtime, h, 'running')
+    })
+  }
+
+  async readOutput(h: IncarnationHandle, cursor: OutputCursor): Promise<{ chunk: string; nextCursor: OutputCursor }> {
+    const runtime = this.runtimes.get(instanceKey(h))
+    const outputLog = runtime ? runtime.outputLog : new OutputLog(join(this.deps.dataDir, h.worker_id, `output-${h.seq}.log`))
+    return outputLog.read(cursor)
+  }
+
+  async state(h: IncarnationHandle): Promise<WorkerContractState> {
+    const runtime = this.runtimes.get(instanceKey(h))
+    if (!runtime) {
+      const metaPath = join(this.deps.dataDir, h.worker_id, `meta-${h.seq}.json`)
+      const raw = await fs.readFile(metaPath, 'utf-8')
+      const meta = JSON.parse(raw) as { state: WorkerContractState }
+      return meta.state
+    }
+    return (await this.syncState(runtime, h)).state
+  }
+
+  async readTrace(_h: IncarnationHandle, _cursor?: TraceCursor): Promise<NormalizedTraceEvent[]> {
+    throw new Error('ClaudeCodeAdapter.readTrace: not implemented until Task 5')
+  }
+
+  async kill(h: IncarnationHandle): Promise<void> {
+    const runtime = this.runtimes.get(instanceKey(h))
+    if (!runtime) {
+      throw new Error(`ClaudeCodeAdapter.kill: no such incarnation ${h.worker_id}#${h.seq} resident in this process`)
+    }
+    await this.getMutex(h.worker_id).run(async () => {
+      if (runtime.state === 'exited') return // 幂等:不覆盖原 ended_reason
+      runtime.killed = true
+      await this.tmux.killSession(runtime.sessionName)
+      await this.transitionExited(runtime, h, 'killed')
+    })
+  }
+
+  capabilities(): AdapterCapabilities {
+    return { fork: true, revive: true, goalMode: false, subagent: false, structuredTrace: true }
+  }
+
+  // --- Internal ---
+
+  /**
+   * 三源合成状态判定:事件文件(新 stop → idle) > tmux isAlive(false → exited) > 默认 running。
+   * 与内存态不同则在互斥锁内原子迁移(改内存 + 写 meta)。返回判定结果与本次读到的 stop 计数
+   * (供 sendInput 复用,避免重复读一遍事件文件)。
+   */
+  private async syncState(runtime: Runtime, h: IncarnationHandle): Promise<{ state: WorkerContractState; stopCount: number }> {
+    if (runtime.state === 'exited') return { state: 'exited', stopCount: runtime.stopBaseline }
+
+    const events = await runtime.eventChannel.readAll()
+    const stopCount = events.filter((e) => e.kind === 'stop').length
+
+    let computed: WorkerContractState
+    if (stopCount > runtime.stopBaseline) {
+      computed = 'idle'
+    } else if (!(await this.tmux.isAlive(runtime.sessionName))) {
+      computed = 'exited'
+    } else {
+      computed = 'running'
+    }
+
+    if (computed !== runtime.state) {
+      await this.getMutex(h.worker_id).run(async () => {
+        if (runtime.state === 'exited') return // 已被并发操作(如 kill)抢先落定,不覆盖
+        if (computed === 'exited') {
+          await this.transitionExited(runtime, h, runtime.killed ? 'killed' : 'completed')
+        } else {
+          await this.transitionState(runtime, h, computed)
+        }
+      })
+    }
+
+    return { state: runtime.state, stopCount }
+  }
+
+  private getMutex(worker_id: string): AsyncMutex {
+    let mutex = this.mutexes.get(worker_id)
+    if (!mutex) {
+      mutex = new AsyncMutex()
+      this.mutexes.set(worker_id, mutex)
+    }
+    return mutex
+  }
+
+  private async transitionState(runtime: Runtime, h: IncarnationHandle, state: WorkerContractState): Promise<void> {
+    await writeMetaAtomic(runtime.dir, runtime.seq, { seq: runtime.seq, state, session_id: runtime.sessionId })
+    runtime.state = state
+    try {
+      this.deps.onStateChange?.(h, state)
+    } catch (err) {
+      console.error(`[ClaudeCodeAdapter] onStateChange callback error for ${h.worker_id}#${h.seq}:`, err)
+    }
+  }
+
+  private async transitionExited(runtime: Runtime, h: IncarnationHandle, ended_reason: IncarnationEndReason): Promise<void> {
+    await writeMetaAtomic(runtime.dir, runtime.seq, {
+      seq: runtime.seq,
+      state: 'exited',
+      session_id: runtime.sessionId,
+      ended_reason,
+    })
+    runtime.state = 'exited'
+    runtime.ended_reason = ended_reason
+    try {
+      this.deps.onStateChange?.(h, 'exited')
+    } catch (err) {
+      console.error(`[ClaudeCodeAdapter] onStateChange callback error for ${h.worker_id}#${h.seq}:`, err)
+    }
+  }
+}
+
+/** CLAUDE.md 里标注的 worker 标签:provision(ws, caps) 拿不到 worker_id,退而取 workspace 目录名兜底。 */
+function workerIdLabelFromWorkspace(ws: Workspace): string {
+  const trimmed = ws.root.replace(/\/+$/, '')
+  const idx = trimmed.lastIndexOf('/')
+  return idx >= 0 ? trimmed.slice(idx + 1) : trimmed
+}

--- a/crabot-agent/src/workers/claude-code/adapter.ts
+++ b/crabot-agent/src/workers/claude-code/adapter.ts
@@ -535,11 +535,15 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
       const events = await runtime.eventChannel.readAll()
       const stopCount = events.filter((e) => e.kind === 'stop').length
 
+      // isAlive 检查提到最前(终态优先):进程可能在发过 stop 事件之后自退(崩溃/OOM/自敲
+      // exit)——stopCount 恒 > baseline 会一直判成 idle,永远走不到下面的 isAlive 分支,
+      // 化身不落 exited,resume 被永久拒绝(P2 review #2)。会话已经不在了就直接 exited,
+      // 不管有没有新 stop 事件;只有会话还活着,才轮到 stop 事件区分 idle/running。
       let computed: WorkerContractState
-      if (stopCount > runtime.stopBaseline) {
-        computed = 'idle'
-      } else if (!(await this.tmux.isAlive(runtime.sessionName))) {
+      if (!(await this.tmux.isAlive(runtime.sessionName))) {
         computed = 'exited'
+      } else if (stopCount > runtime.stopBaseline) {
+        computed = 'idle'
       } else {
         computed = 'running'
       }

--- a/crabot-agent/src/workers/claude-code/adapter.ts
+++ b/crabot-agent/src/workers/claude-code/adapter.ts
@@ -468,7 +468,7 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
     return (await this.syncState(runtime, h)).state
   }
 
-  async readTrace(h: IncarnationHandle, cursor?: TraceCursor): Promise<NormalizedTraceEvent[]> {
+  async readTrace(h: IncarnationHandle, cursor?: TraceCursor): Promise<{ events: NormalizedTraceEvent[]; nextCursor: TraceCursor }> {
     const runtime = this.runtimes.get(instanceKey(h))
     if (!runtime) {
       // trace 文件路径依赖 workspace root,这个信息只存在于内存 runtime 里(meta.json 不落
@@ -483,21 +483,26 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
     try {
       raw = await fs.readFile(filePath, 'utf-8')
     } catch (err) {
-      // 契约(types.ts)里 readTrace 只返回 NormalizedTraceEvent[],没有 unavailable_reason
-      // 的位置——文件缺失(化身还没写过 trace,或 fork 化身的占位 session_id 本就对不上真实
-      // 文件)退化为空数组。
-      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return []
+      // 文件缺失(化身还没写过 trace,或 fork 化身的占位 session_id 本就对不上真实文件)
+      // 退化为空数组,cursor 原样透传——没有新内容可消费,调用方下次仍从原位置续读。
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return { events: [], nextCursor: cursor ?? { offset: 0 } }
       throw err
     }
 
     const lines = raw.split('\n').filter((line) => line.length > 0)
     const start = cursor?.offset ?? 0
     const events: NormalizedTraceEvent[] = []
+    // nextCursor.offset 是"实际消费到的行号",不是 start + events.length——归一化失败/不认识
+    // 的 type(mode/summary/queue-operation 等)不产事件但仍然消费了一行,调用方若用
+    // offset += events.length 来推进游标,会在这些被跳过的行上重复读或漏读(P2 review #4,
+    // protocol-agent-v3 §10.3 要求 next_cursor)。
+    let consumed = start
     for (let i = start; i < lines.length; i++) {
       const event = normalizeTraceLine(lines[i])
       if (event) events.push(event)
+      consumed = i + 1
     }
-    return events
+    return { events, nextCursor: { offset: consumed } }
   }
 
   async kill(h: IncarnationHandle): Promise<void> {

--- a/crabot-agent/src/workers/cli-events.ts
+++ b/crabot-agent/src/workers/cli-events.ts
@@ -1,0 +1,168 @@
+/**
+ * CliEventChannel — CLI hook 事件文件通道(通知三段式的中段)。
+ *
+ * claude code 的 Stop/Notification hook、codex 的 notify 会执行 hookCommand(kind)
+ * 产出的 shell 片段,往事件文件追加一行 JSON;harness 侧用 watch()/readAll() 消费。
+ * 与 P1 harness 亲历的 events.jsonl 分开命名(events-cli.jsonl),避免混淆。
+ */
+import * as fs from 'fs/promises'
+import * as path from 'path'
+import { watch as fsWatch, type FSWatcher } from 'fs'
+
+export interface CliEvent {
+  ts: string
+  kind: 'stop' | 'notification' | 'session_start' | string
+  raw: unknown
+}
+
+// POSIX shell 单引号转义:结束引号、插入一个已转义的单引号、重新开始引号。
+function shQuote(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`
+}
+
+const POLL_INTERVAL_MS = 2000
+
+export class CliEventChannel {
+  constructor(private filePath: string) {}
+
+  /**
+   * 生成供 CLI hook 使用的 shell 片段(POSIX sh,不依赖 node/jq 等非必装工具)。
+   * 只用 printf + date -u 拼一行 JSON 并追加到事件文件。
+   *
+   * 设计取舍:hook 的 stdin(如 claude code 会喂 JSON payload)在这一版**直接丢弃**,
+   * raw 固定为 null——把 stdin 内容原样塞进 JSON 字符串涉及运行时转义(引号、换行、
+   * 反斜杠等),在纯 POSIX shell 里做这件事风险远大于收益。后续如果需要 payload,
+   * 再升级为读 stdin 并转义写入 raw 字段。
+   */
+  hookCommand(kind: string): string {
+    // kind 在生成时(而非 hook 运行时)就已知,这里直接做一次 JSON 字符串转义,
+    // 再整体当作单个 shell 单引号字面量传给 printf 的 %s——避免 kind 内容
+    // 里出现 % 之类字符被 printf 误当格式指令解析。
+    const kindJsonEscaped = JSON.stringify(kind).slice(1, -1)
+    const format = '{"ts":"%s","kind":"%s","raw":null}\\n'
+    return [
+      'ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)',
+      `printf '${format}' "$ts" ${shQuote(kindJsonEscaped)} >> ${shQuote(this.filePath)}`,
+    ].join('; ')
+  }
+
+  async readAll(): Promise<CliEvent[]> {
+    let text: string
+    try {
+      text = await fs.readFile(this.filePath, 'utf-8')
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return []
+      throw error
+    }
+    const events: CliEvent[] = []
+    for (const line of text.split('\n')) {
+      const event = parseLine(line)
+      if (event) events.push(event)
+    }
+    return events
+  }
+
+  /**
+   * 监视事件文件的新增行:fs.watch(目录)作为快路径 + 2s 轮询兜底。
+   * 按已读字节 offset 去重;文件/目录此时可能尚不存在,容忍并等待其出现。
+   * 坏行(完整换行终结但内容损坏)跳过且不中断;半行(尚无换行符,写入未完成)
+   * 留到下次补全读——offset 只推进到最后一个完整换行处。
+   */
+  watch(onEvent: (e: CliEvent) => void): () => void {
+    let stopped = false
+    let pumping = false
+    let offset = 0
+    let watcher: FSWatcher | null = null
+
+    const dir = path.dirname(this.filePath)
+    const base = path.basename(this.filePath)
+
+    const pump = async () => {
+      if (stopped || pumping) return
+      pumping = true
+      try {
+        let stat
+        try {
+          stat = await fs.stat(this.filePath)
+        } catch {
+          return // 文件尚不存在,等下一次触发
+        }
+        if (stat.size <= offset) return
+
+        const fd = await fs.open(this.filePath, 'r')
+        try {
+          const len = stat.size - offset
+          const buffer = Buffer.alloc(len)
+          await fd.read(buffer, 0, len, offset)
+          const text = buffer.toString('utf-8')
+          const lines = text.split('\n')
+          // 最后一段要么是空串(文本以 \n 结尾),要么是尚未写完的半行——
+          // 两种情况都不当作"完整行"处理,offset 也不为它推进。
+          const completeLines = lines.slice(0, -1)
+
+          let consumedBytes = 0
+          for (const line of completeLines) {
+            consumedBytes += Buffer.byteLength(line, 'utf-8') + 1 // +1 for '\n'
+            if (stopped) break
+            const event = parseLine(line)
+            if (event) onEvent(event)
+          }
+          offset += consumedBytes
+        } finally {
+          await fd.close()
+        }
+      } finally {
+        pumping = false
+      }
+    }
+
+    const trySetupWatcher = () => {
+      if (watcher || stopped) return
+      try {
+        const w = fsWatch(dir, (_eventType, filename) => {
+          if (stopped) return
+          if (!filename || filename === base) void pump()
+        })
+        w.on('error', () => {
+          // 目录可能被删除/重建等导致 watcher 失效,回退到轮询兜底,下次轮询会重试建立。
+          if (watcher === w) watcher = null
+        })
+        watcher = w
+      } catch {
+        // 目录此时可能还不存在,fs.watch 会抛错;轮询兜底会在目录出现后重试。
+      }
+    }
+
+    trySetupWatcher()
+    void pump() // 文件可能已有历史内容,立即读一次
+
+    const interval = setInterval(() => {
+      if (stopped) return
+      trySetupWatcher()
+      void pump()
+    }, POLL_INTERVAL_MS)
+
+    return () => {
+      stopped = true
+      clearInterval(interval)
+      if (watcher) {
+        watcher.close()
+        watcher = null
+      }
+    }
+  }
+}
+
+function parseLine(line: string): CliEvent | null {
+  const trimmed = line.trim()
+  if (!trimmed) return null
+  try {
+    const parsed = JSON.parse(trimmed)
+    if (parsed && typeof parsed === 'object' && typeof parsed.ts === 'string' && typeof parsed.kind === 'string') {
+      return { ts: parsed.ts, kind: parsed.kind, raw: 'raw' in parsed ? parsed.raw : null }
+    }
+    return null
+  } catch {
+    return null // 坏行:跳过,不中断
+  }
+}

--- a/crabot-agent/src/workers/codex/adapter.ts
+++ b/crabot-agent/src/workers/codex/adapter.ts
@@ -198,6 +198,9 @@ interface Runtime {
   readonly rolloutPath?: string
   readonly outputLog: OutputLog
   readonly eventChannel: CliEventChannel
+  /** spawn 时 session 发现的结果:'discovered' 表示发现了真实 rollout 文件,'placeholder' 表示超时降级。
+   * 内部状态机用,会透传到 meta 文件。 */
+  readonly sessionDiscoveryStatus: 'discovered' | 'placeholder'
   state: WorkerContractState
   ended_reason?: IncarnationEndReason
   /** 自上一次 sendInput(或 spawn)以来"已计入"的 turn-complete 通知数;新计数超过它才判定
@@ -348,10 +351,16 @@ export class CodexWorkerAdapter implements WorkerAdapter {
     // provision 的职责。
     try {
       const authRaw = await fs.readFile(join(this.codexHomeSource, 'auth.json'), 'utf-8')
-      await fs.writeFile(join(codexDir, 'auth.json'), authRaw, 'utf-8')
+      const authPath = join(codexDir, 'auth.json')
+      await fs.writeFile(authPath, authRaw, 'utf-8')
+      // auth.json 包含凭据,设置严格权限防止泄露
+      await fs.chmod(authPath, 0o600)
     } catch {
       // 忽略:本机未登录/测试环境本就没有 auth.json
     }
+
+    // .codex/ 整个隔离 HOME 都不应入库(凭据、临时缓存等),写入 .gitignore
+    await fs.writeFile(join(codexDir, '.gitignore'), '*\n', 'utf-8')
 
     // codex-docs: skills 支持 .codex/skills/(项目级)或 ~/.codex/skills/(个人级);本方案下
     // .codex/ 本身就是 CODEX_HOME,两个语义重合到同一目录。
@@ -395,6 +404,12 @@ export class CodexWorkerAdapter implements WorkerAdapter {
     // session 发现:见文件头注释"session 发现"节。找不到就退化为本地占位 uuid(已知限制)。
     const discovered = await pollForNewRollout(join(codexHome, 'sessions'), spawnStartedAt, this.sessionDiscoveryTimeoutMs)
     const sessionId = discovered?.sessionId ?? randomUUID()
+    const sessionDiscoveryStatus = discovered ? 'discovered' : 'placeholder'
+    if (sessionDiscoveryStatus === 'placeholder') {
+      console.warn(
+        `[codex-adapter] session discovery timed out for ${spec.worker_id}, using placeholder uuid; resume/readTrace will degrade`,
+      )
+    }
 
     const runtime: Runtime = {
       worker_id: spec.worker_id,
@@ -407,12 +422,13 @@ export class CodexWorkerAdapter implements WorkerAdapter {
       rolloutPath: discovered?.path,
       outputLog: new OutputLog(outputFile),
       eventChannel: new CliEventChannel(eventsFilePath(spec.workspace)),
+      sessionDiscoveryStatus,
       state: 'running',
       stopBaseline: 0,
       killed: false,
     }
 
-    await writeMetaAtomic(dir, seq, { seq, state: 'running', session_id: sessionId })
+    await writeMetaAtomic(dir, seq, { seq, state: 'running', session_id: sessionId, session_discovery: sessionDiscoveryStatus })
     this.runtimes.set(instanceKey(handle), runtime)
 
     // 首条任务输入注入失败:不能放任 running——按 kill 路径清理 tmux 会话后落
@@ -474,12 +490,13 @@ export class CodexWorkerAdapter implements WorkerAdapter {
       rolloutPath: prevRuntime.rolloutPath,
       outputLog: new OutputLog(outputFile),
       eventChannel: new CliEventChannel(eventsFilePath({ root: prevRuntime.workspaceRoot })),
+      sessionDiscoveryStatus: prevRuntime.sessionDiscoveryStatus,
       state: 'running',
       stopBaseline: 0,
       killed: false,
     }
 
-    await writeMetaAtomic(dir, seq, { seq, state: 'running', session_id: prev.session_ref })
+    await writeMetaAtomic(dir, seq, { seq, state: 'running', session_id: prev.session_ref, session_discovery: prevRuntime.sessionDiscoveryStatus })
     this.runtimes.set(instanceKey(handle), runtime)
 
     // 首条 wakeInput 注入失败:按 spawn 同款纪律处理——已注册的化身清理 tmux 会话后落
@@ -642,7 +659,7 @@ export class CodexWorkerAdapter implements WorkerAdapter {
   }
 
   private async transitionState(runtime: Runtime, h: IncarnationHandle, state: WorkerContractState): Promise<void> {
-    await writeMetaAtomic(runtime.dir, runtime.seq, { seq: runtime.seq, state, session_id: runtime.sessionId })
+    await writeMetaAtomic(runtime.dir, runtime.seq, { seq: runtime.seq, state, session_id: runtime.sessionId, session_discovery: runtime.sessionDiscoveryStatus })
     runtime.state = state
     try {
       this.deps.onStateChange?.(h, state)
@@ -657,6 +674,7 @@ export class CodexWorkerAdapter implements WorkerAdapter {
       state: 'exited',
       session_id: runtime.sessionId,
       ended_reason,
+      session_discovery: runtime.sessionDiscoveryStatus,
     })
     runtime.state = 'exited'
     runtime.ended_reason = ended_reason

--- a/crabot-agent/src/workers/codex/adapter.ts
+++ b/crabot-agent/src/workers/codex/adapter.ts
@@ -207,6 +207,9 @@ interface Runtime {
    * 本轮 idle。语义与 cc 的 stopBaseline 完全对应。 */
   stopBaseline: number
   killed: boolean
+  /** 是否已经被 resume 过一次。resume() 锁内检测"对同一 prev 的重复 resume"(先到先得,
+   * 后来者报错),对齐 builtin/cc 同款语义(P2 review #2)。 */
+  resumed?: boolean
 }
 
 function instanceKey(h: { worker_id: string; seq: number }): string {
@@ -462,14 +465,18 @@ export class CodexWorkerAdapter implements WorkerAdapter {
 
     const dir = prevRuntime.dir
 
-    // seq 分配(nextSeq(),该 worker 现存所有化身 max seq + 1)+ tmux newSession + 提交
-    // (meta+runtime)整体在该 worker 的互斥锁内原子完成——不能再用 prev.seq+1 这种固定公式:
-    // codex 的 resume 链条与 cc 同款语义,继续用 prev.seq+1 会在被更早一次操作占用同一号位
-    // 时假死(见 cc adapter.ts 同款修复、P2 review #1)。newSession 只是起一个 tmux pane
-    // (不等待 CLI 完整应答),放进锁内不违反"耗时较长操作留在锁外"的纪律。
+    // 重复 resume 检测(先到先得)+ seq 分配(nextSeq(),该 worker 现存所有化身 max seq + 1)+
+    // tmux newSession + 提交(meta+runtime+resumed 标记)整体在该 worker 的互斥锁内原子完成,
+    // 与 cc adapter.ts 同款修复(见其 resume() 注释、P2 review #1/#2):nextSeq() 避免撞号;
+    // resumed 标记避免并发/连续 resume 同一 exited prev 各起一个 tmux 会话跑 `codex resume`
+    // 同一 session id——那不是 resume 想要的语义,应先到先得、后来者报错。resumed 标记必须
+    // 在 writeMeta 成功之后才提交,保证失败路径(newSession 抛错)幂等可重试。
     let handle!: IncarnationHandle
     let runtime!: Runtime
     await this.getMutex(prev.worker_id).run(async () => {
+      if (prevRuntime.resumed) {
+        throw new Error(`CodexWorkerAdapter.resume: incarnation ${prev.worker_id}#${prev.seq} already resumed (concurrent resume of the same prev incarnation?)`)
+      }
       const seq = this.nextSeq(prev.worker_id)
       handle = { worker_id: prev.worker_id, seq, impl: 'codex' }
       const sessionName = `crabot-w-${prev.worker_id}-${seq}`
@@ -503,6 +510,7 @@ export class CodexWorkerAdapter implements WorkerAdapter {
 
       await writeMetaAtomic(dir, seq, { seq, state: 'running', session_id: prev.session_ref, session_discovery: prevRuntime.sessionDiscoveryStatus })
       this.runtimes.set(instanceKey(handle), runtime)
+      prevRuntime.resumed = true
     })
 
     // 首条 wakeInput 注入失败:按 spawn 同款纪律处理——已注册的化身清理 tmux 会话后落

--- a/crabot-agent/src/workers/codex/adapter.ts
+++ b/crabot-agent/src/workers/codex/adapter.ts
@@ -572,33 +572,39 @@ export class CodexWorkerAdapter implements WorkerAdapter {
     return (await this.syncState(runtime, h)).state
   }
 
-  async readTrace(h: IncarnationHandle, cursor?: TraceCursor): Promise<NormalizedTraceEvent[]> {
+  async readTrace(h: IncarnationHandle, cursor?: TraceCursor): Promise<{ events: NormalizedTraceEvent[]; nextCursor: TraceCursor }> {
     const runtime = this.runtimes.get(instanceKey(h))
     if (!runtime) {
       throw new Error(`CodexWorkerAdapter.readTrace: no such incarnation ${h.worker_id}#${h.seq} resident in this process`)
     }
 
     if (!runtime.rolloutPath) {
-      // spawn 时没能发现 rollout 文件(占位 session_id,已知限制)——没有路径可读,退化为空数组。
-      return []
+      // spawn 时没能发现 rollout 文件(占位 session_id,已知限制)——没有路径可读,退化为空
+      // 数组,cursor 原样透传。
+      return { events: [], nextCursor: cursor ?? { offset: 0 } }
     }
 
     let raw: string
     try {
       raw = await fs.readFile(runtime.rolloutPath, 'utf-8')
     } catch (err) {
-      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return []
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return { events: [], nextCursor: cursor ?? { offset: 0 } }
       throw err
     }
 
     const lines = raw.split('\n').filter((line) => line.length > 0)
     const start = cursor?.offset ?? 0
     const events: NormalizedTraceEvent[] = []
+    // nextCursor.offset 是"实际消费到的行号",不是 start + events.length——未识别的顶层
+    // type/子类型、坏 JSON 都不产事件但仍然消费了一行,调用方用 offset += events.length 推进
+    // 游标会在这些被跳过的行上重复读或漏读(P2 review #4,同 cc adapter 修复)。
+    let consumed = start
     for (let i = start; i < lines.length; i++) {
       const event = normalizeRolloutLine(lines[i])
       if (event) events.push(event)
+      consumed = i + 1
     }
-    return events
+    return { events, nextCursor: { offset: consumed } }
   }
 
   async kill(h: IncarnationHandle): Promise<void> {

--- a/crabot-agent/src/workers/codex/adapter.ts
+++ b/crabot-agent/src/workers/codex/adapter.ts
@@ -627,9 +627,10 @@ export class CodexWorkerAdapter implements WorkerAdapter {
   // --- Internal ---
 
   /**
-   * 三源合成状态判定:事件文件(新 turn-complete 通知 → idle) > tmux isAlive(false →
-   * exited) > 默认 running。与内存态不同则在互斥锁内原子迁移(改内存 + 写 meta)。判定与
-   * 提交整体在锁内完成,理由与 cc 完全一致(见文件头注释,避免过期快照覆盖并发落定的新结果)。
+   * 三源合成状态判定:tmux isAlive(false → exited,终态优先) > 事件文件(会话还活着时,新
+   * turn-complete 通知 → idle) > 默认 running。与内存态不同则在互斥锁内原子迁移(改内存 +
+   * 写 meta)。判定与提交整体在锁内完成,理由与 cc 完全一致(见 cc adapter.ts 文件头注释,
+   * 避免过期快照覆盖并发落定的新结果)。
    */
   private async syncState(runtime: Runtime, h: IncarnationHandle): Promise<{ state: WorkerContractState; stopCount: number }> {
     if (runtime.state === 'exited') return { state: 'exited', stopCount: runtime.stopBaseline }

--- a/crabot-agent/src/workers/codex/adapter.ts
+++ b/crabot-agent/src/workers/codex/adapter.ts
@@ -600,7 +600,13 @@ export class CodexWorkerAdapter implements WorkerAdapter {
       throw err
     }
 
-    const lines = raw.split('\n').filter((line) => line.length > 0)
+    // 半行纪律(对齐 cli-events.ts watch()):trace(rollout)文件由 codex 持续追加、这里懒
+    // 解析式轮询读取,读到写入中途是常态。split 末尾要么是空串(文本以 \n 结尾)要么是尚未
+    // 写完的半行,两种情况都不能当"已消费的完整行"处理——统一 pop 掉,不产事件也不推进
+    // nextCursor,保证下次连同补全后的内容重新完整读取该行,不会永久丢事件。
+    const rawLines = raw.split('\n')
+    rawLines.pop()
+    const lines = rawLines.filter((line) => line.length > 0)
     const start = cursor?.offset ?? 0
     const events: NormalizedTraceEvent[] = []
     // nextCursor.offset 是"实际消费到的行号",不是 start + events.length——未识别的顶层

--- a/crabot-agent/src/workers/codex/adapter.ts
+++ b/crabot-agent/src/workers/codex/adapter.ts
@@ -1,0 +1,785 @@
+/**
+ * CodexWorkerAdapter — WorkerAdapter 契约的 OpenAI codex CLI 实现。
+ *
+ * 本机没有安装 codex,以下行为全部依据公开文档/codex 源码(github.com/openai/codex,
+ * developers.openai.com/codex 系列页面,已跳转到 learn.chatgpt.com/docs/*)推断实现,每个
+ * 引用点在下面用 `codex-docs:` 标注出处;真机行为需要在真正装上 codex 之后校准(见 Task 6
+ * 报告"未经确认待真机校准清单")。
+ *
+ * ## 与 cc adapter 的关键差异(决定了本文件的整体形状)
+ *
+ * 1. **没有 `--session-id` 等价参数**:交互态 `codex` 不接受预先指定 session id
+ *    (codex-docs: openai/codex#3817"No way to resume in non-interactive mode when session
+ *    id is not outputted"、openai/codex Discussion #3827"session_id 是会话开始时自动生成,
+ *    无法手动指定/覆盖")。session id 由 codex 自己生成,只能靠事后发现——本 adapter 轮询
+ *    `<CODEX_HOME>/sessions/**\/rollout-*.jsonl` 文件名里内嵌的 uuid(见下方"session 发现"节)。
+ * 2. **notify 不能走"项目级配置自动发现"**:codex 会从 cwd 向上找 `.codex/config.toml`
+ *    作为项目级覆盖层叠加到 `~/.codex/config.toml` 之上,但项目级覆盖明确排除了一批"跑在
+ *    本机、涉及凭据/遥测"的 key,其中就包括 `notify`(codex-docs:
+ *    learn.chatgpt.com/docs/config-file/config-basic 的限制清单原文:"Codex ignores the
+ *    following keys in project-local .codex/config.toml and prints a startup warning...
+ *    notify")。因此本 adapter **不依赖项目级自动发现**,而是把 `<workspace>/.codex/`
+ *    整个目录当成这个 worker 专属的 `CODEX_HOME`(spawn/resume 时经 tmux env 传
+ *    `CODEX_HOME=<workspace>/.codex`),让 notify 在"顶层用户配置"这一层生效。
+ * 3. **没有无头 fork 等价物**:cc 的 fork 靠 `-p ... --resume ... --fork-session
+ *    --output-format text` 一条命令跑完侧问退出;codex 的 `exec` 子命令没有这个能力
+ *    (codex-docs: openai/codex#11750、#17568 两个 open 的 feature request,标题分别是
+ *    "Add `codex exec fork` subcommand for headless/non-interactive fork"、"exec: add fork
+ *    subcommand for non-interactive session forking";#11750 描述目前唯一的变通方案是拉起
+ *    交互式 TUI 塞进伪终端、轮询文件系统等新 rollout 文件出现、杀掉 TUI、再用
+ *    `codex exec resume` 接力——这已经不是"无头一击",是要在 fork() 内部重新实现一遍
+ *    tmux 交互流程)。因此 `capabilities().fork` 如实定为 `false`,`fork()` 直接抛
+ *    `CapabilityNotSupportedError`。
+ *
+ * ## session 发现(spawn 专用)
+ *
+ * codex-docs: rollout 文件路径 `<CODEX_HOME>/sessions/YYYY/MM/DD/
+ * rollout-YYYY-MM-DDThh-mm-ss-<uuid>.jsonl`,来自 codex-rs/rollout/src/list.rs 注释原文
+ * "Directory layout: `~/.codex/sessions/YYYY/MM/DD/rollout-YYYY-MM-DDThh-mm-ss-<uuid>.jsonl`"
+ * 与 codex-rs/rollout/src/lib.rs 的 `SESSIONS_SUBDIR = "sessions"` 常量。spawn() 在 tmux
+ * newSession 成功后、注入首条 prompt 之前,有限时间(`sessionDiscoveryTimeoutMs`,默认
+ * 3000ms)轮询这个目录树,取文件名里的 uuid 作为该化身的真实 session_id;轮询超时(codex
+ * 还没来得及落盘,或本次跑的是不写 rollout 文件的 mock)就退化为本地生成的占位 uuid——
+ * 这个占位 uuid 不对应任何真实 codex 会话文件,该化身自己的 resume()/readTrace() 会因此
+ * 失效(resume 传给 codex 的 session id 是假的;readTrace 因为 `rolloutPath` 是 undefined
+ * 直接退化为空数组),是已知限制,不是本 task 能在没有真机的前提下解决的缺口。
+ *
+ * ## provision:workspace 级配置
+ *
+ * `<ws.root>/.codex/config.toml`:notify 段(指向 `CliEventChannel.hookCommand('notification'
+ * 概念上等价的 'stop')`,用 `/bin/sh -c` 包一层,因为 codex-docs 确认 notify 是"程序+固定参数
+ * 数组,codex 会在末尾追加一个 JSON payload 作为额外参数"——见
+ * learn.chatgpt.com/docs/config-file/config-advanced;固定参数脚本本身不读那个额外参数,
+ * 效果上只是"turn 结束就打一个标记",与 cc 的 Stop hook 语义等价) + mcp_servers 段
+ * (复用 Task 3 的 `renderCodexMcpToml`)。TOML 要求根级 key 必须出现在第一个 table 之前
+ * (codex-docs: config.md 曾用这条规则解释"notify 放最后不生效"的排查案例),所以 notify
+ * 行必须排在 mcp_servers 的 `[mcp_servers."x"]` 表头之前。
+ *
+ * `<ws.root>/.codex/auth.json`:既然 `.codex/` 在这里被当成独立 `CODEX_HOME`,真实登录态
+ * (`codexHomeSource`,默认 `~/.codex`)里的 `auth.json`(codex-docs:
+ * learn.chatgpt.com/docs/auth"Codex caches login details locally... at ~/.codex/auth.json"
+ * )要搬一份过来,否则这个隔离出来的 CODEX_HOME 过不了鉴权;找不到就跳过(本机/CI 未登录),
+ * 不阻塞 provision。
+ *
+ * `<ws.root>/.codex/skills/<name>/`:codex-docs 确认 skills 支持 `.codex/skills/`(项目级)
+ * 或 `~/.codex/skills/`(个人级)两种位置;本方案下 `.codex/` 本身就是 CODEX_HOME,两个
+ * 语义重合到同一目录,直接复用 Task 3 的 `materializeSkills`。
+ *
+ * `<ws.root>/AGENTS.md`:codex-docs 确认 codex 从项目根往下逐级查找 AGENTS.md,与 cc 的
+ * CLAUDE.md 一样落在 workspace 根,复用 `renderContextMd`。
+ *
+ * ## spawn/resume 启动参数
+ *
+ * codex-docs(learn.chatgpt.com/docs/developer-commands):交互态 `codex` 主命令顶层支持
+ * `--ask-for-approval`(`untrusted|on-request|never`)与 `--sandbox`
+ * (`read-only|workspace-write|danger-full-access`)。本 adapter 固定传
+ * `--ask-for-approval never --sandbox workspace-write`,与 cc 用
+ * `--permission-mode acceptEdits` 同样的自动化意图——不能让审批弹窗卡住 tmux pane。
+ * `codex resume <SESSION_ID>` 是独立子命令(不是 `--resume` flag),同一文档页确认;
+ * resume 子命令是否接受与主命令相同的 `--ask-for-approval`/`--sandbox` 未逐条确认,按
+ * 同一 CLI 顶层 flag 的一般惯例沿用,真机校准时需要核实。
+ *
+ * ## 提交纪律与状态判定
+ *
+ * 与 cc 完全一致(锁纪律、三源合成状态判定、spawn/resume 首条输入失败按 kill 路径清理落
+ * exited(crashed)、session_ref UUID 边界校验 + shQuote):tmux newSession 成功之后才落
+ * meta(running)+ 注册 runtime;判定与提交在该 worker 的互斥锁内原子完成。三源合成里的
+ * "事件文件新增" 现在对应的是 codex 的 agent-turn-complete 通知(只有这一种事件类型,
+ * codex-docs 确认目前 notify 仅支持 agent-turn-complete),复用同一个 'stop' kind 字符串
+ * 与 stopBaseline 机制,语义与 cc 的"自上次输入以来新的 Stop 事件"完全对应。
+ *
+ * ## readTrace
+ *
+ * 解析 `<CODEX_HOME>/sessions/.../rollout-*.jsonl`,字段依据 codex-rs 源码抓取确认(见各
+ * 归一化函数内的 codex-docs 注释),fixture 手工构造,真机校准留待安装。只能对本进程内常驻
+ * runtime 的化身调用,同 cc(trace 路径依赖内存态)。
+ */
+import { promises as fs, type Dirent } from 'fs'
+import { join } from 'path'
+import { randomUUID } from 'crypto'
+import { homedir } from 'os'
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+import { TmuxDriver } from '../tmux/driver.js'
+import { CliEventChannel } from '../cli-events.js'
+import { OutputLog } from '../output-log.js'
+import { AsyncMutex } from '../async-mutex.js'
+import { writeMetaAtomic } from '../meta-store.js'
+import { materializeSkills, renderCodexMcpToml, renderContextMd, type ProvisionSources } from '../provision/materialize.js'
+import type {
+  AdapterCapabilities,
+  CapabilityBundle,
+  DetectResult,
+  IncarnationEndReason,
+  IncarnationHandle,
+  IncarnationRef,
+  NormalizedTraceEvent,
+  OutputCursor,
+  SpawnSpec,
+  TraceCursor,
+  WorkerAdapter,
+  WorkerContractState,
+  Workspace,
+} from '../types.js'
+
+const execFileAsync = promisify(execFile)
+
+/** POSIX shell 单引号转义,与 cc adapter 的私有 shQuote 同款用法(独立复制一份)。 */
+function shQuote(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`
+}
+
+/** TOML 双引号字符串转义 + 包裹,与 provision/materialize.ts 的私有 tomlString 同款用法
+ * (独立复制一份,materialize.ts 未导出它——同 cc adapter 复制 shQuote 的先例)。 */
+function tomlString(value: string): string {
+  let out = ''
+  for (const ch of value) {
+    if (ch === '\\') out += '\\\\'
+    else if (ch === '"') out += '\\"'
+    else {
+      const code = ch.charCodeAt(0)
+      if (code < 0x20 || code === 0x7f) out += '\\u' + code.toString(16).padStart(4, '0')
+      else out += ch
+    }
+  }
+  return `"${out}"`
+}
+
+/** UUID 格式校验:标准 UUID 格式(8-4-4-4-12 十六进制段,由连字符分隔)。*/
+function validateSessionRef(sessionRef: string): void {
+  const uuidPattern = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/
+  if (!uuidPattern.test(sessionRef)) {
+    throw new Error(
+      `CodexWorkerAdapter: invalid session_ref format (expected UUID, got '${sessionRef.slice(0, 50)}'). ` +
+        `session_ref must be a valid UUID and cannot contain shell metacharacters.`,
+    )
+  }
+}
+
+/** sendInput 打到已 exited 的化身时抛出。与 cc/builtin 的同名类语义一致,各自独立定义。 */
+export class WorkerExitedError extends Error {
+  constructor(
+    readonly worker_id: string,
+    readonly seq: number,
+  ) {
+    super(`CodexWorkerAdapter: incarnation ${worker_id}#${seq} has exited`)
+    this.name = 'WorkerExitedError'
+  }
+}
+
+/** capabilities() 声明为 false 的能力被调用时抛出的错误(如 fork)。携带 impl/capability
+ * 便于调用方判断这是"能力缺失"而非其它运行时错误。 */
+export class CapabilityNotSupportedError extends Error {
+  constructor(
+    readonly impl: string,
+    readonly capability: string,
+  ) {
+    super(`${impl} adapter does not support capability '${capability}'`)
+    this.name = 'CapabilityNotSupportedError'
+  }
+}
+
+/** hook/notify 事件文件路径约定:workspace 内 .codex/events-cli.jsonl,与 cc 的
+ * .claude/events-cli.jsonl 同构。provision 与 spawn 都按此约定定位,保持一致。 */
+export function eventsFilePath(ws: Workspace): string {
+  return join(ws.root, '.codex', 'events-cli.jsonl')
+}
+
+interface Runtime {
+  readonly worker_id: string
+  readonly seq: number
+  readonly dir: string
+  readonly workspaceRoot: string
+  /** 本 worker 专属的隔离 CODEX_HOME(= `<workspaceRoot>/.codex`),spawn/resume 全程不变。 */
+  readonly codexHome: string
+  readonly sessionName: string
+  readonly sessionId: string
+  /** spawn 时发现的 rollout 文件绝对路径;发现失败(占位 session_id)则为 undefined。 */
+  readonly rolloutPath?: string
+  readonly outputLog: OutputLog
+  readonly eventChannel: CliEventChannel
+  state: WorkerContractState
+  ended_reason?: IncarnationEndReason
+  /** 自上一次 sendInput(或 spawn)以来"已计入"的 turn-complete 通知数;新计数超过它才判定
+   * 本轮 idle。语义与 cc 的 stopBaseline 完全对应。 */
+  stopBaseline: number
+  killed: boolean
+}
+
+function instanceKey(h: { worker_id: string; seq: number }): string {
+  return `${h.worker_id}#${h.seq}`
+}
+
+const ROLLOUT_FILENAME_RE =
+  /^rollout-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})\.jsonl$/
+
+/**
+ * 递归遍历 sessionsDir(约定深度不超过 4 层,覆盖 `YYYY/MM/DD/` 的文档约定布局,也容忍更
+ * 扁平的布局),收集文件名匹配 rollout 命名格式、mtime 不早于 cutoffMs 的候选,取文件名
+ * 字典序最大的一个(文件名内嵌时间戳前缀,字典序等价时间序)。目录不存在(codex 还没来得及
+ * 创建)按"没找到"处理,不抛错。
+ */
+async function findNewestRolloutFile(sessionsDir: string, cutoffMs: number): Promise<{ path: string; sessionId: string } | null> {
+  const candidates: Array<{ path: string; sessionId: string; name: string }> = []
+
+  async function walk(dir: string, depth: number): Promise<void> {
+    if (depth > 4) return
+    let entries: Dirent[]
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true })
+    } catch {
+      return
+    }
+    for (const entry of entries) {
+      const full = join(dir, entry.name)
+      if (entry.isDirectory()) {
+        await walk(full, depth + 1)
+        continue
+      }
+      const match = ROLLOUT_FILENAME_RE.exec(entry.name)
+      if (!match) continue
+      let mtimeMs: number
+      try {
+        mtimeMs = (await fs.stat(full)).mtimeMs
+      } catch {
+        continue
+      }
+      if (mtimeMs < cutoffMs) continue
+      candidates.push({ path: full, sessionId: match[1], name: entry.name })
+    }
+  }
+
+  await walk(sessionsDir, 0)
+  if (candidates.length === 0) return null
+  const best = candidates.reduce((a, b) => (b.name > a.name ? b : a))
+  return { path: best.path, sessionId: best.sessionId }
+}
+
+/** 有限时间轮询 findNewestRolloutFile,50ms 间隔;超时返回 null(调用方退化为占位 uuid)。 */
+async function pollForNewRollout(sessionsDir: string, cutoffMs: number, timeoutMs: number): Promise<{ path: string; sessionId: string } | null> {
+  const intervalMs = 50
+  const deadline = Date.now() + timeoutMs
+  for (;;) {
+    const found = await findNewestRolloutFile(sessionsDir, cutoffMs)
+    if (found) return found
+    if (Date.now() >= deadline) return null
+    await new Promise((r) => setTimeout(r, intervalMs))
+  }
+}
+
+export class CodexWorkerAdapter implements WorkerAdapter {
+  readonly implId = 'codex' as const
+
+  private readonly tmux: TmuxDriver
+  private readonly codexBin: string
+  private readonly codexHomeSource: string
+  private readonly sessionDiscoveryTimeoutMs: number
+  private readonly runtimes = new Map<string, Runtime>()
+  private readonly mutexes = new Map<string, AsyncMutex>()
+
+  constructor(
+    private readonly deps: {
+      readonly dataDir: string
+      readonly codexBin?: string
+      readonly tmux?: TmuxDriver
+      /** 真实登录态所在的 CODEX_HOME,默认 ~/.codex;provision 从这里搬一份 auth.json 到
+       * workspace 隔离出来的 CODEX_HOME,detect() 的 activated 检查也读这里。测试用可注入
+       * fixture 目录,不依赖开发机真实 home。 */
+      readonly codexHomeSource?: string
+      /** spawn() 发现真实 session id 的轮询上限(ms),默认 3000;测试用可调小避免拖慢用例。 */
+      readonly sessionDiscoveryTimeoutMs?: number
+      readonly onStateChange?: (h: IncarnationHandle, state: WorkerContractState) => void
+    },
+  ) {
+    this.tmux = deps.tmux ?? new TmuxDriver()
+    this.codexBin = deps.codexBin ?? 'codex'
+    this.codexHomeSource = deps.codexHomeSource ?? join(homedir(), '.codex')
+    this.sessionDiscoveryTimeoutMs = deps.sessionDiscoveryTimeoutMs ?? 3000
+  }
+
+  async detect(): Promise<DetectResult> {
+    let versionOutput: string
+    try {
+      const { stdout } = await execFileAsync('/bin/sh', ['-c', `${this.codexBin} --version`])
+      versionOutput = stdout.trim()
+    } catch (err) {
+      return { installed: false, activated: false, detail: `codex binary not found or failed to run: ${(err as Error).message}` }
+    }
+
+    let activated = false
+    try {
+      const entries = await fs.readdir(this.codexHomeSource)
+      // codex-docs: 凭据落在 CODEX_HOME/auth.json(learn.chatgpt.com/docs/auth)。config.toml
+      // 存在但没登录过也可能出现,所以两者任一存在都算"至少配置过"——与 cc 检查
+      // settings.json/.credentials.json 同一思路(宽松判定,不做网络调用)。
+      activated = entries.includes('auth.json') || entries.includes('config.toml')
+    } catch {
+      activated = false
+    }
+
+    return { installed: true, activated, detail: versionOutput }
+  }
+
+  async provision(ws: Workspace, caps: CapabilityBundle): Promise<void> {
+    const codexDir = join(ws.root, '.codex')
+    await fs.mkdir(codexDir, { recursive: true })
+
+    const channel = new CliEventChannel(eventsFilePath(ws))
+    // codex-docs: notify 只支持在"顶层用户配置"这层 config.toml 里声明,项目级
+    // .codex/config.toml 里的 notify 会被 codex 忽略并打印启动告警(config-basic 限制清单
+    // 明确包含 notify)。本 adapter 把 <ws.root>/.codex 整个目录当作这个 worker 专属的
+    // CODEX_HOME(spawn/resume 经 tmux env 传递),绕开这条项目级限制。
+    //
+    // notify 的程序契约是"数组:可执行文件 + 固定参数",codex 运行时会在末尾追加一个 JSON
+    // payload 作为额外参数(config-advanced 原文确认)。这里用 `/bin/sh -c <script>` 包一层,
+    // 额外参数会落在 shell 的 $0 上,脚本本身不引用位置参数,效果上只是"turn 结束就打一个
+    // 标记"——与 cc 的 Stop hook(丢弃 stdin payload,同一设计取舍,见 CliEventChannel 头
+    // 注释)语义一致。
+    const notifyLine = `notify = [${tomlString('/bin/sh')}, ${tomlString('-c')}, ${tomlString(channel.hookCommand('stop'))}]\n`
+    const mcpServers = caps.mcp_servers as unknown as ProvisionSources['mcpServers']
+    const mcpToml = renderCodexMcpToml(mcpServers)
+    // TOML 要求根级 key 必须出现在第一个 table 之前,否则会被解析成前一个 table 的子字段——
+    // notify 必须排在 mcp_servers 的 [mcp_servers."x"] 表头之前。
+    await fs.writeFile(join(codexDir, 'config.toml'), notifyLine + '\n' + mcpToml, 'utf-8')
+
+    // codex-docs: 既然 .codex/ 在这里被当成独立 CODEX_HOME,真实登录态里的 auth.json 要搬
+    // 一份过来,否则隔离出来的 CODEX_HOME 过不了鉴权。找不到就跳过(本机/CI 未 `codex
+    // login`)——不阻塞 provision,登录态缺失会在真正 spawn 时体现为 codex 进程报错,不是
+    // provision 的职责。
+    try {
+      const authRaw = await fs.readFile(join(this.codexHomeSource, 'auth.json'), 'utf-8')
+      await fs.writeFile(join(codexDir, 'auth.json'), authRaw, 'utf-8')
+    } catch {
+      // 忽略:本机未登录/测试环境本就没有 auth.json
+    }
+
+    // codex-docs: skills 支持 .codex/skills/(项目级)或 ~/.codex/skills/(个人级);本方案下
+    // .codex/ 本身就是 CODEX_HOME,两个语义重合到同一目录。
+    await materializeSkills(ws.root, caps.skills, '.codex/skills')
+
+    // codex-docs: AGENTS.md 从项目根往下逐级查找,落在 workspace 根,与 cc 的 CLAUDE.md 同构。
+    await fs.writeFile(
+      join(ws.root, 'AGENTS.md'),
+      renderContextMd({
+        workerId: workerIdLabelFromWorkspace(ws),
+        taskTitle: 'Crabot Worker Task',
+        disciplines: '中间产物统一写入工作区内,不要写到工作区之外的路径。',
+      }),
+      'utf-8',
+    )
+  }
+
+  async spawn(spec: SpawnSpec): Promise<IncarnationHandle> {
+    const seq = 1
+    const handle: IncarnationHandle = { worker_id: spec.worker_id, seq, impl: 'codex' }
+    if (this.runtimes.has(instanceKey(handle))) {
+      throw new Error(`CodexWorkerAdapter.spawn: worker_id ${spec.worker_id} already spawned in this process`)
+    }
+
+    const dir = join(this.deps.dataDir, spec.worker_id)
+    await fs.mkdir(dir, { recursive: true })
+
+    const codexHome = join(spec.workspace.root, '.codex')
+    const sessionName = `crabot-w-${spec.worker_id}-${seq}`
+    const outputFile = join(dir, `output-${seq}.log`)
+    // codex-docs: 交互态无 --session-id 等价参数;--ask-for-approval never --sandbox
+    // workspace-write 与 cc 用 --permission-mode acceptEdits 同样的自动化意图。
+    const command = `${this.codexBin} --ask-for-approval never --sandbox workspace-write`
+    const spawnStartedAt = Date.now()
+
+    // newSession 成功之后才落 meta(running)+注册 runtime,同 cc 纪律:tmux 失败时不留任何
+    // 持久痕迹,同 worker_id 可安全重试。CODEX_HOME 经 tmux -e 传给会话进程(execFile 直传
+    // argv,不经过 shell 插值,不需要额外转义)。
+    await this.tmux.newSession({ name: sessionName, cwd: spec.workspace.root, command, outputFile, env: { CODEX_HOME: codexHome } })
+
+    // session 发现:见文件头注释"session 发现"节。找不到就退化为本地占位 uuid(已知限制)。
+    const discovered = await pollForNewRollout(join(codexHome, 'sessions'), spawnStartedAt, this.sessionDiscoveryTimeoutMs)
+    const sessionId = discovered?.sessionId ?? randomUUID()
+
+    const runtime: Runtime = {
+      worker_id: spec.worker_id,
+      seq,
+      dir,
+      workspaceRoot: spec.workspace.root,
+      codexHome,
+      sessionName,
+      sessionId,
+      rolloutPath: discovered?.path,
+      outputLog: new OutputLog(outputFile),
+      eventChannel: new CliEventChannel(eventsFilePath(spec.workspace)),
+      state: 'running',
+      stopBaseline: 0,
+      killed: false,
+    }
+
+    await writeMetaAtomic(dir, seq, { seq, state: 'running', session_id: sessionId })
+    this.runtimes.set(instanceKey(handle), runtime)
+
+    // 首条任务输入注入失败:不能放任 running——按 kill 路径清理 tmux 会话后落
+    // exited(crashed)(不是 killed,不是用户发起的 kill),spawn 仍然 reject。
+    try {
+      await this.tmux.sendText(sessionName, spec.prompt)
+    } catch (err) {
+      await this.getMutex(handle.worker_id).run(async () => {
+        if (runtime.state === 'exited') return
+        await this.tmux.killSession(sessionName)
+        await this.transitionExited(runtime, handle, 'crashed')
+      })
+      throw err
+    }
+
+    return handle
+  }
+
+  async resume(prev: IncarnationRef, wakeInput: string): Promise<IncarnationHandle> {
+    validateSessionRef(prev.session_ref)
+
+    const prevRuntime = this.runtimes.get(instanceKey(prev))
+    if (!prevRuntime) {
+      throw new Error(`CodexWorkerAdapter.resume: no such incarnation ${prev.worker_id}#${prev.seq} resident in this process`)
+    }
+    const prevHandle: IncarnationHandle = { worker_id: prev.worker_id, seq: prev.seq, impl: 'codex' }
+    const { state: prevState } = await this.syncState(prevRuntime, prevHandle)
+    if (prevState !== 'exited') {
+      throw new Error(`CodexWorkerAdapter.resume: incarnation ${prev.worker_id}#${prev.seq} has not exited yet (state=${prevState})`)
+    }
+
+    const seq = prev.seq + 1
+    const handle: IncarnationHandle = { worker_id: prev.worker_id, seq, impl: 'codex' }
+    if (this.runtimes.has(instanceKey(handle))) {
+      throw new Error(`CodexWorkerAdapter.resume: worker_id ${prev.worker_id} seq ${seq} already exists in this process`)
+    }
+
+    const dir = prevRuntime.dir
+    const sessionName = `crabot-w-${prev.worker_id}-${seq}`
+    const outputFile = join(dir, `output-${seq}.log`)
+    // codex-docs: `codex resume <SESSION_ID>` 是独立子命令(不是 --resume flag)。
+    // --ask-for-approval/--sandbox 是否对 resume 子命令同样生效未逐条确认,按同一 CLI 顶层
+    // flag 惯例沿用,真机校准时需要核实(见 Task 6 报告)。
+    const command = `${this.codexBin} resume ${shQuote(prev.session_ref)} --ask-for-approval never --sandbox workspace-write`
+
+    // 锁纪律与 spawn 一致:tmux newSession 成功之后才落 meta(running)+注册 runtime。
+    await this.tmux.newSession({ name: sessionName, cwd: prevRuntime.workspaceRoot, command, outputFile, env: { CODEX_HOME: prevRuntime.codexHome } })
+
+    const runtime: Runtime = {
+      worker_id: prev.worker_id,
+      seq,
+      dir,
+      workspaceRoot: prevRuntime.workspaceRoot,
+      codexHome: prevRuntime.codexHome,
+      sessionName,
+      sessionId: prev.session_ref,
+      // resume 续写的是同一个 rollout 文件(session id 不变),不需要重新发现——直接沿用上一
+      // 化身已发现的路径;上一化身当时若发现失败(占位 uuid),这里同样拿不到,保持未知。
+      rolloutPath: prevRuntime.rolloutPath,
+      outputLog: new OutputLog(outputFile),
+      eventChannel: new CliEventChannel(eventsFilePath({ root: prevRuntime.workspaceRoot })),
+      state: 'running',
+      stopBaseline: 0,
+      killed: false,
+    }
+
+    await writeMetaAtomic(dir, seq, { seq, state: 'running', session_id: prev.session_ref })
+    this.runtimes.set(instanceKey(handle), runtime)
+
+    // 首条 wakeInput 注入失败:按 spawn 同款纪律处理——已注册的化身清理 tmux 会话后落
+    // exited(crashed),resume 仍然 reject。
+    try {
+      await this.tmux.sendText(sessionName, wakeInput)
+    } catch (err) {
+      await this.getMutex(handle.worker_id).run(async () => {
+        if (runtime.state === 'exited') return
+        await this.tmux.killSession(sessionName)
+        await this.transitionExited(runtime, handle, 'crashed')
+      })
+      throw err
+    }
+
+    return handle
+  }
+
+  async fork(_prev: IncarnationRef, _forkInput: string): Promise<IncarnationHandle> {
+    // codex-docs: codex exec 没有 cc `-p ... --fork-session --output-format text` 那种
+    // "一条命令完成侧问"的等价物——openai/codex#11750、#17568 两个 open feature request
+    // 明确指出 exec CLI 目前不支持 fork,唯一记录在案的变通方案是拉起交互式 TUI 塞进伪终端、
+    // 轮询文件系统等新 rollout 文件出现、杀掉 TUI、再用 `codex exec resume` 接力——这已经不是
+    // "无头一击",是要在这里重新实现一遍 tmux 交互流程,不是本 adapter 想提供的 fork 语义。
+    // capabilities().fork 如实定为 false,这里对应抛出同款语义的能力缺失错误。
+    throw new CapabilityNotSupportedError('codex', 'fork')
+  }
+
+  async sendInput(h: IncarnationHandle, text: string, opts?: { raw?: boolean }): Promise<void> {
+    const runtime = this.runtimes.get(instanceKey(h))
+    if (!runtime) {
+      throw new Error(`CodexWorkerAdapter.sendInput: no such incarnation ${h.worker_id}#${h.seq} resident in this process`)
+    }
+
+    const { state: current, stopCount } = await this.syncState(runtime, h)
+    if (current === 'exited') throw new WorkerExitedError(h.worker_id, h.seq)
+
+    // 新一轮开始:把 baseline 推到当前计数,上一轮遗留的 turn-complete 通知不会被误算进新一轮。
+    runtime.stopBaseline = stopCount
+
+    if (opts?.raw) {
+      const keys = text.split(/\s+/).filter((k) => k.length > 0)
+      await this.tmux.sendKeys(runtime.sessionName, keys)
+    } else {
+      await this.tmux.sendText(runtime.sessionName, text)
+    }
+
+    await this.getMutex(h.worker_id).run(async () => {
+      if (runtime.state !== 'exited') await this.transitionState(runtime, h, 'running')
+    })
+  }
+
+  async readOutput(h: IncarnationHandle, cursor: OutputCursor): Promise<{ chunk: string; nextCursor: OutputCursor }> {
+    const runtime = this.runtimes.get(instanceKey(h))
+    const outputLog = runtime ? runtime.outputLog : new OutputLog(join(this.deps.dataDir, h.worker_id, `output-${h.seq}.log`))
+    return outputLog.read(cursor)
+  }
+
+  async state(h: IncarnationHandle): Promise<WorkerContractState> {
+    const runtime = this.runtimes.get(instanceKey(h))
+    if (!runtime) {
+      const metaPath = join(this.deps.dataDir, h.worker_id, `meta-${h.seq}.json`)
+      const raw = await fs.readFile(metaPath, 'utf-8')
+      const meta = JSON.parse(raw) as { state: WorkerContractState }
+      return meta.state
+    }
+    return (await this.syncState(runtime, h)).state
+  }
+
+  async readTrace(h: IncarnationHandle, cursor?: TraceCursor): Promise<NormalizedTraceEvent[]> {
+    const runtime = this.runtimes.get(instanceKey(h))
+    if (!runtime) {
+      throw new Error(`CodexWorkerAdapter.readTrace: no such incarnation ${h.worker_id}#${h.seq} resident in this process`)
+    }
+
+    if (!runtime.rolloutPath) {
+      // spawn 时没能发现 rollout 文件(占位 session_id,已知限制)——没有路径可读,退化为空数组。
+      return []
+    }
+
+    let raw: string
+    try {
+      raw = await fs.readFile(runtime.rolloutPath, 'utf-8')
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return []
+      throw err
+    }
+
+    const lines = raw.split('\n').filter((line) => line.length > 0)
+    const start = cursor?.offset ?? 0
+    const events: NormalizedTraceEvent[] = []
+    for (let i = start; i < lines.length; i++) {
+      const event = normalizeRolloutLine(lines[i])
+      if (event) events.push(event)
+    }
+    return events
+  }
+
+  async kill(h: IncarnationHandle): Promise<void> {
+    const runtime = this.runtimes.get(instanceKey(h))
+    if (!runtime) {
+      throw new Error(`CodexWorkerAdapter.kill: no such incarnation ${h.worker_id}#${h.seq} resident in this process`)
+    }
+    await this.getMutex(h.worker_id).run(async () => {
+      if (runtime.state === 'exited') return // 幂等:不覆盖原 ended_reason
+      runtime.killed = true
+      await this.tmux.killSession(runtime.sessionName)
+      await this.transitionExited(runtime, h, 'killed')
+    })
+  }
+
+  capabilities(): AdapterCapabilities {
+    return { fork: false, revive: true, goalMode: false, subagent: false, structuredTrace: true }
+  }
+
+  // --- Internal ---
+
+  /**
+   * 三源合成状态判定:事件文件(新 turn-complete 通知 → idle) > tmux isAlive(false →
+   * exited) > 默认 running。与内存态不同则在互斥锁内原子迁移(改内存 + 写 meta)。判定与
+   * 提交整体在锁内完成,理由与 cc 完全一致(见文件头注释,避免过期快照覆盖并发落定的新结果)。
+   */
+  private async syncState(runtime: Runtime, h: IncarnationHandle): Promise<{ state: WorkerContractState; stopCount: number }> {
+    if (runtime.state === 'exited') return { state: 'exited', stopCount: runtime.stopBaseline }
+
+    return this.getMutex(h.worker_id).run(async () => {
+      if (runtime.state === 'exited') return { state: 'exited', stopCount: runtime.stopBaseline }
+
+      const events = await runtime.eventChannel.readAll()
+      const stopCount = events.filter((e) => e.kind === 'stop').length
+
+      let computed: WorkerContractState
+      if (stopCount > runtime.stopBaseline) {
+        computed = 'idle'
+      } else if (!(await this.tmux.isAlive(runtime.sessionName))) {
+        computed = 'exited'
+      } else {
+        computed = 'running'
+      }
+
+      if (computed !== runtime.state) {
+        if (computed === 'exited') {
+          await this.transitionExited(runtime, h, runtime.killed ? 'killed' : 'completed')
+        } else {
+          await this.transitionState(runtime, h, computed)
+        }
+      }
+
+      return { state: runtime.state, stopCount }
+    })
+  }
+
+  private getMutex(worker_id: string): AsyncMutex {
+    let mutex = this.mutexes.get(worker_id)
+    if (!mutex) {
+      mutex = new AsyncMutex()
+      this.mutexes.set(worker_id, mutex)
+    }
+    return mutex
+  }
+
+  private async transitionState(runtime: Runtime, h: IncarnationHandle, state: WorkerContractState): Promise<void> {
+    await writeMetaAtomic(runtime.dir, runtime.seq, { seq: runtime.seq, state, session_id: runtime.sessionId })
+    runtime.state = state
+    try {
+      this.deps.onStateChange?.(h, state)
+    } catch (err) {
+      console.error(`[CodexWorkerAdapter] onStateChange callback error for ${h.worker_id}#${h.seq}:`, err)
+    }
+  }
+
+  private async transitionExited(runtime: Runtime, h: IncarnationHandle, ended_reason: IncarnationEndReason): Promise<void> {
+    await writeMetaAtomic(runtime.dir, runtime.seq, {
+      seq: runtime.seq,
+      state: 'exited',
+      session_id: runtime.sessionId,
+      ended_reason,
+    })
+    runtime.state = 'exited'
+    runtime.ended_reason = ended_reason
+    try {
+      this.deps.onStateChange?.(h, 'exited')
+    } catch (err) {
+      console.error(`[CodexWorkerAdapter] onStateChange callback error for ${h.worker_id}#${h.seq}:`, err)
+    }
+  }
+}
+
+/** AGENTS.md 里标注的 worker 标签:provision(ws, caps) 拿不到 worker_id,退而取 workspace
+ * 目录名兜底。与 cc adapter 同款独立实现。 */
+function workerIdLabelFromWorkspace(ws: Workspace): string {
+  const trimmed = ws.root.replace(/\/+$/, '')
+  const idx = trimmed.lastIndexOf('/')
+  return idx >= 0 ? trimmed.slice(idx + 1) : trimmed
+}
+
+function truncate(text: string, max: number): string {
+  return text.length > max ? text.slice(0, max) : text
+}
+
+/**
+ * 归一化单行 codex rollout JSONL 为 NormalizedTraceEvent。
+ *
+ * codex-docs: 每行外层是 `{"type": ..., "payload": ...}`(codex-rs/protocol/src/protocol.rs
+ * 的 `RolloutItem` 枚举 `#[serde(tag = "type", content = "payload", rename_all =
+ * "snake_case")]` 确认),顶层 type 取值 session_meta / response_item / event_msg /
+ * turn_context / world_state / compacted / inter_agent_communication /
+ * inter_agent_communication_metadata——只有前三种映射为 trace 事件,其余跳过,同 cc 对
+ * mode/summary/queue-operation 的处理方式(不认识的行归一化为 null,readTrace 跳过)。
+ */
+function normalizeRolloutLine(line: string): NormalizedTraceEvent | null {
+  let parsed: { type?: unknown; payload?: unknown }
+  try {
+    parsed = JSON.parse(line)
+  } catch {
+    return null
+  }
+  if (!parsed || typeof parsed !== 'object') return null
+  const payload = parsed.payload as Record<string, unknown> | undefined
+
+  if (parsed.type === 'session_meta') {
+    const meta = payload as { timestamp?: string; cwd?: string } | undefined
+    const ts = typeof meta?.timestamp === 'string' ? meta.timestamp : ''
+    return { ts, kind: 'lifecycle', role: 'system', summary: truncate(`session_meta cwd=${meta?.cwd ?? ''}`, 200), detail: payload }
+  }
+
+  if (parsed.type === 'event_msg') {
+    // codex-docs: EventMsg 是内部 tag(`#[serde(tag = "type", rename_all = "snake_case")]`,
+    // 字段直接铺在 payload 里,不像 RolloutItem 那样外套一层 content),取 payload.type 当摘要。
+    const eventType = typeof payload?.type === 'string' ? payload.type : 'event_msg'
+    return { ts: '', kind: 'lifecycle', role: 'system', summary: eventType, detail: payload }
+  }
+
+  if (parsed.type === 'response_item') {
+    return normalizeResponseItem(payload)
+  }
+
+  return null
+}
+
+/**
+ * response_item 的 payload 同样是内部 tag(codex-rs/protocol/src/models.rs 的 `ResponseItem`
+ * 枚举 `#[serde(tag = "type", rename_all = "snake_case")]`)。这里只认领已从源码确认字段形状
+ * 的四种子类型(message/function_call/function_call_output/reasoning);其余子类型
+ * (agent_message/local_shell_call/web_search_call/custom_tool_call/...)未逐一核实字段,
+ * 跳过而非猜测映射。
+ */
+function normalizeResponseItem(payload: Record<string, unknown> | undefined): NormalizedTraceEvent | null {
+  if (!payload || typeof payload.type !== 'string') return null
+
+  if (payload.type === 'message') {
+    const role = payload.role
+    const text = extractContentItemsText(payload.content)
+    return {
+      ts: '',
+      kind: 'message',
+      role: role === 'user' || role === 'assistant' || role === 'system' ? role : undefined,
+      summary: truncate(text, 200),
+      detail: payload,
+    }
+  }
+
+  if (payload.type === 'function_call') {
+    const name = typeof payload.name === 'string' ? payload.name : ''
+    const args = typeof payload.arguments === 'string' ? payload.arguments : ''
+    return { ts: '', kind: 'tool_call', role: 'assistant', summary: truncate(`${name}(${args})`, 200), detail: payload }
+  }
+
+  if (payload.type === 'function_call_output') {
+    // codex-docs: FunctionCallOutput 在 ResponseItem 枚举里没有 role 字段(models.rs),不像
+    // cc 的 tool_result 挂在 role=user 的消息体里——role 留空(undefined)。
+    const output = payload.output
+    return { ts: '', kind: 'tool_result', summary: truncate(typeof output === 'string' ? output : JSON.stringify(output ?? {}), 200), detail: payload }
+  }
+
+  if (payload.type === 'reasoning') {
+    const text = extractReasoningSummaryText(payload.summary)
+    return { ts: '', kind: 'thinking', role: 'assistant', summary: truncate(text, 200), detail: payload }
+  }
+
+  return null
+}
+
+/** ContentItem 数组:只取 input_text/output_text 块的 text 拼接,跳过 input_image/input_audio。 */
+function extractContentItemsText(content: unknown): string {
+  if (!Array.isArray(content)) return ''
+  return content
+    .filter((item): item is { type: string; text?: string } => !!item && typeof item === 'object' && typeof (item as { type?: unknown }).type === 'string')
+    .filter((item) => item.type === 'input_text' || item.type === 'output_text')
+    .map((item) => item.text ?? '')
+    .join('\n')
+}
+
+// codex-docs: ReasoningItemReasoningSummary 的具体字段未在本次源码抓取范围内逐一核实,这里
+// 只做防御性提取——数组里任意元素若带字符串 text 字段就拼接,拼不出内容时 summary 退化为空串
+// (不抛错)。真机校准时需要用真实 reasoning 行核对字段名(见 Task 6 报告"未经确认"清单)。
+function extractReasoningSummaryText(summary: unknown): string {
+  if (!Array.isArray(summary)) return ''
+  return summary
+    .map((item) => (item && typeof item === 'object' && typeof (item as { text?: unknown }).text === 'string' ? (item as { text: string }).text : ''))
+    .filter((t) => t.length > 0)
+    .join('\n')
+}

--- a/crabot-agent/src/workers/codex/adapter.ts
+++ b/crabot-agent/src/workers/codex/adapter.ts
@@ -634,11 +634,15 @@ export class CodexWorkerAdapter implements WorkerAdapter {
       const events = await runtime.eventChannel.readAll()
       const stopCount = events.filter((e) => e.kind === 'stop').length
 
+      // isAlive 检查提到最前(终态优先):进程可能在发过 turn-complete 通知之后自退(崩溃/
+      // OOM/自敲 exit)——stopCount 恒 > baseline 会一直判成 idle,永远走不到下面的 isAlive
+      // 分支,化身不落 exited,resume 被永久拒绝(P2 review #2,同 cc adapter 修复)。会话
+      // 已经不在了就直接 exited,不管有没有新通知;只有会话还活着,才轮到通知区分 idle/running。
       let computed: WorkerContractState
-      if (stopCount > runtime.stopBaseline) {
-        computed = 'idle'
-      } else if (!(await this.tmux.isAlive(runtime.sessionName))) {
+      if (!(await this.tmux.isAlive(runtime.sessionName))) {
         computed = 'exited'
+      } else if (stopCount > runtime.stopBaseline) {
+        computed = 'idle'
       } else {
         computed = 'running'
       }

--- a/crabot-agent/src/workers/codex/adapter.ts
+++ b/crabot-agent/src/workers/codex/adapter.ts
@@ -460,53 +460,59 @@ export class CodexWorkerAdapter implements WorkerAdapter {
       throw new Error(`CodexWorkerAdapter.resume: incarnation ${prev.worker_id}#${prev.seq} has not exited yet (state=${prevState})`)
     }
 
-    const seq = prev.seq + 1
-    const handle: IncarnationHandle = { worker_id: prev.worker_id, seq, impl: 'codex' }
-    if (this.runtimes.has(instanceKey(handle))) {
-      throw new Error(`CodexWorkerAdapter.resume: worker_id ${prev.worker_id} seq ${seq} already exists in this process`)
-    }
-
     const dir = prevRuntime.dir
-    const sessionName = `crabot-w-${prev.worker_id}-${seq}`
-    const outputFile = join(dir, `output-${seq}.log`)
-    // codex-docs: `codex resume <SESSION_ID>` 是独立子命令(不是 --resume flag)。
-    // --ask-for-approval/--sandbox 是否对 resume 子命令同样生效未逐条确认,按同一 CLI 顶层
-    // flag 惯例沿用,真机校准时需要核实(见 Task 6 报告)。
-    const command = `${this.codexBin} resume ${shQuote(prev.session_ref)} --ask-for-approval never --sandbox workspace-write`
 
-    // 锁纪律与 spawn 一致:tmux newSession 成功之后才落 meta(running)+注册 runtime。
-    await this.tmux.newSession({ name: sessionName, cwd: prevRuntime.workspaceRoot, command, outputFile, env: { CODEX_HOME: prevRuntime.codexHome } })
+    // seq 分配(nextSeq(),该 worker 现存所有化身 max seq + 1)+ tmux newSession + 提交
+    // (meta+runtime)整体在该 worker 的互斥锁内原子完成——不能再用 prev.seq+1 这种固定公式:
+    // codex 的 resume 链条与 cc 同款语义,继续用 prev.seq+1 会在被更早一次操作占用同一号位
+    // 时假死(见 cc adapter.ts 同款修复、P2 review #1)。newSession 只是起一个 tmux pane
+    // (不等待 CLI 完整应答),放进锁内不违反"耗时较长操作留在锁外"的纪律。
+    let handle!: IncarnationHandle
+    let runtime!: Runtime
+    await this.getMutex(prev.worker_id).run(async () => {
+      const seq = this.nextSeq(prev.worker_id)
+      handle = { worker_id: prev.worker_id, seq, impl: 'codex' }
+      const sessionName = `crabot-w-${prev.worker_id}-${seq}`
+      const outputFile = join(dir, `output-${seq}.log`)
+      // codex-docs: `codex resume <SESSION_ID>` 是独立子命令(不是 --resume flag)。
+      // --ask-for-approval/--sandbox 是否对 resume 子命令同样生效未逐条确认,按同一 CLI 顶层
+      // flag 惯例沿用,真机校准时需要核实(见 Task 6 报告)。
+      const command = `${this.codexBin} resume ${shQuote(prev.session_ref)} --ask-for-approval never --sandbox workspace-write`
 
-    const runtime: Runtime = {
-      worker_id: prev.worker_id,
-      seq,
-      dir,
-      workspaceRoot: prevRuntime.workspaceRoot,
-      codexHome: prevRuntime.codexHome,
-      sessionName,
-      sessionId: prev.session_ref,
-      // resume 续写的是同一个 rollout 文件(session id 不变),不需要重新发现——直接沿用上一
-      // 化身已发现的路径;上一化身当时若发现失败(占位 uuid),这里同样拿不到,保持未知。
-      rolloutPath: prevRuntime.rolloutPath,
-      outputLog: new OutputLog(outputFile),
-      eventChannel: new CliEventChannel(eventsFilePath({ root: prevRuntime.workspaceRoot })),
-      sessionDiscoveryStatus: prevRuntime.sessionDiscoveryStatus,
-      state: 'running',
-      stopBaseline: 0,
-      killed: false,
-    }
+      // 锁纪律与 spawn 一致:tmux newSession 成功之后才落 meta(running)+注册 runtime。
+      await this.tmux.newSession({ name: sessionName, cwd: prevRuntime.workspaceRoot, command, outputFile, env: { CODEX_HOME: prevRuntime.codexHome } })
 
-    await writeMetaAtomic(dir, seq, { seq, state: 'running', session_id: prev.session_ref, session_discovery: prevRuntime.sessionDiscoveryStatus })
-    this.runtimes.set(instanceKey(handle), runtime)
+      runtime = {
+        worker_id: prev.worker_id,
+        seq,
+        dir,
+        workspaceRoot: prevRuntime.workspaceRoot,
+        codexHome: prevRuntime.codexHome,
+        sessionName,
+        sessionId: prev.session_ref,
+        // resume 续写的是同一个 rollout 文件(session id 不变),不需要重新发现——直接沿用上一
+        // 化身已发现的路径;上一化身当时若发现失败(占位 uuid),这里同样拿不到,保持未知。
+        rolloutPath: prevRuntime.rolloutPath,
+        outputLog: new OutputLog(outputFile),
+        eventChannel: new CliEventChannel(eventsFilePath({ root: prevRuntime.workspaceRoot })),
+        sessionDiscoveryStatus: prevRuntime.sessionDiscoveryStatus,
+        state: 'running',
+        stopBaseline: 0,
+        killed: false,
+      }
+
+      await writeMetaAtomic(dir, seq, { seq, state: 'running', session_id: prev.session_ref, session_discovery: prevRuntime.sessionDiscoveryStatus })
+      this.runtimes.set(instanceKey(handle), runtime)
+    })
 
     // 首条 wakeInput 注入失败:按 spawn 同款纪律处理——已注册的化身清理 tmux 会话后落
     // exited(crashed),resume 仍然 reject。
     try {
-      await this.tmux.sendText(sessionName, wakeInput)
+      await this.tmux.sendText(runtime.sessionName, wakeInput)
     } catch (err) {
       await this.getMutex(handle.worker_id).run(async () => {
         if (runtime.state === 'exited') return
-        await this.tmux.killSession(sessionName)
+        await this.tmux.killSession(runtime.sessionName)
         await this.transitionExited(runtime, handle, 'crashed')
       })
       throw err
@@ -656,6 +662,19 @@ export class CodexWorkerAdapter implements WorkerAdapter {
       this.mutexes.set(worker_id, mutex)
     }
     return mutex
+  }
+
+  /**
+   * worker_id 对应下一个可用的化身序号:该 worker 现存所有化身里最大 seq + 1。resume() 在
+   * mutex.run 内调用,保证不与并发的另一次 resume 撞号。与 cc adapter 的同名方法同一思路
+   * (codex 的 fork() 不支持,不参与这个分配)。
+   */
+  private nextSeq(worker_id: string): number {
+    let max = 0
+    for (const runtime of this.runtimes.values()) {
+      if (runtime.worker_id === worker_id && runtime.seq > max) max = runtime.seq
+    }
+    return max + 1
   }
 
   private async transitionState(runtime: Runtime, h: IncarnationHandle, state: WorkerContractState): Promise<void> {

--- a/crabot-agent/src/workers/meta-store.ts
+++ b/crabot-agent/src/workers/meta-store.ts
@@ -1,0 +1,15 @@
+/**
+ * writeMetaAtomic — meta-<seq>.json 原子写(tmp+rename),供 CLI worker adapter(claude-code/codex)
+ * 复用。P1 builtin 的 writeMeta 是同款写法的独立实现(见 builtin/adapter.ts),按约定不改 builtin,
+ * 这里单独抽一份放在 src/workers/ 根供非 builtin 的 adapter 共享。
+ */
+import { promises as fs } from 'fs'
+import { join } from 'path'
+import { randomUUID } from 'crypto'
+
+export async function writeMetaAtomic(dir: string, seq: number, meta: unknown): Promise<void> {
+  const metaPath = join(dir, `meta-${seq}.json`)
+  const tmpPath = join(dir, `.meta-${seq}.json.tmp-${randomUUID()}`)
+  await fs.writeFile(tmpPath, JSON.stringify(meta), 'utf-8')
+  await fs.rename(tmpPath, metaPath)
+}

--- a/crabot-agent/src/workers/provision/materialize.ts
+++ b/crabot-agent/src/workers/provision/materialize.ts
@@ -1,0 +1,77 @@
+import * as fs from 'node:fs/promises'
+import * as path from 'node:path'
+
+export interface ProvisionSources {
+  skills: ReadonlyArray<{ id: string; name: string; skill_dir: string }>
+  mcpServers: ReadonlyArray<{ name: string; transport: string; command?: string; args?: string[]; url?: string }>
+  selfAwareness: { workerId: string; taskTitle: string; disciplines: string }
+}
+
+/**
+ * 逐 skill 把 skill_dir 整目录复制到 <ws>/<targetSubdir>/<name>/。
+ * 目标目录已存在时先整体清空再复制,保证与源目录结构一致(不残留源中已删除的旧文件)。
+ */
+export async function materializeSkills(
+  ws: string,
+  skills: ProvisionSources['skills'],
+  targetSubdir: string
+): Promise<void> {
+  for (const skill of skills) {
+    const dest = path.join(ws, targetSubdir, skill.name)
+    await fs.rm(dest, { recursive: true, force: true })
+    await fs.mkdir(path.dirname(dest), { recursive: true })
+    await fs.cp(skill.skill_dir, dest, { recursive: true })
+  }
+}
+
+/** cc 标准 .mcp.json:stdio 用 command/args,http/sse 用 url。 */
+export function renderMcpJson(servers: ProvisionSources['mcpServers']): string {
+  const mcpServers: Record<string, Record<string, unknown>> = {}
+  for (const s of servers) {
+    if (s.url !== undefined) {
+      mcpServers[s.name] = { url: s.url }
+    } else {
+      const entry: Record<string, unknown> = { command: s.command }
+      if (s.args !== undefined) entry.args = s.args
+      mcpServers[s.name] = entry
+    }
+  }
+  return JSON.stringify({ mcpServers }, null, 2) + '\n'
+}
+
+function tomlString(value: string): string {
+  return '"' + value.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"'
+}
+
+/** codex config.toml 的 mcp_servers 段:stdio 用 command/args,http/sse 用 url。 */
+export function renderCodexMcpToml(servers: ProvisionSources['mcpServers']): string {
+  const blocks = servers.map((s) => {
+    const lines = [`[mcp_servers.${s.name}]`]
+    if (s.url !== undefined) {
+      lines.push(`url = ${tomlString(s.url)}`)
+    } else {
+      lines.push(`command = ${tomlString(s.command ?? '')}`)
+      if (s.args !== undefined) {
+        lines.push(`args = [${s.args.map(tomlString).join(', ')}]`)
+      }
+    }
+    return lines.join('\n')
+  })
+  return blocks.length === 0 ? '' : blocks.join('\n\n') + '\n'
+}
+
+/** CLAUDE.md/AGENTS.md 正文:worker 身份声明 + 中间产物落盘纪律 + HANDOFF.md 交接约定。 */
+export function renderContextMd(sa: ProvisionSources['selfAwareness']): string {
+  return `# ${sa.taskTitle}
+
+你是 crabot 的 worker(worker_id: ${sa.workerId}),当前工作区只服务于这一个任务。
+
+## 中间产物落盘纪律
+
+${sa.disciplines}
+
+## 交接约定
+
+任务中断或需要交接时,把当前进度、已完成的步骤、下一步计划写入工作区根目录的 \`HANDOFF.md\`,供恢复后的自己或接手的其他 worker 继续。
+`
+}

--- a/crabot-agent/src/workers/provision/materialize.ts
+++ b/crabot-agent/src/workers/provision/materialize.ts
@@ -39,14 +39,34 @@ export function renderMcpJson(servers: ProvisionSources['mcpServers']): string {
   return JSON.stringify({ mcpServers }, null, 2) + '\n'
 }
 
+function escapeTomlBasicString(value: string): string {
+  let result = ''
+  for (const ch of value) {
+    if (ch === '\\') {
+      result += '\\\\'
+    } else if (ch === '"') {
+      result += '\\"'
+    } else {
+      const code = ch.charCodeAt(0)
+      if (code < 0x20 || code === 0x7f) {
+        result += '\\u' + code.toString(16).padStart(4, '0')
+      } else {
+        result += ch
+      }
+    }
+  }
+  return result
+}
+
 function tomlString(value: string): string {
-  return '"' + value.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"'
+  return '"' + escapeTomlBasicString(value) + '"'
 }
 
 /** codex config.toml 的 mcp_servers 段:stdio 用 command/args,http/sse 用 url。 */
 export function renderCodexMcpToml(servers: ProvisionSources['mcpServers']): string {
   const blocks = servers.map((s) => {
-    const lines = [`[mcp_servers.${s.name}]`]
+    const escapedName = escapeTomlBasicString(s.name)
+    const lines = [`[mcp_servers."${escapedName}"]`]
     if (s.url !== undefined) {
       lines.push(`url = ${tomlString(s.url)}`)
     } else {

--- a/crabot-agent/src/workers/provision/materialize.ts
+++ b/crabot-agent/src/workers/provision/materialize.ts
@@ -8,18 +8,21 @@ export interface ProvisionSources {
 }
 
 /**
- * skill.name 校验:非空、不含路径分隔符(`/`、`\`)、不是 `..`,且 resolve 后仍落在
- * targetRoot 前缀内。name 来自外部数据(skill 定义),未经校验直接拼进 fs.rm(recursive,
- * force) 的目标路径会让恶意/畸形 name(如含 `/`、`..`)逃出 targetRoot、删掉 workspace 内
- * 甚至外的任意目录(P2 review #3)。
+ * skill.name 校验:非空、不含路径分隔符(`/`、`\`)、不是 `..`、不是 `.`,且 resolve 后
+ * 必须是 targetRoot 的真子路径(不能等于 targetRoot 本身)。name 来自外部数据(skill 定义),
+ * 未经校验直接拼进 fs.rm(recursive, force) 的目标路径会让恶意/畸形 name(如含 `/`、`..`)
+ * 逃出 targetRoot、删掉 workspace 内甚至外的任意目录(P2 review #3)。`.` 是这条规则里
+ * 容易漏掉的一种:不含 `/`、不等于 `..`,resolve(targetRoot, '.') 却恰好等于 targetRoot
+ * 本身——旧校验只检查"逃出前缀",没检查"等于自身",会把 dest 算成 targetRoot,
+ * fs.rm 直接清空整个 skills 目标目录(P2 复审 #4)。
  */
 function validateSkillName(name: string, targetRoot: string): void {
-  if (!name || name.includes('/') || name.includes('\\') || name === '..') {
-    throw new Error(`materializeSkills: invalid skill.name ${JSON.stringify(name)} (must be non-empty, contain no path separators, and not be '..')`)
+  if (!name || name.includes('/') || name.includes('\\') || name === '..' || name === '.') {
+    throw new Error(`materializeSkills: invalid skill.name ${JSON.stringify(name)} (must be non-empty, contain no path separators, and not be '.' or '..')`)
   }
   const resolvedRoot = path.resolve(targetRoot)
   const resolved = path.resolve(targetRoot, name)
-  if (resolved !== resolvedRoot && !resolved.startsWith(resolvedRoot + path.sep)) {
+  if (!resolved.startsWith(resolvedRoot + path.sep)) {
     throw new Error(`materializeSkills: skill.name ${JSON.stringify(name)} escapes target directory`)
   }
 }

--- a/crabot-agent/src/workers/provision/materialize.ts
+++ b/crabot-agent/src/workers/provision/materialize.ts
@@ -8,6 +8,23 @@ export interface ProvisionSources {
 }
 
 /**
+ * skill.name 校验:非空、不含路径分隔符(`/`、`\`)、不是 `..`,且 resolve 后仍落在
+ * targetRoot 前缀内。name 来自外部数据(skill 定义),未经校验直接拼进 fs.rm(recursive,
+ * force) 的目标路径会让恶意/畸形 name(如含 `/`、`..`)逃出 targetRoot、删掉 workspace 内
+ * 甚至外的任意目录(P2 review #3)。
+ */
+function validateSkillName(name: string, targetRoot: string): void {
+  if (!name || name.includes('/') || name.includes('\\') || name === '..') {
+    throw new Error(`materializeSkills: invalid skill.name ${JSON.stringify(name)} (must be non-empty, contain no path separators, and not be '..')`)
+  }
+  const resolvedRoot = path.resolve(targetRoot)
+  const resolved = path.resolve(targetRoot, name)
+  if (resolved !== resolvedRoot && !resolved.startsWith(resolvedRoot + path.sep)) {
+    throw new Error(`materializeSkills: skill.name ${JSON.stringify(name)} escapes target directory`)
+  }
+}
+
+/**
  * 逐 skill 把 skill_dir 整目录复制到 <ws>/<targetSubdir>/<name>/。
  * 目标目录已存在时先整体清空再复制,保证与源目录结构一致(不残留源中已删除的旧文件)。
  */
@@ -16,8 +33,10 @@ export async function materializeSkills(
   skills: ProvisionSources['skills'],
   targetSubdir: string
 ): Promise<void> {
+  const targetRoot = path.join(ws, targetSubdir)
   for (const skill of skills) {
-    const dest = path.join(ws, targetSubdir, skill.name)
+    validateSkillName(skill.name, targetRoot)
+    const dest = path.join(targetRoot, skill.name)
     await fs.rm(dest, { recursive: true, force: true })
     await fs.mkdir(path.dirname(dest), { recursive: true })
     await fs.cp(skill.skill_dir, dest, { recursive: true })

--- a/crabot-agent/src/workers/tmux/driver.ts
+++ b/crabot-agent/src/workers/tmux/driver.ts
@@ -6,9 +6,10 @@
  * 一旦创建就可能立即产生输出(如 `echo`),两次独立调用之间的进程启动开销就足以让这段输出在
  * pipe-pane 挂上前漏掉。批处理让 tmux server 在同一事务内背靠背执行两条子命令,消除这个竞态。
  */
-import { execFile } from 'node:child_process'
+import { execFile, spawn } from 'node:child_process'
 import { promisify } from 'node:util'
 import * as fs from 'node:fs/promises'
+import { randomUUID } from 'node:crypto'
 
 const execFileAsync = promisify(execFile)
 
@@ -64,16 +65,24 @@ export class TmuxDriver {
     ])
   }
 
+  /**
+   * 整段 text 当一条消息注入,走 bracketed paste 路径,而不是逐行 send-keys -l + Enter。
+   * 后者对每一行都发一个 Enter,cc/codex TUI 收到 Enter 会把当前行当完整消息立即提交——
+   * 多行 prompt(任务简报:标题+背景+验收,多行是常态)第一行就被提交、其余逐条进队列,
+   * 语义碎裂。改法:load-buffer 从 stdin 读入整段文本(不经 shell 参数,注入安全)存进一个
+   * 临时命名的 buffer,paste-buffer -p 触发 bracketed paste(目标程序若已请求 bracketed
+   * paste,tmux 会用 \x1b[200~ ... \x1b[201~ 包裹这段内容,程序会把它当"粘贴的一整块",
+   * 内部换行不当提交触发;未请求的程序则原样收到内容,行为等同直接输入),-r 禁用默认的
+   * LF→CR 替换以保留原始换行符,-d 用完即删避免 buffer 堆积。最后单独发一个真实 Enter 提交
+   * 整条消息。单行文本也走同一路径,不再区分单行/多行。
+   */
   async sendText(name: string, text: string): Promise<void> {
-    let lines = text.split('\n')
-    if (text.endsWith('\n')) lines = lines.slice(0, -1)
-
-    for (const line of lines) {
-      if (line.length > 0) {
-        await this.run(['send-keys', '-t', name, '-l', '--', line])
-      }
-      await this.run(['send-keys', '-t', name, 'Enter'])
+    if (text.length > 0) {
+      const bufferName = `crabot-sendtext-${randomUUID()}`
+      await this.loadBufferFromStdin(bufferName, text)
+      await this.run(['paste-buffer', '-p', '-r', '-d', '-b', bufferName, '-t', name])
     }
+    await this.run(['send-keys', '-t', name, 'Enter'])
   }
 
   async sendKeys(name: string, keys: string[]): Promise<void> {
@@ -111,6 +120,24 @@ export class TmuxDriver {
 
   private run(args: string[]): Promise<{ stdout: string; stderr: string }> {
     return execFileAsync(this.tmuxBin, args)
+  }
+
+  /** `tmux load-buffer -b <name> -` 从 stdin 灌入内容,不把文本经过 shell 参数或临时文件。 */
+  private loadBufferFromStdin(bufferName: string, content: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const child = spawn(this.tmuxBin, ['load-buffer', '-b', bufferName, '-'])
+      let stderr = ''
+      child.stderr.on('data', (chunk: Buffer) => {
+        stderr += chunk.toString('utf-8')
+      })
+      child.on('error', reject)
+      child.on('close', (code) => {
+        if (code === 0) resolve()
+        else reject(new Error(`tmux load-buffer exited with code ${code}: ${stderr}`))
+      })
+      child.stdin.write(content)
+      child.stdin.end()
+    })
   }
 }
 

--- a/crabot-agent/src/workers/tmux/driver.ts
+++ b/crabot-agent/src/workers/tmux/driver.ts
@@ -1,0 +1,119 @@
+/**
+ * TmuxDriver — 驱动 tmux 会话的最小封装,供外部 CLI worker adapter(claude-code/codex)复用。
+ *
+ * newSession 把 `new-session` 与 `pipe-pane` 合并进同一次 tmux 调用(用 `;` 分隔的批处理),
+ * 而不是发两条独立的进程调用。原因:pipe-pane 只捕获挂上之后的新输出,不补历史;pane 内命令
+ * 一旦创建就可能立即产生输出(如 `echo`),两次独立调用之间的进程启动开销就足以让这段输出在
+ * pipe-pane 挂上前漏掉。批处理让 tmux server 在同一事务内背靠背执行两条子命令,消除这个竞态。
+ */
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import * as fs from 'node:fs/promises'
+
+const execFileAsync = promisify(execFile)
+
+export interface TmuxSessionSpec {
+  name: string // 约定 crabot-w-<worker_id>-<seq>
+  cwd: string
+  command: string // 在 pane 内执行的命令行
+  env?: Record<string, string>
+  outputFile: string // pipe-pane 追加目标
+}
+
+export class TmuxDriver {
+  private readonly tmuxBin: string
+
+  constructor(opts?: { tmuxBin?: string }) {
+    this.tmuxBin = opts?.tmuxBin ?? 'tmux'
+  }
+
+  async available(): Promise<boolean> {
+    try {
+      await execFileAsync(this.tmuxBin, ['-V'])
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  async newSession(spec: TmuxSessionSpec): Promise<void> {
+    // pipe-pane 首次落盘前文件应已存在,方便调用方直接 watch;不截断已存在内容。
+    await fs.writeFile(spec.outputFile, '', { flag: 'a' })
+
+    const envArgs: string[] = []
+    for (const [key, value] of Object.entries(spec.env ?? {})) {
+      envArgs.push('-e', `${key}=${value}`)
+    }
+
+    const pipeCmd = `cat >> ${shQuote(spec.outputFile)}`
+    await this.run([
+      'new-session',
+      '-d',
+      '-s',
+      spec.name,
+      '-c',
+      spec.cwd,
+      ...envArgs,
+      spec.command,
+      ';',
+      'pipe-pane',
+      '-o',
+      '-t',
+      spec.name,
+      pipeCmd,
+    ])
+  }
+
+  async sendText(name: string, text: string): Promise<void> {
+    let lines = text.split('\n')
+    if (text.endsWith('\n')) lines = lines.slice(0, -1)
+
+    for (const line of lines) {
+      if (line.length > 0) {
+        await this.run(['send-keys', '-t', name, '-l', '--', line])
+      }
+      await this.run(['send-keys', '-t', name, 'Enter'])
+    }
+  }
+
+  async sendKeys(name: string, keys: string[]): Promise<void> {
+    await this.run(['send-keys', '-t', name, ...keys])
+  }
+
+  async isAlive(name: string): Promise<boolean> {
+    try {
+      await this.run(['has-session', '-t', name])
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  async paneCommand(name: string): Promise<string | null> {
+    try {
+      // tmux 对不存在的 target 也会以 exit 0 返回空输出(不抛错),所以用是否有内容来判定,
+      // 而不是依赖 catch。
+      const { stdout } = await this.run(['display-message', '-p', '-t', name, '#{pane_current_command}'])
+      const trimmed = stdout.trim()
+      return trimmed.length > 0 ? trimmed : null
+    } catch {
+      return null
+    }
+  }
+
+  async killSession(name: string): Promise<void> {
+    try {
+      await this.run(['kill-session', '-t', name])
+    } catch {
+      // 幂等:会话不存在时不抛错
+    }
+  }
+
+  private run(args: string[]): Promise<{ stdout: string; stderr: string }> {
+    return execFileAsync(this.tmuxBin, args)
+  }
+}
+
+function shQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`
+}

--- a/crabot-agent/src/workers/types.ts
+++ b/crabot-agent/src/workers/types.ts
@@ -66,7 +66,7 @@ export interface WorkerAdapter {
   sendInput(h: IncarnationHandle, text: string, opts?: { raw?: boolean }): Promise<void>
   readOutput(h: IncarnationHandle, cursor: OutputCursor): Promise<{ chunk: string; nextCursor: OutputCursor }>
   state(h: IncarnationHandle): Promise<WorkerContractState>
-  readTrace?(h: IncarnationHandle, cursor?: TraceCursor): Promise<NormalizedTraceEvent[]>
+  readTrace?(h: IncarnationHandle, cursor?: TraceCursor): Promise<{ events: NormalizedTraceEvent[]; nextCursor: TraceCursor }>
   kill(h: IncarnationHandle): Promise<void>
   capabilities(): AdapterCapabilities
 }

--- a/crabot-agent/tests/workers/claude-code-adapter.test.ts
+++ b/crabot-agent/tests/workers/claude-code-adapter.test.ts
@@ -1006,7 +1006,7 @@ describe('ClaudeCodeAdapter.readTrace', () => {
     await fs.mkdir(slugDir, { recursive: true })
     await fs.writeFile(path.join(slugDir, `${sessionId}.jsonl`), sampleJsonl(sessionId), 'utf-8')
 
-    const events = await adapter.readTrace(h)
+    const { events, nextCursor } = await adapter.readTrace(h)
     expect(events).toHaveLength(5)
 
     expect(events[0]).toMatchObject({ kind: 'message', role: 'user' })
@@ -1023,6 +1023,10 @@ describe('ClaudeCodeAdapter.readTrace', () => {
 
     expect(events[4]).toMatchObject({ kind: 'lifecycle', role: 'system', summary: 'turn_duration' })
 
+    // 原始行数是 7(5 条产生事件 + 1 条 queue-operation 跳过 + 1 条坏 JSON 跳过),
+    // nextCursor 必须计入被跳过的行,不能等于 events.length。
+    expect(nextCursor.offset).toBe(7)
+
     await adapter.kill(h)
   })
 
@@ -1036,24 +1040,69 @@ describe('ClaudeCodeAdapter.readTrace', () => {
     await fs.mkdir(slugDir, { recursive: true })
     await fs.writeFile(path.join(slugDir, `${sessionId}.jsonl`), sampleJsonl(sessionId), 'utf-8')
 
-    const events = await adapter.readTrace(h, { offset: 2 })
+    const { events, nextCursor } = await adapter.readTrace(h, { offset: 2 })
     expect(events).toHaveLength(3)
     expect(events[0].kind).toBe('tool_result')
     expect(events[1].kind).toBe('message')
     expect(events[2].kind).toBe('lifecycle')
+    expect(nextCursor.offset).toBe(7)
 
     await adapter.kill(h)
   })
 
-  it('trace 文件不存在 → 返回空数组,不抛错', async () => {
+  it('nextCursor 计入跳过的坏行/未知类型行,两次 readTrace 按 nextCursor 续读不重不漏', async () => {
+    const tmux = new NoopTmux()
+    const adapter = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin: 'unused', claudeProjectsDir })
+    const workerId = `cctest-${randomUUID().slice(0, 8)}`
+    const { h, sessionId } = await spawnedHandle(adapter, workerId)
+
+    const slugDir = path.join(claudeProjectsDir, projectSlug(workspaceRoot))
+    await fs.mkdir(slugDir, { recursive: true })
+    const filePath = path.join(slugDir, `${sessionId}.jsonl`)
+    await fs.writeFile(filePath, sampleJsonl(sessionId), 'utf-8')
+
+    const first = await adapter.readTrace(h)
+    expect(first.events).toHaveLength(5)
+    // 若调用方错误地用 offset += events.length(5)推进游标,会漏掉被跳过的 queue-operation
+    // 行和坏 JSON 行(原始 7 行)——nextCursor 必须落在 7,不是 5。
+    expect(first.nextCursor.offset).toBe(7)
+
+    // 追加新一批(1 条有效消息 + 1 条坏 JSON),用上一次的 nextCursor 续读。
+    const newLine = {
+      parentUuid: '55555555-5555-5555-5555-555555555555',
+      isSidechain: false,
+      type: 'user',
+      message: { role: 'user', content: '还有一个问题' },
+      uuid: '66666666-6666-6666-6666-666666666666',
+      timestamp: '2026-07-29T01:00:05.000Z',
+      sessionId,
+    }
+    await fs.appendFile(filePath, '\n' + JSON.stringify(newLine) + '\nanother bad line{{{\n', 'utf-8')
+
+    const second = await adapter.readTrace(h, first.nextCursor)
+    expect(second.events).toHaveLength(1)
+    expect(second.events[0].summary).toContain('还有一个问题')
+    // 没有重复读到第一批的任何事件。
+    expect(second.events.map((e) => e.summary)).not.toContain('这个函数为什么会抛 TypeError?')
+    expect(second.nextCursor.offset).toBe(9)
+
+    await adapter.kill(h)
+  })
+
+  it('trace 文件不存在 → 返回空事件数组,不抛错,cursor 原样透传', async () => {
     const tmux = new NoopTmux()
     const adapter = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin: 'unused', claudeProjectsDir })
     const workerId = `cctest-${randomUUID().slice(0, 8)}`
     const { h } = await spawnedHandle(adapter, workerId)
     // 不写任何 fixture 文件。
 
-    const events = await adapter.readTrace(h)
+    const { events, nextCursor } = await adapter.readTrace(h)
     expect(events).toEqual([])
+    expect(nextCursor).toEqual({ offset: 0 })
+
+    const { events: events2, nextCursor: nextCursor2 } = await adapter.readTrace(h, { offset: 3 })
+    expect(events2).toEqual([])
+    expect(nextCursor2).toEqual({ offset: 3 })
 
     await adapter.kill(h)
   })

--- a/crabot-agent/tests/workers/claude-code-adapter.test.ts
+++ b/crabot-agent/tests/workers/claude-code-adapter.test.ts
@@ -797,6 +797,65 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter.fork', () => {
     },
     15000,
   )
+
+  it(
+    '连续两次 fork 同一个 prev,seq 用 nextSeq() 递增分配,不撞号(P2 review #1)',
+    async () => {
+      const tmux = new CountingTmux()
+      const argvFile = path.join(dataDir, 'fork-argv-seq.jsonl')
+      const claudeBin = forkClaudeBin(argvFile, '侧问回复')
+      const adapter = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin })
+      await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
+      const workerId = `cctest-${randomUUID().slice(0, 8)}`
+
+      const h1 = await adapter.spawn({ worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } })
+      const meta1 = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8')) as { session_id: string }
+
+      const h2 = await adapter.fork({ worker_id: workerId, seq: 1, session_ref: meta1.session_id }, '第一次侧问')
+      expect(h2.seq).toBe(2)
+
+      // 对同一个 prev(h1)再 fork 一次:fork 化身常驻不删,旧实现用固定公式 prev.seq+1 算出
+      // seq=2,与 h2 撞号,抛"already exists"。新实现用 nextSeq()(该 worker 现存所有化身
+      // max seq + 1)分配到 3。
+      const h3 = await adapter.fork({ worker_id: workerId, seq: 1, session_ref: meta1.session_id }, '第二次侧问')
+      expect(h3.seq).toBe(3)
+
+      const meta3 = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-3.json'), 'utf-8')) as { state: WorkerContractState }
+      expect(meta3.state).toBe('exited')
+
+      await adapter.kill(h1)
+    },
+    15000,
+  )
+
+  it(
+    'fork 之后 resume 主线,seq 用 nextSeq() 分配,不与 fork 化身撞号(P2 review #1)',
+    async () => {
+      const tmux = new CountingTmux()
+      const argvFile = path.join(dataDir, 'fork-then-resume-argv.jsonl')
+      const claudeBin = forkClaudeBin(argvFile, '侧问回复')
+      const adapter = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin })
+      await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
+      const workerId = `cctest-${randomUUID().slice(0, 8)}`
+
+      const h1 = await adapter.spawn({ worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } })
+      const meta1 = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8')) as { session_id: string }
+
+      const h2 = await adapter.fork({ worker_id: workerId, seq: 1, session_ref: meta1.session_id }, '侧问')
+      expect(h2.seq).toBe(2)
+
+      // 主线还在跑,先 kill 让它落 exited,满足 resume 的前置条件。
+      await adapter.kill(h1)
+
+      // resume 主线:fork 化身 h2(seq=2)常驻不删,旧实现用固定公式 prev.seq+1=2 会与它撞号,
+      // 抛"already exists"。新实现用 nextSeq() 分配到 3。
+      const h3 = await adapter.resume({ worker_id: workerId, seq: 1, session_ref: meta1.session_id }, '继续')
+      expect(h3.seq).toBe(3)
+
+      await adapter.kill(h3)
+    },
+    15000,
+  )
 })
 
 /** 全程无操作的假 TmuxDriver——readTrace 测试只需要一个"常驻 runtime"的化身,不关心 tmux 行为本身。 */

--- a/crabot-agent/tests/workers/claude-code-adapter.test.ts
+++ b/crabot-agent/tests/workers/claude-code-adapter.test.ts
@@ -190,6 +190,39 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter (tmux + mock CLI)', () => {
   )
 
   it(
+    'stop 事件已到但会话被外部 kill(不经 adapter.kill)→ 判定 exited,不永远卡在 idle(P2 review #2)',
+    async () => {
+      const { adapter, workerId } = await provisionedAdapter([{ output: '答完但不退出', emitStop: true }])
+      const h = await adapter.spawn(makeSpec(workerId, '你好'))
+
+      // 等 mock CLI 真的跑完 emitStop(把 stop 事件写进事件文件),再从外部直接杀掉 tmux
+      // 会话(不经 adapter.kill,模拟进程自己崩溃/被系统杀掉,adapter 对此完全不知情)。
+      // 旧实现:syncState 先看 stop 事件,stopCount>baseline 恒判 idle,永远走不到 isAlive
+      // 分支——这里会一直卡在 idle,waitForState(exited) 超时失败。
+      const deadline = Date.now() + 5000
+      let sawStop = false
+      while (Date.now() < deadline) {
+        const raw = await fs.readFile(eventsFilePath({ root: workspaceRoot }), 'utf-8').catch(() => '')
+        if (raw.includes('"kind":"stop"')) {
+          sawStop = true
+          break
+        }
+        await new Promise((r) => setTimeout(r, 50))
+      }
+      expect(sawStop).toBe(true)
+      execFileSync('tmux', ['kill-session', '-t', `crabot-w-${workerId}-1`], { stdio: 'ignore' })
+
+      await waitForState(adapter, h, 'exited')
+
+      const metaRaw = await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8')
+      const meta = JSON.parse(metaRaw) as { state: WorkerContractState; ended_reason?: string }
+      expect(meta.state).toBe('exited')
+      expect(meta.ended_reason).toBe('completed')
+    },
+    15000,
+  )
+
+  it(
     '④ kill → tmux killSession,收敛 exited(killed),再次 kill 幂等',
     async () => {
       const { adapter, workerId } = await provisionedAdapter([{ output: '还在跑' }])
@@ -303,29 +336,29 @@ describe('ClaudeCodeAdapter — syncState 锁纪律(P2 Task 4 评审 Important #
       const workerId = `cctest-${randomUUID().slice(0, 8)}`
       const h = await adapter.spawn({ worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } })
 
-      // A:第一次 state() 读到 stopCount=0(还没有 stop 事件),卡在 isAlive() 上等我们放行。
+      // A:第一次 state() 进锁,isAlive 检查提到最前(P2 review #2),无论 stopCount 是否已有
+      // 新事件都要先卡在 isAlive() 上等我们放行。
       const pA = adapter.state(h)
       await waitUntil(() => tmux.pendingCount === 1)
 
       // 此时才有一条新鲜 stop 事件抵达。
       await fs.appendFile(eventsFilePath({ root: workspaceRoot }), '{"ts":"2026-01-01T00:00:00Z","kind":"stop","raw":null}\n')
 
-      // B:第二次 state() 应该看到新事件、判定 idle 并落盘——不等待 A。
+      // B:第二次 state() 进同一把互斥锁排队——必须等 A 的读+判定+提交整体在锁内收尾之后才能
+      // 开始(锁纪律早已是这样;这里只是确认 isAlive 检查顺序调整后仍然成立)。
       const pB = adapter.state(h)
 
-      // 给 B 一点时间尽量在旧实现下抢先完成(新实现里 B 会排在 A 持锁期间之后,不影响正确性)。
-      await new Promise((r) => setTimeout(r, 300))
+      // 放行 A 的 isAlive(会话仍存活)→ A 判定 running(stopCount=0 未越 baseline),
+      // 与当前状态相同,无需落盘,锁释放。
+      tmux.releaseOne(true)
 
-      // 放行 A 的 isAlive(会话仍存活)。旧实现:A 用过期快照(stopCount=0,isAlive=true)算出
-      // computed='running',在锁内无条件覆盖 B 刚落的 idle。新实现:A/B 全程在锁内重读,
-      // 不会用过期快照覆盖新鲜结果。
+      // B 才真正开始执行:读到新的 stop 事件(stopCount=1),同样先卡在 isAlive() 上。
+      await waitUntil(() => tmux.pendingCount === 1)
       tmux.releaseOne(true)
 
       await Promise.all([pA, pB])
 
-      // 直接读盘上的终态,不经过 adapter.state()——避免再触发一次 syncState 把回退掩盖过去
-      // (回退后的 running 在下一次 syncState 时,若 stopCount 仍 > baseline 会被重新判成 idle,
-      // 从而掩盖了这次评审要抓的竞态)。
+      // 直接读盘上的终态,不经过 adapter.state()——避免再触发一次 syncState 把回退掩盖过去。
       const meta = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8')) as { state: WorkerContractState }
       expect(meta.state).toBe('idle')
     },

--- a/crabot-agent/tests/workers/claude-code-adapter.test.ts
+++ b/crabot-agent/tests/workers/claude-code-adapter.test.ts
@@ -465,6 +465,102 @@ describe('ClaudeCodeAdapter.detect', () => {
   })
 })
 
+describe('ClaudeCodeAdapter — session_ref UUID 边界校验', () => {
+  let dataDir: string
+  let workspaceRoot: string
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'cc-adapter-session-ref-data-'))
+    workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'cc-adapter-session-ref-ws-'))
+  })
+
+  afterEach(async () => {
+    await fs.rm(dataDir, { recursive: true, force: true }).catch(() => {})
+    await fs.rm(workspaceRoot, { recursive: true, force: true }).catch(() => {})
+  })
+
+  it('resume() 拒绝非 UUID 格式的 session_ref(含 shell 注入特征),不执行任何命令', async () => {
+    const adapter = new ClaudeCodeAdapter({ dataDir, claudeBin: 'unused' })
+    const workerId = `w-${randomUUID().slice(0, 8)}`
+
+    // 先 spawn 一个真实化身以供 resume 前置条件
+    // 但这里其实需要一个已 exited 的化身,测试难度较高。改为直接测试 fork() 的拒绝。
+    // 实际上 resume 入口需要前置化身已 exited,我们用一个简化的方式:
+    // 直接测试恶意 session_ref 被拒绝。
+
+    const maliciousSessionRef = 'x; touch /tmp/pwned'
+
+    await expect(
+      adapter.resume(
+        { worker_id: workerId, seq: 1, session_ref: maliciousSessionRef },
+        'payload',
+      ),
+    ).rejects.toThrow(/invalid.*session_ref|UUID|session reference/i)
+  })
+
+  it('fork() 拒绝非 UUID 格式的 session_ref(含 shell 注入特征),不执行子进程', async () => {
+    const adapter = new ClaudeCodeAdapter({ dataDir, claudeBin: 'unused' })
+    const workerId = `w-${randomUUID().slice(0, 8)}`
+
+    const maliciousSessionRef = 'x; touch /tmp/pwned'
+
+    await expect(
+      adapter.fork({ worker_id: workerId, seq: 1, session_ref: maliciousSessionRef }, 'payload'),
+    ).rejects.toThrow(/invalid.*session_ref|UUID|session reference/i)
+
+    // 验证没有副作用文件产生
+    await expect(fs.access('/tmp/pwned')).rejects.toThrow()
+  })
+
+  it('resume() 拒绝空白或特殊字符 session_ref', async () => {
+    const adapter = new ClaudeCodeAdapter({ dataDir, claudeBin: 'unused' })
+    const workerId = `w-${randomUUID().slice(0, 8)}`
+
+    const invalidRefs = ['', ' ', '$(whoami)', '`id`', '{test}', '../../../etc/passwd']
+
+    for (const ref of invalidRefs) {
+      await expect(
+        adapter.resume({ worker_id: workerId, seq: 1, session_ref: ref }, 'payload'),
+      ).rejects.toThrow(/invalid.*session_ref|UUID|session reference/i)
+    }
+  })
+
+  it('fork() 拒绝空白或特殊字符 session_ref', async () => {
+    const adapter = new ClaudeCodeAdapter({ dataDir, claudeBin: 'unused' })
+    const workerId = `w-${randomUUID().slice(0, 8)}`
+
+    const invalidRefs = ['', ' ', '$(whoami)', '`id`', '{test}', '../../../etc/passwd']
+
+    for (const ref of invalidRefs) {
+      await expect(
+        adapter.fork({ worker_id: workerId, seq: 1, session_ref: ref }, 'payload'),
+      ).rejects.toThrow(/invalid.*session_ref|UUID|session reference/i)
+    }
+  })
+
+  it('resume() 接受有效 UUID 格式的 session_ref(至少通过前置校验)', async () => {
+    const adapter = new ClaudeCodeAdapter({ dataDir, claudeBin: 'unused' })
+    const workerId = `w-${randomUUID().slice(0, 8)}`
+    const validUuid = randomUUID()
+
+    // 会因为"不存在该化身"抛错,但不是 session_ref 格式错误
+    await expect(
+      adapter.resume({ worker_id: workerId, seq: 1, session_ref: validUuid }, 'payload'),
+    ).rejects.toThrow(/no such incarnation|not resident/i)
+  })
+
+  it('fork() 接受有效 UUID 格式的 session_ref(至少通过前置校验)', async () => {
+    const adapter = new ClaudeCodeAdapter({ dataDir, claudeBin: 'unused' })
+    const workerId = `w-${randomUUID().slice(0, 8)}`
+    const validUuid = randomUUID()
+
+    // 会因为"不存在该化身"抛错,但不是 session_ref 格式错误
+    await expect(adapter.fork({ worker_id: workerId, seq: 1, session_ref: validUuid }, 'payload')).rejects.toThrow(
+      /no such incarnation|not resident/i,
+    )
+  })
+})
+
 describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter.resume', () => {
   let dataDir: string
   let workspaceRoot: string

--- a/crabot-agent/tests/workers/claude-code-adapter.test.ts
+++ b/crabot-agent/tests/workers/claude-code-adapter.test.ts
@@ -5,7 +5,7 @@ import * as fs from 'node:fs/promises'
 import * as os from 'node:os'
 import * as path from 'node:path'
 import { ClaudeCodeAdapter, eventsFilePath, WorkerExitedError } from '../../src/workers/claude-code/adapter.js'
-import { TmuxDriver } from '../../src/workers/tmux/driver.js'
+import { TmuxDriver, type TmuxSessionSpec } from '../../src/workers/tmux/driver.js'
 import { CliEventChannel } from '../../src/workers/cli-events.js'
 import type { IncarnationHandle, SpawnSpec, WorkerContractState } from '../../src/workers/types.js'
 
@@ -193,6 +193,198 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter (tmux + mock CLI)', () => {
       await waitForState(adapter, h, 'exited')
 
       await expect(adapter.sendInput(h, '还有件事')).rejects.toBeInstanceOf(WorkerExitedError)
+    },
+    15000,
+  )
+})
+
+/** isAlive 可手动挂起/放行的假 TmuxDriver——不起真实 tmux 进程,专供锁纪律竞态测试控制时序。 */
+class RaceTmux extends TmuxDriver {
+  private pending: Array<(v: boolean) => void> = []
+  get pendingCount(): number {
+    return this.pending.length
+  }
+  async newSession(_spec: TmuxSessionSpec): Promise<void> {}
+  async sendText(_name: string, _text: string): Promise<void> {}
+  async sendKeys(_name: string, _keys: string[]): Promise<void> {}
+  async isAlive(_name: string): Promise<boolean> {
+    return new Promise((resolve) => {
+      this.pending.push(resolve)
+    })
+  }
+  async killSession(_name: string): Promise<void> {}
+  /** 放行最早挂起的一次 isAlive() 调用。 */
+  releaseOne(value: boolean): void {
+    const resolve = this.pending.shift()
+    if (resolve) resolve(value)
+  }
+}
+
+/** 转发到可替换的底层 TmuxDriver——用于"先用坏 bin 失败一次,再换成好 bin 重试"的测试场景。 */
+class SwitchableTmuxDriver extends TmuxDriver {
+  current: TmuxDriver
+  constructor(initial: TmuxDriver) {
+    super()
+    this.current = initial
+  }
+  async available(): Promise<boolean> {
+    return this.current.available()
+  }
+  async newSession(spec: TmuxSessionSpec): Promise<void> {
+    return this.current.newSession(spec)
+  }
+  async sendText(name: string, text: string): Promise<void> {
+    return this.current.sendText(name, text)
+  }
+  async sendKeys(name: string, keys: string[]): Promise<void> {
+    return this.current.sendKeys(name, keys)
+  }
+  async isAlive(name: string): Promise<boolean> {
+    return this.current.isAlive(name)
+  }
+  async killSession(name: string): Promise<void> {
+    return this.current.killSession(name)
+  }
+}
+
+async function waitUntil(cond: () => boolean, timeoutMs = 2000): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (cond()) return
+    await new Promise((r) => setTimeout(r, 5))
+  }
+  throw new Error('waitUntil timeout')
+}
+
+describe('ClaudeCodeAdapter — syncState 锁纪律(P2 Task 4 评审 Important #1)', () => {
+  let dataDir: string
+  let workspaceRoot: string
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'cc-adapter-lock-data-'))
+    workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'cc-adapter-lock-ws-'))
+    await fs.mkdir(path.join(workspaceRoot, '.claude'), { recursive: true })
+  })
+
+  afterEach(async () => {
+    await fs.rm(dataDir, { recursive: true, force: true }).catch(() => {})
+    await fs.rm(workspaceRoot, { recursive: true, force: true }).catch(() => {})
+  })
+
+  it(
+    '并发 state() 与事件到达交错后,终读 idle 不回退成 running',
+    async () => {
+      const tmux = new RaceTmux()
+      const adapter = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin: 'unused-in-this-test' })
+      const workerId = `w-${randomUUID().slice(0, 8)}`
+      const h = await adapter.spawn({ worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } })
+
+      // A:第一次 state() 读到 stopCount=0(还没有 stop 事件),卡在 isAlive() 上等我们放行。
+      const pA = adapter.state(h)
+      await waitUntil(() => tmux.pendingCount === 1)
+
+      // 此时才有一条新鲜 stop 事件抵达。
+      await fs.appendFile(eventsFilePath({ root: workspaceRoot }), '{"ts":"2026-01-01T00:00:00Z","kind":"stop","raw":null}\n')
+
+      // B:第二次 state() 应该看到新事件、判定 idle 并落盘——不等待 A。
+      const pB = adapter.state(h)
+
+      // 给 B 一点时间尽量在旧实现下抢先完成(新实现里 B 会排在 A 持锁期间之后,不影响正确性)。
+      await new Promise((r) => setTimeout(r, 300))
+
+      // 放行 A 的 isAlive(会话仍存活)。旧实现:A 用过期快照(stopCount=0,isAlive=true)算出
+      // computed='running',在锁内无条件覆盖 B 刚落的 idle。新实现:A/B 全程在锁内重读,
+      // 不会用过期快照覆盖新鲜结果。
+      tmux.releaseOne(true)
+
+      await Promise.all([pA, pB])
+
+      // 直接读盘上的终态,不经过 adapter.state()——避免再触发一次 syncState 把回退掩盖过去
+      // (回退后的 running 在下一次 syncState 时,若 stopCount 仍 > baseline 会被重新判成 idle,
+      // 从而掩盖了这次评审要抓的竞态)。
+      const meta = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8')) as { state: WorkerContractState }
+      expect(meta.state).toBe('idle')
+    },
+    10000,
+  )
+})
+
+describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — spawn 提交纪律(P2 Task 4 评审 Important #2)', () => {
+  let dataDir: string
+  let workspaceRoot: string
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'cc-adapter-spawn-data-'))
+    workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'cc-adapter-spawn-ws-'))
+  })
+
+  afterEach(async () => {
+    await fs.rm(dataDir, { recursive: true, force: true }).catch(() => {})
+    await fs.rm(workspaceRoot, { recursive: true, force: true }).catch(() => {})
+  })
+
+  it(
+    'tmux 二进制不存在时 spawn reject 且不留 meta,改回正常 tmux 后同 worker_id 重试可成功',
+    async () => {
+      const badTmux = new TmuxDriver({ tmuxBin: '/nonexistent/tmux-bin-does-not-exist-crabot-test' })
+      const tmux = new SwitchableTmuxDriver(badTmux)
+      const channel = new CliEventChannel(eventsFilePath({ root: workspaceRoot }))
+      const stopHookCmd = channel.hookCommand('stop')
+      // claudeBin 用一个存在的 sleep 命令(附加参数被 bash -c 脚本忽略),不依赖真实 claude 二进制,
+      // 只用来验证 tmux 会话能正常起来、sendText 能正常注入。
+      const adapter = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin: `bash -c 'sleep 5'` })
+      await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
+      const workerId = `w-${randomUUID().slice(0, 8)}`
+      const spec: SpawnSpec = { worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } }
+
+      await expect(adapter.spawn(spec)).rejects.toThrow()
+
+      // 失败(tmux newSession 拒绝)不落任何 meta——不留孤儿"running"痕迹。
+      await expect(fs.access(path.join(dataDir, workerId, 'meta-1.json'))).rejects.toThrow()
+
+      // 改回正常 tmux,同一个 worker_id 重新 spawn 应当成功(不被残留的"already spawned"卡住)。
+      tmux.current = new TmuxDriver()
+      const h = await adapter.spawn(spec)
+      expect(h.worker_id).toBe(workerId)
+
+      const metaRaw = await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8')
+      const meta = JSON.parse(metaRaw) as { state: WorkerContractState }
+      expect(meta.state).toBe('running')
+
+      await adapter.kill(h)
+    },
+    15000,
+  )
+
+  it(
+    '首条 sendText 失败时,不放任 running——按 kill 路径落 exited(crashed),spawn 仍 reject',
+    async () => {
+      class NewSessionOkSendTextFailsTmux extends TmuxDriver {
+        killed = false
+        async newSession(spec: TmuxSessionSpec): Promise<void> {
+          return super.newSession(spec)
+        }
+        async sendText(_name: string, _text: string): Promise<void> {
+          throw new Error('simulated sendText failure')
+        }
+        async killSession(name: string): Promise<void> {
+          this.killed = true
+          return super.killSession(name)
+        }
+      }
+      const tmux = new NewSessionOkSendTextFailsTmux()
+      const adapter = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin: `bash -c 'sleep 5'` })
+      await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
+      const workerId = `w-${randomUUID().slice(0, 8)}`
+      const spec: SpawnSpec = { worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } }
+
+      await expect(adapter.spawn(spec)).rejects.toThrow('simulated sendText failure')
+
+      const metaRaw = await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8')
+      const meta = JSON.parse(metaRaw) as { state: WorkerContractState; ended_reason?: string }
+      expect(meta.state).toBe('exited')
+      expect(meta.ended_reason).toBe('crashed')
+      expect(tmux.killed).toBe(true)
     },
     15000,
   )

--- a/crabot-agent/tests/workers/claude-code-adapter.test.ts
+++ b/crabot-agent/tests/workers/claude-code-adapter.test.ts
@@ -699,6 +699,36 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter.resume', () => {
     },
     15000,
   )
+
+  it(
+    '对同一个已 exited 的 prev 连续 resume 两次,第二次应被拒绝(先到先得,对齐 builtin,P2 review #2)',
+    async () => {
+      const channel = new CliEventChannel(eventsFilePath({ root: workspaceRoot }))
+      const stopHookCmd = channel.hookCommand('stop')
+      const claudeBin = claudeBinFor([{ output: '第一轮输出', exit: true }], stopHookCmd)
+      const adapter = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin })
+      await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
+      const workerId = `cctest-${randomUUID().slice(0, 8)}`
+
+      const h1 = await adapter.spawn({ worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } })
+      await waitForState(adapter, h1, 'exited')
+
+      const meta1 = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8')) as { session_id: string }
+
+      const h2 = await adapter.resume({ worker_id: workerId, seq: 1, session_ref: meta1.session_id }, '继续 1')
+      expect(h2.seq).toBe(2)
+
+      // 对同一个 prev(h1)再 resume 一次:nextSeq() 本身不撞号,但 prev 已被 h2 标记
+      // resumed——后来者应被拒绝,不产出第二个 resume 化身(先到先得,对齐 builtin 同款
+      // resumed 语义)。
+      await expect(
+        adapter.resume({ worker_id: workerId, seq: 1, session_ref: meta1.session_id }, '继续 2'),
+      ).rejects.toThrow(/already resumed/)
+
+      await adapter.kill(h2)
+    },
+    15000,
+  )
 })
 
 /** 转发到内部真实 TmuxDriver 并记调用次数——用于断言 fork() 全程没碰 tmux。 */

--- a/crabot-agent/tests/workers/claude-code-adapter.test.ts
+++ b/crabot-agent/tests/workers/claude-code-adapter.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
+import * as fs from 'node:fs/promises'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { ClaudeCodeAdapter, eventsFilePath, WorkerExitedError } from '../../src/workers/claude-code/adapter.js'
+import { TmuxDriver } from '../../src/workers/tmux/driver.js'
+import { CliEventChannel } from '../../src/workers/cli-events.js'
+import type { IncarnationHandle, SpawnSpec, WorkerContractState } from '../../src/workers/types.js'
+
+function detectTmux(): boolean {
+  try {
+    execFileSync('which', ['tmux'], { stdio: 'ignore' })
+    return true
+  } catch {
+    return false
+  }
+}
+const tmuxAvailable = detectTmux()
+
+const MOCK_CLI = path.resolve(__dirname, 'fixtures/mock-cli.mjs')
+
+interface MockStep {
+  output?: string
+  emitStop?: boolean
+  exit?: boolean
+  exitCode?: number
+}
+
+// POSIX shell 单引号转义,与 tmux/driver.ts 的私有 shQuote 同款用法(这里独立复制一份,
+// 仅供测试拼装 `env VAR=... node mock-cli.mjs` 命令行使用)。
+function shQuote(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`
+}
+
+/** 拼一条 `env MOCK_CLI_SCRIPT=... MOCK_CLI_STOP_HOOK_CMD=... node mock-cli.mjs` 命令行,
+ * 充当测试用的 claudeBin——mock CLI 不解析 settings.json,直接从 env 拿脚本和 stop hook 命令。 */
+function claudeBinFor(script: MockStep[], stopHookCmd: string): string {
+  return `env MOCK_CLI_SCRIPT=${shQuote(JSON.stringify(script))} MOCK_CLI_STOP_HOOK_CMD=${shQuote(stopHookCmd)} node ${shQuote(MOCK_CLI)}`
+}
+
+async function waitForState(
+  adapter: ClaudeCodeAdapter,
+  h: IncarnationHandle,
+  target: WorkerContractState,
+  timeoutMs = 8000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  let last: WorkerContractState | undefined
+  while (Date.now() < deadline) {
+    last = await adapter.state(h)
+    if (last === target) return
+    await new Promise((r) => setTimeout(r, 100))
+  }
+  throw new Error(`waitForState timeout: expected '${target}', last seen '${last}'`)
+}
+
+describe('ClaudeCodeAdapter.provision', () => {
+  let ws: string
+
+  beforeEach(async () => {
+    ws = await fs.mkdtemp(path.join(os.tmpdir(), 'cc-adapter-provision-'))
+  })
+
+  afterEach(async () => {
+    await fs.rm(ws, { recursive: true, force: true }).catch(() => {})
+  })
+
+  it('写出 .claude/settings.json(含 Stop/Notification hook 与 permissions)、.mcp.json、CLAUDE.md', async () => {
+    const adapter = new ClaudeCodeAdapter({ dataDir: ws })
+    await adapter.provision({ root: ws }, { skills: [], mcp_servers: [{ name: 'x', transport: 'stdio', command: 'node' }] })
+
+    const settings = JSON.parse(await fs.readFile(path.join(ws, '.claude/settings.json'), 'utf-8'))
+    expect(settings.hooks.Stop[0].hooks[0].command).toContain('events-cli.jsonl')
+    expect(settings.hooks.Notification[0].hooks[0].command).toContain('events-cli.jsonl')
+    expect(settings.permissions.defaultMode).toBe('acceptEdits')
+
+    const mcpJson = JSON.parse(await fs.readFile(path.join(ws, '.mcp.json'), 'utf-8'))
+    expect(mcpJson.mcpServers.x.command).toBe('node')
+
+    const claudeMd = await fs.readFile(path.join(ws, 'CLAUDE.md'), 'utf-8')
+    expect(claudeMd).toContain('你是 crabot 的 worker')
+  })
+})
+
+describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter (tmux + mock CLI)', () => {
+  let dataDir: string
+  let workspaceRoot: string
+  let tmux: TmuxDriver
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'cc-adapter-data-'))
+    workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'cc-adapter-ws-'))
+    tmux = new TmuxDriver()
+  })
+
+  afterEach(async () => {
+    await fs.rm(dataDir, { recursive: true, force: true }).catch(() => {})
+    await fs.rm(workspaceRoot, { recursive: true, force: true }).catch(() => {})
+  })
+
+  async function provisionedAdapter(script: MockStep[]): Promise<{ adapter: ClaudeCodeAdapter; workerId: string }> {
+    const channel = new CliEventChannel(eventsFilePath({ root: workspaceRoot }))
+    const stopHookCmd = channel.hookCommand('stop')
+    const adapter = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin: claudeBinFor(script, stopHookCmd) })
+    // provision 建 .claude/ 目录 —— hook 写入目标目录必须先存在,否则 printf >> 静默失败。
+    await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
+    return { adapter, workerId: `w-${randomUUID().slice(0, 8)}` }
+  }
+
+  function makeSpec(workerId: string, prompt: string): SpawnSpec {
+    return { worker_id: workerId, prompt, workspace: { root: workspaceRoot } }
+  }
+
+  it(
+    '① spawn → mock 输出 → Stop hook → state 收敛 idle,readOutput 可读到该输出',
+    async () => {
+      const { adapter, workerId } = await provisionedAdapter([{ output: '第一段输出', emitStop: true }])
+      const h = await adapter.spawn(makeSpec(workerId, '你好'))
+
+      await waitForState(adapter, h, 'idle')
+
+      const { chunk } = await adapter.readOutput(h, { offset: 0 })
+      expect(chunk).toContain('第一段输出')
+    },
+    15000,
+  )
+
+  it(
+    '② sendInput 续答:第二段输出追加而非覆盖,再次收敛 idle',
+    async () => {
+      const { adapter, workerId } = await provisionedAdapter([
+        { output: '第一段输出', emitStop: true },
+        { output: '第二段输出', emitStop: true },
+      ])
+      const h = await adapter.spawn(makeSpec(workerId, '你好'))
+      await waitForState(adapter, h, 'idle')
+
+      const before = await adapter.readOutput(h, { offset: 0 })
+      expect(before.chunk).toContain('第一段输出')
+
+      await adapter.sendInput(h, '继续')
+      await waitForState(adapter, h, 'idle')
+
+      const after = await adapter.readOutput(h, { offset: 0 })
+      expect(after.chunk).toContain('第一段输出')
+      expect(after.chunk).toContain('第二段输出')
+    },
+    15000,
+  )
+
+  it(
+    '③ 进程自退(不经 Stop hook)→ tmux isAlive 判定 exited',
+    async () => {
+      const { adapter, workerId } = await provisionedAdapter([{ output: '收尾输出', exit: true }])
+      const h = await adapter.spawn(makeSpec(workerId, '你好'))
+
+      await waitForState(adapter, h, 'exited')
+
+      const metaRaw = await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8')
+      const meta = JSON.parse(metaRaw)
+      expect(meta.ended_reason).toBe('completed')
+    },
+    15000,
+  )
+
+  it(
+    '④ kill → tmux killSession,收敛 exited(killed),再次 kill 幂等',
+    async () => {
+      const { adapter, workerId } = await provisionedAdapter([{ output: '还在跑' }])
+      const h = await adapter.spawn(makeSpec(workerId, '你好'))
+
+      await adapter.kill(h)
+      await waitForState(adapter, h, 'exited')
+
+      const metaRaw = await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8')
+      const meta = JSON.parse(metaRaw)
+      expect(meta.ended_reason).toBe('killed')
+
+      await expect(adapter.kill(h)).resolves.toBeUndefined()
+      const metaAfterSecondKill = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8'))
+      expect(metaAfterSecondKill.ended_reason).toBe('killed')
+    },
+    15000,
+  )
+
+  it(
+    '对 exited 化身 sendInput 抛 WorkerExitedError',
+    async () => {
+      const { adapter, workerId } = await provisionedAdapter([{ output: '收尾输出', exit: true }])
+      const h = await adapter.spawn(makeSpec(workerId, '你好'))
+      await waitForState(adapter, h, 'exited')
+
+      await expect(adapter.sendInput(h, '还有件事')).rejects.toBeInstanceOf(WorkerExitedError)
+    },
+    15000,
+  )
+})

--- a/crabot-agent/tests/workers/claude-code-adapter.test.ts
+++ b/crabot-agent/tests/workers/claude-code-adapter.test.ts
@@ -1119,6 +1119,70 @@ describe('ClaudeCodeAdapter.readTrace', () => {
     await adapter.kill(h)
   })
 
+  it('半行(CLI 写入未完成,无结尾换行符)不消费,补全后续读不丢事件', async () => {
+    const tmux = new NoopTmux()
+    const adapter = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin: 'unused', claudeProjectsDir })
+    const workerId = `cctest-${randomUUID().slice(0, 8)}`
+    const { h, sessionId } = await spawnedHandle(adapter, workerId)
+
+    const slugDir = path.join(claudeProjectsDir, projectSlug(workspaceRoot))
+    await fs.mkdir(slugDir, { recursive: true })
+    const filePath = path.join(slugDir, `${sessionId}.jsonl`)
+
+    const line1 = {
+      parentUuid: null,
+      isSidechain: false,
+      type: 'user',
+      message: { role: 'user', content: '第一条' },
+      uuid: '11111111-1111-1111-1111-111111111111',
+      timestamp: '2026-07-29T01:00:00.000Z',
+      sessionId,
+    }
+    // trace 文件由 CLI 持续追加、readTrace 轮询懒解析,读到写入中途是常态:第一行完整,
+    // 第二行只写了一半(无结尾换行符)。
+    await fs.writeFile(filePath, JSON.stringify(line1) + '\n{"type":"user","message":{"rol', 'utf-8')
+
+    const first = await adapter.readTrace(h)
+    expect(first.events).toHaveLength(1)
+    expect(first.events[0].summary).toContain('第一条')
+    // 半行不算已消费的完整行——cursor 必须停在第一行之后,不能越过半行,否则半行补全后
+    // 的事件会被永久跳过。
+    expect(first.nextCursor.offset).toBe(1)
+
+    // 半行补全 + 追加新行。
+    const line2 = {
+      parentUuid: '11111111-1111-1111-1111-111111111111',
+      isSidechain: false,
+      type: 'user',
+      message: { role: 'user', content: '第二条(补全)' },
+      uuid: '22222222-2222-2222-2222-222222222222',
+      timestamp: '2026-07-29T01:00:01.000Z',
+      sessionId,
+    }
+    const line3 = {
+      parentUuid: '22222222-2222-2222-2222-222222222222',
+      isSidechain: false,
+      type: 'user',
+      message: { role: 'user', content: '第三条' },
+      uuid: '33333333-3333-3333-3333-333333333333',
+      timestamp: '2026-07-29T01:00:02.000Z',
+      sessionId,
+    }
+    await fs.writeFile(
+      filePath,
+      JSON.stringify(line1) + '\n' + JSON.stringify(line2) + '\n' + JSON.stringify(line3) + '\n',
+      'utf-8',
+    )
+
+    const second = await adapter.readTrace(h, first.nextCursor)
+    expect(second.events).toHaveLength(2)
+    expect(second.events[0].summary).toContain('第二条(补全)')
+    expect(second.events[1].summary).toContain('第三条')
+    expect(second.nextCursor.offset).toBe(3)
+
+    await adapter.kill(h)
+  })
+
   it('trace 文件不存在 → 返回空事件数组,不抛错,cursor 原样透传', async () => {
     const tmux = new NoopTmux()
     const adapter = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin: 'unused', claudeProjectsDir })

--- a/crabot-agent/tests/workers/claude-code-adapter.test.ts
+++ b/crabot-agent/tests/workers/claude-code-adapter.test.ts
@@ -20,6 +20,8 @@ function detectTmux(): boolean {
 const tmuxAvailable = detectTmux()
 
 const MOCK_CLI = path.resolve(__dirname, 'fixtures/mock-cli.mjs')
+const FAKE_CLAUDE_VERSION = path.resolve(__dirname, 'fixtures/fake-claude-version.mjs')
+const FAKE_CLAUDE_FORK = path.resolve(__dirname, 'fixtures/fake-claude-fork.mjs')
 
 interface MockStep {
   output?: string
@@ -34,10 +36,13 @@ function shQuote(s: string): string {
   return `'${s.replace(/'/g, `'\\''`)}'`
 }
 
-/** 拼一条 `env MOCK_CLI_SCRIPT=... MOCK_CLI_STOP_HOOK_CMD=... node mock-cli.mjs` 命令行,
- * 充当测试用的 claudeBin——mock CLI 不解析 settings.json,直接从 env 拿脚本和 stop hook 命令。 */
-function claudeBinFor(script: MockStep[], stopHookCmd: string): string {
-  return `env MOCK_CLI_SCRIPT=${shQuote(JSON.stringify(script))} MOCK_CLI_STOP_HOOK_CMD=${shQuote(stopHookCmd)} node ${shQuote(MOCK_CLI)}`
+/** 拼一条 `env MOCK_CLI_SCRIPT=... MOCK_CLI_STOP_HOOK_CMD=... [MOCK_CLI_ARGV_FILE=...] node mock-cli.mjs`
+ * 命令行,充当测试用的 claudeBin——mock CLI 不解析 settings.json,直接从 env 拿脚本和 stop
+ * hook 命令。argvFile 可选:传了就让 mock-cli 把收到的 argv(如 resume 的 `--resume <id>`)
+ * 记一行 JSON 进这个文件,供测试断言。 */
+function claudeBinFor(script: MockStep[], stopHookCmd: string, argvFile?: string): string {
+  const argvEnv = argvFile ? `MOCK_CLI_ARGV_FILE=${shQuote(argvFile)} ` : ''
+  return `env MOCK_CLI_SCRIPT=${shQuote(JSON.stringify(script))} MOCK_CLI_STOP_HOOK_CMD=${shQuote(stopHookCmd)} ${argvEnv}node ${shQuote(MOCK_CLI)}`
 }
 
 async function waitForState(
@@ -388,4 +393,463 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — spawn 提交纪律(P2 Tas
     },
     15000,
   )
+})
+
+describe('ClaudeCodeAdapter.detect', () => {
+  let dataDir: string
+  let home: string
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'cc-adapter-detect-data-'))
+    home = await fs.mkdtemp(path.join(os.tmpdir(), 'cc-adapter-detect-home-'))
+  })
+
+  afterEach(async () => {
+    await fs.rm(dataDir, { recursive: true, force: true }).catch(() => {})
+    await fs.rm(home, { recursive: true, force: true }).catch(() => {})
+  })
+
+  function versionBin(version: string): string {
+    return `env FAKE_CLAUDE_VERSION=${shQuote(version)} node ${shQuote(FAKE_CLAUDE_VERSION)}`
+  }
+
+  it('claude 二进制不存在/不可执行 → installed:false, activated:false', async () => {
+    const adapter = new ClaudeCodeAdapter({
+      dataDir,
+      claudeBin: '/nonexistent/claude-bin-does-not-exist-crabot-test',
+    })
+    const result = await adapter.detect()
+    expect(result.installed).toBe(false)
+    expect(result.activated).toBe(false)
+  })
+
+  it('claude 已安装且凭据目录下有 settings.json → installed:true, activated:true', async () => {
+    const claudeDir = path.join(home, '.claude')
+    await fs.mkdir(claudeDir, { recursive: true })
+    await fs.writeFile(path.join(claudeDir, 'settings.json'), '{}', 'utf-8')
+
+    const adapter = new ClaudeCodeAdapter({
+      dataDir,
+      claudeBin: versionBin('9.9.9 (Claude Code)'),
+      claudeProjectsDir: path.join(claudeDir, 'projects'),
+    })
+    const result = await adapter.detect()
+    expect(result.installed).toBe(true)
+    expect(result.activated).toBe(true)
+    expect(result.detail).toContain('9.9.9')
+  })
+
+  it('claude 已安装但凭据目录下没有 settings.json/.credentials.json → activated:false', async () => {
+    const claudeDir = path.join(home, '.claude')
+    await fs.mkdir(claudeDir, { recursive: true }) // 目录存在,但里面空的
+
+    const adapter = new ClaudeCodeAdapter({
+      dataDir,
+      claudeBin: versionBin('9.9.9 (Claude Code)'),
+      claudeProjectsDir: path.join(claudeDir, 'projects'),
+    })
+    const result = await adapter.detect()
+    expect(result.installed).toBe(true)
+    expect(result.activated).toBe(false)
+  })
+
+  it('claude 已安装但 ~/.claude/ 目录本身不存在 → activated:false(不抛错)', async () => {
+    const adapter = new ClaudeCodeAdapter({
+      dataDir,
+      claudeBin: versionBin('9.9.9 (Claude Code)'),
+      claudeProjectsDir: path.join(home, '.claude-does-not-exist', 'projects'),
+    })
+    const result = await adapter.detect()
+    expect(result.installed).toBe(true)
+    expect(result.activated).toBe(false)
+  })
+})
+
+describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter.resume', () => {
+  let dataDir: string
+  let workspaceRoot: string
+  let tmux: TmuxDriver
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'cc-adapter-resume-data-'))
+    workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'cc-adapter-resume-ws-'))
+    tmux = new TmuxDriver()
+  })
+
+  afterEach(async () => {
+    await fs.rm(dataDir, { recursive: true, force: true }).catch(() => {})
+    await fs.rm(workspaceRoot, { recursive: true, force: true }).catch(() => {})
+  })
+
+  it(
+    'resume 后新会话收到 --resume <session_ref> 参数;session_ref 不变,新化身 seq+1',
+    async () => {
+      const channel = new CliEventChannel(eventsFilePath({ root: workspaceRoot }))
+      const stopHookCmd = channel.hookCommand('stop')
+      const argvFile = path.join(dataDir, 'argv.jsonl')
+      const claudeBin = claudeBinFor([{ output: '第一轮输出', exit: true }], stopHookCmd, argvFile)
+      const adapter = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin })
+      await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
+      const workerId = `w-${randomUUID().slice(0, 8)}`
+
+      const h1 = await adapter.spawn({ worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } })
+      await waitForState(adapter, h1, 'exited')
+
+      const meta1 = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8')) as { session_id: string }
+
+      const h2 = await adapter.resume({ worker_id: workerId, seq: 1, session_ref: meta1.session_id }, '继续,把上次的活干完')
+      expect(h2.worker_id).toBe(workerId)
+      expect(h2.seq).toBe(2)
+
+      const meta2Raw = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-2.json'), 'utf-8')) as {
+        session_id: string
+        state: WorkerContractState
+      }
+      // session_ref(cc 会话 uuid)在 resume 前后不变。
+      expect(meta2Raw.session_id).toBe(meta1.session_id)
+      expect(meta2Raw.state).toBe('running')
+
+      // resume 出的 mock 进程收到 wakeInput 才会跑 step0(输出+exit);等它收敛到 exited,
+      // 确保子进程真的启动过、argv 记录行已经落盘,再读 argvFile——resume() 本身返回时只保证
+      // tmux newSession/sendText 已提交,不保证 pane 里的 node 进程已经跑到记录 argv 那一行。
+      await waitForState(adapter, h2, 'exited')
+
+      const argvLines = (await fs.readFile(argvFile, 'utf-8'))
+        .trim()
+        .split('\n')
+        .map((l) => JSON.parse(l) as string[])
+      // 最后一行是 resume 这次调用收到的 argv(第一行是 spawn 那次的 --session-id ...)。
+      const resumeArgv = argvLines[argvLines.length - 1]
+      expect(resumeArgv).toContain('--resume')
+      expect(resumeArgv[resumeArgv.indexOf('--resume') + 1]).toBe(meta1.session_id)
+
+      await adapter.kill(h2)
+    },
+    15000,
+  )
+
+  it(
+    '对尚未 exited 的 prev 调用 resume 应拒绝',
+    async () => {
+      const channel = new CliEventChannel(eventsFilePath({ root: workspaceRoot }))
+      const stopHookCmd = channel.hookCommand('stop')
+      const claudeBin = claudeBinFor([{ output: '还在跑,不退出也不 emitStop' }], stopHookCmd)
+      const adapter = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin })
+      await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
+      const workerId = `w-${randomUUID().slice(0, 8)}`
+
+      const h1 = await adapter.spawn({ worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } })
+      const meta1 = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8')) as { session_id: string }
+
+      await expect(
+        adapter.resume({ worker_id: workerId, seq: 1, session_ref: meta1.session_id }, '继续'),
+      ).rejects.toThrow()
+
+      await adapter.kill(h1)
+    },
+    15000,
+  )
+})
+
+/** 转发到内部真实 TmuxDriver 并记调用次数——用于断言 fork() 全程没碰 tmux。 */
+class CountingTmux extends TmuxDriver {
+  calls = { newSession: 0, sendText: 0, sendKeys: 0, killSession: 0 }
+  private readonly real = new TmuxDriver()
+  async newSession(spec: TmuxSessionSpec): Promise<void> {
+    this.calls.newSession++
+    return this.real.newSession(spec)
+  }
+  async sendText(name: string, text: string): Promise<void> {
+    this.calls.sendText++
+    return this.real.sendText(name, text)
+  }
+  async sendKeys(name: string, keys: string[]): Promise<void> {
+    this.calls.sendKeys++
+    return this.real.sendKeys(name, keys)
+  }
+  async isAlive(name: string): Promise<boolean> {
+    return this.real.isAlive(name)
+  }
+  async killSession(name: string): Promise<void> {
+    this.calls.killSession++
+    return this.real.killSession(name)
+  }
+}
+
+describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter.fork', () => {
+  let dataDir: string
+  let workspaceRoot: string
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'cc-adapter-fork-data-'))
+    workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'cc-adapter-fork-ws-'))
+  })
+
+  afterEach(async () => {
+    await fs.rm(dataDir, { recursive: true, force: true }).catch(() => {})
+    await fs.rm(workspaceRoot, { recursive: true, force: true }).catch(() => {})
+  })
+
+  function forkClaudeBin(argvFile: string, stdout: string, exitCode?: number): string {
+    const exitEnv = exitCode !== undefined ? `FAKE_FORK_EXIT_CODE=${exitCode} ` : ''
+    return `env FAKE_ARGV_FILE=${shQuote(argvFile)} FAKE_FORK_STDOUT=${shQuote(stdout)} ${exitEnv}node ${shQuote(FAKE_CLAUDE_FORK)}`
+  }
+
+  it(
+    'fork 走无头子进程(-p ... --resume ... --fork-session ...),不触碰 tmux;exit 0 → exited(completed)',
+    async () => {
+      const tmux = new CountingTmux()
+      const argvFile = path.join(dataDir, 'fork-argv.jsonl')
+      const claudeBin = forkClaudeBin(argvFile, '侧问回复内容')
+      const adapter = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin })
+      await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
+      const workerId = `w-${randomUUID().slice(0, 8)}`
+
+      // 主线:交互态,fake-claude-fork.mjs 在无 -p 的调用形态下空转不退出。
+      const h1 = await adapter.spawn({ worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } })
+      const meta1 = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8')) as { session_id: string }
+
+      const callsBeforeFork = { ...tmux.calls }
+
+      const h2 = await adapter.fork(
+        { worker_id: workerId, seq: 1, session_ref: meta1.session_id },
+        '这个函数为什么报错?',
+      )
+      expect(h2.worker_id).toBe(workerId)
+      expect(h2.seq).toBe(2)
+
+      // fork 全程没有调用任何 tmux 方法——不进 tmux。
+      expect(tmux.calls).toEqual(callsBeforeFork)
+
+      const state2 = await adapter.state(h2)
+      expect(state2).toBe('exited')
+
+      const meta2 = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-2.json'), 'utf-8')) as {
+        state: WorkerContractState
+        ended_reason?: string
+      }
+      expect(meta2.state).toBe('exited')
+      expect(meta2.ended_reason).toBe('completed')
+
+      const { chunk } = await adapter.readOutput(h2, { offset: 0 })
+      expect(chunk).toContain('侧问回复内容')
+
+      const argvLines = (await fs.readFile(argvFile, 'utf-8'))
+        .trim()
+        .split('\n')
+        .map((l) => JSON.parse(l) as string[])
+      const forkArgv = argvLines[argvLines.length - 1]
+      expect(forkArgv).toEqual([
+        '-p',
+        '这个函数为什么报错?',
+        '--resume',
+        meta1.session_id,
+        '--fork-session',
+        '--output-format',
+        'text',
+      ])
+
+      await adapter.kill(h1)
+    },
+    15000,
+  )
+
+  it(
+    'fork 子进程非 0 退出 → exited(crashed)',
+    async () => {
+      const tmux = new CountingTmux()
+      const argvFile = path.join(dataDir, 'fork-argv-crash.jsonl')
+      const claudeBin = forkClaudeBin(argvFile, '', 1)
+      const adapter = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin })
+      await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
+      const workerId = `w-${randomUUID().slice(0, 8)}`
+
+      const h1 = await adapter.spawn({ worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } })
+      const meta1 = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8')) as { session_id: string }
+
+      const h2 = await adapter.fork({ worker_id: workerId, seq: 1, session_ref: meta1.session_id }, '触发崩溃')
+
+      const meta2 = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-2.json'), 'utf-8')) as {
+        ended_reason?: string
+      }
+      expect(meta2.ended_reason).toBe('crashed')
+
+      await adapter.kill(h1)
+      void h2
+    },
+    15000,
+  )
+})
+
+/** 全程无操作的假 TmuxDriver——readTrace 测试只需要一个"常驻 runtime"的化身,不关心 tmux 行为本身。 */
+class NoopTmux extends TmuxDriver {
+  async newSession(_spec: TmuxSessionSpec): Promise<void> {}
+  async sendText(_name: string, _text: string): Promise<void> {}
+  async sendKeys(_name: string, _keys: string[]): Promise<void> {}
+  async isAlive(_name: string): Promise<boolean> {
+    return true
+  }
+  async killSession(_name: string): Promise<void> {}
+}
+
+describe('ClaudeCodeAdapter.readTrace', () => {
+  let dataDir: string
+  let workspaceRoot: string
+  let claudeProjectsDir: string
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'cc-adapter-trace-data-'))
+    workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'cc-adapter-trace-ws-'))
+    claudeProjectsDir = await fs.mkdtemp(path.join(os.tmpdir(), 'cc-adapter-trace-projects-'))
+  })
+
+  afterEach(async () => {
+    await fs.rm(dataDir, { recursive: true, force: true }).catch(() => {})
+    await fs.rm(workspaceRoot, { recursive: true, force: true }).catch(() => {})
+    await fs.rm(claudeProjectsDir, { recursive: true, force: true }).catch(() => {})
+  })
+
+  function projectSlug(cwd: string): string {
+    return cwd.replace(/[/.]/g, '-')
+  }
+
+  async function spawnedHandle(adapter: ClaudeCodeAdapter, workerId: string): Promise<{ h: IncarnationHandle; sessionId: string }> {
+    const h = await adapter.spawn({ worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } })
+    const meta = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8')) as { session_id: string }
+    return { h, sessionId: meta.session_id }
+  }
+
+  // 手工构造的样例 JSONL(字段名对齐 ~/.claude/projects/ 下真实会话的侦察结果:user/assistant
+  // 记录含 type/uuid/parentUuid/sessionId/timestamp/message,system 含 subtype/content),
+  // 内容全部原创,不摘抄真实会话。
+  function sampleJsonl(sessionId: string): string {
+    const lines = [
+      // 0: user,纯文本消息 → kind message
+      {
+        parentUuid: null,
+        isSidechain: false,
+        type: 'user',
+        message: { role: 'user', content: '这个函数为什么会抛 TypeError?' },
+        uuid: '11111111-1111-1111-1111-111111111111',
+        timestamp: '2026-07-29T01:00:00.000Z',
+        sessionId,
+      },
+      // 1: assistant,tool_use content block → kind tool_call
+      {
+        parentUuid: '11111111-1111-1111-1111-111111111111',
+        isSidechain: false,
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'tool_use', id: 'toolu_01', name: 'Read', input: { file_path: '/tmp/x.ts' } }],
+        },
+        uuid: '22222222-2222-2222-2222-222222222222',
+        timestamp: '2026-07-29T01:00:01.000Z',
+        sessionId,
+      },
+      // 2: user,带 toolUseResult → kind tool_result
+      {
+        parentUuid: '22222222-2222-2222-2222-222222222222',
+        isSidechain: false,
+        type: 'user',
+        message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'toolu_01', content: '文件内容摘要' }] },
+        uuid: '33333333-3333-3333-3333-333333333333',
+        timestamp: '2026-07-29T01:00:02.000Z',
+        toolUseResult: { success: true, content: '文件内容摘要' },
+        sessionId,
+      },
+      // 3: assistant,纯文本回答 → kind message
+      {
+        parentUuid: '33333333-3333-3333-3333-333333333333',
+        isSidechain: false,
+        type: 'assistant',
+        message: { role: 'assistant', content: [{ type: 'text', text: '问题在于第 12 行没有判空。' }] },
+        uuid: '44444444-4444-4444-4444-444444444444',
+        timestamp: '2026-07-29T01:00:03.000Z',
+        sessionId,
+      },
+      // 4: system → kind lifecycle
+      {
+        parentUuid: '44444444-4444-4444-4444-444444444444',
+        isSidechain: false,
+        type: 'system',
+        subtype: 'turn_duration',
+        timestamp: '2026-07-29T01:00:04.000Z',
+        uuid: '55555555-5555-5555-5555-555555555555',
+        sessionId,
+      },
+      // 5: 其他 type → 跳过
+      { type: 'queue-operation', op: 'push', sessionId },
+    ]
+    // 6: 坏行(非法 JSON)→ 跳过,不中断
+    return lines.map((l) => JSON.stringify(l)).join('\n') + '\nnot valid json{{{\n'
+  }
+
+  it('按 ~/.claude/projects/<slug>/<session_id>.jsonl 解析并归一化', async () => {
+    const tmux = new NoopTmux()
+    const adapter = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin: 'unused', claudeProjectsDir })
+    const workerId = `w-${randomUUID().slice(0, 8)}`
+    const { h, sessionId } = await spawnedHandle(adapter, workerId)
+
+    const slugDir = path.join(claudeProjectsDir, projectSlug(workspaceRoot))
+    await fs.mkdir(slugDir, { recursive: true })
+    await fs.writeFile(path.join(slugDir, `${sessionId}.jsonl`), sampleJsonl(sessionId), 'utf-8')
+
+    const events = await adapter.readTrace(h)
+    expect(events).toHaveLength(5)
+
+    expect(events[0]).toMatchObject({ kind: 'message', role: 'user' })
+    expect(events[0].summary).toContain('这个函数为什么会抛 TypeError?')
+
+    expect(events[1]).toMatchObject({ kind: 'tool_call', role: 'assistant' })
+    expect(events[1].summary).toContain('Read')
+
+    expect(events[2]).toMatchObject({ kind: 'tool_result', role: 'user' })
+    expect(events[2].summary).toContain('文件内容摘要')
+
+    expect(events[3]).toMatchObject({ kind: 'message', role: 'assistant' })
+    expect(events[3].summary).toContain('问题在于第 12 行没有判空。')
+
+    expect(events[4]).toMatchObject({ kind: 'lifecycle', role: 'system', summary: 'turn_duration' })
+
+    await adapter.kill(h)
+  })
+
+  it('cursor.offset 按行号跳过已读部分', async () => {
+    const tmux = new NoopTmux()
+    const adapter = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin: 'unused', claudeProjectsDir })
+    const workerId = `w-${randomUUID().slice(0, 8)}`
+    const { h, sessionId } = await spawnedHandle(adapter, workerId)
+
+    const slugDir = path.join(claudeProjectsDir, projectSlug(workspaceRoot))
+    await fs.mkdir(slugDir, { recursive: true })
+    await fs.writeFile(path.join(slugDir, `${sessionId}.jsonl`), sampleJsonl(sessionId), 'utf-8')
+
+    const events = await adapter.readTrace(h, { offset: 2 })
+    expect(events).toHaveLength(3)
+    expect(events[0].kind).toBe('tool_result')
+    expect(events[1].kind).toBe('message')
+    expect(events[2].kind).toBe('lifecycle')
+
+    await adapter.kill(h)
+  })
+
+  it('trace 文件不存在 → 返回空数组,不抛错', async () => {
+    const tmux = new NoopTmux()
+    const adapter = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin: 'unused', claudeProjectsDir })
+    const workerId = `w-${randomUUID().slice(0, 8)}`
+    const { h } = await spawnedHandle(adapter, workerId)
+    // 不写任何 fixture 文件。
+
+    const events = await adapter.readTrace(h)
+    expect(events).toEqual([])
+
+    await adapter.kill(h)
+  })
+
+  it('对本进程内不常驻的 incarnation 调用 readTrace 应拒绝', async () => {
+    const tmux = new NoopTmux()
+    const adapter = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin: 'unused', claudeProjectsDir })
+    await expect(adapter.readTrace({ worker_id: 'nope', seq: 1, impl: 'claude-code' })).rejects.toThrow()
+  })
 })

--- a/crabot-agent/tests/workers/claude-code-adapter.test.ts
+++ b/crabot-agent/tests/workers/claude-code-adapter.test.ts
@@ -19,6 +19,24 @@ function detectTmux(): boolean {
 }
 const tmuxAvailable = detectTmux()
 
+/** 清理所有匹配前缀的 tmux 会话——兜底处理测试泄漏 */
+async function cleanupTmuxSessions(prefix = 'crabot-w-cctest-'): Promise<void> {
+  if (!tmuxAvailable) return
+  try {
+    const output = execFileSync('tmux', ['ls', '-F', '#{session_name}'], { encoding: 'utf-8' })
+    const sessions = output.trim().split('\n').filter((s) => s.startsWith(prefix))
+    for (const session of sessions) {
+      try {
+        execFileSync('tmux', ['kill-session', '-t', session], { stdio: 'ignore' })
+      } catch {
+        // 会话已不存在或其他错误，忽略
+      }
+    }
+  } catch {
+    // tmux ls 失败或其他问题，忽略
+  }
+}
+
 const MOCK_CLI = path.resolve(__dirname, 'fixtures/mock-cli.mjs')
 const FAKE_CLAUDE_VERSION = path.resolve(__dirname, 'fixtures/fake-claude-version.mjs')
 const FAKE_CLAUDE_FORK = path.resolve(__dirname, 'fixtures/fake-claude-fork.mjs')
@@ -101,6 +119,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter (tmux + mock CLI)', () => {
   })
 
   afterEach(async () => {
+    await cleanupTmuxSessions()
     await fs.rm(dataDir, { recursive: true, force: true }).catch(() => {})
     await fs.rm(workspaceRoot, { recursive: true, force: true }).catch(() => {})
   })
@@ -111,7 +130,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter (tmux + mock CLI)', () => {
     const adapter = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin: claudeBinFor(script, stopHookCmd) })
     // provision 建 .claude/ 目录 —— hook 写入目标目录必须先存在,否则 printf >> 静默失败。
     await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
-    return { adapter, workerId: `w-${randomUUID().slice(0, 8)}` }
+    return { adapter, workerId: `cctest-${randomUUID().slice(0, 8)}` }
   }
 
   function makeSpec(workerId: string, prompt: string): SpawnSpec {
@@ -281,7 +300,7 @@ describe('ClaudeCodeAdapter — syncState 锁纪律(P2 Task 4 评审 Important #
     async () => {
       const tmux = new RaceTmux()
       const adapter = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin: 'unused-in-this-test' })
-      const workerId = `w-${randomUUID().slice(0, 8)}`
+      const workerId = `cctest-${randomUUID().slice(0, 8)}`
       const h = await adapter.spawn({ worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } })
 
       // A:第一次 state() 读到 stopCount=0(还没有 stop 事件),卡在 isAlive() 上等我们放行。
@@ -324,6 +343,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — spawn 提交纪律(P2 Tas
   })
 
   afterEach(async () => {
+    await cleanupTmuxSessions()
     await fs.rm(dataDir, { recursive: true, force: true }).catch(() => {})
     await fs.rm(workspaceRoot, { recursive: true, force: true }).catch(() => {})
   })
@@ -339,7 +359,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — spawn 提交纪律(P2 Tas
       // 只用来验证 tmux 会话能正常起来、sendText 能正常注入。
       const adapter = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin: `bash -c 'sleep 5'` })
       await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
-      const workerId = `w-${randomUUID().slice(0, 8)}`
+      const workerId = `cctest-${randomUUID().slice(0, 8)}`
       const spec: SpawnSpec = { worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } }
 
       await expect(adapter.spawn(spec)).rejects.toThrow()
@@ -380,7 +400,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — spawn 提交纪律(P2 Tas
       const tmux = new NewSessionOkSendTextFailsTmux()
       const adapter = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin: `bash -c 'sleep 5'` })
       await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
-      const workerId = `w-${randomUUID().slice(0, 8)}`
+      const workerId = `cctest-${randomUUID().slice(0, 8)}`
       const spec: SpawnSpec = { worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } }
 
       await expect(adapter.spawn(spec)).rejects.toThrow('simulated sendText failure')
@@ -481,7 +501,7 @@ describe('ClaudeCodeAdapter — session_ref UUID 边界校验', () => {
 
   it('resume() 拒绝非 UUID 格式的 session_ref(含 shell 注入特征),不执行任何命令', async () => {
     const adapter = new ClaudeCodeAdapter({ dataDir, claudeBin: 'unused' })
-    const workerId = `w-${randomUUID().slice(0, 8)}`
+    const workerId = `cctest-${randomUUID().slice(0, 8)}`
 
     // 先 spawn 一个真实化身以供 resume 前置条件
     // 但这里其实需要一个已 exited 的化身,测试难度较高。改为直接测试 fork() 的拒绝。
@@ -500,7 +520,7 @@ describe('ClaudeCodeAdapter — session_ref UUID 边界校验', () => {
 
   it('fork() 拒绝非 UUID 格式的 session_ref(含 shell 注入特征),不执行子进程', async () => {
     const adapter = new ClaudeCodeAdapter({ dataDir, claudeBin: 'unused' })
-    const workerId = `w-${randomUUID().slice(0, 8)}`
+    const workerId = `cctest-${randomUUID().slice(0, 8)}`
 
     const maliciousSessionRef = 'x; touch /tmp/pwned'
 
@@ -514,7 +534,7 @@ describe('ClaudeCodeAdapter — session_ref UUID 边界校验', () => {
 
   it('resume() 拒绝空白或特殊字符 session_ref', async () => {
     const adapter = new ClaudeCodeAdapter({ dataDir, claudeBin: 'unused' })
-    const workerId = `w-${randomUUID().slice(0, 8)}`
+    const workerId = `cctest-${randomUUID().slice(0, 8)}`
 
     const invalidRefs = ['', ' ', '$(whoami)', '`id`', '{test}', '../../../etc/passwd']
 
@@ -527,7 +547,7 @@ describe('ClaudeCodeAdapter — session_ref UUID 边界校验', () => {
 
   it('fork() 拒绝空白或特殊字符 session_ref', async () => {
     const adapter = new ClaudeCodeAdapter({ dataDir, claudeBin: 'unused' })
-    const workerId = `w-${randomUUID().slice(0, 8)}`
+    const workerId = `cctest-${randomUUID().slice(0, 8)}`
 
     const invalidRefs = ['', ' ', '$(whoami)', '`id`', '{test}', '../../../etc/passwd']
 
@@ -540,7 +560,7 @@ describe('ClaudeCodeAdapter — session_ref UUID 边界校验', () => {
 
   it('resume() 接受有效 UUID 格式的 session_ref(至少通过前置校验)', async () => {
     const adapter = new ClaudeCodeAdapter({ dataDir, claudeBin: 'unused' })
-    const workerId = `w-${randomUUID().slice(0, 8)}`
+    const workerId = `cctest-${randomUUID().slice(0, 8)}`
     const validUuid = randomUUID()
 
     // 会因为"不存在该化身"抛错,但不是 session_ref 格式错误
@@ -551,7 +571,7 @@ describe('ClaudeCodeAdapter — session_ref UUID 边界校验', () => {
 
   it('fork() 接受有效 UUID 格式的 session_ref(至少通过前置校验)', async () => {
     const adapter = new ClaudeCodeAdapter({ dataDir, claudeBin: 'unused' })
-    const workerId = `w-${randomUUID().slice(0, 8)}`
+    const workerId = `cctest-${randomUUID().slice(0, 8)}`
     const validUuid = randomUUID()
 
     // 会因为"不存在该化身"抛错,但不是 session_ref 格式错误
@@ -573,6 +593,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter.resume', () => {
   })
 
   afterEach(async () => {
+    await cleanupTmuxSessions()
     await fs.rm(dataDir, { recursive: true, force: true }).catch(() => {})
     await fs.rm(workspaceRoot, { recursive: true, force: true }).catch(() => {})
   })
@@ -586,7 +607,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter.resume', () => {
       const claudeBin = claudeBinFor([{ output: '第一轮输出', exit: true }], stopHookCmd, argvFile)
       const adapter = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin })
       await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
-      const workerId = `w-${randomUUID().slice(0, 8)}`
+      const workerId = `cctest-${randomUUID().slice(0, 8)}`
 
       const h1 = await adapter.spawn({ worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } })
       await waitForState(adapter, h1, 'exited')
@@ -632,7 +653,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter.resume', () => {
       const claudeBin = claudeBinFor([{ output: '还在跑,不退出也不 emitStop' }], stopHookCmd)
       const adapter = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin })
       await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
-      const workerId = `w-${randomUUID().slice(0, 8)}`
+      const workerId = `cctest-${randomUUID().slice(0, 8)}`
 
       const h1 = await adapter.spawn({ worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } })
       const meta1 = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8')) as { session_id: string }
@@ -682,6 +703,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter.fork', () => {
   })
 
   afterEach(async () => {
+    await cleanupTmuxSessions()
     await fs.rm(dataDir, { recursive: true, force: true }).catch(() => {})
     await fs.rm(workspaceRoot, { recursive: true, force: true }).catch(() => {})
   })
@@ -699,7 +721,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter.fork', () => {
       const claudeBin = forkClaudeBin(argvFile, '侧问回复内容')
       const adapter = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin })
       await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
-      const workerId = `w-${randomUUID().slice(0, 8)}`
+      const workerId = `cctest-${randomUUID().slice(0, 8)}`
 
       // 主线:交互态,fake-claude-fork.mjs 在无 -p 的调用形态下空转不退出。
       const h1 = await adapter.spawn({ worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } })
@@ -758,7 +780,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter.fork', () => {
       const claudeBin = forkClaudeBin(argvFile, '', 1)
       const adapter = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin })
       await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
-      const workerId = `w-${randomUUID().slice(0, 8)}`
+      const workerId = `cctest-${randomUUID().slice(0, 8)}`
 
       const h1 = await adapter.spawn({ worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } })
       const meta1 = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8')) as { session_id: string }
@@ -800,6 +822,7 @@ describe('ClaudeCodeAdapter.readTrace', () => {
   })
 
   afterEach(async () => {
+    await cleanupTmuxSessions()
     await fs.rm(dataDir, { recursive: true, force: true }).catch(() => {})
     await fs.rm(workspaceRoot, { recursive: true, force: true }).catch(() => {})
     await fs.rm(claudeProjectsDir, { recursive: true, force: true }).catch(() => {})
@@ -884,7 +907,7 @@ describe('ClaudeCodeAdapter.readTrace', () => {
   it('按 ~/.claude/projects/<slug>/<session_id>.jsonl 解析并归一化', async () => {
     const tmux = new NoopTmux()
     const adapter = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin: 'unused', claudeProjectsDir })
-    const workerId = `w-${randomUUID().slice(0, 8)}`
+    const workerId = `cctest-${randomUUID().slice(0, 8)}`
     const { h, sessionId } = await spawnedHandle(adapter, workerId)
 
     const slugDir = path.join(claudeProjectsDir, projectSlug(workspaceRoot))
@@ -914,7 +937,7 @@ describe('ClaudeCodeAdapter.readTrace', () => {
   it('cursor.offset 按行号跳过已读部分', async () => {
     const tmux = new NoopTmux()
     const adapter = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin: 'unused', claudeProjectsDir })
-    const workerId = `w-${randomUUID().slice(0, 8)}`
+    const workerId = `cctest-${randomUUID().slice(0, 8)}`
     const { h, sessionId } = await spawnedHandle(adapter, workerId)
 
     const slugDir = path.join(claudeProjectsDir, projectSlug(workspaceRoot))
@@ -933,7 +956,7 @@ describe('ClaudeCodeAdapter.readTrace', () => {
   it('trace 文件不存在 → 返回空数组,不抛错', async () => {
     const tmux = new NoopTmux()
     const adapter = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin: 'unused', claudeProjectsDir })
-    const workerId = `w-${randomUUID().slice(0, 8)}`
+    const workerId = `cctest-${randomUUID().slice(0, 8)}`
     const { h } = await spawnedHandle(adapter, workerId)
     // 不写任何 fixture 文件。
 

--- a/crabot-agent/tests/workers/cli-events.test.ts
+++ b/crabot-agent/tests/workers/cli-events.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import * as fs from 'node:fs/promises'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { CliEventChannel, type CliEvent } from '../../src/workers/cli-events.js'
+
+const execFileAsync = promisify(execFile)
+
+describe('CliEventChannel', () => {
+  let tempDir: string
+  let filePath: string
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'cli-events-test-'))
+    filePath = path.join(tempDir, 'events-cli.jsonl')
+  })
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true })
+  })
+
+  it('hookCommand 产出的命令在 bash 里执行后, readAll 能解析出对应 kind', async () => {
+    const channel = new CliEventChannel(filePath)
+    const cmd = channel.hookCommand('stop')
+
+    await execFileAsync('/bin/bash', ['-c', cmd])
+
+    const events = await channel.readAll()
+    expect(events).toHaveLength(1)
+    expect(events[0].kind).toBe('stop')
+    expect(events[0].raw).toBeNull()
+    expect(typeof events[0].ts).toBe('string')
+    // ts should be a valid ISO-8601 UTC timestamp
+    expect(events[0].ts).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/)
+  })
+
+  it('hookCommand 对不同 kind 各自产出可解析的独立事件', async () => {
+    const channel = new CliEventChannel(filePath)
+
+    await execFileAsync('/bin/bash', ['-c', channel.hookCommand('notification')])
+    await execFileAsync('/bin/bash', ['-c', channel.hookCommand('session_start')])
+
+    const events = await channel.readAll()
+    expect(events.map((e) => e.kind)).toEqual(['notification', 'session_start'])
+  })
+
+  it('readAll 对不存在的文件返回空数组', async () => {
+    const channel = new CliEventChannel(path.join(tempDir, 'does-not-exist.jsonl'))
+    const events = await channel.readAll()
+    expect(events).toEqual([])
+  })
+
+  it('readAll 跳过坏行, 保留好行', async () => {
+    await fs.writeFile(
+      filePath,
+      ['not json at all', '{"ts":"2026-01-01T00:00:00Z","kind":"stop","raw":null}', '{broken json'].join('\n') + '\n',
+      'utf-8',
+    )
+    const channel = new CliEventChannel(filePath)
+    const events = await channel.readAll()
+    expect(events).toHaveLength(1)
+    expect(events[0].kind).toBe('stop')
+  })
+
+  it('watch 能收到真实 fs 追加驱动的事件(文件此前不存在, 先 watch 后创建)', async () => {
+    const channel = new CliEventChannel(filePath)
+    const received: CliEvent[] = []
+
+    const stop = channel.watch((e) => received.push(e))
+    try {
+      // 文件此前不存在;watch 已启动,随后才创建并写入
+      await fs.writeFile(filePath, '{"ts":"2026-01-01T00:00:00Z","kind":"session_start","raw":null}\n', 'utf-8')
+
+      await vi.waitFor(
+        () => {
+          expect(received).toHaveLength(1)
+        },
+        { timeout: 3000, interval: 50 },
+      )
+      expect(received[0].kind).toBe('session_start')
+    } finally {
+      stop()
+    }
+  })
+
+  it('watch 追加第二行也能收到, 且坏行/半行不打断后续解析', async () => {
+    const channel = new CliEventChannel(filePath)
+    const received: CliEvent[] = []
+    const stop = channel.watch((e) => received.push(e))
+
+    try {
+      await fs.writeFile(filePath, '{"ts":"2026-01-01T00:00:00Z","kind":"stop","raw":null}\n', 'utf-8')
+      await vi.waitFor(() => expect(received).toHaveLength(1), { timeout: 3000, interval: 50 })
+
+      // 追加一条坏行(完整换行终结,但内容损坏——模拟并发写交错截断)
+      await fs.appendFile(filePath, 'garbled{{{not-json\n', 'utf-8')
+
+      // 追加一条半行(尚无换行符——模拟正在写入过程中被读到)
+      await fs.appendFile(filePath, '{"ts":"2026-01-01T00:00:01Z","kind":"noti', 'utf-8')
+
+      // 给 half-line 一点时间,确认此时不会因半行而报错或提前解析出坏结果
+      await new Promise((resolve) => setTimeout(resolve, 200))
+      expect(received).toHaveLength(1) // 仍只有第一条:坏行被跳过,半行未完成
+
+      // 补全半行
+      await fs.appendFile(filePath, 'fication","raw":null}\n', 'utf-8')
+
+      await vi.waitFor(() => expect(received).toHaveLength(2), { timeout: 3000, interval: 50 })
+      expect(received[1].kind).toBe('notification')
+    } finally {
+      stop()
+    }
+  })
+
+  it('stop() 后不再回调', async () => {
+    const channel = new CliEventChannel(filePath)
+    const received: CliEvent[] = []
+    const stop = channel.watch((e) => received.push(e))
+
+    await fs.writeFile(filePath, '{"ts":"2026-01-01T00:00:00Z","kind":"stop","raw":null}\n', 'utf-8')
+    await vi.waitFor(() => expect(received).toHaveLength(1), { timeout: 3000, interval: 50 })
+
+    stop()
+
+    await fs.appendFile(filePath, '{"ts":"2026-01-01T00:00:01Z","kind":"notification","raw":null}\n', 'utf-8')
+    // 停止后给足够时间(覆盖轮询周期量级),确认没有新回调
+    await new Promise((resolve) => setTimeout(resolve, 500))
+    expect(received).toHaveLength(1)
+  })
+})

--- a/crabot-agent/tests/workers/codex-adapter.test.ts
+++ b/crabot-agent/tests/workers/codex-adapter.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { execFileSync } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 import * as fs from 'node:fs/promises'
@@ -123,6 +123,25 @@ describe('CodexWorkerAdapter.provision', () => {
 
     const auth = await fs.readFile(path.join(ws, '.codex/auth.json'), 'utf-8')
     expect(auth).toBe('{"token":"fake"}')
+  })
+
+  it('provision auth.json 权限为 0o600,防止凭据泄露', async () => {
+    await fs.writeFile(path.join(codexHomeSource, 'auth.json'), '{"token":"fake"}', 'utf-8')
+    const adapter = new CodexWorkerAdapter({ dataDir: ws, codexHomeSource })
+    await adapter.provision({ root: ws }, { skills: [], mcp_servers: [] })
+
+    const authPath = path.join(ws, '.codex/auth.json')
+    const stat = await fs.stat(authPath)
+    expect((stat.mode & 0o777)).toBe(0o600)
+  })
+
+  it('provision 在 .codex/ 目录下写入 .gitignore 防止整个隔离 HOME 入库', async () => {
+    const adapter = new CodexWorkerAdapter({ dataDir: ws, codexHomeSource })
+    await adapter.provision({ root: ws }, { skills: [], mcp_servers: [] })
+
+    const gitignorePath = path.join(ws, '.codex/.gitignore')
+    const content = await fs.readFile(gitignorePath, 'utf-8')
+    expect(content).toBe('*\n')
   })
 
   it('codexHomeSource 下没有 auth.json 时不阻塞 provision', async () => {
@@ -264,14 +283,16 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter (tmux + mock CLI)', () => {
   )
 
   it(
-    'session 发现:mock CLI 落 rollout 文件时,meta.session_id 等于文件名里的 uuid',
+    'session 发现:mock CLI 落 rollout 文件时,meta.session_id 等于文件名里的 uuid,标记 session_discovery:discovered',
     async () => {
       const { adapter, workerId, rolloutUuid } = await provisionedAdapter([{ output: '第一段输出', emitStop: true }], { withRollout: true })
       const h = await adapter.spawn(makeSpec(workerId, '你好'))
       await waitForState(adapter, h, 'idle')
 
-      const meta = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8')) as { session_id: string }
+      const meta = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8')) as { session_id: string; session_discovery?: string }
       expect(meta.session_id).toBe(rolloutUuid)
+      // 发现成功应该标记为 'discovered'
+      expect(meta.session_discovery).toBe('discovered')
     },
     15000,
   )
@@ -283,8 +304,31 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter (tmux + mock CLI)', () => {
       const h = await adapter.spawn(makeSpec(workerId, '你好'))
       await waitForState(adapter, h, 'idle')
 
-      const meta = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8')) as { session_id: string }
+      const meta = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8')) as { session_id: string; session_discovery?: string }
       expect(meta.session_id).toMatch(/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/)
+      // 降级路径应该标记 session_discovery: 'placeholder'
+      expect(meta.session_discovery).toBe('placeholder')
+    },
+    15000,
+  )
+
+  it(
+    'session 发现:轮询超时降级时输出 console.warn 日志',
+    async () => {
+      const { adapter, workerId } = await provisionedAdapter([{ output: '第一段输出', emitStop: true }])
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      const h = await adapter.spawn(makeSpec(workerId, '你好'))
+      await waitForState(adapter, h, 'idle')
+
+      // 检查 console.warn 被调用且消息包含关键字
+      expect(warnSpy).toHaveBeenCalled()
+      const calls = warnSpy.mock.calls
+      const warnMessage = calls[0]?.[0] ?? ''
+      expect(String(warnMessage)).toContain('[codex-adapter]')
+      expect(String(warnMessage)).toContain('session discovery')
+
+      warnSpy.mockRestore()
     },
     15000,
   )

--- a/crabot-agent/tests/workers/codex-adapter.test.ts
+++ b/crabot-agent/tests/workers/codex-adapter.test.ts
@@ -367,7 +367,7 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter (tmux + mock CLI)', () => {
   )
 
   it(
-    '对同一个已 exited 的 prev 连续 resume 两次,seq 用 nextSeq() 递增分配,不撞号(P2 review #1)',
+    '对同一个已 exited 的 prev 连续 resume 两次,第二次应被拒绝(先到先得,对齐 builtin,P2 review #2)',
     async () => {
       const { adapter, workerId } = await provisionedAdapter([{ output: '主线输出', exit: true }])
       const h1 = await adapter.spawn(makeSpec(workerId, '你好'))
@@ -378,14 +378,14 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter (tmux + mock CLI)', () => {
       const h2 = await adapter.resume({ worker_id: workerId, seq: 1, session_ref: meta1.session_id }, '继续 1')
       expect(h2.seq).toBe(2)
 
-      // 对同一个 prev(h1,仍是 exited 终态)再 resume 一次:旧实现用固定公式 prev.seq+1
-      // 算出 seq=2,与 h2 撞号,抛"already exists"。新实现用 nextSeq()(该 worker 现存所有
-      // 化身 max seq + 1)分配到 3。
-      const h3 = await adapter.resume({ worker_id: workerId, seq: 1, session_ref: meta1.session_id }, '继续 2')
-      expect(h3.seq).toBe(3)
+      // 对同一个 prev(h1,仍是 exited 终态)再 resume 一次:nextSeq() 本身不撞号(会分配到
+      // 3),但 prev 已被 h2 标记 resumed——后来者应被拒绝,不产出第二个 resume 化身(先到
+      // 先得,对齐 builtin 同款 resumed 语义,P2 review #2)。
+      await expect(
+        adapter.resume({ worker_id: workerId, seq: 1, session_ref: meta1.session_id }, '继续 2'),
+      ).rejects.toThrow(/already resumed/)
 
       await adapter.kill(h2)
-      await adapter.kill(h3)
     },
     15000,
   )

--- a/crabot-agent/tests/workers/codex-adapter.test.ts
+++ b/crabot-agent/tests/workers/codex-adapter.test.ts
@@ -1,0 +1,669 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
+import * as fs from 'node:fs/promises'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { CodexWorkerAdapter, eventsFilePath, WorkerExitedError, CapabilityNotSupportedError } from '../../src/workers/codex/adapter.js'
+import { TmuxDriver, type TmuxSessionSpec } from '../../src/workers/tmux/driver.js'
+import { CliEventChannel } from '../../src/workers/cli-events.js'
+import type { IncarnationHandle, SpawnSpec, WorkerContractState } from '../../src/workers/types.js'
+
+function detectTmux(): boolean {
+  try {
+    execFileSync('which', ['tmux'], { stdio: 'ignore' })
+    return true
+  } catch {
+    return false
+  }
+}
+const tmuxAvailable = detectTmux()
+
+/** 清理所有匹配前缀的 tmux 会话——兜底处理测试泄漏 */
+async function cleanupTmuxSessions(prefix = 'crabot-w-codextest-'): Promise<void> {
+  if (!tmuxAvailable) return
+  try {
+    const output = execFileSync('tmux', ['ls', '-F', '#{session_name}'], { encoding: 'utf-8' })
+    const sessions = output.trim().split('\n').filter((s) => s.startsWith(prefix))
+    for (const session of sessions) {
+      try {
+        execFileSync('tmux', ['kill-session', '-t', session], { stdio: 'ignore' })
+      } catch {
+        // 会话已不存在或其他错误,忽略
+      }
+    }
+  } catch {
+    // tmux ls 失败或其他问题,忽略
+  }
+}
+
+const MOCK_CLI = path.resolve(__dirname, 'fixtures/mock-cli.mjs')
+const FAKE_CODEX_VERSION = path.resolve(__dirname, 'fixtures/fake-codex-version.mjs')
+
+interface MockStep {
+  output?: string
+  emitStop?: boolean
+  exit?: boolean
+  exitCode?: number
+}
+
+// POSIX shell 单引号转义,与 tmux/driver.ts 的私有 shQuote 同款用法(独立复制一份,
+// 仅供测试拼装 `env VAR=... node mock-cli.mjs` 命令行使用)。
+function shQuote(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`
+}
+
+/** rollout 文件名:`rollout-YYYY-MM-DDThh-mm-ss-<uuid>.jsonl`,与 codex 源码确认的命名格式
+ * 一致(见 adapter.ts 头注释"session 发现"节)。 */
+function rolloutFileNameFor(uuid: string): string {
+  const now = new Date()
+  const pad = (n: number) => String(n).padStart(2, '0')
+  const ts = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}T${pad(now.getHours())}-${pad(now.getMinutes())}-${pad(now.getSeconds())}`
+  return `rollout-${ts}-${uuid}.jsonl`
+}
+
+/** 拼一条 `env MOCK_CLI_SCRIPT=... MOCK_CLI_STOP_HOOK_CMD=... [MOCK_CLI_ARGV_FILE=...]
+ * [MOCK_CLI_ROLLOUT_FILE=...] node mock-cli.mjs` 命令行,充当测试用的 codexBin。 */
+function codexBinFor(script: MockStep[], stopHookCmd: string, opts?: { argvFile?: string; rolloutFile?: string }): string {
+  const argvEnv = opts?.argvFile ? `MOCK_CLI_ARGV_FILE=${shQuote(opts.argvFile)} ` : ''
+  const rolloutEnv = opts?.rolloutFile ? `MOCK_CLI_ROLLOUT_FILE=${shQuote(opts.rolloutFile)} ` : ''
+  return `env MOCK_CLI_SCRIPT=${shQuote(JSON.stringify(script))} MOCK_CLI_STOP_HOOK_CMD=${shQuote(stopHookCmd)} ${argvEnv}${rolloutEnv}node ${shQuote(MOCK_CLI)}`
+}
+
+async function waitForState(
+  adapter: CodexWorkerAdapter,
+  h: IncarnationHandle,
+  target: WorkerContractState,
+  timeoutMs = 8000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  let last: WorkerContractState | undefined
+  while (Date.now() < deadline) {
+    last = await adapter.state(h)
+    if (last === target) return
+    await new Promise((r) => setTimeout(r, 100))
+  }
+  throw new Error(`waitForState timeout: expected '${target}', last seen '${last}'`)
+}
+
+describe('CodexWorkerAdapter.provision', () => {
+  let ws: string
+  let codexHomeSource: string
+
+  beforeEach(async () => {
+    ws = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-adapter-provision-'))
+    codexHomeSource = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-adapter-home-src-'))
+  })
+
+  afterEach(async () => {
+    await fs.rm(ws, { recursive: true, force: true }).catch(() => {})
+    await fs.rm(codexHomeSource, { recursive: true, force: true }).catch(() => {})
+  })
+
+  it('写出 .codex/config.toml(notify 段在 mcp_servers 表头之前)、AGENTS.md', async () => {
+    const adapter = new CodexWorkerAdapter({ dataDir: ws, codexHomeSource })
+    await adapter.provision({ root: ws }, { skills: [], mcp_servers: [{ name: 'x', transport: 'stdio', command: 'node' }] })
+
+    const configToml = await fs.readFile(path.join(ws, '.codex/config.toml'), 'utf-8')
+    expect(configToml).toContain('notify = ')
+    expect(configToml).toContain('events-cli.jsonl')
+    expect(configToml).toContain('[mcp_servers."x"]')
+    expect(configToml).toContain('command = "node"')
+    // TOML 根级 key(notify)必须出现在第一个 table([mcp_servers...])之前。
+    expect(configToml.indexOf('notify =')).toBeLessThan(configToml.indexOf('[mcp_servers'))
+
+    const agentsMd = await fs.readFile(path.join(ws, 'AGENTS.md'), 'utf-8')
+    expect(agentsMd).toContain('你是 crabot 的 worker')
+  })
+
+  it('provision 把 codexHomeSource/auth.json 复制进 workspace 隔离出来的 .codex/auth.json', async () => {
+    await fs.writeFile(path.join(codexHomeSource, 'auth.json'), '{"token":"fake"}', 'utf-8')
+    const adapter = new CodexWorkerAdapter({ dataDir: ws, codexHomeSource })
+    await adapter.provision({ root: ws }, { skills: [], mcp_servers: [] })
+
+    const auth = await fs.readFile(path.join(ws, '.codex/auth.json'), 'utf-8')
+    expect(auth).toBe('{"token":"fake"}')
+  })
+
+  it('codexHomeSource 下没有 auth.json 时不阻塞 provision', async () => {
+    const adapter = new CodexWorkerAdapter({ dataDir: ws, codexHomeSource })
+    await expect(adapter.provision({ root: ws }, { skills: [], mcp_servers: [] })).resolves.toBeUndefined()
+    await expect(fs.access(path.join(ws, '.codex/auth.json'))).rejects.toThrow()
+  })
+})
+
+describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter (tmux + mock CLI)', () => {
+  let dataDir: string
+  let workspaceRoot: string
+  let tmux: TmuxDriver
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-adapter-data-'))
+    workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-adapter-ws-'))
+    tmux = new TmuxDriver()
+  })
+
+  afterEach(async () => {
+    await cleanupTmuxSessions()
+    await fs.rm(dataDir, { recursive: true, force: true }).catch(() => {})
+    await fs.rm(workspaceRoot, { recursive: true, force: true }).catch(() => {})
+  })
+
+  async function provisionedAdapter(
+    script: MockStep[],
+    opts?: { withRollout?: boolean },
+  ): Promise<{ adapter: CodexWorkerAdapter; workerId: string; rolloutUuid?: string; rolloutFile?: string }> {
+    const channel = new CliEventChannel(eventsFilePath({ root: workspaceRoot }))
+    const stopHookCmd = channel.hookCommand('stop')
+    const codexHome = path.join(workspaceRoot, '.codex')
+
+    let rolloutUuid: string | undefined
+    let rolloutFile: string | undefined
+    if (opts?.withRollout) {
+      rolloutUuid = randomUUID()
+      const now = new Date()
+      const pad = (n: number) => String(n).padStart(2, '0')
+      const datePath = path.join(String(now.getFullYear()), pad(now.getMonth() + 1), pad(now.getDate()))
+      rolloutFile = path.join(codexHome, 'sessions', datePath, rolloutFileNameFor(rolloutUuid))
+    }
+
+    const codexBin = codexBinFor(script, stopHookCmd, { rolloutFile })
+    // 测试用小轮询上限,避免"故意不配置 rollout 文件"的用例拖慢整个套件。
+    const adapter = new CodexWorkerAdapter({ dataDir, tmux, codexBin, sessionDiscoveryTimeoutMs: 1500 })
+    // provision 建 .codex/ 目录——hook 写入目标目录必须先存在,否则 printf >> 静默失败。
+    await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
+    return { adapter, workerId: `codextest-${randomUUID().slice(0, 8)}`, rolloutUuid, rolloutFile }
+  }
+
+  function makeSpec(workerId: string, prompt: string): SpawnSpec {
+    return { worker_id: workerId, prompt, workspace: { root: workspaceRoot } }
+  }
+
+  it(
+    '① spawn → mock 输出 → notify → state 收敛 idle,readOutput 可读到该输出',
+    async () => {
+      const { adapter, workerId } = await provisionedAdapter([{ output: '第一段输出', emitStop: true }])
+      const h = await adapter.spawn(makeSpec(workerId, '你好'))
+
+      await waitForState(adapter, h, 'idle')
+
+      const { chunk } = await adapter.readOutput(h, { offset: 0 })
+      expect(chunk).toContain('第一段输出')
+    },
+    15000,
+  )
+
+  it(
+    '② sendInput 续答:第二段输出追加而非覆盖,再次收敛 idle',
+    async () => {
+      const { adapter, workerId } = await provisionedAdapter([
+        { output: '第一段输出', emitStop: true },
+        { output: '第二段输出', emitStop: true },
+      ])
+      const h = await adapter.spawn(makeSpec(workerId, '你好'))
+      await waitForState(adapter, h, 'idle')
+
+      const before = await adapter.readOutput(h, { offset: 0 })
+      expect(before.chunk).toContain('第一段输出')
+
+      await adapter.sendInput(h, '继续')
+      await waitForState(adapter, h, 'idle')
+
+      const after = await adapter.readOutput(h, { offset: 0 })
+      expect(after.chunk).toContain('第一段输出')
+      expect(after.chunk).toContain('第二段输出')
+    },
+    15000,
+  )
+
+  it(
+    '③ 进程自退(不经 notify)→ tmux isAlive 判定 exited',
+    async () => {
+      const { adapter, workerId } = await provisionedAdapter([{ output: '收尾输出', exit: true }])
+      const h = await adapter.spawn(makeSpec(workerId, '你好'))
+
+      await waitForState(adapter, h, 'exited')
+
+      const metaRaw = await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8')
+      const meta = JSON.parse(metaRaw)
+      expect(meta.ended_reason).toBe('completed')
+    },
+    15000,
+  )
+
+  it(
+    '④ kill → tmux killSession,收敛 exited(killed),再次 kill 幂等',
+    async () => {
+      const { adapter, workerId } = await provisionedAdapter([{ output: '还在跑' }])
+      const h = await adapter.spawn(makeSpec(workerId, '你好'))
+
+      await adapter.kill(h)
+      await waitForState(adapter, h, 'exited')
+
+      const metaRaw = await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8')
+      const meta = JSON.parse(metaRaw)
+      expect(meta.ended_reason).toBe('killed')
+
+      await expect(adapter.kill(h)).resolves.toBeUndefined()
+      const metaAfterSecondKill = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8'))
+      expect(metaAfterSecondKill.ended_reason).toBe('killed')
+    },
+    15000,
+  )
+
+  it(
+    '对 exited 化身 sendInput 抛 WorkerExitedError',
+    async () => {
+      const { adapter, workerId } = await provisionedAdapter([{ output: '收尾输出', exit: true }])
+      const h = await adapter.spawn(makeSpec(workerId, '你好'))
+      await waitForState(adapter, h, 'exited')
+
+      await expect(adapter.sendInput(h, '还有件事')).rejects.toBeInstanceOf(WorkerExitedError)
+    },
+    15000,
+  )
+
+  it(
+    'session 发现:mock CLI 落 rollout 文件时,meta.session_id 等于文件名里的 uuid',
+    async () => {
+      const { adapter, workerId, rolloutUuid } = await provisionedAdapter([{ output: '第一段输出', emitStop: true }], { withRollout: true })
+      const h = await adapter.spawn(makeSpec(workerId, '你好'))
+      await waitForState(adapter, h, 'idle')
+
+      const meta = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8')) as { session_id: string }
+      expect(meta.session_id).toBe(rolloutUuid)
+    },
+    15000,
+  )
+
+  it(
+    'session 发现:没有 rollout 文件时轮询超时,退化为本地占位 uuid(仍是合法 uuid,spawn 不因此失败)',
+    async () => {
+      const { adapter, workerId } = await provisionedAdapter([{ output: '第一段输出', emitStop: true }])
+      const h = await adapter.spawn(makeSpec(workerId, '你好'))
+      await waitForState(adapter, h, 'idle')
+
+      const meta = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8')) as { session_id: string }
+      expect(meta.session_id).toMatch(/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/)
+    },
+    15000,
+  )
+})
+
+/** 转发到可替换的底层 TmuxDriver——用于"先用坏 bin 失败一次,再换成好 bin 重试"的测试场景。 */
+class SwitchableTmuxDriver extends TmuxDriver {
+  current: TmuxDriver
+  constructor(initial: TmuxDriver) {
+    super()
+    this.current = initial
+  }
+  async available(): Promise<boolean> {
+    return this.current.available()
+  }
+  async newSession(spec: TmuxSessionSpec): Promise<void> {
+    return this.current.newSession(spec)
+  }
+  async sendText(name: string, text: string): Promise<void> {
+    return this.current.sendText(name, text)
+  }
+  async sendKeys(name: string, keys: string[]): Promise<void> {
+    return this.current.sendKeys(name, keys)
+  }
+  async isAlive(name: string): Promise<boolean> {
+    return this.current.isAlive(name)
+  }
+  async killSession(name: string): Promise<void> {
+    return this.current.killSession(name)
+  }
+}
+
+describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter — spawn 提交纪律', () => {
+  let dataDir: string
+  let workspaceRoot: string
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-adapter-spawn-data-'))
+    workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-adapter-spawn-ws-'))
+  })
+
+  afterEach(async () => {
+    await cleanupTmuxSessions()
+    await fs.rm(dataDir, { recursive: true, force: true }).catch(() => {})
+    await fs.rm(workspaceRoot, { recursive: true, force: true }).catch(() => {})
+  })
+
+  it(
+    'tmux 二进制不存在时 spawn reject 且不留 meta,改回正常 tmux 后同 worker_id 重试可成功',
+    async () => {
+      const badTmux = new TmuxDriver({ tmuxBin: '/nonexistent/tmux-bin-does-not-exist-crabot-test' })
+      const tmux = new SwitchableTmuxDriver(badTmux)
+      const adapter = new CodexWorkerAdapter({ dataDir, tmux, codexBin: `bash -c 'sleep 5'`, sessionDiscoveryTimeoutMs: 200 })
+      await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
+      const workerId = `codextest-${randomUUID().slice(0, 8)}`
+      const spec: SpawnSpec = { worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } }
+
+      await expect(adapter.spawn(spec)).rejects.toThrow()
+
+      // 失败(tmux newSession 拒绝)不落任何 meta——不留孤儿"running"痕迹。
+      await expect(fs.access(path.join(dataDir, workerId, 'meta-1.json'))).rejects.toThrow()
+
+      // 改回正常 tmux,同一个 worker_id 重新 spawn 应当成功(不被残留的"already spawned"卡住)。
+      tmux.current = new TmuxDriver()
+      const h = await adapter.spawn(spec)
+      expect(h.worker_id).toBe(workerId)
+
+      const metaRaw = await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8')
+      const meta = JSON.parse(metaRaw) as { state: WorkerContractState }
+      expect(meta.state).toBe('running')
+
+      await adapter.kill(h)
+    },
+    15000,
+  )
+
+  it(
+    '首条 sendText 失败时,不放任 running——按 kill 路径落 exited(crashed),spawn 仍 reject',
+    async () => {
+      class NewSessionOkSendTextFailsTmux extends TmuxDriver {
+        killed = false
+        async newSession(spec: TmuxSessionSpec): Promise<void> {
+          return super.newSession(spec)
+        }
+        async sendText(_name: string, _text: string): Promise<void> {
+          throw new Error('simulated sendText failure')
+        }
+        async killSession(name: string): Promise<void> {
+          this.killed = true
+          return super.killSession(name)
+        }
+      }
+      const tmux = new NewSessionOkSendTextFailsTmux()
+      const adapter = new CodexWorkerAdapter({ dataDir, tmux, codexBin: `bash -c 'sleep 5'`, sessionDiscoveryTimeoutMs: 200 })
+      await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
+      const workerId = `codextest-${randomUUID().slice(0, 8)}`
+      const spec: SpawnSpec = { worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } }
+
+      await expect(adapter.spawn(spec)).rejects.toThrow('simulated sendText failure')
+
+      const metaRaw = await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8')
+      const meta = JSON.parse(metaRaw) as { state: WorkerContractState; ended_reason?: string }
+      expect(meta.state).toBe('exited')
+      expect(meta.ended_reason).toBe('crashed')
+      expect(tmux.killed).toBe(true)
+    },
+    15000,
+  )
+})
+
+describe('CodexWorkerAdapter.detect', () => {
+  let dataDir: string
+  let home: string
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-adapter-detect-data-'))
+    home = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-adapter-detect-home-'))
+  })
+
+  afterEach(async () => {
+    await fs.rm(dataDir, { recursive: true, force: true }).catch(() => {})
+    await fs.rm(home, { recursive: true, force: true }).catch(() => {})
+  })
+
+  function versionBin(version: string): string {
+    return `env FAKE_CODEX_VERSION=${shQuote(version)} node ${shQuote(FAKE_CODEX_VERSION)}`
+  }
+
+  it('codex 二进制不存在/不可执行 → installed:false, activated:false', async () => {
+    const adapter = new CodexWorkerAdapter({
+      dataDir,
+      codexBin: '/nonexistent/codex-bin-does-not-exist-crabot-test',
+    })
+    const result = await adapter.detect()
+    expect(result.installed).toBe(false)
+    expect(result.activated).toBe(false)
+  })
+
+  it('codex 已安装且 codexHomeSource 下有 auth.json → installed:true, activated:true', async () => {
+    await fs.writeFile(path.join(home, 'auth.json'), '{}', 'utf-8')
+
+    const adapter = new CodexWorkerAdapter({
+      dataDir,
+      codexBin: versionBin('0.45.0'),
+      codexHomeSource: home,
+    })
+    const result = await adapter.detect()
+    expect(result.installed).toBe(true)
+    expect(result.activated).toBe(true)
+    expect(result.detail).toContain('0.45.0')
+  })
+
+  it('codex 已安装但 codexHomeSource 下没有 auth.json/config.toml → activated:false', async () => {
+    const adapter = new CodexWorkerAdapter({
+      dataDir,
+      codexBin: versionBin('0.45.0'),
+      codexHomeSource: home, // 目录存在,但里面空的
+    })
+    const result = await adapter.detect()
+    expect(result.installed).toBe(true)
+    expect(result.activated).toBe(false)
+  })
+
+  it('codex 已安装但 codexHomeSource 目录本身不存在 → activated:false(不抛错)', async () => {
+    const adapter = new CodexWorkerAdapter({
+      dataDir,
+      codexBin: versionBin('0.45.0'),
+      codexHomeSource: path.join(home, 'does-not-exist'),
+    })
+    const result = await adapter.detect()
+    expect(result.installed).toBe(true)
+    expect(result.activated).toBe(false)
+  })
+})
+
+describe('CodexWorkerAdapter — session_ref UUID 边界校验(resume)', () => {
+  let dataDir: string
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-adapter-session-ref-data-'))
+  })
+
+  afterEach(async () => {
+    await fs.rm(dataDir, { recursive: true, force: true }).catch(() => {})
+  })
+
+  it('resume() 拒绝非 UUID 格式的 session_ref(含 shell 注入特征),不执行任何命令', async () => {
+    const adapter = new CodexWorkerAdapter({ dataDir, codexBin: 'unused' })
+    const workerId = `codextest-${randomUUID().slice(0, 8)}`
+    const maliciousSessionRef = 'x; touch /tmp/pwned'
+
+    await expect(
+      adapter.resume({ worker_id: workerId, seq: 1, session_ref: maliciousSessionRef }, 'payload'),
+    ).rejects.toThrow(/invalid.*session_ref|UUID|session reference/i)
+
+    await expect(fs.access('/tmp/pwned')).rejects.toThrow()
+  })
+
+  it('resume() 拒绝空白或特殊字符 session_ref', async () => {
+    const adapter = new CodexWorkerAdapter({ dataDir, codexBin: 'unused' })
+    const workerId = `codextest-${randomUUID().slice(0, 8)}`
+    const invalidRefs = ['', ' ', '$(whoami)', '`id`', '{test}', '../../../etc/passwd']
+
+    for (const ref of invalidRefs) {
+      await expect(
+        adapter.resume({ worker_id: workerId, seq: 1, session_ref: ref }, 'payload'),
+      ).rejects.toThrow(/invalid.*session_ref|UUID|session reference/i)
+    }
+  })
+
+  it('resume() 接受有效 UUID 格式的 session_ref(至少通过前置校验)', async () => {
+    const adapter = new CodexWorkerAdapter({ dataDir, codexBin: 'unused' })
+    const workerId = `codextest-${randomUUID().slice(0, 8)}`
+    const validUuid = randomUUID()
+
+    // 会因为"不存在该化身"抛错,但不是 session_ref 格式错误
+    await expect(
+      adapter.resume({ worker_id: workerId, seq: 1, session_ref: validUuid }, 'payload'),
+    ).rejects.toThrow(/no such incarnation|not resident/i)
+  })
+})
+
+describe('CodexWorkerAdapter.fork — capabilities.fork=false', () => {
+  let dataDir: string
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-adapter-fork-data-'))
+  })
+
+  afterEach(async () => {
+    await fs.rm(dataDir, { recursive: true, force: true }).catch(() => {})
+  })
+
+  it('capabilities().fork === false', () => {
+    const adapter = new CodexWorkerAdapter({ dataDir, codexBin: 'unused' })
+    expect(adapter.capabilities().fork).toBe(false)
+  })
+
+  it('fork() 始终抛 CapabilityNotSupportedError,不触碰 tmux/子进程', async () => {
+    const adapter = new CodexWorkerAdapter({ dataDir, codexBin: 'unused' })
+    const workerId = `codextest-${randomUUID().slice(0, 8)}`
+    const validUuid = randomUUID()
+
+    await expect(adapter.fork({ worker_id: workerId, seq: 1, session_ref: validUuid }, '侧问问题')).rejects.toBeInstanceOf(
+      CapabilityNotSupportedError,
+    )
+  })
+})
+
+/** 全程无操作的假 TmuxDriver——readTrace 测试只需要一个"常驻 runtime"的化身,不关心 tmux 行为本身。 */
+class NoopTmux extends TmuxDriver {
+  async newSession(_spec: TmuxSessionSpec): Promise<void> {}
+  async sendText(_name: string, _text: string): Promise<void> {}
+  async sendKeys(_name: string, _keys: string[]): Promise<void> {}
+  async isAlive(_name: string): Promise<boolean> {
+    return true
+  }
+  async killSession(_name: string): Promise<void> {}
+}
+
+describe('CodexWorkerAdapter.readTrace', () => {
+  let dataDir: string
+  let workspaceRoot: string
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-adapter-trace-data-'))
+    workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-adapter-trace-ws-'))
+  })
+
+  afterEach(async () => {
+    await fs.rm(dataDir, { recursive: true, force: true }).catch(() => {})
+    await fs.rm(workspaceRoot, { recursive: true, force: true }).catch(() => {})
+  })
+
+  // 归一化本身(session_meta/message/function_call/function_call_output/reasoning/event_msg
+  // 的字段映射)在下面 tmux+mock 的 describe 块里端到端验证(spawn 真的发现 rollout 路径后
+  // 再读)。这里只验证"没有可读路径时的降级行为",不需要真实 tmux 进程。
+
+  it('trace 文件不存在(rolloutPath 未知,占位 session_id)→ 返回空数组,不抛错', async () => {
+    const tmux = new NoopTmux()
+    const adapter = new CodexWorkerAdapter({ dataDir, tmux, codexBin: 'unused', sessionDiscoveryTimeoutMs: 50 })
+    const workerId = `codextest-${randomUUID().slice(0, 8)}`
+    const h = await adapter.spawn({ worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } })
+
+    const events = await adapter.readTrace(h)
+    expect(events).toEqual([])
+
+    await adapter.kill(h)
+  })
+
+  it('对本进程内不常驻的 incarnation 调用 readTrace 应拒绝', async () => {
+    const tmux = new NoopTmux()
+    const adapter = new CodexWorkerAdapter({ dataDir, tmux, codexBin: 'unused' })
+    await expect(adapter.readTrace({ worker_id: 'nope', seq: 1, impl: 'codex' })).rejects.toThrow()
+  })
+})
+
+describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter.readTrace(已发现 rollout 路径)', () => {
+  let dataDir: string
+  let workspaceRoot: string
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-adapter-trace2-data-'))
+    workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-adapter-trace2-ws-'))
+  })
+
+  afterEach(async () => {
+    await cleanupTmuxSessions('crabot-w-codextest-')
+    await fs.rm(dataDir, { recursive: true, force: true }).catch(() => {})
+    await fs.rm(workspaceRoot, { recursive: true, force: true }).catch(() => {})
+  })
+
+  function sampleRolloutJsonl(sessionId: string): string {
+    const lines = [
+      { type: 'session_meta', payload: { timestamp: '2026-07-29T01:00:00Z', cwd: workspaceRoot, id: sessionId } },
+      {
+        type: 'response_item',
+        payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: '这个函数为什么会抛 TypeError?' }] },
+      },
+      { type: 'response_item', payload: { type: 'function_call', name: 'shell', call_id: 'call_1', arguments: '{"command":["cat","x.ts"]}' } },
+      { type: 'response_item', payload: { type: 'function_call_output', call_id: 'call_1', output: '文件内容摘要' } },
+      { type: 'response_item', payload: { type: 'reasoning', summary: [{ text: '先看文件再判断' }] } },
+      {
+        type: 'response_item',
+        payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: '问题在于第 12 行没有判空。' }] },
+      },
+      { type: 'event_msg', payload: { type: 'turn_complete' } },
+      { type: 'turn_context', payload: { model: 'gpt-5.5' } },
+      { type: 'response_item', payload: { type: 'web_search_call', query: 'typescript typeerror' } },
+    ]
+    return lines.map((l) => JSON.stringify(l)).join('\n') + '\nnot valid json{{{\n'
+  }
+
+  it('spawn 发现 rollout 路径后,readTrace 按行解析并归一化,cursor 跳过已读部分', async () => {
+    const channel = new CliEventChannel(eventsFilePath({ root: workspaceRoot }))
+    const stopHookCmd = channel.hookCommand('stop')
+    const codexHome = path.join(workspaceRoot, '.codex')
+    const rolloutUuid = randomUUID()
+    const now = new Date()
+    const pad = (n: number) => String(n).padStart(2, '0')
+    const datePath = path.join(String(now.getFullYear()), pad(now.getMonth() + 1), pad(now.getDate()))
+    const rolloutFile = path.join(codexHome, 'sessions', datePath, rolloutFileNameFor(rolloutUuid))
+
+    const codexBin = codexBinFor([{ output: '第一段输出', emitStop: true }], stopHookCmd, { rolloutFile })
+    const adapter = new CodexWorkerAdapter({ dataDir, tmux: new TmuxDriver(), codexBin, sessionDiscoveryTimeoutMs: 1500 })
+    await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
+    const workerId = `codextest-${randomUUID().slice(0, 8)}`
+
+    const h = await adapter.spawn({ worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } })
+    await waitForState(adapter, h, 'idle')
+
+    const meta = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8')) as { session_id: string }
+    expect(meta.session_id).toBe(rolloutUuid)
+
+    // mock CLI 只写了个占位 session_meta 行(供发现用),这里覆写成完整样例内容再读。
+    await fs.writeFile(rolloutFile, sampleRolloutJsonl(rolloutUuid), 'utf-8')
+
+    const events = await adapter.readTrace(h)
+    expect(events).toHaveLength(7)
+    expect(events[0]).toMatchObject({ kind: 'lifecycle', role: 'system' })
+    expect(events[1]).toMatchObject({ kind: 'message', role: 'user' })
+    expect(events[1].summary).toContain('这个函数为什么会抛 TypeError?')
+    expect(events[2]).toMatchObject({ kind: 'tool_call', role: 'assistant' })
+    expect(events[2].summary).toContain('shell')
+    expect(events[3]).toMatchObject({ kind: 'tool_result' })
+    expect(events[3].summary).toContain('文件内容摘要')
+    expect(events[3].role).toBeUndefined()
+    expect(events[4]).toMatchObject({ kind: 'thinking', role: 'assistant' })
+    expect(events[4].summary).toContain('先看文件再判断')
+    expect(events[5]).toMatchObject({ kind: 'message', role: 'assistant' })
+    expect(events[5].summary).toContain('问题在于第 12 行没有判空。')
+    expect(events[6]).toMatchObject({ kind: 'lifecycle', role: 'system', summary: 'turn_complete' })
+
+    const partial = await adapter.readTrace(h, { offset: 4 })
+    expect(partial).toHaveLength(3)
+    expect(partial[0].kind).toBe('thinking')
+    expect(partial[1].kind).toBe('message')
+    expect(partial[2].kind).toBe('lifecycle')
+
+    await adapter.kill(h)
+  }, 15000)
+})

--- a/crabot-agent/tests/workers/codex-adapter.test.ts
+++ b/crabot-agent/tests/workers/codex-adapter.test.ts
@@ -822,4 +822,51 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter.readTrace(已发现 rollout 
 
     await adapter.kill(h)
   }, 15000)
+
+  it('半行(CLI 写入未完成,无结尾换行符)不消费,补全后续读不丢事件', async () => {
+    const channel = new CliEventChannel(eventsFilePath({ root: workspaceRoot }))
+    const stopHookCmd = channel.hookCommand('stop')
+    const codexHome = path.join(workspaceRoot, '.codex')
+    const rolloutUuid = randomUUID()
+    const now = new Date()
+    const pad = (n: number) => String(n).padStart(2, '0')
+    const datePath = path.join(String(now.getFullYear()), pad(now.getMonth() + 1), pad(now.getDate()))
+    const rolloutFile = path.join(codexHome, 'sessions', datePath, rolloutFileNameFor(rolloutUuid))
+
+    const codexBin = codexBinFor([{ output: '第一段输出', emitStop: true }], stopHookCmd, { rolloutFile })
+    const adapter = new CodexWorkerAdapter({ dataDir, tmux: new TmuxDriver(), codexBin, sessionDiscoveryTimeoutMs: 1500 })
+    await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
+    const workerId = `codextest-${randomUUID().slice(0, 8)}`
+
+    const h = await adapter.spawn({ worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } })
+    await waitForState(adapter, h, 'idle')
+
+    // trace(rollout)文件由 codex 持续追加、readTrace 轮询懒解析,读到写入中途是常态:
+    // 第一行完整,第二行只写了一半(无结尾换行符)。
+    const line1 = { type: 'event_msg', payload: { type: 'task_started' } }
+    await fs.writeFile(rolloutFile, JSON.stringify(line1) + '\n{"type":"event_msg","payload":{"ty', 'utf-8')
+
+    const first = await adapter.readTrace(h)
+    expect(first.events).toHaveLength(1)
+    // 半行不算已消费的完整行——cursor 必须停在第一行之后,不能越过半行,否则半行补全后
+    // 的事件会被永久跳过。
+    expect(first.nextCursor.offset).toBe(1)
+
+    // 半行补全 + 追加新行。
+    const line2 = { type: 'event_msg', payload: { type: 'task_complete' } }
+    const line3 = { type: 'event_msg', payload: { type: 'shutdown_complete' } }
+    await fs.writeFile(
+      rolloutFile,
+      JSON.stringify(line1) + '\n' + JSON.stringify(line2) + '\n' + JSON.stringify(line3) + '\n',
+      'utf-8',
+    )
+
+    const second = await adapter.readTrace(h, first.nextCursor)
+    expect(second.events).toHaveLength(2)
+    expect(second.events[0].summary).toBe('task_complete')
+    expect(second.events[1].summary).toBe('shutdown_complete')
+    expect(second.nextCursor.offset).toBe(3)
+
+    await adapter.kill(h)
+  }, 15000)
 })

--- a/crabot-agent/tests/workers/codex-adapter.test.ts
+++ b/crabot-agent/tests/workers/codex-adapter.test.ts
@@ -251,6 +251,39 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter (tmux + mock CLI)', () => {
   )
 
   it(
+    'notify 已到但会话被外部 kill(不经 adapter.kill)→ 判定 exited,不永远卡在 idle(P2 review #2)',
+    async () => {
+      const { adapter, workerId } = await provisionedAdapter([{ output: '答完但不退出', emitStop: true }])
+      const h = await adapter.spawn(makeSpec(workerId, '你好'))
+
+      // 等 mock CLI 真的跑完 emitStop(把 stop/notify 事件写进事件文件),再从外部直接杀掉
+      // tmux 会话(不经 adapter.kill,模拟进程自己崩溃/被系统杀掉)。旧实现:syncState 先看
+      // notify 事件,stopCount>baseline 恒判 idle,永远走不到 isAlive 分支——这里会一直卡在
+      // idle,waitForState(exited) 超时失败。
+      const deadline = Date.now() + 5000
+      let sawStop = false
+      while (Date.now() < deadline) {
+        const raw = await fs.readFile(eventsFilePath({ root: workspaceRoot }), 'utf-8').catch(() => '')
+        if (raw.includes('"kind":"stop"')) {
+          sawStop = true
+          break
+        }
+        await new Promise((r) => setTimeout(r, 50))
+      }
+      expect(sawStop).toBe(true)
+      execFileSync('tmux', ['kill-session', '-t', `crabot-w-${workerId}-1`], { stdio: 'ignore' })
+
+      await waitForState(adapter, h, 'exited')
+
+      const metaRaw = await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8')
+      const meta = JSON.parse(metaRaw) as { state: WorkerContractState; ended_reason?: string }
+      expect(meta.state).toBe('exited')
+      expect(meta.ended_reason).toBe('completed')
+    },
+    15000,
+  )
+
+  it(
     '④ kill → tmux killSession,收敛 exited(killed),再次 kill 幂等',
     async () => {
       const { adapter, workerId } = await provisionedAdapter([{ output: '还在跑' }])

--- a/crabot-agent/tests/workers/codex-adapter.test.ts
+++ b/crabot-agent/tests/workers/codex-adapter.test.ts
@@ -332,6 +332,30 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter (tmux + mock CLI)', () => {
     },
     15000,
   )
+
+  it(
+    '对同一个已 exited 的 prev 连续 resume 两次,seq 用 nextSeq() 递增分配,不撞号(P2 review #1)',
+    async () => {
+      const { adapter, workerId } = await provisionedAdapter([{ output: '主线输出', exit: true }])
+      const h1 = await adapter.spawn(makeSpec(workerId, '你好'))
+      await waitForState(adapter, h1, 'exited')
+
+      const meta1 = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8')) as { session_id: string }
+
+      const h2 = await adapter.resume({ worker_id: workerId, seq: 1, session_ref: meta1.session_id }, '继续 1')
+      expect(h2.seq).toBe(2)
+
+      // 对同一个 prev(h1,仍是 exited 终态)再 resume 一次:旧实现用固定公式 prev.seq+1
+      // 算出 seq=2,与 h2 撞号,抛"already exists"。新实现用 nextSeq()(该 worker 现存所有
+      // 化身 max seq + 1)分配到 3。
+      const h3 = await adapter.resume({ worker_id: workerId, seq: 1, session_ref: meta1.session_id }, '继续 2')
+      expect(h3.seq).toBe(3)
+
+      await adapter.kill(h2)
+      await adapter.kill(h3)
+    },
+    15000,
+  )
 })
 
 /** 转发到可替换的底层 TmuxDriver——用于"先用坏 bin 失败一次,再换成好 bin 重试"的测试场景。 */

--- a/crabot-agent/tests/workers/codex-adapter.test.ts
+++ b/crabot-agent/tests/workers/codex-adapter.test.ts
@@ -664,14 +664,19 @@ describe('CodexWorkerAdapter.readTrace', () => {
   // 的字段映射)在下面 tmux+mock 的 describe 块里端到端验证(spawn 真的发现 rollout 路径后
   // 再读)。这里只验证"没有可读路径时的降级行为",不需要真实 tmux 进程。
 
-  it('trace 文件不存在(rolloutPath 未知,占位 session_id)→ 返回空数组,不抛错', async () => {
+  it('trace 文件不存在(rolloutPath 未知,占位 session_id)→ 返回空事件数组,不抛错,cursor 原样透传', async () => {
     const tmux = new NoopTmux()
     const adapter = new CodexWorkerAdapter({ dataDir, tmux, codexBin: 'unused', sessionDiscoveryTimeoutMs: 50 })
     const workerId = `codextest-${randomUUID().slice(0, 8)}`
     const h = await adapter.spawn({ worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } })
 
-    const events = await adapter.readTrace(h)
+    const { events, nextCursor } = await adapter.readTrace(h)
     expect(events).toEqual([])
+    expect(nextCursor).toEqual({ offset: 0 })
+
+    const { events: events2, nextCursor: nextCursor2 } = await adapter.readTrace(h, { offset: 3 })
+    expect(events2).toEqual([])
+    expect(nextCursor2).toEqual({ offset: 3 })
 
     await adapter.kill(h)
   })
@@ -743,7 +748,7 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter.readTrace(已发现 rollout 
     // mock CLI 只写了个占位 session_meta 行(供发现用),这里覆写成完整样例内容再读。
     await fs.writeFile(rolloutFile, sampleRolloutJsonl(rolloutUuid), 'utf-8')
 
-    const events = await adapter.readTrace(h)
+    const { events, nextCursor } = await adapter.readTrace(h)
     expect(events).toHaveLength(7)
     expect(events[0]).toMatchObject({ kind: 'lifecycle', role: 'system' })
     expect(events[1]).toMatchObject({ kind: 'message', role: 'user' })
@@ -758,12 +763,62 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter.readTrace(已发现 rollout 
     expect(events[5]).toMatchObject({ kind: 'message', role: 'assistant' })
     expect(events[5].summary).toContain('问题在于第 12 行没有判空。')
     expect(events[6]).toMatchObject({ kind: 'lifecycle', role: 'system', summary: 'turn_complete' })
+    // 原始行数是 10(7 条产生事件 + turn_context/web_search_call 两条未识别子类型跳过 +
+    // 1 条坏 JSON 跳过),nextCursor 必须计入被跳过的行,不能等于 events.length。
+    expect(nextCursor.offset).toBe(10)
 
     const partial = await adapter.readTrace(h, { offset: 4 })
-    expect(partial).toHaveLength(3)
-    expect(partial[0].kind).toBe('thinking')
-    expect(partial[1].kind).toBe('message')
-    expect(partial[2].kind).toBe('lifecycle')
+    expect(partial.events).toHaveLength(3)
+    expect(partial.events[0].kind).toBe('thinking')
+    expect(partial.events[1].kind).toBe('message')
+    expect(partial.events[2].kind).toBe('lifecycle')
+    expect(partial.nextCursor.offset).toBe(10)
+
+    await adapter.kill(h)
+  }, 15000)
+
+  it('nextCursor 计入跳过的行(未识别 type/坏 JSON),两次 readTrace 按 nextCursor 续读不重不漏', async () => {
+    const channel = new CliEventChannel(eventsFilePath({ root: workspaceRoot }))
+    const stopHookCmd = channel.hookCommand('stop')
+    const codexHome = path.join(workspaceRoot, '.codex')
+    const rolloutUuid = randomUUID()
+    const now = new Date()
+    const pad = (n: number) => String(n).padStart(2, '0')
+    const datePath = path.join(String(now.getFullYear()), pad(now.getMonth() + 1), pad(now.getDate()))
+    const rolloutFile = path.join(codexHome, 'sessions', datePath, rolloutFileNameFor(rolloutUuid))
+
+    const codexBin = codexBinFor([{ output: '第一段输出', emitStop: true }], stopHookCmd, { rolloutFile })
+    const adapter = new CodexWorkerAdapter({ dataDir, tmux: new TmuxDriver(), codexBin, sessionDiscoveryTimeoutMs: 1500 })
+    await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
+    const workerId = `codextest-${randomUUID().slice(0, 8)}`
+
+    const h = await adapter.spawn({ worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } })
+    await waitForState(adapter, h, 'idle')
+
+    // 覆写成:1 条有效 event_msg + 1 条未识别顶层 type(跳过) + 1 条坏 JSON(跳过)。
+    const initialLines = [
+      { type: 'event_msg', payload: { type: 'task_started' } },
+      { type: 'turn_context', payload: { model: 'gpt-5.5' } },
+    ]
+    await fs.writeFile(rolloutFile, initialLines.map((l) => JSON.stringify(l)).join('\n') + '\nnot valid json{{{\n', 'utf-8')
+
+    const first = await adapter.readTrace(h)
+    expect(first.events).toHaveLength(1)
+    // 3 行原始数据(1 条有效 + 2 条被跳过),offset += events.length(1)会漏掉后面 2 行——
+    // nextCursor 必须落在 3,不是 1。
+    expect(first.nextCursor.offset).toBe(3)
+
+    // 追加新一批(1 条有效 + 1 条坏 JSON),用上一次的 nextCursor 续读。
+    await fs.appendFile(
+      rolloutFile,
+      '\n' + JSON.stringify({ type: 'event_msg', payload: { type: 'task_complete' } }) + '\nmore bad json{{{\n',
+      'utf-8',
+    )
+
+    const second = await adapter.readTrace(h, first.nextCursor)
+    expect(second.events).toHaveLength(1)
+    expect(second.events[0].summary).toBe('task_complete')
+    expect(second.nextCursor.offset).toBe(5)
 
     await adapter.kill(h)
   }, 15000)

--- a/crabot-agent/tests/workers/contract-claude-code.test.ts
+++ b/crabot-agent/tests/workers/contract-claude-code.test.ts
@@ -1,0 +1,137 @@
+/**
+ * claude-code adapter 接入可复用契约套件(见 contract-suite.ts 文件头注释)。真机没有 claude
+ * 二进制,claudeBin 换成 mock-cli.mjs(与 claude-code-adapter.test.ts 同款 mock,细节见该
+ * fixture 文件头注释)——契约套件本身不关心底层怎么产出 idle/exited,只关心
+ * WorkerAdapter 接口的行为收敛是否符合约定。
+ *
+ * 契约套件的 makeSpec(workerId, script) 是同步签名,但 cc adapter 的 claudeBin 是构造时就
+ * 定死的一整条命令行,脚本内容却要等每个 it() 调 makeSpec() 时才知道(晚于构造)——这里
+ * 用一个固定路径的 scriptFile 间接传递:makeSpec() 同步写文件,mock-cli 进程启动时再读
+ * (MOCK_CLI_SCRIPT_FILE,mock-cli.mjs 本次改动新增)。
+ *
+ * 无 tmux 的环境下整个文件 skip(与 claude-code-adapter.test.ts 的 skipIf 守卫同一判断)。
+ */
+import { describe, it } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { writeFileSync } from 'node:fs'
+import * as fs from 'node:fs/promises'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { ClaudeCodeAdapter, eventsFilePath } from '../../src/workers/claude-code/adapter.js'
+import { TmuxDriver } from '../../src/workers/tmux/driver.js'
+import { CliEventChannel } from '../../src/workers/cli-events.js'
+import type { IncarnationHandle, IncarnationRef, SpawnSpec } from '../../src/workers/types.js'
+import { runContractSuite, type ScriptStep, type ContractFixture } from './contract-suite.js'
+
+function detectTmux(): boolean {
+  try {
+    execFileSync('which', ['tmux'], { stdio: 'ignore' })
+    return true
+  } catch {
+    return false
+  }
+}
+const tmuxAvailable = detectTmux()
+
+/** 清理某个 worker_id 名下的所有 tmux 会话(sessionName 约定 `crabot-w-<worker_id>-<seq>`)。
+ * 必须按具体 worker_id 精确匹配,不能用共享前缀(如 `crabot-w-contract-`)一把梭——
+ * contract-claude-code.test.ts 与 contract-codex.test.ts 的 freshWorkerId() 都来自
+ * contract-suite.ts,生成的 worker_id 都是 `contract-<uuid>`,两个文件在 vitest 默认并行
+ * worker 下同时跑时前缀完全一样,一把梭清理会误杀另一个文件里仍在跑的会话
+ * (曾实测到 "can't find pane" 报错,根因就是这个)。 */
+async function killSessionsForWorker(workerId: string): Promise<void> {
+  if (!tmuxAvailable) return
+  try {
+    const output = execFileSync('tmux', ['ls', '-F', '#{session_name}'], { encoding: 'utf-8' })
+    const prefix = `crabot-w-${workerId}-`
+    const sessions = output.trim().split('\n').filter((s) => s.startsWith(prefix))
+    for (const session of sessions) {
+      try {
+        execFileSync('tmux', ['kill-session', '-t', session], { stdio: 'ignore' })
+      } catch {
+        // 会话已不存在或其他错误,忽略
+      }
+    }
+  } catch {
+    // tmux ls 失败或其他问题,忽略
+  }
+}
+
+const MOCK_CLI = path.resolve(__dirname, 'fixtures/mock-cli.mjs')
+
+interface MockStep {
+  output?: string
+  emitStop?: boolean
+  exit?: boolean
+  exitCode?: number
+}
+
+// POSIX shell 单引号转义,与 tmux/driver.ts 的私有 shQuote 同款用法(独立复制一份)。
+function shQuote(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`
+}
+
+/** ScriptStep → mock-cli 的 MockStep:'idle' 触发 stop hook 但不退出;'exit_success'/
+ * 'exit_failure' 输出后分别以 0/非 0 退出——cc adapter 的三源合成状态判定只认 tmux
+ * isAlive(不看退出码),两者都收敛为 exited(ended_reason 恒 completed,除非被 kill),
+ * 契约套件④本身也只断言 state==='exited',不区分退出码,见 contract-suite.ts。 */
+function toMockSteps(script: ScriptStep[]): MockStep[] {
+  return script.map((step) =>
+    step.then === 'idle'
+      ? { output: step.output, emitStop: true }
+      : { output: step.output, exit: true, exitCode: step.then === 'exit_success' ? 0 : 1 },
+  )
+}
+
+async function makeClaudeCodeFixture(): Promise<ContractFixture> {
+  const dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'contract-cc-data-'))
+  const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'contract-cc-ws-'))
+  // 隔离出来的 ~/.claude/projects 等价目录,detect() 的 activated 检查读它——不依赖/不触碰
+  // 开发机真实 ~/.claude/。
+  const claudeProjectsDir = await fs.mkdtemp(path.join(os.tmpdir(), 'contract-cc-projects-'))
+  const scriptFile = path.join(dataDir, 'mock-script.json')
+  writeFileSync(scriptFile, '[]', 'utf-8')
+
+  const channel = new CliEventChannel(eventsFilePath({ root: workspaceRoot }))
+  const stopHookCmd = channel.hookCommand('stop')
+  // -p 一次性调用(fork 用)、--version 一次性调用(detect 用)都不读 scriptFile,
+  // mock-cli.mjs 遇到这两个 flag 直接回显/打印版本号并 exit 0。
+  const claudeBin = `env MOCK_CLI_SCRIPT_FILE=${shQuote(scriptFile)} MOCK_CLI_STOP_HOOK_CMD=${shQuote(stopHookCmd)} node ${shQuote(MOCK_CLI)}`
+
+  const tmux = new TmuxDriver()
+  const adapter = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin, claudeProjectsDir })
+  // provision 建 .claude/ 目录——hook 写入目标目录必须先存在,否则 printf >> 静默失败
+  // (mock-cli 直接执行 hookCmd 本身,不解析 settings.json,但事件文件所在目录仍要求先存在)。
+  await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
+
+  const workerIds: string[] = []
+
+  const makeSpec = (workerId: string, script: ScriptStep[]): SpawnSpec => {
+    workerIds.push(workerId)
+    writeFileSync(scriptFile, JSON.stringify(toMockSteps(script)), 'utf-8')
+    return { worker_id: workerId, prompt: '契约测试任务', workspace: { root: workspaceRoot } }
+  }
+
+  const refFor = async (h: IncarnationHandle): Promise<IncarnationRef> => {
+    const metaRaw = await fs.readFile(path.join(dataDir, h.worker_id, `meta-${h.seq}.json`), 'utf-8')
+    const meta = JSON.parse(metaRaw) as { session_id: string }
+    return { worker_id: h.worker_id, seq: h.seq, session_ref: meta.session_id }
+  }
+
+  const cleanup = async (): Promise<void> => {
+    for (const workerId of workerIds) await killSessionsForWorker(workerId)
+    await fs.rm(dataDir, { recursive: true, force: true }).catch(() => {})
+    await fs.rm(workspaceRoot, { recursive: true, force: true }).catch(() => {})
+    await fs.rm(claudeProjectsDir, { recursive: true, force: true }).catch(() => {})
+  }
+
+  return { adapter, makeSpec, refFor, cleanup }
+}
+
+if (tmuxAvailable) {
+  runContractSuite('claude-code', makeClaudeCodeFixture)
+} else {
+  describe.skip('WorkerAdapter contract: claude-code(tmux 不可用,整个文件 skip)', () => {
+    it('skipped', () => {})
+  })
+}

--- a/crabot-agent/tests/workers/contract-codex.test.ts
+++ b/crabot-agent/tests/workers/contract-codex.test.ts
@@ -1,0 +1,134 @@
+/**
+ * codex adapter 接入可复用契约套件(见 contract-suite.ts 文件头注释)。真机没有 codex
+ * 二进制,codexBin 换成 mock-cli.mjs(与 codex-adapter.test.ts 同款 mock)——契约套件本身
+ * 不关心底层怎么产出 idle/exited,只关心 WorkerAdapter 接口的行为收敛是否符合约定。
+ *
+ * capabilities().fork === false 是本次 P2 Task 7 对 P1 遗留验证点的首次实测:契约套件⑦a
+ * 在 caps.fork 为假时只断言 fork() reject,不要求它是特定错误类型——实测 codex adapter
+ * 的 fork() 始终抛 CapabilityNotSupportedError,符合契约(细节见报告)。
+ *
+ * makeSpec 的同步签名与 scriptFile 中转方案,与 contract-claude-code.test.ts 同构,注释见
+ * 该文件头。session 发现(spawn 轮询 rollout 文件拿真实 session_id)与本契约套件无关——
+ * 不提供 MOCK_CLI_ROLLOUT_FILE,固定走"轮询超时降级为本地占位 uuid"路径,占位 uuid
+ * 本身仍是合法 UUID,不影响 resume()/fork() 的 session_ref 契约测试;sessionDiscoveryTimeoutMs
+ * 调小避免拖慢每个 spawn。
+ *
+ * 无 tmux 的环境下整个文件 skip(与 codex-adapter.test.ts 的 skipIf 守卫同一判断)。
+ */
+import { describe, it } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { writeFileSync } from 'node:fs'
+import * as fs from 'node:fs/promises'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { CodexWorkerAdapter, eventsFilePath } from '../../src/workers/codex/adapter.js'
+import { TmuxDriver } from '../../src/workers/tmux/driver.js'
+import { CliEventChannel } from '../../src/workers/cli-events.js'
+import type { IncarnationHandle, IncarnationRef, SpawnSpec } from '../../src/workers/types.js'
+import { runContractSuite, type ScriptStep, type ContractFixture } from './contract-suite.js'
+
+function detectTmux(): boolean {
+  try {
+    execFileSync('which', ['tmux'], { stdio: 'ignore' })
+    return true
+  } catch {
+    return false
+  }
+}
+const tmuxAvailable = detectTmux()
+
+/** 清理某个 worker_id 名下的所有 tmux 会话(sessionName 约定 `crabot-w-<worker_id>-<seq>`)。
+ * 必须按具体 worker_id 精确匹配,不能用共享前缀(如 `crabot-w-contract-`)一把梭——
+ * contract-claude-code.test.ts 与 contract-codex.test.ts 的 freshWorkerId() 都来自
+ * contract-suite.ts,生成的 worker_id 都是 `contract-<uuid>`,两个文件在 vitest 默认并行
+ * worker 下同时跑时前缀完全一样,一把梭清理会误杀另一个文件里仍在跑的会话
+ * (曾实测到 "can't find pane" 报错,根因就是这个)。 */
+async function killSessionsForWorker(workerId: string): Promise<void> {
+  if (!tmuxAvailable) return
+  try {
+    const output = execFileSync('tmux', ['ls', '-F', '#{session_name}'], { encoding: 'utf-8' })
+    const prefix = `crabot-w-${workerId}-`
+    const sessions = output.trim().split('\n').filter((s) => s.startsWith(prefix))
+    for (const session of sessions) {
+      try {
+        execFileSync('tmux', ['kill-session', '-t', session], { stdio: 'ignore' })
+      } catch {
+        // 会话已不存在或其他错误,忽略
+      }
+    }
+  } catch {
+    // tmux ls 失败或其他问题,忽略
+  }
+}
+
+const MOCK_CLI = path.resolve(__dirname, 'fixtures/mock-cli.mjs')
+
+interface MockStep {
+  output?: string
+  emitStop?: boolean
+  exit?: boolean
+  exitCode?: number
+}
+
+// POSIX shell 单引号转义,与 tmux/driver.ts 的私有 shQuote 同款用法(独立复制一份)。
+function shQuote(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`
+}
+
+/** ScriptStep → mock-cli 的 MockStep:语义与 contract-claude-code.test.ts 的同名函数一致
+ * (codex adapter 的状态判定同样只看 tmux isAlive,不看退出码)。 */
+function toMockSteps(script: ScriptStep[]): MockStep[] {
+  return script.map((step) =>
+    step.then === 'idle'
+      ? { output: step.output, emitStop: true }
+      : { output: step.output, exit: true, exitCode: step.then === 'exit_success' ? 0 : 1 },
+  )
+}
+
+async function makeCodexFixture(): Promise<ContractFixture> {
+  const dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'contract-codex-data-'))
+  const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'contract-codex-ws-'))
+  const codexHomeSource = await fs.mkdtemp(path.join(os.tmpdir(), 'contract-codex-home-src-'))
+  const scriptFile = path.join(dataDir, 'mock-script.json')
+  writeFileSync(scriptFile, '[]', 'utf-8')
+
+  const channel = new CliEventChannel(eventsFilePath({ root: workspaceRoot }))
+  const stopHookCmd = channel.hookCommand('stop')
+  const codexBin = `env MOCK_CLI_SCRIPT_FILE=${shQuote(scriptFile)} MOCK_CLI_STOP_HOOK_CMD=${shQuote(stopHookCmd)} node ${shQuote(MOCK_CLI)}`
+
+  const tmux = new TmuxDriver()
+  const adapter = new CodexWorkerAdapter({ dataDir, tmux, codexBin, codexHomeSource, sessionDiscoveryTimeoutMs: 300 })
+  // provision 建 .codex/ 目录——hook 写入目标目录必须先存在,否则 printf >> 静默失败。
+  await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
+
+  const workerIds: string[] = []
+
+  const makeSpec = (workerId: string, script: ScriptStep[]): SpawnSpec => {
+    workerIds.push(workerId)
+    writeFileSync(scriptFile, JSON.stringify(toMockSteps(script)), 'utf-8')
+    return { worker_id: workerId, prompt: '契约测试任务', workspace: { root: workspaceRoot } }
+  }
+
+  const refFor = async (h: IncarnationHandle): Promise<IncarnationRef> => {
+    const metaRaw = await fs.readFile(path.join(dataDir, h.worker_id, `meta-${h.seq}.json`), 'utf-8')
+    const meta = JSON.parse(metaRaw) as { session_id: string }
+    return { worker_id: h.worker_id, seq: h.seq, session_ref: meta.session_id }
+  }
+
+  const cleanup = async (): Promise<void> => {
+    for (const workerId of workerIds) await killSessionsForWorker(workerId)
+    await fs.rm(dataDir, { recursive: true, force: true }).catch(() => {})
+    await fs.rm(workspaceRoot, { recursive: true, force: true }).catch(() => {})
+    await fs.rm(codexHomeSource, { recursive: true, force: true }).catch(() => {})
+  }
+
+  return { adapter, makeSpec, refFor, cleanup }
+}
+
+if (tmuxAvailable) {
+  runContractSuite('codex', makeCodexFixture)
+} else {
+  describe.skip('WorkerAdapter contract: codex(tmux 不可用,整个文件 skip)', () => {
+    it('skipped', () => {})
+  })
+}

--- a/crabot-agent/tests/workers/fixtures/fake-claude-fork.mjs
+++ b/crabot-agent/tests/workers/fixtures/fake-claude-fork.mjs
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+// fake-claude-fork.mjs — fork()/resume() 测试共用的假 cc 二进制。
+//
+// 两种调用形态都可能落到同一个 claudeBin(adapter 的 claudeBin 是单个字段,spawn 的 tmux
+// 命令和 resume/fork 的子进程调用共享它):
+//   ① 交互态(spawn/resume,tmux pane 里跑,无 `-p`):只管把 argv 记进 FAKE_ARGV_FILE(若设),
+//      然后空转,不退出(避免 tmux 会话瞬间消亡)。
+//   ② 无头一击(fork,`-p ...`):把 argv 记进 FAKE_ARGV_FILE,打印 FAKE_FORK_STDOUT,
+//      以 FAKE_FORK_EXIT_CODE(默认 0)退出。
+import { appendFileSync } from 'node:fs'
+
+const argv = process.argv.slice(2)
+const argvFile = process.env.FAKE_ARGV_FILE
+if (argvFile) appendFileSync(argvFile, JSON.stringify(argv) + '\n')
+
+if (argv.includes('-p')) {
+  const stdout = process.env.FAKE_FORK_STDOUT ?? ''
+  if (stdout) process.stdout.write(stdout)
+  process.exit(Number(process.env.FAKE_FORK_EXIT_CODE ?? '0'))
+}
+
+// 交互态:空转,等待测试结束后由 kill/进程回收清理。
+setInterval(() => {}, 1_000_000)

--- a/crabot-agent/tests/workers/fixtures/fake-claude-version.mjs
+++ b/crabot-agent/tests/workers/fixtures/fake-claude-version.mjs
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+// fake-claude-version.mjs — detect() 测试用的假 cc 二进制:只认 `--version`,打印
+// FAKE_CLAUDE_VERSION(env,默认一个形似真实版本号的字符串)后退出。
+const version = process.env.FAKE_CLAUDE_VERSION ?? '2.1.220 (Claude Code)'
+process.stdout.write(version + '\n')
+process.exit(0)

--- a/crabot-agent/tests/workers/fixtures/fake-codex-version.mjs
+++ b/crabot-agent/tests/workers/fixtures/fake-codex-version.mjs
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+// fake-codex-version.mjs — detect() 测试用的假 codex 二进制:只认 `--version`,打印
+// FAKE_CODEX_VERSION(env,默认一个形似真实版本号的字符串)后退出。
+const version = process.env.FAKE_CODEX_VERSION ?? '0.45.0'
+process.stdout.write(version + '\n')
+process.exit(0)

--- a/crabot-agent/tests/workers/fixtures/mock-cli.mjs
+++ b/crabot-agent/tests/workers/fixtures/mock-cli.mjs
@@ -1,16 +1,24 @@
 #!/usr/bin/env node
-// mock-cli.mjs — 测试用的假 cc 进程,扮演 claude code 的最小交互行为:每收到一行 stdin
+// mock-cli.mjs — 测试用的假 cc/codex 进程,扮演其最小交互行为:每收到一行 stdin
 // (对应 tmux sendText 注入的一行输入)就消费脚本的下一步。脚本经 env MOCK_CLI_SCRIPT 传入
 // (JSON 数组,元素形如 { output？, emitStop？, exit？, exitCode？ })。
 //
-// 真实 cc 靠 .claude/settings.json 里配置的 Stop hook 命令来上报"我空闲了";mock 不解析
-// settings.json,而是直接执行 env MOCK_CLI_STOP_HOOK_CMD 传入的 hook 命令本身(即
+// 真实 cc 靠 .claude/settings.json 里配置的 Stop hook 命令来上报"我空闲了";真实 codex 靠
+// config.toml 的 notify 程序上报 agent-turn-complete。mock 不解析 settings.json/config.toml,
+// 而是直接执行 env MOCK_CLI_STOP_HOOK_CMD 传入的 hook/notify 命令本身(即
 // CliEventChannel.hookCommand('stop') 的产物字符串)——效果等价,省去在 mock 里实现一个
-// JSON 配置解析器。命令行参数(--session-id/--resume 等)默认原样忽略,除非设置了
+// JSON/TOML 配置解析器。命令行参数(--session-id/--resume 等)默认原样忽略,除非设置了
 // MOCK_CLI_ARGV_FILE(Task 5 resume 测试用它断言 --resume 参数确实被传下去了)。
+//
+// codex 专用:MOCK_CLI_ROLLOUT_FILE(可选,绝对路径)——真实 codex 在会话开始时会在
+// `<CODEX_HOME>/sessions/YYYY/MM/DD/rollout-...-<uuid>.jsonl` 落一个 rollout 文件,codex
+// adapter 的 spawn() 靠轮询发现这个文件名里的 uuid 来拿到会话真实 session_id(codex 没有
+// 类似 cc `--session-id` 的入参,session id 由 codex 内部生成)。mock 在进入 stdin 循环前
+// 同步创建这个文件(内容占位,发现逻辑只认文件名),模拟这一时序。
 import { exec } from 'node:child_process'
 import { promisify } from 'node:util'
-import { appendFileSync } from 'node:fs'
+import { appendFileSync, mkdirSync, writeFileSync } from 'node:fs'
+import { dirname } from 'node:path'
 import readline from 'node:readline'
 
 const execAsync = promisify(exec)
@@ -20,6 +28,12 @@ const stopHookCmd = process.env.MOCK_CLI_STOP_HOOK_CMD || ''
 
 const argvFile = process.env.MOCK_CLI_ARGV_FILE
 if (argvFile) appendFileSync(argvFile, JSON.stringify(process.argv.slice(2)) + '\n')
+
+const rolloutFile = process.env.MOCK_CLI_ROLLOUT_FILE
+if (rolloutFile) {
+  mkdirSync(dirname(rolloutFile), { recursive: true })
+  writeFileSync(rolloutFile, JSON.stringify({ type: 'session_meta', payload: { timestamp: new Date().toISOString() } }) + '\n')
+}
 
 let stepIndex = 0
 

--- a/crabot-agent/tests/workers/fixtures/mock-cli.mjs
+++ b/crabot-agent/tests/workers/fixtures/mock-cli.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+// mock-cli.mjs — 测试用的假 cc 进程,扮演 claude code 的最小交互行为:每收到一行 stdin
+// (对应 tmux sendText 注入的一行输入)就消费脚本的下一步。脚本经 env MOCK_CLI_SCRIPT 传入
+// (JSON 数组,元素形如 { output？, emitStop？, exit？, exitCode？ })。
+//
+// 真实 cc 靠 .claude/settings.json 里配置的 Stop hook 命令来上报"我空闲了";mock 不解析
+// settings.json,而是直接执行 env MOCK_CLI_STOP_HOOK_CMD 传入的 hook 命令本身(即
+// CliEventChannel.hookCommand('stop') 的产物字符串)——效果等价,省去在 mock 里实现一个
+// JSON 配置解析器。命令行参数(--session-id 等)原样忽略。
+import { exec } from 'node:child_process'
+import { promisify } from 'node:util'
+import readline from 'node:readline'
+
+const execAsync = promisify(exec)
+
+const script = JSON.parse(process.env.MOCK_CLI_SCRIPT || '[]')
+const stopHookCmd = process.env.MOCK_CLI_STOP_HOOK_CMD || ''
+
+let stepIndex = 0
+
+async function runStep() {
+  if (stepIndex >= script.length) return
+  const step = script[stepIndex]
+  stepIndex += 1
+
+  if (step.output) process.stdout.write(step.output + '\n')
+
+  if (step.emitStop && stopHookCmd) {
+    try {
+      await execAsync(stopHookCmd, { shell: '/bin/bash' })
+    } catch (err) {
+      process.stderr.write(`mock-cli: stop hook failed: ${err}\n`)
+    }
+  }
+
+  if (step.exit) {
+    process.exit(step.exitCode ?? 0)
+  }
+}
+
+const rl = readline.createInterface({ input: process.stdin })
+rl.on('line', () => {
+  void runStep()
+})

--- a/crabot-agent/tests/workers/fixtures/mock-cli.mjs
+++ b/crabot-agent/tests/workers/fixtures/mock-cli.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
-// mock-cli.mjs — 测试用的假 cc/codex 进程,扮演其最小交互行为:每收到一行 stdin
-// (对应 tmux sendText 注入的一行输入)就消费脚本的下一步。脚本经 env MOCK_CLI_SCRIPT 传入
-// (JSON 数组,元素形如 { output？, emitStop？, exit？, exitCode？ })。
+// mock-cli.mjs — 测试用的假 cc/codex 进程,扮演其最小交互行为:每收到一条完整消息 stdin
+// (对应 tmux sendText 注入的一次输入,不区分单行/多行)就消费脚本的下一步。脚本经
+// env MOCK_CLI_SCRIPT 传入(JSON 数组,元素形如 { output？, emitStop？, exit？, exitCode？ })。
 //
 // 真实 cc 靠 .claude/settings.json 里配置的 Stop hook 命令来上报"我空闲了";真实 codex 靠
 // config.toml 的 notify 程序上报 agent-turn-complete。mock 不解析 settings.json/config.toml,
@@ -28,11 +28,22 @@
 // 出现 -p 就判定为这种一次性调用,原样把入参回显到 stdout 并立即 exit 0,不进入下面的
 // stdin 循环。同理,adapter.detect() 会拿同一条 claudeBin/codexBin 命令行加一个 --version
 // 单独跑一次(也是一次性调用,不写 stdin),argv 里出现 --version 同样立即打印版本号退出。
+//
+// bracketed paste(P2 review #2,tmux/driver.ts sendText 修复):真实 cc/codex TUI 启动时
+// 会请求 bracketed paste mode(发 \x1b[?2004h),这样 tmux `paste-buffer -p` 才会把整段
+// 粘贴内容用 \x1b[200~ ... \x1b[201~ 包裹,程序据此把包裹内的内容当"粘贴的一整块"处理,
+// 内部换行不当提交触发,只有标记外的真实 Enter 才提交。mock 复刻同款语义(而不是简单按行
+// readline),这样契约测试才能验证 sendText 对多行文本真的整段一次性到达,不会被拆成
+// 逐行提交。MOCK_CLI_STDIN_LOG(可选,绝对路径)——设置后每次"提交"(收到一条完整消息)
+// 都往这个文件追加一行 JSON 字符串(消息原文,含内部换行),供测试断言提交次数与内容。
+// MOCK_CLI_READY_FILE(可选,绝对路径)——请求 bracketed paste 之后落一个空文件,供测试在
+// 发送输入前等待"mock 已完成启动、已经请求过 bracketed paste",避免 tmux new-session 一
+// 返回就立刻 sendText 时与 node 进程自身的启动耗时赛跑(这个赛跑本身是测试时序问题,不是
+// sendText 机制的问题——真实 cc/codex 进程启动更慢,同样需要先起来才能谈 bracketed paste)。
 import { exec } from 'node:child_process'
 import { promisify } from 'node:util'
 import { appendFileSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { dirname } from 'node:path'
-import readline from 'node:readline'
 
 const execAsync = promisify(exec)
 
@@ -83,7 +94,75 @@ async function runStep() {
   }
 }
 
-const rl = readline.createInterface({ input: process.stdin })
-rl.on('line', () => {
+const stdinLogFile = process.env.MOCK_CLI_STDIN_LOG
+
+const PASTE_START = '\x1b[200~'
+const PASTE_END = '\x1b[201~'
+
+// 请求 bracketed paste mode——没有这一步,tmux `paste-buffer -p` 不会包裹标记,mock 就
+// 观察不到"一整块"与"逐行"的区别(等价于真实 TUI 没开这个能力时的降级行为)。
+if (process.stdin.isTTY) process.stdin.setRawMode(true)
+process.stdin.resume()
+process.stdout.write('\x1b[?2004h')
+
+const readyFile = process.env.MOCK_CLI_READY_FILE
+if (readyFile) writeFileSync(readyFile, '')
+
+let insidePaste = false
+let pending = '' // 尚未解析完的原始字节(可能横跨多个 data 事件,含被截断的半个标记)
+let lineBuffer = '' // 当前累积中的一条逻辑消息内容
+
+/** str 末尾是否是 marker 的某个前缀(用于避免把跨 chunk 被截断的标记误判成普通内容)。 */
+function trailingMarkerPrefixLen(str, marker) {
+  const maxLen = Math.min(str.length, marker.length - 1)
+  for (let len = maxLen; len > 0; len--) {
+    if (str.endsWith(marker.slice(0, len))) return len
+  }
+  return 0
+}
+
+function submit(content) {
+  if (stdinLogFile) appendFileSync(stdinLogFile, JSON.stringify(content) + '\n')
   void runStep()
+}
+
+process.stdin.on('data', (chunk) => {
+  pending += chunk.toString('utf-8')
+
+  while (pending.length > 0) {
+    if (insidePaste) {
+      const endIdx = pending.indexOf(PASTE_END)
+      if (endIdx !== -1) {
+        lineBuffer += pending.slice(0, endIdx)
+        pending = pending.slice(endIdx + PASTE_END.length)
+        insidePaste = false
+        continue
+      }
+      const holdBack = trailingMarkerPrefixLen(pending, PASTE_END)
+      lineBuffer += pending.slice(0, pending.length - holdBack)
+      pending = pending.slice(pending.length - holdBack)
+      break
+    }
+
+    const startIdx = pending.indexOf(PASTE_START)
+    const nlIdx = pending.search(/[\r\n]/)
+    if (startIdx !== -1 && (nlIdx === -1 || startIdx < nlIdx)) {
+      lineBuffer += pending.slice(0, startIdx)
+      pending = pending.slice(startIdx + PASTE_START.length)
+      insidePaste = true
+      continue
+    }
+    if (nlIdx !== -1) {
+      lineBuffer += pending.slice(0, nlIdx)
+      pending = pending.slice(nlIdx + 1)
+      const content = lineBuffer
+      lineBuffer = ''
+      submit(content)
+      continue
+    }
+    const holdBack = trailingMarkerPrefixLen(pending, PASTE_START)
+    lineBuffer += pending.slice(0, pending.length - holdBack)
+    pending = pending.slice(pending.length - holdBack)
+    break
+  }
 })

--- a/crabot-agent/tests/workers/fixtures/mock-cli.mjs
+++ b/crabot-agent/tests/workers/fixtures/mock-cli.mjs
@@ -15,15 +15,41 @@
 // adapter 的 spawn() 靠轮询发现这个文件名里的 uuid 来拿到会话真实 session_id(codex 没有
 // 类似 cc `--session-id` 的入参,session id 由 codex 内部生成)。mock 在进入 stdin 循环前
 // 同步创建这个文件(内容占位,发现逻辑只认文件名),模拟这一时序。
+//
+// 契约套件专用(P2 Task 7):MOCK_CLI_SCRIPT_FILE(可选,绝对路径)——契约套件的 fixture
+// 里 adapter 只在构造时定死 claudeBin/codexBin 这一整条命令行,但脚本内容(ScriptStep[])
+// 是每个 it() 用例调用 makeSpec() 时才知道的,晚于 adapter 构造。用一个固定路径的文件间接
+// 传递脚本内容,makeSpec() 同步写文件、mock-cli 进程启动时再读,取代内联进命令行的
+// MOCK_CLI_SCRIPT。两者都设置时 SCRIPT_FILE 优先;都没设置时脚本为空数组(现有用例的默认)。
+//
+// 契约套件的 fork() 用例还需要一次"无头一击"调用(cc adapter 的 fork 把 -p <input> 拼进
+// 同一条 claudeBin 命令行,不经 tmux,直接 sh -c 执行、等子进程退出):不能沿用 stdin 驱动
+// 的交互式脚本循环(exec 不会写任何东西到子进程 stdin,会一直挂起等不到的一行)。argv 里
+// 出现 -p 就判定为这种一次性调用,原样把入参回显到 stdout 并立即 exit 0,不进入下面的
+// stdin 循环。同理,adapter.detect() 会拿同一条 claudeBin/codexBin 命令行加一个 --version
+// 单独跑一次(也是一次性调用,不写 stdin),argv 里出现 --version 同样立即打印版本号退出。
 import { exec } from 'node:child_process'
 import { promisify } from 'node:util'
-import { appendFileSync, mkdirSync, writeFileSync } from 'node:fs'
+import { appendFileSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { dirname } from 'node:path'
 import readline from 'node:readline'
 
 const execAsync = promisify(exec)
 
-const script = JSON.parse(process.env.MOCK_CLI_SCRIPT || '[]')
+const pFlagIndex = process.argv.indexOf('-p')
+if (pFlagIndex !== -1) {
+  const forkInput = process.argv[pFlagIndex + 1] ?? ''
+  process.stdout.write(`mock headless reply: ${forkInput}\n`)
+  process.exit(0)
+}
+
+if (process.argv.includes('--version')) {
+  process.stdout.write('mock-cli 0.0.0-test\n')
+  process.exit(0)
+}
+
+const scriptFile = process.env.MOCK_CLI_SCRIPT_FILE
+const script = scriptFile ? JSON.parse(readFileSync(scriptFile, 'utf-8')) : JSON.parse(process.env.MOCK_CLI_SCRIPT || '[]')
 const stopHookCmd = process.env.MOCK_CLI_STOP_HOOK_CMD || ''
 
 const argvFile = process.env.MOCK_CLI_ARGV_FILE

--- a/crabot-agent/tests/workers/fixtures/mock-cli.mjs
+++ b/crabot-agent/tests/workers/fixtures/mock-cli.mjs
@@ -6,15 +6,20 @@
 // 真实 cc 靠 .claude/settings.json 里配置的 Stop hook 命令来上报"我空闲了";mock 不解析
 // settings.json,而是直接执行 env MOCK_CLI_STOP_HOOK_CMD 传入的 hook 命令本身(即
 // CliEventChannel.hookCommand('stop') 的产物字符串)——效果等价,省去在 mock 里实现一个
-// JSON 配置解析器。命令行参数(--session-id 等)原样忽略。
+// JSON 配置解析器。命令行参数(--session-id/--resume 等)默认原样忽略,除非设置了
+// MOCK_CLI_ARGV_FILE(Task 5 resume 测试用它断言 --resume 参数确实被传下去了)。
 import { exec } from 'node:child_process'
 import { promisify } from 'node:util'
+import { appendFileSync } from 'node:fs'
 import readline from 'node:readline'
 
 const execAsync = promisify(exec)
 
 const script = JSON.parse(process.env.MOCK_CLI_SCRIPT || '[]')
 const stopHookCmd = process.env.MOCK_CLI_STOP_HOOK_CMD || ''
+
+const argvFile = process.env.MOCK_CLI_ARGV_FILE
+if (argvFile) appendFileSync(argvFile, JSON.stringify(process.argv.slice(2)) + '\n')
 
 let stepIndex = 0
 

--- a/crabot-agent/tests/workers/provision.test.ts
+++ b/crabot-agent/tests/workers/provision.test.ts
@@ -68,6 +68,26 @@ describe('materializeSkills', () => {
     const names = (await fs.readdir(path.join(ws, '.claude/skills'))).sort()
     expect(names).toEqual(['crabot-cli', 'crabot-cli-copy'])
   })
+
+  // skill.name 未经校验就拼进 fs.rm(dest, {recursive, force}) 的目标路径——含 `/` 或 `..`
+  // 的恶意/畸形 name 能让 dest 逃出 <ws>/.claude/skills/,递归删掉 workspace 内甚至外的任意
+  // 目录(P2 review #3)。这里逐一验证每种恶意 name 都被 reject,且 reject 发生在任何
+  // fs.rm/fs.cp 之前——已经物化好的哨兵文件必须原封不动。
+  describe.each([['../../x'], ['a/b'], [''], ['..']])('拒绝恶意 skill.name %j', (maliciousName) => {
+    it(`reject 且不删除任何目录、不产生越权写入(name=${JSON.stringify(maliciousName)})`, async () => {
+      const skillsDir = path.join(ws, '.claude/skills')
+      await fs.mkdir(skillsDir, { recursive: true })
+      const sentinelPath = path.join(skillsDir, 'sentinel.txt')
+      await fs.writeFile(sentinelPath, 'still here')
+
+      const skills: ProvisionSources['skills'] = [{ id: 'x', name: maliciousName, skill_dir: FIXTURE_SKILL_DIR }]
+
+      await expect(materializeSkills(ws, skills, '.claude/skills')).rejects.toThrow()
+
+      // 哨兵文件原样还在——validateSkillName 在任何 fs.rm/fs.cp 之前就已经 throw。
+      await expect(fs.readFile(sentinelPath, 'utf-8')).resolves.toBe('still here')
+    })
+  })
 })
 
 describe('renderMcpJson', () => {

--- a/crabot-agent/tests/workers/provision.test.ts
+++ b/crabot-agent/tests/workers/provision.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import * as fs from 'node:fs/promises'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import {
+  materializeSkills,
+  renderMcpJson,
+  renderCodexMcpToml,
+  renderContextMd,
+  type ProvisionSources,
+} from '../../src/workers/provision/materialize.js'
+
+// 真实 builtin skill,作为 fixture 源(含 references/ 子目录),验证复制后结构完整
+const FIXTURE_SKILL_DIR = path.resolve(__dirname, '../../../crabot-admin/builtins/skills/crabot-cli')
+
+describe('materializeSkills', () => {
+  let ws: string
+
+  beforeEach(async () => {
+    ws = await fs.mkdtemp(path.join(os.tmpdir(), 'provision-test-'))
+  })
+
+  afterEach(async () => {
+    await fs.rm(ws, { recursive: true, force: true })
+  })
+
+  it('把 skill_dir 整目录(含子目录)复制到 <ws>/<targetSubdir>/<name>/,按 name 而非 id 命名', async () => {
+    const skills: ProvisionSources['skills'] = [
+      { id: 'skill-id-xyz', name: 'crabot-cli', skill_dir: FIXTURE_SKILL_DIR },
+    ]
+
+    await materializeSkills(ws, skills, '.claude/skills')
+
+    const destRoot = path.join(ws, '.claude/skills/crabot-cli')
+    const [skillMd, refMd, srcSkillMd, srcRefMd] = await Promise.all([
+      fs.readFile(path.join(destRoot, 'SKILL.md'), 'utf-8'),
+      fs.readFile(path.join(destRoot, 'references/command-ref.md'), 'utf-8'),
+      fs.readFile(path.join(FIXTURE_SKILL_DIR, 'SKILL.md'), 'utf-8'),
+      fs.readFile(path.join(FIXTURE_SKILL_DIR, 'references/command-ref.md'), 'utf-8'),
+    ])
+
+    expect(skillMd).toBe(srcSkillMd)
+    expect(refMd).toBe(srcRefMd)
+  })
+
+  it('目标目录已存在时整目录覆盖,清除源中不再存在的旧文件', async () => {
+    const destRoot = path.join(ws, '.claude/skills/crabot-cli')
+    await fs.mkdir(path.join(destRoot, 'references'), { recursive: true })
+    await fs.writeFile(path.join(destRoot, 'stale.txt'), 'stale content')
+
+    const skills: ProvisionSources['skills'] = [
+      { id: 'crabot-cli', name: 'crabot-cli', skill_dir: FIXTURE_SKILL_DIR },
+    ]
+    await materializeSkills(ws, skills, '.claude/skills')
+
+    await expect(fs.access(path.join(destRoot, 'stale.txt'))).rejects.toThrow()
+    const skillMd = await fs.readFile(path.join(destRoot, 'SKILL.md'), 'utf-8')
+    expect(skillMd.length).toBeGreaterThan(0)
+  })
+
+  it('支持一次物化多个 skill,各自落在独立子目录', async () => {
+    const skills: ProvisionSources['skills'] = [
+      { id: 'a', name: 'crabot-cli', skill_dir: FIXTURE_SKILL_DIR },
+      { id: 'b', name: 'crabot-cli-copy', skill_dir: FIXTURE_SKILL_DIR },
+    ]
+    await materializeSkills(ws, skills, '.claude/skills')
+
+    const names = (await fs.readdir(path.join(ws, '.claude/skills'))).sort()
+    expect(names).toEqual(['crabot-cli', 'crabot-cli-copy'])
+  })
+})
+
+describe('renderMcpJson', () => {
+  it('渲染 cc 标准 .mcp.json: stdio 用 command/args,http/sse 用 url', () => {
+    const servers: ProvisionSources['mcpServers'] = [
+      { name: 'crabot', transport: 'stdio', command: 'node', args: ['mcp-server.js'] },
+      { name: 'remote', transport: 'http', url: 'https://example.com/mcp' },
+    ]
+
+    expect(renderMcpJson(servers)).toBe(`{
+  "mcpServers": {
+    "crabot": {
+      "command": "node",
+      "args": [
+        "mcp-server.js"
+      ]
+    },
+    "remote": {
+      "url": "https://example.com/mcp"
+    }
+  }
+}
+`)
+  })
+
+  it('stdio server 无 args 时省略 args 字段', () => {
+    const servers: ProvisionSources['mcpServers'] = [{ name: 'bare', transport: 'stdio', command: 'crabot-mcp' }]
+
+    expect(renderMcpJson(servers)).toBe(`{
+  "mcpServers": {
+    "bare": {
+      "command": "crabot-mcp"
+    }
+  }
+}
+`)
+  })
+
+  it('空 server 列表渲染出空 mcpServers 对象', () => {
+    expect(renderMcpJson([])).toBe(`{
+  "mcpServers": {}
+}
+`)
+  })
+})
+
+describe('renderCodexMcpToml', () => {
+  it('渲染 codex config.toml 的 mcp_servers 段: stdio 用 command/args,http/sse 用 url', () => {
+    const servers: ProvisionSources['mcpServers'] = [
+      { name: 'crabot', transport: 'stdio', command: 'node', args: ['mcp-server.js', '--flag'] },
+      { name: 'remote', transport: 'http', url: 'https://example.com/mcp' },
+    ]
+
+    expect(renderCodexMcpToml(servers)).toBe(`[mcp_servers.crabot]
+command = "node"
+args = ["mcp-server.js", "--flag"]
+
+[mcp_servers.remote]
+url = "https://example.com/mcp"
+`)
+  })
+
+  it('command 中含引号和反斜杠时正确转义为 TOML 字符串', () => {
+    const servers: ProvisionSources['mcpServers'] = [
+      { name: 'weird', transport: 'stdio', command: 'C:\\bin\\"crabot".exe' },
+    ]
+
+    expect(renderCodexMcpToml(servers)).toBe(`[mcp_servers.weird]
+command = "C:\\\\bin\\\\\\"crabot\\".exe"
+`)
+  })
+
+  it('空 server 列表渲染为空字符串', () => {
+    expect(renderCodexMcpToml([])).toBe('')
+  })
+})
+
+describe('renderContextMd', () => {
+  it('正文包含 workerId、身份声明、原文嵌入的落盘纪律与 HANDOFF 交接约定', () => {
+    const sa: ProvisionSources['selfAwareness'] = {
+      workerId: 'w-123',
+      taskTitle: '修复登录超时问题',
+      disciplines: '中间产物必须写入 workspace/scratch/,不得写入系统 /tmp。',
+    }
+
+    const md = renderContextMd(sa)
+
+    expect(md).toContain('w-123')
+    expect(md).toContain('修复登录超时问题')
+    expect(md).toContain('你是 crabot 的 worker')
+    expect(md).toContain(sa.disciplines)
+    expect(md).toContain('HANDOFF.md')
+  })
+})

--- a/crabot-agent/tests/workers/provision.test.ts
+++ b/crabot-agent/tests/workers/provision.test.ts
@@ -73,7 +73,7 @@ describe('materializeSkills', () => {
   // 的恶意/畸形 name 能让 dest 逃出 <ws>/.claude/skills/,递归删掉 workspace 内甚至外的任意
   // 目录(P2 review #3)。这里逐一验证每种恶意 name 都被 reject,且 reject 发生在任何
   // fs.rm/fs.cp 之前——已经物化好的哨兵文件必须原封不动。
-  describe.each([['../../x'], ['a/b'], [''], ['..']])('拒绝恶意 skill.name %j', (maliciousName) => {
+  describe.each([['../../x'], ['a/b'], [''], ['..'], ['.']])('拒绝恶意 skill.name %j', (maliciousName) => {
     it(`reject 且不删除任何目录、不产生越权写入(name=${JSON.stringify(maliciousName)})`, async () => {
       const skillsDir = path.join(ws, '.claude/skills')
       await fs.mkdir(skillsDir, { recursive: true })

--- a/crabot-agent/tests/workers/provision.test.ts
+++ b/crabot-agent/tests/workers/provision.test.ts
@@ -121,11 +121,11 @@ describe('renderCodexMcpToml', () => {
       { name: 'remote', transport: 'http', url: 'https://example.com/mcp' },
     ]
 
-    expect(renderCodexMcpToml(servers)).toBe(`[mcp_servers.crabot]
+    expect(renderCodexMcpToml(servers)).toBe(`[mcp_servers."crabot"]
 command = "node"
 args = ["mcp-server.js", "--flag"]
 
-[mcp_servers.remote]
+[mcp_servers."remote"]
 url = "https://example.com/mcp"
 `)
   })
@@ -135,9 +135,69 @@ url = "https://example.com/mcp"
       { name: 'weird', transport: 'stdio', command: 'C:\\bin\\"crabot".exe' },
     ]
 
-    expect(renderCodexMcpToml(servers)).toBe(`[mcp_servers.weird]
+    expect(renderCodexMcpToml(servers)).toBe(`[mcp_servers."weird"]
 command = "C:\\\\bin\\\\\\"crabot\\".exe"
 `)
+  })
+
+  it('server name 含点号时用 quoted key 正确表示', () => {
+    const servers: ProvisionSources['mcpServers'] = [
+      { name: 'my.server', transport: 'stdio', command: 'cmd' },
+    ]
+
+    const output = renderCodexMcpToml(servers)
+    expect(output).toContain('[mcp_servers."my.server"]')
+    expect(output).toContain('command = "cmd"')
+  })
+
+  it('server name 含空格时用 quoted key 正确表示', () => {
+    const servers: ProvisionSources['mcpServers'] = [
+      { name: 'my server', transport: 'stdio', command: 'cmd' },
+    ]
+
+    const output = renderCodexMcpToml(servers)
+    expect(output).toContain('[mcp_servers."my server"]')
+    expect(output).toContain('command = "cmd"')
+  })
+
+  it('server name 含双引号时正确转义', () => {
+    const servers: ProvisionSources['mcpServers'] = [
+      { name: 'server"test', transport: 'stdio', command: 'cmd' },
+    ]
+
+    const output = renderCodexMcpToml(servers)
+    expect(output).toContain('[mcp_servers."server\\"test"]')
+    expect(output).toContain('command = "cmd"')
+  })
+
+  it('server name 含反斜杠时正确转义', () => {
+    const servers: ProvisionSources['mcpServers'] = [
+      { name: 'server\\test', transport: 'stdio', command: 'cmd' },
+    ]
+
+    const output = renderCodexMcpToml(servers)
+    expect(output).toContain('[mcp_servers."server\\\\test"]')
+    expect(output).toContain('command = "cmd"')
+  })
+
+  it('server name 含中文时用 quoted key 正确表示', () => {
+    const servers: ProvisionSources['mcpServers'] = [
+      { name: '服务器', transport: 'stdio', command: 'cmd' },
+    ]
+
+    const output = renderCodexMcpToml(servers)
+    expect(output).toContain('[mcp_servers."服务器"]')
+    expect(output).toContain('command = "cmd"')
+  })
+
+  it('server name 仅含允许的字符时也统一使用 quoted key 形式', () => {
+    const servers: ProvisionSources['mcpServers'] = [
+      { name: 'simple_name-v2', transport: 'stdio', command: 'cmd' },
+    ]
+
+    const output = renderCodexMcpToml(servers)
+    expect(output).toContain('[mcp_servers."simple_name-v2"]')
+    expect(output).toContain('command = "cmd"')
   })
 
   it('空 server 列表渲染为空字符串', () => {

--- a/crabot-agent/tests/workers/tmux-driver.test.ts
+++ b/crabot-agent/tests/workers/tmux-driver.test.ts
@@ -17,6 +17,12 @@ function detectTmux(): boolean {
 
 const tmuxAvailable = detectTmux()
 
+// POSIX shell 单引号转义,拼 `env VAR=... node mock-cli.mjs` 命令行用(与 adapter 测试里的
+// 同名 helper 用法一致)。
+function shQuote(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`
+}
+
 async function waitFor(check: () => Promise<boolean>, timeoutMs = 5000, intervalMs = 50): Promise<void> {
   const deadline = Date.now() + timeoutMs
   while (Date.now() < deadline) {
@@ -91,7 +97,7 @@ describe.skipIf(!tmuxAvailable)('TmuxDriver', () => {
     expect(await fs.readFile(outputFile, 'utf-8')).toContain('VAL=bar123')
   })
 
-  it('sendText sends multi-line input line by line and it echoes back through cat', async () => {
+  it('sendText delivers multi-line text to a plain (non-bracketed-paste) consumer and it echoes back through cat', async () => {
     await driver.newSession({
       name: sessionName,
       cwd: tempDir,
@@ -105,6 +111,49 @@ describe.skipIf(!tmuxAvailable)('TmuxDriver', () => {
     const content = await fs.readFile(outputFile, 'utf-8')
     expect(content).toContain('line one')
     expect(content).toContain('line two')
+  })
+
+  it('sendText 发送多行文本时,bracketed-paste 消费方把它当一条完整消息收到,不按行拆成多条提交', async () => {
+    const mockCli = path.resolve(__dirname, 'fixtures/mock-cli.mjs')
+    const stdinLogFile = path.join(tempDir, 'stdin.log')
+    const readyFile = path.join(tempDir, 'ready')
+    const command = `env MOCK_CLI_SCRIPT=${shQuote('[]')} MOCK_CLI_STDIN_LOG=${shQuote(stdinLogFile)} MOCK_CLI_READY_FILE=${shQuote(readyFile)} node ${shQuote(mockCli)}`
+
+    await driver.newSession({
+      name: sessionName,
+      cwd: tempDir,
+      command,
+      outputFile,
+    })
+
+    // 等 mock 真正起来、已经请求过 bracketed paste,再发送——否则 sendText 会和 node 进程
+    // 自身的启动耗时赛跑(纯测试时序问题,不是 sendText 机制本身的问题)。
+    await waitFor(async () => {
+      try {
+        await fs.access(readyFile)
+        return true
+      } catch {
+        return false
+      }
+    })
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    const multilineText = '标题:修复登录闪退\n背景:v3.2 上线后部分用户反馈登录后立即闪退\n验收:连续登录 10 次不再复现'
+    await driver.sendText(sessionName, multilineText)
+
+    await waitFor(async () => {
+      try {
+        return (await fs.readFile(stdinLogFile, 'utf-8')).trim().length > 0
+      } catch {
+        return false
+      }
+    })
+
+    // 消费方(mock CLI)只应观察到一次"提交",且内容就是完整的多行原文——如果 sendText
+    // 仍是逐行 send-keys + Enter,第一行会被当独立消息立即提交,mock 会记到 3 条日志而不是 1 条。
+    const logLines = (await fs.readFile(stdinLogFile, 'utf-8')).trim().split('\n')
+    expect(logLines).toHaveLength(1)
+    expect(JSON.parse(logLines[0])).toBe(multilineText)
   })
 
   it('isAlive reflects session lifecycle', async () => {

--- a/crabot-agent/tests/workers/tmux-driver.test.ts
+++ b/crabot-agent/tests/workers/tmux-driver.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
+import * as fs from 'node:fs/promises'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { TmuxDriver } from '../../src/workers/tmux/driver.js'
+
+function detectTmux(): boolean {
+  try {
+    execFileSync('which', ['tmux'], { stdio: 'ignore' })
+    return true
+  } catch {
+    return false
+  }
+}
+
+const tmuxAvailable = detectTmux()
+
+async function waitFor(check: () => Promise<boolean>, timeoutMs = 5000, intervalMs = 50): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (await check()) return
+    await new Promise((resolve) => setTimeout(resolve, intervalMs))
+  }
+  throw new Error('waitFor timed out')
+}
+
+describe.skipIf(!tmuxAvailable)('TmuxDriver', () => {
+  const driver = new TmuxDriver()
+  let tempDir: string
+  let sessionName: string
+  let outputFile: string
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tmux-driver-test-'))
+    sessionName = `crabot-w-test-${randomUUID().slice(0, 8)}`
+    outputFile = path.join(tempDir, 'output.log')
+  })
+
+  afterEach(async () => {
+    // 哪怕断言失败也要清理,不留孤儿会话
+    await driver.killSession(sessionName)
+    await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {})
+  })
+
+  it('available() resolves true for the real tmux binary', async () => {
+    expect(await driver.available()).toBe(true)
+  })
+
+  it('available() resolves false for a bogus binary', async () => {
+    const bogus = new TmuxDriver({ tmuxBin: 'definitely-not-a-real-tmux-binary' })
+    expect(await bogus.available()).toBe(false)
+  })
+
+  it('newSession runs the command and pipes its output to outputFile', async () => {
+    await driver.newSession({
+      name: sessionName,
+      cwd: tempDir,
+      command: `bash -c 'echo hello; sleep 30'`,
+      outputFile,
+    })
+
+    await waitFor(async () => (await fs.readFile(outputFile, 'utf-8')).includes('hello'))
+    expect(await fs.readFile(outputFile, 'utf-8')).toContain('hello')
+  })
+
+  it('newSession quotes outputFile paths containing spaces and quotes safely', async () => {
+    const trickyOutput = path.join(tempDir, "out with space & 'quote.log")
+    await driver.newSession({
+      name: sessionName,
+      cwd: tempDir,
+      command: `bash -c 'echo marker; sleep 5'`,
+      outputFile: trickyOutput,
+    })
+
+    await waitFor(async () => (await fs.readFile(trickyOutput, 'utf-8')).includes('marker'))
+    expect(await fs.readFile(trickyOutput, 'utf-8')).toContain('marker')
+  })
+
+  it('newSession passes env vars through to the command', async () => {
+    await driver.newSession({
+      name: sessionName,
+      cwd: tempDir,
+      command: `bash -c 'echo "VAL=$FOO"; sleep 5'`,
+      env: { FOO: 'bar123' },
+      outputFile,
+    })
+
+    await waitFor(async () => (await fs.readFile(outputFile, 'utf-8')).includes('VAL=bar123'))
+    expect(await fs.readFile(outputFile, 'utf-8')).toContain('VAL=bar123')
+  })
+
+  it('sendText sends multi-line input line by line and it echoes back through cat', async () => {
+    await driver.newSession({
+      name: sessionName,
+      cwd: tempDir,
+      command: 'cat',
+      outputFile,
+    })
+
+    await driver.sendText(sessionName, 'line one\nline two')
+
+    await waitFor(async () => (await fs.readFile(outputFile, 'utf-8')).includes('line two'))
+    const content = await fs.readFile(outputFile, 'utf-8')
+    expect(content).toContain('line one')
+    expect(content).toContain('line two')
+  })
+
+  it('isAlive reflects session lifecycle', async () => {
+    expect(await driver.isAlive(sessionName)).toBe(false)
+
+    await driver.newSession({
+      name: sessionName,
+      cwd: tempDir,
+      command: `bash -c 'sleep 30'`,
+      outputFile,
+    })
+    expect(await driver.isAlive(sessionName)).toBe(true)
+  })
+
+  it('killSession terminates the session and is idempotent', async () => {
+    await driver.newSession({
+      name: sessionName,
+      cwd: tempDir,
+      command: `bash -c 'sleep 30'`,
+      outputFile,
+    })
+    expect(await driver.isAlive(sessionName)).toBe(true)
+
+    await driver.killSession(sessionName)
+    expect(await driver.isAlive(sessionName)).toBe(false)
+
+    // 幂等:再次 kill 一个不存在的会话不应抛错
+    await expect(driver.killSession(sessionName)).resolves.toBeUndefined()
+  })
+
+  it('sendKeys drives an interactive read -p prompt with raw key names', async () => {
+    const scriptPath = path.join(tempDir, 'confirm.sh')
+    await fs.writeFile(
+      scriptPath,
+      `#!/bin/bash\nread -p "confirm? " ans\necho "answer=$ans" >> ${JSON.stringify(outputFile)}\n`,
+      { mode: 0o755 },
+    )
+
+    await driver.newSession({
+      name: sessionName,
+      cwd: tempDir,
+      command: `bash ${JSON.stringify(scriptPath)}`,
+      outputFile,
+    })
+
+    await driver.sendKeys(sessionName, ['y', 'Enter'])
+
+    await waitFor(async () => (await fs.readFile(outputFile, 'utf-8')).includes('answer=y'))
+    expect(await fs.readFile(outputFile, 'utf-8')).toContain('answer=y')
+  })
+
+  it('paneCommand reports the pane foreground command, and null for a dead session', async () => {
+    expect(await driver.paneCommand(sessionName)).toBeNull()
+
+    await driver.newSession({
+      name: sessionName,
+      cwd: tempDir,
+      command: `bash -c 'sleep 30'`,
+      outputFile,
+    })
+
+    await waitFor(async () => (await driver.paneCommand(sessionName)) !== null)
+    expect(await driver.paneCommand(sessionName)).toBe('sleep')
+  })
+})


### PR DESCRIPTION
## 概述

Manager/Worker 拆分第二个落地 PR(P2/P8)。**纯新增、未激活**:现网路径零 import,engine/、agent-handler.ts、builtin/ 与 P1 契约文件零改动。

- 路线图:`crabot-docs/superpowers/plans/2026-07-28-manager-worker-split-roadmap.md`(本 PR = P2)
- 细化 plan:`crabot-docs/superpowers/plans/2026-07-29-mw-p2-tmux-cli-adapters.md`
- 协议:`crabot-docs/protocols/protocol-agent-v3.md` §6/§8(本次终审已同步修正两处:codex fork 定案不支持、通知机制为事件文件通道,crabot-docs 5e95b20)

## 交付内容

- `src/workers/tmux/driver.ts`:tmux 原语层(new-session+pipe-pane 单次批处理——两次独立调用有稳定丢首输出的竞态,10/10 复现;send-keys `-l --` 防键名/flag 注入)
- `src/workers/cli-events.ts`:hook 事件文件通道(纯 POSIX printf 追加一行 JSON + fs.watch/2s 轮询兜底,无 HTTP 端点;12 种恶意 kind 注入向量实测拦截)
- `src/workers/provision/materialize.ts`:skill 整目录物化 / `.mcp.json` 与 codex TOML(quoted-key 转义)渲染 / 自述文件
- `src/workers/claude-code/adapter.ts`:spawn 用 `--session-id` 预知 session_ref;Stop/Notification hook 通知;resume `--resume`;**侧问走无头一击** `-p --resume --fork-session`(不进 tmux);readTrace 解析 `~/.claude/projects` JSONL;session_ref UUID 边界校验+shQuote 双层防注入
- `src/workers/codex/adapter.ts`:文档语义实现(逐点 `codex-docs:` 出处注释)——CODEX_HOME 隔离(notify 在项目级配置被忽略)、rollout 文件名 session 发现(超时降级可观测)、auth.json 0600+gitignore、**fork 定案不支持**(openai/codex#11750/#17568,CapabilityNotSupportedError)
- 契约套件复跑:`contract-claude-code/codex.test.ts` 各 10 例,mock CLI 走真实 tmux;tests/workers 共 163 用例,全仓回归零新增失败

## 已知限制与 CI 说明

- **本机无 codex**:其 adapter 按官方文档+源码实现,8 项待真机校准清单在执行记录;detect() 如实报 not installed
- **tmux CI 依赖**:tmux 相关测试有 skipIf 守卫;CI 若要跑全量需 `apt-get install -y tmux`

## 评审沉淀(逐 task 评审 + fable 终审)

P1 锁纪律在 cc adapter 的两处回归被抓回(syncState 全段入锁、spawn 提交后置);后台安全审查修掉 session_ref 命令注入;终审 Minor 裁决表与三条 P3 建议(tmux -t 精确匹配、注册入锁、auth 写入 mode)记录在案。

🤖 Generated with [Claude Code](https://claude.com/claude-code)