### PR TITLE
feat(workers): Manager/Worker 拆分 P3——台账与 harness

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,6 +1,13 @@
 # Crabot 项目进度
 
-> 最后更新：2026-07-29 — Manager/Worker 拆分 P2：tmux 驱动与外部 CLI adapter（PR 待合并）
+> 最后更新：2026-07-29 — Manager/Worker 拆分 P3：台账与 harness（PR 待合并）
+
+## 2026-07-29 — Manager/Worker 拆分 P3：台账与 harness
+
+- P2（PR #48）当日两轮 review 后合并。P3 交付（纯新增未激活）：worker 台账（每对话对象一文件 + 互斥 + 跨文件 worker_id 索引）、v3 精简 task 状态机（从 admin 移植纯函数 + reviveTask 受控出口）、worker 事件流与原生 session 收割、workspace 管理（realpath 边界防串台）、信箱与安全态投递（in-flight 语义）、`WorkerHarness` 编排（spawn/send/read/list/kill/query + 状态回调路由）、透明接续（revive / handoff / switchWorkerImpl）、重启对账与监护移交。tests/workers 326 用例（P2 末 179 → P3 末 326）。
+- 协议同步三次：`Incarnation.forked_from` + `IncarnationHandle.session_ref`（1f65202）、§5.2 接续例外 + §6.1 seq 已知限制（cb47a4f）。
+- 评审沉淀（10 个 task + 全分支终审，多轮 PoC 实证）：fork 化身劫持主线、drain 与 in-flight 双投、workspace 软链绕过、revive 不回填旧化身终态、handoff 死结、主线守卫漏 impl、kill 与 in-flight 竞态复活 cancelled——均已修复并有回归测试；顺带修掉 cc/codex `state()` 无 runtime 时不探活（曾使"tmux worker 存活→重连接管"对 CLI worker 失效）。
+- 已知限制（入协议或执行记录）：化身 seq 非跨实例全局唯一（(impl,seq) 末条匹配已缓解）、`isAlive=true` 时 state 精度限于 meta 快照、tsconfig 排除 tests 致测试从未被类型检查（另开小 PR）。
 
 ## 2026-07-29 — Manager/Worker 拆分 P2：tmux 驱动与外部 CLI adapter
 

--- a/crabot-agent/src/core/data-paths.ts
+++ b/crabot-agent/src/core/data-paths.ts
@@ -54,3 +54,16 @@ export function getWorkspaceDir(): string {
   // 默认 homedir() 与 MM 默认一致（agent 看到用户真实文件，不是 Crabot 内脏）
   return homedir()
 }
+
+/**
+ * Per-task worker workspace 根目录。
+ * 与 getWorkspaceDir() 语义不同：
+ * - getWorkspaceDir()：Agent 的全局工作目录（WORKSPACE_DIR env，默认 homedir）
+ * - getWorkspacesRootDir()：Per-task worker 工作区根（WORKER_WORKSPACES_DIR env，默认 <dataRoot>/workspaces）
+ */
+export function getWorkspacesRootDir(): string {
+  if (process.env.WORKER_WORKSPACES_DIR) {
+    return path.resolve(process.env.WORKER_WORKSPACES_DIR)
+  }
+  return path.resolve(getDataRootDir(), 'workspaces')
+}

--- a/crabot-agent/src/workers/builtin/adapter.ts
+++ b/crabot-agent/src/workers/builtin/adapter.ts
@@ -254,7 +254,7 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
         throw new Error(`BuiltinWorkerAdapter.resume: incarnation ${prev.worker_id}#${prev.seq} already resumed (concurrent resume of the same prev incarnation?)`)
       }
 
-      const newSeq = this.nextSeq(prev.worker_id)
+      const newSeq = await this.nextSeq(prev.worker_id)
       const dir = join(this.deps.dataDir, prev.worker_id)
       let sessionTree = this.findSessionTreeForWorker(prev.worker_id)
       if (!sessionTree) {
@@ -306,7 +306,7 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
         sessionTree = await SessionTree.load(join(dir, 'session.jsonl'))
       }
 
-      const newSeq = this.nextSeq(prev.worker_id)
+      const newSeq = await this.nextSeq(prev.worker_id)
       const outputLog = new OutputLog(join(dir, `output-${newSeq}.log`))
       const forkId = await sessionTree.append(prev.session_ref, createUserMessage(forkInput))
 
@@ -752,11 +752,31 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
    * worker_id 对应下一个可用的化身序号：该 worker 现存所有化身（主线 + fork 分支）里
    * 最大 seq + 1。resume 和 fork 共用这一个分配逻辑，且都在各自的 mutex.run 内调用，
    * 保证两者不会分配出相同的 seq。
+   *
+   * 五轮 review 修复：磁盘感知，理由与 cc/codex adapter 的同名方法一致——只扫内存
+   * instances 会漏掉磁盘上未被重建到内存的旧化身（如跨进程重启后的历史化身），算出的
+   * "下一个"号位实际是别人已经占用的，静默覆盖其 meta-<seq>.json、复用其 output-<seq>.log。
+   * 改为 max(内存已知 seq, 磁盘上 <dataDir>/<worker_id>/ 下 meta-*.json 的最大 seq) + 1——
+   * builtin 的 writeMeta 是独立实现（不复用 meta-store.ts，见该方法注释），这里同样不引入
+   * 跨模块耦合，本地内联一份同款扫盘逻辑。目录不存在（还没 spawn 过）视为无历史，不报错。
    */
-  private nextSeq(worker_id: string): number {
+  private async nextSeq(worker_id: string): Promise<number> {
     let max = 0
     for (const instance of this.instances.values()) {
       if (instance.worker_id === worker_id && instance.seq > max) max = instance.seq
+    }
+    const dir = join(this.deps.dataDir, worker_id)
+    let entries: string[]
+    try {
+      entries = await fs.readdir(dir)
+    } catch {
+      entries = []
+    }
+    for (const name of entries) {
+      const m = /^meta-(\d+)\.json$/.exec(name)
+      if (!m) continue
+      const seq = Number(m[1])
+      if (Number.isFinite(seq) && seq > max) max = seq
     }
     return max + 1
   }

--- a/crabot-agent/src/workers/builtin/adapter.ts
+++ b/crabot-agent/src/workers/builtin/adapter.ts
@@ -211,7 +211,7 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
         pendingInputs: [],
       }
 
-      const newHandle: IncarnationHandle = { worker_id: spec.worker_id, seq, impl: 'builtin' }
+      const newHandle: IncarnationHandle = { worker_id: spec.worker_id, seq, impl: 'builtin', session_ref: rootId }
       // writeMeta 成功之后才注册到 instances/builtinConfigs，跟 resume 保持一致的提交次序：
       // 磁盘失败时不留孤儿实例。注意此时上面的"已 spawn"三重守卫（builtinConfigs 命中 /
       // instances 命中 / 磁盘 meta-${seq}.json 存在）全部落空——writeMeta 还没成功过，没有
@@ -274,7 +274,7 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
         pendingInputs: [],
       }
 
-      const newHandle: IncarnationHandle = { worker_id: prev.worker_id, seq: newSeq, impl: 'builtin' }
+      const newHandle: IncarnationHandle = { worker_id: prev.worker_id, seq: newSeq, impl: 'builtin', session_ref: wakeId }
       // writeMeta 成功之后才注册到 instances 并标记 resumed，确保磁盘失败时不留孤儿实例。
       await this.writeMeta(newInstance)
       this.instances.set(instanceKey(prev.worker_id, newSeq), newInstance)
@@ -321,7 +321,7 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
         pendingInputs: [],
       }
 
-      const newHandle: IncarnationHandle = { worker_id: prev.worker_id, seq: newSeq, impl: 'builtin' }
+      const newHandle: IncarnationHandle = { worker_id: prev.worker_id, seq: newSeq, impl: 'builtin', session_ref: forkId }
       // writeMeta 成功之后才注册到 instances，和 resume 保持一致的提交次序：磁盘失败时
       // 不留孤儿实例。
       await this.writeMeta(newInstance)
@@ -458,7 +458,8 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
         const tmpPath = join(dir, `.meta-${seq}.json.tmp-${randomUUID()}`)
         await fs.writeFile(tmpPath, JSON.stringify(updated), 'utf-8')
         await fs.rename(tmpPath, metaPath)
-        orphans.push({ worker_id, seq, impl: 'builtin' })
+        const tipNodeId = typeof meta.tip_node_id === 'string' ? meta.tip_node_id : ''
+        orphans.push({ worker_id, seq, impl: 'builtin', session_ref: tipNodeId })
       }
     }
 

--- a/crabot-agent/src/workers/builtin/adapter.ts
+++ b/crabot-agent/src/workers/builtin/adapter.ts
@@ -45,6 +45,7 @@ import type { Resolvable } from '../../engine/types.js'
 import { SessionTree } from '../session-tree.js'
 import { OutputLog } from '../output-log.js'
 import { AsyncMutex } from '../async-mutex.js'
+import { WorkerExitedError } from '../errors.js'
 import type {
   AdapterCapabilities,
   CapabilityBundle,
@@ -62,19 +63,8 @@ import type {
 /** fork 是一次性侧问，maxTurns 取小值，避免侧问跑成一次完整任务。 */
 const FORK_MAX_TURNS = 8
 
-/**
- * sendInput 打到已 exited 的化身时抛出。透明接续（自动 resume 并重投）是 harness（P3）
- * 的职责，adapter 层保持窄语义，只负责如实报告"这个化身已经结束了"。
- */
-export class WorkerExitedError extends Error {
-  constructor(
-    readonly worker_id: string,
-    readonly seq: number,
-  ) {
-    super(`BuiltinWorkerAdapter: incarnation ${worker_id}#${seq} has exited`)
-    this.name = 'WorkerExitedError'
-  }
-}
+/** Re-export for backward compatibility and convenience. */
+export { WorkerExitedError }
 
 const FINISH_TASK_TOOL: ToolDefinition = {
   ...defineTool({

--- a/crabot-agent/src/workers/builtin/adapter.ts
+++ b/crabot-agent/src/workers/builtin/adapter.ts
@@ -793,8 +793,12 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     instance.state = state
     // 观察者（onStateChange）的异常永远不能中断状态机的推进。任何回调错误都被捕获
     // 并仅作 console.error 记录，防止阻塞状态转移或导致后续 burst/sendInput 卡死。
+    // session_ref 现读现取 instance.tip（不是调用方传入、创建化身那一刻闭包住的旧
+    // handle.session_ref）——builtin 的 tip 每轮 burst 前进，harness 侧靠这个字段把台账
+    // 刷新到"最近一次完成的状态转换点"，否则活跃化身上的 fork/resume 会从旧节点分叉、
+    // 丢中间上下文（cc/codex 的 session id 整个化身稳定，不受这个问题影响）。
     try {
-      this.deps.onStateChange?.(handle, state)
+      this.deps.onStateChange?.({ ...handle, session_ref: instance.tip }, state)
     } catch (err) {
       console.error(`[BuiltinWorkerAdapter] onStateChange callback error for ${handle.worker_id}#${handle.seq}:`, err)
     }
@@ -816,8 +820,9 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     if (outcome !== undefined) instance.outcome = outcome
     // 观察者（onStateChange）的异常永远不能中断状态机的推进。任何回调错误都被捕获
     // 并仅作 console.error 记录，防止阻塞状态转移或导致后续 burst/sendInput 卡死。
+    // session_ref 现读现取 instance.tip，同 transitionState 的注释。
     try {
-      this.deps.onStateChange?.(handle, 'exited')
+      this.deps.onStateChange?.({ ...handle, session_ref: instance.tip }, 'exited')
     } catch (err) {
       console.error(`[BuiltinWorkerAdapter] onStateChange callback error for ${handle.worker_id}#${handle.seq}:`, err)
     }

--- a/crabot-agent/src/workers/claude-code/adapter.ts
+++ b/crabot-agent/src/workers/claude-code/adapter.ts
@@ -83,6 +83,7 @@ import { CliEventChannel } from '../cli-events.js'
 import { OutputLog } from '../output-log.js'
 import { AsyncMutex } from '../async-mutex.js'
 import { writeMetaAtomic } from '../meta-store.js'
+import { WorkerExitedError } from '../errors.js'
 import { materializeSkills, renderMcpJson, renderContextMd, type ProvisionSources } from '../provision/materialize.js'
 import type {
   AdapterCapabilities,
@@ -118,16 +119,8 @@ function validateSessionRef(sessionRef: string): void {
   }
 }
 
-/** sendInput 打到已 exited 的化身时抛出。与 builtin 的同名类语义一致,各自独立定义(不共享 import)。 */
-export class WorkerExitedError extends Error {
-  constructor(
-    readonly worker_id: string,
-    readonly seq: number,
-  ) {
-    super(`ClaudeCodeAdapter: incarnation ${worker_id}#${seq} has exited`)
-    this.name = 'WorkerExitedError'
-  }
-}
+/** Re-export for backward compatibility and convenience. */
+export { WorkerExitedError }
 
 /** hook 事件文件路径约定:workspace 内 .claude/events-cli.jsonl。provision 与 spawn 都按此约定定位,保持一致。 */
 export function eventsFilePath(ws: Workspace): string {

--- a/crabot-agent/src/workers/claude-code/adapter.ts
+++ b/crabot-agent/src/workers/claude-code/adapter.ts
@@ -232,7 +232,8 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
 
   async spawn(spec: SpawnSpec): Promise<IncarnationHandle> {
     const seq = 1
-    const handle: IncarnationHandle = { worker_id: spec.worker_id, seq, impl: 'claude-code' }
+    const sessionId = randomUUID()
+    const handle: IncarnationHandle = { worker_id: spec.worker_id, seq, impl: 'claude-code', session_ref: sessionId }
     if (this.runtimes.has(instanceKey(handle))) {
       throw new Error(`ClaudeCodeAdapter.spawn: worker_id ${spec.worker_id} already spawned in this process`)
     }
@@ -240,7 +241,6 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
     const dir = join(this.deps.dataDir, spec.worker_id)
     await fs.mkdir(dir, { recursive: true })
 
-    const sessionId = randomUUID()
     const sessionName = `crabot-w-${spec.worker_id}-${seq}`
     const outputFile = join(dir, `output-${seq}.log`)
     const command = `${this.claudeBin} --session-id ${sessionId} --permission-mode acceptEdits`
@@ -291,7 +291,7 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
     if (!prevRuntime) {
       throw new Error(`ClaudeCodeAdapter.resume: no such incarnation ${prev.worker_id}#${prev.seq} resident in this process`)
     }
-    const prevHandle: IncarnationHandle = { worker_id: prev.worker_id, seq: prev.seq, impl: 'claude-code' }
+    const prevHandle: IncarnationHandle = { worker_id: prev.worker_id, seq: prev.seq, impl: 'claude-code', session_ref: prev.session_ref }
     const { state: prevState } = await this.syncState(prevRuntime, prevHandle)
     if (prevState !== 'exited') {
       throw new Error(`ClaudeCodeAdapter.resume: incarnation ${prev.worker_id}#${prev.seq} has not exited yet (state=${prevState})`)
@@ -319,7 +319,7 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
         throw new Error(`ClaudeCodeAdapter.resume: incarnation ${prev.worker_id}#${prev.seq} already resumed (concurrent resume of the same prev incarnation?)`)
       }
       const seq = this.nextSeq(prev.worker_id)
-      handle = { worker_id: prev.worker_id, seq, impl: 'claude-code' }
+      handle = { worker_id: prev.worker_id, seq, impl: 'claude-code', session_ref: prev.session_ref }
       const sessionName = `crabot-w-${prev.worker_id}-${seq}`
       const outputFile = join(dir, `output-${seq}.log`)
       // 不重复传 --permission-mode:provision 阶段已把 acceptEdits 写进 settings.json,覆盖
@@ -390,7 +390,7 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
     let runtime!: Runtime
     await this.getMutex(prev.worker_id).run(async () => {
       const seq = this.nextSeq(prev.worker_id)
-      handle = { worker_id: prev.worker_id, seq, impl: 'claude-code' }
+      handle = { worker_id: prev.worker_id, seq, impl: 'claude-code', session_ref: sessionId }
       const outputFile = join(dir, `output-${seq}.log`)
       runtime = {
         worker_id: prev.worker_id,

--- a/crabot-agent/src/workers/claude-code/adapter.ts
+++ b/crabot-agent/src/workers/claude-code/adapter.ts
@@ -468,13 +468,30 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
 
   async state(h: IncarnationHandle): Promise<WorkerContractState> {
     const runtime = this.runtimes.get(instanceKey(h))
-    if (!runtime) {
-      const metaPath = join(this.deps.dataDir, h.worker_id, `meta-${h.seq}.json`)
-      const raw = await fs.readFile(metaPath, 'utf-8')
-      const meta = JSON.parse(raw) as { state: WorkerContractState }
-      return meta.state
-    }
-    return (await this.syncState(runtime, h)).state
+    if (runtime) return (await this.syncState(runtime, h)).state
+
+    // 无常驻 runtime(典型场景:agent 进程重启后新建的 adapter 实例,内存里还没有这个化身
+    // 的 runtime)——tmux 会话名是确定性命名(`crabot-w-<worker_id>-<seq>`,spawn/resume 落盘
+    // 时的同一约定),不依赖内存态也能重建,先做一次真实存活探测,而不是无条件回落读可能
+    // 早已过期的 meta 值(P3 Task 9 评审发现的缺口:旧实现在无 runtime 时直接读 meta,分不清
+    // "tmux 会话仍活着"与"已经真死",reconcileOnStartup 对 cc/codex 只能照抄重启前的旧值,
+    // 可能把一个真实已死的化身误判成 revived)。
+    //
+    // isAlive===false 时一律判 exited,不管 meta 写的是什么——消除"真死判活"的假阳性,是
+    // 本次修复要解决的核心问题;这个分支不需要 meta 文件的任何字段,连读都不读。
+    const sessionName = `crabot-w-${h.worker_id}-${h.seq}`
+    if (!(await this.tmux.isAlive(sessionName))) return 'exited'
+
+    // 会话仍存活:退回读 meta 的 running/idle——这只是"最近一次内存态 syncState 写盘时的
+    // 快照",精度有限(不代表此刻真实的 running/idle,可能已经又转了几轮而这个进程从未
+    // 观察到过),但至少不会再把一个真实存活的会话误判成 exited。未来若要提升精度,可以在
+    // 无 runtime 时也经 CliEventChannel 读一遍事件文件(与 syncState 同款三源合成逻辑);
+    // 这次修复先只解决"真死判活"这个更严重的假阳性,不做那一步。meta 文件缺失/损坏时的
+    // 既有兜底语义(直接抛错)保持不变,不在这里额外兜底。
+    const metaPath = join(this.deps.dataDir, h.worker_id, `meta-${h.seq}.json`)
+    const raw = await fs.readFile(metaPath, 'utf-8')
+    const meta = JSON.parse(raw) as { state: WorkerContractState }
+    return meta.state
   }
 
   async readTrace(h: IncarnationHandle, cursor?: TraceCursor): Promise<{ events: NormalizedTraceEvent[]; nextCursor: TraceCursor }> {

--- a/crabot-agent/src/workers/claude-code/adapter.ts
+++ b/crabot-agent/src/workers/claude-code/adapter.ts
@@ -84,7 +84,7 @@ import { TmuxDriver } from '../tmux/driver.js'
 import { CliEventChannel } from '../cli-events.js'
 import { OutputLog } from '../output-log.js'
 import { AsyncMutex } from '../async-mutex.js'
-import { writeMetaAtomic } from '../meta-store.js'
+import { writeMetaAtomic, maxSeqOnDisk } from '../meta-store.js'
 import { WorkerExitedError } from '../errors.js'
 import { materializeSkills, renderMcpJson, renderContextMd, type ProvisionSources } from '../provision/materialize.js'
 import type {
@@ -332,7 +332,7 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
       if (prevRuntime.resumed) {
         throw new Error(`ClaudeCodeAdapter.resume: incarnation ${prev.worker_id}#${prev.seq} already resumed (concurrent resume of the same prev incarnation?)`)
       }
-      const seq = this.nextSeq(prev.worker_id)
+      const seq = await this.nextSeq(prev.worker_id)
       handle = { worker_id: prev.worker_id, seq, impl: 'claude-code', session_ref: prev.session_ref }
       const sessionName = `crabot-w-${prev.worker_id}-${seq}`
       const outputFile = join(dir, `output-${seq}.log`)
@@ -414,7 +414,7 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
     let handle!: IncarnationHandle
     let runtime!: Runtime
     await this.getMutex(prev.worker_id).run(async () => {
-      const seq = this.nextSeq(prev.worker_id)
+      const seq = await this.nextSeq(prev.worker_id)
       handle = { worker_id: prev.worker_id, seq, impl: 'claude-code', session_ref: sessionId }
       const outputFile = join(dir, `output-${seq}.log`)
       runtime = {
@@ -732,12 +732,21 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
    * 链)里最大 seq + 1。resume() 和 fork() 共用这一个分配逻辑,且都在各自的 mutex.run 内
    * 调用,保证互不撞号(fork 化身常驻不删,不能用 prev.seq+1 这种固定公式——见 fork()/
    * resume() 注释)。与 builtin adapter 的同名方法同一思路。
+   *
+   * 五轮 review 修复:磁盘感知——重启后新 adapter 实例的 runtimes 只含 ensureRuntime 按需
+   * 重建过的那几条(见 ensureRuntime 注释),不是该 worker 的全部历史化身;只扫内存会漏掉
+   * 磁盘上未被重建的旧化身,算出的"下一个"号位实际是别人已经占用的,resume/fork 静默覆盖
+   * 其 meta-<seq>.json、复用其 output-<seq>.log。改为 max(内存已知 seq, 磁盘上
+   * <dataDir>/<worker_id>/ 下 meta-*.json 的最大 seq) + 1——扫盘用文件名解析 seq,坏名/
+   * 目录不存在都当作没有历史处理,不因此报错。
    */
-  private nextSeq(worker_id: string): number {
+  private async nextSeq(worker_id: string): Promise<number> {
     let max = 0
     for (const runtime of this.runtimes.values()) {
       if (runtime.worker_id === worker_id && runtime.seq > max) max = runtime.seq
     }
+    const diskMax = await maxSeqOnDisk(join(this.deps.dataDir, worker_id))
+    if (diskMax > max) max = diskMax
     return max + 1
   }
 

--- a/crabot-agent/src/workers/claude-code/adapter.ts
+++ b/crabot-agent/src/workers/claude-code/adapter.ts
@@ -46,8 +46,9 @@
  * `dirname(claudeProjectsDir)`(即约定的 `~/.claude/`)下是否有 settings.json 或
  * .credentials.json,不做任何网络调用。
  *
- * resume:先取 prev 化身常驻 runtime(未常驻则报错,P1 同款约束:只能 resume 本进程 spawn 过
- * 的化身),校验其已 exited(未 exited 直接拒绝)→ 新 tmux 会话跑
+ * resume:先经 ensureRuntime 取 prev 化身的 runtime(常驻内存直接用,否则从落盘 meta 重建,
+ * 四轮 review 修复;meta 也没有才报错——不再要求"只能 resume 本进程 spawn 过的化身"),校验
+ * 其已 exited(未 exited 直接拒绝)→ 新 tmux 会话跑
  * `<claudeBin> --resume <prev.session_ref>`(不重复传 --permission-mode,provision 阶段已把
  * acceptEdits 写进 settings.json 兜底命令行之外的场景)→ seq+1 化身、独立 meta/output、
  * session_ref 原样透传(cc 侧同一个会话 id)。锁纪律与 spawn 一致:tmux newSession 成功后才
@@ -69,8 +70,9 @@
  * tool_use content block → kind tool_call;user 记录带 toolUseResult 字段 → kind
  * tool_result;type=system → kind lifecycle;其余 type(mode/summary/queue-operation 等)跳过。
  * cursor.offset 是行号(非字节偏移);文件不存在时返回空数组(见下方"与 brief 的偏差")。
- * 只能对本进程内常驻 runtime 的化身调用——trace 文件路径依赖 workspace root,而这个信息
- * 只存在于内存 runtime 里,meta.json 不落它。
+ * trace 文件路径依赖 workspace root——经 ensureRuntime 从 meta 的 workspace_root 字段
+ * (四轮 review 新增持久化)重建,不再要求"只能对本进程内常驻 runtime 的化身调用";老化身
+ * (升级前写的 meta 缺这个字段)时拒绝并给出可诊断错误,不是本次修复能补的历史缺口。
  */
 import { promises as fs } from 'fs'
 import { join, dirname } from 'path'
@@ -263,7 +265,7 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
       killed: false,
     }
 
-    await writeMetaAtomic(dir, seq, { seq, state: 'running', session_id: sessionId })
+    await writeMetaAtomic(dir, seq, { seq, state: 'running', session_id: sessionId, workspace_root: spec.workspace.root })
     this.runtimes.set(instanceKey(handle), runtime)
 
     // 首条任务输入经 sendText 注入,cc 把它当第一条用户消息。注入失败:session 可能已经起来
@@ -287,7 +289,10 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
     // API 边界校验:session_ref 必须是有效 UUID 格式,防止 shell 注入
     validateSessionRef(prev.session_ref)
 
-    const prevRuntime = this.runtimes.get(instanceKey(prev))
+    // 四轮 review 修复:prevRuntime 不再要求"常驻本进程"——resume 的合法目标本来就是一个
+    // 已终态的化身(它自己的 tmux 会话必然已经不在了),ensureRuntime 从落盘 meta 重建它
+    // (见该方法注释:重建不以 tmux 存活为门槛,只有 meta 完全不存在才返回 undefined)。
+    const prevRuntime = await this.ensureRuntime(prev)
     if (!prevRuntime) {
       throw new Error(`ClaudeCodeAdapter.resume: no such incarnation ${prev.worker_id}#${prev.seq} resident in this process`)
     }
@@ -295,6 +300,15 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
     const { state: prevState } = await this.syncState(prevRuntime, prevHandle)
     if (prevState !== 'exited') {
       throw new Error(`ClaudeCodeAdapter.resume: incarnation ${prev.worker_id}#${prev.seq} has not exited yet (state=${prevState})`)
+    }
+    // 重建出的 prevRuntime 若来自缺 workspace_root 的老 meta(升级前写入,已知限制,见
+    // ensureRuntime 注释),workspaceRoot 退化为空串——不能把空串悄悄当 cwd 传给 tmux
+    // newSession,显式拒绝并给出可诊断的错误,而不是让 newSession 之后以费解的方式失败。
+    if (!prevRuntime.workspaceRoot) {
+      throw new Error(
+        `ClaudeCodeAdapter.resume: cannot rebuild workspace for ${prev.worker_id}#${prev.seq} ` +
+          `(meta.json predates workspace_root persistence; this incarnation cannot be resumed after an adapter restart)`,
+      )
     }
 
     const dir = prevRuntime.dir
@@ -345,7 +359,7 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
         killed: false,
       }
 
-      await writeMetaAtomic(dir, seq, { seq, state: 'running', session_id: prev.session_ref })
+      await writeMetaAtomic(dir, seq, { seq, state: 'running', session_id: prev.session_ref, workspace_root: prevRuntime.workspaceRoot })
       this.runtimes.set(instanceKey(handle), runtime)
       prevRuntime.resumed = true
     })
@@ -370,9 +384,20 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
     // API 边界校验:session_ref 必须是有效 UUID 格式,防止 shell 注入
     validateSessionRef(prev.session_ref)
 
-    const prevRuntime = this.runtimes.get(instanceKey(prev))
+    // fork 不检查 prevRuntime 是否存活(cc 的 --fork-session 无头一击直接靠 --resume 打给
+    // cc 自己的会话文件,不依赖任何 tmux pane 还在跑)——ensureRuntime 因此对 fork 同样适用:
+    // 只要 meta 还在,不管 tmux 会话死活都能重建出这里需要的 dir/workspaceRoot。
+    const prevRuntime = await this.ensureRuntime(prev)
     if (!prevRuntime) {
       throw new Error(`ClaudeCodeAdapter.fork: no such incarnation ${prev.worker_id}#${prev.seq} resident in this process`)
+    }
+    if (!prevRuntime.workspaceRoot) {
+      // 重建自缺 workspace_root 的老 meta(已知限制,见 ensureRuntime 注释)——fork 的子进程
+      // cwd 依赖它,不能悄悄传空串。
+      throw new Error(
+        `ClaudeCodeAdapter.fork: cannot rebuild workspace for ${prev.worker_id}#${prev.seq} ` +
+          `(meta.json predates workspace_root persistence; this incarnation cannot be forked after an adapter restart)`,
+      )
     }
 
     const dir = prevRuntime.dir
@@ -405,7 +430,7 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
         stopBaseline: 0,
         killed: false,
       }
-      await writeMetaAtomic(dir, seq, { seq, state: 'running', session_id: sessionId })
+      await writeMetaAtomic(dir, seq, { seq, state: 'running', session_id: sessionId, workspace_root: prevRuntime.workspaceRoot })
       this.runtimes.set(instanceKey(handle), runtime)
     })
 
@@ -437,10 +462,14 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
   }
 
   async sendInput(h: IncarnationHandle, text: string, opts?: { raw?: boolean }): Promise<void> {
-    const runtime = this.runtimes.get(instanceKey(h))
-    if (!runtime) {
-      throw new Error(`ClaudeCodeAdapter.sendInput: no such incarnation ${h.worker_id}#${h.seq} resident in this process`)
-    }
+    // 四轮 review 修复:重启后新建的 adapter 实例 runtimes 必为空,旧实现在这里直接抛通用
+    // Error("no such incarnation...resident in this process")——harness 只对 WorkerExitedError
+    // 转透明接续,通用 Error 会原样穿透砸给调用方,消息永久卡在队首(protocol-agent-v3 §13
+    // "tmux worker 独立存活 → 重启后 harness 重连接管"在操作层的失效)。改用 ensureRuntime
+    // 从落盘 meta 重建;它拿不到任何记录(真·未知化身)时,对 sendInput 的调用方而言效果
+    // 与"已终态"等价(harness 的透明接续兜底不区分这两种情况),同样抛 WorkerExitedError。
+    const runtime = await this.ensureRuntime(h)
+    if (!runtime) throw new WorkerExitedError(h.worker_id, h.seq)
 
     const { state: current, stopCount } = await this.syncState(runtime, h)
     if (current === 'exited') throw new WorkerExitedError(h.worker_id, h.seq)
@@ -466,40 +495,34 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
     return outputLog.read(cursor)
   }
 
+  /**
+   * P3 Task 9 修复"无常驻 runtime 时不做真实存活探测就照抄 meta 旧值"的假阳性(tmux 会话
+   * 名是确定性命名,不依赖内存态也能重建),四轮 review 进一步把这套重建逻辑收拢进
+   * ensureRuntime,供 sendInput/kill/resume/fork/state/readTrace 共用(见该方法注释)。
+   * ensureRuntime 返回 undefined 只有"落盘 meta 也完全不存在"这一种情形(真·未知化身)——
+   * 与旧实现"tmux 会话不存在则返回 exited"的兜底语义一致,直接判 exited。
+   */
   async state(h: IncarnationHandle): Promise<WorkerContractState> {
-    const runtime = this.runtimes.get(instanceKey(h))
-    if (runtime) return (await this.syncState(runtime, h)).state
-
-    // 无常驻 runtime(典型场景:agent 进程重启后新建的 adapter 实例,内存里还没有这个化身
-    // 的 runtime)——tmux 会话名是确定性命名(`crabot-w-<worker_id>-<seq>`,spawn/resume 落盘
-    // 时的同一约定),不依赖内存态也能重建,先做一次真实存活探测,而不是无条件回落读可能
-    // 早已过期的 meta 值(P3 Task 9 评审发现的缺口:旧实现在无 runtime 时直接读 meta,分不清
-    // "tmux 会话仍活着"与"已经真死",reconcileOnStartup 对 cc/codex 只能照抄重启前的旧值,
-    // 可能把一个真实已死的化身误判成 revived)。
-    //
-    // isAlive===false 时一律判 exited,不管 meta 写的是什么——消除"真死判活"的假阳性,是
-    // 本次修复要解决的核心问题;这个分支不需要 meta 文件的任何字段,连读都不读。
-    const sessionName = `crabot-w-${h.worker_id}-${h.seq}`
-    if (!(await this.tmux.isAlive(sessionName))) return 'exited'
-
-    // 会话仍存活:退回读 meta 的 running/idle——这只是"最近一次内存态 syncState 写盘时的
-    // 快照",精度有限(不代表此刻真实的 running/idle,可能已经又转了几轮而这个进程从未
-    // 观察到过),但至少不会再把一个真实存活的会话误判成 exited。未来若要提升精度,可以在
-    // 无 runtime 时也经 CliEventChannel 读一遍事件文件(与 syncState 同款三源合成逻辑);
-    // 这次修复先只解决"真死判活"这个更严重的假阳性,不做那一步。meta 文件缺失/损坏时的
-    // 既有兜底语义(直接抛错)保持不变,不在这里额外兜底。
-    const metaPath = join(this.deps.dataDir, h.worker_id, `meta-${h.seq}.json`)
-    const raw = await fs.readFile(metaPath, 'utf-8')
-    const meta = JSON.parse(raw) as { state: WorkerContractState }
-    return meta.state
+    const runtime = await this.ensureRuntime(h)
+    if (!runtime) return 'exited'
+    return (await this.syncState(runtime, h)).state
   }
 
   async readTrace(h: IncarnationHandle, cursor?: TraceCursor): Promise<{ events: NormalizedTraceEvent[]; nextCursor: TraceCursor }> {
-    const runtime = this.runtimes.get(instanceKey(h))
+    // 四轮 review 修复:trace 文件路径依赖 workspace root,以前这个信息只存在于内存 runtime
+    // 里(meta.json 不落它),不像 readOutput 那样有约定路径可以脱离内存重建——ensureRuntime
+    // 现在从 meta 里的 workspace_root 字段(本轮新增持久化)重建它,readTrace 因此也能在
+    // 无常驻 runtime 时工作,不再是"只能对本进程内常驻的化身调用"。
+    const runtime = await this.ensureRuntime(h)
     if (!runtime) {
-      // trace 文件路径依赖 workspace root,这个信息只存在于内存 runtime 里(meta.json 不落
-      // 它),不像 readOutput 那样有约定路径可以脱离内存重建。
       throw new Error(`ClaudeCodeAdapter.readTrace: no such incarnation ${h.worker_id}#${h.seq} resident in this process`)
+    }
+    if (!runtime.workspaceRoot) {
+      // 重建自缺 workspace_root 的老 meta(升级前写入,已知限制,见 ensureRuntime 注释)。
+      throw new Error(
+        `ClaudeCodeAdapter.readTrace: cannot rebuild workspace for ${h.worker_id}#${h.seq} ` +
+          `(meta.json predates workspace_root persistence; trace unavailable after an adapter restart)`,
+      )
     }
 
     const slug = projectSlug(runtime.workspaceRoot)
@@ -539,10 +562,13 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
   }
 
   async kill(h: IncarnationHandle): Promise<void> {
-    const runtime = this.runtimes.get(instanceKey(h))
-    if (!runtime) {
-      throw new Error(`ClaudeCodeAdapter.kill: no such incarnation ${h.worker_id}#${h.seq} resident in this process`)
-    }
+    // 四轮 review 修复:重启后新建的 adapter 实例对已经确已终态(或压根没有落盘记录)的
+    // 化身调 kill,以前直接抛通用 Error,harness.killWorker/handoffIncarnation 对此没有
+    // try/catch,错误会穿透打断整个操作(半成品:HANDOFF.md 已写、旧化身未标 superseded 却
+    // 卡死)。ensureRuntime 拿不到任何落盘记录时直接幂等返回(无事可做);拿到时 runtime.state
+    // 已经是探活得到的真实值,下面既有的 exited 幂等分支自然覆盖"会话已经不在了"的情形。
+    const runtime = await this.ensureRuntime(h)
+    if (!runtime) return
     await this.getMutex(h.worker_id).run(async () => {
       if (runtime.state === 'exited') return // 幂等:不覆盖原 ended_reason
       runtime.killed = true
@@ -608,6 +634,100 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
   }
 
   /**
+   * 四轮 review 修复:重启后新建的 adapter 实例 `runtimes` 必为空,以前 sendInput/kill/
+   * resume/fork/readTrace 在这种情况下清一色直接抛通用 Error("no such incarnation ...
+   * resident in this process")——这个错误不是 WorkerExitedError,harness 只对
+   * WorkerExitedError 转透明接续,通用 Error 会原样穿透砸给调用方,消息永久卡在队首、
+   * kill 抛错用户无法终止、switchWorkerImpl 半成品重复追加 HANDOFF.md(§13"tmux worker
+   * 独立存活 → 重启后 harness 重连接管"在操作层的失效;Task 10 只修了 state() 自己的探活
+   * 分支,这次把同一探活逻辑收拢成所有操作共用的单一重建入口)。
+   *
+   * runtimes 命中直接返回。未命中时读 meta-<seq>.json——**meta 完全不存在**(从未 spawn
+   * 过,或目录已被清理)是唯一返回 undefined 的情形,调用方据此判断"真·未知化身"。
+   *
+   * 关键设计取舍:tmux 会话是否还活着**不**作为"能不能重建"的门槛,只影响重建出的
+   * `runtime.state` 取值('exited'/'running')。原因:resume()/fork() 的合法调用目标本来
+   * 就是一个已终态的化身——它自己的 tmux 会话必然已经不在了;若"会话不存在"直接返回
+   * undefined,重启后 resume 永远无法工作,正好背离本轮修复的目的。改为让重建出的
+   * runtime.state 如实反映一次真实 tmux isAlive 探测的结果(不采信 meta 里可能陈旧的
+   * state 字段),后续操作各自基于这个准确的 state 得到正确行为:
+   *   - sendInput:见该方法注释,`runtime.state==='exited'` 时既有的 syncState 快路径
+   *     自然产出 WorkerExitedError,等价于"ensureRuntime 直接返回 undefined ⇒ 抛
+   *     WorkerExitedError"这一表面语义(仅当 meta 也不存在时才真的走这条兜底分支)。
+   *   - kill:既有的 exited 幂等分支(不重复 kill、不覆盖 ended_reason)天然覆盖"会话
+   *     已经不在了"的情形,不需要在 kill() 里另外判断。
+   *   - resume/fork:重建成功即可拿到 dir/workspaceRoot 继续走下去,不受 tmux 死活影响。
+   *
+   * workspace_root 是本轮修复新增进 meta 的持久化项(spawn/resume/fork/transitionState/
+   * transitionExited 统一写入)。老化身(升级前写的 meta)缺这个字段时按已知限制降级——
+   * workspaceRoot 退化为空串,eventChannel 指向一个不存在的占位路径(CliEventChannel.readAll
+   * 对不存在的文件返回空数组,不抛错,只是探测不到新 stop 事件,不影响 exited 判定,因为
+   * 那条判定只依赖 tmux isAlive,不依赖事件文件)。resume()/fork()/readTrace() 在真正需要
+   * workspaceRoot 时(tmux newSession 的 cwd、execFile 的 cwd、trace 文件路径)显式拒绝并
+   * 给出可诊断错误,不把空串悄悄传下去。
+   *
+   * stopBaseline 重建时刻起算新基线(当前已存在的 stop 事件数):不知道历史 baseline,把
+   * "此刻已经存在的 stop 事件"当作已核销,避免重启前遗留的 stop 事件被误判成本轮新完成
+   * (与 spawn()/sendInput() 推进 baseline 的动机一致)——代价是重建后首次 syncState 之前
+   * 无法准确复原"当时到底是 running 还是 idle"这个精细区分(只影响 idle 报告精度,不影响
+   * exited 判定的正确性,是可接受的已知限制)。
+   */
+  private async ensureRuntime(ref: { worker_id: string; seq: number; session_ref?: string }): Promise<Runtime | undefined> {
+    const key = instanceKey(ref)
+    const existing = this.runtimes.get(key)
+    if (existing) return existing
+
+    const dir = join(this.deps.dataDir, ref.worker_id)
+    const meta = await this.readMetaFile(dir, ref.seq)
+    if (!meta) return undefined
+
+    const sessionName = `crabot-w-${ref.worker_id}-${ref.seq}`
+    const alive = await this.tmux.isAlive(sessionName)
+    const workspaceRoot = meta.workspace_root ?? ''
+    const sessionId = meta.session_id ?? ref.session_ref ?? ''
+    const outputFile = join(dir, `output-${ref.seq}.log`)
+    const eventsPath = workspaceRoot ? eventsFilePath({ root: workspaceRoot }) : join(dir, `.no-workspace-events-${ref.seq}.jsonl`)
+    const eventChannel = new CliEventChannel(eventsPath)
+
+    let stopBaseline = 0
+    if (workspaceRoot) {
+      const events = await eventChannel.readAll()
+      stopBaseline = events.filter((e) => e.kind === 'stop').length
+    }
+
+    const runtime: Runtime = {
+      worker_id: ref.worker_id,
+      seq: ref.seq,
+      dir,
+      workspaceRoot,
+      sessionName,
+      sessionId,
+      outputLog: new OutputLog(outputFile),
+      eventChannel,
+      state: alive ? 'running' : 'exited',
+      ended_reason: alive ? undefined : meta.ended_reason,
+      stopBaseline,
+      killed: false,
+    }
+    this.runtimes.set(key, runtime)
+    return runtime
+  }
+
+  /** meta-<seq>.json 读取,文件不存在/内容损坏一律返回 undefined(供 ensureRuntime 判定
+   * "真·未知化身")。 */
+  private async readMetaFile(
+    dir: string,
+    seq: number,
+  ): Promise<{ session_id?: string; workspace_root?: string; ended_reason?: IncarnationEndReason } | undefined> {
+    try {
+      const raw = await fs.readFile(join(dir, `meta-${seq}.json`), 'utf-8')
+      return JSON.parse(raw)
+    } catch {
+      return undefined
+    }
+  }
+
+  /**
    * worker_id 对应下一个可用的化身序号:该 worker 现存所有化身(主线 + fork 分支 + resume
    * 链)里最大 seq + 1。resume() 和 fork() 共用这一个分配逻辑,且都在各自的 mutex.run 内
    * 调用,保证互不撞号(fork 化身常驻不删,不能用 prev.seq+1 这种固定公式——见 fork()/
@@ -622,7 +742,7 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
   }
 
   private async transitionState(runtime: Runtime, h: IncarnationHandle, state: WorkerContractState): Promise<void> {
-    await writeMetaAtomic(runtime.dir, runtime.seq, { seq: runtime.seq, state, session_id: runtime.sessionId })
+    await writeMetaAtomic(runtime.dir, runtime.seq, { seq: runtime.seq, state, session_id: runtime.sessionId, workspace_root: runtime.workspaceRoot })
     runtime.state = state
     try {
       this.deps.onStateChange?.(h, state)
@@ -637,6 +757,7 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
       state: 'exited',
       session_id: runtime.sessionId,
       ended_reason,
+      workspace_root: runtime.workspaceRoot,
     })
     runtime.state = 'exited'
     runtime.ended_reason = ended_reason

--- a/crabot-agent/src/workers/codex/adapter.ts
+++ b/crabot-agent/src/workers/codex/adapter.ts
@@ -91,8 +91,9 @@
  * ## readTrace
  *
  * 解析 `<CODEX_HOME>/sessions/.../rollout-*.jsonl`,字段依据 codex-rs 源码抓取确认(见各
- * 归一化函数内的 codex-docs 注释),fixture 手工构造,真机校准留待安装。只能对本进程内常驻
- * runtime 的化身调用,同 cc(trace 路径依赖内存态)。
+ * 归一化函数内的 codex-docs 注释),fixture 手工构造,真机校准留待安装。rolloutPath 经
+ * ensureRuntime 从 meta 的 workspace_root + session_discovery 字段(四轮 review 新增持久化)
+ * 重新按 session_id 精确查找重建,不再要求"只能对本进程内常驻 runtime 的化身调用"(同 cc)。
  */
 import { promises as fs, type Dirent } from 'fs'
 import { join } from 'path'
@@ -254,6 +255,38 @@ async function pollForNewRollout(sessionsDir: string, cutoffMs: number, timeoutM
   }
 }
 
+/**
+ * 四轮 review 修复(ensureRuntime 专用):按已知 session_id 精确查找对应的 rollout 文件——
+ * 不看 mtime,只看文件名里嵌的 uuid 是否匹配 exactly。meta 只落 session_id +
+ * session_discovery 状态,不落 rolloutPath 这个绝对路径(升级前的 meta 结构就没有它,补
+ * 一个字段不如直接按已知的确定性文件名规则重新找一遍,与 sessionName/outputFile 等其它
+ * 重建字段的思路一致——见 ensureRuntime 注释)。同一遍历约定(深度不超过 4 层,目录不存在
+ * 按"没找到"处理)复用自 findNewestRolloutFile。
+ */
+async function findRolloutFileBySessionId(sessionsDir: string, sessionId: string): Promise<string | undefined> {
+  async function walk(dir: string, depth: number): Promise<string | undefined> {
+    if (depth > 4) return undefined
+    let entries: Dirent[]
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true })
+    } catch {
+      return undefined
+    }
+    for (const entry of entries) {
+      const full = join(dir, entry.name)
+      if (entry.isDirectory()) {
+        const found = await walk(full, depth + 1)
+        if (found) return found
+        continue
+      }
+      const match = ROLLOUT_FILENAME_RE.exec(entry.name)
+      if (match && match[1] === sessionId) return full
+    }
+    return undefined
+  }
+  return walk(sessionsDir, 0)
+}
+
 export class CodexWorkerAdapter implements WorkerAdapter {
   readonly implId = 'codex' as const
 
@@ -413,7 +446,13 @@ export class CodexWorkerAdapter implements WorkerAdapter {
       killed: false,
     }
 
-    await writeMetaAtomic(dir, seq, { seq, state: 'running', session_id: sessionId, session_discovery: sessionDiscoveryStatus })
+    await writeMetaAtomic(dir, seq, {
+      seq,
+      state: 'running',
+      session_id: sessionId,
+      session_discovery: sessionDiscoveryStatus,
+      workspace_root: spec.workspace.root,
+    })
     this.runtimes.set(instanceKey(handle), runtime)
 
     // 首条任务输入注入失败:不能放任 running——按 kill 路径清理 tmux 会话后落
@@ -435,7 +474,10 @@ export class CodexWorkerAdapter implements WorkerAdapter {
   async resume(prev: IncarnationRef, wakeInput: string): Promise<IncarnationHandle> {
     validateSessionRef(prev.session_ref)
 
-    const prevRuntime = this.runtimes.get(instanceKey(prev))
+    // 四轮 review 修复(同 cc adapter):prevRuntime 不再要求"常驻本进程"——resume 的合法
+    // 目标本来就是一个已终态的化身,ensureRuntime 从落盘 meta 重建它(重建不以 tmux 存活为
+    // 门槛,只有 meta 完全不存在才返回 undefined,见该方法注释)。
+    const prevRuntime = await this.ensureRuntime(prev)
     if (!prevRuntime) {
       throw new Error(`CodexWorkerAdapter.resume: no such incarnation ${prev.worker_id}#${prev.seq} resident in this process`)
     }
@@ -443,6 +485,14 @@ export class CodexWorkerAdapter implements WorkerAdapter {
     const { state: prevState } = await this.syncState(prevRuntime, prevHandle)
     if (prevState !== 'exited') {
       throw new Error(`CodexWorkerAdapter.resume: incarnation ${prev.worker_id}#${prev.seq} has not exited yet (state=${prevState})`)
+    }
+    // 重建出的 prevRuntime 若来自缺 workspace_root 的老 meta(升级前写入,已知限制),
+    // workspaceRoot/codexHome 都退化为空串——不能悄悄传给 tmux newSession,显式拒绝。
+    if (!prevRuntime.workspaceRoot) {
+      throw new Error(
+        `CodexWorkerAdapter.resume: cannot rebuild workspace for ${prev.worker_id}#${prev.seq} ` +
+          `(meta.json predates workspace_root persistence; this incarnation cannot be resumed after an adapter restart)`,
+      )
     }
 
     const dir = prevRuntime.dir
@@ -490,7 +540,13 @@ export class CodexWorkerAdapter implements WorkerAdapter {
         killed: false,
       }
 
-      await writeMetaAtomic(dir, seq, { seq, state: 'running', session_id: prev.session_ref, session_discovery: prevRuntime.sessionDiscoveryStatus })
+      await writeMetaAtomic(dir, seq, {
+        seq,
+        state: 'running',
+        session_id: prev.session_ref,
+        session_discovery: prevRuntime.sessionDiscoveryStatus,
+        workspace_root: prevRuntime.workspaceRoot,
+      })
       this.runtimes.set(instanceKey(handle), runtime)
       prevRuntime.resumed = true
     })
@@ -522,10 +578,12 @@ export class CodexWorkerAdapter implements WorkerAdapter {
   }
 
   async sendInput(h: IncarnationHandle, text: string, opts?: { raw?: boolean }): Promise<void> {
-    const runtime = this.runtimes.get(instanceKey(h))
-    if (!runtime) {
-      throw new Error(`CodexWorkerAdapter.sendInput: no such incarnation ${h.worker_id}#${h.seq} resident in this process`)
-    }
+    // 四轮 review 修复(同 cc adapter):重启后新建的 adapter 实例 runtimes 必为空,旧实现
+    // 在这里直接抛通用 Error,harness 只对 WorkerExitedError 转透明接续,通用 Error 会原样
+    // 穿透砸给调用方,消息永久卡在队首。ensureRuntime 拿不到任何落盘记录(真·未知化身)
+    // 时,对调用方而言效果与"已终态"等价,同样抛 WorkerExitedError。
+    const runtime = await this.ensureRuntime(h)
+    if (!runtime) throw new WorkerExitedError(h.worker_id, h.seq)
 
     const { state: current, stopCount } = await this.syncState(runtime, h)
     if (current === 'exited') throw new WorkerExitedError(h.worker_id, h.seq)
@@ -551,36 +609,25 @@ export class CodexWorkerAdapter implements WorkerAdapter {
     return outputLog.read(cursor)
   }
 
+  /**
+   * P3 Task 9 修复"无常驻 runtime 时不做真实存活探测就照抄 meta 旧值"的假阳性(与 cc
+   * adapter 同款),四轮 review 进一步把这套重建逻辑收拢进 ensureRuntime,供 sendInput/
+   * kill/resume/state/readTrace 共用(见该方法注释;codex 没有 fork)。ensureRuntime 返回
+   * undefined 只有"落盘 meta 也完全不存在"这一种情形(真·未知化身)——与旧实现"tmux 会话
+   * 不存在则返回 exited"的兜底语义一致,直接判 exited。
+   */
   async state(h: IncarnationHandle): Promise<WorkerContractState> {
-    const runtime = this.runtimes.get(instanceKey(h))
-    if (runtime) return (await this.syncState(runtime, h)).state
-
-    // 无常驻 runtime(典型场景:agent 进程重启后新建的 adapter 实例,内存里还没有这个化身
-    // 的 runtime)——tmux 会话名是确定性命名(`crabot-w-<worker_id>-<seq>`,spawn/resume 落盘
-    // 时的同一约定),不依赖内存态也能重建,先做一次真实存活探测,而不是无条件回落读可能
-    // 早已过期的 meta 值(P3 Task 9 评审发现的缺口,与 cc adapter 同款修复:旧实现在无
-    // runtime 时直接读 meta,分不清"tmux 会话仍活着"与"已经真死",reconcileOnStartup 只能
-    // 照抄重启前的旧值,可能把一个真实已死的化身误判成 revived)。
-    //
-    // isAlive===false 时一律判 exited,不管 meta 写的是什么——消除"真死判活"的假阳性,是
-    // 本次修复要解决的核心问题;这个分支不需要 meta 文件的任何字段,连读都不读。
-    const sessionName = `crabot-w-${h.worker_id}-${h.seq}`
-    if (!(await this.tmux.isAlive(sessionName))) return 'exited'
-
-    // 会话仍存活:退回读 meta 的 running/idle——这只是"最近一次内存态 syncState 写盘时的
-    // 快照",精度有限(不代表此刻真实的 running/idle,可能已经又转了几轮而这个进程从未
-    // 观察到过),但至少不会再把一个真实存活的会话误判成 exited。未来若要提升精度,可以在
-    // 无 runtime 时也经 CliEventChannel 读一遍事件文件(与 syncState 同款三源合成逻辑);
-    // 这次修复先只解决"真死判活"这个更严重的假阳性,不做那一步。meta 文件缺失/损坏时的
-    // 既有兜底语义(直接抛错)保持不变,不在这里额外兜底。
-    const metaPath = join(this.deps.dataDir, h.worker_id, `meta-${h.seq}.json`)
-    const raw = await fs.readFile(metaPath, 'utf-8')
-    const meta = JSON.parse(raw) as { state: WorkerContractState }
-    return meta.state
+    const runtime = await this.ensureRuntime(h)
+    if (!runtime) return 'exited'
+    return (await this.syncState(runtime, h)).state
   }
 
   async readTrace(h: IncarnationHandle, cursor?: TraceCursor): Promise<{ events: NormalizedTraceEvent[]; nextCursor: TraceCursor }> {
-    const runtime = this.runtimes.get(instanceKey(h))
+    // 四轮 review 修复:以前只能对本进程内常驻的化身调用(rolloutPath 只存在于内存
+    // runtime)。ensureRuntime 现在从 meta 的 session_discovery + workspace_root(本轮新增
+    // 持久化)重新推导出 rolloutPath(见 findRolloutFileBySessionId),readTrace 因此也能在
+    // 无常驻 runtime 时工作。
+    const runtime = await this.ensureRuntime(h)
     if (!runtime) {
       throw new Error(`CodexWorkerAdapter.readTrace: no such incarnation ${h.worker_id}#${h.seq} resident in this process`)
     }
@@ -621,10 +668,13 @@ export class CodexWorkerAdapter implements WorkerAdapter {
   }
 
   async kill(h: IncarnationHandle): Promise<void> {
-    const runtime = this.runtimes.get(instanceKey(h))
-    if (!runtime) {
-      throw new Error(`CodexWorkerAdapter.kill: no such incarnation ${h.worker_id}#${h.seq} resident in this process`)
-    }
+    // 四轮 review 修复(同 cc adapter):重启后新建的 adapter 实例对确已终态(或压根没有
+    // 落盘记录)的化身调 kill,以前直接抛通用 Error,harness.killWorker/handoffIncarnation
+    // 没有 try/catch,错误会穿透打断整个操作。ensureRuntime 拿不到任何落盘记录时直接幂等
+    // 返回;拿到时 runtime.state 已经是探活得到的真实值,下面既有的 exited 幂等分支自然
+    // 覆盖"会话已经不在了"的情形。
+    const runtime = await this.ensureRuntime(h)
+    if (!runtime) return
     await this.getMutex(h.worker_id).run(async () => {
       if (runtime.state === 'exited') return // 幂等:不覆盖原 ended_reason
       runtime.killed = true
@@ -689,6 +739,84 @@ export class CodexWorkerAdapter implements WorkerAdapter {
   }
 
   /**
+   * 四轮 review 修复(与 cc adapter 同款设计,见其 ensureRuntime 注释——这里只记 codex
+   * 特有的差异):runtimes 命中直接返回;未命中时读 meta-<seq>.json,meta 完全不存在才
+   * 返回 undefined(真·未知化身)。tmux 会话是否还活着不作为"能不能重建"的门槛,只影响
+   * 重建出的 runtime.state。
+   *
+   * codex 专属字段:codexHome 从 workspace_root 派生(`<workspaceRoot>/.codex`,与
+   * provision/spawn 的约定一致);rolloutPath 不落盘(meta 只落 session_id +
+   * session_discovery),session_discovery==='discovered' 时用
+   * findRolloutFileBySessionId 按已知 session_id 重新在 codexHome/sessions 下精确查找,
+   * 找不到(文件被移走/清理)则退化为 undefined,readTrace 优雅降级为空数组(与 spawn 时
+   * 发现失败的已知限制同一降级路径)。
+   */
+  private async ensureRuntime(ref: { worker_id: string; seq: number; session_ref?: string }): Promise<Runtime | undefined> {
+    const key = instanceKey(ref)
+    const existing = this.runtimes.get(key)
+    if (existing) return existing
+
+    const dir = join(this.deps.dataDir, ref.worker_id)
+    const meta = await this.readMetaFile(dir, ref.seq)
+    if (!meta) return undefined
+
+    const sessionName = `crabot-w-${ref.worker_id}-${ref.seq}`
+    const alive = await this.tmux.isAlive(sessionName)
+    const workspaceRoot = meta.workspace_root ?? ''
+    const sessionId = meta.session_id ?? ref.session_ref ?? ''
+    const codexHome = workspaceRoot ? join(workspaceRoot, '.codex') : ''
+    const sessionDiscoveryStatus: 'discovered' | 'placeholder' = meta.session_discovery ?? 'placeholder'
+    const rolloutPath =
+      sessionDiscoveryStatus === 'discovered' && codexHome ? await findRolloutFileBySessionId(join(codexHome, 'sessions'), sessionId) : undefined
+    const outputFile = join(dir, `output-${ref.seq}.log`)
+    const eventsPath = workspaceRoot ? eventsFilePath({ root: workspaceRoot }) : join(dir, `.no-workspace-events-${ref.seq}.jsonl`)
+    const eventChannel = new CliEventChannel(eventsPath)
+
+    let stopBaseline = 0
+    if (workspaceRoot) {
+      const events = await eventChannel.readAll()
+      stopBaseline = events.filter((e) => e.kind === 'stop').length
+    }
+
+    const runtime: Runtime = {
+      worker_id: ref.worker_id,
+      seq: ref.seq,
+      dir,
+      workspaceRoot,
+      codexHome,
+      sessionName,
+      sessionId,
+      rolloutPath,
+      outputLog: new OutputLog(outputFile),
+      eventChannel,
+      sessionDiscoveryStatus,
+      state: alive ? 'running' : 'exited',
+      ended_reason: alive ? undefined : meta.ended_reason,
+      stopBaseline,
+      killed: false,
+    }
+    this.runtimes.set(key, runtime)
+    return runtime
+  }
+
+  /** meta-<seq>.json 读取,文件不存在/内容损坏一律返回 undefined(供 ensureRuntime 判定
+   * "真·未知化身")。 */
+  private async readMetaFile(
+    dir: string,
+    seq: number,
+  ): Promise<
+    | { session_id?: string; workspace_root?: string; ended_reason?: IncarnationEndReason; session_discovery?: 'discovered' | 'placeholder' }
+    | undefined
+  > {
+    try {
+      const raw = await fs.readFile(join(dir, `meta-${seq}.json`), 'utf-8')
+      return JSON.parse(raw)
+    } catch {
+      return undefined
+    }
+  }
+
+  /**
    * worker_id 对应下一个可用的化身序号:该 worker 现存所有化身里最大 seq + 1。resume() 在
    * mutex.run 内调用,保证不与并发的另一次 resume 撞号。与 cc adapter 的同名方法同一思路
    * (codex 的 fork() 不支持,不参与这个分配)。
@@ -702,7 +830,13 @@ export class CodexWorkerAdapter implements WorkerAdapter {
   }
 
   private async transitionState(runtime: Runtime, h: IncarnationHandle, state: WorkerContractState): Promise<void> {
-    await writeMetaAtomic(runtime.dir, runtime.seq, { seq: runtime.seq, state, session_id: runtime.sessionId, session_discovery: runtime.sessionDiscoveryStatus })
+    await writeMetaAtomic(runtime.dir, runtime.seq, {
+      seq: runtime.seq,
+      state,
+      session_id: runtime.sessionId,
+      session_discovery: runtime.sessionDiscoveryStatus,
+      workspace_root: runtime.workspaceRoot,
+    })
     runtime.state = state
     try {
       this.deps.onStateChange?.(h, state)
@@ -718,6 +852,7 @@ export class CodexWorkerAdapter implements WorkerAdapter {
       session_id: runtime.sessionId,
       ended_reason,
       session_discovery: runtime.sessionDiscoveryStatus,
+      workspace_root: runtime.workspaceRoot,
     })
     runtime.state = 'exited'
     runtime.ended_reason = ended_reason

--- a/crabot-agent/src/workers/codex/adapter.ts
+++ b/crabot-agent/src/workers/codex/adapter.ts
@@ -105,7 +105,7 @@ import { TmuxDriver } from '../tmux/driver.js'
 import { CliEventChannel } from '../cli-events.js'
 import { OutputLog } from '../output-log.js'
 import { AsyncMutex } from '../async-mutex.js'
-import { writeMetaAtomic } from '../meta-store.js'
+import { writeMetaAtomic, maxSeqOnDisk } from '../meta-store.js'
 import { WorkerExitedError, CapabilityNotSupportedError } from '../errors.js'
 import { materializeSkills, renderCodexMcpToml, renderContextMd, type ProvisionSources } from '../provision/materialize.js'
 import type {
@@ -509,7 +509,7 @@ export class CodexWorkerAdapter implements WorkerAdapter {
       if (prevRuntime.resumed) {
         throw new Error(`CodexWorkerAdapter.resume: incarnation ${prev.worker_id}#${prev.seq} already resumed (concurrent resume of the same prev incarnation?)`)
       }
-      const seq = this.nextSeq(prev.worker_id)
+      const seq = await this.nextSeq(prev.worker_id)
       handle = { worker_id: prev.worker_id, seq, impl: 'codex', session_ref: prev.session_ref }
       const sessionName = `crabot-w-${prev.worker_id}-${seq}`
       const outputFile = join(dir, `output-${seq}.log`)
@@ -820,12 +820,18 @@ export class CodexWorkerAdapter implements WorkerAdapter {
    * worker_id 对应下一个可用的化身序号:该 worker 现存所有化身里最大 seq + 1。resume() 在
    * mutex.run 内调用,保证不与并发的另一次 resume 撞号。与 cc adapter 的同名方法同一思路
    * (codex 的 fork() 不支持,不参与这个分配)。
+   *
+   * 五轮 review 修复:磁盘感知,理由与 cc adapter 的同名方法一致——重启后新 adapter 实例
+   * 的 runtimes 只含 ensureRuntime 按需重建过的那几条,只扫内存会把磁盘上未被重建的旧化身
+   * 的号位当成"下一个"分配出去,静默覆盖其 meta/output。
    */
-  private nextSeq(worker_id: string): number {
+  private async nextSeq(worker_id: string): Promise<number> {
     let max = 0
     for (const runtime of this.runtimes.values()) {
       if (runtime.worker_id === worker_id && runtime.seq > max) max = runtime.seq
     }
+    const diskMax = await maxSeqOnDisk(join(this.deps.dataDir, worker_id))
+    if (diskMax > max) max = diskMax
     return max + 1
   }
 

--- a/crabot-agent/src/workers/codex/adapter.ts
+++ b/crabot-agent/src/workers/codex/adapter.ts
@@ -364,8 +364,7 @@ export class CodexWorkerAdapter implements WorkerAdapter {
 
   async spawn(spec: SpawnSpec): Promise<IncarnationHandle> {
     const seq = 1
-    const handle: IncarnationHandle = { worker_id: spec.worker_id, seq, impl: 'codex' }
-    if (this.runtimes.has(instanceKey(handle))) {
+    if (this.runtimes.has(instanceKey({ worker_id: spec.worker_id, seq }))) {
       throw new Error(`CodexWorkerAdapter.spawn: worker_id ${spec.worker_id} already spawned in this process`)
     }
 
@@ -394,6 +393,8 @@ export class CodexWorkerAdapter implements WorkerAdapter {
         `[codex-adapter] session discovery timed out for ${spec.worker_id}, using placeholder uuid; resume/readTrace will degrade`,
       )
     }
+
+    const handle: IncarnationHandle = { worker_id: spec.worker_id, seq, impl: 'codex', session_ref: sessionId }
 
     const runtime: Runtime = {
       worker_id: spec.worker_id,
@@ -438,7 +439,7 @@ export class CodexWorkerAdapter implements WorkerAdapter {
     if (!prevRuntime) {
       throw new Error(`CodexWorkerAdapter.resume: no such incarnation ${prev.worker_id}#${prev.seq} resident in this process`)
     }
-    const prevHandle: IncarnationHandle = { worker_id: prev.worker_id, seq: prev.seq, impl: 'codex' }
+    const prevHandle: IncarnationHandle = { worker_id: prev.worker_id, seq: prev.seq, impl: 'codex', session_ref: prev.session_ref }
     const { state: prevState } = await this.syncState(prevRuntime, prevHandle)
     if (prevState !== 'exited') {
       throw new Error(`CodexWorkerAdapter.resume: incarnation ${prev.worker_id}#${prev.seq} has not exited yet (state=${prevState})`)
@@ -459,7 +460,7 @@ export class CodexWorkerAdapter implements WorkerAdapter {
         throw new Error(`CodexWorkerAdapter.resume: incarnation ${prev.worker_id}#${prev.seq} already resumed (concurrent resume of the same prev incarnation?)`)
       }
       const seq = this.nextSeq(prev.worker_id)
-      handle = { worker_id: prev.worker_id, seq, impl: 'codex' }
+      handle = { worker_id: prev.worker_id, seq, impl: 'codex', session_ref: prev.session_ref }
       const sessionName = `crabot-w-${prev.worker_id}-${seq}`
       const outputFile = join(dir, `output-${seq}.log`)
       // codex-docs: `codex resume <SESSION_ID>` 是独立子命令(不是 --resume flag)。

--- a/crabot-agent/src/workers/codex/adapter.ts
+++ b/crabot-agent/src/workers/codex/adapter.ts
@@ -553,13 +553,30 @@ export class CodexWorkerAdapter implements WorkerAdapter {
 
   async state(h: IncarnationHandle): Promise<WorkerContractState> {
     const runtime = this.runtimes.get(instanceKey(h))
-    if (!runtime) {
-      const metaPath = join(this.deps.dataDir, h.worker_id, `meta-${h.seq}.json`)
-      const raw = await fs.readFile(metaPath, 'utf-8')
-      const meta = JSON.parse(raw) as { state: WorkerContractState }
-      return meta.state
-    }
-    return (await this.syncState(runtime, h)).state
+    if (runtime) return (await this.syncState(runtime, h)).state
+
+    // 无常驻 runtime(典型场景:agent 进程重启后新建的 adapter 实例,内存里还没有这个化身
+    // 的 runtime)——tmux 会话名是确定性命名(`crabot-w-<worker_id>-<seq>`,spawn/resume 落盘
+    // 时的同一约定),不依赖内存态也能重建,先做一次真实存活探测,而不是无条件回落读可能
+    // 早已过期的 meta 值(P3 Task 9 评审发现的缺口,与 cc adapter 同款修复:旧实现在无
+    // runtime 时直接读 meta,分不清"tmux 会话仍活着"与"已经真死",reconcileOnStartup 只能
+    // 照抄重启前的旧值,可能把一个真实已死的化身误判成 revived)。
+    //
+    // isAlive===false 时一律判 exited,不管 meta 写的是什么——消除"真死判活"的假阳性,是
+    // 本次修复要解决的核心问题;这个分支不需要 meta 文件的任何字段,连读都不读。
+    const sessionName = `crabot-w-${h.worker_id}-${h.seq}`
+    if (!(await this.tmux.isAlive(sessionName))) return 'exited'
+
+    // 会话仍存活:退回读 meta 的 running/idle——这只是"最近一次内存态 syncState 写盘时的
+    // 快照",精度有限(不代表此刻真实的 running/idle,可能已经又转了几轮而这个进程从未
+    // 观察到过),但至少不会再把一个真实存活的会话误判成 exited。未来若要提升精度,可以在
+    // 无 runtime 时也经 CliEventChannel 读一遍事件文件(与 syncState 同款三源合成逻辑);
+    // 这次修复先只解决"真死判活"这个更严重的假阳性,不做那一步。meta 文件缺失/损坏时的
+    // 既有兜底语义(直接抛错)保持不变,不在这里额外兜底。
+    const metaPath = join(this.deps.dataDir, h.worker_id, `meta-${h.seq}.json`)
+    const raw = await fs.readFile(metaPath, 'utf-8')
+    const meta = JSON.parse(raw) as { state: WorkerContractState }
+    return meta.state
   }
 
   async readTrace(h: IncarnationHandle, cursor?: TraceCursor): Promise<{ events: NormalizedTraceEvent[]; nextCursor: TraceCursor }> {

--- a/crabot-agent/src/workers/codex/adapter.ts
+++ b/crabot-agent/src/workers/codex/adapter.ts
@@ -105,6 +105,7 @@ import { CliEventChannel } from '../cli-events.js'
 import { OutputLog } from '../output-log.js'
 import { AsyncMutex } from '../async-mutex.js'
 import { writeMetaAtomic } from '../meta-store.js'
+import { WorkerExitedError, CapabilityNotSupportedError } from '../errors.js'
 import { materializeSkills, renderCodexMcpToml, renderContextMd, type ProvisionSources } from '../provision/materialize.js'
 import type {
   AdapterCapabilities,
@@ -156,28 +157,8 @@ function validateSessionRef(sessionRef: string): void {
   }
 }
 
-/** sendInput 打到已 exited 的化身时抛出。与 cc/builtin 的同名类语义一致,各自独立定义。 */
-export class WorkerExitedError extends Error {
-  constructor(
-    readonly worker_id: string,
-    readonly seq: number,
-  ) {
-    super(`CodexWorkerAdapter: incarnation ${worker_id}#${seq} has exited`)
-    this.name = 'WorkerExitedError'
-  }
-}
-
-/** capabilities() 声明为 false 的能力被调用时抛出的错误(如 fork)。携带 impl/capability
- * 便于调用方判断这是"能力缺失"而非其它运行时错误。 */
-export class CapabilityNotSupportedError extends Error {
-  constructor(
-    readonly impl: string,
-    readonly capability: string,
-  ) {
-    super(`${impl} adapter does not support capability '${capability}'`)
-    this.name = 'CapabilityNotSupportedError'
-  }
-}
+/** Re-export for backward compatibility and convenience. */
+export { WorkerExitedError, CapabilityNotSupportedError }
 
 /** hook/notify 事件文件路径约定:workspace 内 .codex/events-cli.jsonl,与 cc 的
  * .claude/events-cli.jsonl 同构。provision 与 spawn 都按此约定定位,保持一致。 */

--- a/crabot-agent/src/workers/errors.ts
+++ b/crabot-agent/src/workers/errors.ts
@@ -25,13 +25,3 @@ export class CapabilityNotSupportedError extends Error {
     this.name = 'CapabilityNotSupportedError'
   }
 }
-
-/** Raised when workspace validation fails. */
-export class InvalidWorkspaceError extends Error {
-  constructor(
-    readonly reason: string,
-  ) {
-    super(`invalid workspace: ${reason}`)
-    this.name = 'InvalidWorkspaceError'
-  }
-}

--- a/crabot-agent/src/workers/errors.ts
+++ b/crabot-agent/src/workers/errors.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared error types for worker adapters.
+ * These are used by all adapter implementations (builtin, claude-code, codex)
+ * to ensure consistent error handling and instanceof checks across implementations.
+ */
+
+/** Raised when sendInput is called on an incarnation that has already exited. */
+export class WorkerExitedError extends Error {
+  constructor(
+    readonly worker_id: string,
+    readonly seq: number,
+  ) {
+    super(`worker ${worker_id}#${seq} has exited`)
+    this.name = 'WorkerExitedError'
+  }
+}
+
+/** Raised when a capability declared as false is invoked (e.g., fork on codex adapter). */
+export class CapabilityNotSupportedError extends Error {
+  constructor(
+    readonly impl: string,
+    readonly capability: string,
+  ) {
+    super(`${impl} does not support ${capability}`)
+    this.name = 'CapabilityNotSupportedError'
+  }
+}

--- a/crabot-agent/src/workers/errors.ts
+++ b/crabot-agent/src/workers/errors.ts
@@ -25,3 +25,13 @@ export class CapabilityNotSupportedError extends Error {
     this.name = 'CapabilityNotSupportedError'
   }
 }
+
+/** Raised when workspace validation fails. */
+export class InvalidWorkspaceError extends Error {
+  constructor(
+    readonly reason: string,
+  ) {
+    super(`invalid workspace: ${reason}`)
+    this.name = 'InvalidWorkspaceError'
+  }
+}

--- a/crabot-agent/src/workers/harness/harness.ts
+++ b/crabot-agent/src/workers/harness/harness.ts
@@ -359,6 +359,24 @@ export class WorkerHarness {
       const found = await this.deps.ledger.findWorker(workerId)
       if (!found) throw new WorkerNotFoundError(workerId)
       const { worker, dialogObjectId } = found
+
+      // task 在锁外投递期间被 killWorker 打断(如 send 卡在 tmux 投递期间调 kill,这条
+      // 消息在拿到这把锁之前就已经确定要走接续路径了):§5.5"唯一硬拒绝:cancelled"只
+      // 约束 sendToWorker 入队前的把关(见该方法顶部),这里是入队之后才发现的迟到判定,
+      // 不能再用同一处把关。cancelled 是终态,不能被下面的 reviveIncarnation/handoffIncarnation
+      // 经 reopenTaskForContinuation → reviveTask 复活成 running——那样会让已经明确要求
+      // 终止的 task 又"activate"出一个新化身。同时"send_to_worker 投递永不因状态失败"
+      // 是调用方(inbox.flush)的既有契约,消息不能静默消失:丢弃这条并记 dead-letter 事件,
+      // 不重新抛出(抛出会砸向早已异步返回的 sendToWorker 调用方,变成没人处理的 rejection)。
+      if (worker.task.status === 'cancelled') {
+        await this.appendEvent(workerId, sourceSeq, 'state_changed', {
+          kind: 'dead_letter',
+          reason: 'task_cancelled',
+          text_len: text.length,
+        })
+        return
+      }
+
       const mainline = mainlineIncarnation(worker)
 
       if (mainline.seq !== sourceSeq) {
@@ -559,6 +577,9 @@ export class WorkerHarness {
       const nextTask = reopenTaskForContinuation(prev.task, now)
       return { ...prev, task: nextTask, incarnations: [...prev.incarnations, newIncarnation], updated_at: now }
     })
+    // 与 reviveIncarnation 收尾时发 'resumed' 事件对称——交接产出的新化身同样是一次"开工",
+    // 缺了这个事件会让事件流看不到 handoff 之后新主线是何时、以何种 impl 建起来的。
+    await this.appendEvent(worker.worker_id, newHandle.seq, 'spawned', { impl: targetImpl, from_seq: source.seq })
   }
 
   async readWorkerOutput(
@@ -802,6 +823,22 @@ export class WorkerHarness {
         return { ...prev, task: nextTask, incarnations, updated_at: now }
       })
       await this.appendEvent(workerId, incarnation.seq, 'killed', reason ? { reason } : undefined)
+
+      // 清空信箱残留:此刻队列里的条目是 kill 之前已入队、deliver 还没轮到的消息(kill 之后
+      // 的 sendToWorker 会命中上面已落定的 cancelled 直接拒绝,不会再有新条目挤进来——入队
+      // 段与这里同在这把 per-worker 锁的临界区内,互斥)。不清空的话,这些条目会在之后被
+      // inbox.flush 摸到、读到台账已 exited,落进 continueTerminalWorker 的接续分支(即使
+      // 加了上面的 cancelled 短路,也是"先接住再丢弃"而不是干脆不投递)。drain() 不等锁,
+      // 不会因为同一信箱另有 flush 卡在 deliver 而卡住这里;逐条记 dead-letter 事件,保证
+      // "消息不静默消失"的调用方契约。
+      const drained = this.getInbox(workerId).drain()
+      for (const item of drained) {
+        await this.appendEvent(workerId, incarnation.seq, 'state_changed', {
+          kind: 'dead_letter',
+          reason: 'killed',
+          text_len: item.text.length,
+        })
+      }
     })
   }
 
@@ -897,7 +934,13 @@ export class WorkerHarness {
       // 主线分支:只有"当前主线化身"的回调才驱动 task.status——fork 之后数组末尾是侧问
       // 分支,不能再用"数组最后一个"判定"是不是当前化身"。
       const mainline = mainlineIncarnation(worker)
-      if (mainline.seq !== h.seq) return // 非当前主线化身的迟到回调,忽略
+      // 按 (impl, seq) 判定,不能只比 seq——跨实现切换(switchWorkerImpl/handoff)后,新
+      // 实现的 adapter 是全新实例,其 seq 计数从头开始,与被 kill 的旧实现化身撞号是常态
+      // (如 codex#1 顶替 claude-code#1)。只比 seq 会把旧实现迟到的 exited 回调误判成
+      // "当前主线化身的回调",错误地把新主线整个判死。这是 findIncarnation/patchIncarnationBySeq
+      // 已经统一的 (impl,seq) 判定原则在这里的收口。
+      if (mainline.seq !== h.seq || mainline.impl !== h.impl) return // 非当前主线化身的迟到回调,忽略
+      if (target.state === 'exited') return // 目标化身已终态,迟到回调忽略(与上面 fork 分支的短路对称,避免对已终态化身再次施加迁移)
       if (isTerminalStatus(worker.task.status)) return // 已是终态(如已被 killWorker 落定),回调迟到,忽略
 
       // idle 是否算"等输入"本属 manager 判断职责(protocol-agent-v3 §5.2);P3 尚无 manager,

--- a/crabot-agent/src/workers/harness/harness.ts
+++ b/crabot-agent/src/workers/harness/harness.ts
@@ -56,6 +56,7 @@
  */
 
 import { randomUUID } from 'crypto'
+import { promises as fs } from 'fs'
 import type {
   WorkerAdapter,
   WorkerImplId,
@@ -66,16 +67,20 @@ import type {
   SpawnSpec,
   OutputCursor,
   CapabilityBundle,
+  Workspace,
 } from '../types'
-import { CapabilityNotSupportedError } from '../errors'
+import { CapabilityNotSupportedError, WorkerExitedError } from '../errors'
 import { AsyncMutex } from '../async-mutex'
 import type { DialogObjectId, Incarnation, LedgerWorker, TaskStatus } from './ledger-types'
 import type { LedgerStore } from './ledger-store'
 import type { WorkspaceManager } from './workspace-manager'
 import { WorkerInbox, type InboxItem } from './inbox'
 import { WorkerEventLog, type HarnessEvent, type HarnessEventKind } from './worker-events'
-import { applyStatusTransition, isTerminalStatus, taskStatusFromIncarnation } from './task-status'
+import { applyStatusTransition, canTransition, isTerminalStatus, taskStatusFromIncarnation } from './task-status'
 import { join } from 'path'
+
+/** 交接材料里"最近输出尾部"的上限(字符数,近似 4KB,见 protocol-agent-v3 §5.3)。 */
+const HANDOFF_TAIL_MAX_CHARS = 4096
 
 /** 请求的 worker_id 在台账中不存在。 */
 export class WorkerNotFoundError extends Error {
@@ -260,6 +265,14 @@ export class WorkerHarness {
       // 主线化身,不能用"数组最后一个"——fork 之后数组末尾是侧问分支,投递必须仍然打到
       // 主线(protocol-agent-v3 §5.3:fork 不影响主线)。
       const incarnation = mainlineIncarnation(found.worker)
+
+      // 台账已经把主线化身记为终态(如异步状态回调已经追上)——不必再尝试一次注定失败的
+      // sendInput,直接进入 §5.3 透明接续。
+      if (incarnation.state === 'exited') {
+        await this.continueTerminalWorker(workerId, item.text, incarnation.seq)
+        return
+      }
+
       const adapter = this.deps.adapters.get(incarnation.impl as WorkerImplId)
       if (!adapter) {
         throw new Error(`WorkerHarness.sendToWorker: no adapter registered for impl '${incarnation.impl}'`)
@@ -270,10 +283,220 @@ export class WorkerHarness {
         impl: incarnation.impl as WorkerImplId,
         session_ref: incarnation.session_ref,
       }
-      // WorkerExitedError 原样向上抛出,不在此拦截伪装——拦截并转入 §5.3 透明接续是
-      // Task 8 的范围(会修改本文件),Task 7 只保证正常路径投递正确。
-      await adapter.sendInput(handle, item.text, { raw: item.raw })
+      try {
+        await adapter.sendInput(handle, item.text, { raw: item.raw })
+      } catch (err) {
+        // adapter 侧权威地判定化身已终态,即使台账的异步状态回调还没追上(见
+        // continueTerminalWorker 的 sourceSeq 核对注释)——同样转入透明接续,对
+        // sendToWorker 的调用方完全无感(不重新抛出)。
+        if (err instanceof WorkerExitedError) {
+          await this.continueTerminalWorker(workerId, item.text, incarnation.seq)
+          return
+        }
+        throw err
+      }
       await this.appendEvent(workerId, handle.seq, 'input_sent', { text_len: item.text.length })
+    })
+  }
+
+  /**
+   * 跨实现切换(manager 主导,protocol-agent-v3 §5.3"跨实现切换")。走与透明接续完全
+   * 相同的交接路径(见 handoffIncarnation),区别只是:目标实现由调用方显式指定(不做
+   * "原 impl 若仍可用则沿用"的自动选择),且源化身可能仍然存活(由 handoffIncarnation
+   * 内部负责在这种情况下先 kill 再标 superseded)。
+   */
+  async switchWorkerImpl(workerId: string, impl: WorkerImplId, note?: string): Promise<void> {
+    await this.withLock(workerId, async () => {
+      const found = await this.deps.ledger.findWorker(workerId)
+      if (!found) throw new WorkerNotFoundError(workerId)
+      const { worker, dialogObjectId } = found
+      const mainline = mainlineIncarnation(worker)
+      await this.handoffIncarnation(dialogObjectId, worker, mainline, impl, note ?? '')
+    })
+  }
+
+  /**
+   * §5.3 透明接续:sendToWorker 命中终态化身时的分流入口。全程在该 worker 的 per-worker
+   * 锁临界区内完成(brief 要求:"接续全过程在该 worker 的临界区内完成,避免与并发
+   * sendToWorker/kill 交错"),调用方(inbox.flush 的 deliver 回调)本身跑在锁外,这里
+   * 重新拿锁。
+   *
+   * sourceSeq 是调用方在锁外观察到的"疑似已终态"的化身 seq(来自台账 incarnation.state
+   * ==='exited' 的读,或 adapter.sendInput 抛出的 WorkerExitedError 所对应的化身)。拿到
+   * 锁之后必须用 sourceSeq(而非再次读到的台账 state 字段)判断"这次接续还要不要做"——
+   * 台账的 state 字段可能滞后于 adapter 的真实状态(handleStateChange 是 fire-and-forget
+   * 异步写台账,sendInput 抛错时台账不一定已经写完),但 sourceSeq 对应的化身"已经不是
+   * 当前主线"这件事(mainline.seq !== sourceSeq)只有在真的发生过一次接续之后才可能为真
+   * ——这是判断"是否已被并发接续抢先完成"唯一可靠的信号,不能用可能滞后的 state 字段替代。
+   */
+  private async continueTerminalWorker(workerId: string, text: string, sourceSeq: number): Promise<void> {
+    await this.withLock(workerId, async () => {
+      const found = await this.deps.ledger.findWorker(workerId)
+      if (!found) throw new WorkerNotFoundError(workerId)
+      const { worker, dialogObjectId } = found
+      const mainline = mainlineIncarnation(worker)
+
+      if (mainline.seq !== sourceSeq) {
+        // 并发窗口:拿锁之前,该 worker 已经被另一次并发触发的接续抢先完成——主线已经
+        // 前进到更新的化身。按普通投递语义把这条消息补送到当前(存活)主线,不重复接续。
+        const adapter = this.deps.adapters.get(mainline.impl as WorkerImplId)
+        if (!adapter) {
+          throw new Error(`WorkerHarness.sendToWorker: no adapter registered for impl '${mainline.impl}'`)
+        }
+        const handle: IncarnationHandle = {
+          worker_id: workerId,
+          seq: mainline.seq,
+          impl: mainline.impl as WorkerImplId,
+          session_ref: mainline.session_ref,
+        }
+        await adapter.sendInput(handle, text)
+        await this.appendEvent(workerId, handle.seq, 'input_sent', { text_len: text.length })
+        return
+      }
+
+      const adapter = this.deps.adapters.get(mainline.impl as WorkerImplId)
+      if (!adapter) {
+        throw new Error(`WorkerHarness.sendToWorker: no adapter registered for impl '${mainline.impl}' (continuation)`)
+      }
+
+      if (adapter.capabilities().revive) {
+        await this.reviveIncarnation(dialogObjectId, worker, mainline, adapter, text)
+      } else {
+        // "原 impl 若仍可用则沿用,否则 defaultImpl"(brief)。三个既有实现目前都是
+        // revive:true,这条分支走不到真实 adapter;为将来的不可复活实现(如 legacy)保留。
+        const targetImpl = this.deps.adapters.has(mainline.impl as WorkerImplId)
+          ? (mainline.impl as WorkerImplId)
+          : this.deps.defaultImpl
+        await this.handoffIncarnation(dialogObjectId, worker, mainline, targetImpl, text)
+      }
+    })
+  }
+
+  /** capabilities().revive===true 分支:adapter.resume 拉起新化身,session 满保真接续。 */
+  private async reviveIncarnation(
+    dialogObjectId: DialogObjectId,
+    worker: LedgerWorker,
+    mainline: Incarnation,
+    adapter: WorkerAdapter,
+    text: string,
+  ): Promise<void> {
+    const prevRef: IncarnationRef = { worker_id: worker.worker_id, seq: mainline.seq, session_ref: mainline.session_ref }
+    // resume 直接把 text 作为 wakeInput 传入——接续就是这次输入的投递方式,不需要在
+    // resume 成功之后再补一次 adapter.sendInput。
+    const newHandle = await adapter.resume(prevRef, text)
+
+    const now = this.deps.now()
+    await this.deps.ledger.upsertWorker(dialogObjectId, worker.worker_id, (prev) => {
+      if (!prev) return undefined
+      const newIncarnation: Incarnation = {
+        seq: newHandle.seq,
+        impl: newHandle.impl,
+        state: 'running',
+        workspace: mainline.workspace,
+        session_ref: newHandle.session_ref,
+        started_at: now,
+        // forked_from 不填——resume 产出的新化身入主线链(protocol-agent-v3 §5.3)。
+      }
+      const nextTask = reopenTaskForContinuation(prev.task, now)
+      return { ...prev, task: nextTask, incarnations: [...prev.incarnations, newIncarnation], updated_at: now }
+    })
+    await this.appendEvent(worker.worker_id, newHandle.seq, 'resumed', { from_seq: mainline.seq })
+  }
+
+  /**
+   * capabilities().revive===false 分支(交接续办),以及 switchWorkerImpl 复用的公共路径。
+   * 顺序对齐 protocol-agent-v3 §5.3"跨实现切换":旧化身写交接文档收尾 → (若仍存活)
+   * kill 标 superseded → 同 workspace provision+spawn 新实现 → 化身链 +1。
+   */
+  private async handoffIncarnation(
+    dialogObjectId: DialogObjectId,
+    worker: LedgerWorker,
+    source: Incarnation,
+    targetImpl: WorkerImplId,
+    input: string,
+  ): Promise<void> {
+    const sourceAdapter = this.deps.adapters.get(source.impl as WorkerImplId)
+    const sourceHandle: IncarnationHandle = {
+      worker_id: worker.worker_id,
+      seq: source.seq,
+      impl: source.impl as WorkerImplId,
+      session_ref: source.session_ref,
+    }
+
+    // 1. 组装交接材料(task.title/goal + 最近输出尾部,上限 4KB + 上一化身 outcome)并写
+    // workspace 下的 HANDOFF.md(已存在则追加带时间戳的新段,不覆盖)。
+    let tail = ''
+    if (sourceAdapter) {
+      try {
+        const { chunk } = await sourceAdapter.readOutput(sourceHandle, { offset: 0 })
+        tail = chunk.length > HANDOFF_TAIL_MAX_CHARS ? chunk.slice(chunk.length - HANDOFF_TAIL_MAX_CHARS) : chunk
+      } catch (err) {
+        // 读取交接材料失败不阻断交接本身——没有尾部信息的 HANDOFF.md 好过完全不交接。
+        console.error(`[WorkerHarness] handoff: readOutput failed for ${worker.worker_id}#${source.seq}, tail omitted:`, err)
+      }
+    }
+    const outcome = worker.task.outcome ?? source.ended_reason ?? 'unknown'
+    const handoffTs = this.deps.now()
+    await appendHandoffFile(source.workspace, {
+      ts: handoffTs,
+      title: worker.task.title,
+      goal: worker.task.goal,
+      outcome,
+      tail,
+      input,
+    })
+    await this.appendEvent(worker.worker_id, source.seq, 'handoff_started', { target_impl: targetImpl })
+
+    // 2. 旧化身若仍非终态(如 switchWorkerImpl 打在一个仍存活的化身上,或台账的终态回调
+    // 还没追上 adapter 的真实状态),先 kill 再标 superseded——不覆盖已经真实记录过的
+    // ended_reason(那种情况下旧化身已经是它自己的终局,不是被这次交接顶替的)。
+    if (source.state !== 'exited') {
+      if (sourceAdapter) {
+        await sourceAdapter.kill(sourceHandle)
+      }
+      const killedAt = this.deps.now()
+      await this.deps.ledger.upsertWorker(dialogObjectId, worker.worker_id, (prev) => {
+        if (!prev) return undefined
+        const incarnations = patchIncarnationBySeq(prev.incarnations, source.seq, {
+          state: 'exited',
+          ended_at: killedAt,
+          ended_reason: 'superseded',
+        })
+        return { ...prev, incarnations, updated_at: killedAt }
+      })
+      await this.appendEvent(worker.worker_id, source.seq, 'superseded')
+    }
+
+    // 3. 同 workspace provision + spawn 新实现,开工输入 = 原任务 + 交接引用 + 本次输入。
+    const newAdapter = this.deps.adapters.get(targetImpl)
+    if (!newAdapter) {
+      throw new Error(`WorkerHarness.handoffIncarnation: no adapter registered for impl '${targetImpl}' (handoff target)`)
+    }
+    const workspace: Workspace = { root: source.workspace }
+    const caps = this.deps.capabilityBundle ? await this.deps.capabilityBundle() : EMPTY_CAPABILITY_BUNDLE
+    await newAdapter.provision(workspace, caps)
+    const prompt = buildHandoffPrompt(worker.task, input)
+    const newHandle = await newAdapter.spawn({
+      worker_id: worker.worker_id,
+      prompt,
+      workspace,
+      goal: worker.task.goal,
+    })
+
+    // 4. 化身链 +1,task 重新回到 running(见 reopenTaskForContinuation 注释)。
+    const now = this.deps.now()
+    await this.deps.ledger.upsertWorker(dialogObjectId, worker.worker_id, (prev) => {
+      if (!prev) return undefined
+      const newIncarnation: Incarnation = {
+        seq: newHandle.seq,
+        impl: targetImpl,
+        state: 'running',
+        workspace: source.workspace,
+        session_ref: newHandle.session_ref,
+        started_at: now,
+      }
+      const nextTask = reopenTaskForContinuation(prev.task, now)
+      return { ...prev, task: nextTask, incarnations: [...prev.incarnations, newIncarnation], updated_at: now }
     })
   }
 
@@ -411,10 +634,17 @@ export class WorkerHarness {
         if (target.state === 'exited') return // 已终态,迟到回调忽略
         await this.deps.ledger.upsertWorker(dialogObjectId, h.worker_id, (prev) => {
           if (!prev) return undefined
+          // session_ref 现读现取(h.session_ref,不是构造 handle 时闭包住的旧值)——
+          // builtin 的 session_ref 随每轮 burst 前进,adapter 侧在每次 onStateChange 回调
+          // 时都重新取 instance.tip 填入 handle(见 builtin/adapter.ts 的 transitionState/
+          // transitionExited);台账因此在每次状态回调时顺带刷新到"最近一次完成的状态
+          // 转换点"。cc/codex 的 session_ref 本就稳定,这里是等价 no-op。
           const incarnations = patchIncarnationBySeq(
             prev.incarnations,
             h.seq,
-            state === 'exited' ? { state, ended_at: now, ended_reason: endReason } : { state }
+            state === 'exited'
+              ? { state, ended_at: now, ended_reason: endReason, session_ref: h.session_ref }
+              : { state, session_ref: h.session_ref }
           )
           return { ...prev, incarnations, updated_at: now }
         })
@@ -441,10 +671,13 @@ export class WorkerHarness {
         // 吞掉,事件跟着一起丢。提前短路成 no-op,让调用方仍能走到 appendEvent 记录这次回调。
         if (nextStatus === prev.task.status) return prev
         const nextTask = applyStatusTransition(prev.task, nextStatus, { now })
+        // session_ref 现读现取,同上面 fork 分支的注释。
         const incarnations = patchIncarnationBySeq(
           prev.incarnations,
           h.seq,
-          state === 'exited' ? { state, ended_at: now, ended_reason: endReason } : { state }
+          state === 'exited'
+            ? { state, ended_at: now, ended_reason: endReason, session_ref: h.session_ref }
+            : { state, session_ref: h.session_ref }
         )
         return { ...prev, task: nextTask, incarnations, updated_at: now }
       })
@@ -513,6 +746,71 @@ function mainlineIncarnation(worker: LedgerWorker): Incarnation {
  */
 function patchIncarnationBySeq(incarnations: Incarnation[], seq: number, patch: Partial<Incarnation>): Incarnation[] {
   return incarnations.map((inc) => (inc.seq === seq ? { ...inc, ...patch } : inc))
+}
+
+/**
+ * §5.3 化身接续:把 task 的状态与派生字段重新置回 running,供接续产出的新化身使用。
+ *
+ * 终态化身之上继续开一个新化身是显式的"延续"动作,不是 task-status.ts 描述的线性状态机
+ * 内的一次迁移——VALID_TRANSITIONS 里终态(completed/failed/cancelled)无出边是"同一次
+ * 尝试内不允许原地复活"的不变量,但接续产出的是全新的化身,因此当 task 已经终态时直接
+ * 重置状态与派生字段,不经过 canTransition 校验(效果等价于 applyStatusTransition 到
+ * running 分支,只是跳过其内部的非法迁移检查)。task 尚未终态(如台账的终态回调还没追上
+ * adapter 的真实状态)时仍走 applyStatusTransition 的正常校验路径。
+ */
+function reopenTaskForContinuation(task: LedgerWorker['task'], now: string): LedgerWorker['task'] {
+  if (canTransition(task.status, 'running')) {
+    return applyStatusTransition(task, 'running', { now })
+  }
+  return { ...task, status: 'running', completed_at: undefined, error: undefined }
+}
+
+/** 交接续办产出的新化身 prompt:原任务描述 + 交接引用(指向 HANDOFF.md)+ 本次输入。 */
+function buildHandoffPrompt(task: LedgerWorker['task'], input: string): string {
+  const goalLine = task.goal ? `\n目标:${task.goal}` : ''
+  const inputBlock = input ? `\n\n${input}` : ''
+  return `${task.title}${goalLine}\n\n(交接续办:详见 workspace 下的 HANDOFF.md,记录了前一化身的执行现场与交接说明)${inputBlock}`
+}
+
+interface HandoffSection {
+  readonly ts: string
+  readonly title: string
+  readonly goal?: string
+  readonly outcome: string
+  readonly tail: string
+  readonly input: string
+}
+
+function renderHandoffSection(s: HandoffSection): string {
+  const lines = [
+    `## Handoff ${s.ts}`,
+    '',
+    `Task: ${s.title}`,
+    ...(s.goal ? [`Goal: ${s.goal}`] : []),
+    `Previous outcome: ${s.outcome}`,
+    ...(s.input ? [`This round input: ${s.input}`] : []),
+    '',
+    '### Recent output (tail)',
+    '```',
+    s.tail || '(no output)',
+    '```',
+  ]
+  return lines.join('\n') + '\n'
+}
+
+/** 写 workspace 下的 HANDOFF.md;已存在则追加带时间戳的新段,不覆盖(protocol-agent-v3 §5.3)。 */
+async function appendHandoffFile(workspaceRoot: string, section: HandoffSection): Promise<void> {
+  const filePath = join(workspaceRoot, 'HANDOFF.md')
+  const block = renderHandoffSection(section)
+  let existing = ''
+  try {
+    existing = await fs.readFile(filePath, 'utf-8')
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err
+  }
+  const next = existing ? `${existing.replace(/\n+$/, '')}\n\n${block}` : block
+  await fs.mkdir(workspaceRoot, { recursive: true })
+  await fs.writeFile(filePath, next, 'utf-8')
 }
 
 // re-export for callers that only import from harness.ts

--- a/crabot-agent/src/workers/harness/harness.ts
+++ b/crabot-agent/src/workers/harness/harness.ts
@@ -112,6 +112,15 @@ export interface HarnessDeps {
   readonly onEvent?: (e: HarnessEvent) => void
   /** provision 素材(P3 可返回空集) */
   readonly capabilityBundle?: () => Promise<CapabilityBundle>
+  /**
+   * handoff(§5.3 交接续办 / switchWorkerImpl)目标实现是 'builtin' 时所需的 LLM 注入
+   * 默认值。`spawnWorker` 的 builtin 注入由调用方随每次调用显式传入(`SpawnWorkerParams.
+   * builtin`),但 handoff 是 harness 内部触发的动作(可能由 sendToWorker 命中终态化身
+   * 自动触发,调用方拿不到再传一次 builtin 注入的机会),因此在 HarnessDeps 这一级配置
+   * 一份可复用的默认值。缺省时 handoffIncarnation 对 builtin 目标做 pre-flight 拒绝
+   * (见该方法注释),不尝试传 `undefined` 让 `BuiltinWorkerAdapter.spawn` 自己再抛错。
+   */
+  readonly builtinSpawnDefaults?: () => SpawnSpec['builtin']
 }
 
 export interface SpawnWorkerParams {
@@ -439,6 +448,28 @@ export class WorkerHarness {
       session_ref: source.session_ref,
     }
 
+    // 0. Pre-flight(裁决 B 修复):目标 adapter 必须存在;若目标是 'builtin',调用方必须
+    // 通过 HarnessDeps.builtinSpawnDefaults 提供了 LLM 注入,否则 step 3 的 newAdapter.spawn
+    // 必然因 spec.builtin 缺失而抛错(BuiltinWorkerAdapter.spawn 本就 fail-loud)。修复前这
+    // 个抛错发生在 step 3——此时旧化身已经在 step 2 被 kill 并标 superseded,worker 卡进
+    // "旧的没了、新的没建成"的死结,且下次投递会重复整套 handoff(重复追加 HANDOFF.md)。
+    // 把这两项检查提到最前面、在写 HANDOFF.md 和 kill 旧化身之前做,失败时旧化身与
+    // HANDOFF.md 都不动,保持可重试。
+    const newAdapter = this.deps.adapters.get(targetImpl)
+    if (!newAdapter) {
+      throw new Error(`WorkerHarness.handoffIncarnation: no adapter registered for impl '${targetImpl}' (handoff target)`)
+    }
+    let builtinInjection: SpawnSpec['builtin']
+    if (targetImpl === 'builtin') {
+      builtinInjection = this.deps.builtinSpawnDefaults?.()
+      if (!builtinInjection) {
+        throw new Error(
+          `WorkerHarness.handoffIncarnation: handoff target impl is 'builtin' but no builtinSpawnDefaults ` +
+            `configured on HarnessDeps; refusing before touching the source incarnation (worker ${worker.worker_id}#${source.seq})`
+        )
+      }
+    }
+
     // 1. 组装交接材料(task.title/goal + 最近输出尾部,上限 4KB + 上一化身 outcome)并写
     // workspace 下的 HANDOFF.md(已存在则追加带时间戳的新段,不覆盖)。
     let tail = ''
@@ -484,10 +515,7 @@ export class WorkerHarness {
     }
 
     // 3. 同 workspace provision + spawn 新实现,开工输入 = 原任务 + 交接引用 + 本次输入。
-    const newAdapter = this.deps.adapters.get(targetImpl)
-    if (!newAdapter) {
-      throw new Error(`WorkerHarness.handoffIncarnation: no adapter registered for impl '${targetImpl}' (handoff target)`)
-    }
+    // newAdapter / builtinInjection 已在上面的 pre-flight 里取好,这里不用再判一次。
     const workspace: Workspace = { root: source.workspace }
     const caps = this.deps.capabilityBundle ? await this.deps.capabilityBundle() : EMPTY_CAPABILITY_BUNDLE
     await newAdapter.provision(workspace, caps)
@@ -497,6 +525,7 @@ export class WorkerHarness {
       prompt,
       workspace,
       goal: worker.task.goal,
+      builtin: builtinInjection,
     })
 
     // 4. 化身链 +1,task 重新回到 running(见 reopenTaskForContinuation 注释)。

--- a/crabot-agent/src/workers/harness/harness.ts
+++ b/crabot-agent/src/workers/harness/harness.ts
@@ -294,7 +294,7 @@ export class WorkerHarness {
       // 台账已经把主线化身记为终态(如异步状态回调已经追上)——不必再尝试一次注定失败的
       // sendInput,直接进入 §5.3 透明接续。
       if (incarnation.state === 'exited') {
-        await this.continueTerminalWorker(workerId, item.text, incarnation.seq)
+        await this.continueTerminalWorker(workerId, item.text, incarnation.impl as WorkerImplId, incarnation.seq, item.raw)
         return
       }
 
@@ -315,7 +315,7 @@ export class WorkerHarness {
         // continueTerminalWorker 的 sourceSeq 核对注释)——同样转入透明接续,对
         // sendToWorker 的调用方完全无感(不重新抛出)。
         if (err instanceof WorkerExitedError) {
-          await this.continueTerminalWorker(workerId, item.text, incarnation.seq)
+          await this.continueTerminalWorker(workerId, item.text, incarnation.impl as WorkerImplId, incarnation.seq, item.raw)
           return
         }
         throw err
@@ -335,6 +335,12 @@ export class WorkerHarness {
       const found = await this.deps.ledger.findWorker(workerId)
       if (!found) throw new WorkerNotFoundError(workerId)
       const { worker, dialogObjectId } = found
+      // cancelled 是唯一硬拒绝(protocol-agent-v3 §5.5,与 sendToWorker/continueTerminalWorker
+      // 的 cancelled 短路对齐)。若主线化身已因 killWorker 落 exited,不加这道校验会让
+      // handoffIncarnation 跳过 kill 段直接 provision+spawn 新化身,reopenTaskForContinuation
+      // 命中终态走 reviveTask——用户明确要求终止的任务被无声复活成 running。completed/failed
+      // 允许切换(等价于"在办任务换实现"续办的合理场景,§5.3),只有 cancelled 硬拒绝。
+      if (worker.task.status === 'cancelled') throw new TaskCancelledError(workerId)
       const mainline = mainlineIncarnation(worker)
       await this.handoffIncarnation(dialogObjectId, worker, mainline, impl, note ?? '')
     })
@@ -346,15 +352,33 @@ export class WorkerHarness {
    * sendToWorker/kill 交错"),调用方(inbox.flush 的 deliver 回调)本身跑在锁外,这里
    * 重新拿锁。
    *
-   * sourceSeq 是调用方在锁外观察到的"疑似已终态"的化身 seq(来自台账 incarnation.state
-   * ==='exited' 的读,或 adapter.sendInput 抛出的 WorkerExitedError 所对应的化身)。拿到
-   * 锁之后必须用 sourceSeq(而非再次读到的台账 state 字段)判断"这次接续还要不要做"——
-   * 台账的 state 字段可能滞后于 adapter 的真实状态(handleStateChange 是 fire-and-forget
-   * 异步写台账,sendInput 抛错时台账不一定已经写完),但 sourceSeq 对应的化身"已经不是
-   * 当前主线"这件事(mainline.seq !== sourceSeq)只有在真的发生过一次接续之后才可能为真
-   * ——这是判断"是否已被并发接续抢先完成"唯一可靠的信号,不能用可能滞后的 state 字段替代。
+   * sourceImpl/sourceSeq 是调用方在锁外观察到的"疑似已终态"的化身 (impl, seq)(来自台账
+   * incarnation.state==='exited' 的读,或 adapter.sendInput 抛出的 WorkerExitedError 所对应
+   * 的化身)。拿到锁之后必须用这对 (sourceImpl, sourceSeq)(而非再次读到的台账 state 字段)
+   * 判断"这次接续还要不要做"——台账的 state 字段可能滞后于 adapter 的真实状态
+   * (handleStateChange 是 fire-and-forget 异步写台账,sendInput 抛错时台账不一定已经写完),
+   * 但 (sourceImpl, sourceSeq) 对应的化身"已经不是当前主线"这件事(mainline.impl !== sourceImpl
+   * || mainline.seq !== sourceSeq)只有在真的发生过一次接续/切换之后才可能为真——这是判断
+   * "是否已被并发接续抢先完成"唯一可靠的信号,不能用可能滞后的 state 字段替代。
+   *
+   * 只比 seq 不比 impl 是不够的(与 processStateChange 约 942 行的 M1 收口同一原则):等锁
+   * 期间若发生的是跨实现接续/切换(如 codex#1 顶替 claude-code#1,两个 adapter 实例各自
+   * nextSeq 从 1 计数,撞号是常态),新旧化身可能撞上同一个 seq——只比 seq 会把这次已经
+   * 发生过的接续误判成"没发生",转而把当前存活的新主线当成终态源再接续一次(对活着的化身
+   * 调 adapter.resume,adapter 侧会因"未终态"拒绝并抛错,错误经 inbox.flush 穿透给
+   * sendToWorker 的调用方,打破"透明接续对调用方无感"的契约)。
+   *
+   * raw 透传:"补送到当前主线"分支和 sendToWorker 正常路径(见上面的 adapter.sendInput 调用)
+   * 必须保持同一投递语义——`raw: true` 的原始敲键消息若在补送时丢了这个标志,会被当成普通
+   * 消息投递,行为对调用方不再透明。
    */
-  private async continueTerminalWorker(workerId: string, text: string, sourceSeq: number): Promise<void> {
+  private async continueTerminalWorker(
+    workerId: string,
+    text: string,
+    sourceImpl: WorkerImplId,
+    sourceSeq: number,
+    raw: boolean
+  ): Promise<void> {
     await this.withLock(workerId, async () => {
       const found = await this.deps.ledger.findWorker(workerId)
       if (!found) throw new WorkerNotFoundError(workerId)
@@ -379,9 +403,10 @@ export class WorkerHarness {
 
       const mainline = mainlineIncarnation(worker)
 
-      if (mainline.seq !== sourceSeq) {
-        // 并发窗口:拿锁之前,该 worker 已经被另一次并发触发的接续抢先完成——主线已经
-        // 前进到更新的化身。按普通投递语义把这条消息补送到当前(存活)主线,不重复接续。
+      if (mainline.seq !== sourceSeq || mainline.impl !== sourceImpl) {
+        // 并发窗口:拿锁之前,该 worker 已经被另一次并发触发的接续/切换抢先完成——主线已经
+        // 前进到更新的化身(按 (impl, seq) 判定,不能只比 seq,见上面方法注释)。按普通投递
+        // 语义把这条消息补送到当前(存活)主线,不重复接续,并保留原条目的 raw 标志。
         const adapter = this.deps.adapters.get(mainline.impl as WorkerImplId)
         if (!adapter) {
           throw new Error(`WorkerHarness.sendToWorker: no adapter registered for impl '${mainline.impl}'`)
@@ -392,7 +417,7 @@ export class WorkerHarness {
           impl: mainline.impl as WorkerImplId,
           session_ref: mainline.session_ref,
         }
-        await adapter.sendInput(handle, text)
+        await adapter.sendInput(handle, text, { raw })
         await this.appendEvent(workerId, handle.seq, 'input_sent', { text_len: text.length })
         return
       }

--- a/crabot-agent/src/workers/harness/harness.ts
+++ b/crabot-agent/src/workers/harness/harness.ts
@@ -76,7 +76,7 @@ import type { LedgerStore } from './ledger-store'
 import type { WorkspaceManager } from './workspace-manager'
 import { WorkerInbox, type InboxItem } from './inbox'
 import { WorkerEventLog, type HarnessEvent, type HarnessEventKind } from './worker-events'
-import { applyStatusTransition, isTerminalStatus, reviveTask, taskStatusFromIncarnation } from './task-status'
+import { applyStatusTransition, canTransition, isTerminalStatus, reviveTask, taskStatusFromIncarnation } from './task-status'
 import { join } from 'path'
 
 /** 交接材料里"最近输出尾部"的上限(字符数,近似 4KB,见 protocol-agent-v3 §5.3)。 */
@@ -134,6 +134,22 @@ export interface SpawnWorkerParams {
   readonly goal?: string
   /** builtin 实现所需的 LLM 注入(P4 提供) */
   readonly builtin?: SpawnSpec['builtin']
+}
+
+/**
+ * reconcileOnStartup 的巡检结果(protocol-agent-v3 §12,替代 admin 的一刀切自愈)。三个
+ * 桶各装 worker_id,供 P4 manager 决定唤醒哪些 monitor:
+ * - revived:本轮确认化身仍活着(running/idle),台账非终态状态得到确认或对齐,需要
+ *   P4 接管后续监护;
+ * - failed:本轮判死(adapter 报 exited、adapter 未注册、或 adapter.state() 抛错三种
+ *   "无法证明还活着"的情形之一),台账已落 failed(ended_reason='crashed');
+ * - unchanged:进入本轮巡检前就已是终态(含上一轮已经判死/前一次调用已经处理过的),
+ *   本轮不做任何动作。
+ */
+export interface ReconcileReport {
+  readonly revived: string[]
+  readonly failed: string[]
+  readonly unchanged: string[]
 }
 
 const EMPTY_CAPABILITY_BUNDLE: CapabilityBundle = { skills: [], mcp_servers: [] }
@@ -570,6 +586,185 @@ export class WorkerHarness {
     return this.deps.ledger.listWorkers(dialogObjectId)
   }
 
+  /**
+   * 崩溃恢复对账(protocol-agent-v3 §12,替代 admin 的一刀切自愈)。agent 进程重启后调用
+   * 一次:巡检台账里所有非终态 worker 的主线化身,凭 adapter.state() 判定它到底是"进程
+   * 没了、化身也没了"(判死)还是"化身独立于 agent 进程,可能还活着"(如 tmux worker),
+   * 而不是像旧 admin 那样把所有非终态任务一律判死。
+   *
+   * 与 BuiltinWorkerAdapter.scanOrphans(P1)的关系——互补而非替代:scanOrphans 是
+   * builtin 自己的 adapter 内部动作,修的是它自己 dataDir 下 meta-<seq>.json 这份"进程内
+   * 存活状态由本进程独占计算"的私有真相(builtin 的执行就是本进程内的 runEngine burst,
+   * 进程重启即等价于 burst 消失,重启前仍是 running 的 meta 就是孤儿,必须先纠正);本方法
+   * 修的是台账(跨三种 impl 的公共真相源)。两者都要跑,顺序上 scanOrphans 必须先于本方法:
+   * 本方法调用 adapter.state() 时,builtin 的 state() 在无常驻内存 instance 时直接回落读
+   * meta-<seq>.json(见 BuiltinWorkerAdapter.state 实现),若 scanOrphans 没有先跑,孤儿
+   * meta 仍标着 'running',本方法会把它误判进"revived"分支。scanOrphans 的调用时机是
+   * "本进程任何 adapter 实例开始活动前"(其自身文档要求),比 harness 构造还早——harness
+   * 拿不到、也不该拿到某个具体 adapter(如 builtin)的私有 dataDir(HarnessDeps 只有
+   * workersDir,是 harness 自己的 events/output 目录,与各 adapter 的私有 dataDir 是两个
+   * 目录),因此不在本方法内部调用 scanOrphans,调用顺序由 P4/bootstrap 层保证(先
+   * `BuiltinWorkerAdapter.scanOrphans(dataDir)`,adapter 塞进 `adapters` Map 之后,再调
+   * `harness.reconcileOnStartup()`)。claude-code/codex 目前没有等价的孤儿扫描——它们的
+   * `state()` 在无常驻 runtime 时同样回落读 meta 文件而不做真实 tmux 存活探测,这是现有
+   * adapter 实现的已知限制(§6.3 描述的"低频巡扫 tmux pane"兜底另有周期机制,不在本方法
+   * 范围内),不是本方法引入的新问题。
+   *
+   * 判定规则(逐 worker 独立判定,整轮不持有任何全局锁——只在每个 worker 自己的
+   * per-worker 临界区内完成"读台账→判adapter.state()→提交"):
+   * - 台账已是终态:跳过,归 unchanged(幂等:重复调用不会把上一轮已经判死的 worker 再判一次)。
+   * - 主线化身的 impl 没有对应 adapter 注册(实现被禁用/未安装):判死。
+   * - `adapter.state(handle)` 抛错:视为不可判定,判死;错误信息记进事件 detail,不让
+   *   这次异常中断整轮对账(逐 worker try/catch,配合 Promise.allSettled 兜底任何未预料
+   *   到的同步/异步异常,一个 worker 出问题不影响其它 worker 被处理)。
+   * - 返回 `exited`:台账仍非终态却已经不在跑了,判死,ended_reason='crashed'。
+   * - 返回 `running`/`idle`:台账保持(不判死)——tmux worker 独立于 agent 进程,重启后
+   *   往往仍活着;按这次实际观察到的 contractState 用 taskStatusFromIncarnation 把
+   *   task.status 对齐到真实值(可能一步都不用走,也可能需要更新化身的 state 字段),
+   *   发 state_changed 事件(detail.source='reconcile',与被动回调路径区分)通知 P4 manager
+   *   接管这个 worker 的后续监护;归 revived。
+   */
+  async reconcileOnStartup(): Promise<ReconcileReport> {
+    const revived: string[] = []
+    const failed: string[] = []
+    const unchanged: string[] = []
+
+    const all = await this.deps.ledger.listAllWorkers()
+    const targets = all.filter(({ worker }) => !isTerminalStatus(worker.task.status))
+    // 报告的 unchanged 桶按 brief 定义包含"终态"(不只是"无需动作但仍被判定过的非终态
+    // worker")——已终态的 worker 在这里直接归档,不进 Promise.allSettled 那批,不占用
+    // per-worker 锁、不调用 adapter.state()(即使重复调用 reconcileOnStartup,已判死过的
+    // worker 从第二次起也是在这一步就被截住,不会再走到 reconcileOneWorker)。
+    unchanged.push(...all.filter(({ worker }) => isTerminalStatus(worker.task.status)).map(({ worker }) => worker.worker_id))
+
+    const settled = await Promise.allSettled(
+      targets.map(({ dialogObjectId, worker }) => this.reconcileOneWorker(dialogObjectId, worker.worker_id))
+    )
+
+    settled.forEach((result, i) => {
+      const workerId = targets[i].worker.worker_id
+      if (result.status === 'fulfilled') {
+        ;(result.value === 'revived' ? revived : result.value === 'failed' ? failed : unchanged).push(workerId)
+      } else {
+        // reconcileOneWorker 内部已经把 adapter.state() 的异常兜底成 'failed' 分类并落盘,
+        // 这里兜的是更意外的情形(如 ledger 写盘失败)——记日志,报告里仍归 failed,不让
+        // 一个 worker 的意外异常掐断整轮 Promise.allSettled 之外的收尾逻辑。
+        console.error(`[WorkerHarness] reconcileOnStartup: unexpected error reconciling ${workerId}:`, result.reason)
+        failed.push(workerId)
+      }
+    })
+
+    return { revived, failed, unchanged }
+  }
+
+  /** reconcileOnStartup 单个 worker 的判定+提交,整体在该 worker 的 per-worker 锁临界区内完成。 */
+  private async reconcileOneWorker(
+    dialogObjectId: DialogObjectId,
+    workerId: string
+  ): Promise<'revived' | 'failed' | 'unchanged'> {
+    return this.withLock(workerId, async () => {
+      const found = await this.deps.ledger.findWorker(workerId)
+      if (!found) return 'unchanged' // 理论不该发生(枚举时刚读到过),防御性处理
+      const { worker } = found
+      // 幂等短路:进锁后重读仍可能已是终态(上一轮已判死,或本轮内已被并发触发的其它
+      // harness 动作收尾)——不重复判定。
+      if (isTerminalStatus(worker.task.status)) return 'unchanged'
+
+      const mainline = mainlineIncarnation(worker)
+      const adapter = this.deps.adapters.get(mainline.impl as WorkerImplId)
+      if (!adapter) {
+        await this.markCrashed(dialogObjectId, worker, mainline, `no adapter registered for impl '${mainline.impl}'`)
+        return 'failed'
+      }
+
+      const handle: IncarnationHandle = {
+        worker_id: worker.worker_id,
+        seq: mainline.seq,
+        impl: mainline.impl as WorkerImplId,
+        session_ref: mainline.session_ref,
+      }
+
+      let observed: WorkerContractState
+      try {
+        observed = await adapter.state(handle)
+      } catch (err) {
+        await this.markCrashed(
+          dialogObjectId,
+          worker,
+          mainline,
+          `adapter.state() threw: ${err instanceof Error ? err.message : String(err)}`
+        )
+        return 'failed'
+      }
+
+      if (observed === 'exited') {
+        await this.markCrashed(dialogObjectId, worker, mainline, 'adapter reports incarnation exited while ledger was non-terminal')
+        return 'failed'
+      }
+
+      await this.realignAliveIncarnation(dialogObjectId, worker, mainline, observed)
+      return 'revived'
+    })
+  }
+
+  /**
+   * reconcileOnStartup 判死分支:落 failed(ended_reason='crashed')+ exited 事件。三种判死
+   * 场景(adapter 报 exited / adapter 未注册 / adapter.state() 抛错)共用同一段收尾——三者
+   * 语义上都是"至此已经没有任何证据证明这个非终态 worker 还活着"。
+   */
+  private async markCrashed(
+    dialogObjectId: DialogObjectId,
+    worker: LedgerWorker,
+    mainline: Incarnation,
+    detailReason: string
+  ): Promise<void> {
+    const now = this.deps.now()
+    await this.deps.ledger.upsertWorker(dialogObjectId, worker.worker_id, (prev) => {
+      if (!prev) return undefined
+      const nextTask = transitionTaskTo(prev.task, 'failed', { error: detailReason, now })
+      const incarnations = patchIncarnationBySeq(prev.incarnations, mainline.impl, mainline.seq, {
+        state: 'exited',
+        ended_at: now,
+        ended_reason: 'crashed',
+      })
+      return { ...prev, task: nextTask, incarnations, updated_at: now }
+    })
+    await this.appendEvent(worker.worker_id, mainline.seq, 'exited', { reason: 'crashed', message: detailReason })
+  }
+
+  /**
+   * reconcileOnStartup 存活分支:台账不判死,只按这次实际观察到的 contractState 对齐
+   * incarnation.state 与 task.status(taskStatusFromIncarnation 同一套映射,与
+   * processStateChange 的被动回调路径共用规则)。若观察结果与台账现状完全一致(既没有
+   * 化身 state 差异也没有 task 状态差异),不做任何写入、不发事件——避免每次巡检都产生
+   * 噪声写盘/事件。
+   */
+  private async realignAliveIncarnation(
+    dialogObjectId: DialogObjectId,
+    worker: LedgerWorker,
+    mainline: Incarnation,
+    observed: WorkerContractState
+  ): Promise<void> {
+    // idle 是否算"等输入"本属 manager 判断职责(protocol-agent-v3 §5.2),这里与
+    // processStateChange 保持同一条保守默认:P4 接线后可按需要覆盖。
+    const waitingInput = observed === 'idle' ? true : undefined
+    const nextStatus = taskStatusFromIncarnation(observed, undefined, waitingInput)
+    const stateChanged = mainline.state !== observed
+    const statusChanged = worker.task.status !== nextStatus
+    if (!stateChanged && !statusChanged) return
+
+    const now = this.deps.now()
+    await this.deps.ledger.upsertWorker(dialogObjectId, worker.worker_id, (prev) => {
+      if (!prev) return undefined
+      const nextTask = statusChanged ? transitionTaskTo(prev.task, nextStatus, { now }) : prev.task
+      const incarnations = stateChanged
+        ? patchIncarnationBySeq(prev.incarnations, mainline.impl, mainline.seq, { state: observed })
+        : prev.incarnations
+      return { ...prev, task: nextTask, incarnations, updated_at: now }
+    })
+    await this.appendEvent(worker.worker_id, mainline.seq, 'state_changed', { to: observed, source: 'reconcile' })
+  }
+
   async killWorker(workerId: string, reason?: string): Promise<void> {
     await this.withLock(workerId, async () => {
       const found = await this.deps.ledger.findWorker(workerId)
@@ -852,6 +1047,28 @@ function reopenTaskForContinuation(task: LedgerWorker['task'], now: string): Led
   if (task.status === 'running') return task
   if (isTerminalStatus(task.status)) return reviveTask(task, { now })
   return applyStatusTransition(task, 'running', { now })
+}
+
+/**
+ * reconcileOnStartup 专用:把 task 状态迁移到目标状态,目标不可从当前状态一步直达时先跳一步
+ * running。VALID_TRANSITIONS 里 `queued` 只有到 `running`/`cancelled` 的边,没有到
+ * `waiting_input`/`failed` 的直达边——但巡检可能在极窄的竞态窗口里撞见"task.status 仍是
+ * queued、主线化身却已经真实 running/idle/判死"的台账(spawnWorker 落初始记录与落
+ * spawn 成功后的第二次提交之间若进程崩溃,见 harness.ts 顶部锁纪律注释),此时直接
+ * applyStatusTransition 会抛 InvalidTaskTransitionError。这里镜像 spawnWorker 失败路径
+ * 已经用过的"queued→running→失败/目标状态"两跳写法,不新增状态机边、不绕开 canTransition
+ * 校验(仍然全程只用 applyStatusTransition,只是必要时多套一层)。
+ */
+function transitionTaskTo(
+  task: LedgerWorker['task'],
+  to: TaskStatus,
+  opts: { error?: string; now: string }
+): LedgerWorker['task'] {
+  if (canTransition(task.status, to)) {
+    return applyStatusTransition(task, to, opts)
+  }
+  const hopped = applyStatusTransition(task, 'running', { now: opts.now })
+  return applyStatusTransition(hopped, to, opts)
 }
 
 /** 交接续办产出的新化身 prompt:原任务描述 + 交接引用(指向 HANDOFF.md)+ 本次输入。 */

--- a/crabot-agent/src/workers/harness/harness.ts
+++ b/crabot-agent/src/workers/harness/harness.ts
@@ -76,7 +76,7 @@ import type { LedgerStore } from './ledger-store'
 import type { WorkspaceManager } from './workspace-manager'
 import { WorkerInbox, type InboxItem } from './inbox'
 import { WorkerEventLog, type HarnessEvent, type HarnessEventKind } from './worker-events'
-import { applyStatusTransition, canTransition, isTerminalStatus, taskStatusFromIncarnation } from './task-status'
+import { applyStatusTransition, isTerminalStatus, reviveTask, taskStatusFromIncarnation } from './task-status'
 import { join } from 'path'
 
 /** 交接材料里"最近输出尾部"的上限(字符数,近似 4KB,见 protocol-agent-v3 §5.3)。 */
@@ -216,7 +216,7 @@ export class WorkerHarness {
             error: err instanceof Error ? err.message : String(err),
             now,
           })
-          const incarnations = patchIncarnationBySeq(prev.incarnations, 1, {
+          const incarnations = patchIncarnationBySeq(prev.incarnations, impl, 1, {
             state: 'exited',
             ended_at: now,
             ended_reason: 'failed',
@@ -237,7 +237,7 @@ export class WorkerHarness {
       const spawned = await this.deps.ledger.upsertWorker(p.dialogObjectId, workerId, (prev) => {
         if (!prev) return undefined
         const nextTask = applyStatusTransition(prev.task, 'running', { now })
-        const incarnations = patchIncarnationBySeq(prev.incarnations, 1, { session_ref: spawnedHandle.session_ref })
+        const incarnations = patchIncarnationBySeq(prev.incarnations, impl, 1, { session_ref: spawnedHandle.session_ref })
         return { ...prev, task: nextTask, incarnations, updated_at: now }
       })
       await this.appendEvent(workerId, 1, 'spawned', { impl })
@@ -397,8 +397,24 @@ export class WorkerHarness {
         started_at: now,
         // forked_from 不填——resume 产出的新化身入主线链(protocol-agent-v3 §5.3)。
       }
+      // 源化身(mainline)台账态若仍非 exited——sendToWorker 经 WorkerExitedError 走到这里时,
+      // 台账的异步状态回调很可能还没追上 adapter 的真实状态(见 continueTerminalWorker 顶部
+      // 注释)——必须在 revive 前把它收尾,否则新化身入链后主线就换成了新 seq,后续迟到的
+      // processStateChange 会因 mainline.seq !== h.seq 被直接丢弃,旧化身永久卡在非终态、
+      // 无终态记录。对齐 handoffIncarnation 对同一竞态的处理(§5.3):这里同样只在源化身
+      // 台账态非 exited 时才回填,不覆盖已经真实记录过的终态。WorkerExitedError 不携带
+      // end reason,拿不到 adapter 给出的精确失败原因时用 'completed' 记录——语境是"已经
+      // 在准备接续续命",不是被 kill,'completed' 是这里能给出的最贴切近似值。
+      const incarnations =
+        mainline.state !== 'exited'
+          ? patchIncarnationBySeq(prev.incarnations, mainline.impl, mainline.seq, {
+              state: 'exited',
+              ended_at: now,
+              ended_reason: 'completed',
+            })
+          : prev.incarnations
       const nextTask = reopenTaskForContinuation(prev.task, now)
-      return { ...prev, task: nextTask, incarnations: [...prev.incarnations, newIncarnation], updated_at: now }
+      return { ...prev, task: nextTask, incarnations: [...incarnations, newIncarnation], updated_at: now }
     })
     await this.appendEvent(worker.worker_id, newHandle.seq, 'resumed', { from_seq: mainline.seq })
   }
@@ -457,7 +473,7 @@ export class WorkerHarness {
       const killedAt = this.deps.now()
       await this.deps.ledger.upsertWorker(dialogObjectId, worker.worker_id, (prev) => {
         if (!prev) return undefined
-        const incarnations = patchIncarnationBySeq(prev.incarnations, source.seq, {
+        const incarnations = patchIncarnationBySeq(prev.incarnations, source.impl, source.seq, {
           state: 'exited',
           ended_at: killedAt,
           ended_reason: 'superseded',
@@ -552,8 +568,9 @@ export class WorkerHarness {
       await this.deps.ledger.upsertWorker(dialogObjectId, workerId, (prev) => {
         if (!prev) return undefined
         const nextTask = applyStatusTransition(prev.task, 'cancelled', { now })
-        // 按 seq 精确定位主线化身条目,不假设它是数组最后一个(fork 之后数组末尾是 fork 化身)。
-        const incarnations = patchIncarnationBySeq(prev.incarnations, incarnation.seq, {
+        // 按 (impl, seq) 精确定位主线化身条目,不假设它是数组最后一个(fork 之后数组末尾是
+        // fork 化身;跨实例撞号时同 seq 可能有多条记录,见 patchIncarnationBySeq 注释)。
+        const incarnations = patchIncarnationBySeq(prev.incarnations, incarnation.impl, incarnation.seq, {
           state: 'exited',
           ended_at: now,
           ended_reason: 'killed',
@@ -641,6 +658,7 @@ export class WorkerHarness {
           // 转换点"。cc/codex 的 session_ref 本就稳定,这里是等价 no-op。
           const incarnations = patchIncarnationBySeq(
             prev.incarnations,
+            h.impl,
             h.seq,
             state === 'exited'
               ? { state, ended_at: now, ended_reason: endReason, session_ref: h.session_ref }
@@ -674,6 +692,7 @@ export class WorkerHarness {
         // session_ref 现读现取,同上面 fork 分支的注释。
         const incarnations = patchIncarnationBySeq(
           prev.incarnations,
+          h.impl,
           h.seq,
           state === 'exited'
             ? { state, ended_at: now, ended_reason: endReason, session_ref: h.session_ref }
@@ -740,12 +759,30 @@ function mainlineIncarnation(worker: LedgerWorker): Incarnation {
 }
 
 /**
- * 按 seq 精确定位并 patch 一个化身条目,不假设它是数组的最后一个——fork 之后数组末尾是
- * fork 化身,继续用"改最后一个"的旧写法会把主线的落定动作(如 kill 后的 exited)误写进
- * fork 条目,或反过来让 fork 化身自己的状态变化误写进主线条目,两个方向都是错的。
+ * 按 (impl, seq) 精确定位并 patch 一个化身条目,不假设它是数组的最后一个——fork 之后数组
+ * 末尾是 fork 化身,继续用"改最后一个"的旧写法会把主线的落定动作(如 kill 后的 exited)
+ * 误写进 fork 条目,或反过来让 fork 化身自己的状态变化误写进主线条目,两个方向都是错的。
+ *
+ * 只按 seq 匹配是不够的(protocol-agent-v3 §6.1"已知限制"):`IncarnationHandle.seq` 由各
+ * adapter 自行分配,只保证同一个 adapter 实例内递增不重复,不保证跨 adapter 实例(跨实现
+ * 切换、进程重启后新建的 adapter 实例)全局唯一——`(impl, seq)` 相同的记录可能因此在同一
+ * 台账里出现不止一条(旧的已归档,新的是当前活跃化身)。化身按时间顺序追加进数组,所以
+ * `(impl, seq)` 相同的多条记录里,数组下标最大的那条才是当前活跃的;用 `.map` 对所有匹配
+ * 项一视同仁地改写,会连带篡改已经归档的旧记录。这里只精确定位并改写最后一条匹配记录,
+ * 更早的同键记录原样保留。
  */
-function patchIncarnationBySeq(incarnations: Incarnation[], seq: number, patch: Partial<Incarnation>): Incarnation[] {
-  return incarnations.map((inc) => (inc.seq === seq ? { ...inc, ...patch } : inc))
+function patchIncarnationBySeq(
+  incarnations: Incarnation[],
+  impl: Incarnation['impl'],
+  seq: number,
+  patch: Partial<Incarnation>
+): Incarnation[] {
+  let lastMatchIndex = -1
+  for (let i = 0; i < incarnations.length; i++) {
+    if (incarnations[i].impl === impl && incarnations[i].seq === seq) lastMatchIndex = i
+  }
+  if (lastMatchIndex === -1) return incarnations
+  return incarnations.map((inc, i) => (i === lastMatchIndex ? { ...inc, ...patch } : inc))
 }
 
 /**
@@ -753,16 +790,19 @@ function patchIncarnationBySeq(incarnations: Incarnation[], seq: number, patch: 
  *
  * 终态化身之上继续开一个新化身是显式的"延续"动作,不是 task-status.ts 描述的线性状态机
  * 内的一次迁移——VALID_TRANSITIONS 里终态(completed/failed/cancelled)无出边是"同一次
- * 尝试内不允许原地复活"的不变量,但接续产出的是全新的化身,因此当 task 已经终态时直接
- * 重置状态与派生字段,不经过 canTransition 校验(效果等价于 applyStatusTransition 到
- * running 分支,只是跳过其内部的非法迁移检查)。task 尚未终态(如台账的终态回调还没追上
- * adapter 的真实状态)时仍走 applyStatusTransition 的正常校验路径。
+ * 尝试内不允许原地复活"的不变量。task 已经终态时,不由 harness 自行拼接字段绕开状态机,
+ * 而是走 task-status.ts 官方暴露的受控出口 `reviveTask`(protocol-agent-v3 §5.2"接续
+ * 例外")——状态机模块自己承载这条例外,harness 只是调用方。
+ *
+ * task 尚未终态时分两种情况:已经是 running 的(如台账的终态回调还没追上 adapter 的真实
+ * 状态,接续发生前 task.status 本就还是 running)不需要任何迁移,直接原样返回(此时按
+ * task-status.ts 维护的不变量,completed_at/error 本就已经是未设置状态,无需重置);
+ * 其余非终态(queued/waiting_input)走 applyStatusTransition 的正常校验路径迁到 running。
  */
 function reopenTaskForContinuation(task: LedgerWorker['task'], now: string): LedgerWorker['task'] {
-  if (canTransition(task.status, 'running')) {
-    return applyStatusTransition(task, 'running', { now })
-  }
-  return { ...task, status: 'running', completed_at: undefined, error: undefined }
+  if (task.status === 'running') return task
+  if (isTerminalStatus(task.status)) return reviveTask(task, { now })
+  return applyStatusTransition(task, 'running', { now })
 }
 
 /** 交接续办产出的新化身 prompt:原任务描述 + 交接引用(指向 HANDOFF.md)+ 本次输入。 */

--- a/crabot-agent/src/workers/harness/harness.ts
+++ b/crabot-agent/src/workers/harness/harness.ts
@@ -106,6 +106,29 @@ export class TaskCancelledError extends Error {
   }
 }
 
+/**
+ * handoff(switchWorkerImpl,或透明接续 revive:false 分支的自动交接)的目标 impl 在这个
+ * worker 名下已经有过化身(含已终态、含 fork 分支)——三个 adapter(builtin/claude-code/
+ * codex)的 spawn 都硬编码 seq=1 且带"already spawned"守卫,不支持对同一 worker_id 二次
+ * spawn,即使旧化身已经被 kill(kill 不清除这个守卫记忆:cc/codex 的内存 runtimes 表不删除
+ * 条目,builtin 的 builtinConfigs + 磁盘 meta-1.json 更是连跨进程都拦)。若不在
+ * handoffIncarnation 的 pre-flight 拦下,step 3 的 newAdapter.spawn 必然抛错,而此时旧
+ * 化身已在 step 1/2 被写过 HANDOFF.md、kill 并标 superseded——重蹈 pre-flight 本该防住的
+ * "旧的没了、新的没建成"死结。根治需要 harness 自己分配 seq(不依赖各 adapter 内部
+ * nextSeq/硬编码 1),这是协议级改动,留待后续(protocol-agent-v3 §6.1 已知限制);这里先
+ * fail-fast,把死结换成一个清晰、可重试、可诊断的错误。
+ */
+export class ImplAlreadyUsedError extends Error {
+  constructor(readonly worker_id: string, readonly impl: WorkerImplId) {
+    super(
+      `worker ${worker_id} already has an incarnation on impl '${impl}'; adapter.spawn is hardcoded to seq=1 and ` +
+        `does not support re-spawning the same worker_id on the same impl (even after kill) — root fix requires ` +
+        `harness-managed seq allocation (protocol-agent-v3 §6.1 known limitation)`
+    )
+    this.name = 'ImplAlreadyUsedError'
+  }
+}
+
 export interface HarnessDeps {
   /** 已 detect 过的可用实现。见文件头"onStateChange 接线契约"——底层 Map 引用可在构造后继续填充。 */
   readonly adapters: ReadonlyMap<WorkerImplId, WorkerAdapter>
@@ -337,6 +360,14 @@ export class WorkerHarness {
    * 相同的交接路径(见 handoffIncarnation),区别只是:目标实现由调用方显式指定(不做
    * "原 impl 若仍可用则沿用"的自动选择),且源化身可能仍然存活(由 handoffIncarnation
    * 内部负责在这种情况下先 kill 再标 superseded)。
+   *
+   * 已知约束(三轮 review 修复,见 ImplAlreadyUsedError 类注释):不支持"切到该 worker
+   * 曾经用过的实现"——含切回原实现(如 cc → codex → cc)、含切到当前正在用的同一实现。
+   * 三个 adapter 的 spawn 都硬编码 seq=1 且带"already spawned"守卫,kill 不清除这道守卫
+   * 记忆,对同一 worker_id 二次 spawn 必然失败。handoffIncarnation 的 pre-flight 会在写
+   * HANDOFF.md、kill 源化身之前用 (worker.incarnations 是否已有 impl 匹配的记录) 判定并
+   * fail-fast 抛 ImplAlreadyUsedError,不留半成品。根治需要 harness 自己分配 seq,是协议
+   * 级改动,留待后续(protocol-agent-v3 §6.1 已知限制)。
    */
   async switchWorkerImpl(workerId: string, impl: WorkerImplId, note?: string): Promise<void> {
     await this.withLock(workerId, async () => {
@@ -483,11 +514,15 @@ export class WorkerHarness {
         if (adapter.capabilities().revive) {
           await this.reviveIncarnation(dialogObjectId, worker, mainline, adapter, text)
         } else {
-          // "原 impl 若仍可用则沿用,否则 defaultImpl"(brief)。三个既有实现目前都是
-          // revive:true,这条分支走不到真实 adapter;为将来的不可复活实现(如 legacy)保留。
-          const targetImpl = this.deps.adapters.has(mainline.impl as WorkerImplId)
-            ? (mainline.impl as WorkerImplId)
-            : this.deps.defaultImpl
+          // "原 impl 若仍可用则沿用,否则 defaultImpl"(brief)是加 ImplAlreadyUsedError 守卫
+          // 之前的选择逻辑,现在必然自绝:mainline.impl 就是正在办理接续的这条化身所在的
+          // impl,它在 worker.incarnations 里必然已经"用过",沿用它会被 handoffIncarnation
+          // 的 pre-flight 直接拒绝。改选一个这个 worker 尚未用过的可用实现(pickUnusedImpl:
+          // defaultImpl 优先,否则从 deps.adapters 里挑第一个未用过的);全都用过时原样交给
+          // handoffIncarnation 的 pre-flight 统一抛 ImplAlreadyUsedError,不在这里重复判断。
+          // 三个既有实现目前都是 revive:true,这条分支走不到真实 adapter;为将来的不可复活
+          // 实现(如 legacy)保留。
+          const targetImpl = pickUnusedImpl(worker, this.deps.adapters, this.deps.defaultImpl)
           await this.handoffIncarnation(dialogObjectId, worker, mainline, targetImpl, text)
         }
         return
@@ -575,7 +610,18 @@ export class WorkerHarness {
       session_ref: source.session_ref,
     }
 
-    // 0. Pre-flight(裁决 B 修复):目标 adapter 必须存在;若目标是 'builtin',调用方必须
+    // 0. Pre-flight(三轮 review 修复):目标 impl 若在这个 worker 名下已经有过任何化身
+    // (含已终态、含 fork 分支,见 ImplAlreadyUsedError 类注释)——即"切到该 worker 曾经用过
+    // 的实现"(含切回原实现、同实现切换)——必然会在下面 step 3 的 newAdapter.spawn 里抛错:
+    // 三个 adapter 的 spawn 都硬编码 seq=1 且带"already spawned"守卫,kill 不清除这道守卫
+    // 记忆。若这里不拦,失败会发生在 step 2(kill 源化身、标 superseded)之后,重蹈本方法
+    // pre-flight 本该防住的"旧的没了、新的没建成"死结。放在最前面、比下面 targetImpl 是否
+    // 有 adapter 注册的检查还早,因为它不需要先查 adapter 就能判定。
+    if (implAlreadyUsed(worker, targetImpl)) {
+      throw new ImplAlreadyUsedError(worker.worker_id, targetImpl)
+    }
+
+    // 0b. Pre-flight(裁决 B 修复):目标 adapter 必须存在;若目标是 'builtin',调用方必须
     // 通过 HarnessDeps.builtinSpawnDefaults 提供了 LLM 注入,否则 step 3 的 newAdapter.spawn
     // 必然因 spec.builtin 缺失而抛错(BuiltinWorkerAdapter.spawn 本就 fail-loud)。修复前这
     // 个抛错发生在 step 3——此时旧化身已经在 step 2 被 kill 并标 superseded,worker 卡进
@@ -1116,6 +1162,35 @@ export class WorkerHarness {
 function mainlineIncarnation(worker: LedgerWorker): Incarnation {
   const mainline = worker.incarnations.filter((inc) => inc.forked_from === undefined)
   return mainline[mainline.length - 1]
+}
+
+/**
+ * 该 worker 名下是否已经存在过某个 impl 的化身——不限主线/fork、不限存活/终态,只要
+ * `worker.incarnations` 里出现过一条 `impl` 匹配的记录就算"用过"。供 handoffIncarnation
+ * 的 pre-flight(ImplAlreadyUsedError)与 pickUnusedImpl 共用同一判定。
+ */
+function implAlreadyUsed(worker: LedgerWorker, impl: WorkerImplId): boolean {
+  return worker.incarnations.some((inc) => inc.impl === impl)
+}
+
+/**
+ * continueTerminalWorker 的 revive:false 分支(自动 handoff)选目标 impl:旧逻辑"原 impl
+ * 若仍可用则沿用"在加了 ImplAlreadyUsedError 守卫之后必然自绝——mainline.impl 本身必然
+ * 已经用过(它就是正在办理接续的这条化身所在的 impl)。改为挑一个这个 worker 尚未用过的
+ * 已注册实现:defaultImpl 优先(未用过就直接用),否则按 `deps.adapters` 的插入顺序取第一个
+ * 未用过的。若全都用过,原样返回 defaultImpl——不在这里重复判断/提前抛错,交给
+ * handoffIncarnation 唯一的 pre-flight 把关点统一抛 ImplAlreadyUsedError。
+ */
+function pickUnusedImpl(
+  worker: LedgerWorker,
+  adapters: ReadonlyMap<WorkerImplId, WorkerAdapter>,
+  defaultImpl: WorkerImplId
+): WorkerImplId {
+  if (!implAlreadyUsed(worker, defaultImpl)) return defaultImpl
+  for (const impl of adapters.keys()) {
+    if (!implAlreadyUsed(worker, impl)) return impl
+  }
+  return defaultImpl
 }
 
 /**

--- a/crabot-agent/src/workers/harness/harness.ts
+++ b/crabot-agent/src/workers/harness/harness.ts
@@ -82,6 +82,14 @@ import { join } from 'path'
 /** 交接材料里"最近输出尾部"的上限(字符数,近似 4KB,见 protocol-agent-v3 §5.3)。 */
 const HANDOFF_TAIL_MAX_CHARS = 4096
 
+/**
+ * continueTerminalWorker 锁内可重入求值循环的上限次数。每一轮代表"主线又换了一次"的
+ * 重新判定,防止病态并发抖动(主线连续多次接续/切换)让这次投递在临界区内无限打转。3
+ * 轮足以覆盖"补送失败一次 → 转接续一次"这种正常竞态收敛路径,仍在这个上限内打转说明
+ * 是异常情况,不应该继续悄悄重试。
+ */
+const MAX_CONTINUATION_ITERATIONS = 3
+
 /** 请求的 worker_id 在台账中不存在。 */
 export class WorkerNotFoundError extends Error {
   constructor(readonly worker_id: string) {
@@ -371,6 +379,26 @@ export class WorkerHarness {
    * raw 透传:"补送到当前主线"分支和 sendToWorker 正常路径(见上面的 adapter.sendInput 调用)
    * 必须保持同一投递语义——`raw: true` 的原始敲键消息若在补送时丢了这个标志,会被当成普通
    * 消息投递,行为对调用方不再透明。
+   *
+   * 二轮 review 收口(锁内可重入求值):上面"补送到当前主线"分支曾经无条件把当前主线当存活
+   * 化身直投,既不查 mainline.state,adapter.sendInput 抛出的 WorkerExitedError 也没像
+   * sendToWorker 正常路径那样被接住转接续——deliver 卡在旧主线投递期间若发生并发接续/
+   * 切换,且等锁期间新主线又自然退出(或 adapter 权威判定它已退出,即便台账还没追上),这个
+   * WorkerExitedError 会原样穿透 inbox.flush,条目 unshift 回队首、错误砸给 sendToWorker
+   * 的调用方,违反"投递永不因状态失败"与"接续对调用方无感"。
+   *
+   * 修法:整个"判定源化身 → 决定补送/接续"改成锁内(同一临界区,不重新拿锁——私有方法
+   * 自身持锁,递归调用会死锁)的可重入求值循环:每轮拿当前源 (curImpl, curSeq) 重新读一次
+   * 台账并判定——
+   *   - 主线就是当前源且已终态 → 走 revive/handoff,结束;
+   *   - 主线已换且存活 → 尝试补送;若 sendInput 抛 WorkerExitedError,不出锁,把这个新主线
+   *     当作新的源回到循环顶部重新求值(即转接续);
+   *   - 主线已换且台账里已是终态 → 不浪费一次注定失败的 sendInput,直接把它当作新的源
+   *     回到循环顶部(同样转接续)。
+   * 循环设上限(MAX_CONTINUATION_ITERATIONS)防病态抖动(主线在极端并发下连续多次切换/
+   * 自然退出撞上同一次投递):超限说明短时间内发生了异常密集的接续/切换,不是本方法能
+   * 收敛处理的情形,记事件后抛出明确错误(调用方 inbox.flush 会把这条消息放回队首,下次
+   * flush 重试)。
    */
   private async continueTerminalWorker(
     workerId: string,
@@ -380,63 +408,103 @@ export class WorkerHarness {
     raw: boolean
   ): Promise<void> {
     await this.withLock(workerId, async () => {
-      const found = await this.deps.ledger.findWorker(workerId)
-      if (!found) throw new WorkerNotFoundError(workerId)
-      const { worker, dialogObjectId } = found
+      let curImpl = sourceImpl
+      let curSeq = sourceSeq
 
-      // task 在锁外投递期间被 killWorker 打断(如 send 卡在 tmux 投递期间调 kill,这条
-      // 消息在拿到这把锁之前就已经确定要走接续路径了):§5.5"唯一硬拒绝:cancelled"只
-      // 约束 sendToWorker 入队前的把关(见该方法顶部),这里是入队之后才发现的迟到判定,
-      // 不能再用同一处把关。cancelled 是终态,不能被下面的 reviveIncarnation/handoffIncarnation
-      // 经 reopenTaskForContinuation → reviveTask 复活成 running——那样会让已经明确要求
-      // 终止的 task 又"activate"出一个新化身。同时"send_to_worker 投递永不因状态失败"
-      // 是调用方(inbox.flush)的既有契约,消息不能静默消失:丢弃这条并记 dead-letter 事件,
-      // 不重新抛出(抛出会砸向早已异步返回的 sendToWorker 调用方,变成没人处理的 rejection)。
-      if (worker.task.status === 'cancelled') {
-        await this.appendEvent(workerId, sourceSeq, 'state_changed', {
-          kind: 'dead_letter',
-          reason: 'task_cancelled',
-          text_len: text.length,
-        })
-        return
-      }
+      for (let iteration = 0; iteration < MAX_CONTINUATION_ITERATIONS; iteration++) {
+        const found = await this.deps.ledger.findWorker(workerId)
+        if (!found) throw new WorkerNotFoundError(workerId)
+        const { worker, dialogObjectId } = found
 
-      const mainline = mainlineIncarnation(worker)
+        // task 在锁外投递期间被 killWorker 打断(如 send 卡在 tmux 投递期间调 kill,这条
+        // 消息在拿到这把锁之前就已经确定要走接续路径了):§5.5"唯一硬拒绝:cancelled"只
+        // 约束 sendToWorker 入队前的把关(见该方法顶部),这里是入队之后才发现的迟到判定,
+        // 不能再用同一处把关。cancelled 是终态,不能被下面的 reviveIncarnation/handoffIncarnation
+        // 经 reopenTaskForContinuation → reviveTask 复活成 running——那样会让已经明确要求
+        // 终止的 task 又"activate"出一个新化身。同时"send_to_worker 投递永不因状态失败"
+        // 是调用方(inbox.flush)的既有契约,消息不能静默消失:丢弃这条并记 dead-letter 事件,
+        // 不重新抛出(抛出会砸向早已异步返回的 sendToWorker 调用方,变成没人处理的 rejection)。
+        if (worker.task.status === 'cancelled') {
+          await this.appendEvent(workerId, curSeq, 'state_changed', {
+            kind: 'dead_letter',
+            reason: 'task_cancelled',
+            text_len: text.length,
+          })
+          return
+        }
 
-      if (mainline.seq !== sourceSeq || mainline.impl !== sourceImpl) {
-        // 并发窗口:拿锁之前,该 worker 已经被另一次并发触发的接续/切换抢先完成——主线已经
-        // 前进到更新的化身(按 (impl, seq) 判定,不能只比 seq,见上面方法注释)。按普通投递
-        // 语义把这条消息补送到当前(存活)主线,不重复接续,并保留原条目的 raw 标志。
+        const mainline = mainlineIncarnation(worker)
+
+        if (mainline.seq !== curSeq || mainline.impl !== curImpl) {
+          // 并发窗口:拿锁之前,该 worker 已经被另一次并发触发的接续/切换抢先完成——主线已经
+          // 前进到更新的化身(按 (impl, seq) 判定,不能只比 seq,见上面方法注释)。
+          if (mainline.state === 'exited') {
+            // 台账已经把这个更新的主线也记为终态——不必再尝试一次注定失败的 sendInput,
+            // 把它当作新的源头,回到循环顶部,以它走接续。
+            curImpl = mainline.impl as WorkerImplId
+            curSeq = mainline.seq
+            continue
+          }
+          // 按普通投递语义把这条消息补送到当前(存活)主线,不重复接续,并保留原条目的
+          // raw 标志。
+          const adapter = this.deps.adapters.get(mainline.impl as WorkerImplId)
+          if (!adapter) {
+            throw new Error(`WorkerHarness.sendToWorker: no adapter registered for impl '${mainline.impl}'`)
+          }
+          const handle: IncarnationHandle = {
+            worker_id: workerId,
+            seq: mainline.seq,
+            impl: mainline.impl as WorkerImplId,
+            session_ref: mainline.session_ref,
+          }
+          try {
+            await adapter.sendInput(handle, text, { raw })
+          } catch (err) {
+            // adapter 侧权威判定这个"看起来存活"的新主线其实也已经终态(台账的异步状态
+            // 回调还没追上)——同样不出锁,把它当作新的源头回到循环顶部转接续,而不是把
+            // 这个错误当成"补送失败"直接抛给调用方。
+            if (err instanceof WorkerExitedError) {
+              curImpl = mainline.impl as WorkerImplId
+              curSeq = mainline.seq
+              continue
+            }
+            throw err
+          }
+          await this.appendEvent(workerId, handle.seq, 'input_sent', { text_len: text.length })
+          return
+        }
+
+        // 主线就是当前源:走接续(revive/handoff)。
         const adapter = this.deps.adapters.get(mainline.impl as WorkerImplId)
         if (!adapter) {
-          throw new Error(`WorkerHarness.sendToWorker: no adapter registered for impl '${mainline.impl}'`)
+          throw new Error(`WorkerHarness.sendToWorker: no adapter registered for impl '${mainline.impl}' (continuation)`)
         }
-        const handle: IncarnationHandle = {
-          worker_id: workerId,
-          seq: mainline.seq,
-          impl: mainline.impl as WorkerImplId,
-          session_ref: mainline.session_ref,
+
+        if (adapter.capabilities().revive) {
+          await this.reviveIncarnation(dialogObjectId, worker, mainline, adapter, text)
+        } else {
+          // "原 impl 若仍可用则沿用,否则 defaultImpl"(brief)。三个既有实现目前都是
+          // revive:true,这条分支走不到真实 adapter;为将来的不可复活实现(如 legacy)保留。
+          const targetImpl = this.deps.adapters.has(mainline.impl as WorkerImplId)
+            ? (mainline.impl as WorkerImplId)
+            : this.deps.defaultImpl
+          await this.handoffIncarnation(dialogObjectId, worker, mainline, targetImpl, text)
         }
-        await adapter.sendInput(handle, text, { raw })
-        await this.appendEvent(workerId, handle.seq, 'input_sent', { text_len: text.length })
         return
       }
 
-      const adapter = this.deps.adapters.get(mainline.impl as WorkerImplId)
-      if (!adapter) {
-        throw new Error(`WorkerHarness.sendToWorker: no adapter registered for impl '${mainline.impl}' (continuation)`)
-      }
-
-      if (adapter.capabilities().revive) {
-        await this.reviveIncarnation(dialogObjectId, worker, mainline, adapter, text)
-      } else {
-        // "原 impl 若仍可用则沿用,否则 defaultImpl"(brief)。三个既有实现目前都是
-        // revive:true,这条分支走不到真实 adapter;为将来的不可复活实现(如 legacy)保留。
-        const targetImpl = this.deps.adapters.has(mainline.impl as WorkerImplId)
-          ? (mainline.impl as WorkerImplId)
-          : this.deps.defaultImpl
-        await this.handoffIncarnation(dialogObjectId, worker, mainline, targetImpl, text)
-      }
+      // 超出重求值上限:短时间内主线连续多次切换/自然退出,撞上了同一次投递的每一次重新
+      // 判定,不是本方法能收敛处理的病态抖动。记事件留痕,抛出明确错误——inbox.flush 会把
+      // 这条消息放回队首、原样向上抛,不静默丢弃,调用方或下一轮 flush 有机会重试。
+      await this.appendEvent(workerId, curSeq, 'state_changed', {
+        kind: 'continuation_loop_exceeded',
+        max_iterations: MAX_CONTINUATION_ITERATIONS,
+        text_len: text.length,
+      })
+      throw new Error(
+        `WorkerHarness.continueTerminalWorker: exceeded max re-evaluation iterations (${MAX_CONTINUATION_ITERATIONS}) ` +
+          `for worker ${workerId}; mainline kept changing/exiting faster than this delivery could settle on a source`
+      )
     })
   }
 

--- a/crabot-agent/src/workers/harness/harness.ts
+++ b/crabot-agent/src/workers/harness/harness.ts
@@ -662,7 +662,7 @@ export class WorkerHarness {
       if (!found) return // 未知 worker,理论不该发生;防御性丢弃,不抛给 adapter 的回调
       const { worker, dialogObjectId } = found
 
-      const target = worker.incarnations.find((inc) => inc.seq === h.seq)
+      const target = findIncarnation(worker, h.impl, h.seq)
       if (!target) return // 未知化身(理论不该发生),防御性丢弃
 
       // WorkerAdapter.onStateChange 只携带 (handle, state) 三态,没有 endReason——kill 触发的
@@ -785,6 +785,26 @@ export class WorkerHarness {
 function mainlineIncarnation(worker: LedgerWorker): Incarnation {
   const mainline = worker.incarnations.filter((inc) => inc.forked_from === undefined)
   return mainline[mainline.length - 1]
+}
+
+/**
+ * 按 (impl, seq) 精确定位一个活跃的化身条目(取最后一条匹配,代表当前活跃化身)。
+ *
+ * 只按 seq 匹配是不够的(protocol-agent-v3 §6.1"已知限制"):IncarnationHandle.seq 由各
+ * adapter 自行分配,只保证同一个 adapter 实例内递增不重复,不保证跨 adapter 实例(跨实现
+ * 切换、进程重启后新建的 adapter 实例)全局唯一——(impl, seq) 相同的记录可能因此在同一
+ * 台账里出现不止一条(旧的已归档,新的是当前活跃化身)。化身按时间顺序追加进数组,所以
+ * (impl, seq) 相同的多条记录里,数组下标最大的那条才是当前活跃的。
+ *
+ * processStateChange 的读路径和 patchIncarnationBySeq 的写路径都必须使用同一原则,
+ * 确保定位的是同一条活跃化身,避免读写分离导致的语义错位。
+ */
+function findIncarnation(worker: LedgerWorker, impl: WorkerImplId, seq: number): Incarnation | undefined {
+  let lastMatch: Incarnation | undefined
+  for (const inc of worker.incarnations) {
+    if (inc.impl === impl && inc.seq === seq) lastMatch = inc
+  }
+  return lastMatch
 }
 
 /**

--- a/crabot-agent/src/workers/harness/harness.ts
+++ b/crabot-agent/src/workers/harness/harness.ts
@@ -765,10 +765,9 @@ export class WorkerHarness {
    * workersDir,是 harness 自己的 events/output 目录,与各 adapter 的私有 dataDir 是两个
    * 目录),因此不在本方法内部调用 scanOrphans,调用顺序由 P4/bootstrap 层保证(先
    * `BuiltinWorkerAdapter.scanOrphans(dataDir)`,adapter 塞进 `adapters` Map 之后,再调
-   * `harness.reconcileOnStartup()`)。claude-code/codex 目前没有等价的孤儿扫描——它们的
-   * `state()` 在无常驻 runtime 时同样回落读 meta 文件而不做真实 tmux 存活探测,这是现有
-   * adapter 实现的已知限制(§6.3 描述的"低频巡扫 tmux pane"兜底另有周期机制,不在本方法
-   * 范围内),不是本方法引入的新问题。
+   * `harness.reconcileOnStartup()`)。claude-code/codex 不需要等价的孤儿扫描——它们的
+   * `state()`(经 ensureRuntime,四轮 review 收拢)在无常驻 runtime 时会先做一次真实 tmux
+   * isAlive 探测再重建,不像 builtin 那样单纯回落读可能过期的 meta 文件。
    *
    * 判定规则(逐 worker 独立判定,整轮不持有任何全局锁——只在每个 worker 自己的
    * per-worker 临界区内完成"读台账→判adapter.state()→提交"):

--- a/crabot-agent/src/workers/harness/harness.ts
+++ b/crabot-agent/src/workers/harness/harness.ts
@@ -176,12 +176,9 @@ export class WorkerHarness {
             impl,
             state: 'running',
             workspace: workspace.root,
-            // WorkerAdapter 契约没有"从 handle 反查 session_ref"的方法(P1/P2 遗留的已知
-            // 空缺,tests/workers/contract-suite.ts 的 fixture-only `refFor` 就是为了绕开
-            // 这个缺口而加的)。harness 在契约不扩展的前提下拿不到真实值,先用空串占位;
-            // queryWorker 的 fork 分支会原样把这个占位值透传给 adapter.fork,对真实
-            // cc/codex adapter(它们会校验 UUID 格式)会失败——这不是 Task 7 引入的新问题,
-            // 是既有契约的已知缺口,留给后续任务(扩展 WorkerAdapter 契约)解决。
+            // adapter.spawn 尚未调用,真实 session_ref 此刻还不存在,先占位;spawn 成功后
+            // 下面会用 adapter.spawn 返回的 IncarnationHandle.session_ref(protocol-agent-v3
+            // §6.1,handle 自描述真值)原子补写,不依赖任何"从 handle 反查"的额外方法。
             session_ref: '',
             started_at: startedAt,
           },
@@ -190,6 +187,7 @@ export class WorkerHarness {
       }
       await this.deps.ledger.upsertWorker(p.dialogObjectId, workerId, () => initial)
 
+      let spawnedHandle: IncarnationHandle
       try {
         const caps = this.deps.capabilityBundle ? await this.deps.capabilityBundle() : EMPTY_CAPABILITY_BUNDLE
         await adapter.provision(workspace, caps)
@@ -200,7 +198,7 @@ export class WorkerHarness {
           goal: p.goal,
           builtin: p.builtin,
         }
-        await adapter.spawn(spec)
+        spawnedHandle = await adapter.spawn(spec)
       } catch (err) {
         const now = this.deps.now()
         await this.deps.ledger.upsertWorker(p.dialogObjectId, workerId, (prev) => {
@@ -213,7 +211,7 @@ export class WorkerHarness {
             error: err instanceof Error ? err.message : String(err),
             now,
           })
-          const incarnations = markLastIncarnation(prev.incarnations, {
+          const incarnations = patchIncarnationBySeq(prev.incarnations, 1, {
             state: 'exited',
             ended_at: now,
             ended_reason: 'failed',
@@ -228,10 +226,14 @@ export class WorkerHarness {
       }
 
       const now = this.deps.now()
+      // adapter.spawn 返回的 handle 自描述真实 session_ref(protocol-agent-v3 §6.1)——初始
+      // 化身注册时(见上面 initial.incarnations[0])这个值还不存在,只能占位;spawn 成功后
+      // 在这里补写真值,和 task 状态一起原子落盘。
       const spawned = await this.deps.ledger.upsertWorker(p.dialogObjectId, workerId, (prev) => {
         if (!prev) return undefined
         const nextTask = applyStatusTransition(prev.task, 'running', { now })
-        return { ...prev, task: nextTask, updated_at: now }
+        const incarnations = patchIncarnationBySeq(prev.incarnations, 1, { session_ref: spawnedHandle.session_ref })
+        return { ...prev, task: nextTask, incarnations, updated_at: now }
       })
       await this.appendEvent(workerId, 1, 'spawned', { impl })
       return spawned as LedgerWorker
@@ -255,7 +257,9 @@ export class WorkerHarness {
     await inbox.flush(async (item) => {
       const found = await this.deps.ledger.findWorker(workerId)
       if (!found) throw new WorkerNotFoundError(workerId)
-      const incarnation = lastIncarnation(found.worker)
+      // 主线化身,不能用"数组最后一个"——fork 之后数组末尾是侧问分支,投递必须仍然打到
+      // 主线(protocol-agent-v3 §5.3:fork 不影响主线)。
+      const incarnation = mainlineIncarnation(found.worker)
       const adapter = this.deps.adapters.get(incarnation.impl as WorkerImplId)
       if (!adapter) {
         throw new Error(`WorkerHarness.sendToWorker: no adapter registered for impl '${incarnation.impl}'`)
@@ -264,6 +268,7 @@ export class WorkerHarness {
         worker_id: workerId,
         seq: incarnation.seq,
         impl: incarnation.impl as WorkerImplId,
+        session_ref: incarnation.session_ref,
       }
       // WorkerExitedError 原样向上抛出,不在此拦截伪装——拦截并转入 §5.3 透明接续是
       // Task 8 的范围(会修改本文件),Task 7 只保证正常路径投递正确。
@@ -278,12 +283,18 @@ export class WorkerHarness {
   ): Promise<{ chunk: string; nextCursor: OutputCursor }> {
     const found = await this.deps.ledger.findWorker(workerId)
     if (!found) throw new WorkerNotFoundError(workerId)
-    const incarnation = lastIncarnation(found.worker)
+    // 主线化身,同 sendToWorker——读输出默认读主线,不被 fork 出的侧问分支顶替。
+    const incarnation = mainlineIncarnation(found.worker)
     const adapter = this.deps.adapters.get(incarnation.impl as WorkerImplId)
     if (!adapter) {
       throw new Error(`WorkerHarness.readWorkerOutput: no adapter registered for impl '${incarnation.impl}'`)
     }
-    const handle: IncarnationHandle = { worker_id: workerId, seq: incarnation.seq, impl: incarnation.impl as WorkerImplId }
+    const handle: IncarnationHandle = {
+      worker_id: workerId,
+      seq: incarnation.seq,
+      impl: incarnation.impl as WorkerImplId,
+      session_ref: incarnation.session_ref,
+    }
     return adapter.readOutput(handle, cursor)
   }
 
@@ -300,11 +311,17 @@ export class WorkerHarness {
       // 幂等:已是终态(含此前已经 kill 过)直接返回,不重复调 adapter.kill、不重复写台账/事件。
       if (isTerminalStatus(worker.task.status)) return
 
-      const incarnation = lastIncarnation(worker)
+      // 主线化身——kill 必须打在主线上,不能被 fork 出的侧问分支顶替(protocol-agent-v3 §5.3)。
+      const incarnation = mainlineIncarnation(worker)
       const implId = incarnation.impl as WorkerImplId
       const adapter = this.deps.adapters.get(implId)
       if (adapter) {
-        const handle: IncarnationHandle = { worker_id: workerId, seq: incarnation.seq, impl: implId }
+        const handle: IncarnationHandle = {
+          worker_id: workerId,
+          seq: incarnation.seq,
+          impl: implId,
+          session_ref: incarnation.session_ref,
+        }
         await adapter.kill(handle)
       }
 
@@ -312,7 +329,8 @@ export class WorkerHarness {
       await this.deps.ledger.upsertWorker(dialogObjectId, workerId, (prev) => {
         if (!prev) return undefined
         const nextTask = applyStatusTransition(prev.task, 'cancelled', { now })
-        const incarnations = markLastIncarnation(prev.incarnations, {
+        // 按 seq 精确定位主线化身条目,不假设它是数组最后一个(fork 之后数组末尾是 fork 化身)。
+        const incarnations = patchIncarnationBySeq(prev.incarnations, incarnation.seq, {
           state: 'exited',
           ended_at: now,
           ended_reason: 'killed',
@@ -328,7 +346,9 @@ export class WorkerHarness {
       const found = await this.deps.ledger.findWorker(workerId)
       if (!found) throw new WorkerNotFoundError(workerId)
       const { worker, dialogObjectId } = found
-      const incarnation = lastIncarnation(worker)
+      // 侧问永远从当前主线化身分叉,不是"数组最后一个"——否则连续两次 query_worker 会让
+      // 第二次 fork 挂在第一次 fork 的分支下面,而不是都从主线分叉(protocol-agent-v3 §5.3)。
+      const incarnation = mainlineIncarnation(worker)
       const implId = incarnation.impl as WorkerImplId
       const adapter = this.deps.adapters.get(implId)
       if (!adapter) {
@@ -345,13 +365,16 @@ export class WorkerHarness {
       await this.deps.ledger.upsertWorker(dialogObjectId, workerId, (prev) => {
         if (!prev) return undefined
         // fork 是一次性侧问,不影响主线 task.status(protocol-agent-v3 §5.3:"不影响主线")。
+        // forked_from 标记它不在主线化身链上(§3);session_ref 取 forkHandle 自己的引用,
+        // 不是父化身的(§6.1 IncarnationHandle 自描述,handle.session_ref 就是 fork 化身真值)。
         const forkIncarnation: Incarnation = {
           seq: forkHandle.seq,
           impl: implId,
           state: 'running',
           workspace: incarnation.workspace,
-          session_ref: incarnation.session_ref,
+          session_ref: forkHandle.session_ref,
           started_at: now,
+          forked_from: incarnation.seq,
         }
         return { ...prev, incarnations: [...prev.incarnations, forkIncarnation], updated_at: now }
       })
@@ -370,27 +393,57 @@ export class WorkerHarness {
       if (!found) return // 未知 worker,理论不该发生;防御性丢弃,不抛给 adapter 的回调
       const { worker, dialogObjectId } = found
 
-      const latest = lastIncarnation(worker)
-      if (latest.seq !== h.seq) return // 非当前化身的迟到回调,忽略
-      if (isTerminalStatus(worker.task.status)) return // 已是终态(如已被 killWorker 落定),回调迟到,忽略
+      const target = worker.incarnations.find((inc) => inc.seq === h.seq)
+      if (!target) return // 未知化身(理论不该发生),防御性丢弃
 
       // WorkerAdapter.onStateChange 只携带 (handle, state) 三态,没有 endReason——kill 触发的
-      // exited 已经由 killWorker 自己直接落定台账(见上面的终态短路),能走到这里、还没被
+      // exited 已经由 killWorker 自己直接落定台账(见下面两处终态短路),能走到这里、还没被
       // 判定为终态的 exited,只可能是"化身自然结束"(非 kill),endReason 取 completed。
       // 真正的崩溃(crashed)辨别依赖主动巡检(protocol-agent-v3 §6.3/§12),不在这条被动
       // 回调路径的能力范围内,由 Task 9 的 reconcileOnStartup 补正。
       const endReason: IncarnationEndReason | undefined = state === 'exited' ? 'completed' : undefined
+      const now = this.deps.now()
+
+      if (target.forked_from !== undefined) {
+        // fork 化身(一次性侧问分支)自己的生命周期只更新它自己的化身条目,不影响主线
+        // task.status——protocol-agent-v3 §5.3"fork 不影响主线"在这里的具体体现:即使这是
+        // fork 化身的终态回调,也绝不能像"当前化身"那样去推进 task 状态机。
+        if (target.state === 'exited') return // 已终态,迟到回调忽略
+        await this.deps.ledger.upsertWorker(dialogObjectId, h.worker_id, (prev) => {
+          if (!prev) return undefined
+          const incarnations = patchIncarnationBySeq(
+            prev.incarnations,
+            h.seq,
+            state === 'exited' ? { state, ended_at: now, ended_reason: endReason } : { state }
+          )
+          return { ...prev, incarnations, updated_at: now }
+        })
+        await this.appendEvent(h.worker_id, h.seq, 'state_changed', { to: state })
+        return
+      }
+
+      // 主线分支:只有"当前主线化身"的回调才驱动 task.status——fork 之后数组末尾是侧问
+      // 分支,不能再用"数组最后一个"判定"是不是当前化身"。
+      const mainline = mainlineIncarnation(worker)
+      if (mainline.seq !== h.seq) return // 非当前主线化身的迟到回调,忽略
+      if (isTerminalStatus(worker.task.status)) return // 已是终态(如已被 killWorker 落定),回调迟到,忽略
+
       // idle 是否算"等输入"本属 manager 判断职责(protocol-agent-v3 §5.2);P3 尚无 manager,
       // 保守默认 idle 一律记 waiting_input,P4 接线后可按需要覆盖这条映射。
       const waitingInput = state === 'idle' ? true : undefined
       const nextStatus: TaskStatus = taskStatusFromIncarnation(state, endReason, waitingInput)
 
-      const now = this.deps.now()
       await this.deps.ledger.upsertWorker(dialogObjectId, h.worker_id, (prev) => {
         if (!prev) return undefined
+        // 同状态重复回调(如 adapter 偶发对同一次转变重复通知)不是合法状态机边(VALID_TRANSITIONS
+        // 没有自环),会被 applyStatusTransition 当非法转换抛错——那样 upsertWorker 直接
+        // reject,连下面的 appendEvent 都不会跑,回调被 handleStateChange 的外层 catch 静默
+        // 吞掉,事件跟着一起丢。提前短路成 no-op,让调用方仍能走到 appendEvent 记录这次回调。
+        if (nextStatus === prev.task.status) return prev
         const nextTask = applyStatusTransition(prev.task, nextStatus, { now })
-        const incarnations = markLastIncarnation(
+        const incarnations = patchIncarnationBySeq(
           prev.incarnations,
+          h.seq,
           state === 'exited' ? { state, ended_at: now, ended_reason: endReason } : { state }
         )
         return { ...prev, task: nextTask, incarnations, updated_at: now }
@@ -439,12 +492,27 @@ export class WorkerHarness {
   }
 }
 
-function lastIncarnation(worker: LedgerWorker): Incarnation {
-  return worker.incarnations[worker.incarnations.length - 1]
+/**
+ * 主线化身链上的最新化身:排除所有 forked_from 有值的一次性侧问分支(protocol-agent-v3
+ * §3、§5.3)。fork 出的化身会被 push 进同一个 incarnations 数组,若继续取"数组最后一个"
+ * 当作当前化身,fork 之后 send_to_worker / kill_worker / read_worker_output / 化身自然结束
+ * 的状态回调全部会被错误地转发到侧问分支——主线因此失联(实测复现:spawn → queryWorker →
+ * sendToWorker/killWorker 都 target 到 fork 的 seq,而不是主线 seq)。
+ *
+ * 前提:worker.incarnations 非空(每个已注册的 worker 至少有 spawn 落下的 seq=1 主线化身)。
+ */
+function mainlineIncarnation(worker: LedgerWorker): Incarnation {
+  const mainline = worker.incarnations.filter((inc) => inc.forked_from === undefined)
+  return mainline[mainline.length - 1]
 }
 
-function markLastIncarnation(incarnations: Incarnation[], patch: Partial<Incarnation>): Incarnation[] {
-  return incarnations.map((inc, idx) => (idx === incarnations.length - 1 ? { ...inc, ...patch } : inc))
+/**
+ * 按 seq 精确定位并 patch 一个化身条目,不假设它是数组的最后一个——fork 之后数组末尾是
+ * fork 化身,继续用"改最后一个"的旧写法会把主线的落定动作(如 kill 后的 exited)误写进
+ * fork 条目,或反过来让 fork 化身自己的状态变化误写进主线条目,两个方向都是错的。
+ */
+function patchIncarnationBySeq(incarnations: Incarnation[], seq: number, patch: Partial<Incarnation>): Incarnation[] {
+  return incarnations.map((inc) => (inc.seq === seq ? { ...inc, ...patch } : inc))
 }
 
 // re-export for callers that only import from harness.ts

--- a/crabot-agent/src/workers/harness/harness.ts
+++ b/crabot-agent/src/workers/harness/harness.ts
@@ -1,0 +1,452 @@
+/**
+ * WorkerHarness —— 生命周期编排(protocol-agent-v3 §5.2/§5.5,plans/2026-07-29-mw-p3-ledger-harness.md Task 7)。
+ *
+ * 职责边界:harness 编排台账(LedgerStore)/信箱(WorkerInbox)/事件流(WorkerEventLog)/workspace
+ * (WorkspaceManager)与三个 WorkerAdapter 实现,是 P4 manager 唯一的调用对象。harness 不感知任何
+ * adapter 内部实现细节,只经 WorkerAdapter 契约方法(provision/spawn/sendInput/kill/fork/state/…)
+ * 获取运行时事实——不读 adapter 的 meta-<seq>.json。
+ *
+ * 锁层级(必须遵守,避免 ABBA):
+ *   外层:harness 自己维护的"每 worker 一把" AsyncMutex(this.mutexes,按 worker_id 取)。
+ *   内层:LedgerStore 内部按 DialogObjectId 维护的另一把 AsyncMutex,完全不透明,只在单次
+ *        `ledger.upsertWorker(...)` 调用内部短暂持有(mutator 是同步纯函数,写盘后立即释放)。
+ * harness 从不显式持有 ledger 的锁,也从不在“持有 ledger 锁”的状态下反过来等待自己的
+ * per-worker 锁——每次 upsertWorker 调用都是一次独立的、有限时长的原子读改写,不会在其
+ * 内部触发对 harness per-worker 锁的等待。因此两把锁只可能是“外层→内层”单向嵌套,不存在
+ * ABBA。同一 worker_id 的所有编排动作(spawnWorker 的注册段、handleStateChange、killWorker、
+ * queryWorker 的判定+fork 段)都在同一把 per-worker 锁的临界区内完成“读台账 → 判断 → 写台账”,
+ * 不允许 check-then-act 跨 await。
+ *
+ * 慢调用是否在锁内:
+ *   - adapter.provision / adapter.spawn:在锁内。理由——这是"从无到有注册一个 worker"的
+ *     唯一时机,必须与"台账已存在该 worker_id"这件事保持原子;锁内持有的时长等于一次
+ *     spawn 编排,不是高频路径,换来的正确性(不会有第二个并发操作在半注册状态下观察到
+ *     这个 worker)值得。
+ *   - adapter.kill / adapter.fork:同样在锁内。二者都是"一次性、有限时长"的编排动作
+ *     (不是像 sendInput 那样可能被连续高频调用的路径),放锁内换来"整个 kill/fork 序列
+ *     原子完成,不会被并发的状态回调或另一次 kill/fork 打断"的简单正确性论证,没有值得
+ *     牺牲这份简单性去换取的并发收益。
+ *   - adapter.sendInput:不在 harness 的 per-worker 锁内。sendToWorker 只把"查台账 + 校验
+ *     cancelled + 入信箱"这段放进锁的临界区(这段不含 slow adapter 调用),真正的投递
+ *     经 `WorkerInbox.flush()` 在锁外进行——inbox 自己的内部 AsyncMutex 已经保证同一信箱
+ *     的并发 flush 不会重复投递。这样长时间的 tmux/CLI 调用不会长期占住 harness 的
+ *     per-worker 锁,不阻塞同一 worker 上的其它编排操作(如状态回调、kill)排队等待。
+ *     deliver 内部对每个 item 都重新查一次台账取当前化身(而不是在入锁那次性 snapshot),
+ *     避免投递期间化身已发生变化(如被 kill/交接)却仍拿着过期 handle 投递的问题;
+ *     即便如此,`flush()` 与其它编排动作之间仍存在"投递到已失效化身"的极小窗口——
+ *     这属于 §5.3 透明接续要处理的场景(Task 8 范围),Task 7 只保证 WorkerExitedError
+ *     会原样从 sendInput → inbox.flush → sendToWorker 向上抛出,不做拦截或伪装。
+ *
+ * onStateChange 接线契约(P4 负责实际接线,P3 只提供出口):
+ *   三个 adapter(builtin/claude-code/codex)都在各自构造函数的 deps 里接受一个可选的
+ *   `onStateChange?: (h, state) => void`,但 HarnessDeps.adapters 要求把"已经构造好的
+ *   adapter"塞进来——adapter 构造在先、harness 构造在后,没法在 adapter 构造时就拿到
+ *   harness 实例的方法引用,形成先有鸡还是先有蛋的问题。
+ *
+ *   解法:harness 把 `handleStateChange` 做成一个公开的、构造时就绑定好 this 的箭头函数
+ *   字段(调用方不需要再 .bind),接线方(P4)按以下顺序组装:
+ *     1. const adapters = new Map<WorkerImplId, WorkerAdapter>()   // 先建一个空壳
+ *     2. const harness = new WorkerHarness({ adapters, ... })      // 把空壳传给 harness
+ *     3. 逐个构造 builtin/cc/codex adapter,构造时 onStateChange: harness.handleStateChange
+ *     4. adapters.set('builtin', builtinAdapter) 等
+ *   第 4 步之所以能生效:HarnessDeps.adapters 的类型是 ReadonlyMap,但底层对象仍是同一个
+ *   可写 Map 引用——本实现全程只通过 `this.deps.adapters.get(impl)` 按需取值,从不在构造
+ *   时把它拷贝成快照,所以第 4 步之后往里 set 的内容对 harness 立即可见。三个 adapter 的
+ *   状态回调最终都指向同一个 harness 实例的 `handleStateChange`,不需要 HarnessDeps 再加字段。
+ */
+
+import { randomUUID } from 'crypto'
+import type {
+  WorkerAdapter,
+  WorkerImplId,
+  WorkerContractState,
+  IncarnationHandle,
+  IncarnationRef,
+  IncarnationEndReason,
+  SpawnSpec,
+  OutputCursor,
+  CapabilityBundle,
+} from '../types'
+import { CapabilityNotSupportedError } from '../errors'
+import { AsyncMutex } from '../async-mutex'
+import type { DialogObjectId, Incarnation, LedgerWorker, TaskStatus } from './ledger-types'
+import type { LedgerStore } from './ledger-store'
+import type { WorkspaceManager } from './workspace-manager'
+import { WorkerInbox, type InboxItem } from './inbox'
+import { WorkerEventLog, type HarnessEvent, type HarnessEventKind } from './worker-events'
+import { applyStatusTransition, isTerminalStatus, taskStatusFromIncarnation } from './task-status'
+import { join } from 'path'
+
+/** 请求的 worker_id 在台账中不存在。 */
+export class WorkerNotFoundError extends Error {
+  constructor(readonly worker_id: string) {
+    super(`worker not found: ${worker_id}`)
+    this.name = 'WorkerNotFoundError'
+  }
+}
+
+/** send_to_worker 命中已 cancelled 的 task(唯一硬拒绝场景,protocol-agent-v3 §5.5)。 */
+export class TaskCancelledError extends Error {
+  constructor(readonly worker_id: string) {
+    super(`worker ${worker_id} task is cancelled`)
+    this.name = 'TaskCancelledError'
+  }
+}
+
+export interface HarnessDeps {
+  /** 已 detect 过的可用实现。见文件头"onStateChange 接线契约"——底层 Map 引用可在构造后继续填充。 */
+  readonly adapters: ReadonlyMap<WorkerImplId, WorkerAdapter>
+  readonly defaultImpl: WorkerImplId
+  readonly ledger: LedgerStore
+  readonly workspaces: WorkspaceManager
+  /** <dataRoot>/agent/workers */
+  readonly workersDir: string
+  /** ISO 时间注入,便于测试 */
+  readonly now: () => string
+  /** P4 manager 的唤醒入口(P3 是可插桩的出口) */
+  readonly onEvent?: (e: HarnessEvent) => void
+  /** provision 素材(P3 可返回空集) */
+  readonly capabilityBundle?: () => Promise<CapabilityBundle>
+}
+
+export interface SpawnWorkerParams {
+  readonly dialogObjectId: DialogObjectId
+  readonly title: string
+  readonly prompt: string
+  readonly origin: LedgerWorker['origin']
+  readonly report_to: LedgerWorker['report_to']
+  readonly impl?: WorkerImplId
+  readonly workspace?: string
+  readonly goal?: string
+  /** builtin 实现所需的 LLM 注入(P4 提供) */
+  readonly builtin?: SpawnSpec['builtin']
+}
+
+const EMPTY_CAPABILITY_BUNDLE: CapabilityBundle = { skills: [], mcp_servers: [] }
+
+export class WorkerHarness {
+  private readonly mutexes = new Map<string, AsyncMutex>()
+  private readonly inboxes = new Map<string, WorkerInbox>()
+  private readonly eventLogs = new Map<string, WorkerEventLog>()
+
+  constructor(private readonly deps: HarnessDeps) {}
+
+  /**
+   * 见文件头"onStateChange 接线契约"。箭头函数字段:构造时绑定 this,P4 可直接把它作为
+   * 三个 adapter 构造 deps 里的 `onStateChange` 传入,不需要 .bind(harness)。
+   * 签名对齐三个 adapter 的 `deps.onStateChange?: (h, state) => void`(同步、无返回值)——
+   * 内部把实际的异步台账更新做成 fire-and-forget,任何失败只 console.error,不抛给 adapter
+   * (adapter 侧本身也已经用 try/catch 包裹了对这个回调的调用,这里双重防御,理由一致:
+   * 观察者的异常不能中断 adapter 自己的状态机推进)。
+   */
+  readonly handleStateChange = (h: IncarnationHandle, state: WorkerContractState): void => {
+    this.processStateChange(h, state).catch((err) => {
+      console.error(`[WorkerHarness] handleStateChange failed for ${h.worker_id}#${h.seq}:`, err)
+    })
+  }
+
+  async spawnWorker(p: SpawnWorkerParams): Promise<LedgerWorker> {
+    const workerId = `w-${randomUUID()}`
+    const impl = p.impl ?? this.deps.defaultImpl
+    const adapter = this.deps.adapters.get(impl)
+    if (!adapter) {
+      throw new Error(`WorkerHarness.spawnWorker: no adapter registered for impl '${impl}'`)
+    }
+
+    // workspace 解析可能失败(InvalidWorkspaceError),放在拿锁/写台账之前——失败时台账
+    // 完全不会出现这条 worker,不留半成品。
+    const workspace = await this.deps.workspaces.resolve(workerId, p.workspace)
+
+    return this.withLock(workerId, async () => {
+      const startedAt = this.deps.now()
+      const initial: LedgerWorker = {
+        worker_id: workerId,
+        task: {
+          id: workerId,
+          title: p.title,
+          status: 'queued',
+          goal: p.goal,
+          created_at: startedAt,
+        },
+        origin: p.origin,
+        report_to: p.report_to,
+        incarnations: [
+          {
+            seq: 1,
+            impl,
+            state: 'running',
+            workspace: workspace.root,
+            // WorkerAdapter 契约没有"从 handle 反查 session_ref"的方法(P1/P2 遗留的已知
+            // 空缺,tests/workers/contract-suite.ts 的 fixture-only `refFor` 就是为了绕开
+            // 这个缺口而加的)。harness 在契约不扩展的前提下拿不到真实值,先用空串占位;
+            // queryWorker 的 fork 分支会原样把这个占位值透传给 adapter.fork,对真实
+            // cc/codex adapter(它们会校验 UUID 格式)会失败——这不是 Task 7 引入的新问题,
+            // 是既有契约的已知缺口,留给后续任务(扩展 WorkerAdapter 契约)解决。
+            session_ref: '',
+            started_at: startedAt,
+          },
+        ],
+        updated_at: startedAt,
+      }
+      await this.deps.ledger.upsertWorker(p.dialogObjectId, workerId, () => initial)
+
+      try {
+        const caps = this.deps.capabilityBundle ? await this.deps.capabilityBundle() : EMPTY_CAPABILITY_BUNDLE
+        await adapter.provision(workspace, caps)
+        const spec: SpawnSpec = {
+          worker_id: workerId,
+          prompt: p.prompt,
+          workspace,
+          goal: p.goal,
+          builtin: p.builtin,
+        }
+        await adapter.spawn(spec)
+      } catch (err) {
+        const now = this.deps.now()
+        await this.deps.ledger.upsertWorker(p.dialogObjectId, workerId, (prev) => {
+          if (!prev) return undefined
+          // VALID_TRANSITIONS 里 queued 没有直达 failed 的边(只能到 running/cancelled)。
+          // spawn 尝试确实发生过(我们已经调用了 provision/spawn),用 queued→running→failed
+          // 两跳把这次失败尝试如实记录下来,而不是绕开状态机改成不符合协议语义的 cancelled。
+          const running = applyStatusTransition(prev.task, 'running', { now })
+          const nextTask = applyStatusTransition(running, 'failed', {
+            error: err instanceof Error ? err.message : String(err),
+            now,
+          })
+          const incarnations = markLastIncarnation(prev.incarnations, {
+            state: 'exited',
+            ended_at: now,
+            ended_reason: 'failed',
+          })
+          return { ...prev, task: nextTask, incarnations, updated_at: now }
+        })
+        await this.appendEvent(workerId, 1, 'exited', {
+          reason: 'spawn_failed',
+          message: err instanceof Error ? err.message : String(err),
+        })
+        throw err
+      }
+
+      const now = this.deps.now()
+      const spawned = await this.deps.ledger.upsertWorker(p.dialogObjectId, workerId, (prev) => {
+        if (!prev) return undefined
+        const nextTask = applyStatusTransition(prev.task, 'running', { now })
+        return { ...prev, task: nextTask, updated_at: now }
+      })
+      await this.appendEvent(workerId, 1, 'spawned', { impl })
+      return spawned as LedgerWorker
+    })
+  }
+
+  async sendToWorker(workerId: string, text: string, opts?: { raw?: boolean }): Promise<void> {
+    const inbox = this.getInbox(workerId)
+
+    // "读台账状态 → 判断 cancelled → 入信箱"在同一临界区完成,不允许 check-then-act 跨 await。
+    await this.withLock(workerId, async () => {
+      const found = await this.deps.ledger.findWorker(workerId)
+      if (!found) throw new WorkerNotFoundError(workerId)
+      if (found.worker.task.status === 'cancelled') throw new TaskCancelledError(workerId)
+      inbox.enqueue({ text, raw: opts?.raw ?? false, enqueued_at: this.deps.now() })
+    })
+
+    // 真正的投递不占用 harness 的 per-worker 锁(见文件头说明);inbox 自身的锁保证同一
+    // 信箱的并发 flush 不重复投递。deliver 内部对每个 item 重新取一次当前化身,避免用
+    // 入队时刻的过期 handle 投递。
+    await inbox.flush(async (item) => {
+      const found = await this.deps.ledger.findWorker(workerId)
+      if (!found) throw new WorkerNotFoundError(workerId)
+      const incarnation = lastIncarnation(found.worker)
+      const adapter = this.deps.adapters.get(incarnation.impl as WorkerImplId)
+      if (!adapter) {
+        throw new Error(`WorkerHarness.sendToWorker: no adapter registered for impl '${incarnation.impl}'`)
+      }
+      const handle: IncarnationHandle = {
+        worker_id: workerId,
+        seq: incarnation.seq,
+        impl: incarnation.impl as WorkerImplId,
+      }
+      // WorkerExitedError 原样向上抛出,不在此拦截伪装——拦截并转入 §5.3 透明接续是
+      // Task 8 的范围(会修改本文件),Task 7 只保证正常路径投递正确。
+      await adapter.sendInput(handle, item.text, { raw: item.raw })
+      await this.appendEvent(workerId, handle.seq, 'input_sent', { text_len: item.text.length })
+    })
+  }
+
+  async readWorkerOutput(
+    workerId: string,
+    cursor: OutputCursor
+  ): Promise<{ chunk: string; nextCursor: OutputCursor }> {
+    const found = await this.deps.ledger.findWorker(workerId)
+    if (!found) throw new WorkerNotFoundError(workerId)
+    const incarnation = lastIncarnation(found.worker)
+    const adapter = this.deps.adapters.get(incarnation.impl as WorkerImplId)
+    if (!adapter) {
+      throw new Error(`WorkerHarness.readWorkerOutput: no adapter registered for impl '${incarnation.impl}'`)
+    }
+    const handle: IncarnationHandle = { worker_id: workerId, seq: incarnation.seq, impl: incarnation.impl as WorkerImplId }
+    return adapter.readOutput(handle, cursor)
+  }
+
+  async listWorkers(dialogObjectId: DialogObjectId): Promise<LedgerWorker[]> {
+    return this.deps.ledger.listWorkers(dialogObjectId)
+  }
+
+  async killWorker(workerId: string, reason?: string): Promise<void> {
+    await this.withLock(workerId, async () => {
+      const found = await this.deps.ledger.findWorker(workerId)
+      if (!found) throw new WorkerNotFoundError(workerId)
+      const { worker, dialogObjectId } = found
+
+      // 幂等:已是终态(含此前已经 kill 过)直接返回,不重复调 adapter.kill、不重复写台账/事件。
+      if (isTerminalStatus(worker.task.status)) return
+
+      const incarnation = lastIncarnation(worker)
+      const implId = incarnation.impl as WorkerImplId
+      const adapter = this.deps.adapters.get(implId)
+      if (adapter) {
+        const handle: IncarnationHandle = { worker_id: workerId, seq: incarnation.seq, impl: implId }
+        await adapter.kill(handle)
+      }
+
+      const now = this.deps.now()
+      await this.deps.ledger.upsertWorker(dialogObjectId, workerId, (prev) => {
+        if (!prev) return undefined
+        const nextTask = applyStatusTransition(prev.task, 'cancelled', { now })
+        const incarnations = markLastIncarnation(prev.incarnations, {
+          state: 'exited',
+          ended_at: now,
+          ended_reason: 'killed',
+        })
+        return { ...prev, task: nextTask, incarnations, updated_at: now }
+      })
+      await this.appendEvent(workerId, incarnation.seq, 'killed', reason ? { reason } : undefined)
+    })
+  }
+
+  async queryWorker(workerId: string, question: string): Promise<{ forkSeq: number }> {
+    return this.withLock(workerId, async () => {
+      const found = await this.deps.ledger.findWorker(workerId)
+      if (!found) throw new WorkerNotFoundError(workerId)
+      const { worker, dialogObjectId } = found
+      const incarnation = lastIncarnation(worker)
+      const implId = incarnation.impl as WorkerImplId
+      const adapter = this.deps.adapters.get(implId)
+      if (!adapter) {
+        throw new Error(`WorkerHarness.queryWorker: no adapter registered for impl '${implId}'`)
+      }
+      if (!adapter.capabilities().fork) {
+        throw new CapabilityNotSupportedError(implId, 'fork')
+      }
+
+      const ref: IncarnationRef = { worker_id: workerId, seq: incarnation.seq, session_ref: incarnation.session_ref }
+      const forkHandle = await adapter.fork(ref, question)
+
+      const now = this.deps.now()
+      await this.deps.ledger.upsertWorker(dialogObjectId, workerId, (prev) => {
+        if (!prev) return undefined
+        // fork 是一次性侧问,不影响主线 task.status(protocol-agent-v3 §5.3:"不影响主线")。
+        const forkIncarnation: Incarnation = {
+          seq: forkHandle.seq,
+          impl: implId,
+          state: 'running',
+          workspace: incarnation.workspace,
+          session_ref: incarnation.session_ref,
+          started_at: now,
+        }
+        return { ...prev, incarnations: [...prev.incarnations, forkIncarnation], updated_at: now }
+      })
+      // HarnessEventKind 没有专门的"fork/query"档位(worker-events.ts 是既定契约,Task 7
+      // 不新增枚举值),用 state_changed 承载,detail 里标明是 fork 产生的新化身。
+      await this.appendEvent(workerId, forkHandle.seq, 'state_changed', { kind: 'fork', from_seq: incarnation.seq })
+      return { forkSeq: forkHandle.seq }
+    })
+  }
+
+  // ---- 内部 ----
+
+  private async processStateChange(h: IncarnationHandle, state: WorkerContractState): Promise<void> {
+    await this.withLock(h.worker_id, async () => {
+      const found = await this.deps.ledger.findWorker(h.worker_id)
+      if (!found) return // 未知 worker,理论不该发生;防御性丢弃,不抛给 adapter 的回调
+      const { worker, dialogObjectId } = found
+
+      const latest = lastIncarnation(worker)
+      if (latest.seq !== h.seq) return // 非当前化身的迟到回调,忽略
+      if (isTerminalStatus(worker.task.status)) return // 已是终态(如已被 killWorker 落定),回调迟到,忽略
+
+      // WorkerAdapter.onStateChange 只携带 (handle, state) 三态,没有 endReason——kill 触发的
+      // exited 已经由 killWorker 自己直接落定台账(见上面的终态短路),能走到这里、还没被
+      // 判定为终态的 exited,只可能是"化身自然结束"(非 kill),endReason 取 completed。
+      // 真正的崩溃(crashed)辨别依赖主动巡检(protocol-agent-v3 §6.3/§12),不在这条被动
+      // 回调路径的能力范围内,由 Task 9 的 reconcileOnStartup 补正。
+      const endReason: IncarnationEndReason | undefined = state === 'exited' ? 'completed' : undefined
+      // idle 是否算"等输入"本属 manager 判断职责(protocol-agent-v3 §5.2);P3 尚无 manager,
+      // 保守默认 idle 一律记 waiting_input,P4 接线后可按需要覆盖这条映射。
+      const waitingInput = state === 'idle' ? true : undefined
+      const nextStatus: TaskStatus = taskStatusFromIncarnation(state, endReason, waitingInput)
+
+      const now = this.deps.now()
+      await this.deps.ledger.upsertWorker(dialogObjectId, h.worker_id, (prev) => {
+        if (!prev) return undefined
+        const nextTask = applyStatusTransition(prev.task, nextStatus, { now })
+        const incarnations = markLastIncarnation(
+          prev.incarnations,
+          state === 'exited' ? { state, ended_at: now, ended_reason: endReason } : { state }
+        )
+        return { ...prev, task: nextTask, incarnations, updated_at: now }
+      })
+      await this.appendEvent(h.worker_id, h.seq, 'state_changed', { to: state })
+    })
+  }
+
+  private withLock<T>(workerId: string, fn: () => Promise<T>): Promise<T> {
+    let mutex = this.mutexes.get(workerId)
+    if (!mutex) {
+      mutex = new AsyncMutex()
+      this.mutexes.set(workerId, mutex)
+    }
+    return mutex.run(fn)
+  }
+
+  private getInbox(workerId: string): WorkerInbox {
+    let inbox = this.inboxes.get(workerId)
+    if (!inbox) {
+      inbox = new WorkerInbox(workerId)
+      this.inboxes.set(workerId, inbox)
+    }
+    return inbox
+  }
+
+  private getEventLog(workerId: string): WorkerEventLog {
+    let log = this.eventLogs.get(workerId)
+    if (!log) {
+      log = new WorkerEventLog(join(this.deps.workersDir, workerId))
+      this.eventLogs.set(workerId, log)
+    }
+    return log
+  }
+
+  private async appendEvent(
+    workerId: string,
+    seq: number,
+    kind: HarnessEventKind,
+    detail?: Record<string, unknown>
+  ): Promise<void> {
+    const ts = this.deps.now()
+    const event: HarnessEvent = detail !== undefined ? { ts, kind, worker_id: workerId, seq, detail } : { ts, kind, worker_id: workerId, seq }
+    await this.getEventLog(workerId).append(event)
+    this.deps.onEvent?.(event)
+  }
+}
+
+function lastIncarnation(worker: LedgerWorker): Incarnation {
+  return worker.incarnations[worker.incarnations.length - 1]
+}
+
+function markLastIncarnation(incarnations: Incarnation[], patch: Partial<Incarnation>): Incarnation[] {
+  return incarnations.map((inc, idx) => (idx === incarnations.length - 1 ? { ...inc, ...patch } : inc))
+}
+
+// re-export for callers that only import from harness.ts
+export type { HarnessEvent, HarnessEventKind } from './worker-events'
+export type { InboxItem } from './inbox'

--- a/crabot-agent/src/workers/harness/inbox.ts
+++ b/crabot-agent/src/workers/harness/inbox.ts
@@ -30,7 +30,8 @@ export interface InboxItem {
 export class WorkerInbox {
   private queue: InboxItem[] = []
   private _held = false
-  private _drained = false
+  /** drain 当刻正在投递的 in-flight 条目;该条目投递失败时仅告警丢弃,post-drain 的条目失败走正常语义。 */
+  private drainedInFlight: InboxItem | null = null
   /** flush 正在投递、已从 queue 取出但尚未结算成败的条目;drain 不把它计入结果。 */
   private inFlight: InboxItem | null = null
   private readonly mutex = new AsyncMutex()
@@ -64,12 +65,15 @@ export class WorkerInbox {
    * 按序投递直到队空或再次被 hold。同一信箱上的并发 flush 调用经 mutex 串行化,
    * 保证同一时刻只有一轮在投递,不会重复投递同一 item。
    * deliver 抛错时该条放回队首、停止本轮、原样向上抛出——除非投递期间已被 drain
-   * (见下方 catch 分支)。
+   * 且该条正好是 drain 当刻的 in-flight 条目(见下方 catch 分支)。
    *
    * 投递中的条目在 await deliver() 之前就从 queue 取出、记到 inFlight,而不是等
    * deliver 返回后再 shift:这样 drain() 才能在 deliver 卡住期间安全地把 queue
    * 视为"确定未投递"的快照,不会把正在投递、随后可能投递成功的条目也一并当作
    * dead-letter 带走,避免同一条目既真正投递、又混进 dead-letter 批次重复投递。
+   *
+   * pending:返回队列中的待投条数。注意:在 await deliver() 期间,该条已从 queue
+   * 取出(shift),所以 pending 不计入 in-flight 条目。
    */
   async flush(deliver: (item: InboxItem) => Promise<void>): Promise<number> {
     return this.mutex.run(async () => {
@@ -83,11 +87,11 @@ export class WorkerInbox {
           delivered++
         } catch (err) {
           this.inFlight = null
-          if (this._drained) {
-            // 化身已终结:drain 早已把 queue 清空并作为 dead-letter 交给调用方,
-            // 这条已经没有队列可放回、也没有人再等这次 flush 的结果——放回会造成
-            // "凭空复活"的幽灵条目,原样向上抛则可能砸向已不再等待的调用方,
-            // 变成未处理的 promise rejection。因此仅告警丢弃。
+          if (this.drainedInFlight === item) {
+            // 该条正好是 drain 当刻的 in-flight:化身已终结,drain 早已把 queue 清空并
+            // 作为 dead-letter 交给调用方。这条已经没有队列可放回、也没有人再等这次
+            // flush 的结果——放回会造成"凭空复活"的幽灵条目,原样向上抛则可能砸向已不再
+            // 等待的调用方,变成未处理的 promise rejection。因此仅告警丢弃。
             console.warn(
               `[WorkerInbox:${this.workerId}] deliver failed after drain, dropping in-flight item: ${
                 err instanceof Error ? err.message : String(err)
@@ -95,6 +99,7 @@ export class WorkerInbox {
             )
             return delivered
           }
+          // post-drain enqueue 的条目或其他情况:走正常语义(放回、抛出)
           this.queue.unshift(item)
           throw err
         }
@@ -110,7 +115,8 @@ export class WorkerInbox {
    * (成功计入投递、失败见 flush 的 catch 分支),避免同一条目既投递又进 dead-letter。
    */
   drain(): InboxItem[] {
-    this._drained = true
+    // 记录 drain 当刻的 in-flight 条目,以便 flush 的 catch 分支判断是否需要吞掉错误
+    this.drainedInFlight = this.inFlight
     const items = this.queue
     this.queue = []
     return items

--- a/crabot-agent/src/workers/harness/inbox.ts
+++ b/crabot-agent/src/workers/harness/inbox.ts
@@ -30,6 +30,9 @@ export interface InboxItem {
 export class WorkerInbox {
   private queue: InboxItem[] = []
   private _held = false
+  private _drained = false
+  /** flush 正在投递、已从 queue 取出但尚未结算成败的条目;drain 不把它计入结果。 */
+  private inFlight: InboxItem | null = null
   private readonly mutex = new AsyncMutex()
 
   constructor(private readonly workerId: string) {}
@@ -60,23 +63,54 @@ export class WorkerInbox {
   /**
    * 按序投递直到队空或再次被 hold。同一信箱上的并发 flush 调用经 mutex 串行化,
    * 保证同一时刻只有一轮在投递,不会重复投递同一 item。
-   * deliver 抛错时该条留在队首(不 shift)、停止本轮、原样向上抛出。
+   * deliver 抛错时该条放回队首、停止本轮、原样向上抛出——除非投递期间已被 drain
+   * (见下方 catch 分支)。
+   *
+   * 投递中的条目在 await deliver() 之前就从 queue 取出、记到 inFlight,而不是等
+   * deliver 返回后再 shift:这样 drain() 才能在 deliver 卡住期间安全地把 queue
+   * 视为"确定未投递"的快照,不会把正在投递、随后可能投递成功的条目也一并当作
+   * dead-letter 带走,避免同一条目既真正投递、又混进 dead-letter 批次重复投递。
    */
   async flush(deliver: (item: InboxItem) => Promise<void>): Promise<number> {
     return this.mutex.run(async () => {
       let delivered = 0
       while (this.queue.length > 0 && !this._held) {
-        const item = this.queue[0]
-        await deliver(item)
-        this.queue.shift()
-        delivered++
+        const item = this.queue.shift()!
+        this.inFlight = item
+        try {
+          await deliver(item)
+          this.inFlight = null
+          delivered++
+        } catch (err) {
+          this.inFlight = null
+          if (this._drained) {
+            // 化身已终结:drain 早已把 queue 清空并作为 dead-letter 交给调用方,
+            // 这条已经没有队列可放回、也没有人再等这次 flush 的结果——放回会造成
+            // "凭空复活"的幽灵条目,原样向上抛则可能砸向已不再等待的调用方,
+            // 变成未处理的 promise rejection。因此仅告警丢弃。
+            console.warn(
+              `[WorkerInbox:${this.workerId}] deliver failed after drain, dropping in-flight item: ${
+                err instanceof Error ? err.message : String(err)
+              }`
+            )
+            return delivered
+          }
+          this.queue.unshift(item)
+          throw err
+        }
       }
       return delivered
     })
   }
 
-  /** 取出全部并清空(化身终结时 dead-letter 用) */
+  /**
+   * 取出全部并清空(化身终结时 dead-letter 用)。同步执行、不走 mutex——化身终结时
+   * 可能正有一轮 flush 卡在 deliver 上(如 tmux 命令挂起、长时间不返回),drain 不能
+   * 无限等锁卡住终结流程。返回结果不含 in-flight 条目:它的成败由 flush 自己结算
+   * (成功计入投递、失败见 flush 的 catch 分支),避免同一条目既投递又进 dead-letter。
+   */
   drain(): InboxItem[] {
+    this._drained = true
     const items = this.queue
     this.queue = []
     return items

--- a/crabot-agent/src/workers/harness/inbox.ts
+++ b/crabot-agent/src/workers/harness/inbox.ts
@@ -1,0 +1,84 @@
+/**
+ * WorkerInbox —— 每 worker 一个信箱(protocol-agent-v3 §5.5)。
+ *
+ * 语义:`send_to_worker` 投递永不因状态失败(唯一硬拒绝是 task 已 cancelled,由调用方在
+ * 投递前把关,不属于本类职责);安全态(running / idle)即投,不安全态(provision 中、
+ * 模态弹窗、化身交接间隙、僵尸态)暂扣,恢复后按序补投。
+ *
+ * hold 选择"布尔"而非计数:harness 侧的暂扣场景(provision / 化身交接)是互斥的单一状态,
+ * 不存在"多个理由同时暂扣、需要逐个撤销"的嵌套需求;若未来出现需要嵌套暂扣的场景,再改
+ * 计数并补测,不在此提前引入复杂度。
+ *
+ * flush 并发安全:用 AsyncMutex 串行化同一信箱的 flush 调用,避免两轮并发 flush 重复投递
+ * 同一条(P1 builtin sendInput 双发竞态同型问题)。deliver 抛错时该条留在队首、停止本轮、
+ * 原样向上抛出,不吞错也不丢消息。
+ *
+ * 纯内存态,无 IO:P3 范围内信箱不跨进程重启存活;后续如需持久化,由 harness 层在此类之上
+ * 加落盘,不在本类内引入。
+ *
+ * @see crabot-docs/protocols/protocol-agent-v3.md §5.5
+ */
+
+import { AsyncMutex } from '../async-mutex'
+
+export interface InboxItem {
+  readonly text: string
+  readonly raw: boolean
+  readonly enqueued_at: string
+}
+
+export class WorkerInbox {
+  private queue: InboxItem[] = []
+  private _held = false
+  private readonly mutex = new AsyncMutex()
+
+  constructor(private readonly workerId: string) {}
+
+  /** 入队;返回本次入队后的待投条数 */
+  enqueue(item: InboxItem): number {
+    this.queue.push(item)
+    return this.queue.length
+  }
+
+  /** 标记不安全(如 provision/交接中),期间 flush 不投递 */
+  hold(_reason: string): void {
+    this._held = true
+  }
+
+  release(): void {
+    this._held = false
+  }
+
+  get held(): boolean {
+    return this._held
+  }
+
+  get pending(): number {
+    return this.queue.length
+  }
+
+  /**
+   * 按序投递直到队空或再次被 hold。同一信箱上的并发 flush 调用经 mutex 串行化,
+   * 保证同一时刻只有一轮在投递,不会重复投递同一 item。
+   * deliver 抛错时该条留在队首(不 shift)、停止本轮、原样向上抛出。
+   */
+  async flush(deliver: (item: InboxItem) => Promise<void>): Promise<number> {
+    return this.mutex.run(async () => {
+      let delivered = 0
+      while (this.queue.length > 0 && !this._held) {
+        const item = this.queue[0]
+        await deliver(item)
+        this.queue.shift()
+        delivered++
+      }
+      return delivered
+    })
+  }
+
+  /** 取出全部并清空(化身终结时 dead-letter 用) */
+  drain(): InboxItem[] {
+    const items = this.queue
+    this.queue = []
+    return items
+  }
+}

--- a/crabot-agent/src/workers/harness/ledger-store.ts
+++ b/crabot-agent/src/workers/harness/ledger-store.ts
@@ -124,6 +124,26 @@ export class LedgerStore {
     })
   }
 
+  /**
+   * 全量枚举所有对话对象下的 worker(跨 dialog_object_id)。listWorkers/findWorker 都是
+   * 针对单个已知对话对象或已知 worker_id 的查找,不满足"扫描整个台账存储"的场景(如
+   * Task 9 崩溃恢复对账 reconcileOnStartup 需要巡检所有对话对象下的非终态 worker)——
+   * 复用 init() 建好的 worker_id → dialog_object_id 索引拿到全部 dialog_object_id,
+   * 再逐个对话对象读一次台账文件拼起来。只读,不新增任何写路径。
+   */
+  async listAllWorkers(): Promise<Array<{ dialogObjectId: DialogObjectId; worker: LedgerWorker }>> {
+    await this.init()
+    const dialogIds = new Set(this.workerIndex.values())
+    const result: Array<{ dialogObjectId: DialogObjectId; worker: LedgerWorker }> = []
+    for (const dialogObjectId of dialogIds) {
+      const ledger = await this.readLedgerFileStrict(dialogObjectId)
+      for (const worker of ledger.workers) {
+        result.push({ dialogObjectId, worker })
+      }
+    }
+    return result
+  }
+
   private getMutex(id: DialogObjectId): AsyncMutex {
     let mutex = this.mutexes.get(id)
     if (!mutex) {

--- a/crabot-agent/src/workers/harness/ledger-store.ts
+++ b/crabot-agent/src/workers/harness/ledger-store.ts
@@ -1,0 +1,202 @@
+/**
+ * LedgerStore —— worker 台账存储(protocol-agent-v3 §7):每 DialogObjectId 一个 JSON 文件,
+ * 一把互斥锁保读-改-写原子性,tmp+rename 保落盘原子性(参照 src/workers/meta-store.ts 的写法)。
+ *
+ * 索引语义:内存维护 worker_id → DialogObjectId 的查找索引,首次访问时扫描目录建索引(幂等)。
+ * findWorker 未命中索引时会重扫一次目录再判,用于兜底外部进程写入台账文件的场景。
+ */
+
+import { promises as fs } from 'fs'
+import { join, dirname } from 'path'
+import { randomUUID } from 'crypto'
+import { AsyncMutex } from '../async-mutex'
+import type { DialogObjectId, LedgerWorker, WorkerLedger } from './ledger-types'
+
+const FILE_SUFFIX = '.json'
+
+/** 段编码:把 [A-Za-z0-9_-] 之外的字符转成 %XX(UTF-8 字节),确保无歧义且可逆 */
+function encodeSegment(s: string): string {
+  return encodeURIComponent(s).replace(
+    /[.!~*'()]/g,
+    (ch) => '%' + ch.charCodeAt(0).toString(16).toUpperCase().padStart(2, '0')
+  )
+}
+
+function decodeSegment(s: string): string {
+  return decodeURIComponent(s)
+}
+
+/** DialogObjectId → 台账文件名(导出以支持双向可逆测试与目录扫描) */
+export function dialogObjectIdToFilename(id: DialogObjectId): string {
+  return `${encodeSegment(id)}${FILE_SUFFIX}`
+}
+
+/** 台账文件名 → DialogObjectId;不是本 store 产出的文件名(不认识的前缀/编码)返回 undefined */
+export function filenameToDialogObjectId(filename: string): DialogObjectId | undefined {
+  if (!filename.endsWith(FILE_SUFFIX)) return undefined
+  const stem = filename.slice(0, -FILE_SUFFIX.length)
+  let decoded: string
+  try {
+    decoded = decodeSegment(stem)
+  } catch {
+    return undefined
+  }
+  if (decoded.startsWith('friend:') || decoded.startsWith('group:')) {
+    return decoded as DialogObjectId
+  }
+  return undefined
+}
+
+async function writeJsonAtomic(path: string, data: unknown): Promise<void> {
+  const tmpPath = join(dirname(path), `.tmp-${randomUUID()}${FILE_SUFFIX}`)
+  await fs.writeFile(tmpPath, JSON.stringify(data, null, 2), 'utf-8')
+  await fs.rename(tmpPath, path)
+}
+
+export class LedgerStore {
+  private readonly ledgersDir: string
+  private readonly mutexes = new Map<DialogObjectId, AsyncMutex>()
+  private workerIndex = new Map<string, DialogObjectId>()
+  private initPromise: Promise<void> | undefined
+
+  constructor(ledgersDir: string) {
+    this.ledgersDir = ledgersDir
+  }
+
+  /** 首次访问时扫描目录建 worker_id → dialog_object_id 内存索引;幂等(重复调用共享同一次扫描) */
+  async init(): Promise<void> {
+    if (!this.initPromise) {
+      this.initPromise = this.scanAndBuildIndex()
+    }
+    await this.initPromise
+  }
+
+  async getLedger(id: DialogObjectId): Promise<WorkerLedger> {
+    await this.init()
+    return this.readLedgerFileStrict(id)
+  }
+
+  async listWorkers(id: DialogObjectId): Promise<LedgerWorker[]> {
+    const ledger = await this.getLedger(id)
+    return ledger.workers
+  }
+
+  /** 跨对话对象按 worker_id 查;索引未命中时重扫一次目录再判 */
+  async findWorker(
+    workerId: string
+  ): Promise<{ dialogObjectId: DialogObjectId; worker: LedgerWorker } | undefined> {
+    await this.init()
+    let id = this.workerIndex.get(workerId)
+    if (!id) {
+      await this.scanAndBuildIndex()
+      id = this.workerIndex.get(workerId)
+      if (!id) return undefined
+    }
+    const ledger = await this.readLedgerFileStrict(id)
+    const worker = ledger.workers.find((w) => w.worker_id === workerId)
+    if (!worker) return undefined
+    return { dialogObjectId: id, worker }
+  }
+
+  /** 读-改-写在该对话对象的互斥锁内完成;mutator 返回 undefined 表示放弃写入 */
+  async upsertWorker(
+    id: DialogObjectId,
+    workerId: string,
+    mutator: (prev: LedgerWorker | undefined) => LedgerWorker | undefined
+  ): Promise<LedgerWorker | undefined> {
+    await this.init()
+    const mutex = this.getMutex(id)
+    return mutex.run(async () => {
+      const ledger = await this.readLedgerFileStrict(id)
+      const idx = ledger.workers.findIndex((w) => w.worker_id === workerId)
+      const prev = idx >= 0 ? ledger.workers[idx] : undefined
+      const next = mutator(prev)
+      if (next === undefined) return undefined
+
+      if (idx >= 0) {
+        ledger.workers[idx] = next
+      } else {
+        ledger.workers.push(next)
+      }
+      await writeJsonAtomic(this.pathFor(id), ledger)
+      this.workerIndex.set(workerId, id)
+      return next
+    })
+  }
+
+  private getMutex(id: DialogObjectId): AsyncMutex {
+    let mutex = this.mutexes.get(id)
+    if (!mutex) {
+      mutex = new AsyncMutex()
+      this.mutexes.set(id, mutex)
+    }
+    return mutex
+  }
+
+  private pathFor(id: DialogObjectId): string {
+    return join(this.ledgersDir, dialogObjectIdToFilename(id))
+  }
+
+  /**
+   * 读取台账文件。不存在返回空壳 { dialog_object_id, workers: [] }(不建文件)。
+   * JSON 内容损坏则抛明确错误——这与 init() 扫描时"跳过并 warn"的语义不同:
+   * getLedger/upsertWorker 是针对单个已知对话对象的读,坏文件如果静默当空,
+   * 后续写入会用空壳覆盖用户原有数据,所以必须显式失败。
+   */
+  private async readLedgerFileStrict(id: DialogObjectId): Promise<WorkerLedger> {
+    const filePath = this.pathFor(id)
+    let raw: string
+    try {
+      raw = await fs.readFile(filePath, 'utf-8')
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        return { dialog_object_id: id, workers: [] }
+      }
+      throw err
+    }
+    try {
+      return JSON.parse(raw) as WorkerLedger
+    } catch (err) {
+      throw new Error(
+        `[LedgerStore] 台账文件损坏(非法 JSON),拒绝当作空壳处理: ${filePath}: ${(err as Error).message}`
+      )
+    }
+  }
+
+  /**
+   * 扫描目录建索引。与 readLedgerFileStrict 语义不同:坏文件在这里只跳过并 console.warn,
+   * 不让一个坏文件毁掉整个索引(索引只是查找加速手段,允许对损坏对话对象暂时缺失)。
+   */
+  private async scanAndBuildIndex(): Promise<void> {
+    await fs.mkdir(this.ledgersDir, { recursive: true })
+    const entries = await fs.readdir(this.ledgersDir)
+    const newIndex = new Map<string, DialogObjectId>()
+
+    for (const entry of entries) {
+      const id = filenameToDialogObjectId(entry)
+      if (!id) continue
+
+      let raw: string
+      try {
+        raw = await fs.readFile(join(this.ledgersDir, entry), 'utf-8')
+      } catch (err) {
+        console.warn(`[LedgerStore] 扫描时读取台账文件失败,跳过: ${entry}: ${(err as Error).message}`)
+        continue
+      }
+
+      let ledger: WorkerLedger
+      try {
+        ledger = JSON.parse(raw) as WorkerLedger
+      } catch (err) {
+        console.warn(`[LedgerStore] 扫描时发现损坏的台账文件(非法 JSON),跳过: ${entry}: ${(err as Error).message}`)
+        continue
+      }
+
+      for (const worker of ledger.workers ?? []) {
+        newIndex.set(worker.worker_id, id)
+      }
+    }
+
+    this.workerIndex = newIndex
+  }
+}

--- a/crabot-agent/src/workers/harness/ledger-types.ts
+++ b/crabot-agent/src/workers/harness/ledger-types.ts
@@ -1,0 +1,96 @@
+/**
+ * P3 台账类型 —— 逐字对齐 protocol-agent-v3.md §3(核心概念与标识)/ §7(台账与存储)。
+ *
+ * 复用协议已在别处落地过的类型,不重复定义:
+ * - ModuleId / FriendId / SessionId / TaskId:crabot-agent/src/types.ts(从 crabot-shared 转出)
+ * - WorkerImplId / WorkerContractState / IncarnationEndReason:src/workers/types.ts(P1/P2 已按协议定义)
+ *
+ * TaskPriority 目前既不在 crabot-shared,也不在 crabot-agent/src/types.ts 中定义,这里按
+ * base-protocol §5.9 原样声明,待上游补齐后再收敛为复用,不在本任务范围内新增导出。
+ *
+ * @see crabot-docs/protocols/protocol-agent-v3.md §3、§7
+ * @see crabot-docs/protocols/base-protocol.md §5.9、§5.10
+ */
+
+import type { ModuleId, FriendId, SessionId, TaskId } from '../../types'
+import type { WorkerImplId, WorkerContractState, IncarnationEndReason } from '../types'
+
+/** base-protocol §5.9 TaskPriority(暂无上游导出,原样声明) */
+export type TaskPriority = 'low' | 'normal' | 'high' | 'urgent'
+
+/**
+ * base-protocol §5.10 TaskStatus 的 v3 精简集(protocol-agent-v3 §5.2)。
+ * 旧值(pending/planning/executing/waiting_human/waiting_bg)已在 v3 弃用,新代码不得使用。
+ */
+export type TaskStatus =
+  | 'queued'
+  | 'running'
+  | 'waiting_input'
+  | 'completed'
+  | 'failed'
+  | 'cancelled'
+
+/** 对话对象 ID:worker 台账的聚合键(protocol-agent-v3 §3) */
+export type DialogObjectId =
+  | `friend:${FriendId}` // 私聊:按 Friend 跨 channel 聚合
+  | `group:${ModuleId}:${SessionId}` // 群聊:单群即一个对话对象
+
+/** Manager 实例键:对话历史(loop 上下文)的粒度(protocol-agent-v3 §3) */
+export type ManagerKey = `${ModuleId}::${SessionId}`
+
+/** 化身(incarnation):worker 在某一实现下的一次连续执行体(protocol-agent-v3 §3) */
+export interface Incarnation {
+  seq: number
+  impl: WorkerImplId | 'legacy'
+  state: WorkerContractState
+  workspace: string
+  /** builtin: session 树文件引用;CLI: 原生 session id;legacy: 旧 ResumeCheckpoint 引用 */
+  session_ref: string
+  tmux_session?: string
+  started_at: string
+  ended_at?: string
+  ended_reason?: IncarnationEndReason
+}
+
+/** 台账中的 worker 条目(task 数据归并于此,agent 即真相源)(protocol-agent-v3 §3) */
+export interface LedgerWorker {
+  worker_id: string
+  task: {
+    id: TaskId
+    title: string
+    status: TaskStatus // 精简状态机,见 base-protocol §5.10
+    priority?: TaskPriority
+    goal?: string
+    outcome?: string
+    created_at: string
+    completed_at?: string
+    error?: string
+  }
+  origin: {
+    spawned_by_session: ManagerKey
+    spawned_by_episode?: string // episode trace_id,可跳转
+    /** 权限身份:以谁的名义执行(权限模板解析依据) */
+    creator_friend_id?: FriendId
+    trigger_type: 'message' | 'scheduled' | 'system'
+  }
+  /** 结果回报目标,默认 = 派发 session */
+  report_to: { channel_id: ModuleId; session_id: SessionId }
+  incarnations: Incarnation[]
+  updated_at: string
+}
+
+/** 台账文件:每对话对象一份(protocol-agent-v3 §3) */
+export interface WorkerLedger {
+  dialog_object_id: DialogObjectId
+  workers: LedgerWorker[]
+}
+
+/** P3 内部辅助:私聊对话对象 ID(task-2-brief.md) */
+export function dialogObjectIdForPrivate(friendId: string): DialogObjectId {
+  return `friend:${friendId}`
+}
+
+/** P3 内部辅助:群聊对话对象 ID(task-2-brief.md) */
+export function dialogObjectIdForGroup(channelId: string, sessionId: string): DialogObjectId {
+  return `group:${channelId}:${sessionId}`
+}

--- a/crabot-agent/src/workers/harness/ledger-types.ts
+++ b/crabot-agent/src/workers/harness/ledger-types.ts
@@ -50,6 +50,9 @@ export interface Incarnation {
   started_at: string
   ended_at?: string
   ended_reason?: IncarnationEndReason
+  /** 本化身是从哪个 seq 的化身 fork 出来的一次性侧问分支;有值即表示它不在主线化身链上,
+   * 不参与 send_to_worker / kill_worker / 化身接续等主线判定(protocol-agent-v3 §3、§5.3)。 */
+  forked_from?: number
 }
 
 /** 台账中的 worker 条目(task 数据归并于此,agent 即真相源)(protocol-agent-v3 §3) */

--- a/crabot-agent/src/workers/harness/task-status.ts
+++ b/crabot-agent/src/workers/harness/task-status.ts
@@ -112,6 +112,25 @@ export function applyStatusTransition(
 }
 
 /**
+ * §5.2"接续例外"的受控出口：终态 task 经 §5.3 透明接续（revive/handoff）触发时，重新
+ * 置回 running。这是 VALID_TRANSITIONS 里终态"无出边"规则唯一允许的出边——不是给状态机
+ * 新增一条常规迁移边，只服务于接续这一显式动作，因此不经 canTransition 校验，而是显式
+ * 校验入参确为终态（非终态调用属于用错入口，常规迁移应走 applyStatusTransition，直接
+ * 抛错防止调用方把它当成通用的"强制置 running"旁路使用）。
+ *
+ * @param task 当前 task（须为终态：completed/failed/cancelled）
+ * @param opts.now 接续发生的时间戳
+ * @returns 新的 task 对象：status='running'，completed_at/error 清空
+ * @throws InvalidTaskTransitionError 若 task 当前不是终态
+ */
+export function reviveTask(task: LedgerWorker['task'], opts: { now: string }): LedgerWorker['task'] {
+  if (!isTerminalStatus(task.status)) {
+    throw new InvalidTaskTransitionError(task.status, 'running')
+  }
+  return { ...task, status: 'running', completed_at: undefined, error: undefined }
+}
+
+/**
  * 化身契约状态 → task 状态的映射。
  *
  * 规则（protocol-agent-v3 §5.2）：

--- a/crabot-agent/src/workers/harness/task-status.ts
+++ b/crabot-agent/src/workers/harness/task-status.ts
@@ -60,15 +60,18 @@ export class InvalidTaskTransitionError extends Error {
 /**
  * 应用状态转换并回填派生字段。
  *
- * 派生字段维护规则：
+ * 派生字段维护规则（task 子对象内）：
  * - completed_at：仅在转换至终态时回填为 now；其他情况清空
  * - error：仅在转换至 failed 时设置（opts.error）；其他情况清空
  * - outcome：按 opts.outcome 透传（如未指定则保持）
  *
+ * 语义边界：updated_at 是 LedgerWorker（父级）的字段，不是 task 子对象的字段。
+ * 维护职责归调用方（harness 在 upsertWorker 时设 LedgerWorker.updated_at）。
+ *
  * @param task 当前 task（来自 LedgerWorker.task）
  * @param to 目标状态
  * @param opts 可选参数：{ error?, outcome?, now }
- * @returns 新的 task 对象（不修改原 task）
+ * @returns 新的 task 对象（不修改原 task，仅回填上述派生字段）
  * @throws InvalidTaskTransitionError 若状态转换非法
  */
 export function applyStatusTransition(
@@ -83,11 +86,6 @@ export function applyStatusTransition(
   }
 
   const next: LedgerWorker['task'] = { ...task, status: to }
-
-  // 派生字段：updated_at（总是更新）
-  if (now) {
-    ;(next as any).updated_at = now
-  }
 
   // 派生字段：completed_at（仅终态回填）
   if (isTerminalStatus(to)) {

--- a/crabot-agent/src/workers/harness/task-status.ts
+++ b/crabot-agent/src/workers/harness/task-status.ts
@@ -1,0 +1,172 @@
+/**
+ * v3 task 状态机：精简状态集下的合法转换表、派生字段维护。
+ *
+ * 协议对齐：base-protocol §5.10（TaskStatus v3 精简集）、protocol-agent-v3 §5.2（化身→task 映射）。
+ * 移植参考：crabot-admin/src/task-state-machine.ts（结构参考，v3 重写）。
+ */
+
+import type { TaskStatus, LedgerWorker } from './ledger-types'
+import type { WorkerContractState, IncarnationEndReason } from '../types'
+
+/**
+ * v3 状态转换表：每个状态的出边列表。
+ * queued → running|cancelled
+ * running → waiting_input|completed|failed|cancelled
+ * waiting_input → running|completed|failed|cancelled
+ * 终态（completed/failed/cancelled） → 无出边
+ */
+export const VALID_TRANSITIONS: Readonly<Record<TaskStatus, readonly TaskStatus[]>> = {
+  queued: ['running', 'cancelled'],
+  running: ['waiting_input', 'completed', 'failed', 'cancelled'],
+  waiting_input: ['running', 'completed', 'failed', 'cancelled'],
+  completed: [],
+  failed: [],
+  cancelled: [],
+} as const
+
+const TERMINAL_STATUSES: ReadonlySet<TaskStatus> = new Set(['completed', 'failed', 'cancelled'])
+
+/**
+ * 判断状态是否为终态。
+ * 终态：completed、failed、cancelled
+ */
+export function isTerminalStatus(status: TaskStatus): boolean {
+  return TERMINAL_STATUSES.has(status)
+}
+
+/**
+ * 检查两个状态之间是否允许转换。
+ */
+export function canTransition(from: TaskStatus, to: TaskStatus): boolean {
+  return VALID_TRANSITIONS[from].includes(to)
+}
+
+/**
+ * 非法转换错误。包含 from/to 字段供调用方诊断。
+ */
+export class InvalidTaskTransitionError extends Error {
+  readonly from: TaskStatus
+  readonly to: TaskStatus
+
+  constructor(from: TaskStatus, to: TaskStatus) {
+    super(`Invalid task transition: ${from} → ${to}`)
+    this.from = from
+    this.to = to
+    this.name = 'InvalidTaskTransitionError'
+    Object.setPrototypeOf(this, InvalidTaskTransitionError.prototype)
+  }
+}
+
+/**
+ * 应用状态转换并回填派生字段。
+ *
+ * 派生字段维护规则：
+ * - completed_at：仅在转换至终态时回填为 now；其他情况清空
+ * - error：仅在转换至 failed 时设置（opts.error）；其他情况清空
+ * - outcome：按 opts.outcome 透传（如未指定则保持）
+ *
+ * @param task 当前 task（来自 LedgerWorker.task）
+ * @param to 目标状态
+ * @param opts 可选参数：{ error?, outcome?, now }
+ * @returns 新的 task 对象（不修改原 task）
+ * @throws InvalidTaskTransitionError 若状态转换非法
+ */
+export function applyStatusTransition(
+  task: LedgerWorker['task'],
+  to: TaskStatus,
+  opts?: { error?: string; outcome?: string; now: string },
+): LedgerWorker['task'] {
+  const { error, outcome, now } = opts || {}
+
+  if (!canTransition(task.status, to)) {
+    throw new InvalidTaskTransitionError(task.status, to)
+  }
+
+  const next: LedgerWorker['task'] = { ...task, status: to }
+
+  // 派生字段：updated_at（总是更新）
+  if (now) {
+    ;(next as any).updated_at = now
+  }
+
+  // 派生字段：completed_at（仅终态回填）
+  if (isTerminalStatus(to)) {
+    next.completed_at = now
+  } else {
+    next.completed_at = undefined
+  }
+
+  // 派生字段：error（仅 failed 时设置）
+  if (to === 'failed') {
+    if (error !== undefined) {
+      next.error = error
+    }
+  } else {
+    next.error = undefined
+  }
+
+  // 派生字段：outcome（按 opts 透传）
+  if (outcome !== undefined) {
+    next.outcome = outcome
+  }
+
+  return next
+}
+
+/**
+ * 化身契约状态 → task 状态的映射。
+ *
+ * 规则（protocol-agent-v3 §5.2）：
+ * - contractState=running → 'running'
+ * - contractState=idle → waitingInput ? 'waiting_input' : 'running'
+ * - contractState=exited:
+ *   - endReason=completed → 'completed'
+ *   - endReason=failed, crashed → 'failed'
+ *   - endReason=killed → 'cancelled'
+ *   - endReason=pre_migration → 'failed'
+ *   - endReason=superseded → 'running'（占位值，调用方应根据新化身决定最终状态）
+ *
+ * 特别说明：当化身被取代（superseded）时，task 生命周期应由化身链新成员决定。
+ * 本函数返回 'running' 作为占位值，调用方需读取新化身并覆盖此状态，不应单用此函数的返回值。
+ *
+ * @param contractState worker 当前合约状态
+ * @param endReason 化身终止原因（exited 状态时必须指定）
+ * @param waitingInput 是否在等待输入（idle 状态时有意义）
+ * @returns 对应的 task 状态
+ */
+export function taskStatusFromIncarnation(
+  contractState: WorkerContractState,
+  endReason?: IncarnationEndReason,
+  waitingInput?: boolean,
+): TaskStatus {
+  switch (contractState) {
+    case 'running':
+      return 'running'
+
+    case 'idle':
+      return waitingInput ? 'waiting_input' : 'running'
+
+    case 'exited':
+      switch (endReason) {
+        case 'completed':
+          return 'completed'
+        case 'failed':
+        case 'crashed':
+          return 'failed'
+        case 'killed':
+          return 'cancelled'
+        case 'pre_migration':
+          return 'failed'
+        case 'superseded':
+          // 占位值：由调用方根据新化身覆盖
+          return 'running'
+        default:
+          // 防守：如果 exited 但无 endReason，视为异常
+          return 'failed'
+      }
+
+    default:
+      // 协议应保证 contractState 是已知值，此分支不应到达
+      return 'running'
+  }
+}

--- a/crabot-agent/src/workers/harness/worker-events.ts
+++ b/crabot-agent/src/workers/harness/worker-events.ts
@@ -1,0 +1,112 @@
+/**
+ * WorkerEventLog —— worker 化身事件流:每个 workerDir 一份 events.jsonl,append-only。
+ * 读写纪律参照 src/workers/cli-events.ts:坏行跳过不抛,半行(尚无换行符终结,写入未完成)
+ * 不消费,留到下次补全后再读。当前是每次全量读(P3 规模足够);若将来量大需要增量读,
+ * 再加 cursor 支持。
+ *
+ * harvestNativeSession 是化身终结时的收尾动作:把 adapter 侧的原生 session 文件(如
+ * claude code / codex 自己维护的会话文件)尽力复制进 <workerDir>/native-session/<seq>/,
+ * 单个源文件缺失或读取失败只 warn,不影响其它源文件的收割,也不让收割动作本身抛出。
+ */
+
+import { promises as fs } from 'fs'
+import { join, basename } from 'path'
+import { AsyncMutex } from '../async-mutex'
+
+export type HarnessEventKind =
+  | 'spawned'
+  | 'input_sent'
+  | 'input_held'
+  | 'state_changed'
+  | 'exited'
+  | 'killed'
+  | 'superseded'
+  | 'handoff_started'
+  | 'resumed'
+
+export interface HarnessEvent {
+  readonly ts: string
+  readonly kind: HarnessEventKind
+  readonly worker_id: string
+  readonly seq: number
+  readonly detail?: Record<string, unknown>
+}
+
+function parseLine(line: string): HarnessEvent | null {
+  const trimmed = line.trim()
+  if (!trimmed) return null
+  try {
+    const parsed = JSON.parse(trimmed)
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      typeof parsed.ts === 'string' &&
+      typeof parsed.kind === 'string' &&
+      typeof parsed.worker_id === 'string' &&
+      typeof parsed.seq === 'number'
+    ) {
+      const event: HarnessEvent = {
+        ts: parsed.ts,
+        kind: parsed.kind,
+        worker_id: parsed.worker_id,
+        seq: parsed.seq,
+      }
+      return 'detail' in parsed ? { ...event, detail: parsed.detail } : event
+    }
+    return null
+  } catch {
+    return null // 坏行:跳过,不中断
+  }
+}
+
+export class WorkerEventLog {
+  private readonly filePath: string
+  private readonly mutex = new AsyncMutex()
+
+  constructor(private readonly workerDir: string) {
+    this.filePath = join(workerDir, 'events.jsonl')
+  }
+
+  /** 缺省 ts 由调用方注入的 now 提供;未提供时用当前时间兜底(仅作最后手段,优先由调用方注入以保证测试确定性) */
+  async append(e: Omit<HarnessEvent, 'ts'> & { ts?: string }): Promise<void> {
+    const event: HarnessEvent = { ...e, ts: e.ts ?? new Date().toISOString() }
+    const line = JSON.stringify(event) + '\n'
+    return this.mutex.run(async () => {
+      await fs.mkdir(this.workerDir, { recursive: true })
+      await fs.appendFile(this.filePath, line, 'utf-8')
+    })
+  }
+
+  async readAll(): Promise<HarnessEvent[]> {
+    let text: string
+    try {
+      text = await fs.readFile(this.filePath, 'utf-8')
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return []
+      throw error
+    }
+    const events: HarnessEvent[] = []
+    for (const line of text.split('\n')) {
+      const event = parseLine(line)
+      if (event) events.push(event)
+    }
+    return events
+  }
+}
+
+/** 化身终结时把 adapter 的原生 session 文件收割进 <workerDir>/native-session/<seq>/,失败仅记不抛 */
+export async function harvestNativeSession(
+  workerDir: string,
+  seq: number,
+  sourcePaths: readonly string[]
+): Promise<void> {
+  const targetDir = join(workerDir, 'native-session', String(seq))
+  for (const sourcePath of sourcePaths) {
+    try {
+      await fs.mkdir(targetDir, { recursive: true })
+      await fs.copyFile(sourcePath, join(targetDir, basename(sourcePath)))
+    } catch (error) {
+      console.warn(`[harvestNativeSession] 收割原生 session 文件失败,跳过: ${sourcePath}: ${(error as Error).message}`)
+    }
+  }
+}

--- a/crabot-agent/src/workers/harness/workspace-manager.ts
+++ b/crabot-agent/src/workers/harness/workspace-manager.ts
@@ -1,0 +1,99 @@
+import path from 'node:path'
+import { promises as fs } from 'node:fs'
+import { getWorkspacesRootDir } from '../../core/data-paths.js'
+import { InvalidWorkspaceError } from '../errors.js'
+import type { Workspace } from '../types.js'
+
+export { InvalidWorkspaceError }
+
+export class WorkspaceManager {
+  private root: string
+
+  constructor(root?: string) {
+    this.root = root ?? getWorkspacesRootDir()
+  }
+
+  /**
+   * 解析和验证 workspace。
+   *
+   * @param taskId 当前 task 的 ID（用于防串台检查）
+   * @param requested workspace 路径。如果未指定，则自动创建 <root>/<taskId>
+   * @returns 验证后的 Workspace
+   * @throws InvalidWorkspaceError 验证失败时
+   */
+  async resolve(taskId: string, requested?: string): Promise<Workspace> {
+    if (requested === undefined) {
+      // 缺省：创建 <root>/<taskId> 并返回
+      const defaultPath = path.resolve(this.root, taskId)
+      await fs.mkdir(defaultPath, { recursive: true })
+      return { root: defaultPath }
+    }
+
+    // 验证 requested 路径
+    return this._validateAndResolve(taskId, requested)
+  }
+
+  private async _validateAndResolve(taskId: string, requested: string): Promise<Workspace> {
+    // 检查 null byte
+    if (requested.includes('\0')) {
+      throw new InvalidWorkspaceError('path contains null byte')
+    }
+
+    // 检查是否为绝对路径
+    if (!path.isAbsolute(requested)) {
+      throw new InvalidWorkspaceError(`path must be absolute, got: ${requested}`)
+    }
+
+    // 检查路径是否存在且是目录
+    let stat
+    try {
+      stat = await fs.stat(requested)
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        throw new InvalidWorkspaceError(`path does not exist: ${requested}`)
+      }
+      throw new InvalidWorkspaceError(`failed to stat path: ${(err as Error).message}`)
+    }
+
+    if (!stat.isDirectory()) {
+      throw new InvalidWorkspaceError(`path is not a directory: ${requested}`)
+    }
+
+    // 防串台检查：确保不落在其他 taskId 的目录内
+    this._checkTaskIdBoundary(taskId, requested)
+
+    return { root: requested }
+  }
+
+  /**
+   * 检查 requested 路径是否违反 task 边界。
+   * 允许：<root>/<taskId> 及其子目录
+   * 拒绝：<root>/<其他 taskId> 及其子目录
+   */
+  private _checkTaskIdBoundary(taskId: string, requestedPath: string): void {
+    const resolved = path.resolve(requestedPath)
+    const rootResolved = path.resolve(this.root)
+
+    // 检查是否在 <root> 内
+    const relative = path.relative(rootResolved, resolved)
+    if (relative.startsWith('..')) {
+      // 在 root 外面，允许
+      return
+    }
+
+    // 在 root 内，检查是否属于当前 taskId
+    const pathParts = relative.split(path.sep).filter((p) => p.length > 0)
+    if (pathParts.length === 0) {
+      // 路径指向 root 本身，拒绝
+      throw new InvalidWorkspaceError(`path must not be the workspaces root: ${requestedPath}`)
+    }
+
+    const topLevelTaskId = pathParts[0]
+    if (topLevelTaskId !== taskId) {
+      // 指向其他 taskId 的目录
+      throw new InvalidWorkspaceError(
+        `path must not reference other task workspace (expected under ${taskId}, got ${topLevelTaskId}): ${requestedPath}`
+      )
+    }
+  }
+}

--- a/crabot-agent/src/workers/harness/workspace-manager.ts
+++ b/crabot-agent/src/workers/harness/workspace-manager.ts
@@ -1,10 +1,17 @@
 import path from 'node:path'
 import { promises as fs } from 'node:fs'
 import { getWorkspacesRootDir } from '../../core/data-paths.js'
-import { InvalidWorkspaceError } from '../errors.js'
 import type { Workspace } from '../types.js'
 
-export { InvalidWorkspaceError }
+/** Raised when workspace validation fails. */
+export class InvalidWorkspaceError extends Error {
+  constructor(
+    readonly reason: string,
+  ) {
+    super(`invalid workspace: ${reason}`)
+    this.name = 'InvalidWorkspaceError'
+  }
+}
 
 export class WorkspaceManager {
   private root: string
@@ -44,10 +51,10 @@ export class WorkspaceManager {
       throw new InvalidWorkspaceError(`path must be absolute, got: ${requested}`)
     }
 
-    // 检查路径是否存在且是目录
-    let stat
+    // 检查路径是否存在，并解析出真实路径（消解符号链接，防止软链绕过边界校验）
+    let realRequested: string
     try {
-      stat = await fs.stat(requested)
+      realRequested = await fs.realpath(requested)
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
         throw new InvalidWorkspaceError(`path does not exist: ${requested}`)
@@ -55,27 +62,48 @@ export class WorkspaceManager {
       throw new InvalidWorkspaceError(`failed to stat path: ${(err as Error).message}`)
     }
 
+    // 检查是否是目录（基于真实路径，与边界判断保持一致）
+    let stat
+    try {
+      stat = await fs.stat(realRequested)
+    } catch (err) {
+      throw new InvalidWorkspaceError(`failed to stat path: ${(err as Error).message}`)
+    }
+
     if (!stat.isDirectory()) {
       throw new InvalidWorkspaceError(`path is not a directory: ${requested}`)
     }
 
-    // 防串台检查：确保不落在其他 taskId 的目录内
-    this._checkTaskIdBoundary(taskId, requested)
+    // 防串台检查：确保不落在其他 taskId 的目录内（基于真实路径，防止软链绕过）
+    await this._checkTaskIdBoundary(taskId, realRequested, requested)
 
-    return { root: requested }
+    return { root: realRequested }
   }
 
   /**
    * 检查 requested 路径是否违反 task 边界。
    * 允许：<root>/<taskId> 及其子目录
    * 拒绝：<root>/<其他 taskId> 及其子目录
+   *
+   * @param realRequestedPath 已经过 fs.realpath 解析的真实路径
+   * @param originalRequested 原始请求路径（仅用于错误信息展示）
    */
-  private _checkTaskIdBoundary(taskId: string, requestedPath: string): void {
-    const resolved = path.resolve(requestedPath)
-    const rootResolved = path.resolve(this.root)
+  private async _checkTaskIdBoundary(
+    taskId: string,
+    realRequestedPath: string,
+    originalRequested: string,
+  ): Promise<void> {
+    // root 本身也可能是符号链接（如 macOS /tmp），两侧都需 realpath 后再比较，
+    // 否则会产生假阳性（合法路径被误拒）。root 尚不存在时退化为字符串规范化。
+    let realRoot: string
+    try {
+      realRoot = await fs.realpath(this.root)
+    } catch {
+      realRoot = path.resolve(this.root)
+    }
 
     // 检查是否在 <root> 内
-    const relative = path.relative(rootResolved, resolved)
+    const relative = path.relative(realRoot, realRequestedPath)
     if (relative.startsWith('..')) {
       // 在 root 外面，允许
       return
@@ -85,14 +113,14 @@ export class WorkspaceManager {
     const pathParts = relative.split(path.sep).filter((p) => p.length > 0)
     if (pathParts.length === 0) {
       // 路径指向 root 本身，拒绝
-      throw new InvalidWorkspaceError(`path must not be the workspaces root: ${requestedPath}`)
+      throw new InvalidWorkspaceError(`path must not be the workspaces root: ${originalRequested}`)
     }
 
     const topLevelTaskId = pathParts[0]
     if (topLevelTaskId !== taskId) {
       // 指向其他 taskId 的目录
       throw new InvalidWorkspaceError(
-        `path must not reference other task workspace (expected under ${taskId}, got ${topLevelTaskId}): ${requestedPath}`
+        `path must not reference other task workspace (expected under ${taskId}, got ${topLevelTaskId}): ${originalRequested}`
       )
     }
   }

--- a/crabot-agent/src/workers/meta-store.ts
+++ b/crabot-agent/src/workers/meta-store.ts
@@ -13,3 +13,27 @@ export async function writeMetaAtomic(dir: string, seq: number, meta: unknown): 
   await fs.writeFile(tmpPath, JSON.stringify(meta), 'utf-8')
   await fs.rename(tmpPath, metaPath)
 }
+
+/**
+ * 扫 dir 下 meta-<seq>.json 文件名,返回其中最大的 seq(没有任何 meta 文件、或 dir 本身不
+ * 存在,都返回 0)。供 nextSeq() 做磁盘感知——五轮 review 修复:重启后新 adapter 实例的
+ * 内存态(runtimes/instances)只含按需重建过的化身,不是该 worker 的全部历史,nextSeq 只看
+ * 内存会把磁盘上未被重建的旧化身的号位当成"下一个"分配出去,静默覆盖其 meta/output。
+ * 坏文件名(不匹配 meta-<数字>.json)一律跳过,不视为错误。
+ */
+export async function maxSeqOnDisk(dir: string): Promise<number> {
+  let entries: string[]
+  try {
+    entries = await fs.readdir(dir)
+  } catch {
+    return 0
+  }
+  let max = 0
+  for (const name of entries) {
+    const m = /^meta-(\d+)\.json$/.exec(name)
+    if (!m) continue
+    const seq = Number(m[1])
+    if (Number.isFinite(seq) && seq > max) max = seq
+  }
+  return max
+}

--- a/crabot-agent/src/workers/types.ts
+++ b/crabot-agent/src/workers/types.ts
@@ -42,6 +42,10 @@ export interface IncarnationHandle {
   readonly worker_id: string
   readonly seq: number
   readonly impl: WorkerImplId
+  /** 本化身自己的会话引用,创建时(spawn/resume/fork 返回前)即由 adapter 填入真值——
+   * builtin: 本化身当前 tip node_id;CLI: 原生 session id(resume 沿用 prev 不变;fork 化身
+   * 填 fork 自己的引用,不是父化身的)。handle 自描述,调用方无需事后反查(protocol-agent-v3 §6.1)。 */
+  readonly session_ref: string
 }
 export interface IncarnationRef {
   readonly worker_id: string

--- a/crabot-agent/tests/workers/builtin-adapter.test.ts
+++ b/crabot-agent/tests/workers/builtin-adapter.test.ts
@@ -183,6 +183,16 @@ describe('BuiltinWorkerAdapter', () => {
     })
 
     const h = await adapter.spawn(s)
+
+    // IncarnationHandle.session_ref 由 adapter 在 spawn 返回前即填入真值(protocol-agent-v3
+    // §6.1),builtin 的真值是本化身创建那一刻的 tip node_id——与彼时磁盘 meta 记录一致。
+    // 必须在 burst(fire-and-forget)推进 tip 之前读,burst 结束后 tip 会前进到会话末尾,
+    // 不再等于 handle 创建时刻的快照(这本身是符合预期的:handle.session_ref 是创建时的
+    // 引用,不是持续跟随的实时游标)。
+    expect(h.session_ref).toBeTruthy()
+    const metaAtSpawn = JSON.parse(await fs.readFile(join(tmp, h.worker_id, 'meta-1.json'), 'utf-8'))
+    expect(h.session_ref).toBe(metaAtSpawn.tip_node_id)
+
     await waitState(adapter, h, 'idle')
 
     const { chunk } = await adapter.readOutput(h, { offset: 0 })
@@ -343,6 +353,15 @@ describe('BuiltinWorkerAdapter', () => {
 
     const h2 = await adapter.resume(prevRef, '我回来了')
     expect(h2.seq).toBe(2)
+
+    // h2.session_ref 是 resume 返回时刻新化身自己的引用，与彼时磁盘 meta-2.json 记录一致，
+    // 且不是 prevRef 那个已经结束的旧化身的引用（protocol-agent-v3 §6.1）。必须在续 burst
+    // （fire-and-forget）推进 tip 之前读，理由同 spawn 测试里的同款断言。
+    expect(h2.session_ref).toBeTruthy()
+    const meta2AtResume = JSON.parse(await fs.readFile(join(tmp, s.worker_id, 'meta-2.json'), 'utf-8'))
+    expect(h2.session_ref).toBe(meta2AtResume.tip_node_id)
+    expect(h2.session_ref).not.toBe(prevRef.session_ref)
+
     await waitState(adapter, h2, 'idle')
 
     const tree = await SessionTree.load(join(tmp, s.worker_id, 'session.jsonl'))
@@ -385,6 +404,15 @@ describe('BuiltinWorkerAdapter', () => {
     const prevRef: IncarnationRef = { worker_id: s.worker_id, seq: 1, session_ref: mainTip! }
     const forkHandle = await adapter.fork(prevRef, '侧问问题')
     expect(forkHandle.seq).toBe(2)
+
+    // forkHandle.session_ref 是 fork 自己的引用(fork 分支节点自己的 tip node_id)，不是主线
+    // mainTip 的照抄(protocol-agent-v3 §6.1:"fork 化身填 fork 自己的引用，不是父化身的")。
+    // 必须在 gate.resolve() 放行 fork 的 burst、推进 fork 自己的 tip 之前读，理由同
+    // spawn/resume 测试里的同款断言。
+    expect(forkHandle.session_ref).toBeTruthy()
+    expect(forkHandle.session_ref).not.toBe(mainTip)
+    const forkMetaAtFork = JSON.parse(await fs.readFile(join(tmp, s.worker_id, 'meta-2.json'), 'utf-8'))
+    expect(forkHandle.session_ref).toBe(forkMetaAtFork.tip_node_id)
 
     // fork 的 burst 还卡在 gate 里没跑完：此时主线状态/tip 必须完全不受影响。注意：不能
     // 用 SessionTree.load(...).latestTip() 判断——那是整个共享文件"最后一次 append"的
@@ -977,7 +1005,7 @@ describe('BuiltinWorkerAdapter', () => {
 
       const orphans = await BuiltinWorkerAdapter.scanOrphans(tmp)
 
-      expect(orphans).toEqual([{ worker_id: 'worker-running', seq: 1, impl: 'builtin' }])
+      expect(orphans).toEqual([{ worker_id: 'worker-running', seq: 1, impl: 'builtin', session_ref: 'node-1' }])
 
       const runningMeta = JSON.parse(await fs.readFile(join(runningDir, 'meta-1.json'), 'utf-8'))
       expect(runningMeta.state).toBe('exited')

--- a/crabot-agent/tests/workers/builtin-adapter.test.ts
+++ b/crabot-agent/tests/workers/builtin-adapter.test.ts
@@ -531,6 +531,68 @@ describe('BuiltinWorkerAdapter', () => {
     await waitState(adapter, resumedHandle, 'idle')
   })
 
+  it('五轮 review PoC：resume 时 nextSeq 必须磁盘感知，不能只看内存 instances（重建/常驻不全时会与磁盘上未重建的化身撞号，覆盖其 meta/output）', async () => {
+    // builtin 的 resume/fork 目前要求 worker_id 在 builtinConfigs 里“本进程 spawn 过”
+    // （见 resume()/fork() 顶部的 fail-fast 守卫），跨进程重启后这个守卫本身就会先于
+    // nextSeq 拒绝调用——不像 cc/codex 那样能在重启后经 ensureRuntime 走到 nextSeq。
+    // 但 nextSeq 只扫 this.instances（内存）这件事本身就是 bug：只要该 worker 有一个化身
+    // 不在 instances 里（不管是因为跨进程重启、还是内存表未完整重建），nextSeq 就会漏看
+    // 磁盘上它的号位。这里不模拟完整重启，而是直接删掉 fork 化身（#2）在内存 instances
+    // 里的条目——精确复现"内存不知道 #2 存在，但磁盘上 meta-2.json/output-2.log 都在"
+    // 这个 nextSeq 唯一关心的前提条件，同时保留 builtinConfigs/#1 条目以满足与本次修复
+    // 无关的既有守卫。
+    const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+    const s = spec({
+      adapter: makeAdapter([
+        { text: '首轮回复', stopReason: 'end_turn' },
+        { text: '侧问回复', stopReason: 'end_turn' },
+        { toolCalls: [{ name: 'finish_task', id: 'call_1', input: { outcome: 'completed', summary: '主线完成' } }], stopReason: 'tool_use' },
+        { text: '重启后继续', stopReason: 'end_turn' },
+      ]),
+    })
+
+    const h = await adapter.spawn(s)
+    await waitState(adapter, h, 'idle')
+
+    const tree1 = await SessionTree.load(join(tmp, s.worker_id, 'session.jsonl'))
+    const mainTip = tree1.latestTip()!
+    const forkRef: IncarnationRef = { worker_id: s.worker_id, seq: 1, session_ref: mainTip }
+    const forkHandle = await adapter.fork(forkRef, '侧问问题')
+    expect(forkHandle.seq).toBe(2)
+    await waitState(adapter, forkHandle, 'exited')
+
+    // 主线继续跑到 finish_task → exited，满足 resume 的前置条件。
+    await adapter.sendInput(h, '继续')
+    await waitState(adapter, h, 'exited')
+
+    const meta2Before = await fs.readFile(join(tmp, s.worker_id, 'meta-2.json'), 'utf-8')
+    const output2Before = await fs.readFile(join(tmp, s.worker_id, 'output-2.log'), 'utf-8')
+
+    const mainMetaRaw = await fs.readFile(join(tmp, s.worker_id, 'meta-1.json'), 'utf-8')
+    const mainMeta = JSON.parse(mainMetaRaw) as { tip_node_id: string }
+    const resumeRef: IncarnationRef = { worker_id: s.worker_id, seq: 1, session_ref: mainMeta.tip_node_id }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const adapterAny = adapter as any
+    expect((adapterAny.instances as Map<string, unknown>).has(`${s.worker_id}#2`)).toBe(true)
+    ;(adapterAny.instances as Map<string, unknown>).delete(`${s.worker_id}#2`)
+
+    // 旧版 nextSeq 只扫内存 instances：此时只剩 #1，算出 2——与磁盘上 #2 的号位撞上，
+    // resume 会用 writeMeta(dir, 2, ...) 覆盖 meta-2.json，新化身的 outputLog 也指向
+    // 复用中的 output-2.log。
+    const resumedHandle = await adapter.resume(resumeRef, '我回来了')
+    await waitState(adapter, resumedHandle, 'idle')
+
+    // 磁盘感知修复后：新化身分配到 3（不是 2），不撞上 #2 的号位。
+    expect(resumedHandle.seq).toBe(3)
+
+    // #2 的 meta/output 原封不动，没有被 resume 静默覆盖/复用。
+    const meta2After = await fs.readFile(join(tmp, s.worker_id, 'meta-2.json'), 'utf-8')
+    const output2After = await fs.readFile(join(tmp, s.worker_id, 'output-2.log'), 'utf-8')
+    expect(meta2After).toBe(meta2Before.toString())
+    expect(output2After).toBe(output2Before.toString())
+  })
+
   it('kill running fork 化身：fork burst 的 abortSignal 被触发，终态 exited(killed) 而不是 crashed', async () => {
     const runEngineSpy = vi.spyOn(engineModule, 'runEngine')
     const gate = deferred<void>()

--- a/crabot-agent/tests/workers/claude-code-adapter.test.ts
+++ b/crabot-agent/tests/workers/claude-code-adapter.test.ts
@@ -255,6 +255,105 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter (tmux + mock CLI)', () => {
   )
 })
 
+describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — 四轮 review PoC 回归:重启后新 adapter 实例(runtimes 为空)重连 tmux 会话(ensureRuntime)', () => {
+  let dataDir: string
+  let workspaceRoot: string
+  let tmux: TmuxDriver
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'cc-adapter-reattach-data-'))
+    workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'cc-adapter-reattach-ws-'))
+    tmux = new TmuxDriver()
+  })
+
+  afterEach(async () => {
+    await cleanupTmuxSessions()
+    await fs.rm(dataDir, { recursive: true, force: true }).catch(() => {})
+    await fs.rm(workspaceRoot, { recursive: true, force: true }).catch(() => {})
+  })
+
+  async function waitForOutputContains(adapter: ClaudeCodeAdapter, h: IncarnationHandle, needle: string, timeoutMs = 8000): Promise<void> {
+    const deadline = Date.now() + timeoutMs
+    while (Date.now() < deadline) {
+      const { chunk } = await adapter.readOutput(h, { offset: 0 })
+      if (chunk.includes(needle)) return
+      await new Promise((r) => setTimeout(r, 100))
+    }
+    throw new Error(`waitForOutputContains timeout: expected output to contain '${needle}'`)
+  }
+
+  it(
+    'PoC①:会话仍存活——新 adapter 实例的 sendInput/kill 应真正作用于该会话(修复前:sendInput 直接抛通用 Error "no such incarnation...resident in this process")',
+    async () => {
+      const channel = new CliEventChannel(eventsFilePath({ root: workspaceRoot }))
+      const stopHookCmd = channel.hookCommand('stop')
+      // 两步都不 exit/emitStop——mock CLI 消费完第一步后挂起原地等下一条 stdin,tmux 会话
+      // 因此持续存活,直到显式 kill,给"重连一个仍存活的会话"提供稳定的时间窗口。
+      const claudeBin = claudeBinFor([{ output: '第一段输出' }, { output: '第二段输出' }], stopHookCmd)
+
+      const adapterA = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin })
+      await adapterA.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
+      const workerId = `cctest-${randomUUID().slice(0, 8)}`
+      const h = await adapterA.spawn({ worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } })
+
+      await waitForOutputContains(adapterA, h, '第一段输出')
+
+      // "重启":全新 adapter 实例,同一 dataDir,内存 runtimes 为空,从未见过这个化身。
+      const adapterB = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin: 'unused-not-invoked-by-sendInput' })
+
+      // 修复前这里直接抛通用 Error;修复后 ensureRuntime 从落盘 meta(含本轮新增的
+      // workspace_root)+ 真实 tmux isAlive 探测重建出可操作的 runtime。
+      await expect(adapterB.sendInput(h, '继续')).resolves.toBeUndefined()
+
+      // sendInput 真正送达存活会话:mock CLI 消费下一步,写出第二段输出。
+      await waitForOutputContains(adapterB, h, '第二段输出')
+
+      // kill 同样应该真正终止这个会话,不是抛错。
+      await expect(adapterB.kill(h)).resolves.toBeUndefined()
+      await waitForState(adapterB, h, 'exited')
+
+      const metaRaw = await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8')
+      const meta = JSON.parse(metaRaw) as { ended_reason?: string }
+      expect(meta.ended_reason).toBe('killed')
+    },
+    15000,
+  )
+
+  it(
+    'PoC②:会话已经死掉(外部 kill,未经 adapter.kill)——新 adapter 实例的 sendInput 应抛 WorkerExitedError,不是通用 Error(harness 靠这个类型判断才会转透明接续)',
+    async () => {
+      const channel = new CliEventChannel(eventsFilePath({ root: workspaceRoot }))
+      const stopHookCmd = channel.hookCommand('stop')
+      const claudeBin = claudeBinFor([{ output: '第一段输出' }], stopHookCmd)
+
+      const adapterA = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin })
+      await adapterA.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
+      const workerId = `cctest-${randomUUID().slice(0, 8)}`
+      const h = await adapterA.spawn({ worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } })
+
+      await waitForOutputContains(adapterA, h, '第一段输出')
+
+      // 绕开 adapter.kill,直接杀死 tmux 会话——模拟"agent 进程重启前,这个 worker 的 tmux
+      // 会话已经先一步真死(崩溃/被系统 OOM kill 等)",没有任何机制把这件事记进 meta。
+      execFileSync('tmux', ['kill-session', '-t', `crabot-w-${workerId}-1`], { stdio: 'ignore' })
+
+      // "重启":全新 adapter 实例,同一 dataDir,内存 runtimes 为空。
+      const adapterB = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin: 'unused-not-invoked-by-sendInput' })
+
+      // 修复前:sendInput 直接抛通用 Error("no such incarnation...resident in this
+      // process")——harness 只对 WorkerExitedError 转透明接续,通用 Error 会原样穿透砸给
+      // 调用方,消息永久卡在队首。修复后:ensureRuntime 重建出 runtime(meta 还在),真实
+      // tmux isAlive 探测发现会话已死 → runtime.state 直接是 'exited' → 既有的 syncState
+      // 快路径产出 WorkerExitedError。
+      await expect(adapterB.sendInput(h, '还有件事')).rejects.toBeInstanceOf(WorkerExitedError)
+
+      // kill 对已经不存在的会话应幂等成功,不抛错。
+      await expect(adapterB.kill(h)).resolves.toBeUndefined()
+    },
+    15000,
+  )
+})
+
 /** isAlive 可手动挂起/放行的假 TmuxDriver——不起真实 tmux 进程,专供锁纪律竞态测试控制时序。 */
 class RaceTmux extends TmuxDriver {
   private pending: Array<(v: boolean) => void> = []

--- a/crabot-agent/tests/workers/claude-code-adapter.test.ts
+++ b/crabot-agent/tests/workers/claude-code-adapter.test.ts
@@ -352,6 +352,53 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — 四轮 review PoC 回归:
     },
     15000,
   )
+
+  it(
+    'PoC③(五轮 review):重启前有主线#1 + fork侧问#2(两份 meta 落盘)——重启后新 adapter 实例对#1 resume,nextSeq 必须磁盘感知,' +
+      '不能只看内存(只重建了#1)算出 2 而撞上#2 的 meta/output(修复前:seq=2,meta-2.json 被覆盖,output-2.log 被复用)',
+    async () => {
+      const argvFile = path.join(dataDir, 'poc3-fork-argv.jsonl')
+      const claudeBin = `env FAKE_ARGV_FILE=${shQuote(argvFile)} FAKE_FORK_STDOUT=${shQuote('侧问回复内容')} node ${shQuote(FAKE_CLAUDE_FORK)}`
+
+      const adapterA = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin })
+      await adapterA.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
+      const workerId = `cctest-${randomUUID().slice(0, 8)}`
+
+      // 重启前:主线 #1(交互态,fake-claude-fork.mjs 无 -p 时空转不退出)。
+      const h1 = await adapterA.spawn({ worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } })
+      const meta1 = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8')) as { session_id: string }
+
+      // 重启前:fork 侧问 #2(无头一击,落自己的 meta-2.json/output-2.log)。
+      const h2 = await adapterA.fork({ worker_id: workerId, seq: 1, session_ref: meta1.session_id }, '侧问一下')
+      expect(h2.seq).toBe(2)
+      await waitForState(adapterA, h2, 'exited')
+      const meta2Before = await fs.readFile(path.join(dataDir, workerId, 'meta-2.json'), 'utf-8')
+      const output2Before = await fs.readFile(path.join(dataDir, workerId, 'output-2.log'), 'utf-8')
+      expect(output2Before).toContain('侧问回复内容')
+
+      // 重启前:主线 #1 落 exited,满足 resume 前置条件。
+      await adapterA.kill(h1)
+
+      // "重启":全新 adapter 实例,同一 dataDir,内存 runtimes 为空——只有磁盘还记得 #1、#2
+      // 两份历史。resume(#1) 会先经 ensureRuntime 只重建出 #1 这一条 runtime(#2 从未被
+      // 提及,不会被重建),旧版 nextSeq 只扫内存 runtimes(此时仅 #1)算出 2,与磁盘上的
+      // #2 撞号。
+      const adapterB = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin })
+      const h3 = await adapterB.resume({ worker_id: workerId, seq: 1, session_ref: meta1.session_id }, '继续')
+
+      // 磁盘感知修复后:新化身分配到 3(不是 2),不撞上 #2 的号位。
+      expect(h3.seq).toBe(3)
+
+      // #2 的 meta/output 原封不动,没有被 resume 静默覆盖/复用。
+      const meta2After = await fs.readFile(path.join(dataDir, workerId, 'meta-2.json'), 'utf-8')
+      const output2After = await fs.readFile(path.join(dataDir, workerId, 'output-2.log'), 'utf-8')
+      expect(meta2After).toBe(meta2Before.toString())
+      expect(output2After).toBe(output2Before.toString())
+
+      await adapterB.kill(h3)
+    },
+    15000,
+  )
 })
 
 /** isAlive 可手动挂起/放行的假 TmuxDriver——不起真实 tmux 进程,专供锁纪律竞态测试控制时序。 */

--- a/crabot-agent/tests/workers/codex-adapter.test.ts
+++ b/crabot-agent/tests/workers/codex-adapter.test.ts
@@ -391,6 +391,89 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter (tmux + mock CLI)', () => {
   )
 })
 
+describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter — 四轮 review PoC 回归:重启后新 adapter 实例(runtimes 为空)重连 tmux 会话(ensureRuntime)', () => {
+  let dataDir: string
+  let workspaceRoot: string
+  let tmux: TmuxDriver
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-adapter-reattach-data-'))
+    workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-adapter-reattach-ws-'))
+    tmux = new TmuxDriver()
+  })
+
+  afterEach(async () => {
+    await cleanupTmuxSessions()
+    await fs.rm(dataDir, { recursive: true, force: true }).catch(() => {})
+    await fs.rm(workspaceRoot, { recursive: true, force: true }).catch(() => {})
+  })
+
+  async function waitForOutputContains(adapter: CodexWorkerAdapter, h: IncarnationHandle, needle: string, timeoutMs = 8000): Promise<void> {
+    const deadline = Date.now() + timeoutMs
+    while (Date.now() < deadline) {
+      const { chunk } = await adapter.readOutput(h, { offset: 0 })
+      if (chunk.includes(needle)) return
+      await new Promise((r) => setTimeout(r, 100))
+    }
+    throw new Error(`waitForOutputContains timeout: expected output to contain '${needle}'`)
+  }
+
+  it(
+    'PoC①:会话仍存活——新 adapter 实例的 sendInput/kill 应真正作用于该会话(修复前:sendInput 直接抛通用 Error "no such incarnation...resident in this process")',
+    async () => {
+      const channel = new CliEventChannel(eventsFilePath({ root: workspaceRoot }))
+      const stopHookCmd = channel.hookCommand('stop')
+      const codexBin = codexBinFor([{ output: '第一段输出' }, { output: '第二段输出' }], stopHookCmd)
+
+      const adapterA = new CodexWorkerAdapter({ dataDir, tmux, codexBin, sessionDiscoveryTimeoutMs: 500 })
+      await adapterA.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
+      const workerId = `codextest-${randomUUID().slice(0, 8)}`
+      const h = await adapterA.spawn({ worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } })
+
+      await waitForOutputContains(adapterA, h, '第一段输出')
+
+      // "重启":全新 adapter 实例,同一 dataDir,内存 runtimes 为空,从未见过这个化身。
+      const adapterB = new CodexWorkerAdapter({ dataDir, tmux, codexBin: 'unused-not-invoked-by-sendInput' })
+
+      await expect(adapterB.sendInput(h, '继续')).resolves.toBeUndefined()
+      await waitForOutputContains(adapterB, h, '第二段输出')
+
+      await expect(adapterB.kill(h)).resolves.toBeUndefined()
+      await waitForState(adapterB, h, 'exited')
+
+      const metaRaw = await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8')
+      const meta = JSON.parse(metaRaw) as { ended_reason?: string }
+      expect(meta.ended_reason).toBe('killed')
+    },
+    15000,
+  )
+
+  it(
+    'PoC②:会话已经死掉(外部 kill,未经 adapter.kill)——新 adapter 实例的 sendInput 应抛 WorkerExitedError,不是通用 Error',
+    async () => {
+      const channel = new CliEventChannel(eventsFilePath({ root: workspaceRoot }))
+      const stopHookCmd = channel.hookCommand('stop')
+      const codexBin = codexBinFor([{ output: '第一段输出' }], stopHookCmd)
+
+      const adapterA = new CodexWorkerAdapter({ dataDir, tmux, codexBin, sessionDiscoveryTimeoutMs: 500 })
+      await adapterA.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
+      const workerId = `codextest-${randomUUID().slice(0, 8)}`
+      const h = await adapterA.spawn({ worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } })
+
+      await waitForOutputContains(adapterA, h, '第一段输出')
+
+      // 绕开 adapter.kill,直接杀死 tmux 会话,模拟"agent 进程重启前已经先一步真死"。
+      execFileSync('tmux', ['kill-session', '-t', `crabot-w-${workerId}-1`], { stdio: 'ignore' })
+
+      const adapterB = new CodexWorkerAdapter({ dataDir, tmux, codexBin: 'unused-not-invoked-by-sendInput' })
+
+      await expect(adapterB.sendInput(h, '还有件事')).rejects.toBeInstanceOf(WorkerExitedError)
+      await expect(adapterB.kill(h)).resolves.toBeUndefined()
+    },
+    15000,
+  )
+})
+
 /** 转发到可替换的底层 TmuxDriver——用于"先用坏 bin 失败一次,再换成好 bin 重试"的测试场景。 */
 class SwitchableTmuxDriver extends TmuxDriver {
   current: TmuxDriver

--- a/crabot-agent/tests/workers/codex-adapter.test.ts
+++ b/crabot-agent/tests/workers/codex-adapter.test.ts
@@ -472,6 +472,53 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter — 四轮 review PoC 回归
     },
     15000,
   )
+
+  it(
+    'PoC③(五轮 review):重启前有主线#1 与 resume 链 #2(两份 meta 落盘)——重启后新 adapter 实例再对#1 resume,' +
+      'nextSeq 必须磁盘感知,不能只看内存(只重建了#1)算出 2 而撞上#2 的 meta/output(修复前:seq=2,meta-2.json 被覆盖,output-2.log 被复用)',
+    async () => {
+      const channel = new CliEventChannel(eventsFilePath({ root: workspaceRoot }))
+      const stopHookCmd = channel.hookCommand('stop')
+      // 每次新起的进程(spawn/resume)都从脚本第 0 步重新跑——mock CLI 每次调用都是全新进程,
+      // 不记跨调用状态。这里让脚本第一步就 exit,主线与每一次 resume 都会立刻落 exited,
+      // 不需要真的等 notify。
+      const codexBin = codexBinFor([{ output: '输出', exit: true }], stopHookCmd)
+
+      const adapterA = new CodexWorkerAdapter({ dataDir, tmux, codexBin, sessionDiscoveryTimeoutMs: 500 })
+      await adapterA.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
+      const workerId = `codextest-${randomUUID().slice(0, 8)}`
+
+      // 重启前:主线 #1。
+      const h1 = await adapterA.spawn({ worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } })
+      await waitForState(adapterA, h1, 'exited')
+      const meta1 = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8')) as { session_id: string }
+
+      // 重启前:resume 链 #2(同一进程内,落自己的 meta-2.json/output-2.log)。
+      const h2 = await adapterA.resume({ worker_id: workerId, seq: 1, session_ref: meta1.session_id }, '继续 1')
+      expect(h2.seq).toBe(2)
+      await waitForState(adapterA, h2, 'exited')
+      const meta2Before = await fs.readFile(path.join(dataDir, workerId, 'meta-2.json'), 'utf-8')
+      const output2Before = await fs.readFile(path.join(dataDir, workerId, 'output-2.log'), 'utf-8')
+
+      // "重启":全新 adapter 实例,同一 dataDir,内存 runtimes 为空——只有磁盘还记得 #1、#2
+      // 两份历史。对 #1 再 resume 一次:ensureRuntime 只重建出 #1 这一条 runtime(#2 从未被
+      // 提及,不会被重建),旧版 nextSeq 只扫内存 runtimes(此时仅 #1)算出 2,与磁盘上的
+      // #2 撞号。
+      const adapterB = new CodexWorkerAdapter({ dataDir, tmux, codexBin, sessionDiscoveryTimeoutMs: 500 })
+      const h3 = await adapterB.resume({ worker_id: workerId, seq: 1, session_ref: meta1.session_id }, '重启后继续')
+      await waitForState(adapterB, h3, 'exited')
+
+      // 磁盘感知修复后:新化身分配到 3(不是 2),不撞上 #2 的号位。
+      expect(h3.seq).toBe(3)
+
+      // #2 的 meta/output 原封不动,没有被 resume 静默覆盖/复用。
+      const meta2After = await fs.readFile(path.join(dataDir, workerId, 'meta-2.json'), 'utf-8')
+      const output2After = await fs.readFile(path.join(dataDir, workerId, 'output-2.log'), 'utf-8')
+      expect(meta2After).toBe(meta2Before.toString())
+      expect(output2After).toBe(output2Before.toString())
+    },
+    15000,
+  )
 })
 
 /** 转发到可替换的底层 TmuxDriver——用于"先用坏 bin 失败一次,再换成好 bin 重试"的测试场景。 */

--- a/crabot-agent/tests/workers/contract-builtin.test.ts
+++ b/crabot-agent/tests/workers/contract-builtin.test.ts
@@ -9,7 +9,7 @@ import { tmpdir } from 'os'
 import { join } from 'path'
 import { vi } from 'vitest'
 import { BuiltinWorkerAdapter } from '../../src/workers/builtin/adapter.js'
-import type { SpawnSpec, IncarnationHandle, IncarnationRef } from '../../src/workers/types.js'
+import type { SpawnSpec } from '../../src/workers/types.js'
 import type { LLMAdapter } from '../../src/engine/llm-adapter-types.js'
 import { chunksFromContent } from '../engine/helpers/mock-stream.js'
 import { runContractSuite, type ScriptStep, type ContractFixture } from './contract-suite.js'
@@ -58,17 +58,11 @@ async function makeBuiltinFixture(): Promise<ContractFixture> {
     },
   })
 
-  const refFor = async (h: IncarnationHandle): Promise<IncarnationRef> => {
-    const metaRaw = await fs.readFile(join(tmp, h.worker_id, `meta-${h.seq}.json`), 'utf-8')
-    const meta = JSON.parse(metaRaw) as { tip_node_id: string }
-    return { worker_id: h.worker_id, seq: h.seq, session_ref: meta.tip_node_id }
-  }
-
   const cleanup = async (): Promise<void> => {
     await fs.rm(tmp, { recursive: true, force: true })
   }
 
-  return { adapter, makeSpec, refFor, cleanup }
+  return { adapter, makeSpec, cleanup }
 }
 
 runContractSuite('builtin', makeBuiltinFixture)

--- a/crabot-agent/tests/workers/contract-claude-code.test.ts
+++ b/crabot-agent/tests/workers/contract-claude-code.test.ts
@@ -20,7 +20,7 @@ import * as path from 'node:path'
 import { ClaudeCodeAdapter, eventsFilePath } from '../../src/workers/claude-code/adapter.js'
 import { TmuxDriver } from '../../src/workers/tmux/driver.js'
 import { CliEventChannel } from '../../src/workers/cli-events.js'
-import type { IncarnationHandle, IncarnationRef, SpawnSpec } from '../../src/workers/types.js'
+import type { SpawnSpec } from '../../src/workers/types.js'
 import { runContractSuite, type ScriptStep, type ContractFixture } from './contract-suite.js'
 
 function detectTmux(): boolean {
@@ -112,12 +112,6 @@ async function makeClaudeCodeFixture(): Promise<ContractFixture> {
     return { worker_id: workerId, prompt: '契约测试任务', workspace: { root: workspaceRoot } }
   }
 
-  const refFor = async (h: IncarnationHandle): Promise<IncarnationRef> => {
-    const metaRaw = await fs.readFile(path.join(dataDir, h.worker_id, `meta-${h.seq}.json`), 'utf-8')
-    const meta = JSON.parse(metaRaw) as { session_id: string }
-    return { worker_id: h.worker_id, seq: h.seq, session_ref: meta.session_id }
-  }
-
   const cleanup = async (): Promise<void> => {
     for (const workerId of workerIds) await killSessionsForWorker(workerId)
     await fs.rm(dataDir, { recursive: true, force: true }).catch(() => {})
@@ -125,7 +119,7 @@ async function makeClaudeCodeFixture(): Promise<ContractFixture> {
     await fs.rm(claudeProjectsDir, { recursive: true, force: true }).catch(() => {})
   }
 
-  return { adapter, makeSpec, refFor, cleanup }
+  return { adapter, makeSpec, cleanup }
 }
 
 if (tmuxAvailable) {

--- a/crabot-agent/tests/workers/contract-codex.test.ts
+++ b/crabot-agent/tests/workers/contract-codex.test.ts
@@ -24,7 +24,7 @@ import * as path from 'node:path'
 import { CodexWorkerAdapter, eventsFilePath } from '../../src/workers/codex/adapter.js'
 import { TmuxDriver } from '../../src/workers/tmux/driver.js'
 import { CliEventChannel } from '../../src/workers/cli-events.js'
-import type { IncarnationHandle, IncarnationRef, SpawnSpec } from '../../src/workers/types.js'
+import type { SpawnSpec } from '../../src/workers/types.js'
 import { runContractSuite, type ScriptStep, type ContractFixture } from './contract-suite.js'
 
 function detectTmux(): boolean {
@@ -109,12 +109,6 @@ async function makeCodexFixture(): Promise<ContractFixture> {
     return { worker_id: workerId, prompt: '契约测试任务', workspace: { root: workspaceRoot } }
   }
 
-  const refFor = async (h: IncarnationHandle): Promise<IncarnationRef> => {
-    const metaRaw = await fs.readFile(path.join(dataDir, h.worker_id, `meta-${h.seq}.json`), 'utf-8')
-    const meta = JSON.parse(metaRaw) as { session_id: string }
-    return { worker_id: h.worker_id, seq: h.seq, session_ref: meta.session_id }
-  }
-
   const cleanup = async (): Promise<void> => {
     for (const workerId of workerIds) await killSessionsForWorker(workerId)
     await fs.rm(dataDir, { recursive: true, force: true }).catch(() => {})
@@ -122,7 +116,7 @@ async function makeCodexFixture(): Promise<ContractFixture> {
     await fs.rm(codexHomeSource, { recursive: true, force: true }).catch(() => {})
   }
 
-  return { adapter, makeSpec, refFor, cleanup }
+  return { adapter, makeSpec, cleanup }
 }
 
 if (tmuxAvailable) {

--- a/crabot-agent/tests/workers/contract-suite.ts
+++ b/crabot-agent/tests/workers/contract-suite.ts
@@ -8,10 +8,10 @@
  * 职责，契约套件本身不关心。
  *
  * session_ref（IncarnationRef 里喂给 fork/resume 的字段）是逐 impl 不透明的格式（builtin：
- * session 树 node_id；CLI：原生 session id），WorkerAdapter 接口没有从 handle 反查它的方法，
- * 所以 fixture 必须额外提供 refFor(handle) 这条通路——这是相对任务简报里给的三字段接口
- * （adapter/makeSpec/cleanup）的一个必要补充，否则 fork/revive 两条契约断言根本没法在
- * impl-agnostic 的前提下发起调用。
+ * session 树 node_id；CLI：原生 session id）。P3 Task 7 之前 WorkerAdapter 接口没有从 handle
+ * 反查它的方法，fixture 曾各自实现一个 refFor(handle) 读 meta 文件绕过这个缺口；现在
+ * IncarnationHandle 自身就带 session_ref（protocol-agent-v3 §6.1，spawn/resume/fork 返回前
+ * 由 adapter 填入真值），fixture 不再需要这条旁路，下面的 toRef() 直接从 handle 取值即可。
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { randomUUID } from 'crypto'
@@ -32,12 +32,16 @@ export interface ContractFixture {
   readonly adapter: WorkerAdapter
   /** 每次 sendInput 消费下一个 script step；第一个 step 由 spawn 的初始 burst 消费。 */
   readonly makeSpec: (workerId: string, script: ScriptStep[]) => SpawnSpec
-  /** 把一个已知 handle 转成可喂给 fork/resume 的 IncarnationRef（session_ref 格式不透明，见文件头注释）。 */
-  readonly refFor: (h: IncarnationHandle) => Promise<IncarnationRef>
   readonly cleanup: () => Promise<void>
 }
 
 export type MakeFixture = () => Promise<ContractFixture>
+
+/** IncarnationHandle → IncarnationRef：handle 自身已携带真实 session_ref（protocol-agent-v3
+ * §6.1），直接取值即可，不需要 fixture 另外提供反查通路。 */
+function toRef(h: IncarnationHandle): IncarnationRef {
+  return { worker_id: h.worker_id, seq: h.seq, session_ref: h.session_ref }
+}
 
 /**
  * 状态收敛轮询：100ms 间隔、5s 超时——给未来 tmux 实现（拉起真实进程）留够裕量。
@@ -84,6 +88,9 @@ export function runContractSuite(name: string, makeFixture: MakeFixture): void {
       async () => {
         const spec = fx.makeSpec(freshWorkerId(), [{ output: '第一段输出', then: 'idle' }])
         const h = await fx.adapter.spawn(spec)
+        // handle.session_ref 由 adapter 在 spawn 返回前即填入真值（protocol-agent-v3
+        // §6.1），跨三个实现的通用契约断言：不能是空串。
+        expect(h.session_ref).toBeTruthy()
         await waitForState(fx.adapter, h, 'idle')
 
         const { chunk } = await fx.adapter.readOutput(h, { offset: 0 })
@@ -184,7 +191,7 @@ export function runContractSuite(name: string, makeFixture: MakeFixture): void {
         const spec = fx.makeSpec(freshWorkerId(), [{ output: '主线输出', then: 'idle' }])
         const h = await fx.adapter.spawn(spec)
         await waitForState(fx.adapter, h, 'idle')
-        const ref = await fx.refFor(h)
+        const ref = toRef(h)
         const caps = fx.adapter.capabilities()
 
         if (caps.fork) {
@@ -206,7 +213,7 @@ export function runContractSuite(name: string, makeFixture: MakeFixture): void {
         const spec = fx.makeSpec(freshWorkerId(), [{ output: '主线输出', then: 'exit_success' }])
         const h = await fx.adapter.spawn(spec)
         await waitForState(fx.adapter, h, 'exited')
-        const ref = await fx.refFor(h)
+        const ref = toRef(h)
         const caps = fx.adapter.capabilities()
 
         if (caps.revive) {

--- a/crabot-agent/tests/workers/errors.test.ts
+++ b/crabot-agent/tests/workers/errors.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest'
 import { WorkerExitedError, CapabilityNotSupportedError } from '../../src/workers/errors.js'
+import { WorkerExitedError as BuiltinExported } from '../../src/workers/builtin/adapter.js'
+import { WorkerExitedError as ClaudeCodeExported } from '../../src/workers/claude-code/adapter.js'
+import { WorkerExitedError as CodexExported, CapabilityNotSupportedError as CodexCapExported } from '../../src/workers/codex/adapter.js'
 
 describe('Shared error types', () => {
   describe('WorkerExitedError', () => {
@@ -53,37 +56,45 @@ describe('Shared error types', () => {
   })
 
   describe('Cross-implementation instanceof checks', () => {
-    it('WorkerExitedError from builtin should be instanceof shared WorkerExitedError', async () => {
-      const { BuiltinWorkerAdapter } = await import('../../src/workers/builtin/adapter.js')
-      // The builtin adapter now imports and re-exports the shared error class
-      // so an instance thrown by it should be instanceof the shared class
-      const BuiltinErr = (BuiltinWorkerAdapter as any).WorkerExitedError || WorkerExitedError
-      const err = new BuiltinErr('w1', 1)
+    it('WorkerExitedError from builtin is the same class reference as shared WorkerExitedError', () => {
+      // The builtin adapter imports and re-exports the shared error class
+      // Verify they are the same class reference
+      expect(BuiltinExported).toBe(WorkerExitedError)
+      // Verify instances created from the exported class work correctly
+      const err = new BuiltinExported('w1', 1)
       expect(err).toBeInstanceOf(WorkerExitedError)
+      expect(err.worker_id).toBe('w1')
+      expect(err.seq).toBe(1)
     })
 
-    it('WorkerExitedError from claude-code should be instanceof shared WorkerExitedError', async () => {
-      const { ClaudeCodeAdapter } = await import('../../src/workers/claude-code/adapter.js')
-      // The claude-code adapter now imports and re-exports the shared error class
-      const ClaudeErr = (ClaudeCodeAdapter as any).WorkerExitedError || WorkerExitedError
-      const err = new ClaudeErr('w2', 2)
+    it('WorkerExitedError from claude-code is the same class reference as shared WorkerExitedError', () => {
+      // The claude-code adapter imports and re-exports the shared error class
+      expect(ClaudeCodeExported).toBe(WorkerExitedError)
+      // Verify instances created from the exported class work correctly
+      const err = new ClaudeCodeExported('w2', 2)
       expect(err).toBeInstanceOf(WorkerExitedError)
+      expect(err.worker_id).toBe('w2')
+      expect(err.seq).toBe(2)
     })
 
-    it('WorkerExitedError from codex should be instanceof shared WorkerExitedError', async () => {
-      const { CodexWorkerAdapter } = await import('../../src/workers/codex/adapter.js')
-      // The codex adapter now imports and re-exports the shared error class
-      const CodexErr = (CodexWorkerAdapter as any).WorkerExitedError || WorkerExitedError
-      const err = new CodexErr('w3', 3)
+    it('WorkerExitedError from codex is the same class reference as shared WorkerExitedError', () => {
+      // The codex adapter imports and re-exports the shared error class
+      expect(CodexExported).toBe(WorkerExitedError)
+      // Verify instances created from the exported class work correctly
+      const err = new CodexExported('w3', 3)
       expect(err).toBeInstanceOf(WorkerExitedError)
+      expect(err.worker_id).toBe('w3')
+      expect(err.seq).toBe(3)
     })
 
-    it('CapabilityNotSupportedError from codex should be instanceof shared CapabilityNotSupportedError', async () => {
-      const { CodexWorkerAdapter } = await import('../../src/workers/codex/adapter.js')
-      // The codex adapter now imports and re-exports the shared error class
-      const CodexErr = (CodexWorkerAdapter as any).CapabilityNotSupportedError || CapabilityNotSupportedError
-      const err = new CodexErr('codex', 'fork')
+    it('CapabilityNotSupportedError from codex is the same class reference as shared CapabilityNotSupportedError', () => {
+      // The codex adapter imports and re-exports the shared error class
+      expect(CodexCapExported).toBe(CapabilityNotSupportedError)
+      // Verify instances created from the exported class work correctly
+      const err = new CodexCapExported('codex', 'fork')
       expect(err).toBeInstanceOf(CapabilityNotSupportedError)
+      expect(err.impl).toBe('codex')
+      expect(err.capability).toBe('fork')
     })
   })
 })

--- a/crabot-agent/tests/workers/errors.test.ts
+++ b/crabot-agent/tests/workers/errors.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest'
+import { WorkerExitedError, CapabilityNotSupportedError } from '../../src/workers/errors.js'
+
+describe('Shared error types', () => {
+  describe('WorkerExitedError', () => {
+    it('should construct with worker_id and seq fields', () => {
+      const err = new WorkerExitedError('worker-123', 5)
+      expect(err).toBeInstanceOf(Error)
+      expect(err).toBeInstanceOf(WorkerExitedError)
+      expect(err.worker_id).toBe('worker-123')
+      expect(err.seq).toBe(5)
+    })
+
+    it('should have correct message format', () => {
+      const err = new WorkerExitedError('my-worker', 42)
+      expect(err.message).toBe('worker my-worker#42 has exited')
+    })
+
+    it('should have correct name property', () => {
+      const err = new WorkerExitedError('w', 1)
+      expect(err.name).toBe('WorkerExitedError')
+    })
+
+    it('should be recognizable as Error subclass', () => {
+      const err = new WorkerExitedError('test', 0)
+      expect(err instanceof Error).toBe(true)
+    })
+  })
+
+  describe('CapabilityNotSupportedError', () => {
+    it('should construct with impl and capability fields', () => {
+      const err = new CapabilityNotSupportedError('codex', 'fork')
+      expect(err).toBeInstanceOf(Error)
+      expect(err).toBeInstanceOf(CapabilityNotSupportedError)
+      expect(err.impl).toBe('codex')
+      expect(err.capability).toBe('fork')
+    })
+
+    it('should have correct message format', () => {
+      const err = new CapabilityNotSupportedError('my-impl', 'my-capability')
+      expect(err.message).toBe('my-impl does not support my-capability')
+    })
+
+    it('should have correct name property', () => {
+      const err = new CapabilityNotSupportedError('x', 'y')
+      expect(err.name).toBe('CapabilityNotSupportedError')
+    })
+
+    it('should be recognizable as Error subclass', () => {
+      const err = new CapabilityNotSupportedError('test', 'test')
+      expect(err instanceof Error).toBe(true)
+    })
+  })
+
+  describe('Cross-implementation instanceof checks', () => {
+    it('WorkerExitedError from builtin should be instanceof shared WorkerExitedError', async () => {
+      const { BuiltinWorkerAdapter } = await import('../../src/workers/builtin/adapter.js')
+      // The builtin adapter now imports and re-exports the shared error class
+      // so an instance thrown by it should be instanceof the shared class
+      const BuiltinErr = (BuiltinWorkerAdapter as any).WorkerExitedError || WorkerExitedError
+      const err = new BuiltinErr('w1', 1)
+      expect(err).toBeInstanceOf(WorkerExitedError)
+    })
+
+    it('WorkerExitedError from claude-code should be instanceof shared WorkerExitedError', async () => {
+      const { ClaudeCodeAdapter } = await import('../../src/workers/claude-code/adapter.js')
+      // The claude-code adapter now imports and re-exports the shared error class
+      const ClaudeErr = (ClaudeCodeAdapter as any).WorkerExitedError || WorkerExitedError
+      const err = new ClaudeErr('w2', 2)
+      expect(err).toBeInstanceOf(WorkerExitedError)
+    })
+
+    it('WorkerExitedError from codex should be instanceof shared WorkerExitedError', async () => {
+      const { CodexWorkerAdapter } = await import('../../src/workers/codex/adapter.js')
+      // The codex adapter now imports and re-exports the shared error class
+      const CodexErr = (CodexWorkerAdapter as any).WorkerExitedError || WorkerExitedError
+      const err = new CodexErr('w3', 3)
+      expect(err).toBeInstanceOf(WorkerExitedError)
+    })
+
+    it('CapabilityNotSupportedError from codex should be instanceof shared CapabilityNotSupportedError', async () => {
+      const { CodexWorkerAdapter } = await import('../../src/workers/codex/adapter.js')
+      // The codex adapter now imports and re-exports the shared error class
+      const CodexErr = (CodexWorkerAdapter as any).CapabilityNotSupportedError || CapabilityNotSupportedError
+      const err = new CodexErr('codex', 'fork')
+      expect(err).toBeInstanceOf(CapabilityNotSupportedError)
+    })
+  })
+})

--- a/crabot-agent/tests/workers/harness/harness-continuation.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-continuation.test.ts
@@ -718,3 +718,169 @@ describe('BuiltinWorkerAdapter → WorkerHarness — session_ref 时效性修复
     expect(afterSecondBurst.incarnations[0].session_ref).not.toBe(spawnTimeSessionRef)
   })
 })
+
+describe('WorkerHarness.processStateChange — 化身查找: 同 (impl, seq) 撞号场景下按最后一条处理', () => {
+  it('同 impl 同 seq 的两条记录（旧的已 exited、新的 running）→ 新的状态回调应该被处理而非被旧条目短路吞掉 (PoC 修复验证)', async () => {
+    const { harness, ledger, adaptersMap } = await makeHarness()
+    const fake = new FakeAdapter({ caps: { revive: true }, onStateChange: harness.handleStateChange })
+    adaptersMap.set('builtin', fake)
+
+    // 1. spawn 初始化身
+    const worker = await harness.spawnWorker(spawnParams())
+    const workerId = worker.worker_id
+    const dialogId = dialogObjectIdForPrivate('friend-1')
+
+    // 2. 让初始化身进入 exited 状态（旧的已归档化身）
+    const handle: IncarnationHandle = { worker_id: workerId, seq: 1, impl: 'builtin', session_ref: worker.incarnations[0].session_ref }
+    fake.emitStateChange(handle, 'exited')
+    await waitUntil(async () => {
+      const [w] = await harness.listWorkers(dialogId)
+      return w.incarnations[0].state === 'exited'
+    })
+
+    const afterFirstExit = (await harness.listWorkers(dialogId))[0]
+    expect(afterFirstExit.incarnations).toHaveLength(1)
+    expect(afterFirstExit.incarnations[0].state).toBe('exited')
+
+    // 3. 人工插入一条新的同 (impl, seq=1) 记录到 incarnations（模拟撞号场景）
+    // —— 新记录仍然是 running，代表真正的活跃化身。这模拟"进程重启后 adapter 又分配了 seq=1"的场景
+    // 同时把 task.status 恢复到 running（模拟新化身入链后的状态）
+    await ledger.upsertWorker(dialogId, workerId, (prev) => {
+      if (!prev) return undefined
+      const newIncarnation = {
+        seq: 1,
+        impl: 'builtin' as const,
+        state: 'running' as const,
+        workspace: prev.incarnations[0].workspace,
+        session_ref: `ref-${workerId}#1-new`,
+        started_at: prev.incarnations[0].started_at,
+      }
+      return {
+        ...prev,
+        incarnations: [...prev.incarnations, newIncarnation],
+        task: { ...prev.task, status: 'running' as const },
+        updated_at: prev.updated_at,
+      }
+    })
+
+    const beforeStateChange = (await harness.listWorkers(dialogId))[0]
+    expect(beforeStateChange.incarnations).toHaveLength(2)
+    expect(beforeStateChange.incarnations[0].state).toBe('exited') // 旧的
+    expect(beforeStateChange.incarnations[1].state).toBe('running') // 新的，真正的活跃化身
+
+    events.length = 0
+
+    // 4. 新化身自然退出，发送状态回调。注意这里用的是新化身的 session_ref
+    const newHandle: IncarnationHandle = { worker_id: workerId, seq: 1, impl: 'builtin', session_ref: `ref-${workerId}#1-new` }
+    fake.emitStateChange(newHandle, 'exited')
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    // 修复前会失败：
+    // - processStateChange 用 find(seq===1) 找到第一条（旧的 exited）
+    // - 被"if (target.state==='exited') return"短路，事件丢失、台账不更新
+    // - incarnations[1]（新的 running 化身）永远保持 running 状态，无人驾驶
+    //
+    // 修复后应该正确处理：
+    // - processStateChange 用 findIncarnation(impl, seq) 按最后一条处理，命中新的（incarnations[1]）
+    // - 新的被更新为 exited(completed)，台账更新 + 事件发出
+
+    const afterStateChange = (await harness.listWorkers(dialogId))[0]
+    // 关键断言：新化身（数组最后一条）被正确更新为 exited
+    expect(afterStateChange.incarnations[1].state).toBe('exited')
+    expect(afterStateChange.incarnations[1].ended_reason).toBe('completed')
+    // 旧化身保持不变（已经是 completed，不被新状态回调覆盖）
+    expect(afterStateChange.incarnations[0].state).toBe('exited')
+    expect(afterStateChange.incarnations[0].ended_reason).toBe('completed') // 旧的没被改动，保持原值
+
+    // 确保事件被正确记录（如果被短路吞掉就不会有事件）
+    const stateChangedEvents = events.filter((e) => e.kind === 'state_changed')
+    expect(stateChangedEvents.length).toBeGreaterThan(0)
+    expect(stateChangedEvents[0].seq).toBe(1)
+  })
+
+  it('同 seq 同 impl 两条 fork 分支化身（旧的已 exited、新的 running）→ 状态更新只影响新的那条，mainline task 不受影响', async () => {
+    const { harness, ledger, adaptersMap } = await makeHarness()
+    const fake = new FakeAdapter({ caps: { fork: false, revive: true }, onStateChange: harness.handleStateChange })
+    adaptersMap.set('builtin', fake)
+
+    // 1. spawn 主线化身 seq=1
+    const worker = await harness.spawnWorker(spawnParams())
+    const workerId = worker.worker_id
+    const dialogId = dialogObjectIdForPrivate('friend-1')
+    const mainlineHandle: IncarnationHandle = {
+      worker_id: workerId,
+      seq: 1,
+      impl: 'builtin',
+      session_ref: worker.incarnations[0].session_ref,
+    }
+
+    // 2. 模拟一个 fork 化身（手动插入，因为 FakeAdapter 不支持 fork）
+    const forkSeq = 2
+    await ledger.upsertWorker(dialogId, workerId, (prev) => {
+      if (!prev) return undefined
+      const forkIncarnation = {
+        seq: forkSeq,
+        impl: 'builtin' as const,
+        state: 'running' as const,
+        workspace: prev.incarnations[0].workspace,
+        session_ref: `fork-${forkSeq}`,
+        started_at: prev.incarnations[0].started_at,
+        forked_from: 1,
+      }
+      return { ...prev, incarnations: [...prev.incarnations, forkIncarnation], updated_at: prev.updated_at }
+    })
+
+    let current = (await harness.listWorkers(dialogId))[0]
+    expect(current.incarnations).toHaveLength(2)
+    expect(current.incarnations[1].forked_from).toBe(1)
+    expect(current.task.status).toBe('running')
+
+    // 3. fork 化身终态（旧的记录）
+    const oldForkHandle: IncarnationHandle = { worker_id: workerId, seq: forkSeq, impl: 'builtin', session_ref: `fork-${forkSeq}` }
+    fake.emitStateChange(oldForkHandle, 'exited')
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    current = (await harness.listWorkers(dialogId))[0]
+    expect(current.incarnations[1].state).toBe('exited') // fork 化身已终态
+    expect(current.task.status).toBe('running') // mainline task 不受影响
+
+    // 4. 人工插入第二个同 seq 的 fork 化身（模拟撞号）
+    await ledger.upsertWorker(dialogId, workerId, (prev) => {
+      if (!prev) return undefined
+      const newForkIncarnation = {
+        seq: forkSeq,
+        impl: 'builtin' as const,
+        state: 'running' as const,
+        workspace: prev.incarnations[0].workspace,
+        session_ref: `fork-${forkSeq}-new`,
+        started_at: prev.incarnations[1].started_at,
+        forked_from: 1,
+      }
+      return {
+        ...prev,
+        incarnations: [...prev.incarnations, newForkIncarnation],
+        task: { ...prev.task, status: 'running' as const },
+        updated_at: prev.updated_at,
+      }
+    })
+
+    current = (await harness.listWorkers(dialogId))[0]
+    expect(current.incarnations).toHaveLength(3)
+    expect(current.incarnations[1].state).toBe('exited') // 旧的 fork
+    expect(current.incarnations[2].state).toBe('running') // 新的 fork
+
+    events.length = 0
+
+    // 5. 新 fork 化身退出
+    const newForkHandle: IncarnationHandle = { worker_id: workerId, seq: forkSeq, impl: 'builtin', session_ref: `fork-${forkSeq}-new` }
+    fake.emitStateChange(newForkHandle, 'exited')
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    // 修复后应该正确更新新 fork 化身，不影响 mainline task
+    current = (await harness.listWorkers(dialogId))[0]
+    expect(current.incarnations[2].state).toBe('exited') // 新的 fork 被更新
+    expect(current.incarnations[2].ended_reason).toBe('completed')
+    expect(current.incarnations[2].forked_from).toBe(1) // 仍然是 fork
+    expect(current.task.status).toBe('running') // mainline task 不受影响
+  })
+})

--- a/crabot-agent/tests/workers/harness/harness-continuation.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-continuation.test.ts
@@ -256,6 +256,53 @@ describe('WorkerHarness — 透明接续：revive (capabilities().revive === tru
     const resumedEvents = events.filter((e) => e.kind === 'resumed')
     expect(resumedEvents).toHaveLength(1)
   })
+
+  it('adapter.sendInput 抛 WorkerExitedError 时台账主线化身仍是 running（迟到状态回调没追上）→ revive 前先把旧化身回填终态，不再永久卡在 running（评审 PoC 实证的修复）', async () => {
+    const { harness, adaptersMap } = await makeHarness()
+    const fake = new FakeAdapter({
+      caps: { revive: true },
+      onStateChange: harness.handleStateChange,
+      sendInputBehavior: (h) => {
+        throw new WorkerExitedError(h.worker_id, h.seq)
+      },
+    })
+    adaptersMap.set('builtin', fake)
+
+    const worker = await harness.spawnWorker(spawnParams())
+    // 没有触发过任何 fake.emitStateChange —— 台账里 incarnations[0].state 此刻仍是
+    // 'running'（spawnWorker 落定后就是 running），模拟"adapter 内部已经退出，但迟到的
+    // 状态回调还没追上"的竞态：这正是评审 PoC 复现的场景。
+    const before = (await harness.listWorkers(dialogObjectIdForPrivate('friend-1')))[0]
+    expect(before.incarnations[0].state).toBe('running')
+    expect(before.incarnations[0].ended_at).toBeUndefined()
+    events.length = 0
+
+    await expect(harness.sendToWorker(worker.worker_id, '继续')).resolves.toBeUndefined()
+
+    const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    expect(w.incarnations).toHaveLength(2)
+    // 修复点：旧化身（seq=1）不再永久卡在 running —— revive 之前已经被回填了终态。
+    const oldEntry = w.incarnations[0]
+    expect(oldEntry.state).toBe('exited')
+    expect(oldEntry.ended_at).toBeTruthy()
+    expect(oldEntry.ended_reason).toBe('completed')
+
+    // 之后即便迟到的状态回调才追上来，也不应该覆盖已经回填的终态记录 —— 此时台账主线
+    // 已经换成 revive 产出的新化身（mainline.seq 已前进），processStateChange 的既有短路
+    // 规则（mainline.seq !== h.seq）会把这条迟到回调当成"非当前主线化身的迟到回调"忽略，
+    // 但这不是本测试要验证的点：本测试要证明的是旧化身在 revive 时已经同步回填，不依赖
+    // 这条本就可能永远不会到达的迟到回调。
+    const staleHandle: IncarnationHandle = {
+      worker_id: worker.worker_id,
+      seq: 1,
+      impl: 'builtin',
+      session_ref: oldEntry.session_ref,
+    }
+    fake.emitStateChange(staleHandle, 'exited')
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    const [w2] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    expect(w2.incarnations[0].ended_reason).toBe('completed')
+  })
 })
 
 describe('WorkerHarness — 透明接续：handoff (capabilities().revive === false)', () => {
@@ -424,6 +471,76 @@ describe('WorkerHarness — 接续过程中的并发', () => {
     expect(fake.resumeCalls).toHaveLength(1)
     // 第二条消息通过"mainline.seq !== sourceSeq"分支，作为普通投递补送到了新主线。
     expect(fake.sendInputCalls.some((c) => c.text === '第二条')).toBe(true)
+  })
+})
+
+describe('WorkerHarness — 化身 seq 跨实例撞号（protocol-agent-v3 §6.1 已知限制）', () => {
+  it('接续产出的新化身与已归档的旧化身 seq 相同（跨 adapter 实例重新从 1 计数）→ 状态回调只改最后一条，不篡改已归档记录', async () => {
+    const { harness, adaptersMap } = await makeHarness()
+    const fake = new FakeAdapter({
+      caps: { revive: true },
+      onStateChange: harness.handleStateChange,
+      sendInputBehavior: (h) => {
+        throw new WorkerExitedError(h.worker_id, h.seq)
+      },
+      // 模拟"跨 adapter 实例"场景：resume 产出的新化身复用 seq=1，与已经在台账里的旧化身
+      // （同样 seq=1，同 impl='builtin'）撞号——真实场景下这是"新的 adapter 实例内部
+      // nextSeq 从头计数"（进程重启 / 跨实现切换回同一实现）。
+      resumeBehavior: (prev) => ({
+        worker_id: prev.worker_id,
+        seq: 1,
+        impl: 'builtin',
+        session_ref: `resumed-collision-ref-${prev.worker_id}`,
+      }),
+    })
+    adaptersMap.set('builtin', fake)
+
+    const worker = await harness.spawnWorker(spawnParams())
+    events.length = 0
+
+    // 触发接续：旧化身（seq=1）台账态仍是 running，WorkerExitedError 触发 revive；revive
+    // 前会先把旧化身回填终态（Task 8 修复 1），resume 产出的新化身同样是 seq=1（撞号）。
+    await harness.sendToWorker(worker.worker_id, '继续')
+
+    const [afterRevive] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    expect(afterRevive.incarnations).toHaveLength(2)
+    const archived = afterRevive.incarnations[0]
+    const active = afterRevive.incarnations[1]
+    expect(archived.seq).toBe(1)
+    expect(active.seq).toBe(1) // 撞号：两条记录 seq 相同
+    expect(archived.state).toBe('exited') // 已归档（revive 前回填的终态）
+    expect(active.state).toBe('running')
+    const archivedSessionRefBefore = archived.session_ref
+    const archivedEndedReasonBefore = archived.ended_reason
+
+    // 新化身（active，seq=1）自然结束（非 kill）→ processStateChange 状态回调命中 seq=1。
+    // 撞号意味着"按 seq 匹配"会同时命中 archived 和 active 两条记录——修复前
+    // patchIncarnationBySeq 用 .map 逐条匹配 seq，会把 archived 也一起改写；修复后按
+    // (impl, seq) 只改最后一条（active），archived 保持原样。
+    const activeHandle: IncarnationHandle = {
+      worker_id: worker.worker_id,
+      seq: 1,
+      impl: 'builtin',
+      session_ref: active.session_ref,
+    }
+    fake.emitStateChange(activeHandle, 'exited')
+    await waitUntil(async () => {
+      const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+      return w.incarnations[1].state === 'exited'
+    })
+
+    const [afterStateChange] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const archivedAfter = afterStateChange.incarnations[0]
+    const activeAfter = afterStateChange.incarnations[1]
+
+    // active（最后一条同 (impl,seq) 记录）被正确更新。
+    expect(activeAfter.state).toBe('exited')
+    expect(activeAfter.ended_reason).toBe('completed')
+
+    // archived（已归档的同 (impl,seq) 旧记录）必须完全不受这次状态回调影响。
+    expect(archivedAfter.state).toBe('exited')
+    expect(archivedAfter.ended_reason).toBe(archivedEndedReasonBefore)
+    expect(archivedAfter.session_ref).toBe(archivedSessionRefBefore)
   })
 })
 

--- a/crabot-agent/tests/workers/harness/harness-continuation.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-continuation.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { promises as fs } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
-import { WorkerHarness, WorkerNotFoundError, type HarnessDeps, type SpawnWorkerParams } from '../../../src/workers/harness/harness'
+import { WorkerHarness, WorkerNotFoundError, TaskCancelledError, type HarnessDeps, type SpawnWorkerParams } from '../../../src/workers/harness/harness'
 import { LedgerStore } from '../../../src/workers/harness/ledger-store'
 import { WorkspaceManager } from '../../../src/workers/harness/workspace-manager'
 import { dialogObjectIdForPrivate } from '../../../src/workers/harness/ledger-types'
@@ -1020,5 +1020,117 @@ describe('WorkerHarness — 终审 PoC 回归：M2 kill 与 in-flight flush 竞�
 
     const deadLetterEvents = events.filter((e) => e.kind === 'state_changed' && (e.detail as Record<string, unknown> | undefined)?.kind === 'dead_letter')
     expect(deadLetterEvents.length).toBeGreaterThan(0)
+  })
+})
+
+describe('WorkerHarness — 终审 PoC 回归：M3 continueTerminalWorker 守卫按 (impl,seq) 收口 + raw 透传', () => {
+  it('deliver 卡在 sendInput 期间发生跨实现 switchWorkerImpl（seq 撞号）：不误把存活新主线当终态接续，补送到新主线且保留 raw', async () => {
+    const { harness, adaptersMap } = await makeHarness()
+    let releaseGate!: (err: Error) => void
+    const gate = new Promise<void>((_resolve, reject) => {
+      releaseGate = (err) => reject(err)
+    })
+    const source = new FakeAdapter({
+      implId: 'claude-code',
+      caps: { revive: true },
+      onStateChange: harness.handleStateChange,
+      sendInputBehavior: async () => {
+        await gate
+      },
+    })
+    // target 的 resume 复刻真实 adapter（claude-code/codex）对"未终态就 resume"的拒绝
+    // 语义（"has not exited yet"）——修复前的 bug 正是把这个存活化身误当终态源去 resume。
+    let target!: FakeAdapter
+    target = new FakeAdapter({
+      implId: 'codex',
+      caps: { revive: true },
+      onStateChange: harness.handleStateChange,
+      resumeBehavior: async (prev) => {
+        const st = await target.state({ worker_id: prev.worker_id, seq: prev.seq, impl: 'codex', session_ref: prev.session_ref })
+        if (st !== 'exited') {
+          throw new Error(`FakeAdapter(codex).resume: incarnation ${prev.worker_id}#${prev.seq} has not exited yet (state=${st})`)
+        }
+        return { worker_id: prev.worker_id, seq: prev.seq + 1, impl: 'codex', session_ref: `resumed-${prev.worker_id}` }
+      },
+    })
+    adaptersMap.set('claude-code', source)
+    adaptersMap.set('codex', target)
+
+    const worker = await harness.spawnWorker(spawnParams({ impl: 'claude-code' }))
+    events.length = 0
+
+    // 第一条投递卡在 claude-code 的 sendInput 里（模拟"读到还未终态、真正在投递中"）——
+    // adapter.sendInput 不占用 harness 的 per-worker 锁（见文件头锁纪律注释），此刻锁空闲。
+    const send = harness.sendToWorker(worker.worker_id, '带 raw 的敲键', { raw: true })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(source.sendInputCalls).toHaveLength(1)
+
+    // 等投递期间发生跨实现切换：codex#1 顶替 claude-code#1——两个 FakeAdapter 各自 nextSeq
+    // 从 1 计数，与旧主线（claude-code#1）seq 撞号，这正是本条 PoC 的复现前提（M1 回归
+    // 测试已确认这种撞号是跨实现切换的常态）。
+    await harness.switchWorkerImpl(worker.worker_id, 'codex', '并发切换')
+    const afterSwitch = (await harness.listWorkers(dialogObjectIdForPrivate('friend-1')))[0]
+    const newMainline = afterSwitch.incarnations[afterSwitch.incarnations.length - 1]
+    expect(newMainline.impl).toBe('codex')
+    expect(newMainline.seq).toBe(1) // 撞号
+    expect(newMainline.state).toBe('running') // 存活
+
+    // 放行卡住的 sendInput，抛出 WorkerExitedError——deliver 的 catch 分支据此转入
+    // continueTerminalWorker(sourceImpl='claude-code', sourceSeq=1)，此时它已经不再是主线。
+    releaseGate(new WorkerExitedError(worker.worker_id, 1))
+
+    // 核心断言：只比 seq 不比 impl 会把撞号的存活新主线（codex#1）误当终态源，对它调用
+    // adapter.resume（其状态仍 running，会抛 "has not exited yet"），该错误穿透 inbox.flush
+    // 一路砸给 sendToWorker 的调用方——修复前这里应当 reject。
+    await expect(send).resolves.toBeUndefined()
+
+    // 没有把存活的 codex#1 误当终态化身去 revive。
+    expect(target.resumeCalls).toHaveLength(0)
+
+    // 消息按"普通投递"语义补送到当前（存活）新主线 codex#1，且原样保留 raw 标志。
+    expect(target.sendInputCalls).toHaveLength(1)
+    expect(target.sendInputCalls[0].text).toBe('带 raw 的敲键')
+    expect(target.sendInputCalls[0].opts).toEqual({ raw: true })
+
+    // 没有产生第三个化身（没有误触发一次多余的 revive/handoff）。
+    const after = (await harness.listWorkers(dialogObjectIdForPrivate('friend-1')))[0]
+    expect(after.incarnations).toHaveLength(2)
+  })
+})
+
+describe('WorkerHarness.switchWorkerImpl — 终审 PoC 回归：M3 cancelled 是唯一硬拒绝，不得复活', () => {
+  it('对已 cancelled 的 worker 调 switchWorkerImpl → 抛 TaskCancelledError，不 provision/不 spawn，task 仍是 cancelled', async () => {
+    const { harness, adaptersMap } = await makeHarness()
+    const source = new FakeAdapter({ implId: 'claude-code', caps: { revive: false } })
+    const target = new FakeAdapter({ implId: 'codex', caps: { revive: false } })
+    adaptersMap.set('claude-code', source)
+    adaptersMap.set('codex', target)
+
+    const worker = await harness.spawnWorker(spawnParams({ impl: 'claude-code' }))
+    await harness.killWorker(worker.worker_id, '用户明确终止')
+
+    const beforeSwitch = (await harness.listWorkers(dialogObjectIdForPrivate('friend-1')))[0]
+    expect(beforeSwitch.task.status).toBe('cancelled')
+    events.length = 0
+
+    // 主线化身已 exited（killed）→ handoffIncarnation 会跳过 kill 段，直接 provision+spawn
+    // 新化身，reopenTaskForContinuation 命中终态走 reviveTask——task 会被无声复活成
+    // running。这与 sendToWorker/continueTerminalWorker 已有的 cancelled 短路（§5.5"唯一
+    // 硬拒绝"）不一致：用户明确要求终止的任务不应该被跨实现切换复活。
+    await expect(harness.switchWorkerImpl(worker.worker_id, 'codex', '试图复活')).rejects.toThrow(TaskCancelledError)
+
+    // 没有触碰目标实现：不 provision、不 spawn。
+    expect(target.provisionCalls).toHaveLength(0)
+    expect(target.spawnCalls).toHaveLength(0)
+
+    // 台账原样：task 仍 cancelled，没有多出新化身。
+    const after = (await harness.listWorkers(dialogObjectIdForPrivate('friend-1')))[0]
+    expect(after.task.status).toBe('cancelled')
+    expect(after.incarnations).toHaveLength(1)
+
+    // 没有产生 handoff_started / superseded / spawned 事件——pre-flight 在写 HANDOFF.md 和
+    // kill 旧化身之前就已经拒绝。
+    expect(events.filter((e) => e.kind === 'handoff_started')).toHaveLength(0)
+    expect(events.filter((e) => e.kind === 'spawned')).toHaveLength(0)
   })
 })

--- a/crabot-agent/tests/workers/harness/harness-continuation.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-continuation.test.ts
@@ -1,0 +1,425 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { promises as fs } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { WorkerHarness, WorkerNotFoundError, type HarnessDeps, type SpawnWorkerParams } from '../../../src/workers/harness/harness'
+import { LedgerStore } from '../../../src/workers/harness/ledger-store'
+import { WorkspaceManager } from '../../../src/workers/harness/workspace-manager'
+import { dialogObjectIdForPrivate } from '../../../src/workers/harness/ledger-types'
+import type { HarnessEvent } from '../../../src/workers/harness/worker-events'
+import { WorkerExitedError } from '../../../src/workers/errors'
+import type {
+  WorkerAdapter,
+  WorkerImplId,
+  WorkerContractState,
+  IncarnationHandle,
+  IncarnationRef,
+  SpawnSpec,
+  Workspace,
+  OutputCursor,
+  CapabilityBundle,
+  AdapterCapabilities,
+  DetectResult,
+} from '../../../src/workers/types'
+
+// ---- FakeAdapter：与 Task 7 harness-lifecycle.test.ts 同款可编程桩，本文件独立一份
+// （resume/kill/readOutput 需要按接续场景编程，不复用别的测试文件的实现）。----
+
+function handleKey(h: IncarnationHandle): string {
+  return `${h.worker_id}#${h.seq}`
+}
+
+interface FakeAdapterOpts {
+  readonly implId?: WorkerImplId
+  readonly caps?: Partial<AdapterCapabilities>
+  readonly onStateChange?: (h: IncarnationHandle, state: WorkerContractState) => void
+  readonly sendInputBehavior?: (h: IncarnationHandle, text: string, opts?: { raw?: boolean }) => Promise<void> | void
+  readonly resumeBehavior?: (prev: IncarnationRef, wakeInput: string) => Promise<IncarnationHandle> | IncarnationHandle
+  readonly spawnBehavior?: (spec: SpawnSpec) => Promise<IncarnationHandle> | IncarnationHandle
+  readonly outputChunk?: string
+}
+
+class FakeAdapter implements WorkerAdapter {
+  readonly implId: WorkerImplId
+  readonly provisionCalls: Array<{ ws: Workspace; caps: CapabilityBundle }> = []
+  readonly spawnCalls: SpawnSpec[] = []
+  readonly resumeCalls: Array<{ prev: IncarnationRef; wakeInput: string }> = []
+  readonly sendInputCalls: Array<{ h: IncarnationHandle; text: string; opts?: { raw?: boolean } }> = []
+  readonly killCalls: IncarnationHandle[] = []
+  readonly readOutputCalls: IncarnationHandle[] = []
+  private readonly states = new Map<string, WorkerContractState>()
+  private nextSeq = 1
+
+  constructor(private readonly opts: FakeAdapterOpts = {}) {
+    this.implId = opts.implId ?? 'builtin'
+  }
+
+  async detect(): Promise<DetectResult> {
+    return { installed: true, activated: true }
+  }
+
+  async provision(ws: Workspace, caps: CapabilityBundle): Promise<void> {
+    this.provisionCalls.push({ ws, caps })
+  }
+
+  async spawn(spec: SpawnSpec): Promise<IncarnationHandle> {
+    this.spawnCalls.push(spec)
+    if (this.opts.spawnBehavior) {
+      const handle = await this.opts.spawnBehavior(spec)
+      this.states.set(handleKey(handle), 'running')
+      return handle
+    }
+    const seq = this.nextSeq++
+    const handle: IncarnationHandle = { worker_id: spec.worker_id, seq, impl: this.implId, session_ref: `ref-${spec.worker_id}#${seq}` }
+    this.states.set(handleKey(handle), 'running')
+    return handle
+  }
+
+  async resume(prev: IncarnationRef, wakeInput: string): Promise<IncarnationHandle> {
+    this.resumeCalls.push({ prev, wakeInput })
+    if (this.opts.resumeBehavior) {
+      const handle = await this.opts.resumeBehavior(prev, wakeInput)
+      this.states.set(handleKey(handle), 'running')
+      return handle
+    }
+    const seq = Math.max(this.nextSeq, prev.seq + 1)
+    this.nextSeq = seq + 1
+    const handle: IncarnationHandle = { worker_id: prev.worker_id, seq, impl: this.implId, session_ref: `resumed-ref-${prev.worker_id}#${seq}` }
+    this.states.set(handleKey(handle), 'running')
+    return handle
+  }
+
+  async fork(_prev: IncarnationRef, _forkInput: string): Promise<IncarnationHandle> {
+    throw new Error('FakeAdapter.fork: not exercised by Task 8 continuation tests')
+  }
+
+  async sendInput(h: IncarnationHandle, text: string, opts?: { raw?: boolean }): Promise<void> {
+    this.sendInputCalls.push({ h, text, opts })
+    if (this.opts.sendInputBehavior) await this.opts.sendInputBehavior(h, text, opts)
+  }
+
+  async readOutput(h: IncarnationHandle, cursor: OutputCursor): Promise<{ chunk: string; nextCursor: OutputCursor }> {
+    this.readOutputCalls.push(h)
+    return { chunk: this.opts.outputChunk ?? '', nextCursor: cursor }
+  }
+
+  async state(h: IncarnationHandle): Promise<WorkerContractState> {
+    return this.states.get(handleKey(h)) ?? 'exited'
+  }
+
+  async kill(h: IncarnationHandle): Promise<void> {
+    this.killCalls.push(h)
+    this.states.set(handleKey(h), 'exited')
+  }
+
+  capabilities(): AdapterCapabilities {
+    return { fork: false, revive: false, goalMode: false, subagent: false, structuredTrace: false, ...this.opts.caps }
+  }
+
+  /** 测试专用：模拟 adapter 自己触发一次状态回调（镜像真实 adapter 内部调用 deps.onStateChange）。 */
+  emitStateChange(h: IncarnationHandle, state: WorkerContractState): void {
+    this.states.set(handleKey(h), state)
+    this.opts.onStateChange?.(h, state)
+  }
+}
+
+// ---- 测试夹具（与 harness-lifecycle.test.ts 同款：FakeAdapter 桩场景）----
+
+let dataDir: string
+let nowValue: number
+const events: HarnessEvent[] = []
+
+function now(): string {
+  nowValue += 1000
+  return new Date(nowValue).toISOString()
+}
+
+async function makeHarness(): Promise<{
+  harness: WorkerHarness
+  ledger: LedgerStore
+  adaptersMap: Map<WorkerImplId, WorkerAdapter>
+  defaultImpl: WorkerImplId
+}> {
+  const ledgersDir = join(dataDir, 'ledgers')
+  const workspacesRoot = join(dataDir, 'workspaces')
+  const workersDir = join(dataDir, 'workers')
+  await fs.mkdir(workspacesRoot, { recursive: true })
+
+  const ledger = new LedgerStore(ledgersDir)
+  const workspaces = new WorkspaceManager(workspacesRoot)
+
+  const adaptersMap = new Map<WorkerImplId, WorkerAdapter>()
+  const deps: HarnessDeps = {
+    adapters: adaptersMap,
+    defaultImpl: 'builtin',
+    ledger,
+    workspaces,
+    workersDir,
+    now,
+    onEvent: (e) => events.push(e),
+  }
+  const harness = new WorkerHarness(deps)
+  return { harness, ledger, adaptersMap, defaultImpl: 'builtin' }
+}
+
+function spawnParams(overrides: Partial<SpawnWorkerParams> = {}): SpawnWorkerParams {
+  return {
+    dialogObjectId: dialogObjectIdForPrivate('friend-1'),
+    title: '测试任务',
+    goal: '把活干完',
+    prompt: '把活干完',
+    origin: { spawned_by_session: 'wechat::sess-1', trigger_type: 'message' },
+    report_to: { channel_id: 'wechat', session_id: 'sess-1' },
+    ...overrides,
+  }
+}
+
+beforeEach(async () => {
+  dataDir = await fs.mkdtemp(join(tmpdir(), 'harness-continuation-test-'))
+  nowValue = Date.parse('2026-01-01T00:00:00.000Z')
+  events.length = 0
+})
+
+afterEach(async () => {
+  await fs.rm(dataDir, { recursive: true, force: true })
+})
+
+async function waitUntil(cond: () => Promise<boolean>, timeoutMs = 2000, intervalMs = 10): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (await cond()) return
+    await new Promise((resolve) => setTimeout(resolve, intervalMs))
+  }
+  throw new Error('waitUntil timed out')
+}
+
+describe('WorkerHarness — 透明接续：revive (capabilities().revive === true)', () => {
+  it('台账主线化身已 exited → adapter.resume 被调用（prevRef 用主线化身的 handle）→ 新化身入主线链 → sendToWorker 无感返回 → 事件 resumed', async () => {
+    const { harness, adaptersMap } = await makeHarness()
+    const fake = new FakeAdapter({ caps: { revive: true }, onStateChange: harness.handleStateChange })
+    adaptersMap.set('builtin', fake)
+
+    const worker = await harness.spawnWorker(spawnParams())
+    const mainlineHandle: IncarnationHandle = { worker_id: worker.worker_id, seq: 1, impl: 'builtin', session_ref: `ref-${worker.worker_id}#1` }
+
+    // 化身自然结束（非 kill）→ processStateChange 把台账主线化身落 exited(completed)。
+    fake.emitStateChange(mainlineHandle, 'exited')
+    await waitUntil(async () => {
+      const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+      return w.incarnations[0].state === 'exited'
+    })
+    events.length = 0
+    fake.sendInputCalls.length = 0
+
+    // sendToWorker 命中终态化身：deliver() 在调用 adapter.sendInput 之前就发现台账已
+    // exited，直接走透明接续，resume 被调用、adapter.sendInput 完全不会被触碰。
+    await expect(harness.sendToWorker(worker.worker_id, '还有件事要办')).resolves.toBeUndefined()
+
+    expect(fake.sendInputCalls).toHaveLength(0)
+    expect(fake.resumeCalls).toHaveLength(1)
+    expect(fake.resumeCalls[0].prev).toEqual({ worker_id: worker.worker_id, seq: 1, session_ref: mainlineHandle.session_ref })
+    expect(fake.resumeCalls[0].wakeInput).toBe('还有件事要办')
+
+    const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    expect(w.incarnations).toHaveLength(2)
+    expect(w.incarnations[1].forked_from).toBeUndefined() // 入主线链，不是侧问分支
+    expect(w.incarnations[1].state).toBe('running')
+    expect(w.incarnations[1].impl).toBe('builtin')
+    expect(w.task.status).toBe('running') // 终态化身之上接续，task 重新回到 running
+
+    const resumedEvents = events.filter((e) => e.kind === 'resumed')
+    expect(resumedEvents).toHaveLength(1)
+    expect(resumedEvents[0].seq).toBe(w.incarnations[1].seq)
+  })
+
+  it('adapter.sendInput 抛 WorkerExitedError（台账还没追上）→ 同样透明接续，事件 resumed', async () => {
+    const { harness, adaptersMap } = await makeHarness()
+    const fake = new FakeAdapter({
+      caps: { revive: true },
+      onStateChange: harness.handleStateChange,
+      sendInputBehavior: (h) => {
+        throw new WorkerExitedError(h.worker_id, h.seq)
+      },
+    })
+    adaptersMap.set('builtin', fake)
+
+    const worker = await harness.spawnWorker(spawnParams())
+    events.length = 0
+
+    await expect(harness.sendToWorker(worker.worker_id, '继续')).resolves.toBeUndefined()
+
+    expect(fake.sendInputCalls).toHaveLength(1) // 确实尝试过一次正常投递，才捕获到 WorkerExitedError
+    expect(fake.resumeCalls).toHaveLength(1)
+    const resumedEvents = events.filter((e) => e.kind === 'resumed')
+    expect(resumedEvents).toHaveLength(1)
+  })
+})
+
+describe('WorkerHarness — 透明接续：handoff (capabilities().revive === false)', () => {
+  it('HANDOFF.md 含标题/输出尾/上次 outcome，新化身 prompt 含交接引用与本次输入，旧化身标 superseded，事件 handoff_started', async () => {
+    const { harness, adaptersMap } = await makeHarness()
+    const fake = new FakeAdapter({
+      caps: { revive: false },
+      onStateChange: harness.handleStateChange,
+      outputChunk: '这是执行到一半的输出\n还差一步',
+      sendInputBehavior: (h) => {
+        throw new WorkerExitedError(h.worker_id, h.seq)
+      },
+    })
+    adaptersMap.set('builtin', fake)
+
+    const worker = await harness.spawnWorker(spawnParams())
+    const workspaceRoot = worker.incarnations[0].workspace
+    events.length = 0
+
+    await expect(harness.sendToWorker(worker.worker_id, '接着把剩下的做完')).resolves.toBeUndefined()
+
+    // resume 完全没被调用（revive:false 分支）；handoff 走的是 spawn。
+    expect(fake.resumeCalls).toHaveLength(0)
+    expect(fake.spawnCalls.length).toBeGreaterThanOrEqual(1)
+    const handoffSpawn = fake.spawnCalls[fake.spawnCalls.length - 1]
+    expect(handoffSpawn.prompt).toContain('HANDOFF.md')
+    expect(handoffSpawn.prompt).toContain('接着把剩下的做完')
+
+    // HANDOFF.md 写入 workspace，含标题、输出尾、上次 outcome 标签。
+    const handoffPath = join(workspaceRoot, 'HANDOFF.md')
+    const handoffContent = await fs.readFile(handoffPath, 'utf-8')
+    expect(handoffContent).toContain('测试任务') // task.title
+    expect(handoffContent).toContain('这是执行到一半的输出') // 输出尾
+    expect(handoffContent).toMatch(/Previous outcome:/)
+
+    // 旧化身（seq=1）标 superseded：源化身在台账里还非终态时，先 kill 再落 exited(superseded)。
+    expect(fake.killCalls).toHaveLength(1)
+    expect(fake.killCalls[0].seq).toBe(1)
+    const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const oldEntry = w.incarnations.find((i) => i.seq === 1)!
+    expect(oldEntry.state).toBe('exited')
+    expect(oldEntry.ended_reason).toBe('superseded')
+
+    // 新化身入主线链。
+    const newEntry = w.incarnations[w.incarnations.length - 1]
+    expect(newEntry.forked_from).toBeUndefined()
+    expect(newEntry.state).toBe('running')
+    expect(w.task.status).toBe('running')
+
+    const handoffEvents = events.filter((e) => e.kind === 'handoff_started')
+    expect(handoffEvents).toHaveLength(1)
+    expect(handoffEvents[0].seq).toBe(1)
+    const supersededEvents = events.filter((e) => e.kind === 'superseded')
+    expect(supersededEvents).toHaveLength(1)
+  })
+
+  it('HANDOFF.md 已存在时追加带时间戳的新段，旧内容仍在（不覆盖）', async () => {
+    const { harness, adaptersMap } = await makeHarness()
+    const fake = new FakeAdapter({
+      caps: { revive: false },
+      onStateChange: harness.handleStateChange,
+      sendInputBehavior: (h) => {
+        throw new WorkerExitedError(h.worker_id, h.seq)
+      },
+    })
+    adaptersMap.set('builtin', fake)
+
+    const worker = await harness.spawnWorker(spawnParams())
+    const workspaceRoot = worker.incarnations[0].workspace
+    const handoffPath = join(workspaceRoot, 'HANDOFF.md')
+    await fs.mkdir(workspaceRoot, { recursive: true })
+    await fs.writeFile(handoffPath, '# 手工写入的既有交接记录\n旧内容不能丢\n', 'utf-8')
+
+    await harness.sendToWorker(worker.worker_id, '第二次交接')
+
+    const content = await fs.readFile(handoffPath, 'utf-8')
+    expect(content).toContain('# 手工写入的既有交接记录')
+    expect(content).toContain('旧内容不能丢')
+    expect(content).toMatch(/## Handoff \d{4}-\d{2}-\d{2}T/) // 新段带时间戳标题
+    expect(content).toContain('第二次交接')
+  })
+})
+
+describe('WorkerHarness.switchWorkerImpl — 跨实现切换', () => {
+  it('走同一条 handoff 路径，目标 adapter 由参数指定，源化身仍存活时先 kill 再标 superseded', async () => {
+    const { harness, adaptersMap } = await makeHarness()
+    const source = new FakeAdapter({ implId: 'claude-code', caps: { revive: true }, onStateChange: harness.handleStateChange, outputChunk: '侧问一半的输出' })
+    const target = new FakeAdapter({ implId: 'codex', caps: { revive: true }, onStateChange: harness.handleStateChange })
+    adaptersMap.set('claude-code', source)
+    adaptersMap.set('codex', target)
+
+    const worker = await harness.spawnWorker(spawnParams({ impl: 'claude-code' }))
+    events.length = 0
+
+    await harness.switchWorkerImpl(worker.worker_id, 'codex', '手工切换到 codex')
+
+    // 源化身仍是 running（没有触发过任何自然退出），走"仍非终态"分支：先 kill 再标 superseded。
+    expect(source.killCalls).toHaveLength(1)
+    expect(source.killCalls[0].seq).toBe(1)
+    // 目标 adapter 正确：codex 的 spawn 被调用一次；claude-code 只有最初 spawnWorker
+    // 那一次调用，没有因为这次切换被再 spawn 第二次。
+    expect(target.spawnCalls).toHaveLength(1)
+    expect(source.spawnCalls).toHaveLength(1)
+    expect(target.spawnCalls[0].prompt).toContain('手工切换到 codex')
+
+    const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const oldEntry = w.incarnations.find((i) => i.seq === 1)!
+    expect(oldEntry.ended_reason).toBe('superseded')
+    const newEntry = w.incarnations[w.incarnations.length - 1]
+    expect(newEntry.impl).toBe('codex')
+    expect(newEntry.forked_from).toBeUndefined()
+
+    expect(events.filter((e) => e.kind === 'handoff_started')).toHaveLength(1)
+    expect(events.filter((e) => e.kind === 'superseded')).toHaveLength(1)
+  })
+})
+
+describe('WorkerHarness — 接续过程中的并发', () => {
+  it('接续进行中来的 sendToWorker 不与之交错（在同一把 per-worker 锁内排队）', async () => {
+    const { harness, adaptersMap } = await makeHarness()
+    let releaseResume!: () => void
+    const resumeGate = new Promise<void>((resolve) => {
+      releaseResume = resolve
+    })
+    const fake = new FakeAdapter({
+      caps: { revive: true },
+      onStateChange: harness.handleStateChange,
+      resumeBehavior: async (prev) => {
+        await resumeGate
+        return { worker_id: prev.worker_id, seq: prev.seq + 1, impl: 'builtin', session_ref: `resumed-${prev.worker_id}` }
+      },
+    })
+    adaptersMap.set('builtin', fake)
+
+    const worker = await harness.spawnWorker(spawnParams())
+    const mainlineHandle: IncarnationHandle = { worker_id: worker.worker_id, seq: 1, impl: 'builtin', session_ref: `ref-${worker.worker_id}#1` }
+    fake.emitStateChange(mainlineHandle, 'exited')
+    await waitUntil(async () => {
+      const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+      return w.incarnations[0].state === 'exited'
+    })
+
+    // 第一次 sendToWorker 触发接续，卡在 resumeGate 上（resume 还没返回，per-worker 锁被占着）。
+    const firstSend = harness.sendToWorker(worker.worker_id, '第一条')
+
+    // 第二次 sendToWorker 此时应该排队等锁：它的 deliver() 也会经 inbox 尝试投递，但由于
+    // inbox.flush 内部同样串行、且第一条的接续持有 per-worker 锁，第二条不会在接续完成前
+    // 观察到"半接续"的中间态（比如两条化身同时挂进主线链）。
+    let secondResolved = false
+    const secondSend = harness.sendToWorker(worker.worker_id, '第二条').then(() => {
+      secondResolved = true
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(secondResolved).toBe(false)
+    expect(fake.resumeCalls).toHaveLength(1) // 第二次没有并发触发第二次 resume
+
+    releaseResume()
+    await firstSend
+    await secondSend
+
+    expect(secondResolved).toBe(true)
+    // 接续完成后台账只多了一个新主线化身（不是两个并发接续各自产出一个）。
+    const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    expect(w.incarnations).toHaveLength(2)
+    expect(fake.resumeCalls).toHaveLength(1)
+    // 第二条消息通过"mainline.seq !== sourceSeq"分支，作为普通投递补送到了新主线。
+    expect(fake.sendInputCalls.some((c) => c.text === '第二条')).toBe(true)
+  })
+})

--- a/crabot-agent/tests/workers/harness/harness-continuation.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-continuation.test.ts
@@ -884,3 +884,141 @@ describe('WorkerHarness.processStateChange — 化身查找: 同 (impl, seq) 撞
     expect(current.task.status).toBe('running') // mainline task 不受影响
   })
 })
+
+describe('WorkerHarness — 终审 PoC 回归：M1 主线守卫按 (impl,seq) 收口', () => {
+  it('switchWorkerImpl 到新实现后（seq 撞号），旧实现的迟到 exited 回调不得误杀新主线，也不得覆盖旧化身的 superseded', async () => {
+    const { harness, adaptersMap } = await makeHarness()
+    const source = new FakeAdapter({ implId: 'claude-code', caps: { revive: true }, onStateChange: harness.handleStateChange })
+    const target = new FakeAdapter({ implId: 'codex', caps: { revive: true }, onStateChange: harness.handleStateChange })
+    adaptersMap.set('claude-code', source)
+    adaptersMap.set('codex', target)
+
+    const worker = await harness.spawnWorker(spawnParams({ impl: 'claude-code' }))
+    // handoff 里 kill 旧化身触发的 exited 回调本该走这个 handle；这里手动重放，模拟它比
+    // handoff 收尾还慢的时序（真实 adapter 内部是异步触发 onStateChange，此处同型直调）。
+    const oldHandle: IncarnationHandle = { worker_id: worker.worker_id, seq: 1, impl: 'claude-code', session_ref: `ref-${worker.worker_id}#1` }
+    events.length = 0
+
+    await harness.switchWorkerImpl(worker.worker_id, 'codex', '手工切换到 codex')
+
+    // handoff 后新主线是 codex#1 —— target 是全新 FakeAdapter 实例，nextSeq 从 1 开始，
+    // 与被 kill 的旧化身 claude-code#1 在 seq 上撞号，这正是终审 PoC 复现的前提。
+    const afterHandoff = (await harness.listWorkers(dialogObjectIdForPrivate('friend-1')))[0]
+    const newMainline = afterHandoff.incarnations[afterHandoff.incarnations.length - 1]
+    expect(newMainline.impl).toBe('codex')
+    expect(newMainline.seq).toBe(1)
+    expect(afterHandoff.task.status).toBe('running')
+
+    // 顺带修复：handoff 产出的新化身也发了 spawned 事件（与 revive 路径的 resumed 对称）。
+    expect(events.filter((e) => e.kind === 'spawned')).toHaveLength(1)
+
+    // 旧 adapter（claude-code）的迟到 exited 回调打到 handoff 之前的 handle 上，seq 与新
+    // 主线 codex#1 相同——只比 seq 不比 impl 的守卫会把它误判成"当前主线化身的回调"。
+    source.emitStateChange(oldHandle, 'exited')
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    const after = (await harness.listWorkers(dialogObjectIdForPrivate('friend-1')))[0]
+    // 新主线（codex#1）未被这条属于旧实现的迟到回调误杀。
+    expect(after.task.status).toBe('running')
+    const stillMainline = after.incarnations[after.incarnations.length - 1]
+    expect(stillMainline.impl).toBe('codex')
+    expect(stillMainline.state).toBe('running')
+
+    // 旧化身（claude-code#1）的终态记录不被这条迟到回调覆盖——仍是 handoff 时记录的
+    // superseded，不是被误判成 completed。
+    const oldEntry = after.incarnations.find((i) => i.impl === 'claude-code' && i.seq === 1)!
+    expect(oldEntry.ended_reason).toBe('superseded')
+  })
+})
+
+describe('WorkerHarness — 终审 PoC 回归：M2 kill 与 in-flight flush 竞态', () => {
+  it('send 卡在投递期间 kill：残留队列条目被 drain 并记 dead-letter，task 保持 cancelled，不触发 resume 复活', async () => {
+    const { harness, adaptersMap } = await makeHarness()
+    let releaseFirst!: () => void
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve
+    })
+    const fake = new FakeAdapter({
+      caps: { revive: true },
+      onStateChange: harness.handleStateChange,
+      sendInputBehavior: async (_h, text) => {
+        if (text === '第一条(卡住)') await firstGate
+      },
+    })
+    adaptersMap.set('builtin', fake)
+
+    const worker = await harness.spawnWorker(spawnParams())
+    events.length = 0
+
+    // 第一条投递卡在 adapter.sendInput（模拟 tmux 命令挂起），占住 inbox 自己的 flush 锁。
+    const firstSend = harness.sendToWorker(worker.worker_id, '第一条(卡住)')
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(fake.sendInputCalls).toHaveLength(1) // 确认已经卡在 sendInput 里面
+
+    // 第二条这时候只能排进 inbox 队列，还没被 deliver 摸到（flush 的 mutex 被第一条占着）。
+    const secondSend = harness.sendToWorker(worker.worker_id, '第二条(残留队列)')
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(fake.sendInputCalls).toHaveLength(1) // 第二条还没被投递
+
+    // kill 走 harness 自己的 per-worker 锁，不被卡住的 sendInput 阻塞，立即完成。
+    await harness.killWorker(worker.worker_id, 'M2 PoC')
+
+    const afterKill = (await harness.listWorkers(dialogObjectIdForPrivate('friend-1')))[0]
+    expect(afterKill.task.status).toBe('cancelled')
+
+    // 放行第一条，让它的 sendInput 正常返回，flush 的 while 循环继续处理队列里的第二条。
+    releaseFirst()
+    await firstSend
+    await secondSend
+
+    const after = (await harness.listWorkers(dialogObjectIdForPrivate('friend-1')))[0]
+    // 核心断言：task 没有被第二条残留消息的透明接续复活成 running。
+    expect(after.task.status).toBe('cancelled')
+    expect(fake.resumeCalls).toHaveLength(0)
+
+    // 残留条目没有静默消失：有 dead-letter 记录。
+    const deadLetterEvents = events.filter((e) => e.kind === 'state_changed' && (e.detail as Record<string, unknown> | undefined)?.kind === 'dead_letter')
+    expect(deadLetterEvents.length).toBeGreaterThan(0)
+  })
+
+  it('send 卡住期间被 kill，之后 adapter.sendInput 才抛 WorkerExitedError 走透明接续：in-flight 条目不经过 drain，cancelled task 仍不被 continueTerminalWorker 复活', async () => {
+    const { harness, adaptersMap } = await makeHarness()
+    let releaseGate!: (err: Error) => void
+    const gate = new Promise<void>((_resolve, reject) => {
+      releaseGate = (err) => reject(err)
+    })
+    const fake = new FakeAdapter({
+      caps: { revive: true },
+      onStateChange: harness.handleStateChange,
+      sendInputBehavior: async () => {
+        await gate
+      },
+    })
+    adaptersMap.set('builtin', fake)
+
+    const worker = await harness.spawnWorker(spawnParams())
+    events.length = 0
+
+    const send = harness.sendToWorker(worker.worker_id, '卡住的一条')
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(fake.sendInputCalls).toHaveLength(1) // 确认已经卡在 sendInput 里面，是 in-flight 条目
+
+    await harness.killWorker(worker.worker_id, 'M2 PoC 2')
+    const afterKill = (await harness.listWorkers(dialogObjectIdForPrivate('friend-1')))[0]
+    expect(afterKill.task.status).toBe('cancelled')
+
+    // 放行卡住的 sendInput，让它抛出 WorkerExitedError（模拟 adapter 发现化身已经真的没了）
+    // —— deliver() 的 catch 分支会把它转入 continueTerminalWorker。这条条目在 kill 发生时
+    // 正处于 in-flight（已从 inbox 队列取出），drain() 明确不清空 in-flight 条目，所以这条
+    // 用例验证的是 continueTerminalWorker 自己的 cancelled 检查，而不是 killWorker 的 drain。
+    releaseGate(new WorkerExitedError(worker.worker_id, 1))
+    await send
+
+    const after = (await harness.listWorkers(dialogObjectIdForPrivate('friend-1')))[0]
+    expect(after.task.status).toBe('cancelled') // 核心断言：没有被复活成 running
+    expect(fake.resumeCalls).toHaveLength(0)
+
+    const deadLetterEvents = events.filter((e) => e.kind === 'state_changed' && (e.detail as Record<string, unknown> | undefined)?.kind === 'dead_letter')
+    expect(deadLetterEvents.length).toBeGreaterThan(0)
+  })
+})

--- a/crabot-agent/tests/workers/harness/harness-continuation.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-continuation.test.ts
@@ -1098,6 +1098,176 @@ describe('WorkerHarness — 终审 PoC 回归：M3 continueTerminalWorker 守卫
   })
 })
 
+describe('WorkerHarness — 二轮 review PoC 回归：continueTerminalWorker 补送分支的终态竞态收口（锁内可重入求值）', () => {
+  it('deliver 卡在旧主线投递期间发生跨实现切换，且新主线在本调用拿锁前也已自然终态（台账已落 exited）：不误对已终态化身调 sendInput，径直转接续，调用方无感', async () => {
+    const { harness, adaptersMap } = await makeHarness()
+    let releaseGate!: (err: Error) => void
+    const gate = new Promise<void>((_resolve, reject) => {
+      releaseGate = (err) => reject(err)
+    })
+    const source = new FakeAdapter({
+      implId: 'claude-code',
+      caps: { revive: true },
+      onStateChange: harness.handleStateChange,
+      sendInputBehavior: async () => {
+        await gate
+      },
+    })
+    const target = new FakeAdapter({
+      implId: 'codex',
+      caps: { revive: true },
+      onStateChange: harness.handleStateChange,
+      // 修复前：continueTerminalWorker 的"补送"分支无条件对当前主线调 sendInput，即使
+      // 台账已经把它记为 exited——真实 adapter 对已退出化身的 sendInput 权威地抛
+      // WorkerExitedError，这里如实模拟。修复后这条分支应当在读到 mainline.state==='exited'
+      // 后直接跳过 sendInput、转入接续，这个桩函数根本不会被调用（用 sendInputCalls 断言）。
+      sendInputBehavior: (h) => {
+        throw new WorkerExitedError(h.worker_id, h.seq)
+      },
+    })
+    adaptersMap.set('claude-code', source)
+    adaptersMap.set('codex', target)
+
+    const worker = await harness.spawnWorker(spawnParams({ impl: 'claude-code' }))
+    events.length = 0
+
+    // 第一条投递卡在 claude-code 的 sendInput 里，此刻 per-worker 锁空闲。
+    const send = harness.sendToWorker(worker.worker_id, '并发终态竞态', { raw: true })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(source.sendInputCalls).toHaveLength(1)
+
+    // 投递期间发生跨实现切换：codex#1 顶替 claude-code#1。
+    await harness.switchWorkerImpl(worker.worker_id, 'codex', '并发切换')
+    const afterSwitch = (await harness.listWorkers(dialogObjectIdForPrivate('friend-1')))[0]
+    const newMainline = afterSwitch.incarnations[afterSwitch.incarnations.length - 1]
+    expect(newMainline.impl).toBe('codex')
+    expect(newMainline.seq).toBe(1)
+    expect(newMainline.state).toBe('running')
+
+    // 关键并发窗口：在 continueTerminalWorker 真正拿到 per-worker 锁之前，新主线
+    // （codex#1）自己也已经自然退出——processStateChange 抢先拿锁，把它落定为 exited。
+    const newMainlineHandle: IncarnationHandle = {
+      worker_id: worker.worker_id,
+      seq: 1,
+      impl: 'codex',
+      session_ref: newMainline.session_ref,
+    }
+    target.emitStateChange(newMainlineHandle, 'exited')
+    await waitUntil(async () => {
+      const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+      const ml = w.incarnations[w.incarnations.length - 1]
+      return ml.impl === 'codex' && ml.state === 'exited'
+    })
+
+    // 放行卡住的 sendInput，抛出 WorkerExitedError——deliver 的 catch 分支据此转入
+    // continueTerminalWorker(sourceImpl='claude-code', sourceSeq=1)，此时主线早已换成
+    // 已终态的 codex#1。
+    releaseGate(new WorkerExitedError(worker.worker_id, 1))
+
+    // 核心断言：修复前，补送分支对已终态的新主线仍无条件调 sendInput，抛出的
+    // WorkerExitedError 穿透 inbox.flush、条目 unshift 回队首，砸给 sendToWorker 的
+    // 调用方——这里会 reject。修复后应当无感 resolve。
+    await expect(send).resolves.toBeUndefined()
+
+    // 已终态的新主线不该被无谓地 sendInput 一次（对失败必然发生的调用做了跳过判断）。
+    expect(target.sendInputCalls).toHaveLength(0)
+    // 而是被当作接续的新源头，走 revive。
+    expect(target.resumeCalls).toHaveLength(1)
+    expect(target.resumeCalls[0].prev).toEqual({
+      worker_id: worker.worker_id,
+      seq: 1,
+      session_ref: newMainline.session_ref,
+    })
+    expect(target.resumeCalls[0].wakeInput).toBe('并发终态竞态')
+
+    const after = (await harness.listWorkers(dialogObjectIdForPrivate('friend-1')))[0]
+    expect(after.incarnations).toHaveLength(3)
+    const finalMainline = after.incarnations[after.incarnations.length - 1]
+    expect(finalMainline.impl).toBe('codex')
+    expect(finalMainline.state).toBe('running')
+
+    // 消息没有滞留：没有产生 dead-letter。
+    const deadLetterEvents = events.filter(
+      (e) => e.kind === 'state_changed' && (e.detail as Record<string, unknown> | undefined)?.kind === 'dead_letter'
+    )
+    expect(deadLetterEvents).toHaveLength(0)
+  })
+
+  it('新主线仍存活（台账未落终态）但 adapter.sendInput 权威地抛 WorkerExitedError：同样转入接续，不砸向调用方', async () => {
+    const { harness, adaptersMap } = await makeHarness()
+    let releaseGate!: (err: Error) => void
+    const gate = new Promise<void>((_resolve, reject) => {
+      releaseGate = (err) => reject(err)
+    })
+    const source = new FakeAdapter({
+      implId: 'claude-code',
+      caps: { revive: true },
+      onStateChange: harness.handleStateChange,
+      sendInputBehavior: async () => {
+        await gate
+      },
+    })
+    const target = new FakeAdapter({
+      implId: 'codex',
+      caps: { revive: true },
+      onStateChange: harness.handleStateChange,
+      // 台账里新主线仍是 running（没有触发过任何状态回调），但 adapter 自己权威地判定
+      // 化身已经不在了——修复前，补送分支对这次 sendInput 抛出的 WorkerExitedError 不做
+      // 任何捕获，原样穿透。
+      sendInputBehavior: (h) => {
+        throw new WorkerExitedError(h.worker_id, h.seq)
+      },
+    })
+    adaptersMap.set('claude-code', source)
+    adaptersMap.set('codex', target)
+
+    const worker = await harness.spawnWorker(spawnParams({ impl: 'claude-code' }))
+    events.length = 0
+
+    const send = harness.sendToWorker(worker.worker_id, '权威抛错场景', { raw: true })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(source.sendInputCalls).toHaveLength(1)
+
+    await harness.switchWorkerImpl(worker.worker_id, 'codex', '并发切换')
+    const afterSwitch = (await harness.listWorkers(dialogObjectIdForPrivate('friend-1')))[0]
+    const newMainline = afterSwitch.incarnations[afterSwitch.incarnations.length - 1]
+    expect(newMainline.impl).toBe('codex')
+    expect(newMainline.seq).toBe(1)
+    expect(newMainline.state).toBe('running') // 台账未落终态，与上一条用例的区别所在
+
+    releaseGate(new WorkerExitedError(worker.worker_id, 1))
+
+    // 核心断言：修复前会 reject（补送分支的 sendInput 抛错未被捕获）。
+    await expect(send).resolves.toBeUndefined()
+
+    // 确实尝试过一次对新主线的正常投递，才发现它已经不在了。
+    expect(target.sendInputCalls).toHaveLength(1)
+    // 随后转入接续，以这个新主线为源头 revive。
+    expect(target.resumeCalls).toHaveLength(1)
+    expect(target.resumeCalls[0].prev).toEqual({
+      worker_id: worker.worker_id,
+      seq: 1,
+      session_ref: newMainline.session_ref,
+    })
+    expect(target.resumeCalls[0].wakeInput).toBe('权威抛错场景')
+
+    const after = (await harness.listWorkers(dialogObjectIdForPrivate('friend-1')))[0]
+    expect(after.incarnations).toHaveLength(3)
+    // codex#1 被 revive 之前的补写收尾成终态（reviveIncarnation 既有逻辑：台账态未追上
+    // adapter 真实状态时先回填）。
+    const codexFirst = after.incarnations.find((i) => i.impl === 'codex' && i.state === 'exited')!
+    expect(codexFirst.ended_reason).toBe('completed')
+    const finalMainline = after.incarnations[after.incarnations.length - 1]
+    expect(finalMainline.impl).toBe('codex')
+    expect(finalMainline.state).toBe('running')
+
+    const deadLetterEvents = events.filter(
+      (e) => e.kind === 'state_changed' && (e.detail as Record<string, unknown> | undefined)?.kind === 'dead_letter'
+    )
+    expect(deadLetterEvents).toHaveLength(0)
+  })
+})
+
 describe('WorkerHarness.switchWorkerImpl — 终审 PoC 回归：M3 cancelled 是唯一硬拒绝，不得复活', () => {
   it('对已 cancelled 的 worker 调 switchWorkerImpl → 抛 TaskCancelledError，不 provision/不 spawn，task 仍是 cancelled', async () => {
     const { harness, adaptersMap } = await makeHarness()

--- a/crabot-agent/tests/workers/harness/harness-continuation.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-continuation.test.ts
@@ -8,6 +8,9 @@ import { WorkspaceManager } from '../../../src/workers/harness/workspace-manager
 import { dialogObjectIdForPrivate } from '../../../src/workers/harness/ledger-types'
 import type { HarnessEvent } from '../../../src/workers/harness/worker-events'
 import { WorkerExitedError } from '../../../src/workers/errors'
+import { BuiltinWorkerAdapter } from '../../../src/workers/builtin/adapter'
+import type { LLMAdapter } from '../../../src/engine/llm-adapter-types.js'
+import { chunksFromContent } from '../../engine/helpers/mock-stream'
 import type {
   WorkerAdapter,
   WorkerImplId,
@@ -421,5 +424,65 @@ describe('WorkerHarness — 接续过程中的并发', () => {
     expect(fake.resumeCalls).toHaveLength(1)
     // 第二条消息通过"mainline.seq !== sourceSeq"分支，作为普通投递补送到了新主线。
     expect(fake.sendInputCalls.some((c) => c.text === '第二条')).toBe(true)
+  })
+})
+
+// ---- session_ref 时效性修复：用真实 BuiltinWorkerAdapter（mock LLM），跑两轮 burst，
+// 断言台账里的 session_ref 已经推进到新 tip，而不是 spawn 时的初值。----
+
+function makeMockLLMAdapter(
+  responses: Array<{ text?: string; stopReason: 'end_turn' | 'tool_use' }>,
+): LLMAdapter {
+  let i = 0
+  return {
+    stream: async function* () {
+      const r = responses[i++] ?? responses[responses.length - 1]
+      const content: unknown[] = []
+      if (r.text) content.push({ type: 'text', text: r.text })
+      yield* chunksFromContent(content, r.stopReason, { inputTokens: 100, outputTokens: 50 })
+    },
+    updateConfig: () => {},
+  } as unknown as LLMAdapter
+}
+
+describe('BuiltinWorkerAdapter → WorkerHarness — session_ref 时效性修复', () => {
+  it('两轮 burst 后，台账里的 session_ref 已推进到新 tip（不是 spawn 时的初值）', async () => {
+    const builtinDataDir = join(dataDir, 'builtin-runtime')
+    await fs.mkdir(builtinDataDir, { recursive: true })
+
+    const { harness, adaptersMap } = await makeHarness()
+    const builtinAdapter = new BuiltinWorkerAdapter({ dataDir: builtinDataDir, onStateChange: harness.handleStateChange })
+    adaptersMap.set('builtin', builtinAdapter)
+
+    const llmAdapter = makeMockLLMAdapter([
+      { text: '第一轮回复', stopReason: 'end_turn' },
+      { text: '第二轮回复', stopReason: 'end_turn' },
+    ])
+
+    const worker = await harness.spawnWorker(
+      spawnParams({ builtin: { adapter: llmAdapter, model: 'test', systemPrompt: '', tools: [] } })
+    )
+    const spawnTimeSessionRef = worker.incarnations[0].session_ref
+    expect(spawnTimeSessionRef).toBeTruthy()
+
+    await waitUntil(async () => {
+      const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+      return w.incarnations[0].state === 'idle'
+    })
+    const [afterFirstBurst] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    // 第一轮 burst 结束后，台账的 session_ref 已经从 spawn 时的根节点前进到新 tip——
+    // 不再是创建时刻的快照，而是"最近一次完成的状态转换点"。
+    expect(afterFirstBurst.incarnations[0].session_ref).not.toBe(spawnTimeSessionRef)
+    const afterFirstBurstRef = afterFirstBurst.incarnations[0].session_ref
+
+    await harness.sendToWorker(worker.worker_id, '第二轮输入')
+    await waitUntil(async () => {
+      const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+      return w.incarnations[0].state === 'idle' && w.incarnations[0].session_ref !== afterFirstBurstRef
+    })
+
+    const [afterSecondBurst] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    expect(afterSecondBurst.incarnations[0].session_ref).not.toBe(afterFirstBurstRef)
+    expect(afterSecondBurst.incarnations[0].session_ref).not.toBe(spawnTimeSessionRef)
   })
 })

--- a/crabot-agent/tests/workers/harness/harness-continuation.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-continuation.test.ts
@@ -160,6 +160,12 @@ async function makeHarness(): Promise<{
     workersDir,
     now,
     onEvent: (e) => events.push(e),
+    // 本文件里 FakeAdapter 缺省 implId 就是 'builtin'（多数测试拿它当泛化的"随便一个实现"
+    // 桩用，不关心真实 LLM 注入）；handoffIncarnation 的 pre-flight（裁决 B 修复）对目标
+    // impl==='builtin' 硬性要求 HarnessDeps.builtinSpawnDefaults，这里给个无害的桩值，
+    // 让不专门测这条 pre-flight 的既有用例不受影响。专门测 pre-flight 行为的用例会自建
+    // 不含这个字段的 deps（见下面两个 describe 块）。
+    builtinSpawnDefaults: () => ({ adapter: {} as LLMAdapter, model: 'test-model', systemPrompt: '', tools: [] }),
   }
   const harness = new WorkerHarness(deps)
   return { harness, ledger, adaptersMap, defaultImpl: 'builtin' }
@@ -471,6 +477,115 @@ describe('WorkerHarness — 接续过程中的并发', () => {
     expect(fake.resumeCalls).toHaveLength(1)
     // 第二条消息通过"mainline.seq !== sourceSeq"分支，作为普通投递补送到了新主线。
     expect(fake.sendInputCalls.some((c) => c.text === '第二条')).toBe(true)
+  })
+})
+
+describe('WorkerHarness.handoffIncarnation — handoff 目标是 builtin 时的 pre-flight（裁决 B 修复）', () => {
+  it('目标是 builtin 且未配置 HarnessDeps.builtinSpawnDefaults → pre-flight 直接抛错，旧化身状态与 HANDOFF.md 均未被改动（可重试）', async () => {
+    // 不用共享的 makeHarness() —— 它为了不影响其它不专门测这条 pre-flight 的既有用例，
+    // 默认给 builtinSpawnDefaults 配了桩值；这里要专门测"没配置"的场景，必须自建 deps。
+    const ledgersDir = join(dataDir, 'ledgers')
+    const workspacesRoot = join(dataDir, 'workspaces')
+    const workersDir = join(dataDir, 'workers')
+    await fs.mkdir(workspacesRoot, { recursive: true })
+    const ledger = new LedgerStore(ledgersDir)
+    const workspaces = new WorkspaceManager(workspacesRoot)
+    const adaptersMap = new Map<WorkerImplId, WorkerAdapter>()
+    const deps: HarnessDeps = {
+      adapters: adaptersMap,
+      defaultImpl: 'claude-code',
+      ledger,
+      workspaces,
+      workersDir,
+      now,
+      onEvent: (e) => events.push(e),
+      // 关键：没有 builtinSpawnDefaults。
+    }
+    const harness = new WorkerHarness(deps)
+    const source = new FakeAdapter({
+      implId: 'claude-code',
+      caps: { revive: true },
+      onStateChange: harness.handleStateChange,
+      outputChunk: '还没做完的工作',
+    })
+    const builtinTarget = new FakeAdapter({ implId: 'builtin', onStateChange: harness.handleStateChange })
+    adaptersMap.set('claude-code', source)
+    adaptersMap.set('builtin', builtinTarget)
+
+    const worker = await harness.spawnWorker(spawnParams({ impl: 'claude-code' }))
+    const workspaceRoot = worker.incarnations[0].workspace
+    events.length = 0
+
+    await expect(harness.switchWorkerImpl(worker.worker_id, 'builtin', '切到 builtin')).rejects.toThrow(
+      /builtinSpawnDefaults/
+    )
+
+    // pre-flight 失败必须发生在"碰旧化身"之前：不能 kill、不能改台账、不能写 HANDOFF.md，
+    // 否则下次重试会重复整套 handoff（重复追加 HANDOFF.md），且 worker 卡在"旧的没了、
+    // 新的没建成"的死结里。
+    expect(source.killCalls).toHaveLength(0)
+    expect(builtinTarget.spawnCalls).toHaveLength(0)
+    const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    expect(w.incarnations).toHaveLength(1)
+    expect(w.incarnations[0].state).toBe('running') // 源化身原样存活，未被标 superseded
+    expect(w.incarnations[0].ended_reason).toBeUndefined()
+
+    await expect(fs.readFile(join(workspaceRoot, 'HANDOFF.md'), 'utf-8')).rejects.toThrow() // 文件未被创建
+
+    expect(events.filter((e) => e.kind === 'handoff_started')).toHaveLength(0)
+    expect(events.filter((e) => e.kind === 'superseded')).toHaveLength(0)
+  })
+
+  it('目标是 builtin 且配置了 HarnessDeps.builtinSpawnDefaults → handoff 正常完成，新化身 spawn 时带上了注入的 builtin 配置', async () => {
+    const ledgersDir = join(dataDir, 'ledgers')
+    const workspacesRoot = join(dataDir, 'workspaces')
+    const workersDir = join(dataDir, 'workers')
+    await fs.mkdir(workspacesRoot, { recursive: true })
+    const ledger = new LedgerStore(ledgersDir)
+    const workspaces = new WorkspaceManager(workspacesRoot)
+    const builtinDefaults: NonNullable<SpawnSpec['builtin']> = {
+      adapter: {} as LLMAdapter,
+      model: 'test-model',
+      systemPrompt: '',
+      tools: [],
+    }
+
+    // 见 harness.ts 文件头"onStateChange 接线契约":先建空壳 Map、建 harness，再建各 adapter
+    // （构造时把 harness.handleStateChange 传进去），最后把 adapter 塞进 Map。
+    const adaptersMap = new Map<WorkerImplId, WorkerAdapter>()
+    const deps: HarnessDeps = {
+      adapters: adaptersMap,
+      defaultImpl: 'claude-code',
+      ledger,
+      workspaces,
+      workersDir,
+      now,
+      onEvent: (e) => events.push(e),
+      builtinSpawnDefaults: () => builtinDefaults,
+    }
+    const harness = new WorkerHarness(deps)
+    const source = new FakeAdapter({
+      implId: 'claude-code',
+      caps: { revive: true },
+      onStateChange: harness.handleStateChange,
+      outputChunk: '还没做完的工作',
+    })
+    const builtinTarget = new FakeAdapter({ implId: 'builtin', onStateChange: harness.handleStateChange })
+    adaptersMap.set('claude-code', source)
+    adaptersMap.set('builtin', builtinTarget)
+
+    const worker = await harness.spawnWorker(spawnParams({ impl: 'claude-code' }))
+    events.length = 0
+
+    await harness.switchWorkerImpl(worker.worker_id, 'builtin', '切到 builtin')
+
+    expect(builtinTarget.spawnCalls).toHaveLength(1)
+    expect(builtinTarget.spawnCalls[0].builtin).toBe(builtinDefaults)
+
+    const [w] = await ledger.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const newEntry = w.incarnations[w.incarnations.length - 1]
+    expect(newEntry.impl).toBe('builtin')
+    expect(newEntry.state).toBe('running')
   })
 })
 

--- a/crabot-agent/tests/workers/harness/harness-continuation.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-continuation.test.ts
@@ -2,7 +2,14 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { promises as fs } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
-import { WorkerHarness, WorkerNotFoundError, TaskCancelledError, type HarnessDeps, type SpawnWorkerParams } from '../../../src/workers/harness/harness'
+import {
+  WorkerHarness,
+  WorkerNotFoundError,
+  TaskCancelledError,
+  ImplAlreadyUsedError,
+  type HarnessDeps,
+  type SpawnWorkerParams,
+} from '../../../src/workers/harness/harness'
 import { LedgerStore } from '../../../src/workers/harness/ledger-store'
 import { WorkspaceManager } from '../../../src/workers/harness/workspace-manager'
 import { dialogObjectIdForPrivate } from '../../../src/workers/harness/ledger-types'
@@ -323,6 +330,13 @@ describe('WorkerHarness — 透明接续：handoff (capabilities().revive === fa
       },
     })
     adaptersMap.set('builtin', fake)
+    // 三轮 review 修复后，revive:false 的自动 handoff 不再"原 impl 沿用"（mainline.impl 在
+    // worker.incarnations 里必然已经用过，沿用会被 ImplAlreadyUsedError pre-flight 拒绝），
+    // 而是改选一个该 worker 尚未用过的实现（pickUnusedImpl）——必须再注册一个未用过的
+    // adapter，否则 handoff 会因为"全都用过"而抛 ImplAlreadyUsedError，无法测到 handoff 本体
+    // 逻辑（HANDOFF.md 内容/superseded/spawned 事件）。
+    const target = new FakeAdapter({ implId: 'claude-code', onStateChange: harness.handleStateChange })
+    adaptersMap.set('claude-code', target)
 
     const worker = await harness.spawnWorker(spawnParams())
     const workspaceRoot = worker.incarnations[0].workspace
@@ -330,10 +344,12 @@ describe('WorkerHarness — 透明接续：handoff (capabilities().revive === fa
 
     await expect(harness.sendToWorker(worker.worker_id, '接着把剩下的做完')).resolves.toBeUndefined()
 
-    // resume 完全没被调用（revive:false 分支）；handoff 走的是 spawn。
+    // resume 完全没被调用（revive:false 分支）；handoff 走的是 spawn，且目标是未用过的
+    // 'claude-code'（不是原 impl 'builtin'）。
     expect(fake.resumeCalls).toHaveLength(0)
-    expect(fake.spawnCalls.length).toBeGreaterThanOrEqual(1)
-    const handoffSpawn = fake.spawnCalls[fake.spawnCalls.length - 1]
+    expect(target.resumeCalls).toHaveLength(0)
+    expect(target.spawnCalls).toHaveLength(1)
+    const handoffSpawn = target.spawnCalls[0]
     expect(handoffSpawn.prompt).toContain('HANDOFF.md')
     expect(handoffSpawn.prompt).toContain('接着把剩下的做完')
 
@@ -344,7 +360,8 @@ describe('WorkerHarness — 透明接续：handoff (capabilities().revive === fa
     expect(handoffContent).toContain('这是执行到一半的输出') // 输出尾
     expect(handoffContent).toMatch(/Previous outcome:/)
 
-    // 旧化身（seq=1）标 superseded：源化身在台账里还非终态时，先 kill 再落 exited(superseded)。
+    // 旧化身（seq=1，impl='builtin'）标 superseded：源化身在台账里还非终态时，先 kill 再落
+    // exited(superseded)。
     expect(fake.killCalls).toHaveLength(1)
     expect(fake.killCalls[0].seq).toBe(1)
     const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
@@ -352,8 +369,9 @@ describe('WorkerHarness — 透明接续：handoff (capabilities().revive === fa
     expect(oldEntry.state).toBe('exited')
     expect(oldEntry.ended_reason).toBe('superseded')
 
-    // 新化身入主线链。
+    // 新化身入主线链，impl 是改选出来的 'claude-code'。
     const newEntry = w.incarnations[w.incarnations.length - 1]
+    expect(newEntry.impl).toBe('claude-code')
     expect(newEntry.forked_from).toBeUndefined()
     expect(newEntry.state).toBe('running')
     expect(w.task.status).toBe('running')
@@ -375,6 +393,9 @@ describe('WorkerHarness — 透明接续：handoff (capabilities().revive === fa
       },
     })
     adaptersMap.set('builtin', fake)
+    // 同上：需要一个未用过的目标 impl，否则 pickUnusedImpl 找不到可用目标，handoff 会被
+    // ImplAlreadyUsedError pre-flight 拒绝。
+    adaptersMap.set('claude-code', new FakeAdapter({ implId: 'claude-code', onStateChange: harness.handleStateChange }))
 
     const worker = await harness.spawnWorker(spawnParams())
     const workspaceRoot = worker.incarnations[0].workspace
@@ -1302,5 +1323,201 @@ describe('WorkerHarness.switchWorkerImpl — 终审 PoC 回归：M3 cancelled �
     // kill 旧化身之前就已经拒绝。
     expect(events.filter((e) => e.kind === 'handoff_started')).toHaveLength(0)
     expect(events.filter((e) => e.kind === 'spawned')).toHaveLength(0)
+  })
+})
+
+// ---- 三轮 review PoC 回归：handoff 目标是该 worker 已用过的 impl（含切回原实现、同实现
+// 切换）必然在真实 adapter 上撞上"already spawned"守卫（三个 adapter 的 spawn 都硬编码
+// seq=1，kill 不清除这道守卫记忆），重蹈 pre-flight 本该防住的"旧的没了、新的没建成"死结。
+// FakeAdapter 默认没有这道守卫（spawnCalls 可以无限次成功），必须显式配 spawnBehavior 复刻
+// 真实 adapter 的行为，测试才能真实复现死结，而不是被 FakeAdapter 的宽松行为掩盖。----
+
+/**
+ * 复刻真实 adapter（cc/codex/builtin）spawn 硬编码 seq=1 + "already spawned" 守卫的
+ * spawnBehavior：同一 (impl, worker_id) 第二次调用 spawn 必然抛错，且 kill 不会清除这道
+ * 记忆（`spawnedOnce` 是模块外部传入、跨越 kill 持续存在的状态，对齐真实 adapter 里
+ * runtimes/builtinConfigs 不因 kill 被删除条目的事实）。
+ */
+function guardedSpawnBehavior(implLabel: string, spawnedOnce: Set<string>, impl: WorkerImplId) {
+  return (spec: SpawnSpec): IncarnationHandle => {
+    const key = `${impl}:${spec.worker_id}`
+    if (spawnedOnce.has(key)) {
+      throw new Error(`FakeAdapter(${implLabel}).spawn: worker_id ${spec.worker_id} already spawned in this process`)
+    }
+    spawnedOnce.add(key)
+    return { worker_id: spec.worker_id, seq: 1, impl, session_ref: `ref-${spec.worker_id}#1` }
+  }
+}
+
+describe('WorkerHarness — 三轮 review PoC 回归：handoff 目标是该 worker 已用过的 impl（含切回原实现、同实现切换）', () => {
+  it('switchWorkerImpl 切回曾经用过的实现（cc → codex → cc）→ 抛 ImplAlreadyUsedError；源化身（当前主线 codex#1）状态未变、HANDOFF.md 未被再次追加、目标（cc）adapter 无新增 provision/spawn 调用', async () => {
+    const { harness, adaptersMap } = await makeHarness()
+    const spawnedOnce = new Set<string>()
+    const cc = new FakeAdapter({
+      implId: 'claude-code',
+      caps: { revive: true },
+      onStateChange: harness.handleStateChange,
+      spawnBehavior: guardedSpawnBehavior('claude-code', spawnedOnce, 'claude-code'),
+    })
+    const codex = new FakeAdapter({
+      implId: 'codex',
+      caps: { revive: true },
+      onStateChange: harness.handleStateChange,
+      spawnBehavior: guardedSpawnBehavior('codex', spawnedOnce, 'codex'),
+    })
+    adaptersMap.set('claude-code', cc)
+    adaptersMap.set('codex', codex)
+
+    const worker = await harness.spawnWorker(spawnParams({ impl: 'claude-code' }))
+    const workspaceRoot = worker.incarnations[0].workspace
+
+    // 第一次切换：cc → codex，单向切换不撞上这个守卫，正常完成。
+    await harness.switchWorkerImpl(worker.worker_id, 'codex', '切到 codex')
+    expect(codex.spawnCalls).toHaveLength(1)
+    expect(cc.spawnCalls).toHaveLength(1) // 只有最初 spawnWorker 那一次
+
+    const handoffBefore = await fs.readFile(join(workspaceRoot, 'HANDOFF.md'), 'utf-8')
+    events.length = 0
+
+    // 第二次切换：切回 claude-code（曾经用过的实现）。修复前会走到 handoffIncarnation
+    // step 2（kill 当前主线 codex#1、标 superseded）之后，step 3 的 cc.spawn 撞上
+    // guardedSpawnBehavior 的"already spawned"守卫抛错——此时 codex#1 已经被 kill，
+    // 新化身建不成，worker 卡进死结。修复后 pre-flight 在 kill 之前就已经拒绝。
+    await expect(harness.switchWorkerImpl(worker.worker_id, 'claude-code', '切回 cc')).rejects.toThrow(
+      ImplAlreadyUsedError
+    )
+
+    // 目标（claude-code）没有新增 provision/spawn 调用——仍然只有最初 spawnWorker 那一次。
+    expect(cc.spawnCalls).toHaveLength(1)
+    expect(cc.provisionCalls).toHaveLength(1)
+
+    // 源化身（当前主线 codex#1）状态未变：没有被 kill，没有被标 superseded——这正是死结
+    // 场景里会被破坏的不变量。
+    expect(codex.killCalls).toHaveLength(0)
+    const [after] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const mainlineAfter = after.incarnations[after.incarnations.length - 1]
+    expect(mainlineAfter.impl).toBe('codex')
+    expect(mainlineAfter.seq).toBe(1)
+    expect(mainlineAfter.state).toBe('running')
+    expect(mainlineAfter.ended_reason).toBeUndefined()
+    expect(after.incarnations).toHaveLength(2) // 没有多出第三条化身
+
+    // HANDOFF.md 未被再次追加。
+    const handoffAfter = await fs.readFile(join(workspaceRoot, 'HANDOFF.md'), 'utf-8')
+    expect(handoffAfter).toBe(handoffBefore)
+
+    // 没有产生新的 handoff_started / superseded 事件——pre-flight 在写 HANDOFF.md 和 kill
+    // 源化身之前就已经拒绝。
+    expect(events.filter((e) => e.kind === 'handoff_started')).toHaveLength(0)
+    expect(events.filter((e) => e.kind === 'superseded')).toHaveLength(0)
+  })
+
+  it('switchWorkerImpl 切到当前正在用的同一个 impl（未曾切换过）→ 同样被 ImplAlreadyUsedError 拒绝，源化身原样存活', async () => {
+    const { harness, adaptersMap } = await makeHarness()
+    const spawnedOnce = new Set<string>()
+    const cc = new FakeAdapter({
+      implId: 'claude-code',
+      caps: { revive: true },
+      onStateChange: harness.handleStateChange,
+      spawnBehavior: guardedSpawnBehavior('claude-code', spawnedOnce, 'claude-code'),
+    })
+    adaptersMap.set('claude-code', cc)
+
+    const worker = await harness.spawnWorker(spawnParams({ impl: 'claude-code' }))
+    const workspaceRoot = worker.incarnations[0].workspace
+    events.length = 0
+
+    await expect(harness.switchWorkerImpl(worker.worker_id, 'claude-code', '切到同一个 impl')).rejects.toThrow(
+      ImplAlreadyUsedError
+    )
+
+    expect(cc.killCalls).toHaveLength(0)
+    expect(cc.spawnCalls).toHaveLength(1) // 仍然只有最初 spawnWorker 那一次
+
+    const [after] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    expect(after.incarnations).toHaveLength(1)
+    expect(after.incarnations[0].state).toBe('running')
+    expect(after.incarnations[0].ended_reason).toBeUndefined()
+
+    await expect(fs.readFile(join(workspaceRoot, 'HANDOFF.md'), 'utf-8')).rejects.toThrow() // 文件未被创建
+    expect(events.filter((e) => e.kind === 'handoff_started')).toHaveLength(0)
+  })
+
+  it('sendToWorker 触发的自动 handoff（revive:false）在"原 impl 已用过"时改选一个未用过的 impl 并成功', async () => {
+    const { harness, adaptersMap } = await makeHarness()
+    const spawnedOnce = new Set<string>()
+    // mainline 用的实现（revive:false，触发自动 handoff）——它本身就是"已用过"的那个 impl，
+    // handoffIncarnation 若沿用它会必然撞上 spawn 守卫。
+    const mainlineAdapter = new FakeAdapter({
+      implId: 'claude-code',
+      caps: { revive: false },
+      onStateChange: harness.handleStateChange,
+      sendInputBehavior: (h) => {
+        throw new WorkerExitedError(h.worker_id, h.seq)
+      },
+      spawnBehavior: guardedSpawnBehavior('claude-code', spawnedOnce, 'claude-code'),
+    })
+    // 未用过的目标：defaultImpl（'builtin'，见 makeHarness）本身就还没被这个 worker 用过，
+    // pickUnusedImpl 应该直接选中它。
+    const builtinTarget = new FakeAdapter({
+      implId: 'builtin',
+      onStateChange: harness.handleStateChange,
+      spawnBehavior: guardedSpawnBehavior('builtin', spawnedOnce, 'builtin'),
+    })
+    adaptersMap.set('claude-code', mainlineAdapter)
+    adaptersMap.set('builtin', builtinTarget)
+
+    const worker = await harness.spawnWorker(spawnParams({ impl: 'claude-code' }))
+    events.length = 0
+
+    await expect(harness.sendToWorker(worker.worker_id, '接着做完')).resolves.toBeUndefined()
+
+    // 改选到了未用过的 'builtin'，不是原 impl 'claude-code'。
+    expect(builtinTarget.spawnCalls).toHaveLength(1)
+    expect(mainlineAdapter.killCalls).toHaveLength(1) // 源化身（claude-code#1）被 kill 标 superseded
+
+    const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const newEntry = w.incarnations[w.incarnations.length - 1]
+    expect(newEntry.impl).toBe('builtin')
+    expect(newEntry.state).toBe('running')
+    expect(w.task.status).toBe('running')
+    expect(events.filter((e) => e.kind === 'handoff_started')).toHaveLength(1)
+  })
+
+  it('sendToWorker 触发的自动 handoff（revive:false）在所有已注册 impl 都用过时 → 抛 ImplAlreadyUsedError，不动源化身', async () => {
+    const { harness, adaptersMap } = await makeHarness()
+    const spawnedOnce = new Set<string>()
+    // 只注册一个实现（'builtin'，恰好也是 makeHarness 的 defaultImpl），且它就是 mainline
+    // 正在用的 impl——除它之外没有任何"未用过"的可选目标，pickUnusedImpl 只能落回
+    // defaultImpl（同样已用过），handoffIncarnation 的 pre-flight 统一抛错。
+    const mainlineAdapter = new FakeAdapter({
+      implId: 'builtin',
+      caps: { revive: false },
+      onStateChange: harness.handleStateChange,
+      sendInputBehavior: (h) => {
+        throw new WorkerExitedError(h.worker_id, h.seq)
+      },
+      spawnBehavior: guardedSpawnBehavior('builtin', spawnedOnce, 'builtin'),
+    })
+    adaptersMap.set('builtin', mainlineAdapter)
+
+    const worker = await harness.spawnWorker(spawnParams())
+    const workspaceRoot = worker.incarnations[0].workspace
+    events.length = 0
+
+    // sendToWorker 的契约是"投递永不因状态失败"——continueTerminalWorker 的 cancelled 短路
+    // 走 dead-letter 不重新抛出，但 ImplAlreadyUsedError 不是那种"消息可以留到下次重试"的
+    // 场景（不是并发窗口、也不是 cancelled），是配置/能力层面的硬失败，原样向上抛给调用方。
+    await expect(harness.sendToWorker(worker.worker_id, '接着做完')).rejects.toThrow(ImplAlreadyUsedError)
+
+    // 源化身没有被 kill、没有被标 superseded——pre-flight 在 kill 之前就已经拒绝。
+    expect(mainlineAdapter.killCalls).toHaveLength(0)
+    const [after] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    expect(after.incarnations).toHaveLength(1)
+    expect(after.incarnations[0].state).toBe('running')
+    expect(after.incarnations[0].ended_reason).toBeUndefined()
+
+    await expect(fs.readFile(join(workspaceRoot, 'HANDOFF.md'), 'utf-8')).rejects.toThrow() // 文件未被创建
+    expect(events.filter((e) => e.kind === 'handoff_started')).toHaveLength(0)
   })
 })

--- a/crabot-agent/tests/workers/harness/harness-integration.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-integration.test.ts
@@ -1,0 +1,524 @@
+/**
+ * WorkerHarness — 真实 adapter 集成冒烟(P3 Task 10)。
+ *
+ * Task 7-9 的 harness 测试全部用 FakeAdapter 桩证明编排逻辑本身正确,但从未验证过
+ * harness 与真实 adapter 之间的接线契约(onStateChange 绑定顺序、handle 字段、
+ * capabilities() 判断)是否真的对得上——桩可以被写成"凑巧满足断言"的样子,不代表真实
+ * adapter 也这样用。本文件补上这一层:
+ *
+ * 1. 真实 BuiltinWorkerAdapter(mock LLM,不碰真实网络)跑一遍 spawn → readWorkerOutput →
+ *    sendToWorker 续跑 → finish_task → 台账终态 → reconcileOnStartup 幂等的全链路。
+ * 2. 真实 ClaudeCodeAdapter + mock CLI(tests/workers/fixtures/mock-cli.mjs)+ 真实 tmux
+ *    (无 tmux 环境 skip)跑 spawn → sendToWorker → killWorker,断言台账/事件正确。
+ * 3. 真实 tmux 场景复现并验证 Task 9 评审指出的缺口修复:cc adapter 的 state() 在无常驻
+ *    runtime(agent 重启后新建的 adapter 实例)时不再照抄 meta 旧值,而是先做一次 tmux
+ *    isAlive 探测——叠加 harness.reconcileOnStartup,证明"重启后仍存活的 worker 归
+ *    revived、被外部杀掉 tmux 会话的 worker 归 failed"。
+ *
+ * 三个 adapter 都按 harness.ts 文件头"onStateChange 接线契约"的真实顺序接线(先建空壳
+ * Map 传给 harness,harness 构造完成后再构造 adapter 把 harness.handleStateChange 传入
+ * 构造函数,最后把 adapter 塞回同一个 Map 引用),不是像 Task 7-9 FakeAdapter 那样手动
+ * 调用 onStateChange 触发回调。
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { promises as fs } from 'fs'
+import { execFileSync } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import * as path from 'node:path'
+
+import { WorkerHarness, type HarnessDeps } from '../../../src/workers/harness/harness'
+import { LedgerStore } from '../../../src/workers/harness/ledger-store'
+import { WorkspaceManager } from '../../../src/workers/harness/workspace-manager'
+import { dialogObjectIdForPrivate } from '../../../src/workers/harness/ledger-types'
+import type { HarnessEvent } from '../../../src/workers/harness/worker-events'
+import { BuiltinWorkerAdapter } from '../../../src/workers/builtin/adapter.js'
+import { ClaudeCodeAdapter, eventsFilePath as ccEventsFilePath } from '../../../src/workers/claude-code/adapter.js'
+import { CliEventChannel } from '../../../src/workers/cli-events.js'
+import type { WorkerImplId, WorkerAdapter } from '../../../src/workers/types'
+import type { LLMAdapter } from '../../../src/engine/llm-adapter-types.js'
+import { chunksFromContent } from '../../engine/helpers/mock-stream.js'
+
+async function waitUntil(cond: () => Promise<boolean> | boolean, timeoutMs = 8000, intervalMs = 20): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (await cond()) return
+    await new Promise((resolve) => setTimeout(resolve, intervalMs))
+  }
+  throw new Error('waitUntil timed out')
+}
+
+// ---- Part 1: 真实 builtin adapter(mock LLM)----
+
+function makeLLM(
+  responses: Array<{
+    text?: string
+    toolCalls?: Array<{ name: string; id: string; input: Record<string, unknown> }>
+    stopReason: 'end_turn' | 'tool_use'
+  }>,
+): LLMAdapter {
+  let i = 0
+  return {
+    stream: vi.fn(async function* () {
+      const r = responses[i++] ?? responses[responses.length - 1]
+      const content: unknown[] = []
+      if (r.text) content.push({ type: 'text', text: r.text })
+      for (const tc of r.toolCalls ?? []) {
+        content.push({ type: 'tool_use', id: tc.id, name: tc.name, input: tc.input })
+      }
+      yield* chunksFromContent(content, r.stopReason, { inputTokens: 100, outputTokens: 50 })
+    }),
+    updateConfig: () => {},
+  } as unknown as LLMAdapter
+}
+
+describe('WorkerHarness — 真实 builtin adapter 集成冒烟(mock LLM)', () => {
+  let dataDir: string
+  let nowValue: number
+  const events: HarnessEvent[] = []
+
+  function now(): string {
+    nowValue += 1000
+    return new Date(nowValue).toISOString()
+  }
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(join(tmpdir(), 'harness-integ-builtin-'))
+    nowValue = Date.parse('2026-01-01T00:00:00.000Z')
+    events.length = 0
+  })
+
+  afterEach(async () => {
+    await fs.rm(dataDir, { recursive: true, force: true })
+  })
+
+  it(
+    'spawn → readWorkerOutput → sendToWorker 续跑 → finish_task → 台账终态正确,reconcileOnStartup 幂等不误判已终态',
+    async () => {
+      const ledgersDir = join(dataDir, 'ledgers')
+      const workspacesRoot = join(dataDir, 'workspaces')
+      const workersDir = join(dataDir, 'workers')
+      const builtinDataDir = join(dataDir, 'builtin-adapter')
+      await fs.mkdir(workspacesRoot, { recursive: true })
+
+      const ledger = new LedgerStore(ledgersDir)
+      const workspaces = new WorkspaceManager(workspacesRoot)
+      const adaptersMap = new Map<WorkerImplId, WorkerAdapter>()
+      const deps: HarnessDeps = {
+        adapters: adaptersMap,
+        defaultImpl: 'builtin',
+        ledger,
+        workspaces,
+        workersDir,
+        now,
+        onEvent: (e) => events.push(e),
+      }
+      const harness = new WorkerHarness(deps)
+      // onStateChange 接线契约(harness.ts 文件头):harness 先构造好、把 handleStateChange
+      // 传给真实 adapter 的构造函数,再把 adapter 塞回同一个底层 Map——与 P4 的真实接线顺序
+      // 完全一致,不是像 Task 7-9 的 FakeAdapter 那样手动模拟回调触发。
+      const builtinAdapter = new BuiltinWorkerAdapter({ dataDir: builtinDataDir, onStateChange: harness.handleStateChange })
+      adaptersMap.set('builtin', builtinAdapter)
+
+      const llm = makeLLM([
+        { text: '先看看情况,遇事不决,问一句:A 还是 B?', stopReason: 'end_turn' },
+        { toolCalls: [{ name: 'finish_task', id: 'call_1', input: { outcome: 'completed', summary: '搞定了' } }], stopReason: 'tool_use' },
+      ])
+
+      const dialogObjectId = dialogObjectIdForPrivate('friend-builtin-integ')
+      const worker = await harness.spawnWorker({
+        dialogObjectId,
+        title: '集成冒烟任务',
+        prompt: '把活干完',
+        origin: { spawned_by_session: 'wechat::sess-1', trigger_type: 'message' },
+        report_to: { channel_id: 'wechat', session_id: 'sess-1' },
+        impl: 'builtin',
+        builtin: { adapter: llm, model: 'test', systemPrompt: '', tools: [] },
+      })
+
+      expect(worker.task.status).toBe('running')
+      expect(worker.incarnations[0].session_ref).toBeTruthy()
+
+      // burst 是 fire-and-forget:等真实的 onStateChange → harness.handleStateChange 回调把
+      // 台账推进到 waiting_input(builtin 的 idle 映射,harness 保守默认 idle→waiting_input),
+      // 不是靠猜时序或手动触发回调。
+      await waitUntil(async () => {
+        const [w] = await harness.listWorkers(dialogObjectId)
+        return w.task.status === 'waiting_input'
+      })
+
+      // 经 harness.readWorkerOutput(不是直接戳 adapter)拿到 builtin 真实写盘的输出——
+      // 证明 harness → adapter.readOutput 这条接线是通的。
+      const { chunk } = await harness.readWorkerOutput(worker.worker_id, { offset: 0 })
+      expect(chunk).toContain('A 还是 B')
+
+      // sendToWorker 续跑:走 harness 的正常投递路径(per-worker 锁 + inbox.flush),命中
+      // 真实 adapter.sendInput,不是断言 FakeAdapter 桩记录的 sendInputCalls。
+      await harness.sendToWorker(worker.worker_id, '选 A 吧,继续')
+
+      await waitUntil(async () => {
+        const [w] = await harness.listWorkers(dialogObjectId)
+        return w.task.status === 'completed'
+      })
+
+      const [finalWorker] = await harness.listWorkers(dialogObjectId)
+      expect(finalWorker.task.status).toBe('completed')
+      // 注:harness 的被动状态回调路径(processStateChange)目前不回填 task.outcome(P3
+      // 范围内没有把 adapter 的 ended_reason/finish_task outcome 透传进 applyStatusTransition
+      // 的 opts.outcome——终态判定完全靠 task.status + incarnation.ended_reason,outcome 字段
+      // 留空是当前实现的既有行为,不是本次集成测试要覆盖的缺口。
+      expect(finalWorker.incarnations).toHaveLength(1)
+      expect(finalWorker.incarnations[0].state).toBe('exited')
+      expect(finalWorker.incarnations[0].ended_reason).toBe('completed')
+
+      expect(events.filter((e) => e.kind === 'spawned')).toHaveLength(1)
+      expect(events.filter((e) => e.kind === 'input_sent')).toHaveLength(1)
+      // 至少两次真实状态回调(idle 一次、exited 一次)经 handleStateChange 落盘并外发。
+      expect(events.filter((e) => e.kind === 'state_changed').length).toBeGreaterThanOrEqual(2)
+
+      // reconcileOnStartup 幂等:worker 已是终态,巡检不该把它错误判成 revived/failed,
+      // 也不该再调用 adapter.state()(harness.ts reconcileOnStartup 的设计:已终态 worker
+      // 直接归 unchanged,不进 Promise.allSettled 批次)——台账不应被巡检动过。
+      const beforeReconcile = await harness.listWorkers(dialogObjectId)
+      const report = await harness.reconcileOnStartup()
+      expect(report.unchanged).toContain(worker.worker_id)
+      expect(report.revived).not.toContain(worker.worker_id)
+      expect(report.failed).not.toContain(worker.worker_id)
+      const afterReconcile = await harness.listWorkers(dialogObjectId)
+      expect(afterReconcile).toEqual(beforeReconcile)
+
+      // 再调用一次,证明幂等不是"只对一次调用生效"的巧合。
+      const report2 = await harness.reconcileOnStartup()
+      expect(report2.unchanged).toContain(worker.worker_id)
+    },
+    15000,
+  )
+})
+
+// ---- Part 2/3: 真实 claude-code adapter + mock CLI + 真实 tmux ----
+
+function detectTmux(): boolean {
+  try {
+    execFileSync('which', ['tmux'], { stdio: 'ignore' })
+    return true
+  } catch {
+    return false
+  }
+}
+const tmuxAvailable = detectTmux()
+
+const MOCK_CLI = path.resolve(__dirname, '../fixtures/mock-cli.mjs')
+
+interface MockStep {
+  output?: string
+  emitStop?: boolean
+  exit?: boolean
+  exitCode?: number
+}
+
+// POSIX shell 单引号转义,与 tmux/driver.ts 的私有 shQuote 同款用法(独立复制一份,与
+// tests/workers/claude-code-adapter.test.ts 的同名 helper 同一先例)。
+function shQuote(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`
+}
+
+/** 拼一条 `env MOCK_CLI_SCRIPT=... MOCK_CLI_STOP_HOOK_CMD=... node mock-cli.mjs` 命令行,
+ * 充当测试用的 claudeBin——mock CLI 不解析 settings.json,直接从 env 拿脚本和 stop hook 命令。 */
+function claudeBinFor(script: MockStep[], stopHookCmd: string): string {
+  return `env MOCK_CLI_SCRIPT=${shQuote(JSON.stringify(script))} MOCK_CLI_STOP_HOOK_CMD=${shQuote(stopHookCmd)} node ${shQuote(MOCK_CLI)}`
+}
+
+async function killTmuxSessionsQuietly(names: readonly string[]): Promise<void> {
+  for (const name of names) {
+    try {
+      execFileSync('tmux', ['kill-session', '-t', name], { stdio: 'ignore' })
+    } catch {
+      // 会话已不存在(如已被 adapter.kill 正常收尾),忽略。
+    }
+  }
+}
+
+describe.skipIf(!tmuxAvailable)('WorkerHarness — 真实 claude-code adapter 集成冒烟(mock CLI + 真实 tmux)', () => {
+  let dataDir: string
+  let workspaceRoot: string
+  let nowValue: number
+  const events: HarnessEvent[] = []
+  const sessionsToCleanup: string[] = []
+
+  function now(): string {
+    nowValue += 1000
+    return new Date(nowValue).toISOString()
+  }
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(join(tmpdir(), 'harness-integ-cc-data-'))
+    workspaceRoot = await fs.mkdtemp(join(tmpdir(), 'harness-integ-cc-ws-'))
+    nowValue = Date.parse('2026-01-01T00:00:00.000Z')
+    events.length = 0
+    sessionsToCleanup.length = 0
+  })
+
+  afterEach(async () => {
+    await killTmuxSessionsQuietly(sessionsToCleanup)
+    await fs.rm(dataDir, { recursive: true, force: true }).catch(() => {})
+    await fs.rm(workspaceRoot, { recursive: true, force: true }).catch(() => {})
+  })
+
+  it(
+    'spawn → sendToWorker → killWorker,台账/事件正确(harness 与真实 cc adapter 的接线,不只是对 FakeAdapter 桩正确)',
+    async () => {
+      const ledgersDir = join(dataDir, 'ledgers')
+      const workspacesRoot = join(dataDir, 'workspaces')
+      const workersDir = join(dataDir, 'workers')
+      const ccDataDir = join(dataDir, 'cc-adapter')
+      await fs.mkdir(workspacesRoot, { recursive: true })
+
+      // workspace 显式指定为预先建好的目录(而不是让 harness 用随机 worker_id 兜底生成),
+      // 这样才能在构造 adapter(进而拼出 claudeBin)之前就算出这个 workspace 对应的
+      // events-cli.jsonl 路径,喂给 mock CLI 的 MOCK_CLI_STOP_HOOK_CMD——真实场景里 cc
+      // adapter 的 provision() 会把等价的 hook 命令写进 .claude/settings.json,这里只是
+      // 用 mock CLI 直接执行同一段命令,省去解析 settings.json。
+      const channel = new CliEventChannel(ccEventsFilePath({ root: workspaceRoot }))
+      const stopHookCmd = channel.hookCommand('stop')
+      const claudeBin = claudeBinFor(
+        [
+          { output: '第一段输出', emitStop: true },
+          { output: '第二段输出', emitStop: true },
+        ],
+        stopHookCmd,
+      )
+
+      const ledger = new LedgerStore(ledgersDir)
+      const workspaces = new WorkspaceManager(workspacesRoot)
+      const adaptersMap = new Map<WorkerImplId, WorkerAdapter>()
+      const deps: HarnessDeps = {
+        adapters: adaptersMap,
+        defaultImpl: 'claude-code',
+        ledger,
+        workspaces,
+        workersDir,
+        now,
+        onEvent: (e) => events.push(e),
+      }
+      const harness = new WorkerHarness(deps)
+      const ccAdapter = new ClaudeCodeAdapter({ dataDir: ccDataDir, claudeBin, onStateChange: harness.handleStateChange })
+      adaptersMap.set('claude-code', ccAdapter)
+
+      const dialogObjectId = dialogObjectIdForPrivate('friend-cc-integ')
+      const worker = await harness.spawnWorker({
+        dialogObjectId,
+        title: '真实 cc 冒烟任务',
+        prompt: '你好',
+        origin: { spawned_by_session: 'wechat::sess-1', trigger_type: 'message' },
+        report_to: { channel_id: 'wechat', session_id: 'sess-1' },
+        impl: 'claude-code',
+        workspace: workspaceRoot,
+      })
+      sessionsToCleanup.push(`crabot-w-${worker.worker_id}-1`)
+
+      expect(worker.task.status).toBe('running')
+      // cc adapter 的真实 session uuid(spawn 返回前即由 adapter 填入,不是台账初始化时的
+      // 占位空串),证明 harness 原子补写了 adapter.spawn 返回的真实 handle.session_ref。
+      expect(worker.incarnations[0].session_ref).toBeTruthy()
+      expect(worker.incarnations[0].session_ref).toMatch(/^[0-9a-fA-F-]{36}$/)
+
+      // 经 harness.readWorkerOutput 轮询到 mock CLI 真实写入 pipe-pane 的第一段输出——
+      // 证明 tmux newSession + pipe-pane + OutputLog 这条真实链路是通的。
+      await waitUntil(async () => {
+        const { chunk } = await harness.readWorkerOutput(worker.worker_id, { offset: 0 })
+        return chunk.includes('第一段输出')
+      })
+
+      // 直接读事件文件确认 Stop hook 真的执行过(证明 CliEventChannel.hookCommand 的产物
+      // 被 mock CLI 真实 exec 了一遍,不是 harness/adapter 自己编出来的假信号)。
+      await waitUntil(async () => {
+        const raw = await fs.readFile(ccEventsFilePath({ root: workspaceRoot }), 'utf-8').catch(() => '')
+        return raw.includes('"kind":"stop"')
+      })
+
+      // sendToWorker 续跑:走 harness 正常投递路径,命中真实 adapter.sendInput → tmux
+      // sendText,不是断言桩记录的调用参数。
+      await harness.sendToWorker(worker.worker_id, '继续')
+
+      await waitUntil(async () => {
+        const { chunk } = await harness.readWorkerOutput(worker.worker_id, { offset: 0 })
+        return chunk.includes('第二段输出')
+      })
+
+      // 真实 adapter 的状态回调(idle→running,可能不止一次)经 handleStateChange 落盘并
+      // 外发——不是 FakeAdapter.emitStateChange 手动触发的。
+      await waitUntil(() => events.filter((e) => e.kind === 'state_changed').length >= 2)
+
+      await harness.killWorker(worker.worker_id, '冒烟测试收尾')
+
+      const [finalWorker] = await harness.listWorkers(dialogObjectId)
+      expect(finalWorker.task.status).toBe('cancelled')
+      expect(finalWorker.incarnations).toHaveLength(1)
+      expect(finalWorker.incarnations[0].state).toBe('exited')
+      expect(finalWorker.incarnations[0].ended_reason).toBe('killed')
+
+      expect(events.filter((e) => e.kind === 'spawned')).toHaveLength(1)
+      expect(events.filter((e) => e.kind === 'input_sent')).toHaveLength(1)
+      expect(events.filter((e) => e.kind === 'killed')).toHaveLength(1)
+    },
+    20000,
+  )
+})
+
+describe.skipIf(!tmuxAvailable)(
+  'WorkerHarness.reconcileOnStartup — 真实 tmux 存活探测(P3 Task 10 修复:cc 的 state() 无 runtime 时不再照抄 meta 旧值)',
+  () => {
+    let dataDir: string
+    let nowValue: number
+    const sessionsToCleanup: string[] = []
+
+    function now(): string {
+      nowValue += 1000
+      return new Date(nowValue).toISOString()
+    }
+
+    beforeEach(async () => {
+      dataDir = await fs.mkdtemp(join(tmpdir(), 'harness-integ-cc-restart-'))
+      nowValue = Date.parse('2026-01-01T00:00:00.000Z')
+      sessionsToCleanup.length = 0
+    })
+
+    afterEach(async () => {
+      await killTmuxSessionsQuietly(sessionsToCleanup)
+      await fs.rm(dataDir, { recursive: true, force: true }).catch(() => {})
+    })
+
+    it(
+      '"重启":新 harness + 新 adapter 实例(内存 runtimes 为空)指向同一份台账/dataDir——仍存活的 worker 归 revived,' +
+        '被外部杀掉 tmux 会话(bypass adapter.kill,meta 仍停留在 running)的 worker 归 failed,不是照抄 meta 旧值',
+      async () => {
+        const ledgersDir = join(dataDir, 'ledgers')
+        const workspacesRoot = join(dataDir, 'workspaces')
+        const workersDir = join(dataDir, 'workers')
+        const ccDataDir = join(dataDir, 'cc-adapter')
+        await fs.mkdir(workspacesRoot, { recursive: true })
+
+        // 这组测试只关心 isAlive 探活本身,不依赖 Stop hook/idle 转换——脚本不 emitStop,
+        // 进程跑完这一步后原地等下一条 stdin,tmux 会话因此持续存活直到被显式杀掉。
+        const claudeBin = claudeBinFor([{ output: '跑着' }], ':')
+
+        const ledger = new LedgerStore(ledgersDir)
+        const workspaces = new WorkspaceManager(workspacesRoot)
+        const dialogObjectId = dialogObjectIdForPrivate('friend-cc-restart')
+
+        // "重启前":harness1 + adapterA spawn 两个 worker。
+        const adaptersMap1 = new Map<WorkerImplId, WorkerAdapter>()
+        const harness1 = new WorkerHarness({
+          adapters: adaptersMap1,
+          defaultImpl: 'claude-code',
+          ledger,
+          workspaces,
+          workersDir,
+          now,
+        })
+        const adapterA = new ClaudeCodeAdapter({ dataDir: ccDataDir, claudeBin, onStateChange: harness1.handleStateChange })
+        adaptersMap1.set('claude-code', adapterA)
+
+        const aliveWorker = await harness1.spawnWorker({
+          dialogObjectId,
+          title: '存活 worker',
+          prompt: '你好',
+          origin: { spawned_by_session: 'wechat::sess-1', trigger_type: 'message' },
+          report_to: { channel_id: 'wechat', session_id: 'sess-1' },
+          impl: 'claude-code',
+        })
+        sessionsToCleanup.push(`crabot-w-${aliveWorker.worker_id}-1`)
+
+        const deadWorker = await harness1.spawnWorker({
+          dialogObjectId,
+          title: '将被外部杀掉的 worker',
+          prompt: '你好',
+          origin: { spawned_by_session: 'wechat::sess-1', trigger_type: 'message' },
+          report_to: { channel_id: 'wechat', session_id: 'sess-1' },
+          impl: 'claude-code',
+        })
+
+        // 绕开 adapter.kill,直接杀死 tmux 会话——模拟"agent 进程重启前,这个 worker 的
+        // tmux 会话已经先一步真死(崩溃/被系统 OOM kill 等),但没有任何机制把这件事记进
+        // 台账/meta(P3 没有主动巡扫机制)",复现 Task 9 评审指出的"真死判活"场景。
+        execFileSync('tmux', ['kill-session', '-t', `crabot-w-${deadWorker.worker_id}-1`], { stdio: 'ignore' })
+
+        // 台账此刻仍然认为两个 worker 都在 running——没人告诉它 deadWorker 已经死了。
+        const beforeRestart = await harness1.listWorkers(dialogObjectId)
+        expect(beforeRestart.every((w) => w.task.status === 'running')).toBe(true)
+
+        // "重启":全新 harness + adapter 实例,指向同一份台账(同一个 LedgerStore 实例即
+        // 代表同一份磁盘台账)和同一个 cc adapter 私有 dataDir,但内存 runtimes 为空——
+        // 复现进程重启后新建 adapter 实例、丢失所有内存态的真实状况。
+        const adaptersMap2 = new Map<WorkerImplId, WorkerAdapter>()
+        const harness2 = new WorkerHarness({
+          adapters: adaptersMap2,
+          defaultImpl: 'claude-code',
+          ledger,
+          workspaces,
+          workersDir,
+          now,
+        })
+        const adapterB = new ClaudeCodeAdapter({ dataDir: ccDataDir, claudeBin, onStateChange: harness2.handleStateChange })
+        adaptersMap2.set('claude-code', adapterB)
+
+        // 修复前:adapterB.state() 无 runtime 时直接读 meta,两个 worker 的 meta 都还停留
+        // 在 spawn 时写的 'running'——deadWorker 会被误判成 revived(假阳性)。
+        // 修复后:isAlive() 先探活,deadWorker 的 tmux 会话已经不在了,一律判 exited。
+        const report = await harness2.reconcileOnStartup()
+
+        expect(report.revived).toContain(aliveWorker.worker_id)
+        expect(report.failed).toContain(deadWorker.worker_id)
+
+        const afterAll = await harness2.listWorkers(dialogObjectId)
+        const afterAlive = afterAll.find((w) => w.worker_id === aliveWorker.worker_id)!
+        expect(afterAlive.task.status).toBe('running')
+
+        const afterDead = afterAll.find((w) => w.worker_id === deadWorker.worker_id)!
+        expect(afterDead.task.status).toBe('failed')
+        expect(afterDead.incarnations[0].state).toBe('exited')
+        expect(afterDead.incarnations[0].ended_reason).toBe('crashed')
+      },
+      20000,
+    )
+
+    it(
+      'adapter.state() 本身:isAlive 存活时回落读 meta,tmux 会话被外部杀掉后新实例判 exited(不是照抄 meta 旧值)',
+      async () => {
+        const ccDataDir = join(dataDir, 'cc-adapter-direct')
+        const workspaceRoot = await fs.mkdtemp(join(tmpdir(), 'harness-integ-cc-restart-ws-'))
+
+        const claudeBin = claudeBinFor([{ output: '先答一句' }], ':')
+        const adapterA = new ClaudeCodeAdapter({ dataDir: ccDataDir, claudeBin })
+        await adapterA.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
+
+        const workerId = `cctest-restart-${randomUUID().slice(0, 8)}`
+        sessionsToCleanup.push(`crabot-w-${workerId}-1`)
+        const h = await adapterA.spawn({ worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } })
+
+        // 等 mock CLI 真的处理完首条输入、写完输出,确认会话已经稳定跑起来。
+        await waitUntil(async () => {
+          const { chunk } = await adapterA.readOutput(h, { offset: 0 })
+          return chunk.includes('先答一句')
+        })
+
+        // 模拟"重启":全新 adapter 实例,同一 dataDir,内存 runtimes 为空,从未见过这个化身。
+        const adapterB = new ClaudeCodeAdapter({ dataDir: ccDataDir, claudeBin: 'unused-not-invoked-by-state' })
+
+        // tmux 会话仍存活 → 回落读 meta(running,spawn 时写的值)——精度有限但至少不是
+        // 编造的 exited。
+        expect(await adapterB.state(h)).toBe('running')
+
+        // 绕开 adapter.kill,直接杀死 tmux 会话——meta 文件不会被这次外部 kill 更新,
+        // 仍然停留在 'running'。
+        execFileSync('tmux', ['kill-session', '-t', `crabot-w-${workerId}-1`], { stdio: 'ignore' })
+
+        // 修复前:adapterB.state() 无 runtime 时直接读 meta,拿到过期的 'running'(假阳性)。
+        // 修复后:isAlive() 探测发现会话已死,一律判 exited,不管 meta 写了什么。
+        await waitUntil(async () => (await adapterB.state(h)) === 'exited')
+      },
+      15000,
+    )
+  },
+)

--- a/crabot-agent/tests/workers/harness/harness-integration.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-integration.test.ts
@@ -370,6 +370,7 @@ describe.skipIf(!tmuxAvailable)(
   'WorkerHarness.reconcileOnStartup — 真实 tmux 存活探测(P3 Task 10 修复:cc 的 state() 无 runtime 时不再照抄 meta 旧值)',
   () => {
     let dataDir: string
+    let workspaceRoot: string | undefined
     let nowValue: number
     const sessionsToCleanup: string[] = []
 
@@ -380,6 +381,7 @@ describe.skipIf(!tmuxAvailable)(
 
     beforeEach(async () => {
       dataDir = await fs.mkdtemp(join(tmpdir(), 'harness-integ-cc-restart-'))
+      workspaceRoot = undefined
       nowValue = Date.parse('2026-01-01T00:00:00.000Z')
       sessionsToCleanup.length = 0
     })
@@ -387,6 +389,9 @@ describe.skipIf(!tmuxAvailable)(
     afterEach(async () => {
       await killTmuxSessionsQuietly(sessionsToCleanup)
       await fs.rm(dataDir, { recursive: true, force: true }).catch(() => {})
+      if (workspaceRoot) {
+        await fs.rm(workspaceRoot, { recursive: true, force: true }).catch(() => {})
+      }
     })
 
     it(
@@ -487,7 +492,7 @@ describe.skipIf(!tmuxAvailable)(
       'adapter.state() 本身:isAlive 存活时回落读 meta,tmux 会话被外部杀掉后新实例判 exited(不是照抄 meta 旧值)',
       async () => {
         const ccDataDir = join(dataDir, 'cc-adapter-direct')
-        const workspaceRoot = await fs.mkdtemp(join(tmpdir(), 'harness-integ-cc-restart-ws-'))
+        workspaceRoot = await fs.mkdtemp(join(tmpdir(), 'harness-integ-cc-restart-ws-'))
 
         const claudeBin = claudeBinFor([{ output: '先答一句' }], ':')
         const adapterA = new ClaudeCodeAdapter({ dataDir: ccDataDir, claudeBin })

--- a/crabot-agent/tests/workers/harness/harness-integration.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-integration.test.ts
@@ -525,5 +525,145 @@ describe.skipIf(!tmuxAvailable)(
       },
       15000,
     )
+
+    it(
+      'PoC③(四轮 review):"重启"后 harness2 通过 sendToWorker/killWorker 真正操作仍存活的化身,' +
+        '不再抛通用 Error(修复前:adapter.sendInput/kill 对无常驻 runtime 的化身抛通用 Error,' +
+        'sendToWorker 会 reject、killWorker 整段失败,task 卡在 running 无法终止)',
+      async () => {
+        const ledgersDir = join(dataDir, 'ledgers')
+        const workspacesRoot = join(dataDir, 'workspaces')
+        const workersDir = join(dataDir, 'workers')
+        const ccDataDir = join(dataDir, 'cc-adapter')
+        await fs.mkdir(workspacesRoot, { recursive: true })
+
+        // 两步都不退出、不 emitStop——会话持续存活到显式 kill,给"重连一个仍存活的会话"
+        // 提供稳定的时间窗口。
+        const claudeBin = claudeBinFor([{ output: '第一段输出' }, { output: '第二段输出' }], ':')
+
+        const ledger = new LedgerStore(ledgersDir)
+        const workspaces = new WorkspaceManager(workspacesRoot)
+        const dialogObjectId = dialogObjectIdForPrivate('friend-cc-poc3')
+
+        const adaptersMap1 = new Map<WorkerImplId, WorkerAdapter>()
+        const harness1 = new WorkerHarness({ adapters: adaptersMap1, defaultImpl: 'claude-code', ledger, workspaces, workersDir, now })
+        const adapterA = new ClaudeCodeAdapter({ dataDir: ccDataDir, claudeBin, onStateChange: harness1.handleStateChange })
+        adaptersMap1.set('claude-code', adapterA)
+
+        const worker = await harness1.spawnWorker({
+          dialogObjectId,
+          title: 'PoC③ worker',
+          prompt: '你好',
+          origin: { spawned_by_session: 'wechat::sess-1', trigger_type: 'message' },
+          report_to: { channel_id: 'wechat', session_id: 'sess-1' },
+          impl: 'claude-code',
+        })
+        sessionsToCleanup.push(`crabot-w-${worker.worker_id}-1`)
+
+        await waitUntil(async () => {
+          const { chunk } = await harness1.readWorkerOutput(worker.worker_id, { offset: 0 })
+          return chunk.includes('第一段输出')
+        })
+
+        // "重启":全新 harness + adapter 实例,指向同一份台账/dataDir,内存 runtimes 为空。
+        const adaptersMap2 = new Map<WorkerImplId, WorkerAdapter>()
+        const harness2 = new WorkerHarness({ adapters: adaptersMap2, defaultImpl: 'claude-code', ledger, workspaces, workersDir, now })
+        const adapterB = new ClaudeCodeAdapter({ dataDir: ccDataDir, claudeBin, onStateChange: harness2.handleStateChange })
+        adaptersMap2.set('claude-code', adapterB)
+
+        const report = await harness2.reconcileOnStartup()
+        expect(report.revived).toContain(worker.worker_id)
+
+        // 会话仍然存活,压根不该走接续,只是简单投递——修复前这里会因为 adapterB.sendInput
+        // 抛通用 Error 而 reject(不是像 WorkerExitedError 那样被接住转接续,是直接穿透)。
+        await expect(harness2.sendToWorker(worker.worker_id, '继续')).resolves.toBeUndefined()
+
+        await waitUntil(async () => {
+          const { chunk } = await harness2.readWorkerOutput(worker.worker_id, { offset: 0 })
+          return chunk.includes('第二段输出')
+        })
+
+        // 修复前:adapterB.kill 对无常驻 runtime 的化身直接抛通用 Error,killWorker 没有
+        // try/catch,整段失败——task 卡在 running,用户无法终止。
+        await harness2.killWorker(worker.worker_id, 'PoC③ 收尾')
+
+        const [finalWorker] = await harness2.listWorkers(dialogObjectId)
+        expect(finalWorker.task.status).toBe('cancelled')
+        expect(finalWorker.incarnations[0].state).toBe('exited')
+        expect(finalWorker.incarnations[0].ended_reason).toBe('killed')
+      },
+      20000,
+    )
+
+    it(
+      'PoC④(四轮 review):sendToWorker 撞上已经死掉的 tmux 会话(未先调 reconcileOnStartup)时经透明接续正确续办,' +
+        '不永久卡在 running(修复前:WorkerExitedError 被通用 Error 掩盖,continueTerminalWorker 走不到,' +
+        '消息永久卡在 inbox 队首)',
+      async () => {
+        const ledgersDir = join(dataDir, 'ledgers')
+        const workspacesRoot = join(dataDir, 'workspaces')
+        const workersDir = join(dataDir, 'workers')
+        const ccDataDir = join(dataDir, 'cc-adapter')
+        await fs.mkdir(workspacesRoot, { recursive: true })
+
+        const claudeBin = claudeBinFor([{ output: '第一段输出' }], ':')
+
+        const ledger = new LedgerStore(ledgersDir)
+        const workspaces = new WorkspaceManager(workspacesRoot)
+        const dialogObjectId = dialogObjectIdForPrivate('friend-cc-poc4')
+
+        const adaptersMap1 = new Map<WorkerImplId, WorkerAdapter>()
+        const harness1 = new WorkerHarness({ adapters: adaptersMap1, defaultImpl: 'claude-code', ledger, workspaces, workersDir, now })
+        const adapterA = new ClaudeCodeAdapter({ dataDir: ccDataDir, claudeBin, onStateChange: harness1.handleStateChange })
+        adaptersMap1.set('claude-code', adapterA)
+
+        const worker = await harness1.spawnWorker({
+          dialogObjectId,
+          title: 'PoC④ worker',
+          prompt: '你好',
+          origin: { spawned_by_session: 'wechat::sess-1', trigger_type: 'message' },
+          report_to: { channel_id: 'wechat', session_id: 'sess-1' },
+          impl: 'claude-code',
+        })
+
+        await waitUntil(async () => {
+          const { chunk } = await harness1.readWorkerOutput(worker.worker_id, { offset: 0 })
+          return chunk.includes('第一段输出')
+        })
+
+        // 绕开 adapter.kill,直接杀死 tmux 会话——模拟"agent 进程重启前,这个 worker 的 tmux
+        // 会话已经先一步真死",台账此刻仍然认为它在 running(没人告诉它已经死了)。
+        execFileSync('tmux', ['kill-session', '-t', `crabot-w-${worker.worker_id}-1`], { stdio: 'ignore' })
+
+        const beforeRestart = await harness1.listWorkers(dialogObjectId)
+        expect(beforeRestart[0].task.status).toBe('running')
+        expect(beforeRestart[0].incarnations[0].state).not.toBe('exited')
+
+        // "重启":全新 harness + adapter,刻意不先调 reconcileOnStartup——只验证
+        // sendToWorker 自己的透明接续(adapter.sendInput 抛 WorkerExitedError →
+        // continueTerminalWorker → reviveIncarnation)能不能独立兜住这种场景。
+        const adaptersMap2 = new Map<WorkerImplId, WorkerAdapter>()
+        const harness2 = new WorkerHarness({ adapters: adaptersMap2, defaultImpl: 'claude-code', ledger, workspaces, workersDir, now })
+        const adapterB = new ClaudeCodeAdapter({ dataDir: ccDataDir, claudeBin, onStateChange: harness2.handleStateChange })
+        adaptersMap2.set('claude-code', adapterB)
+
+        await expect(harness2.sendToWorker(worker.worker_id, '接着办')).resolves.toBeUndefined()
+
+        const [afterWorker] = await harness2.listWorkers(dialogObjectId)
+        expect(afterWorker.task.status).toBe('running')
+        expect(afterWorker.incarnations).toHaveLength(2)
+        expect(afterWorker.incarnations[0].state).toBe('exited')
+        expect(afterWorker.incarnations[1].state).toBe('running')
+        sessionsToCleanup.push(`crabot-w-${worker.worker_id}-${afterWorker.incarnations[1].seq}`)
+
+        // 新化身真的在跑:wakeInput 送达 mock CLI,readWorkerOutput(读主线=新化身)应该
+        // 拿到新会话独立重跑一遍脚本产出的第一段输出。
+        await waitUntil(async () => {
+          const { chunk } = await harness2.readWorkerOutput(worker.worker_id, { offset: 0 })
+          return chunk.includes('第一段输出')
+        })
+      },
+      20000,
+    )
   },
 )

--- a/crabot-agent/tests/workers/harness/harness-lifecycle.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-lifecycle.test.ts
@@ -1,0 +1,445 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { promises as fs } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { WorkerHarness, WorkerNotFoundError, TaskCancelledError, type HarnessDeps, type SpawnWorkerParams } from '../../../src/workers/harness/harness'
+import { LedgerStore } from '../../../src/workers/harness/ledger-store'
+import { WorkspaceManager } from '../../../src/workers/harness/workspace-manager'
+import { dialogObjectIdForPrivate } from '../../../src/workers/harness/ledger-types'
+import type { HarnessEvent } from '../../../src/workers/harness/worker-events'
+import { CapabilityNotSupportedError } from '../../../src/workers/errors'
+import type {
+  WorkerAdapter,
+  WorkerImplId,
+  WorkerContractState,
+  IncarnationHandle,
+  IncarnationRef,
+  SpawnSpec,
+  Workspace,
+  OutputCursor,
+  CapabilityBundle,
+  AdapterCapabilities,
+  DetectResult,
+} from '../../../src/workers/types'
+
+// ---- FakeAdapter:实现 WorkerAdapter 契约的可编程桩,不碰 tmux/LLM ----
+
+function handleKey(h: IncarnationHandle): string {
+  return `${h.worker_id}#${h.seq}`
+}
+
+interface FakeAdapterOpts {
+  readonly implId?: WorkerImplId
+  readonly caps?: Partial<AdapterCapabilities>
+  readonly onStateChange?: (h: IncarnationHandle, state: WorkerContractState) => void
+  readonly spawnShouldFail?: Error
+  readonly forkShouldFail?: Error
+  readonly sendInputBehavior?: (h: IncarnationHandle, text: string, opts?: { raw?: boolean }) => Promise<void> | void
+}
+
+class FakeAdapter implements WorkerAdapter {
+  readonly implId: WorkerImplId
+  readonly provisionCalls: Array<{ ws: Workspace; caps: CapabilityBundle }> = []
+  readonly spawnCalls: SpawnSpec[] = []
+  readonly sendInputCalls: Array<{ h: IncarnationHandle; text: string; opts?: { raw?: boolean } }> = []
+  readonly killCalls: IncarnationHandle[] = []
+  readonly forkCalls: Array<{ prev: IncarnationRef; forkInput: string }> = []
+  private readonly states = new Map<string, WorkerContractState>()
+  private nextForkSeq = 2
+
+  constructor(private readonly opts: FakeAdapterOpts = {}) {
+    this.implId = opts.implId ?? 'builtin'
+  }
+
+  async detect(): Promise<DetectResult> {
+    return { installed: true, activated: true }
+  }
+
+  async provision(ws: Workspace, caps: CapabilityBundle): Promise<void> {
+    this.provisionCalls.push({ ws, caps })
+  }
+
+  async spawn(spec: SpawnSpec): Promise<IncarnationHandle> {
+    this.spawnCalls.push(spec)
+    if (this.opts.spawnShouldFail) throw this.opts.spawnShouldFail
+    const handle: IncarnationHandle = { worker_id: spec.worker_id, seq: 1, impl: this.implId }
+    this.states.set(handleKey(handle), 'running')
+    return handle
+  }
+
+  async resume(_prev: IncarnationRef, _wakeInput: string): Promise<IncarnationHandle> {
+    throw new Error('FakeAdapter.resume: not exercised by Task 7 tests')
+  }
+
+  async fork(prev: IncarnationRef, forkInput: string): Promise<IncarnationHandle> {
+    this.forkCalls.push({ prev, forkInput })
+    if (this.opts.forkShouldFail) throw this.opts.forkShouldFail
+    const handle: IncarnationHandle = { worker_id: prev.worker_id, seq: this.nextForkSeq++, impl: this.implId }
+    this.states.set(handleKey(handle), 'running')
+    return handle
+  }
+
+  async sendInput(h: IncarnationHandle, text: string, opts?: { raw?: boolean }): Promise<void> {
+    this.sendInputCalls.push({ h, text, opts })
+    if (this.opts.sendInputBehavior) await this.opts.sendInputBehavior(h, text, opts)
+  }
+
+  async readOutput(_h: IncarnationHandle, cursor: OutputCursor): Promise<{ chunk: string; nextCursor: OutputCursor }> {
+    return { chunk: '', nextCursor: cursor }
+  }
+
+  async state(h: IncarnationHandle): Promise<WorkerContractState> {
+    return this.states.get(handleKey(h)) ?? 'exited'
+  }
+
+  async kill(h: IncarnationHandle): Promise<void> {
+    this.killCalls.push(h)
+    this.states.set(handleKey(h), 'exited')
+  }
+
+  capabilities(): AdapterCapabilities {
+    return { fork: false, revive: false, goalMode: false, subagent: false, structuredTrace: false, ...this.opts.caps }
+  }
+
+  /** 测试专用:模拟 adapter 自己触发一次状态回调(镜像真实 adapter 内部调用 deps.onStateChange)。 */
+  emitStateChange(h: IncarnationHandle, state: WorkerContractState): void {
+    this.states.set(handleKey(h), state)
+    this.opts.onStateChange?.(h, state)
+  }
+}
+
+// ---- 测试夹具 ----
+
+let dataDir: string
+let nowValue: number
+const events: HarnessEvent[] = []
+
+function now(): string {
+  nowValue += 1000
+  return new Date(nowValue).toISOString()
+}
+
+async function makeHarness(fakeOpts: FakeAdapterOpts = {}): Promise<{ harness: WorkerHarness; fake: FakeAdapter; adaptersMap: Map<WorkerImplId, WorkerAdapter> }> {
+  const ledgersDir = join(dataDir, 'ledgers')
+  const workspacesRoot = join(dataDir, 'workspaces')
+  const workersDir = join(dataDir, 'workers')
+  await fs.mkdir(workspacesRoot, { recursive: true })
+
+  const ledger = new LedgerStore(ledgersDir)
+  const workspaces = new WorkspaceManager(workspacesRoot)
+
+  // onStateChange 接线契约(见 harness.ts 文件头):先建空壳 Map 传给 harness,harness 构造
+  // 完成后再构造 adapter(把 harness.handleStateChange 接进去),最后把 adapter 塞回同一个
+  // Map 引用——harness 读取的是同一份底层数据,这一步之后立即可见。
+  const adaptersMap = new Map<WorkerImplId, WorkerAdapter>()
+  const deps: HarnessDeps = {
+    adapters: adaptersMap,
+    defaultImpl: 'builtin',
+    ledger,
+    workspaces,
+    workersDir,
+    now,
+    onEvent: (e) => events.push(e),
+  }
+  const harness = new WorkerHarness(deps)
+  const fake = new FakeAdapter({ ...fakeOpts, onStateChange: harness.handleStateChange })
+  adaptersMap.set(fake.implId, fake)
+
+  return { harness, fake, adaptersMap }
+}
+
+function spawnParams(overrides: Partial<SpawnWorkerParams> = {}): SpawnWorkerParams {
+  return {
+    dialogObjectId: dialogObjectIdForPrivate('friend-1'),
+    title: '测试任务',
+    prompt: '把活干完',
+    origin: { spawned_by_session: 'wechat::sess-1', trigger_type: 'message' },
+    report_to: { channel_id: 'wechat', session_id: 'sess-1' },
+    ...overrides,
+  }
+}
+
+beforeEach(async () => {
+  dataDir = await fs.mkdtemp(join(tmpdir(), 'harness-lifecycle-test-'))
+  nowValue = Date.parse('2026-01-01T00:00:00.000Z')
+  events.length = 0
+})
+
+afterEach(async () => {
+  await fs.rm(dataDir, { recursive: true, force: true })
+})
+
+describe('WorkerHarness.spawnWorker', () => {
+  it('全链路成功:worker_id = task.id、台账终态 running、化身 seq=1 running、事件 spawned、onEvent 外发', async () => {
+    const { harness, fake } = await makeHarness()
+    const worker = await harness.spawnWorker(spawnParams())
+
+    expect(worker.worker_id).toMatch(/^w-/)
+    expect(worker.task.id).toBe(worker.worker_id)
+    expect(worker.task.status).toBe('running')
+    expect(worker.incarnations).toHaveLength(1)
+    expect(worker.incarnations[0]).toMatchObject({ seq: 1, impl: 'builtin', state: 'running' })
+
+    // provision 在 spawn 之前被调用,且拿到了解析后的 workspace
+    expect(fake.provisionCalls).toHaveLength(1)
+    expect(fake.spawnCalls).toHaveLength(1)
+    expect(fake.spawnCalls[0].worker_id).toBe(worker.worker_id)
+
+    const spawnedEvents = events.filter((e) => e.kind === 'spawned')
+    expect(spawnedEvents).toHaveLength(1)
+    expect(spawnedEvents[0].worker_id).toBe(worker.worker_id)
+    expect(spawnedEvents[0].seq).toBe(1)
+
+    // 台账已落盘且可查
+    const listed = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    expect(listed.map((w) => w.worker_id)).toContain(worker.worker_id)
+  })
+
+  it('adapter.spawn 失败 → 台账落 failed(经 queued→running→failed)、化身 exited(failed)、事件外发,错误抛给调用方', async () => {
+    const boom = new Error('spawn 炸了')
+    const { harness } = await makeHarness({ spawnShouldFail: boom })
+
+    await expect(harness.spawnWorker(spawnParams())).rejects.toThrow('spawn 炸了')
+
+    const listed = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    expect(listed).toHaveLength(1)
+    const worker = listed[0]
+    expect(worker.task.status).toBe('failed')
+    expect(worker.task.error).toBe('spawn 炸了')
+    expect(worker.incarnations[0].state).toBe('exited')
+    expect(worker.incarnations[0].ended_reason).toBe('failed')
+
+    const exitedEvents = events.filter((e) => e.kind === 'exited')
+    expect(exitedEvents).toHaveLength(1)
+    expect(exitedEvents[0].detail?.reason).toBe('spawn_failed')
+  })
+})
+
+describe('WorkerHarness.handleStateChange', () => {
+  it('状态回调驱动台账 task.status 与化身 state,并经 onEvent 外发', async () => {
+    const { harness, fake } = await makeHarness()
+    const worker = await harness.spawnWorker(spawnParams())
+    events.length = 0
+
+    fake.emitStateChange({ worker_id: worker.worker_id, seq: 1, impl: 'builtin' }, 'idle')
+
+    // handleStateChange 签名对齐 adapter 的同步回调(h, state) => void,内部是 fire-and-forget
+    // 的异步台账更新——用轮询等待收敛(与 tests/workers/contract-suite.ts 的 waitForState
+    // 同一套路,不是"睡一下猜时序",是"有界轮询直到可观察结果达到预期,超时即失败")。
+    await waitUntil(async () => {
+      const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+      return w.task.status === 'waiting_input'
+    })
+
+    const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    expect(w.task.status).toBe('waiting_input')
+    expect(w.incarnations[0].state).toBe('idle')
+
+    const stateEvents = events.filter((e) => e.kind === 'state_changed')
+    expect(stateEvents).toHaveLength(1)
+    expect(stateEvents[0].detail).toEqual({ to: 'idle' })
+
+    // 化身自然结束(非 kill)→ completed
+    fake.emitStateChange({ worker_id: worker.worker_id, seq: 1, impl: 'builtin' }, 'exited')
+    await waitUntil(async () => {
+      const [w2] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+      return w2.task.status === 'completed'
+    })
+    const [w2] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    expect(w2.task.status).toBe('completed')
+    expect(w2.incarnations[0].ended_reason).toBe('completed')
+  })
+
+  it('已终态 worker 的迟到状态回调被忽略,不覆盖已有终局', async () => {
+    const { harness, fake } = await makeHarness()
+    const worker = await harness.spawnWorker(spawnParams())
+    await harness.killWorker(worker.worker_id)
+
+    fake.emitStateChange({ worker_id: worker.worker_id, seq: 1, impl: 'builtin' }, 'idle')
+
+    // 确定性同步屏障(不用 setTimeout 猜时序):emitStateChange 同步触发的
+    // handleStateChange 在其调用栈内同步完成了对同一 worker_id 的 per-worker 锁排队
+    // (AsyncMutex.run 在第一个 await 之前就把自己接进了队列),所以紧接着对同一
+    // worker_id 再发起一次会拿同一把锁的调用,必定排在它之后才执行。这里复用
+        // 复用 killWorker 的幂等短路(worker 已是终态,直接 no-op 不产生任何副作用,已由
+    // 上面的"幂等"用例单独验证过)作为屏障:等它 resolve,前面排队的状态回调
+    // 一定已经跑完。
+    await harness.killWorker(worker.worker_id)
+
+    const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    expect(w.task.status).toBe('cancelled')
+  })
+})
+
+describe('WorkerHarness.sendToWorker', () => {
+  it('正常投递:running worker 收到输入,adapter.sendInput 被正确调用,事件 input_sent 外发', async () => {
+    const { harness, fake } = await makeHarness()
+    const worker = await harness.spawnWorker(spawnParams())
+    events.length = 0
+
+    await harness.sendToWorker(worker.worker_id, '继续干活')
+
+    expect(fake.sendInputCalls).toHaveLength(1)
+    expect(fake.sendInputCalls[0].h).toEqual({ worker_id: worker.worker_id, seq: 1, impl: 'builtin' })
+    expect(fake.sendInputCalls[0].text).toBe('继续干活')
+
+    const inputEvents = events.filter((e) => e.kind === 'input_sent')
+    expect(inputEvents).toHaveLength(1)
+    expect(inputEvents[0].detail?.text_len).toBe('继续干活'.length)
+  })
+
+  it('raw 选项透传给 adapter.sendInput', async () => {
+    const { harness, fake } = await makeHarness()
+    const worker = await harness.spawnWorker(spawnParams())
+
+    await harness.sendToWorker(worker.worker_id, '/exit', { raw: true })
+
+    expect(fake.sendInputCalls[0].opts).toEqual({ raw: true })
+  })
+
+  it('不存在的 worker_id → WorkerNotFoundError', async () => {
+    const { harness } = await makeHarness()
+    await expect(harness.sendToWorker('w-does-not-exist', 'hi')).rejects.toThrow(WorkerNotFoundError)
+  })
+
+  it('task 已 cancelled → 硬拒绝 TaskCancelledError,不触碰 adapter', async () => {
+    const { harness, fake } = await makeHarness()
+    const worker = await harness.spawnWorker(spawnParams())
+    await harness.killWorker(worker.worker_id)
+    fake.sendInputCalls.length = 0
+
+    await expect(harness.sendToWorker(worker.worker_id, '还在吗')).rejects.toThrow(TaskCancelledError)
+    expect(fake.sendInputCalls).toHaveLength(0)
+  })
+})
+
+describe('WorkerHarness.killWorker', () => {
+  it('adapter.kill 被调用,台账落 cancelled,化身 exited(killed),事件外发', async () => {
+    const { harness, fake } = await makeHarness()
+    const worker = await harness.spawnWorker(spawnParams())
+    events.length = 0
+
+    await harness.killWorker(worker.worker_id, '用户要求终止')
+
+    expect(fake.killCalls).toHaveLength(1)
+    expect(fake.killCalls[0]).toEqual({ worker_id: worker.worker_id, seq: 1, impl: 'builtin' })
+
+    const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    expect(w.task.status).toBe('cancelled')
+    expect(w.incarnations[0].state).toBe('exited')
+    expect(w.incarnations[0].ended_reason).toBe('killed')
+
+    const killedEvents = events.filter((e) => e.kind === 'killed')
+    expect(killedEvents).toHaveLength(1)
+    expect(killedEvents[0].detail).toEqual({ reason: '用户要求终止' })
+  })
+
+  it('幂等:对已 cancelled 的 worker 再次 kill 不报错、不重复调用 adapter.kill、不重复发事件', async () => {
+    const { harness, fake } = await makeHarness()
+    const worker = await harness.spawnWorker(spawnParams())
+    await harness.killWorker(worker.worker_id)
+    expect(fake.killCalls).toHaveLength(1)
+    events.length = 0
+
+    await expect(harness.killWorker(worker.worker_id)).resolves.toBeUndefined()
+    expect(fake.killCalls).toHaveLength(1) // 未被再次调用
+    expect(events.filter((e) => e.kind === 'killed')).toHaveLength(0)
+  })
+
+  it('不存在的 worker_id → WorkerNotFoundError', async () => {
+    const { harness } = await makeHarness()
+    await expect(harness.killWorker('w-does-not-exist')).rejects.toThrow(WorkerNotFoundError)
+  })
+})
+
+describe('WorkerHarness.queryWorker', () => {
+  it('capabilities().fork 为 false → 抛 CapabilityNotSupportedError,不调用 adapter.fork', async () => {
+    const { harness, fake } = await makeHarness({ caps: { fork: false } })
+    const worker = await harness.spawnWorker(spawnParams())
+
+    await expect(harness.queryWorker(worker.worker_id, '侧问一下')).rejects.toThrow(CapabilityNotSupportedError)
+    expect(fake.forkCalls).toHaveLength(0)
+  })
+
+  it('capabilities().fork 为 true → adapter.fork 被调用,新化身入化身链,事件外发,主线 task.status 不受影响', async () => {
+    const { harness, fake } = await makeHarness({ caps: { fork: true } })
+    const worker = await harness.spawnWorker(spawnParams())
+    events.length = 0
+
+    const result = await harness.queryWorker(worker.worker_id, '侧问一下')
+
+    expect(result.forkSeq).toBe(2)
+    expect(fake.forkCalls).toHaveLength(1)
+    expect(fake.forkCalls[0].forkInput).toBe('侧问一下')
+
+    const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    expect(w.incarnations).toHaveLength(2)
+    expect(w.incarnations[1]).toMatchObject({ seq: 2, impl: 'builtin', state: 'running' })
+    expect(w.task.status).toBe('running') // fork 不影响主线状态
+
+    const stateEvents = events.filter((e) => e.kind === 'state_changed')
+    expect(stateEvents).toHaveLength(1)
+    expect(stateEvents[0].seq).toBe(2)
+    expect(stateEvents[0].detail).toEqual({ kind: 'fork', from_seq: 1 })
+  })
+})
+
+describe('WorkerHarness 锁纪律', () => {
+  it('spawnWorker 持锁期间(adapter.spawn 卡住未返回),并发 sendToWorker 的"读台账+入信箱"临界区必须排队等待,不能在半注册态下抢跑', async () => {
+    let releaseSpawn!: () => void
+    const spawnGate = new Promise<void>((resolve) => {
+      releaseSpawn = resolve
+    })
+    const { harness, fake } = await makeHarness()
+    // 用 deferred 卡住 adapter.spawn,模拟"provision/spawn 慢调用占着锁"这个真实场景,
+    // 不靠 setTimeout 猜时序——spawnGate 不 release,fake.spawn 就永远卡在这一行。
+    const originalSpawn = fake.spawn.bind(fake)
+    fake.spawn = async (spec: SpawnSpec) => {
+      await spawnGate
+      return originalSpawn(spec)
+    }
+
+    const spawnPromise = harness.spawnWorker(spawnParams())
+
+    // 初始台账写入(status='queued')发生在 provision/spawn 之前、拿锁之后,所以能很快
+    // 从台账里读到 worker_id——用有界轮询发现它(不是猜测完成时机,只是等这一次已知会
+    // 发生的早期写入落盘)。
+    let workerId: string | undefined
+    await waitUntil(async () => {
+      const list = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+      if (list.length > 0) {
+        workerId = list[0].worker_id
+        return true
+      }
+      return false
+    })
+
+    let sendResolved = false
+    const sendPromise = harness.sendToWorker(workerId!, '并发消息').then(() => {
+      sendResolved = true
+    })
+
+    // spawnWorker 仍持有该 worker_id 的锁(卡在 adapter.spawn 里),sendToWorker 的
+    // "读台账 → 判断 cancelled → 入信箱"临界区必须排在后面,不能抢先执行。
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(sendResolved).toBe(false)
+    expect(fake.sendInputCalls).toHaveLength(0)
+
+    releaseSpawn()
+    await spawnPromise
+    await sendPromise
+
+    expect(sendResolved).toBe(true)
+    expect(fake.sendInputCalls).toHaveLength(1)
+    expect(fake.sendInputCalls[0].text).toBe('并发消息')
+  })
+})
+
+async function waitUntil(cond: () => Promise<boolean>, timeoutMs = 2000, intervalMs = 10): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (await cond()) return
+    await new Promise((resolve) => setTimeout(resolve, intervalMs))
+  }
+  throw new Error('waitUntil timed out')
+}

--- a/crabot-agent/tests/workers/harness/harness-lifecycle.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-lifecycle.test.ts
@@ -44,6 +44,7 @@ class FakeAdapter implements WorkerAdapter {
   readonly sendInputCalls: Array<{ h: IncarnationHandle; text: string; opts?: { raw?: boolean } }> = []
   readonly killCalls: IncarnationHandle[] = []
   readonly forkCalls: Array<{ prev: IncarnationRef; forkInput: string }> = []
+  readonly readOutputCalls: IncarnationHandle[] = []
   private readonly states = new Map<string, WorkerContractState>()
   private nextForkSeq = 2
 
@@ -62,7 +63,7 @@ class FakeAdapter implements WorkerAdapter {
   async spawn(spec: SpawnSpec): Promise<IncarnationHandle> {
     this.spawnCalls.push(spec)
     if (this.opts.spawnShouldFail) throw this.opts.spawnShouldFail
-    const handle: IncarnationHandle = { worker_id: spec.worker_id, seq: 1, impl: this.implId }
+    const handle: IncarnationHandle = { worker_id: spec.worker_id, seq: 1, impl: this.implId, session_ref: `ref-${spec.worker_id}#1` }
     this.states.set(handleKey(handle), 'running')
     return handle
   }
@@ -74,7 +75,10 @@ class FakeAdapter implements WorkerAdapter {
   async fork(prev: IncarnationRef, forkInput: string): Promise<IncarnationHandle> {
     this.forkCalls.push({ prev, forkInput })
     if (this.opts.forkShouldFail) throw this.opts.forkShouldFail
-    const handle: IncarnationHandle = { worker_id: prev.worker_id, seq: this.nextForkSeq++, impl: this.implId }
+    const seq = this.nextForkSeq++
+    // fork 自己的 session_ref，刻意与 prev.session_ref(父化身/主线的引用)不同，好让
+    // 回归测试能验证 harness 没有把父化身的引用错抄给 fork 化身(protocol-agent-v3 §6.1)。
+    const handle: IncarnationHandle = { worker_id: prev.worker_id, seq, impl: this.implId, session_ref: `fork-ref-${prev.worker_id}#${seq}` }
     this.states.set(handleKey(handle), 'running')
     return handle
   }
@@ -84,7 +88,8 @@ class FakeAdapter implements WorkerAdapter {
     if (this.opts.sendInputBehavior) await this.opts.sendInputBehavior(h, text, opts)
   }
 
-  async readOutput(_h: IncarnationHandle, cursor: OutputCursor): Promise<{ chunk: string; nextCursor: OutputCursor }> {
+  async readOutput(h: IncarnationHandle, cursor: OutputCursor): Promise<{ chunk: string; nextCursor: OutputCursor }> {
+    this.readOutputCalls.push(h)
     return { chunk: '', nextCursor: cursor }
   }
 
@@ -179,6 +184,9 @@ describe('WorkerHarness.spawnWorker', () => {
     expect(worker.task.status).toBe('running')
     expect(worker.incarnations).toHaveLength(1)
     expect(worker.incarnations[0]).toMatchObject({ seq: 1, impl: 'builtin', state: 'running' })
+    // adapter.spawn 返回的 handle.session_ref 原子补写进初始化身条目，不再是占位空串
+    // (protocol-agent-v3 §6.1，harness 从 handle 直接取真值存台账)。
+    expect(worker.incarnations[0].session_ref).toBe(`ref-${worker.worker_id}#1`)
 
     // provision 在 spawn 之前被调用,且拿到了解析后的 workspace
     expect(fake.provisionCalls).toHaveLength(1)
@@ -221,7 +229,7 @@ describe('WorkerHarness.handleStateChange', () => {
     const worker = await harness.spawnWorker(spawnParams())
     events.length = 0
 
-    fake.emitStateChange({ worker_id: worker.worker_id, seq: 1, impl: 'builtin' }, 'idle')
+    fake.emitStateChange({ worker_id: worker.worker_id, seq: 1, impl: 'builtin', session_ref: `ref-${worker.worker_id}#1` }, 'idle')
 
     // handleStateChange 签名对齐 adapter 的同步回调(h, state) => void,内部是 fire-and-forget
     // 的异步台账更新——用轮询等待收敛(与 tests/workers/contract-suite.ts 的 waitForState
@@ -240,7 +248,7 @@ describe('WorkerHarness.handleStateChange', () => {
     expect(stateEvents[0].detail).toEqual({ to: 'idle' })
 
     // 化身自然结束(非 kill)→ completed
-    fake.emitStateChange({ worker_id: worker.worker_id, seq: 1, impl: 'builtin' }, 'exited')
+    fake.emitStateChange({ worker_id: worker.worker_id, seq: 1, impl: 'builtin', session_ref: `ref-${worker.worker_id}#1` }, 'exited')
     await waitUntil(async () => {
       const [w2] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
       return w2.task.status === 'completed'
@@ -255,7 +263,7 @@ describe('WorkerHarness.handleStateChange', () => {
     const worker = await harness.spawnWorker(spawnParams())
     await harness.killWorker(worker.worker_id)
 
-    fake.emitStateChange({ worker_id: worker.worker_id, seq: 1, impl: 'builtin' }, 'idle')
+    fake.emitStateChange({ worker_id: worker.worker_id, seq: 1, impl: 'builtin', session_ref: `ref-${worker.worker_id}#1` }, 'idle')
 
     // 确定性同步屏障(不用 setTimeout 猜时序):emitStateChange 同步触发的
     // handleStateChange 在其调用栈内同步完成了对同一 worker_id 的 per-worker 锁排队
@@ -280,7 +288,7 @@ describe('WorkerHarness.sendToWorker', () => {
     await harness.sendToWorker(worker.worker_id, '继续干活')
 
     expect(fake.sendInputCalls).toHaveLength(1)
-    expect(fake.sendInputCalls[0].h).toEqual({ worker_id: worker.worker_id, seq: 1, impl: 'builtin' })
+    expect(fake.sendInputCalls[0].h).toEqual({ worker_id: worker.worker_id, seq: 1, impl: 'builtin', session_ref: `ref-${worker.worker_id}#1` })
     expect(fake.sendInputCalls[0].text).toBe('继续干活')
 
     const inputEvents = events.filter((e) => e.kind === 'input_sent')
@@ -322,7 +330,7 @@ describe('WorkerHarness.killWorker', () => {
     await harness.killWorker(worker.worker_id, '用户要求终止')
 
     expect(fake.killCalls).toHaveLength(1)
-    expect(fake.killCalls[0]).toEqual({ worker_id: worker.worker_id, seq: 1, impl: 'builtin' })
+    expect(fake.killCalls[0]).toEqual({ worker_id: worker.worker_id, seq: 1, impl: 'builtin', session_ref: `ref-${worker.worker_id}#1` })
 
     const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
     expect(w.task.status).toBe('cancelled')
@@ -376,6 +384,11 @@ describe('WorkerHarness.queryWorker', () => {
     expect(w.incarnations).toHaveLength(2)
     expect(w.incarnations[1]).toMatchObject({ seq: 2, impl: 'builtin', state: 'running' })
     expect(w.task.status).toBe('running') // fork 不影响主线状态
+
+    // forked_from 标记它不在主线化身链上(protocol-agent-v3 §3);session_ref 取
+    // adapter.fork 返回的 handle 自己的引用,不是从主线(seq=1)照抄的(§6.1)。
+    expect(w.incarnations[1].forked_from).toBe(1)
+    expect(w.incarnations[1].session_ref).not.toBe(w.incarnations[0].session_ref)
 
     const stateEvents = events.filter((e) => e.kind === 'state_changed')
     expect(stateEvents).toHaveLength(1)
@@ -432,6 +445,122 @@ describe('WorkerHarness 锁纪律', () => {
     expect(sendResolved).toBe(true)
     expect(fake.sendInputCalls).toHaveLength(1)
     expect(fake.sendInputCalls[0].text).toBe('并发消息')
+  })
+})
+
+describe('WorkerHarness — fork 不劫持主线(protocol-agent-v3 §5.3 回归)', () => {
+  it('queryWorker fork 之后,sendToWorker/readWorkerOutput/killWorker 仍作用于主线化身(seq=1),不被 fork(seq=2)顶替', async () => {
+    const { harness, fake } = await makeHarness({ caps: { fork: true } })
+    const worker = await harness.spawnWorker(spawnParams())
+    events.length = 0
+
+    const { forkSeq } = await harness.queryWorker(worker.worker_id, '侧问一下')
+    expect(forkSeq).toBe(2)
+
+    // 修复前:lastIncarnation() 取数组最后一个,fork 之后就是 seq=2 的侧问分支——
+    // sendToWorker/killWorker/readWorkerOutput 全部会错误地 target 到它,主线失联。
+    await harness.sendToWorker(worker.worker_id, '继续干活')
+    expect(fake.sendInputCalls).toHaveLength(1)
+    expect(fake.sendInputCalls[0].h.seq).toBe(1)
+
+    await harness.readWorkerOutput(worker.worker_id, { offset: 0 })
+    expect(fake.readOutputCalls).toHaveLength(1)
+    expect(fake.readOutputCalls[0].seq).toBe(1)
+
+    await harness.killWorker(worker.worker_id, '测试终止')
+    expect(fake.killCalls).toHaveLength(1)
+    expect(fake.killCalls[0].seq).toBe(1)
+
+    const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    expect(w.task.status).toBe('cancelled') // 主线被正确终结,不是台账显示 fork 被 kill 而主线孤儿
+    const mainEntry = w.incarnations.find((i) => i.seq === 1)!
+    expect(mainEntry.state).toBe('exited')
+    expect(mainEntry.ended_reason).toBe('killed')
+    // fork 化身条目不受主线 kill 动作影响(kill 只调用了 adapter.kill 一次,且 target 是 seq=1)。
+    const forkEntry = w.incarnations.find((i) => i.seq === 2)!
+    expect(forkEntry.state).toBe('running')
+  })
+
+  it('processStateChange:fork 化身(seq=2)自己的状态变化只更新它自己的化身条目,不推进主线 task.status', async () => {
+    const { harness, fake } = await makeHarness({ caps: { fork: true } })
+    const worker = await harness.spawnWorker(spawnParams())
+    await harness.queryWorker(worker.worker_id, '侧问一下')
+    events.length = 0
+
+    // fork 化身自然结束(如 builtin 的 runForkBurst 跑完侧问),不是 harness.killWorker 触发。
+    fake.emitStateChange({ worker_id: worker.worker_id, seq: 2, impl: 'builtin', session_ref: 'fork-ref' }, 'exited')
+
+    await waitUntil(async () => {
+      const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+      return w.incarnations.find((i) => i.seq === 2)?.state === 'exited'
+    })
+
+    const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    // 主线(seq=1)完全不受 fork 结束的影响——修复前 lastIncarnation() 会把这次回调当成
+    // "当前化身"的回调,错误地把 task.status 推进到 completed。
+    expect(w.task.status).toBe('running')
+    const mainEntry = w.incarnations.find((i) => i.seq === 1)!
+    expect(mainEntry.state).toBe('running')
+
+    const forkEntry = w.incarnations.find((i) => i.seq === 2)!
+    expect(forkEntry.state).toBe('exited')
+    expect(forkEntry.ended_reason).toBe('completed')
+
+    const stateEvents = events.filter((e) => e.kind === 'state_changed' && e.seq === 2)
+    expect(stateEvents).toHaveLength(1)
+    expect(stateEvents[0].detail).toEqual({ to: 'exited' })
+  })
+})
+
+describe('WorkerHarness.readWorkerOutput', () => {
+  it('正常路径:透传 adapter.readOutput 的结果', async () => {
+    const { harness, fake } = await makeHarness()
+    const worker = await harness.spawnWorker(spawnParams())
+
+    const result = await harness.readWorkerOutput(worker.worker_id, { offset: 0 })
+
+    expect(result).toEqual({ chunk: '', nextCursor: { offset: 0 } })
+    expect(fake.readOutputCalls).toHaveLength(1)
+    expect(fake.readOutputCalls[0]).toEqual({ worker_id: worker.worker_id, seq: 1, impl: 'builtin', session_ref: `ref-${worker.worker_id}#1` })
+  })
+
+  it('不存在的 worker_id → WorkerNotFoundError', async () => {
+    const { harness } = await makeHarness()
+    await expect(harness.readWorkerOutput('w-does-not-exist', { offset: 0 })).rejects.toThrow(WorkerNotFoundError)
+  })
+
+  it('化身实现没有注册对应 adapter → 抛错,不静默返回空结果', async () => {
+    const { harness, fake, adaptersMap } = await makeHarness()
+    const worker = await harness.spawnWorker(spawnParams())
+    adaptersMap.delete(fake.implId)
+
+    await expect(harness.readWorkerOutput(worker.worker_id, { offset: 0 })).rejects.toThrow(/no adapter registered/)
+  })
+})
+
+describe('WorkerHarness.handleStateChange — 同状态重复回调', () => {
+  it('重复收到同一状态的回调不抛错、不丢事件、台账状态保持不变', async () => {
+    const { harness, fake } = await makeHarness()
+    const worker = await harness.spawnWorker(spawnParams())
+    events.length = 0
+
+    // worker 已是 running;再收一次 'running' 回调——taskStatusFromIncarnation 算出的
+    // nextStatus 与当前 task.status 相同,VALID_TRANSITIONS 里 running 没有到 running 的
+    // 自环边,applyStatusTransition 会抛 InvalidTaskTransitionError。修复前这个错误在
+    // handleStateChange 的 fire-and-forget catch 里被静默吞掉,appendEvent 也不会跑,
+    // 这次回调的事件凭空丢失。
+    fake.emitStateChange({ worker_id: worker.worker_id, seq: 1, impl: 'builtin', session_ref: `ref-${worker.worker_id}#1` }, 'running')
+
+    // 用一次已知会走同一把 per-worker 锁的调用作确定性屏障(手法与本文件"已终态 worker
+    // 的迟到状态回调被忽略"用例一致):等它 resolve,前面排队的状态回调必定已经跑完。
+    await harness.sendToWorker(worker.worker_id, '还在干活')
+
+    const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    expect(w.task.status).toBe('running') // 没有被非法转换破坏,也没有抛出未捕获错误
+
+    const stateEvents = events.filter((e) => e.kind === 'state_changed')
+    expect(stateEvents).toHaveLength(1) // 事件仍然被记录,没有跟着错误一起被吞掉
+    expect(stateEvents[0].detail).toEqual({ to: 'running' })
   })
 })
 

--- a/crabot-agent/tests/workers/harness/harness-recovery.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-recovery.test.ts
@@ -1,0 +1,364 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { promises as fs } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { WorkerHarness, type HarnessDeps, type ReconcileReport } from '../../../src/workers/harness/harness'
+import { LedgerStore } from '../../../src/workers/harness/ledger-store'
+import { WorkspaceManager } from '../../../src/workers/harness/workspace-manager'
+import {
+  dialogObjectIdForPrivate,
+  dialogObjectIdForGroup,
+  type DialogObjectId,
+  type LedgerWorker,
+} from '../../../src/workers/harness/ledger-types'
+import type { HarnessEvent } from '../../../src/workers/harness/worker-events'
+import type {
+  WorkerAdapter,
+  WorkerImplId,
+  WorkerContractState,
+  IncarnationHandle,
+  IncarnationRef,
+  SpawnSpec,
+  OutputCursor,
+  AdapterCapabilities,
+  DetectResult,
+} from '../../../src/workers/types'
+
+// ---- FakeAdapter：Task 9 崩溃恢复对账专用桩——只关心 state()，spawn/resume/fork/sendInput
+// 均不被 reconcileOnStartup 用到（本文件的台账记录都是直接经 LedgerStore.upsertWorker 手工
+// 构造的"进程重启前的现场"，不经过 harness.spawnWorker，避免混入不相关的编排语义）。----
+
+function handleKey(h: { worker_id: string; seq: number }): string {
+  return `${h.worker_id}#${h.seq}`
+}
+
+class FakeAdapter implements WorkerAdapter {
+  readonly implId: WorkerImplId
+  readonly stateCalls: IncarnationHandle[] = []
+  private readonly states = new Map<string, WorkerContractState>()
+  private readonly throwers = new Map<string, Error>()
+
+  constructor(implId: WorkerImplId = 'builtin') {
+    this.implId = implId
+  }
+
+  /** 编程本次巡检 adapter.state(handle) 应该返回什么。 */
+  setState(h: { worker_id: string; seq: number }, state: WorkerContractState): void {
+    this.states.set(handleKey(h), state)
+  }
+
+  /** 编程本次巡检 adapter.state(handle) 应该抛什么错。 */
+  setStateError(h: { worker_id: string; seq: number }, err: Error): void {
+    this.throwers.set(handleKey(h), err)
+  }
+
+  async detect(): Promise<DetectResult> {
+    return { installed: true, activated: true }
+  }
+
+  async provision(): Promise<void> {}
+
+  async spawn(_spec: SpawnSpec): Promise<IncarnationHandle> {
+    throw new Error('FakeAdapter.spawn: not exercised by harness-recovery tests')
+  }
+
+  async resume(_prev: IncarnationRef, _wakeInput: string): Promise<IncarnationHandle> {
+    throw new Error('FakeAdapter.resume: not exercised by harness-recovery tests')
+  }
+
+  async fork(_prev: IncarnationRef, _forkInput: string): Promise<IncarnationHandle> {
+    throw new Error('FakeAdapter.fork: not exercised by harness-recovery tests')
+  }
+
+  async sendInput(): Promise<void> {
+    throw new Error('FakeAdapter.sendInput: not exercised by harness-recovery tests')
+  }
+
+  async readOutput(_h: IncarnationHandle, cursor: OutputCursor): Promise<{ chunk: string; nextCursor: OutputCursor }> {
+    return { chunk: '', nextCursor: cursor }
+  }
+
+  async state(h: IncarnationHandle): Promise<WorkerContractState> {
+    this.stateCalls.push(h)
+    const err = this.throwers.get(handleKey(h))
+    if (err) throw err
+    return this.states.get(handleKey(h)) ?? 'exited'
+  }
+
+  async kill(_h: IncarnationHandle): Promise<void> {}
+
+  capabilities(): AdapterCapabilities {
+    return { fork: false, revive: false, goalMode: false, subagent: false, structuredTrace: false }
+  }
+}
+
+// ---- 测试夹具 ----
+
+let dataDir: string
+let nowValue: number
+const events: HarnessEvent[] = []
+
+function now(): string {
+  nowValue += 1000
+  return new Date(nowValue).toISOString()
+}
+
+async function makeHarness(): Promise<{ harness: WorkerHarness; ledger: LedgerStore; adaptersMap: Map<WorkerImplId, WorkerAdapter> }> {
+  const ledgersDir = join(dataDir, 'ledgers')
+  const workspacesRoot = join(dataDir, 'workspaces')
+  const workersDir = join(dataDir, 'workers')
+  await fs.mkdir(workspacesRoot, { recursive: true })
+
+  const ledger = new LedgerStore(ledgersDir)
+  const workspaces = new WorkspaceManager(workspacesRoot)
+  const adaptersMap = new Map<WorkerImplId, WorkerAdapter>()
+  const deps: HarnessDeps = {
+    adapters: adaptersMap,
+    defaultImpl: 'builtin',
+    ledger,
+    workspaces,
+    workersDir,
+    now,
+    onEvent: (e) => events.push(e),
+  }
+  const harness = new WorkerHarness(deps)
+  return { harness, ledger, adaptersMap }
+}
+
+/** 直接构造一条"进程重启前留在台账里的现场"，不经过 harness.spawnWorker 的编排语义。 */
+function makeWorker(workerId: string, overrides: Partial<LedgerWorker> = {}): LedgerWorker {
+  const ts = new Date(nowValue).toISOString()
+  return {
+    worker_id: workerId,
+    task: {
+      id: `task-${workerId}`,
+      title: '测试任务',
+      status: 'running',
+      created_at: ts,
+    },
+    origin: { spawned_by_session: 'wechat::sess-1', trigger_type: 'message' },
+    report_to: { channel_id: 'wechat', session_id: 'sess-1' },
+    incarnations: [
+      { seq: 1, impl: 'builtin', state: 'running', workspace: '/tmp/ws', session_ref: `ref-${workerId}#1`, started_at: ts },
+    ],
+    updated_at: ts,
+    ...overrides,
+  }
+}
+
+async function seed(ledger: LedgerStore, dialogObjectId: DialogObjectId, worker: LedgerWorker): Promise<void> {
+  await ledger.upsertWorker(dialogObjectId, worker.worker_id, () => worker)
+}
+
+async function getWorker(ledger: LedgerStore, workerId: string): Promise<LedgerWorker> {
+  const found = await ledger.findWorker(workerId)
+  if (!found) throw new Error(`worker not found in test: ${workerId}`)
+  return found.worker
+}
+
+const DIALOG = dialogObjectIdForPrivate('friend-1')
+
+beforeEach(async () => {
+  dataDir = await fs.mkdtemp(join(tmpdir(), 'harness-recovery-test-'))
+  nowValue = Date.parse('2026-01-01T00:00:00.000Z')
+  events.length = 0
+})
+
+afterEach(async () => {
+  await fs.rm(dataDir, { recursive: true, force: true })
+})
+
+describe('WorkerHarness.reconcileOnStartup — 三态判定', () => {
+  it('adapter 报 exited 而台账非终态 → 落 failed(ended_reason=crashed) + 事件，归 failed', async () => {
+    const { harness, ledger, adaptersMap } = await makeHarness()
+    const fake = new FakeAdapter('builtin')
+    adaptersMap.set('builtin', fake)
+    const worker = makeWorker('w-exited', { task: { id: 'task-w-exited', title: '测试任务', status: 'running', created_at: now() } })
+    await seed(ledger, DIALOG, worker)
+    fake.setState({ worker_id: 'w-exited', seq: 1 }, 'exited')
+
+    const report = await harness.reconcileOnStartup()
+
+    expect(report).toEqual<ReconcileReport>({ revived: [], failed: ['w-exited'], unchanged: [] })
+    const after = await getWorker(ledger, 'w-exited')
+    expect(after.task.status).toBe('failed')
+    expect(after.task.error).toBeTruthy()
+    expect(after.incarnations[0].state).toBe('exited')
+    expect(after.incarnations[0].ended_reason).toBe('crashed')
+    expect(after.incarnations[0].ended_at).toBeTruthy()
+
+    const exitedEvents = events.filter((e) => e.kind === 'exited' && e.worker_id === 'w-exited')
+    expect(exitedEvents).toHaveLength(1)
+    expect(exitedEvents[0].detail?.reason).toBe('crashed')
+  })
+
+  it('adapter 报 running 且与台账一致 → 台账保持不动、不发事件，归 revived', async () => {
+    const { harness, ledger, adaptersMap } = await makeHarness()
+    const fake = new FakeAdapter('builtin')
+    adaptersMap.set('builtin', fake)
+    const worker = makeWorker('w-running')
+    await seed(ledger, DIALOG, worker)
+    fake.setState({ worker_id: 'w-running', seq: 1 }, 'running')
+
+    const report = await harness.reconcileOnStartup()
+
+    expect(report).toEqual<ReconcileReport>({ revived: ['w-running'], failed: [], unchanged: [] })
+    const after = await getWorker(ledger, 'w-running')
+    expect(after.task.status).toBe('running')
+    expect(after.incarnations[0].state).toBe('running')
+    expect(after.updated_at).toBe(worker.updated_at) // 完全没有写盘
+
+    expect(events.filter((e) => e.worker_id === 'w-running')).toHaveLength(0)
+  })
+
+  it('adapter 报 idle 且台账仍是 running → 对齐 incarnation.state=idle + task.status=waiting_input，发 state_changed(source=reconcile)，归 revived', async () => {
+    const { harness, ledger, adaptersMap } = await makeHarness()
+    const fake = new FakeAdapter('builtin')
+    adaptersMap.set('builtin', fake)
+    const worker = makeWorker('w-idle')
+    await seed(ledger, DIALOG, worker)
+    fake.setState({ worker_id: 'w-idle', seq: 1 }, 'idle')
+
+    const report = await harness.reconcileOnStartup()
+
+    expect(report).toEqual<ReconcileReport>({ revived: ['w-idle'], failed: [], unchanged: [] })
+    const after = await getWorker(ledger, 'w-idle')
+    expect(after.task.status).toBe('waiting_input')
+    expect(after.incarnations[0].state).toBe('idle')
+
+    const stateEvents = events.filter((e) => e.kind === 'state_changed' && e.worker_id === 'w-idle')
+    expect(stateEvents).toHaveLength(1)
+    expect(stateEvents[0].detail).toEqual({ to: 'idle', source: 'reconcile' })
+  })
+
+  it('主线化身的 impl 没有注册 adapter(已禁用/未安装) → 落 failed(crashed)，detail 记原因，不调用任何 adapter.state()', async () => {
+    const { harness, ledger, adaptersMap } = await makeHarness()
+    // 只注册 builtin，worker 的主线化身是 codex —— adapters.get('codex') 落空。
+    const builtinFake = new FakeAdapter('builtin')
+    adaptersMap.set('builtin', builtinFake)
+    const worker = makeWorker('w-no-adapter', {
+      incarnations: [{ seq: 1, impl: 'codex', state: 'running', workspace: '/tmp/ws', session_ref: 'ref-w-no-adapter#1', started_at: now() }],
+    })
+    await seed(ledger, DIALOG, worker)
+
+    const report = await harness.reconcileOnStartup()
+
+    expect(report).toEqual<ReconcileReport>({ revived: [], failed: ['w-no-adapter'], unchanged: [] })
+    const after = await getWorker(ledger, 'w-no-adapter')
+    expect(after.task.status).toBe('failed')
+    expect(after.incarnations[0].ended_reason).toBe('crashed')
+    const exitedEvents = events.filter((e) => e.kind === 'exited' && e.worker_id === 'w-no-adapter')
+    expect(exitedEvents[0].detail?.message).toContain('codex')
+    expect(builtinFake.stateCalls).toHaveLength(0) // 不存在的 impl，不该错调到别的 adapter 上
+  })
+
+  it('adapter.state() 抛错 → 视为不可判定，落 failed(crashed)，detail 记错误信息，不中断整轮对账（其余 worker 仍被正常处理）', async () => {
+    const { harness, ledger, adaptersMap } = await makeHarness()
+    const fake = new FakeAdapter('builtin')
+    adaptersMap.set('builtin', fake)
+    const throwingWorker = makeWorker('w-throws')
+    const okWorker = makeWorker('w-ok')
+    await seed(ledger, DIALOG, throwingWorker)
+    await seed(ledger, DIALOG, okWorker)
+    fake.setStateError({ worker_id: 'w-throws', seq: 1 }, new Error('tmux pane 探测失败：session 不存在'))
+    fake.setState({ worker_id: 'w-ok', seq: 1 }, 'running')
+
+    const report = await harness.reconcileOnStartup()
+
+    expect(report.failed).toEqual(['w-throws'])
+    expect(report.revived).toEqual(['w-ok']) // 另一个 worker 没有被这次异常连累，正常判定
+
+    const after = await getWorker(ledger, 'w-throws')
+    expect(after.task.status).toBe('failed')
+    expect(after.incarnations[0].ended_reason).toBe('crashed')
+    const exitedEvents = events.filter((e) => e.kind === 'exited' && e.worker_id === 'w-throws')
+    expect(exitedEvents[0].detail?.message).toContain('tmux pane 探测失败')
+  })
+})
+
+describe('WorkerHarness.reconcileOnStartup — 终态 worker 不被触碰', () => {
+  it('台账已是终态(completed/failed/cancelled) → 不调用 adapter.state()，不发事件，归 unchanged', async () => {
+    const { harness, ledger, adaptersMap } = await makeHarness()
+    const fake = new FakeAdapter('builtin')
+    adaptersMap.set('builtin', fake)
+
+    const completed = makeWorker('w-completed', {
+      task: { id: 'task-w-completed', title: '测试任务', status: 'completed', created_at: now(), completed_at: now() },
+      incarnations: [{ seq: 1, impl: 'builtin', state: 'exited', workspace: '/tmp/ws', session_ref: 'ref#1', started_at: now(), ended_at: now(), ended_reason: 'completed' }],
+    })
+    const failedAlready = makeWorker('w-failed-already', {
+      task: { id: 'task-w-failed-already', title: '测试任务', status: 'failed', created_at: now(), completed_at: now(), error: 'boom' },
+      incarnations: [{ seq: 1, impl: 'builtin', state: 'exited', workspace: '/tmp/ws', session_ref: 'ref#1', started_at: now(), ended_at: now(), ended_reason: 'failed' }],
+    })
+    const cancelled = makeWorker('w-cancelled', {
+      task: { id: 'task-w-cancelled', title: '测试任务', status: 'cancelled', created_at: now(), completed_at: now() },
+      incarnations: [{ seq: 1, impl: 'builtin', state: 'exited', workspace: '/tmp/ws', session_ref: 'ref#1', started_at: now(), ended_at: now(), ended_reason: 'killed' }],
+    })
+    await seed(ledger, DIALOG, completed)
+    await seed(ledger, DIALOG, failedAlready)
+    await seed(ledger, DIALOG, cancelled)
+
+    const report = await harness.reconcileOnStartup()
+
+    expect(report.unchanged.sort()).toEqual(['w-cancelled', 'w-completed', 'w-failed-already'])
+    expect(report.revived).toEqual([])
+    expect(report.failed).toEqual([])
+    expect(fake.stateCalls).toHaveLength(0)
+    expect(events).toHaveLength(0)
+  })
+})
+
+describe('WorkerHarness.reconcileOnStartup — 报告分类 + 跨对话对象', () => {
+  it('私聊与群聊两个对话对象下的 worker 混合 revived/failed/unchanged，一次调用全部正确分类', async () => {
+    const { harness, ledger, adaptersMap } = await makeHarness()
+    const fake = new FakeAdapter('builtin')
+    adaptersMap.set('builtin', fake)
+
+    const group = dialogObjectIdForGroup('wechat', 'group-1')
+    await seed(ledger, DIALOG, makeWorker('priv-alive'))
+    await seed(ledger, DIALOG, makeWorker('priv-dead'))
+    await seed(
+      ledger,
+      group,
+      makeWorker('group-done', {
+        task: { id: 'task-group-done', title: '测试任务', status: 'completed', created_at: now(), completed_at: now() },
+        incarnations: [{ seq: 1, impl: 'builtin', state: 'exited', workspace: '/tmp/ws', session_ref: 'ref#1', started_at: now(), ended_at: now(), ended_reason: 'completed' }],
+      })
+    )
+    fake.setState({ worker_id: 'priv-alive', seq: 1 }, 'running')
+    fake.setState({ worker_id: 'priv-dead', seq: 1 }, 'exited')
+
+    const report = await harness.reconcileOnStartup()
+
+    expect(report.revived).toEqual(['priv-alive'])
+    expect(report.failed).toEqual(['priv-dead'])
+    expect(report.unchanged).toEqual(['group-done'])
+  })
+})
+
+describe('WorkerHarness.reconcileOnStartup — 幂等', () => {
+  it('重复调用不重复判死、不重复发事件：第二次调用时前一轮判死的 worker 已是终态 → 归 unchanged', async () => {
+    const { harness, ledger, adaptersMap } = await makeHarness()
+    const fake = new FakeAdapter('builtin')
+    adaptersMap.set('builtin', fake)
+    const worker = makeWorker('w-repeat')
+    await seed(ledger, DIALOG, worker)
+    fake.setState({ worker_id: 'w-repeat', seq: 1 }, 'exited')
+
+    const first = await harness.reconcileOnStartup()
+    expect(first).toEqual<ReconcileReport>({ revived: [], failed: ['w-repeat'], unchanged: [] })
+    const afterFirst = await getWorker(ledger, 'w-repeat')
+    expect(afterFirst.task.status).toBe('failed')
+    const eventsAfterFirst = events.filter((e) => e.worker_id === 'w-repeat')
+    expect(eventsAfterFirst).toHaveLength(1)
+
+    const second = await harness.reconcileOnStartup()
+    expect(second).toEqual<ReconcileReport>({ revived: [], failed: [], unchanged: ['w-repeat'] })
+    // adapter.state() 完全不会再被这个已终态 worker 调用第二次。
+    expect(fake.stateCalls.filter((h) => h.worker_id === 'w-repeat')).toHaveLength(1)
+    // 没有产生第二条事件。
+    expect(events.filter((e) => e.worker_id === 'w-repeat')).toHaveLength(1)
+    const afterSecond = await getWorker(ledger, 'w-repeat')
+    expect(afterSecond).toEqual(afterFirst) // 台账没有被第二次改写
+  })
+})

--- a/crabot-agent/tests/workers/harness/inbox.test.ts
+++ b/crabot-agent/tests/workers/harness/inbox.test.ts
@@ -218,6 +218,62 @@ describe('WorkerInbox', () => {
     warnSpy.mockRestore()
   })
 
+  it('drain → enqueue → flush 且 deliver 失败:新条目应当抛出、留队首(仅吞 drain 当刻的 in-flight)', async () => {
+    // 复审 Minor:drain 之后的 enqueue('z') 若投递失败,本应抛出且保留队首,
+    // 但当前实现因为 _drained 永久粘性,会错误地吞掉错误。
+    // 修复:只吞 drain 当刻的那个 in-flight 条目,post-drain enqueue 走正常语义。
+    const inbox = new WorkerInbox('worker-1')
+    inbox.enqueue(makeItem('a'))
+
+    let rejectDeliverA!: (err: Error) => void
+    const deliverAGate = new Promise<void>((_resolve, reject) => {
+      rejectDeliverA = reject
+    })
+    const boom = new Error('deliver failed on a after drain')
+
+    const flushPromise = inbox.flush(async (item) => {
+      if (item.text === 'a') {
+        await deliverAGate
+      }
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    // drain 当刻 'a' 在 in-flight 中
+    inbox.drain()
+
+    // post-drain 新入队
+    inbox.enqueue(makeItem('z'))
+    expect(inbox.pending).toBe(1) // drain 后队列是空的,'z' 是新的第一条
+
+    // 让 'a' 的投递失败(drain 当刻的 in-flight)
+    rejectDeliverA(boom)
+    await expect(flushPromise).resolves.toBe(0) // 'a' 是 drain 当刻的 in-flight,吞掉错误
+
+    // 现在尝试投递 'z'(post-drain 新条目)
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const boomZ = new Error('deliver failed on z')
+
+    const delivered: string[] = []
+    let thrown: unknown
+    try {
+      await inbox.flush(async (item) => {
+        if (item.text === 'z') throw boomZ
+        delivered.push(item.text)
+      })
+    } catch (err) {
+      thrown = err
+    }
+
+    // 'z' 是 post-drain 新条目,失败应当抛出(不被 _drained 吞掉)
+    expect(thrown).toBe(boomZ)
+    expect(delivered).toEqual([])
+    expect(inbox.pending).toBe(1) // 'z' 应放回队首
+    expect(warnSpy).not.toHaveBeenCalled() // 不应告警(仅 drain 当刻的 in-flight 才告警)
+
+    warnSpy.mockRestore()
+  })
+
   it('drain 取出全部并清空队列', () => {
     const inbox = new WorkerInbox('worker-1')
     inbox.enqueue(makeItem('a'))

--- a/crabot-agent/tests/workers/harness/inbox.test.ts
+++ b/crabot-agent/tests/workers/harness/inbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { WorkerInbox, type InboxItem } from '../../../src/workers/harness/inbox'
 
 function makeItem(text: string, overrides: Partial<InboxItem> = {}): InboxItem {
@@ -146,6 +146,76 @@ describe('WorkerInbox', () => {
     expect(inbox.held).toBe(true)
     expect(inbox.pending).toBe(2)
     expect(inbox.drain().map((i) => i.text)).toEqual(['b', 'c'])
+  })
+
+  it('drain 在 flush 卡在 deliver 期间调用,不把 in-flight 条目重复计入 dead-letter', async () => {
+    // PoC(评审复现):flush 卡在 deliver('a') 时若 drain 直接 this.queue = [] 重新赋值,
+    // 会把正在被投递的 'a' 也当作"未投递"一并 drain 出去;'a' 随后投递成功,导致它
+    // 既被真正投递、又混进 dead-letter 批次 —— 调用方按注释重投 dead-letter 时 'a' 被投两次。
+    const inbox = new WorkerInbox('worker-1')
+    inbox.enqueue(makeItem('a'))
+    inbox.enqueue(makeItem('b'))
+    inbox.enqueue(makeItem('c'))
+
+    let releaseDeliverA!: () => void
+    const deliverAGate = new Promise<void>((resolve) => {
+      releaseDeliverA = resolve
+    })
+    const delivered: string[] = []
+
+    const flushPromise = inbox.flush(async (item) => {
+      if (item.text === 'a') {
+        await deliverAGate // 卡住,模拟 deliver('a') 长时间不返回(如 tmux 命令挂起)
+      }
+      delivered.push(item.text)
+    })
+
+    // 让出事件循环,确保 flush 已经进入 deliver('a') 并卡住
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    const drained = inbox.drain()
+    // 'a' 正在被投递中,不应出现在 drain 结果里;其成败由 flush 自己结算
+    expect(drained.map((i) => i.text)).toEqual(['b', 'c'])
+    expect(inbox.pending).toBe(0)
+
+    releaseDeliverA()
+    const count = await flushPromise
+
+    // deliver('a') 最终成功,flush 的簿记应准确反映:只投了 'a' 一条,不重复、不丢
+    expect(delivered).toEqual(['a'])
+    expect(count).toBe(1)
+  })
+
+  it('drain 之后 in-flight 条目投递失败:不放回队列、不向上抛未捕获,仅告警', async () => {
+    const inbox = new WorkerInbox('worker-1')
+    inbox.enqueue(makeItem('a'))
+
+    let rejectDeliverA!: (err: Error) => void
+    const deliverAGate = new Promise<void>((_resolve, reject) => {
+      rejectDeliverA = reject
+    })
+    const boom = new Error('deliver failed on a after drain')
+
+    const flushPromise = inbox.flush(async (item) => {
+      if (item.text === 'a') {
+        await deliverAGate
+      }
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    const drained = inbox.drain()
+    expect(drained).toEqual([])
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    rejectDeliverA(boom)
+
+    // 化身已终结(已 drain),该条已无投递目标:flush 不应把此失败向上抛出
+    await expect(flushPromise).resolves.toBe(0)
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(inbox.pending).toBe(0)
+
+    warnSpy.mockRestore()
   })
 
   it('drain 取出全部并清空队列', () => {

--- a/crabot-agent/tests/workers/harness/inbox.test.ts
+++ b/crabot-agent/tests/workers/harness/inbox.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from 'vitest'
+import { WorkerInbox, type InboxItem } from '../../../src/workers/harness/inbox'
+
+function makeItem(text: string, overrides: Partial<InboxItem> = {}): InboxItem {
+  return { text, raw: false, enqueued_at: new Date().toISOString(), ...overrides }
+}
+
+describe('WorkerInbox', () => {
+  it('enqueue 返回入队后的待投条数', () => {
+    const inbox = new WorkerInbox('worker-1')
+    expect(inbox.enqueue(makeItem('a'))).toBe(1)
+    expect(inbox.enqueue(makeItem('b'))).toBe(2)
+    expect(inbox.pending).toBe(2)
+  })
+
+  it('hold 期间 flush 不投递', async () => {
+    const inbox = new WorkerInbox('worker-1')
+    inbox.enqueue(makeItem('a'))
+    inbox.enqueue(makeItem('b'))
+    inbox.hold('provisioning')
+    expect(inbox.held).toBe(true)
+
+    const delivered: string[] = []
+    const count = await inbox.flush(async (item) => {
+      delivered.push(item.text)
+    })
+
+    expect(count).toBe(0)
+    expect(delivered).toEqual([])
+    expect(inbox.pending).toBe(2)
+  })
+
+  it('release 后按序补投', async () => {
+    const inbox = new WorkerInbox('worker-1')
+    inbox.hold('handoff')
+    inbox.enqueue(makeItem('a'))
+    inbox.enqueue(makeItem('b'))
+    inbox.enqueue(makeItem('c'))
+
+    const heldCount = await inbox.flush(async () => {
+      throw new Error('should not be called while held')
+    })
+    expect(heldCount).toBe(0)
+
+    inbox.release()
+    expect(inbox.held).toBe(false)
+
+    const delivered: string[] = []
+    const count = await inbox.flush(async (item) => {
+      delivered.push(item.text)
+    })
+
+    expect(count).toBe(3)
+    expect(delivered).toEqual(['a', 'b', 'c'])
+    expect(inbox.pending).toBe(0)
+  })
+
+  it('deliver 抛错时该条不丢、留在队首、后续不投,并原样抛出', async () => {
+    const inbox = new WorkerInbox('worker-1')
+    inbox.enqueue(makeItem('a'))
+    inbox.enqueue(makeItem('b'))
+    inbox.enqueue(makeItem('c'))
+
+    const delivered: string[] = []
+    const boom = new Error('deliver failed on b')
+    let thrown: unknown
+
+    try {
+      await inbox.flush(async (item) => {
+        if (item.text === 'b') throw boom
+        delivered.push(item.text)
+      })
+    } catch (err) {
+      thrown = err
+    }
+
+    expect(thrown).toBe(boom)
+    // a 已成功投递;b 失败留队首;c 未投
+    expect(delivered).toEqual(['a'])
+    expect(inbox.pending).toBe(2)
+    expect(inbox.drain().map((i) => i.text)).toEqual(['b', 'c'])
+  })
+
+  it('deliver 抛错后重新 flush 从失败条目续投(不重复投已成功的)', async () => {
+    const inbox = new WorkerInbox('worker-1')
+    inbox.enqueue(makeItem('a'))
+    inbox.enqueue(makeItem('b'))
+
+    let failOnce = true
+    const delivered: string[] = []
+    await expect(
+      inbox.flush(async (item) => {
+        if (item.text === 'b' && failOnce) {
+          failOnce = false
+          throw new Error('transient')
+        }
+        delivered.push(item.text)
+      })
+    ).rejects.toThrow('transient')
+
+    expect(delivered).toEqual(['a'])
+    expect(inbox.pending).toBe(1)
+
+    const count = await inbox.flush(async (item) => {
+      delivered.push(item.text)
+    })
+    expect(count).toBe(1)
+    expect(delivered).toEqual(['a', 'b'])
+    expect(inbox.pending).toBe(0)
+  })
+
+  it('并发 flush 不重复投递同一 item', async () => {
+    const inbox = new WorkerInbox('worker-1')
+    const items = ['a', 'b', 'c', 'd']
+    for (const text of items) inbox.enqueue(makeItem(text))
+
+    const delivered: string[] = []
+    const deliver = async (item: InboxItem) => {
+      // 制造重叠窗口,模拟两个并发 flush 调用交叠执行
+      await new Promise((resolve) => setTimeout(resolve, 5))
+      delivered.push(item.text)
+    }
+
+    const [count1, count2] = await Promise.all([inbox.flush(deliver), inbox.flush(deliver)])
+
+    expect(delivered).toEqual(items)
+    expect(new Set(delivered).size).toBe(items.length)
+    expect(count1 + count2).toBe(items.length)
+    expect(inbox.pending).toBe(0)
+  })
+
+  it('flush 途中再次被 hold 则停止本轮,已入队未投的保留', async () => {
+    const inbox = new WorkerInbox('worker-1')
+    inbox.enqueue(makeItem('a'))
+    inbox.enqueue(makeItem('b'))
+    inbox.enqueue(makeItem('c'))
+
+    const delivered: string[] = []
+    const count = await inbox.flush(async (item) => {
+      delivered.push(item.text)
+      if (item.text === 'a') inbox.hold('modal-detected')
+    })
+
+    expect(count).toBe(1)
+    expect(delivered).toEqual(['a'])
+    expect(inbox.held).toBe(true)
+    expect(inbox.pending).toBe(2)
+    expect(inbox.drain().map((i) => i.text)).toEqual(['b', 'c'])
+  })
+
+  it('drain 取出全部并清空队列', () => {
+    const inbox = new WorkerInbox('worker-1')
+    inbox.enqueue(makeItem('a'))
+    inbox.enqueue(makeItem('b'))
+
+    const items = inbox.drain()
+    expect(items.map((i) => i.text)).toEqual(['a', 'b'])
+    expect(inbox.pending).toBe(0)
+    expect(inbox.drain()).toEqual([])
+  })
+})

--- a/crabot-agent/tests/workers/harness/ledger-store.test.ts
+++ b/crabot-agent/tests/workers/harness/ledger-store.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { promises as fs } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import {
+  LedgerStore,
+  dialogObjectIdToFilename,
+  filenameToDialogObjectId,
+} from '../../../src/workers/harness/ledger-store'
+import {
+  dialogObjectIdForPrivate,
+  dialogObjectIdForGroup,
+  type DialogObjectId,
+  type LedgerWorker,
+} from '../../../src/workers/harness/ledger-types'
+
+function makeWorker(workerId: string, overrides: Partial<LedgerWorker> = {}): LedgerWorker {
+  const now = new Date().toISOString()
+  return {
+    worker_id: workerId,
+    task: {
+      id: `task-${workerId}`,
+      title: 'test task',
+      status: 'running',
+      created_at: now,
+    },
+    origin: {
+      spawned_by_session: 'wechat::sess-1',
+      trigger_type: 'message',
+    },
+    report_to: { channel_id: 'wechat', session_id: 'sess-1' },
+    incarnations: [],
+    updated_at: now,
+    ...overrides,
+  }
+}
+
+describe('LedgerStore', () => {
+  let dir: string
+  let store: LedgerStore
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(join(tmpdir(), 'ledger-store-test-'))
+    store = new LedgerStore(dir)
+  })
+
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true })
+  })
+
+  it('upsert 新建 worker 后 getLedger 可见且文件落盘', async () => {
+    const id = dialogObjectIdForPrivate('friend-1')
+    const result = await store.upsertWorker(id, 'worker-1', (prev) => {
+      expect(prev).toBeUndefined()
+      return makeWorker('worker-1')
+    })
+    expect(result?.worker_id).toBe('worker-1')
+
+    const ledger = await store.getLedger(id)
+    expect(ledger.dialog_object_id).toBe(id)
+    expect(ledger.workers).toHaveLength(1)
+    expect(ledger.workers[0].worker_id).toBe('worker-1')
+
+    const filePath = join(dir, dialogObjectIdToFilename(id))
+    const raw = await fs.readFile(filePath, 'utf-8')
+    const onDisk = JSON.parse(raw)
+    expect(onDisk.workers).toHaveLength(1)
+    expect(onDisk.workers[0].worker_id).toBe('worker-1')
+  })
+
+  it('同一对话对象并发 10 次 upsert 不丢', async () => {
+    const id = dialogObjectIdForGroup('wechat', 'group-1')
+    await Promise.all(
+      Array.from({ length: 10 }, (_, i) =>
+        store.upsertWorker(id, `worker-${i}`, (prev) => {
+          expect(prev).toBeUndefined()
+          return makeWorker(`worker-${i}`)
+        })
+      )
+    )
+    const workers = await store.listWorkers(id)
+    expect(workers).toHaveLength(10)
+    const ids = new Set(workers.map((w) => w.worker_id))
+    expect(ids.size).toBe(10)
+  })
+
+  it('findWorker 跨文件命中', async () => {
+    const idA = dialogObjectIdForPrivate('friend-a')
+    const idB = dialogObjectIdForPrivate('friend-b')
+    await store.upsertWorker(idA, 'worker-a', () => makeWorker('worker-a'))
+    await store.upsertWorker(idB, 'worker-b', () => makeWorker('worker-b'))
+
+    const foundA = await store.findWorker('worker-a')
+    expect(foundA?.dialogObjectId).toBe(idA)
+    expect(foundA?.worker.worker_id).toBe('worker-a')
+
+    const foundB = await store.findWorker('worker-b')
+    expect(foundB?.dialogObjectId).toBe(idB)
+    expect(foundB?.worker.worker_id).toBe('worker-b')
+  })
+
+  it('索引未命中时重扫目录再判(外部进程写入的场景)', async () => {
+    await store.init()
+
+    // 手工往目录塞一个文件,不经过 store 的写入路径(模拟外部进程写入)
+    const externalId = dialogObjectIdForPrivate('friend-external')
+    const filename = dialogObjectIdToFilename(externalId)
+    const worker = makeWorker('worker-external')
+    await fs.writeFile(
+      join(dir, filename),
+      JSON.stringify({ dialog_object_id: externalId, workers: [worker] }),
+      'utf-8'
+    )
+
+    const found = await store.findWorker('worker-external')
+    expect(found?.dialogObjectId).toBe(externalId)
+    expect(found?.worker.worker_id).toBe('worker-external')
+  })
+
+  it('文件名编码对含 : 与 / 的 id 双向可逆', () => {
+    const idWithSlash = dialogObjectIdForPrivate('user/with:colon') as DialogObjectId
+    const idGroup = dialogObjectIdForGroup('chan/nel', 'sess:ion/x')
+    for (const id of [idWithSlash, idGroup]) {
+      const filename = dialogObjectIdToFilename(id)
+      expect(filename.endsWith('.json')).toBe(true)
+      const decoded = filenameToDialogObjectId(filename)
+      expect(decoded).toBe(id)
+    }
+  })
+
+  it('mutator 返回 undefined 时不写盘', async () => {
+    const id = dialogObjectIdForPrivate('friend-none')
+    const result = await store.upsertWorker(id, 'worker-none', () => undefined)
+    expect(result).toBeUndefined()
+
+    const filePath = join(dir, dialogObjectIdToFilename(id))
+    await expect(fs.access(filePath)).rejects.toThrow()
+
+    const ledger = await store.getLedger(id)
+    expect(ledger.workers).toHaveLength(0)
+  })
+
+  it('init 扫描遇到坏 JSON 文件时跳过并 warn,不影响其它文件索引', async () => {
+    const goodId = dialogObjectIdForPrivate('friend-good')
+    await fs.writeFile(join(dir, dialogObjectIdToFilename(goodId)), 'not json', 'utf-8')
+
+    const okId = dialogObjectIdForPrivate('friend-ok')
+    await store.upsertWorker(okId, 'worker-ok', () => makeWorker('worker-ok'))
+
+    const otherStore = new LedgerStore(dir)
+    const warnSpy = (await import('vitest')).vi.spyOn(console, 'warn').mockImplementation(() => {})
+    await otherStore.init()
+    expect(warnSpy).toHaveBeenCalled()
+    warnSpy.mockRestore()
+
+    const found = await otherStore.findWorker('worker-ok')
+    expect(found?.worker.worker_id).toBe('worker-ok')
+  })
+
+  it('getLedger 读到坏 JSON 文件应抛明确错误,不静默当空', async () => {
+    const id = dialogObjectIdForPrivate('friend-corrupt')
+    await fs.writeFile(join(dir, dialogObjectIdToFilename(id)), 'not json', 'utf-8')
+
+    await expect(store.getLedger(id)).rejects.toThrow()
+  })
+})

--- a/crabot-agent/tests/workers/harness/task-status.test.ts
+++ b/crabot-agent/tests/workers/harness/task-status.test.ts
@@ -1,0 +1,277 @@
+import { describe, it, expect } from 'vitest'
+import {
+  VALID_TRANSITIONS,
+  isTerminalStatus,
+  canTransition,
+  applyStatusTransition,
+  InvalidTaskTransitionError,
+  taskStatusFromIncarnation,
+} from '../../../src/workers/harness/task-status'
+import type { TaskStatus } from '../../../src/workers/harness/ledger-types'
+import type { WorkerContractState, IncarnationEndReason } from '../../src/workers/types'
+
+describe('v3 task 状态机', () => {
+  describe('VALID_TRANSITIONS', () => {
+    it('应定义所有 6 个状态', () => {
+      const states: TaskStatus[] = ['queued', 'running', 'waiting_input', 'completed', 'failed', 'cancelled']
+      states.forEach((s) => {
+        expect(VALID_TRANSITIONS).toHaveProperty(s)
+        expect(Array.isArray(VALID_TRANSITIONS[s])).toBe(true)
+      })
+    })
+
+    it('queued 可转换至 running 和 cancelled', () => {
+      const allowed = VALID_TRANSITIONS.queued
+      expect(allowed).toContain('running')
+      expect(allowed).toContain('cancelled')
+      expect(allowed).not.toContain('waiting_input')
+      expect(allowed).not.toContain('completed')
+      expect(allowed).not.toContain('failed')
+    })
+
+    it('running 可转换至 waiting_input, completed, failed, cancelled', () => {
+      const allowed = VALID_TRANSITIONS.running
+      expect(allowed).toContain('waiting_input')
+      expect(allowed).toContain('completed')
+      expect(allowed).toContain('failed')
+      expect(allowed).toContain('cancelled')
+      expect(allowed).not.toContain('queued')
+    })
+
+    it('waiting_input 可转换至 running, completed, failed, cancelled', () => {
+      const allowed = VALID_TRANSITIONS.waiting_input
+      expect(allowed).toContain('running')
+      expect(allowed).toContain('completed')
+      expect(allowed).toContain('failed')
+      expect(allowed).toContain('cancelled')
+      expect(allowed).not.toContain('queued')
+    })
+
+    it('终态 completed, failed, cancelled 无出边', () => {
+      expect(VALID_TRANSITIONS.completed).toEqual([])
+      expect(VALID_TRANSITIONS.failed).toEqual([])
+      expect(VALID_TRANSITIONS.cancelled).toEqual([])
+    })
+  })
+
+  describe('isTerminalStatus', () => {
+    it('completed, failed, cancelled 是终态', () => {
+      expect(isTerminalStatus('completed')).toBe(true)
+      expect(isTerminalStatus('failed')).toBe(true)
+      expect(isTerminalStatus('cancelled')).toBe(true)
+    })
+
+    it('queued, running, waiting_input 非终态', () => {
+      expect(isTerminalStatus('queued')).toBe(false)
+      expect(isTerminalStatus('running')).toBe(false)
+      expect(isTerminalStatus('waiting_input')).toBe(false)
+    })
+  })
+
+  describe('canTransition', () => {
+    it('合法迁移返回 true', () => {
+      expect(canTransition('queued', 'running')).toBe(true)
+      expect(canTransition('running', 'waiting_input')).toBe(true)
+      expect(canTransition('waiting_input', 'completed')).toBe(true)
+    })
+
+    it('非法迁移返回 false', () => {
+      expect(canTransition('queued', 'waiting_input')).toBe(false)
+      expect(canTransition('completed', 'running')).toBe(false)
+      expect(canTransition('failed', 'cancelled')).toBe(false)
+    })
+  })
+
+  describe('applyStatusTransition', () => {
+    const baseTask = {
+      id: 'task-1',
+      title: 'Test Task',
+      status: 'queued' as TaskStatus,
+      created_at: '2026-07-28T00:00:00Z',
+    }
+    const now = '2026-07-28T12:00:00Z'
+
+    it('合法迁移应成功', () => {
+      const task = applyStatusTransition(baseTask, 'running', { now })
+      expect(task.status).toBe('running')
+      expect(task.updated_at).toBe(now)
+      expect(task.completed_at).toBeUndefined()
+    })
+
+    it('非法迁移应抛 InvalidTaskTransitionError 并含 from/to 字段', () => {
+      expect(() => {
+        applyStatusTransition(baseTask, 'waiting_input', { now })
+      }).toThrow(InvalidTaskTransitionError)
+
+      try {
+        applyStatusTransition(baseTask, 'waiting_input', { now })
+      } catch (e) {
+        const err = e as InvalidTaskTransitionError
+        expect(err.from).toBe('queued')
+        expect(err.to).toBe('waiting_input')
+      }
+    })
+
+    it('终态迁移应回填 completed_at', () => {
+      const runningTask = { ...baseTask, status: 'running' as TaskStatus }
+      const task = applyStatusTransition(runningTask, 'completed', { now })
+      expect(task.status).toBe('completed')
+      expect(task.completed_at).toBe(now)
+    })
+
+    it('失败迁移应设置 error 字段', () => {
+      const runningTask = { ...baseTask, status: 'running' as TaskStatus }
+      const task = applyStatusTransition(runningTask, 'failed', { now, error: 'Connection timeout' })
+      expect(task.status).toBe('failed')
+      expect(task.error).toBe('Connection timeout')
+      expect(task.completed_at).toBe(now)
+    })
+
+    it('outcome 应透传', () => {
+      const runningTask = { ...baseTask, status: 'running' as TaskStatus }
+      const task = applyStatusTransition(runningTask, 'completed', { now, outcome: 'Success' })
+      expect(task.outcome).toBe('Success')
+    })
+
+    it('返回新对象不改变原 task', () => {
+      const original = { ...baseTask }
+      const task = applyStatusTransition(baseTask, 'running', { now })
+      expect(baseTask).toEqual(original)
+      expect(task).not.toBe(baseTask)
+    })
+
+    it('非失败迁移时 error 应被清空', () => {
+      const runningTask = { ...baseTask, status: 'running' as TaskStatus, error: 'Old error' }
+      const task = applyStatusTransition(runningTask, 'completed', { now })
+      expect(task.error).toBeUndefined()
+    })
+
+    it('终态之间的迁移应失败', () => {
+      const completedTask = { ...baseTask, status: 'completed' as TaskStatus }
+      expect(() => {
+        applyStatusTransition(completedTask, 'failed', { now })
+      }).toThrow(InvalidTaskTransitionError)
+    })
+  })
+
+  describe('taskStatusFromIncarnation', () => {
+    describe('contractState=running', () => {
+      it('应返回 running', () => {
+        const status = taskStatusFromIncarnation('running')
+        expect(status).toBe('running')
+      })
+
+      it('endReason 和 waitingInput 应被忽略', () => {
+        expect(taskStatusFromIncarnation('running', 'completed')).toBe('running')
+        expect(taskStatusFromIncarnation('running', 'failed', true)).toBe('running')
+      })
+    })
+
+    describe('contractState=idle', () => {
+      it('waitingInput=true 应返回 waiting_input', () => {
+        const status = taskStatusFromIncarnation('idle', undefined, true)
+        expect(status).toBe('waiting_input')
+      })
+
+      it('waitingInput=false 或 undefined 应返回 running', () => {
+        expect(taskStatusFromIncarnation('idle', undefined, false)).toBe('running')
+        expect(taskStatusFromIncarnation('idle')).toBe('running')
+      })
+    })
+
+    describe('contractState=exited', () => {
+      it('endReason=completed 应返回 completed', () => {
+        const status = taskStatusFromIncarnation('exited', 'completed')
+        expect(status).toBe('completed')
+      })
+
+      it('endReason=failed 应返回 failed', () => {
+        const status = taskStatusFromIncarnation('exited', 'failed')
+        expect(status).toBe('failed')
+      })
+
+      it('endReason=crashed 应返回 failed', () => {
+        const status = taskStatusFromIncarnation('exited', 'crashed')
+        expect(status).toBe('failed')
+      })
+
+      it('endReason=killed 应返回 cancelled', () => {
+        const status = taskStatusFromIncarnation('exited', 'killed')
+        expect(status).toBe('cancelled')
+      })
+
+      it('endReason=pre_migration 应返回 failed', () => {
+        const status = taskStatusFromIncarnation('exited', 'pre_migration')
+        expect(status).toBe('failed')
+      })
+
+      it('endReason=superseded 应返回 running（由调用方覆盖化身链新成员决定）', () => {
+        // 当化身被取代时，task 生命周期应由新化身决定，不由本函数决定
+        // 因此返回 running 作为占位值，调用方会读新化身并覆盖此状态
+        const status = taskStatusFromIncarnation('exited', 'superseded')
+        expect(status).toBe('running')
+      })
+    })
+
+    it('6 种 endReason + idle 的 waitingInput 两态全覆盖', () => {
+      // 6 种 endReason
+      const endReasons: IncarnationEndReason[] = ['completed', 'failed', 'killed', 'superseded', 'crashed', 'pre_migration']
+      endReasons.forEach((reason) => {
+        expect(() => {
+          taskStatusFromIncarnation('exited', reason)
+        }).not.toThrow()
+      })
+
+      // idle 的 waitingInput 两态
+      expect(() => {
+        taskStatusFromIncarnation('idle', undefined, true)
+      }).not.toThrow()
+      expect(() => {
+        taskStatusFromIncarnation('idle', undefined, false)
+      }).not.toThrow()
+    })
+  })
+
+  describe('迁移矩阵完整性检验', () => {
+    const states: TaskStatus[] = ['queued', 'running', 'waiting_input', 'completed', 'failed', 'cancelled']
+
+    it('6 状态两两组合 36 对，合法的按 VALID_TRANSITIONS，其余全 false', () => {
+      for (const from of states) {
+        for (const to of states) {
+          const expected = VALID_TRANSITIONS[from].includes(to)
+          const actual = canTransition(from, to)
+          expect(actual).toBe(expected, `canTransition(${from}, ${to}) 应返回 ${expected}`)
+        }
+      }
+    })
+
+    it('终态无出边（自迁移也不行）', () => {
+      const terminalStates: TaskStatus[] = ['completed', 'failed', 'cancelled']
+      terminalStates.forEach((s) => {
+        expect(VALID_TRANSITIONS[s].length).toBe(0)
+        states.forEach((to) => {
+          expect(canTransition(s, to)).toBe(false, `${s} 不能转换至 ${to}`)
+        })
+      })
+    })
+  })
+
+  describe('InvalidTaskTransitionError', () => {
+    it('应是 Error 的子类', () => {
+      const err = new InvalidTaskTransitionError('queued', 'waiting_input')
+      expect(err).toBeInstanceOf(Error)
+    })
+
+    it('应含 from 和 to 字段', () => {
+      const err = new InvalidTaskTransitionError('queued', 'waiting_input')
+      expect(err.from).toBe('queued')
+      expect(err.to).toBe('waiting_input')
+    })
+
+    it('message 应包含 from 和 to 状态', () => {
+      const err = new InvalidTaskTransitionError('queued', 'waiting_input')
+      expect(err.message).toContain('queued')
+      expect(err.message).toContain('waiting_input')
+    })
+  })
+})

--- a/crabot-agent/tests/workers/harness/task-status.test.ts
+++ b/crabot-agent/tests/workers/harness/task-status.test.ts
@@ -8,7 +8,7 @@ import {
   taskStatusFromIncarnation,
 } from '../../../src/workers/harness/task-status'
 import type { TaskStatus } from '../../../src/workers/harness/ledger-types'
-import type { WorkerContractState, IncarnationEndReason } from '../../src/workers/types'
+import type { WorkerContractState, IncarnationEndReason } from '../../../src/workers/types'
 
 describe('v3 task 状态机', () => {
   describe('VALID_TRANSITIONS', () => {
@@ -94,7 +94,7 @@ describe('v3 task 状态机', () => {
     it('合法迁移应成功', () => {
       const task = applyStatusTransition(baseTask, 'running', { now })
       expect(task.status).toBe('running')
-      expect(task.updated_at).toBe(now)
+      expect(task.updated_at).toBeUndefined()
       expect(task.completed_at).toBeUndefined()
     })
 

--- a/crabot-agent/tests/workers/harness/task-status.test.ts
+++ b/crabot-agent/tests/workers/harness/task-status.test.ts
@@ -6,6 +6,7 @@ import {
   applyStatusTransition,
   InvalidTaskTransitionError,
   taskStatusFromIncarnation,
+  reviveTask,
 } from '../../../src/workers/harness/task-status'
 import type { TaskStatus } from '../../../src/workers/harness/ledger-types'
 import type { WorkerContractState, IncarnationEndReason } from '../../../src/workers/types'
@@ -253,6 +254,70 @@ describe('v3 task 状态机', () => {
           expect(canTransition(s, to)).toBe(false, `${s} 不能转换至 ${to}`)
         })
       })
+    })
+  })
+
+  describe('reviveTask（protocol-agent-v3 §5.2 接续例外的受控出口）', () => {
+    const now = '2026-07-28T12:00:00Z'
+
+    it('终态 task 经 reviveTask 重新置回 running，清空 completed_at/error', () => {
+      const failedTask = {
+        id: 'task-1',
+        title: 'Test Task',
+        status: 'failed' as TaskStatus,
+        created_at: '2026-07-28T00:00:00Z',
+        completed_at: '2026-07-28T01:00:00Z',
+        error: 'boom',
+      }
+      const task = reviveTask(failedTask, { now })
+      expect(task.status).toBe('running')
+      expect(task.completed_at).toBeUndefined()
+      expect(task.error).toBeUndefined()
+    })
+
+    it('completed / cancelled 终态同样可被 reviveTask 重新置回 running', () => {
+      const completedTask = {
+        id: 'task-2',
+        title: 'Test Task',
+        status: 'completed' as TaskStatus,
+        created_at: '2026-07-28T00:00:00Z',
+        completed_at: '2026-07-28T01:00:00Z',
+      }
+      expect(reviveTask(completedTask, { now }).status).toBe('running')
+
+      const cancelledTask = { ...completedTask, status: 'cancelled' as TaskStatus }
+      expect(reviveTask(cancelledTask, { now }).status).toBe('running')
+    })
+
+    it('非终态 task 调用 reviveTask 应抛 InvalidTaskTransitionError（不是给状态机新增自由出边，只服务终态接续）', () => {
+      const runningTask = {
+        id: 'task-3',
+        title: 'Test Task',
+        status: 'running' as TaskStatus,
+        created_at: '2026-07-28T00:00:00Z',
+      }
+      expect(() => reviveTask(runningTask, { now })).toThrow(InvalidTaskTransitionError)
+
+      const queuedTask = { ...runningTask, status: 'queued' as TaskStatus }
+      expect(() => reviveTask(queuedTask, { now })).toThrow(InvalidTaskTransitionError)
+
+      const waitingTask = { ...runningTask, status: 'waiting_input' as TaskStatus }
+      expect(() => reviveTask(waitingTask, { now })).toThrow(InvalidTaskTransitionError)
+    })
+
+    it('返回新对象，不修改原 task', () => {
+      const failedTask = {
+        id: 'task-1',
+        title: 'Test Task',
+        status: 'failed' as TaskStatus,
+        created_at: '2026-07-28T00:00:00Z',
+        completed_at: '2026-07-28T01:00:00Z',
+        error: 'boom',
+      }
+      const original = { ...failedTask }
+      const task = reviveTask(failedTask, { now })
+      expect(failedTask).toEqual(original)
+      expect(task).not.toBe(failedTask)
     })
   })
 

--- a/crabot-agent/tests/workers/harness/worker-events.test.ts
+++ b/crabot-agent/tests/workers/harness/worker-events.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { promises as fs } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { WorkerEventLog, harvestNativeSession } from '../../../src/workers/harness/worker-events'
+import type { HarnessEvent } from '../../../src/workers/harness/worker-events'
+
+describe('WorkerEventLog', () => {
+  let dir: string
+  let workerDir: string
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(join(tmpdir(), 'worker-events-test-'))
+    workerDir = join(dir, 'worker-1')
+  })
+
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true })
+  })
+
+  it('append 后 readAll 能原样往返读回', async () => {
+    const log = new WorkerEventLog(workerDir)
+    await log.append({ kind: 'spawned', worker_id: 'w-1', seq: 0, ts: '2026-01-01T00:00:00Z' })
+    await log.append({ kind: 'state_changed', worker_id: 'w-1', seq: 0, detail: { from: 'idle', to: 'running' } })
+
+    const events: HarnessEvent[] = await log.readAll()
+    expect(events).toHaveLength(2)
+    expect(events[0]).toEqual({ kind: 'spawned', worker_id: 'w-1', seq: 0, ts: '2026-01-01T00:00:00Z' })
+    expect(events[1].kind).toBe('state_changed')
+    expect(events[1].detail).toEqual({ from: 'idle', to: 'running' })
+    expect(typeof events[1].ts).toBe('string')
+  })
+
+  it('未传 ts 时缺省用当前时间兜底', async () => {
+    const log = new WorkerEventLog(workerDir)
+    const before = Date.now()
+    await log.append({ kind: 'input_sent', worker_id: 'w-1', seq: 0 })
+    const after = Date.now()
+
+    const events = await log.readAll()
+    expect(events).toHaveLength(1)
+    const ts = Date.parse(events[0].ts)
+    expect(ts).toBeGreaterThanOrEqual(before)
+    expect(ts).toBeLessThanOrEqual(after)
+  })
+
+  it('目录不存在时 append 自动创建', async () => {
+    const nested = join(dir, 'a', 'b', 'worker-x')
+    const log = new WorkerEventLog(nested)
+    await log.append({ kind: 'spawned', worker_id: 'w-x', seq: 0 })
+
+    const stat = await fs.stat(join(nested, 'events.jsonl'))
+    expect(stat.isFile()).toBe(true)
+  })
+
+  it('readAll 对不存在的文件返回空数组', async () => {
+    const log = new WorkerEventLog(workerDir)
+    expect(await log.readAll()).toEqual([])
+  })
+
+  it('readAll 跳过坏行,保留好行', async () => {
+    await fs.mkdir(workerDir, { recursive: true })
+    await fs.writeFile(
+      join(workerDir, 'events.jsonl'),
+      [
+        'not json at all',
+        '{"ts":"2026-01-01T00:00:00Z","kind":"spawned","worker_id":"w-1","seq":0}',
+        '{broken json',
+      ].join('\n') + '\n',
+      'utf-8'
+    )
+    const log = new WorkerEventLog(workerDir)
+    const events = await log.readAll()
+    expect(events).toHaveLength(1)
+    expect(events[0].kind).toBe('spawned')
+  })
+
+  it('半行(无换行符终结)不被消费,补全后可读', async () => {
+    const log = new WorkerEventLog(workerDir)
+    await fs.mkdir(workerDir, { recursive: true })
+    const filePath = join(workerDir, 'events.jsonl')
+
+    // 写入一条半行:没有结尾换行符,模拟并发写入过程中被读到
+    await fs.writeFile(filePath, '{"ts":"2026-01-01T00:00:00Z","kind":"exi', 'utf-8')
+    expect(await log.readAll()).toEqual([])
+
+    // 补全该行
+    await fs.appendFile(filePath, 'ted","worker_id":"w-1","seq":0}\n', 'utf-8')
+    const events = await log.readAll()
+    expect(events).toHaveLength(1)
+    expect(events[0].kind).toBe('exited')
+  })
+
+  it('并发 append 不交错,行数与内容完整', async () => {
+    const log = new WorkerEventLog(workerDir)
+    await Promise.all(
+      Array.from({ length: 20 }, (_, i) =>
+        log.append({ kind: 'input_sent', worker_id: 'w-1', seq: i, detail: { text_len: i } })
+      )
+    )
+    const events = await log.readAll()
+    expect(events).toHaveLength(20)
+    const seqs = events.map((e) => e.seq).sort((a, b) => a - b)
+    expect(seqs).toEqual(Array.from({ length: 20 }, (_, i) => i))
+  })
+})
+
+describe('harvestNativeSession', () => {
+  let dir: string
+  let workerDir: string
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(join(tmpdir(), 'harvest-native-session-test-'))
+    workerDir = join(dir, 'worker-1')
+  })
+
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true })
+  })
+
+  it('把源文件复制到 native-session/<seq>/<basename>', async () => {
+    const srcDir = await fs.mkdtemp(join(tmpdir(), 'harvest-src-'))
+    const srcPath = join(srcDir, 'session.json')
+    await fs.writeFile(srcPath, '{"session":"data"}', 'utf-8')
+
+    await harvestNativeSession(workerDir, 3, [srcPath])
+
+    const dstPath = join(workerDir, 'native-session', '3', 'session.json')
+    const content = await fs.readFile(dstPath, 'utf-8')
+    expect(content).toBe('{"session":"data"}')
+
+    await fs.rm(srcDir, { recursive: true, force: true })
+  })
+
+  it('源文件不存在时仅 warn,不抛出', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    await expect(
+      harvestNativeSession(workerDir, 1, [join(dir, 'does-not-exist.json')])
+    ).resolves.toBeUndefined()
+    expect(warnSpy).toHaveBeenCalled()
+    warnSpy.mockRestore()
+  })
+
+  it('目标文件已存在则覆盖', async () => {
+    const srcDir = await fs.mkdtemp(join(tmpdir(), 'harvest-src-'))
+    const srcPath = join(srcDir, 'session.json')
+
+    const targetDir = join(workerDir, 'native-session', '5')
+    await fs.mkdir(targetDir, { recursive: true })
+    await fs.writeFile(join(targetDir, 'session.json'), 'old content', 'utf-8')
+
+    await fs.writeFile(srcPath, 'new content', 'utf-8')
+    await harvestNativeSession(workerDir, 5, [srcPath])
+
+    const content = await fs.readFile(join(targetDir, 'session.json'), 'utf-8')
+    expect(content).toBe('new content')
+
+    await fs.rm(srcDir, { recursive: true, force: true })
+  })
+})

--- a/crabot-agent/tests/workers/harness/workspace-manager.test.ts
+++ b/crabot-agent/tests/workers/harness/workspace-manager.test.ts
@@ -177,6 +177,58 @@ describe('WorkspaceManager', () => {
     })
   })
 
+  describe('requested 校验：防串台 - 符号链接绕过', () => {
+    it('root 外的软链指向其他 taskId 目录应被拒绝（PoC：符号链接绕过边界校验）', async () => {
+      const task2Dir = resolve(root, 'task-2')
+      await fs.mkdir(task2Dir, { recursive: true })
+
+      const outsideDir = await fs.mkdtemp(join(tmpdir(), 'symlink-poc-'))
+      const linkPath = join(outsideDir, 'link-to-task-2')
+      try {
+        await fs.symlink(task2Dir, linkPath, 'dir')
+        await expect(manager.resolve('task-1', linkPath)).rejects.toThrow(InvalidWorkspaceError)
+      } finally {
+        await fs.rm(outsideDir, { recursive: true, force: true })
+      }
+    })
+
+    it('软链指向自己 taskId 的目录应被允许，返回 realpath', async () => {
+      const task1Dir = resolve(root, 'task-1')
+      await fs.mkdir(task1Dir, { recursive: true })
+
+      const outsideDir = await fs.mkdtemp(join(tmpdir(), 'symlink-self-'))
+      const linkPath = join(outsideDir, 'link-to-task-1')
+      try {
+        await fs.symlink(task1Dir, linkPath, 'dir')
+        const ws = await manager.resolve('task-1', linkPath)
+        expect(ws.root).toBe(await fs.realpath(task1Dir))
+      } finally {
+        await fs.rm(outsideDir, { recursive: true, force: true })
+      }
+    })
+
+    it('root 本身是软链时，合法路径不应被误拒（两侧都要 realpath 再比较）', async () => {
+      const realRoot = await fs.mkdtemp(join(tmpdir(), 'real-root-'))
+      const rootLinkParent = await fs.mkdtemp(join(tmpdir(), 'root-link-parent-'))
+      const rootLink = join(rootLinkParent, 'root-link')
+      try {
+        await fs.symlink(realRoot, rootLink, 'dir')
+        const linkedManager = new WorkspaceManager(rootLink)
+
+        const task1Dir = resolve(realRoot, 'task-1')
+        await fs.mkdir(task1Dir, { recursive: true })
+
+        // 通过 root 软链路径请求，应通过（不因 root 是软链而误判越界）
+        const requestedViaLink = resolve(rootLink, 'task-1')
+        const ws = await linkedManager.resolve('task-1', requestedViaLink)
+        expect(ws.root).toBe(await fs.realpath(task1Dir))
+      } finally {
+        await fs.rm(realRoot, { recursive: true, force: true })
+        await fs.rm(rootLinkParent, { recursive: true, force: true })
+      }
+    })
+  })
+
   describe('constructor 默认 root', () => {
     it('不指定 root 时应使用 getWorkspacesRootDir()', async () => {
       // 临时更改环境变量来测试

--- a/crabot-agent/tests/workers/harness/workspace-manager.test.ts
+++ b/crabot-agent/tests/workers/harness/workspace-manager.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { promises as fs } from 'fs'
+import { tmpdir } from 'os'
+import { join, resolve } from 'path'
+import { WorkspaceManager, InvalidWorkspaceError } from '../../../src/workers/harness/workspace-manager'
+
+describe('WorkspaceManager', () => {
+  let root: string
+  let manager: WorkspaceManager
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(join(tmpdir(), 'workspace-manager-test-'))
+    manager = new WorkspaceManager(root)
+  })
+
+  afterEach(async () => {
+    await fs.rm(root, { recursive: true, force: true })
+  })
+
+  describe('默认行为：缺省创建 <root>/<taskId> 且幂等', () => {
+    it('缺省 requested 时创建 <root>/<taskId> 目录', async () => {
+      const ws = await manager.resolve('task-1')
+      expect(ws.root).toBe(resolve(root, 'task-1'))
+
+      // 验证目录已创建
+      const stat = await fs.stat(ws.root)
+      expect(stat.isDirectory()).toBe(true)
+    })
+
+    it('重复调用同一 taskId 幂等', async () => {
+      const ws1 = await manager.resolve('task-1')
+      const ws2 = await manager.resolve('task-1')
+      expect(ws1.root).toBe(ws2.root)
+
+      // 验证只有一个目录
+      const stat = await fs.stat(ws1.root)
+      expect(stat.isDirectory()).toBe(true)
+    })
+
+    it('多个不同 taskId 分别创建各自目录', async () => {
+      const ws1 = await manager.resolve('task-1')
+      const ws2 = await manager.resolve('task-2')
+      expect(ws1.root).not.toBe(ws2.root)
+
+      const stat1 = await fs.stat(ws1.root)
+      const stat2 = await fs.stat(ws2.root)
+      expect(stat1.isDirectory()).toBe(true)
+      expect(stat2.isDirectory()).toBe(true)
+    })
+  })
+
+  describe('requested 校验：绝对路径且已存在的目录', () => {
+    it('requested 是已存在的绝对目录路径时通过', async () => {
+      const externalDir = await fs.mkdtemp(join(tmpdir(), 'external-ws-'))
+      try {
+        const ws = await manager.resolve('task-1', externalDir)
+        expect(ws.root).toBe(externalDir)
+      } finally {
+        await fs.rm(externalDir, { recursive: true, force: true })
+      }
+    })
+  })
+
+  describe('requested 校验：拒绝相对路径', () => {
+    it('相对路径应被拒绝', async () => {
+      await expect(manager.resolve('task-1', './relative/path')).rejects.toThrow(InvalidWorkspaceError)
+    })
+
+    it('包含 .. 的相对路径应被拒绝', async () => {
+      await expect(manager.resolve('task-1', '../parent')).rejects.toThrow(InvalidWorkspaceError)
+    })
+  })
+
+  describe('requested 校验：拒绝不存在的目录', () => {
+    it('不存在的路径应被拒绝', async () => {
+      const nonExistent = resolve(tmpdir(), 'non-existent-dir-12345')
+      await expect(manager.resolve('task-1', nonExistent)).rejects.toThrow(InvalidWorkspaceError)
+    })
+  })
+
+  describe('requested 校验：拒绝指向文件的路径', () => {
+    it('指向文件的路径应被拒绝', async () => {
+      const filePath = join(root, 'test-file.txt')
+      await fs.writeFile(filePath, 'test')
+      await expect(manager.resolve('task-1', filePath)).rejects.toThrow(InvalidWorkspaceError)
+    })
+  })
+
+  describe('requested 校验：拒绝含 \\0 的路径', () => {
+    it('含有 null byte 的路径应被拒绝', async () => {
+      const pathWithNull = '/tmp/path\0with\0null'
+      await expect(manager.resolve('task-1', pathWithNull)).rejects.toThrow(InvalidWorkspaceError)
+    })
+  })
+
+  describe('requested 校验：防串台 - 拒绝其他 taskId 的目录', () => {
+    it('落在 <root>/<其他 taskId> 的路径应被拒绝', async () => {
+      // 先创建 task-2 的目录
+      const task2Dir = resolve(root, 'task-2')
+      await fs.mkdir(task2Dir, { recursive: true })
+
+      // task-1 试图请求 task-2 的目录应被拒绝
+      await expect(manager.resolve('task-1', task2Dir)).rejects.toThrow(InvalidWorkspaceError)
+    })
+
+    it('落在 <root>/<其他 taskId> 子目录的路径应被拒绝', async () => {
+      // 先创建 task-2 的子目录
+      const task2SubDir = resolve(root, 'task-2', 'subdir')
+      await fs.mkdir(task2SubDir, { recursive: true })
+
+      // task-1 试图请求 task-2 的子目录应被拒绝
+      await expect(manager.resolve('task-1', task2SubDir)).rejects.toThrow(InvalidWorkspaceError)
+    })
+  })
+
+  describe('requested 校验：允许自己的 taskId 目录', () => {
+    it('落在 <root>/<自己的 taskId> 的路径应通过', async () => {
+      const task1Dir = resolve(root, 'task-1')
+      await fs.mkdir(task1Dir, { recursive: true })
+
+      const ws = await manager.resolve('task-1', task1Dir)
+      expect(ws.root).toBe(task1Dir)
+    })
+
+    it('落在 <root>/<自己的 taskId> 子目录的路径应通过', async () => {
+      const task1SubDir = resolve(root, 'task-1', 'subdir')
+      await fs.mkdir(task1SubDir, { recursive: true })
+
+      const ws = await manager.resolve('task-1', task1SubDir)
+      expect(ws.root).toBe(task1SubDir)
+    })
+  })
+
+  describe('错误报告：InvalidWorkspaceError 应含 reason 字段', () => {
+    it('relative path 错误应含 reason', async () => {
+      try {
+        await manager.resolve('task-1', './relative')
+        expect.fail('should have thrown')
+      } catch (err) {
+        expect(err).toBeInstanceOf(InvalidWorkspaceError)
+        expect((err as InvalidWorkspaceError).reason).toBeDefined()
+        expect(typeof (err as InvalidWorkspaceError).reason).toBe('string')
+      }
+    })
+
+    it('non-existent path 错误应含 reason', async () => {
+      try {
+        await manager.resolve('task-1', '/tmp/non-existent-12345')
+        expect.fail('should have thrown')
+      } catch (err) {
+        expect(err).toBeInstanceOf(InvalidWorkspaceError)
+        expect((err as InvalidWorkspaceError).reason).toBeDefined()
+      }
+    })
+
+    it('null byte 错误应含 reason', async () => {
+      try {
+        await manager.resolve('task-1', '/tmp/path\0null')
+        expect.fail('should have thrown')
+      } catch (err) {
+        expect(err).toBeInstanceOf(InvalidWorkspaceError)
+        expect((err as InvalidWorkspaceError).reason).toBeDefined()
+      }
+    })
+
+    it('other task 错误应含 reason', async () => {
+      const otherTaskDir = resolve(root, 'task-2')
+      await fs.mkdir(otherTaskDir, { recursive: true })
+
+      try {
+        await manager.resolve('task-1', otherTaskDir)
+        expect.fail('should have thrown')
+      } catch (err) {
+        expect(err).toBeInstanceOf(InvalidWorkspaceError)
+        expect((err as InvalidWorkspaceError).reason).toBeDefined()
+      }
+    })
+  })
+
+  describe('constructor 默认 root', () => {
+    it('不指定 root 时应使用 getWorkspacesRootDir()', async () => {
+      // 临时更改环境变量来测试
+      const oldEnv = process.env.WORKER_WORKSPACES_DIR
+      try {
+        const testDir = await fs.mkdtemp(join(tmpdir(), 'workspaces-root-'))
+        process.env.WORKER_WORKSPACES_DIR = testDir
+        const mgr = new WorkspaceManager()
+        const ws = await mgr.resolve('task-default')
+        expect(ws.root).toBe(resolve(testDir, 'task-default'))
+        await fs.rm(testDir, { recursive: true, force: true })
+      } finally {
+        if (oldEnv !== undefined) {
+          process.env.WORKER_WORKSPACES_DIR = oldEnv
+        } else {
+          delete process.env.WORKER_WORKSPACES_DIR
+        }
+      }
+    })
+  })
+})


### PR DESCRIPTION
## 概述

Manager/Worker 拆分第三个落地 PR(P3/P8),manager 登场前的最后一块底座。**纯新增、未激活**:现网路径零 import,engine/、agent-handler.ts、unified-agent.ts、orchestration/ 零改动。

- 路线图:`crabot-docs/superpowers/plans/2026-07-28-manager-worker-split-roadmap.md`(本 PR = P3)
- 细化 plan:`crabot-docs/superpowers/plans/2026-07-29-mw-p3-ledger-harness.md`
- 协议:`protocol-agent-v3.md` §3/§5/§7/§12(本分支期间同步两次:1f65202、cb47a4f)

## 交付内容

`src/workers/harness/` 新层 + `src/workers/errors.ts`:

- **台账**(`ledger-store.ts`):每对话对象一文件、per-file 互斥、tmp+rename 原子写、跨文件 worker_id 索引(未命中重扫)
- **task 状态机**(`task-status.ts`):v3 精简集(queued/running/waiting_input/终态),从 admin 移植纯函数;`reviveTask` 是终态唯一的受控出口(协议 §5.2 接续例外)
- **事件流**(`worker-events.ts`):`events.jsonl` 追加/读取(半行纪律对齐 cli-events)、原生 session 收割
- **workspace**(`workspace-manager.ts`):默认 `<root>/<taskId>`,requested 走 realpath 校验防软链串台
- **信箱**(`inbox.ts`):安全态投递、hold/release、in-flight 与 drain 不重复交付
- **`WorkerHarness`**(`harness.ts`):spawn/send/read/list/kill/query 编排 + 状态回调路由 + **透明接续**(revive / handoff / switchWorkerImpl)+ **重启对账**(reconcileOnStartup,替代 admin 一刀切自愈)
- 错误类收敛(跨实现 `instanceof`,harness 透明接续的前提)

tests/workers **326 用例**(P2 末 179);集成冒烟用真实 builtin(mock LLM)与真实 cc adapter + 真实 tmux,不只对桩正确。

## 评审沉淀(10 task + 全分支终审,多轮 PoC 实证)

修掉的真实缺陷:fork 化身劫持主线、inbox drain 与 in-flight 双投、workspace 软链绕过、revive 不回填旧化身终态致永久卡 running、handoff 到 builtin 缺注入把 worker 打进死结、主线守卫漏 impl 致 handoff 后新主线被迟到回调误杀、kill 与 in-flight 竞态复活 cancelled;并顺带修掉 cc/codex `state()` 无 runtime 时不探活——它曾使 spec 承诺的"tmux worker 存活→重连接管"对 CLI worker 完全失效。

## 已知限制(均入协议或执行记录)

- 化身 `seq` 非跨实例全局唯一(读写两路已统一 `(impl,seq)` 取末条缓解;根治需 harness 自管 seq,留 P4+)
- `isAlive=true` 时 state 精度限于 meta 快照(真死判活已消除)
- tsconfig 排除 tests → 测试从未被类型检查(全仓性质,另开小 PR)
- P4 接线点:`onEvent` 出口、`handleStateChange` 接线契约、`reconcileOnStartup` 三桶报告、`builtinSpawnDefaults`

🤖 Generated with [Claude Code](https://claude.com/claude-code)