### PR TITLE
fix(workers): codex adapter 真机校准(m2 实测 codex-cli 0.144.1)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,6 +1,15 @@
 # Crabot 项目进度
 
-> 最后更新：2026-07-29 — Manager/Worker 拆分 P3：台账与 harness（PR 待合并）
+> 最后更新：2026-07-30 — codex adapter 真机校准（PR 待合并）
+
+## 2026-07-30 — codex adapter 真机校准（部署机 m2，codex-cli 0.144.1）
+
+- 背景：P2 的 codex adapter 是"照文档/源码实现"，8 项待真机校准。本次在部署机 m2 上用隔离 `CODEX_HOME` 探针实测（不动生产实例与用户 `~/.codex`，探针目录已清理）。
+- 修复四项：① session 发现优先读 rollout 首行的 `session_meta.payload.session_id`（权威）而非文件名解析；② nvm 部署陷阱——codex 常是 nvm 装的 node 脚本，adapter 经 tmux 拉起时须把 codex 二进制所在目录前置进 PATH，否则必报 `env: node: No such file or directory`（实测踩到），`detect()` 也区分"没装"与"装了但 node 不可解析"；③ 交互态命令参数校正（见下）；④ `readTrace` 按真实 rollout 结构校准（统一信封 `{type,timestamp,payload}`，五类 type，消息在 `response_item` 按 `payload.role` 分、assistant 用 `output_text`）。
+- **一次自我纠错**：中途误把 `codex exec` 路径的实测结论（`--skip-git-repo-check`、选项顺序）套用到 adapter 实际驱动的交互式顶层命令，给 spawn/resume 加了顶层不存在的 flag——那会让真机 100% usage 错误退出，比修之前更糟。评审拦下后回 m2 用 `--help` 确证顶层选项清单，改为不传该 flag、并用 config.toml 的 `[projects."<path>"] trust_level = "trusted"` 授信 workspace。
+- 另一次纠错：曾据 `codex fork` 子命令存在而宣称"P2 判错了"，实测证明 `exec resume` 无论加不加 `--ephemeral` 都是续写原会话（rollout 持续增长、总数不变），codex 确无 headless fork——`capabilities().fork = false` 与协议表述原本就正确。
+- 协议同步：§6.1 新增"codex 的 session 发现是限时轮询"已知限制（超时退化占位 id 会使该化身 resume/readTrace 不可用）。
+- 验证：tests/workers 349 用例全绿、tsc 干净。
 
 ## 2026-07-29 — Manager/Worker 拆分 P3：台账与 harness
 

--- a/crabot-agent/src/workers/codex/adapter.ts
+++ b/crabot-agent/src/workers/codex/adapter.ts
@@ -217,10 +217,14 @@ async function resolveBinDir(bin: string): Promise<string | undefined> {
   }
 }
 
+/** 标准 UUID 格式(8-4-4-4-12 十六进制段,由连字符分隔)——session_ref 前置校验与"从 rollout
+ * 内容里读出的 session_id"校验共用同一条正则(五轮 review 修复:后者此前没做格式校验,畸形
+ * id 会静默写进 meta/handle.session_ref)。 */
+const UUID_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/
+
 /** UUID 格式校验:标准 UUID 格式(8-4-4-4-12 十六进制段,由连字符分隔)。*/
 function validateSessionRef(sessionRef: string): void {
-  const uuidPattern = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/
-  if (!uuidPattern.test(sessionRef)) {
+  if (!UUID_RE.test(sessionRef)) {
     throw new Error(
       `CodexWorkerAdapter: invalid session_ref format (expected UUID, got '${sessionRef.slice(0, 50)}'). ` +
         `session_ref must be a valid UUID and cannot contain shell metacharacters.`,
@@ -335,7 +339,10 @@ async function pollForNewRollout(sessionsDir: string, cutoffMs: number, timeoutM
 /** 读 rollout 文件首行的 session_meta.payload.session_id(m2 真机实测的权威字段)。首行还
  * 不是完整/合法的 session_meta(文件刚创建、还没来得及写完)一律返回 undefined,调用方退回
  * 文件名解析,不抛错、不重试——真机实测文件名与内容里的 id 完全一致,这里只是"能拿到内容
- * 就优先信内容"的加固,拿不到不算失败。 */
+ * 就优先信内容"的加固,拿不到不算失败。五轮 review 修复:读出的 id 额外按 UUID_RE 校验格式,
+ * 不合法(畸形值)一律当成"拿不到",打 warn 并退回文件名解析——避免畸形 id 未经校验就被
+ * 写进 meta.session_id 与 handle.session_ref(会让 spawn 静默成功、resume/readTrace 必然
+ * 失效)。 */
 async function readSessionIdFromRolloutContent(path: string): Promise<string | undefined> {
   let raw: string
   try {
@@ -352,7 +359,12 @@ async function readSessionIdFromRolloutContent(path: string): Promise<string | u
     return undefined
   }
   if (parsed?.type === 'session_meta' && typeof parsed.payload?.session_id === 'string') {
-    return parsed.payload.session_id
+    const id = parsed.payload.session_id
+    if (!UUID_RE.test(id)) {
+      console.warn(`[codex-adapter] rollout content session_id is not a valid UUID, falling back to filename parse: ${path} id='${id.slice(0, 50)}'`)
+      return undefined
+    }
+    return id
   }
   return undefined
 }
@@ -364,8 +376,18 @@ async function readSessionIdFromRolloutContent(path: string): Promise<string | u
  * 一个字段不如直接按已知的确定性文件名规则重新找一遍,与 sessionName/outputFile 等其它
  * 重建字段的思路一致——见 ensureRuntime 注释)。同一遍历约定(深度不超过 4 层,目录不存在
  * 按"没找到"处理)复用自 findNewestRolloutFile。
+ *
+ * 五轮 review 修复:spawn 时的 session 发现优先信 rollout 内容里的 session_id(见
+ * pollForNewRollout),与文件名内嵌的 uuid 分歧时,meta.session_id 落的是内容里的值——
+ * 这里若仍然只按文件名精确匹配,分歧场景下重启后会精确匹配不到、rolloutPath 变 undefined、
+ * readTrace 静默降级为空数组(尽管文件明明还在)。文件名不中时退一步遍历候选 rollout 文件
+ * (同一趟遍历顺带收集,不重复扫盘),逐个读取其内容首行的 session_id 兜底匹配;命中打一条
+ * warn(便于诊断"为什么按文件名找不到,但按内容能找到"),仍然找不到才返回 undefined(与
+ * 原语义一致,readTrace 优雅降级)。
  */
 async function findRolloutFileBySessionId(sessionsDir: string, sessionId: string): Promise<string | undefined> {
+  const candidates: string[] = []
+
   async function walk(dir: string, depth: number): Promise<string | undefined> {
     if (depth > 4) return undefined
     let entries: Dirent[]
@@ -382,11 +404,24 @@ async function findRolloutFileBySessionId(sessionsDir: string, sessionId: string
         continue
       }
       const match = ROLLOUT_FILENAME_RE.exec(entry.name)
-      if (match && match[1] === sessionId) return full
+      if (!match) continue
+      if (match[1] === sessionId) return full
+      candidates.push(full)
     }
     return undefined
   }
-  return walk(sessionsDir, 0)
+
+  const exact = await walk(sessionsDir, 0)
+  if (exact) return exact
+
+  for (const candidate of candidates) {
+    const contentSessionId = await readSessionIdFromRolloutContent(candidate)
+    if (contentSessionId === sessionId) {
+      console.warn(`[codex-adapter] rollout file located via content session_id fallback (filename uuid did not match): ${candidate}`)
+      return candidate
+    }
+  }
+  return undefined
 }
 
 export class CodexWorkerAdapter implements WorkerAdapter {
@@ -399,7 +434,11 @@ export class CodexWorkerAdapter implements WorkerAdapter {
   private readonly runtimes = new Map<string, Runtime>()
   private readonly mutexes = new Map<string, AsyncMutex>()
   /** resolveBinDir(codexBin) 的缓存 promise——codexBin 构造后不变,没必要每次 detect/spawn/
-   * resume 都重新 `command -v` + `realpath` 一遍。 */
+   * resume 都重新 `command -v` + `realpath` 一遍。五轮 review 修复:只缓存*成功*的解析结果。
+   * 解析失败(undefined)不固化——启动时 codex 还没装好/PATH 未生效是常见时序,若把失败也
+   * 缓存住,用户随后装好 codex 后所有后续 spawn/resume 仍会拿到永久 undefined,PATH 不再
+   * 前置,直接复现本文件要修的 nvm `env: node: No such file or directory` 陷阱,且要等
+   * agent 重启才能自愈。见 resolveBinDirCached()。 */
   private cachedBinDir?: Promise<string | undefined>
 
   constructor(
@@ -422,9 +461,17 @@ export class CodexWorkerAdapter implements WorkerAdapter {
     this.sessionDiscoveryTimeoutMs = deps.sessionDiscoveryTimeoutMs ?? 3000
   }
 
-  /** codexBin 所在真实目录(nvm 部署陷阱修复,见 resolveBinDir 注释),懒解析并缓存。 */
+  /** codexBin 所在真实目录(nvm 部署陷阱修复,见 resolveBinDir 注释),懒解析并缓存——但只
+   * 缓存成功结果(见 cachedBinDir 字段注释)。解析中的 promise 仍然去重(并发调用不会打出
+   * 一阵 `command -v` 风暴),解析出 undefined 时把缓存清空,让下一次调用重新解析;resolveBinDir
+   * 内部已经 try/catch 过,这里的 promise 不会 reject,不产生 unhandled rejection。 */
   private resolveBinDirCached(): Promise<string | undefined> {
-    if (!this.cachedBinDir) this.cachedBinDir = resolveBinDir(this.codexBin)
+    if (!this.cachedBinDir) {
+      this.cachedBinDir = resolveBinDir(this.codexBin).then((dir) => {
+        if (!dir) this.cachedBinDir = undefined
+        return dir
+      })
+    }
     return this.cachedBinDir
   }
 

--- a/crabot-agent/src/workers/codex/adapter.ts
+++ b/crabot-agent/src/workers/codex/adapter.ts
@@ -4,11 +4,14 @@
  * 2026-07-30 在部署机 m2(codex-cli 0.144.1)上做了一轮真机校准,修正了四处此前只能靠文档/
  * 源码推断的行为:session 发现(优先信 rollout 内容里的权威 session_id,见下方"session 发现"
  * 节)、nvm 部署形态下 tmux 拉起子进程解析不到 codex 自身 node 的陷阱(见 resolveBinDir/
- * buildEnv)、spawn/resume 命令行参数顺序与 --skip-git-repo-check(见"spawn/resume 启动参数"
- * 节)、readTrace 的 rollout 行结构(见 normalizeRolloutLine)。未被这轮校准覆盖的细节仍按
- * 公开文档/codex 源码(github.com/openai/codex,developers.openai.com/codex 系列页面,已
- * 跳转到 learn.chatgpt.com/docs/*)推断实现,标注为 `codex-docs:` 的引用点维持原样,后续如
- * 有出入以真机行为为准。
+ * buildEnv)、spawn/resume 命令行参数顺序(见"spawn/resume 启动参数"节)、readTrace 的
+ * rollout 行结构(见 normalizeRolloutLine)。同日的后续一轮校准修正了上一轮引入的一个回归:
+ * 曾误把 `codex exec` 专属的 `--skip-git-repo-check` 当成交互式顶层命令也支持的参数加了
+ * 上去,m2 实测顶层 `codex`/`codex resume` 的 Options 全清单里都没有这个 flag,传了会被 clap
+ * 拒绝——已改为 provision 时把 workspace 写成 config.toml 里的受信任目录(见"provision"节的
+ * trust_level 段)。未被这两轮校准覆盖的细节仍按公开文档/codex 源码(github.com/openai/codex,
+ * developers.openai.com/codex 系列页面,已跳转到 learn.chatgpt.com/docs/*)推断实现,标注为
+ * `codex-docs:` 的引用点维持原样,后续如有出入以真机行为为准。
  *
  * ## 与 cc adapter 的关键差异(决定了本文件的整体形状)
  *
@@ -57,10 +60,14 @@
  * 概念上等价的 'stop')`,用 `/bin/sh -c` 包一层,因为 codex-docs 确认 notify 是"程序+固定参数
  * 数组,codex 会在末尾追加一个 JSON payload 作为额外参数"——见
  * learn.chatgpt.com/docs/config-file/config-advanced;固定参数脚本本身不读那个额外参数,
- * 效果上只是"turn 结束就打一个标记",与 cc 的 Stop hook 语义等价) + mcp_servers 段
- * (复用 Task 3 的 `renderCodexMcpToml`)。TOML 要求根级 key 必须出现在第一个 table 之前
- * (codex-docs: config.md 曾用这条规则解释"notify 放最后不生效"的排查案例),所以 notify
- * 行必须排在 mcp_servers 的 `[mcp_servers."x"]` 表头之前。
+ * 效果上只是"turn 结束就打一个标记",与 cc 的 Stop hook 语义等价) + `[projects."<realpath>"]`
+ * 段(`trust_level = "trusted"`,把 workspace 声明成受信任目录——codex 源码里交互式 TUI 判断
+ * "是否受信目录"的真实机制,取代不存在的 `--skip-git-repo-check` flag,见"spawn/resume 启动
+ * 参数"节;path 用 `fs.realpath(ws.root)` 解析符号链接后按本文件的 `tomlString` 转义) +
+ * mcp_servers 段(复用 Task 3 的 `renderCodexMcpToml`)。TOML 要求根级 key 必须出现在第一个
+ * table 之前(codex-docs: config.md 曾用这条规则解释"notify 放最后不生效"的排查案例),所以
+ * notify 行必须排在 `[projects...]`/`[mcp_servers."x"]` 表头之前(这两个表之间的先后顺序不
+ * 影响解析,各自表头下只跟自己的键)。
  *
  * `<ws.root>/.codex/auth.json`:既然 `.codex/` 在这里被当成独立 `CODEX_HOME`,真实登录态
  * (`codexHomeSource`,默认 `~/.codex`)里的 `auth.json`(codex-docs:
@@ -89,9 +96,13 @@
  *    never --sandbox workspace-write`(选项跟在 `resume <id>` 后面)会被 codex 当成 usage
  *    错误、exit=2 拒绝——本 adapter 曾经就是这么拼的(未验证的猜测),已按实测改成
  *    `codex --ask-for-approval never --sandbox workspace-write resume <id>`(选项在前)。
- * 2. **非受信目录下必须带 `--skip-git-repo-check`**:worker workspace 不是用户显式
- *    `git init`/信任过的仓库,不带这个 flag 会报 "Not inside a trusted directory" 直接
- *    卡住——spawn 与 resume 的命令行都固定加上。
+ * 2. **不传 `--skip-git-repo-check`,改用 config.toml 的 `[projects."<path>"] trust_level`**:
+ *    上一轮曾给 spawn/resume 加过 `--skip-git-repo-check`,诊断("worker workspace 不是受信
+ *    目录,不处理会卡住")是对的,但这个 flag **只注册在 `codex exec` 子解析器上**——m2 实测
+ *    `codex --help`/`codex resume --help` 的顶层交互式 Options 全清单里都没有它,传给交互式
+ *    `codex`/`codex resume` 会被 clap 当 usage 错误直接拒绝(exit=2),是把 `codex exec` 路径
+ *    下的真机结论错误套用到了交互式路径(exec 路径实测,交互态未单独验证)。已改为 provision
+ *    时把 workspace 写成 config.toml 里的受信任目录,见"provision"节。
  *
  * 另外 PATH 显式经 `buildEnv()`/`resolveBinDir()` 前置了 codexBin 解析出的真实目录(nvm
  * 部署陷阱,见该函数注释):tmux server 是常驻进程,其环境不一定等于当前 agent 进程的环境
@@ -476,11 +487,19 @@ export class CodexWorkerAdapter implements WorkerAdapter {
     // 标记"——与 cc 的 Stop hook(丢弃 stdin payload,同一设计取舍,见 CliEventChannel 头
     // 注释)语义一致。
     const notifyLine = `notify = [${tomlString('/bin/sh')}, ${tomlString('-c')}, ${tomlString(channel.hookCommand('stop'))}]\n`
+
+    // codex 源码里交互式 TUI 判断"是否受信目录"的真实机制是 config.toml 的
+    // [projects."<绝对路径>"] 表 + trust_level = "trusted"(取代不存在的 --skip-git-repo-check
+    // flag,见文件头"spawn/resume 启动参数"节)。path 用 ws.root 的 realpath(worker workspace
+    // 可能经符号链接到达,codex 内部按规范化后的路径比较)。
+    const realRoot = await fs.realpath(ws.root)
+    const trustLine = `[projects.${tomlString(realRoot)}]\ntrust_level = "trusted"\n`
+
     const mcpServers = caps.mcp_servers as unknown as ProvisionSources['mcpServers']
     const mcpToml = renderCodexMcpToml(mcpServers)
     // TOML 要求根级 key 必须出现在第一个 table 之前,否则会被解析成前一个 table 的子字段——
-    // notify 必须排在 mcp_servers 的 [mcp_servers."x"] 表头之前。
-    await fs.writeFile(join(codexDir, 'config.toml'), notifyLine + '\n' + mcpToml, 'utf-8')
+    // notify 必须排在 [projects...]/[mcp_servers."x"] 表头之前。
+    await fs.writeFile(join(codexDir, 'config.toml'), notifyLine + '\n' + trustLine + '\n' + mcpToml, 'utf-8')
 
     // codex-docs: 既然 .codex/ 在这里被当成独立 CODEX_HOME,真实登录态里的 auth.json 要搬
     // 一份过来,否则隔离出来的 CODEX_HOME 过不了鉴权。找不到就跳过(本机/CI 未 `codex
@@ -529,9 +548,10 @@ export class CodexWorkerAdapter implements WorkerAdapter {
     const outputFile = join(dir, `output-${seq}.log`)
     // codex-docs + m2 实测:交互态无 --session-id 等价参数;--ask-for-approval never
     // --sandbox workspace-write 与 cc 用 --permission-mode acceptEdits 同样的自动化意图。
-    // --skip-git-repo-check 是 m2 实测新增:worker workspace 不是用户显式信任过的 git
-    // 仓库,不带这个 flag 会报 "Not inside a trusted directory" 直接卡住。
-    const command = `${this.codexBin} --skip-git-repo-check --ask-for-approval never --sandbox workspace-write`
+    // 不传 --skip-git-repo-check(m2 实测顶层交互式 codex 不支持这个 flag,只有 codex exec
+    // 才有——见文件头"spawn/resume 启动参数"节);受信目录改由 provision 写进 config.toml 的
+    // [projects."<realpath>"] trust_level = "trusted" 解决。
+    const command = `${this.codexBin} --ask-for-approval never --sandbox workspace-write`
     const spawnStartedAt = Date.now()
 
     // newSession 成功之后才落 meta(running)+注册 runtime,同 cc 纪律:tmux 失败时不留任何
@@ -637,10 +657,11 @@ export class CodexWorkerAdapter implements WorkerAdapter {
       const sessionName = `crabot-w-${prev.worker_id}-${seq}`
       const outputFile = join(dir, `output-${seq}.log`)
       // codex-docs: `codex resume <SESSION_ID>` 是独立子命令(不是 --resume flag)。
-      // m2 实测:--skip-git-repo-check/--ask-for-approval/--sandbox 这类主命令级选项必须
-      // 排在 `resume` 子命令**之前**——放在 `resume <id>` 后面 codex 会报 usage 错、exit=2
-      // (原实现把它们放在 `resume <id>` 之后,是未经真机验证的错误猜测,这里按实测结果改正)。
-      const command = `${this.codexBin} --skip-git-repo-check --ask-for-approval never --sandbox workspace-write resume ${shQuote(prev.session_ref)}`
+      // m2 实测:--ask-for-approval/--sandbox 这类主命令级选项必须排在 `resume` 子命令**之前**
+      // ——放在 `resume <id>` 后面 codex 会报 usage 错、exit=2(原实现把它们放在 `resume <id>`
+      // 之后,是未经真机验证的错误猜测,这里按实测结果改正)。不传 --skip-git-repo-check,
+      // 理由同 spawn(见文件头"spawn/resume 启动参数"节)。
+      const command = `${this.codexBin} --ask-for-approval never --sandbox workspace-write resume ${shQuote(prev.session_ref)}`
 
       // 锁纪律与 spawn 一致:tmux newSession 成功之后才落 meta(running)+注册 runtime;
       // PATH 前置同 spawn(nvm 部署陷阱)。

--- a/crabot-agent/src/workers/codex/adapter.ts
+++ b/crabot-agent/src/workers/codex/adapter.ts
@@ -1,10 +1,14 @@
 /**
  * CodexWorkerAdapter — WorkerAdapter 契约的 OpenAI codex CLI 实现。
  *
- * 本机没有安装 codex,以下行为全部依据公开文档/codex 源码(github.com/openai/codex,
- * developers.openai.com/codex 系列页面,已跳转到 learn.chatgpt.com/docs/*)推断实现,每个
- * 引用点在下面用 `codex-docs:` 标注出处;真机行为需要在真正装上 codex 之后校准(见 Task 6
- * 报告"未经确认待真机校准清单")。
+ * 2026-07-30 在部署机 m2(codex-cli 0.144.1)上做了一轮真机校准,修正了四处此前只能靠文档/
+ * 源码推断的行为:session 发现(优先信 rollout 内容里的权威 session_id,见下方"session 发现"
+ * 节)、nvm 部署形态下 tmux 拉起子进程解析不到 codex 自身 node 的陷阱(见 resolveBinDir/
+ * buildEnv)、spawn/resume 命令行参数顺序与 --skip-git-repo-check(见"spawn/resume 启动参数"
+ * 节)、readTrace 的 rollout 行结构(见 normalizeRolloutLine)。未被这轮校准覆盖的细节仍按
+ * 公开文档/codex 源码(github.com/openai/codex,developers.openai.com/codex 系列页面,已
+ * 跳转到 learn.chatgpt.com/docs/*)推断实现,标注为 `codex-docs:` 的引用点维持原样,后续如
+ * 有出入以真机行为为准。
  *
  * ## 与 cc adapter 的关键差异(决定了本文件的整体形状)
  *
@@ -33,16 +37,19 @@
  *
  * ## session 发现(spawn 专用)
  *
- * codex-docs: rollout 文件路径 `<CODEX_HOME>/sessions/YYYY/MM/DD/
- * rollout-YYYY-MM-DDThh-mm-ss-<uuid>.jsonl`,来自 codex-rs/rollout/src/list.rs 注释原文
- * "Directory layout: `~/.codex/sessions/YYYY/MM/DD/rollout-YYYY-MM-DDThh-mm-ss-<uuid>.jsonl`"
- * 与 codex-rs/rollout/src/lib.rs 的 `SESSIONS_SUBDIR = "sessions"` 常量。spawn() 在 tmux
- * newSession 成功后、注入首条 prompt 之前,有限时间(`sessionDiscoveryTimeoutMs`,默认
- * 3000ms)轮询这个目录树,取文件名里的 uuid 作为该化身的真实 session_id;轮询超时(codex
- * 还没来得及落盘,或本次跑的是不写 rollout 文件的 mock)就退化为本地生成的占位 uuid——
- * 这个占位 uuid 不对应任何真实 codex 会话文件,该化身自己的 resume()/readTrace() 会因此
- * 失效(resume 传给 codex 的 session id 是假的;readTrace 因为 `rolloutPath` 是 undefined
- * 直接退化为空数组),是已知限制,不是本 task 能在没有真机的前提下解决的缺口。
+ * codex 走的是交互式 TUI(本 adapter 用 tmux 拉起 `codex ...`,不是 `codex exec`),拿不到
+ * `codex exec --json` 的 `thread.started` 事件流,只能靠事后发现——codex-docs: rollout 文件
+ * 路径 `<CODEX_HOME>/sessions/YYYY/MM/DD/rollout-YYYY-MM-DDThh-mm-ss-<uuid>.jsonl`(来自
+ * codex-rs/rollout/src/list.rs 注释)。spawn() 在 tmux newSession 成功后、注入首条 prompt
+ * 之前,有限时间(`sessionDiscoveryTimeoutMs`,默认 3000ms)轮询这个目录树找新出现的
+ * rollout 文件;m2 真机实测:文件一旦被发现,优先读它首行 `session_meta.payload.session_id`
+ * 作为权威 session_id(比文件名解析更可靠,是 codex 自己声明的值),内容还没写完整(文件刚
+ * 创建的竞态、或老版本 codex 不写这个字段)才退回文件名里嵌的 uuid(实测两者完全一致,退回
+ * 不算精度损失)。轮询超时(codex 还没来得及落盘,或本次跑的是不写 rollout 文件的 mock)
+ * 就退化为本地生成的占位 uuid——这个占位 uuid 不对应任何真实 codex 会话文件,该化身自己的
+ * resume()/readTrace() 会因此失效(resume 传给 codex 的 session id 是假的;readTrace 因为
+ * `rolloutPath` 是 undefined 直接退化为空数组),是已知限制,真机环境下正常运行基本不会
+ * 触发(轮询窗口内文件必现)。
  *
  * ## provision:workspace 级配置
  *
@@ -75,9 +82,21 @@
  * (`read-only|workspace-write|danger-full-access`)。本 adapter 固定传
  * `--ask-for-approval never --sandbox workspace-write`,与 cc 用
  * `--permission-mode acceptEdits` 同样的自动化意图——不能让审批弹窗卡住 tmux pane。
- * `codex resume <SESSION_ID>` 是独立子命令(不是 `--resume` flag),同一文档页确认;
- * resume 子命令是否接受与主命令相同的 `--ask-for-approval`/`--sandbox` 未逐条确认,按
- * 同一 CLI 顶层 flag 的一般惯例沿用,真机校准时需要核实。
+ * `codex resume <SESSION_ID>` 是独立子命令(不是 `--resume` flag),同一文档页确认。
+ *
+ * m2 真机实测校准了两点原先靠猜测沿用、未经验证的行为:
+ * 1. **主命令级选项必须排在 `resume` 子命令之前**:`codex resume <id> --ask-for-approval
+ *    never --sandbox workspace-write`(选项跟在 `resume <id>` 后面)会被 codex 当成 usage
+ *    错误、exit=2 拒绝——本 adapter 曾经就是这么拼的(未验证的猜测),已按实测改成
+ *    `codex --ask-for-approval never --sandbox workspace-write resume <id>`(选项在前)。
+ * 2. **非受信目录下必须带 `--skip-git-repo-check`**:worker workspace 不是用户显式
+ *    `git init`/信任过的仓库,不带这个 flag 会报 "Not inside a trusted directory" 直接
+ *    卡住——spawn 与 resume 的命令行都固定加上。
+ *
+ * 另外 PATH 显式经 `buildEnv()`/`resolveBinDir()` 前置了 codexBin 解析出的真实目录(nvm
+ * 部署陷阱,见该函数注释):tmux server 是常驻进程,其环境不一定等于当前 agent 进程的环境
+ * (m2 上 codex 是 nvm 装的 node 脚本,tmux server 环境不含对应 node 的 bin 目录时,子进程
+ * 直接报 `env: node: No such file or directory`)。
  *
  * ## 提交纪律与状态判定
  *
@@ -96,7 +115,7 @@
  * 重新按 session_id 精确查找重建,不再要求"只能对本进程内常驻 runtime 的化身调用"(同 cc)。
  */
 import { promises as fs, type Dirent } from 'fs'
-import { join } from 'path'
+import { join, dirname } from 'path'
 import { randomUUID } from 'crypto'
 import { homedir } from 'os'
 import { execFile } from 'child_process'
@@ -145,6 +164,46 @@ function tomlString(value: string): string {
     }
   }
   return `"${out}"`
+}
+
+/** 从 codexBin 配置里摘出"实际会被 exec 的可执行文件"这一个 token。生产配置通常就是单个
+ * 命令名(如 'codex')或绝对路径;测试注入的 mock codexBin 是复合 shell 命令行
+ * (`env VAR=... node fixture.mjs`),这里跳过 `env` 与它后面的 `KEY=VALUE` 前缀,取到真正
+ * 的可执行文件 token(如 `node`)。 */
+function firstExecutableToken(bin: string): string | undefined {
+  const tokens = bin.trim().split(/\s+/).filter((t) => t.length > 0)
+  let i = 0
+  if (tokens[i] === 'env') {
+    i += 1
+    while (i < tokens.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[i])) i += 1
+  }
+  return tokens[i]
+}
+
+/** nvm 部署陷阱(m2 实测):codex 常是 nvm 装的 node 脚本(shebang `#!/usr/bin/env node`),
+ * 经 tmux 拉起时若 tmux server 自身的环境不含这个 node 的 bin 目录,必现
+ * `env: node: No such file or directory`——tmux server 是常驻进程,其环境不一定等于当前
+ * agent 进程的环境(可能在 nvm 生效之前就已启动)。用 `command -v`(POSIX shell 内置,不
+ * 依赖是否装了独立的 `which` 二进制)+ `fs.realpath` 解析出 codexBin 真实所在目录,调用方
+ * 把它前置进传给 tmux/子进程的 PATH——不硬编码任何 nvm 路径,覆盖"CLI 与其 node 同目录"
+ * 的任意安装形态(nvm/fnm/asdf/系统包管理器等)。解析不出来(codex 压根不在 PATH 上,或
+ * 传入的就是一段无法定位可执行文件的复合命令)返回 undefined,调用方退回继承的 PATH,
+ * 不阻塞。 */
+async function resolveBinDir(bin: string): Promise<string | undefined> {
+  const token = firstExecutableToken(bin)
+  if (!token) return undefined
+  try {
+    let resolved: string
+    if (token.includes('/')) {
+      resolved = await fs.realpath(token)
+    } else {
+      const { stdout } = await execFileAsync('/bin/sh', ['-c', `command -v ${shQuote(token)}`])
+      resolved = await fs.realpath(stdout.trim())
+    }
+    return dirname(resolved)
+  } catch {
+    return undefined
+  }
 }
 
 /** UUID 格式校验:标准 UUID 格式(8-4-4-4-12 十六进制段,由连字符分隔)。*/
@@ -243,16 +302,48 @@ async function findNewestRolloutFile(sessionsDir: string, cutoffMs: number): Pro
   return { path: best.path, sessionId: best.sessionId }
 }
 
-/** 有限时间轮询 findNewestRolloutFile,50ms 间隔;超时返回 null(调用方退化为占位 uuid)。 */
+/** 有限时间轮询 findNewestRolloutFile,50ms 间隔;超时返回 null(调用方退化为占位 uuid)。
+ * 找到候选文件后,优先读文件内容里的 session_meta.payload.session_id(m2 真机实测:与
+ * 文件名内嵌的 uuid 完全一致,但内容字段是 codex 自己声明的权威值,文件名只是我们这边按
+ * 命名约定反解——见文件头"session 发现"节);内容还没写完整/字段缺失(老版本 codex、写入
+ * 竞态)就退回文件名解析出的 uuid,不因此判超时。 */
 async function pollForNewRollout(sessionsDir: string, cutoffMs: number, timeoutMs: number): Promise<{ path: string; sessionId: string } | null> {
   const intervalMs = 50
   const deadline = Date.now() + timeoutMs
   for (;;) {
     const found = await findNewestRolloutFile(sessionsDir, cutoffMs)
-    if (found) return found
+    if (found) {
+      const contentSessionId = await readSessionIdFromRolloutContent(found.path)
+      return { path: found.path, sessionId: contentSessionId ?? found.sessionId }
+    }
     if (Date.now() >= deadline) return null
     await new Promise((r) => setTimeout(r, intervalMs))
   }
+}
+
+/** 读 rollout 文件首行的 session_meta.payload.session_id(m2 真机实测的权威字段)。首行还
+ * 不是完整/合法的 session_meta(文件刚创建、还没来得及写完)一律返回 undefined,调用方退回
+ * 文件名解析,不抛错、不重试——真机实测文件名与内容里的 id 完全一致,这里只是"能拿到内容
+ * 就优先信内容"的加固,拿不到不算失败。 */
+async function readSessionIdFromRolloutContent(path: string): Promise<string | undefined> {
+  let raw: string
+  try {
+    raw = await fs.readFile(path, 'utf-8')
+  } catch {
+    return undefined
+  }
+  const firstLine = raw.split('\n', 1)[0]
+  if (!firstLine) return undefined
+  let parsed: { type?: unknown; payload?: { session_id?: unknown } }
+  try {
+    parsed = JSON.parse(firstLine)
+  } catch {
+    return undefined
+  }
+  if (parsed?.type === 'session_meta' && typeof parsed.payload?.session_id === 'string') {
+    return parsed.payload.session_id
+  }
+  return undefined
 }
 
 /**
@@ -296,6 +387,9 @@ export class CodexWorkerAdapter implements WorkerAdapter {
   private readonly sessionDiscoveryTimeoutMs: number
   private readonly runtimes = new Map<string, Runtime>()
   private readonly mutexes = new Map<string, AsyncMutex>()
+  /** resolveBinDir(codexBin) 的缓存 promise——codexBin 构造后不变,没必要每次 detect/spawn/
+   * resume 都重新 `command -v` + `realpath` 一遍。 */
+  private cachedBinDir?: Promise<string | undefined>
 
   constructor(
     private readonly deps: {
@@ -317,12 +411,38 @@ export class CodexWorkerAdapter implements WorkerAdapter {
     this.sessionDiscoveryTimeoutMs = deps.sessionDiscoveryTimeoutMs ?? 3000
   }
 
+  /** codexBin 所在真实目录(nvm 部署陷阱修复,见 resolveBinDir 注释),懒解析并缓存。 */
+  private resolveBinDirCached(): Promise<string | undefined> {
+    if (!this.cachedBinDir) this.cachedBinDir = resolveBinDir(this.codexBin)
+    return this.cachedBinDir
+  }
+
+  /** 传给 tmux newSession 的 env:PATH 前置 codexBin 所在真实目录(解析不出来就用继承的
+   * PATH,不阻塞),外加调用方传入的额外变量(如 CODEX_HOME)。 */
+  private async buildEnv(extra: Record<string, string>): Promise<Record<string, string>> {
+    const dir = await this.resolveBinDirCached()
+    const path = dir ? `${dir}:${process.env.PATH ?? ''}` : (process.env.PATH ?? '')
+    return { PATH: path, ...extra }
+  }
+
   async detect(): Promise<DetectResult> {
+    const binDir = await this.resolveBinDirCached()
+    const versionEnv = { ...process.env, PATH: binDir ? `${binDir}:${process.env.PATH ?? ''}` : (process.env.PATH ?? '') }
     let versionOutput: string
     try {
-      const { stdout } = await execFileAsync('/bin/sh', ['-c', `${this.codexBin} --version`])
+      const { stdout } = await execFileAsync('/bin/sh', ['-c', `${this.codexBin} --version`], { env: versionEnv })
       versionOutput = stdout.trim()
     } catch (err) {
+      if (binDir) {
+        // codexBin 本身能被 `command -v` 定位到(装了),但跑起来仍然失败——大概率是它的
+        // node 解释器解析不到(nvm 之类的部署形态、或安装本身损坏),不是"没装",错误信息
+        // 需要能区分这两种情形,不能都归成一句"not found"。
+        return {
+          installed: false,
+          activated: false,
+          detail: `codex binary found at ${binDir} but failed to execute (its node interpreter may be unresolved, e.g. nvm-style install with a stale PATH): ${(err as Error).message}`,
+        }
+      }
       return { installed: false, activated: false, detail: `codex binary not found or failed to run: ${(err as Error).message}` }
     }
 
@@ -407,15 +527,18 @@ export class CodexWorkerAdapter implements WorkerAdapter {
     const codexHome = join(spec.workspace.root, '.codex')
     const sessionName = `crabot-w-${spec.worker_id}-${seq}`
     const outputFile = join(dir, `output-${seq}.log`)
-    // codex-docs: 交互态无 --session-id 等价参数;--ask-for-approval never --sandbox
-    // workspace-write 与 cc 用 --permission-mode acceptEdits 同样的自动化意图。
-    const command = `${this.codexBin} --ask-for-approval never --sandbox workspace-write`
+    // codex-docs + m2 实测:交互态无 --session-id 等价参数;--ask-for-approval never
+    // --sandbox workspace-write 与 cc 用 --permission-mode acceptEdits 同样的自动化意图。
+    // --skip-git-repo-check 是 m2 实测新增:worker workspace 不是用户显式信任过的 git
+    // 仓库,不带这个 flag 会报 "Not inside a trusted directory" 直接卡住。
+    const command = `${this.codexBin} --skip-git-repo-check --ask-for-approval never --sandbox workspace-write`
     const spawnStartedAt = Date.now()
 
     // newSession 成功之后才落 meta(running)+注册 runtime,同 cc 纪律:tmux 失败时不留任何
     // 持久痕迹,同 worker_id 可安全重试。CODEX_HOME 经 tmux -e 传给会话进程(execFile 直传
-    // argv,不经过 shell 插值,不需要额外转义)。
-    await this.tmux.newSession({ name: sessionName, cwd: spec.workspace.root, command, outputFile, env: { CODEX_HOME: codexHome } })
+    // argv,不经过 shell 插值,不需要额外转义);PATH 同样经 -e 显式前置 codexBin 所在真实
+    // 目录(nvm 部署陷阱,见 buildEnv/resolveBinDir 注释),不依赖 tmux server 自身环境。
+    await this.tmux.newSession({ name: sessionName, cwd: spec.workspace.root, command, outputFile, env: await this.buildEnv({ CODEX_HOME: codexHome }) })
 
     // session 发现:见文件头注释"session 发现"节。找不到就退化为本地占位 uuid(已知限制)。
     const discovered = await pollForNewRollout(join(codexHome, 'sessions'), spawnStartedAt, this.sessionDiscoveryTimeoutMs)
@@ -514,12 +637,14 @@ export class CodexWorkerAdapter implements WorkerAdapter {
       const sessionName = `crabot-w-${prev.worker_id}-${seq}`
       const outputFile = join(dir, `output-${seq}.log`)
       // codex-docs: `codex resume <SESSION_ID>` 是独立子命令(不是 --resume flag)。
-      // --ask-for-approval/--sandbox 是否对 resume 子命令同样生效未逐条确认,按同一 CLI 顶层
-      // flag 惯例沿用,真机校准时需要核实(见 Task 6 报告)。
-      const command = `${this.codexBin} resume ${shQuote(prev.session_ref)} --ask-for-approval never --sandbox workspace-write`
+      // m2 实测:--skip-git-repo-check/--ask-for-approval/--sandbox 这类主命令级选项必须
+      // 排在 `resume` 子命令**之前**——放在 `resume <id>` 后面 codex 会报 usage 错、exit=2
+      // (原实现把它们放在 `resume <id>` 之后,是未经真机验证的错误猜测,这里按实测结果改正)。
+      const command = `${this.codexBin} --skip-git-repo-check --ask-for-approval never --sandbox workspace-write resume ${shQuote(prev.session_ref)}`
 
-      // 锁纪律与 spawn 一致:tmux newSession 成功之后才落 meta(running)+注册 runtime。
-      await this.tmux.newSession({ name: sessionName, cwd: prevRuntime.workspaceRoot, command, outputFile, env: { CODEX_HOME: prevRuntime.codexHome } })
+      // 锁纪律与 spawn 一致:tmux newSession 成功之后才落 meta(running)+注册 runtime;
+      // PATH 前置同 spawn(nvm 部署陷阱)。
+      await this.tmux.newSession({ name: sessionName, cwd: prevRuntime.workspaceRoot, command, outputFile, env: await this.buildEnv({ CODEX_HOME: prevRuntime.codexHome }) })
 
       runtime = {
         worker_id: prev.worker_id,

--- a/crabot-agent/src/workers/codex/adapter.ts
+++ b/crabot-agent/src/workers/codex/adapter.ts
@@ -109,9 +109,9 @@
  *
  * ## readTrace
  *
- * 解析 `<CODEX_HOME>/sessions/.../rollout-*.jsonl`,字段依据 codex-rs 源码抓取确认(见各
- * 归一化函数内的 codex-docs 注释),fixture 手工构造,真机校准留待安装。rolloutPath 经
- * ensureRuntime 从 meta 的 workspace_root + session_discovery 字段(四轮 review 新增持久化)
+ * 解析 `<CODEX_HOME>/sessions/.../rollout-*.jsonl`,信封结构与五种顶层 type 的字段形状已按
+ * m2 真机实测校准(见 normalizeRolloutLine 注释),测试 fixture 按实测字段手写。rolloutPath
+ * 经 ensureRuntime 从 meta 的 workspace_root + session_discovery 字段(四轮 review 新增持久化)
  * 重新按 session_id 精确查找重建,不再要求"只能对本进程内常驻 runtime 的化身调用"(同 cc)。
  */
 import { promises as fs, type Dirent } from 'fs'
@@ -1010,94 +1010,107 @@ function truncate(text: string, max: number): string {
 /**
  * 归一化单行 codex rollout JSONL 为 NormalizedTraceEvent。
  *
- * codex-docs: 每行外层是 `{"type": ..., "payload": ...}`(codex-rs/protocol/src/protocol.rs
- * 的 `RolloutItem` 枚举 `#[serde(tag = "type", content = "payload", rename_all =
- * "snake_case")]` 确认),顶层 type 取值 session_meta / response_item / event_msg /
- * turn_context / world_state / compacted / inter_agent_communication /
- * inter_agent_communication_metadata——只有前三种映射为 trace 事件,其余跳过,同 cc 对
- * mode/summary/queue-operation 的处理方式(不认识的行归一化为 null,readTrace 跳过)。
+ * m2 真机实测(codex-cli 0.144.1)校准的信封结构:每行是 `{type, timestamp, payload}`
+ * (`timestamp` 挂在信封顶层,不是嵌在 payload 里——之前按 codex-docs 猜测的字段位置是错的,
+ * 这里已按实测改正),顶层 type 取值 session_meta / event_msg / response_item / world_state /
+ * turn_context 五种(未见 compacted/inter_agent_communication* 之类的推测类型):
+ *
+ * - `session_meta`:payload 有 `session_id`(权威,比文件名解析出的 uuid 更可靠,见 spawn()
+ *   的"session 发现"节)、`cli_version`、`cwd`、`model_provider`、`context_window`、
+ *   `originator`——映射为 lifecycle。
+ * - `event_msg`:payload 有 `type`(如 `task_started`)、`turn_id`、`started_at`、
+ *   `model_context_window`——映射为 lifecycle,摘要取 payload.type。
+ * - `response_item`:见 normalizeResponseItem()。
+ * - `world_state`:payload 是全量状态快照(`full`/`state`),对"发生了什么"的摘要时间线没有
+ *   直接信息量(它是状态,不是事件),跳过——需要全量状态可以直接读原始 rollout 文件
+ *   (detail 只保留 response_item/event_msg/session_meta 各自的 payload,不代表 world_state
+ *   不存在,只是不进这条摘要时间线)。
+ * - `turn_context`:payload 是回合配置(`model`/`effort`/`cwd`/`approval_policy`/`summary`
+ *   等),同样不是"发生的事",跳过。
  */
 function normalizeRolloutLine(line: string): NormalizedTraceEvent | null {
-  let parsed: { type?: unknown; payload?: unknown }
+  let parsed: { type?: unknown; timestamp?: unknown; payload?: unknown }
   try {
     parsed = JSON.parse(line)
   } catch {
     return null
   }
   if (!parsed || typeof parsed !== 'object') return null
+  const ts = typeof parsed.timestamp === 'string' ? parsed.timestamp : ''
   const payload = parsed.payload as Record<string, unknown> | undefined
 
   if (parsed.type === 'session_meta') {
-    const meta = payload as { timestamp?: string; cwd?: string } | undefined
-    const ts = typeof meta?.timestamp === 'string' ? meta.timestamp : ''
-    return { ts, kind: 'lifecycle', role: 'system', summary: truncate(`session_meta cwd=${meta?.cwd ?? ''}`, 200), detail: payload }
+    const meta = payload as { session_id?: string; cli_version?: string; cwd?: string } | undefined
+    const summary = `session_meta session_id=${meta?.session_id ?? ''} cli_version=${meta?.cli_version ?? ''} cwd=${meta?.cwd ?? ''}`
+    return { ts, kind: 'lifecycle', role: 'system', summary: truncate(summary, 200), detail: payload }
   }
 
   if (parsed.type === 'event_msg') {
-    // codex-docs: EventMsg 是内部 tag(`#[serde(tag = "type", rename_all = "snake_case")]`,
-    // 字段直接铺在 payload 里,不像 RolloutItem 那样外套一层 content),取 payload.type 当摘要。
     const eventType = typeof payload?.type === 'string' ? payload.type : 'event_msg'
-    return { ts: '', kind: 'lifecycle', role: 'system', summary: eventType, detail: payload }
+    return { ts, kind: 'lifecycle', role: 'system', summary: eventType, detail: payload }
   }
 
   if (parsed.type === 'response_item') {
-    return normalizeResponseItem(payload)
+    return normalizeResponseItem(payload, ts)
   }
 
+  // world_state/turn_context(以及其它未在真机实测里见过的顶层 type)跳过,见函数头注释。
   return null
 }
 
 /**
- * response_item 的 payload 同样是内部 tag(codex-rs/protocol/src/models.rs 的 `ResponseItem`
- * 枚举 `#[serde(tag = "type", rename_all = "snake_case")]`)。这里只认领已从源码确认字段形状
- * 的四种子类型(message/function_call/function_call_output/reasoning);其余子类型
- * (agent_message/local_shell_call/web_search_call/custom_tool_call/...)未逐一核实字段,
- * 跳过而非猜测映射。
+ * response_item 的 payload 同样是内部 tag(`type` 字段区分子类型)。这里只认领已从 m2 真机
+ * 实测或源码确认字段形状的四种子类型(message/function_call/function_call_output/
+ * reasoning);其余子类型(local_shell_call/web_search_call/custom_tool_call/...)未逐一
+ * 核实字段,跳过而非猜测映射。
  */
-function normalizeResponseItem(payload: Record<string, unknown> | undefined): NormalizedTraceEvent | null {
+function normalizeResponseItem(payload: Record<string, unknown> | undefined, ts: string): NormalizedTraceEvent | null {
   if (!payload || typeof payload.type !== 'string') return null
 
   if (payload.type === 'message') {
+    // m2 实测:role 取值 developer/user/assistant(developer 是 codex 侧的系统级指令角色,
+    // 语义上对应我们协议里的 'system',见 types.ts 的 NormalizedTraceEvent.role 只允许
+    // assistant/user/system 三种,不新增 'developer' 这个协议外的值)。summary 只取 content
+    // 里第一个 input_text/output_text 块的 text(不是拼接全部块),截断。
     const role = payload.role
-    const text = extractContentItemsText(payload.content)
-    return {
-      ts: '',
-      kind: 'message',
-      role: role === 'user' || role === 'assistant' || role === 'system' ? role : undefined,
-      summary: truncate(text, 200),
-      detail: payload,
-    }
+    const mappedRole = role === 'developer' ? 'system' : role === 'user' || role === 'assistant' || role === 'system' ? role : undefined
+    const text = extractFirstContentText(payload.content)
+    return { ts, kind: 'message', role: mappedRole, summary: truncate(text, 200), detail: payload }
   }
 
   if (payload.type === 'function_call') {
     const name = typeof payload.name === 'string' ? payload.name : ''
     const args = typeof payload.arguments === 'string' ? payload.arguments : ''
-    return { ts: '', kind: 'tool_call', role: 'assistant', summary: truncate(`${name}(${args})`, 200), detail: payload }
+    return { ts, kind: 'tool_call', role: 'assistant', summary: truncate(`${name}(${args})`, 200), detail: payload }
   }
 
   if (payload.type === 'function_call_output') {
-    // codex-docs: FunctionCallOutput 在 ResponseItem 枚举里没有 role 字段(models.rs),不像
-    // cc 的 tool_result 挂在 role=user 的消息体里——role 留空(undefined)。
+    // codex-docs: FunctionCallOutput 在 ResponseItem 枚举里没有 role 字段,不像 cc 的
+    // tool_result 挂在 role=user 的消息体里——role 留空(undefined)。
     const output = payload.output
-    return { ts: '', kind: 'tool_result', summary: truncate(typeof output === 'string' ? output : JSON.stringify(output ?? {}), 200), detail: payload }
+    return { ts, kind: 'tool_result', summary: truncate(typeof output === 'string' ? output : JSON.stringify(output ?? {}), 200), detail: payload }
   }
 
   if (payload.type === 'reasoning') {
     const text = extractReasoningSummaryText(payload.summary)
-    return { ts: '', kind: 'thinking', role: 'assistant', summary: truncate(text, 200), detail: payload }
+    return { ts, kind: 'thinking', role: 'assistant', summary: truncate(text, 200), detail: payload }
   }
 
   return null
 }
 
-/** ContentItem 数组:只取 input_text/output_text 块的 text 拼接,跳过 input_image/input_audio。 */
-function extractContentItemsText(content: unknown): string {
+/** ContentItem 数组:取第一个 input_text/output_text 块的 text(m2 实测口径:summary 只要
+ * "第一个",不是拼接全部块;跳过 input_image/input_audio 等非文本块)。 */
+function extractFirstContentText(content: unknown): string {
   if (!Array.isArray(content)) return ''
-  return content
-    .filter((item): item is { type: string; text?: string } => !!item && typeof item === 'object' && typeof (item as { type?: unknown }).type === 'string')
-    .filter((item) => item.type === 'input_text' || item.type === 'output_text')
-    .map((item) => item.text ?? '')
-    .join('\n')
+  const item = content.find(
+    (it): it is { type: string; text?: string } =>
+      !!it &&
+      typeof it === 'object' &&
+      typeof (it as { type?: unknown }).type === 'string' &&
+      ((it as { type: string }).type === 'input_text' || (it as { type: string }).type === 'output_text'),
+  )
+  return item?.text ?? ''
 }
 
 // codex-docs: ReasoningItemReasoningSummary 的具体字段未在本次源码抓取范围内逐一核实,这里

--- a/crabot-agent/tests/workers/codex-adapter.test.ts
+++ b/crabot-agent/tests/workers/codex-adapter.test.ts
@@ -394,6 +394,46 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter (tmux + mock CLI)', () => {
   )
 
   it(
+    '五轮 review PoC②:rollout 内容里的 session_id 不是合法 UUID(畸形值)时退回文件名解析出的 uuid,并打 warn' +
+      '(修复前:内容里的 id 未经格式校验就直接采信,畸形 id 会写进 meta.session_id/handle.session_ref,spawn 静默成功但 resume 必然失败)',
+    async () => {
+      const { adapter, workerId } = await provisionedAdapter([{ output: '第一段输出', emitStop: true }])
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const uuidFromFilename = randomUUID()
+      const malformedContentId = 'not-a-valid-uuid; rm -rf /'
+
+      const spawnPromise = adapter.spawn(makeSpec(workerId, '你好'))
+
+      const now = new Date()
+      const pad = (n: number) => String(n).padStart(2, '0')
+      const datePath = path.join(String(now.getFullYear()), pad(now.getMonth() + 1), pad(now.getDate()))
+      const sessionsDir = path.join(workspaceRoot, '.codex', 'sessions', datePath)
+      await fs.mkdir(sessionsDir, { recursive: true })
+      await fs.writeFile(
+        path.join(sessionsDir, rolloutFileNameFor(uuidFromFilename)),
+        JSON.stringify({ type: 'session_meta', payload: { session_id: malformedContentId, timestamp: new Date().toISOString(), cwd: workspaceRoot } }) + '\n',
+        'utf-8',
+      )
+
+      const h = await spawnPromise
+      await waitForState(adapter, h, 'idle')
+
+      const meta = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8')) as { session_id: string; session_discovery?: string }
+      // 退回文件名解析出的 uuid,不是畸形内容值。
+      expect(meta.session_id).toBe(uuidFromFilename)
+      expect(meta.session_id).not.toBe(malformedContentId)
+      expect(meta.session_discovery).toBe('discovered')
+      expect(h.session_ref).toBe(uuidFromFilename)
+
+      const warned = warnSpy.mock.calls.some((call) => String(call[0] ?? '').includes('not a valid UUID'))
+      expect(warned).toBe(true)
+
+      warnSpy.mockRestore()
+    },
+    15000,
+  )
+
+  it(
     'session 发现:轮询超时降级时输出 console.warn 日志',
     async () => {
       const { adapter, workerId } = await provisionedAdapter([{ output: '第一段输出', emitStop: true }])
@@ -766,6 +806,56 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter — spawn 提交纪律', () 
     },
     15000,
   )
+
+  it(
+    '五轮 review PoC③:resolveBinDir 首次解析失败(codex 还没装好/PATH 未生效)不永久缓存 undefined——用户随后装好后,同一 adapter 实例下一次 spawn 应重新解析并前置 PATH' +
+      '(修复前:cachedBinDir 固化第一次的 undefined,后续 spawn/resume 永远拿不到前置 PATH,直到 agent 重启才自愈)',
+    async () => {
+      class RecordingTmuxDriver extends TmuxDriver {
+        envs: Array<Record<string, string> | undefined> = []
+        async newSession(spec: TmuxSessionSpec): Promise<void> {
+          this.envs.push(spec.env)
+          return super.newSession(spec)
+        }
+      }
+      const toolDir = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-adapter-bindir-retry-'))
+      const fakeBinName = `crabot-test-fake-codex-${randomUUID().slice(0, 8)}`
+      await fs.writeFile(path.join(toolDir, fakeBinName), '#!/bin/sh\nexit 0\n', { mode: 0o755 })
+
+      const originalPath = process.env.PATH ?? ''
+      const tmux = new RecordingTmuxDriver()
+      // 裸命令名(不含 '/'),命中 resolveBinDir 的 `command -v` 分支——对应真实 nvm 场景
+      // (codex 是 PATH 上的一个命令名,不是绝对路径)。
+      const adapter = new CodexWorkerAdapter({ dataDir, tmux, codexBin: fakeBinName, sessionDiscoveryTimeoutMs: 200 })
+      await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
+
+      try {
+        // 第一次 spawn:toolDir 还不在 PATH 上,`command -v` 找不到,resolveBinDir 解析失败
+        // → 回退到继承的 PATH(不前置任何目录)。
+        const workerId1 = `codextest-${randomUUID().slice(0, 8)}`
+        await adapter.spawn({ worker_id: workerId1, prompt: '你好', workspace: { root: workspaceRoot } }).catch(() => {})
+        expect(tmux.envs[0]).toBeDefined()
+        expect(tmux.envs[0]!.PATH).toBe(originalPath)
+
+        // "用户随后装好了 codex"(如 nvm use / 重新 source shell rc)——把 toolDir 加进 PATH。
+        process.env.PATH = `${toolDir}:${originalPath}`
+
+        // 第二次 spawn,同一个 adapter 实例(不重启进程):resolveBinDir 应重新解析成功并
+        // 前置 toolDir——PATH 里会出现两份 toolDir(一份是本次显式前置,一份已经在继承的
+        // process.env.PATH 里)。修复前:cachedBinDir 固化了第一次的 undefined,PATH 只回退
+        // 到(此时已含 toolDir 的)继承值,只有一份 toolDir,不会再前置——本用例正是靠"一份
+        // 还是两份 toolDir"区分修复前后。
+        const workerId2 = `codextest-${randomUUID().slice(0, 8)}`
+        await adapter.spawn({ worker_id: workerId2, prompt: '你好', workspace: { root: workspaceRoot } }).catch(() => {})
+        expect(tmux.envs[1]).toBeDefined()
+        expect(tmux.envs[1]!.PATH).toBe(`${toolDir}:${process.env.PATH}`)
+      } finally {
+        process.env.PATH = originalPath
+        await fs.rm(toolDir, { recursive: true, force: true }).catch(() => {})
+      }
+    },
+    15000,
+  )
 })
 
 describe('CodexWorkerAdapter.detect', () => {
@@ -980,6 +1070,48 @@ describe('CodexWorkerAdapter.readTrace', () => {
     const adapter = new CodexWorkerAdapter({ dataDir, tmux, codexBin: 'unused' })
     await expect(adapter.readTrace({ worker_id: 'nope', seq: 1, impl: 'codex' })).rejects.toThrow()
   })
+
+  it(
+    '五轮 review PoC①:内容 session_id 与文件名 uuid 分歧、重启后新 adapter 实例——findRolloutFileBySessionId 应退一步按内容匹配到同一文件,readTrace 能读到事件' +
+      '(修复前:只按文件名精确匹配,分歧时 rolloutPath 变 undefined,尽管 session_discovery===discovered 且文件明明还在,仍静默返回空数组)',
+    async () => {
+      const tmux = new NoopTmux()
+      const adapter = new CodexWorkerAdapter({ dataDir, tmux, codexBin: 'unused' })
+      const workerId = `codextest-${randomUUID().slice(0, 8)}`
+
+      // 模拟 spawn 时"内容优先"加固已经生效:meta.session_id 落的是内容里的 uuidFromContent,
+      // 但 rollout 文件名内嵌的仍是 uuidFromFilename(两者分歧,同 adapter.ts 头注释描述的
+      // 竞态/沿用场景)。
+      const uuidFromFilename = randomUUID()
+      const uuidFromContent = randomUUID()
+
+      const now = new Date()
+      const pad = (n: number) => String(n).padStart(2, '0')
+      const datePath = path.join(String(now.getFullYear()), pad(now.getMonth() + 1), pad(now.getDate()))
+      const sessionsDir = path.join(workspaceRoot, '.codex', 'sessions', datePath)
+      await fs.mkdir(sessionsDir, { recursive: true })
+      await fs.writeFile(
+        path.join(sessionsDir, rolloutFileNameFor(uuidFromFilename)),
+        JSON.stringify({ type: 'session_meta', timestamp: '2026-07-30T00:00:00Z', payload: { session_id: uuidFromContent, cli_version: '0.144.1', cwd: workspaceRoot } }) + '\n',
+        'utf-8',
+      )
+
+      // "重启后重建的 meta":session_discovery: 'discovered',session_id 是内容里的权威值。
+      const workerDir = path.join(dataDir, workerId)
+      await fs.mkdir(workerDir, { recursive: true })
+      await fs.writeFile(
+        path.join(workerDir, 'meta-1.json'),
+        JSON.stringify({ seq: 1, state: 'idle', session_id: uuidFromContent, session_discovery: 'discovered', workspace_root: workspaceRoot }),
+        'utf-8',
+      )
+
+      // 新 adapter 实例的 runtimes 为空(模拟重启),ensureRuntime 只能从 meta 重建。
+      const { events } = await adapter.readTrace({ worker_id: workerId, seq: 1, impl: 'codex', session_ref: uuidFromContent })
+      expect(events).toHaveLength(1)
+      expect(events[0]).toMatchObject({ kind: 'lifecycle', role: 'system' })
+      expect(events[0].summary).toContain(uuidFromContent)
+    },
+  )
 })
 
 describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter.readTrace(已发现 rollout 路径)', () => {

--- a/crabot-agent/tests/workers/codex-adapter.test.ts
+++ b/crabot-agent/tests/workers/codex-adapter.test.ts
@@ -982,23 +982,47 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter.readTrace(已发现 rollout 
   // payload},timestamp 在信封顶层(不是嵌进 payload 里)。覆盖五种顶层 type 中的
   // session_meta/event_msg/response_item/world_state/turn_context,其中后两种应被
   // readTrace 跳过(不产生事件,但仍计入 nextCursor)。
+  // 按 m2 真机实测(codex-cli 0.144.1)的 rollout 信封结构手写:每行 {type, timestamp,
+  // payload},timestamp 在信封顶层(不是嵌进 payload 里)。覆盖五种顶层 type 中的
+  // session_meta/event_msg/response_item/world_state/turn_context,其中后两种应被
+  // readTrace 跳过(不产生事件,但仍计入 nextCursor)。
   function sampleRolloutJsonl(sessionId: string): string {
     const lines = [
-      { type: 'session_meta', payload: { timestamp: '2026-07-29T01:00:00Z', cwd: workspaceRoot, id: sessionId } },
+      {
+        type: 'session_meta',
+        timestamp: '2026-07-30T01:00:00Z',
+        payload: { session_id: sessionId, cli_version: '0.144.1', cwd: workspaceRoot, model_provider: 'openai', context_window: 200000, originator: 'cli' },
+      },
+      { type: 'turn_context', timestamp: '2026-07-30T01:00:01Z', payload: { model: 'gpt-5.5', effort: 'medium', cwd: workspaceRoot, approval_policy: 'never' } },
       {
         type: 'response_item',
+        timestamp: '2026-07-30T01:00:02Z',
+        payload: { type: 'message', role: 'developer', content: [{ type: 'input_text', text: '你是 crabot 的 worker。' }] },
+      },
+      {
+        type: 'response_item',
+        timestamp: '2026-07-30T01:00:03Z',
         payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: '这个函数为什么会抛 TypeError?' }] },
       },
-      { type: 'response_item', payload: { type: 'function_call', name: 'shell', call_id: 'call_1', arguments: '{"command":["cat","x.ts"]}' } },
-      { type: 'response_item', payload: { type: 'function_call_output', call_id: 'call_1', output: '文件内容摘要' } },
-      { type: 'response_item', payload: { type: 'reasoning', summary: [{ text: '先看文件再判断' }] } },
       {
         type: 'response_item',
+        timestamp: '2026-07-30T01:00:04Z',
+        payload: { type: 'function_call', name: 'shell', call_id: 'call_1', arguments: '{"command":["cat","x.ts"]}' },
+      },
+      { type: 'response_item', timestamp: '2026-07-30T01:00:05Z', payload: { type: 'function_call_output', call_id: 'call_1', output: '文件内容摘要' } },
+      { type: 'response_item', timestamp: '2026-07-30T01:00:06Z', payload: { type: 'reasoning', summary: [{ text: '先看文件再判断' }] } },
+      {
+        type: 'response_item',
+        timestamp: '2026-07-30T01:00:07Z',
         payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: '问题在于第 12 行没有判空。' }] },
       },
-      { type: 'event_msg', payload: { type: 'turn_complete' } },
-      { type: 'turn_context', payload: { model: 'gpt-5.5' } },
-      { type: 'response_item', payload: { type: 'web_search_call', query: 'typescript typeerror' } },
+      {
+        type: 'event_msg',
+        timestamp: '2026-07-30T01:00:08Z',
+        payload: { type: 'turn_complete', turn_id: 'turn_1', started_at: '2026-07-30T01:00:00Z', model_context_window: 200000 },
+      },
+      { type: 'world_state', timestamp: '2026-07-30T01:00:09Z', payload: { full: true, state: {} } },
+      { type: 'response_item', timestamp: '2026-07-30T01:00:10Z', payload: { type: 'web_search_call', query: 'typescript typeerror' } },
     ]
     return lines.map((l) => JSON.stringify(l)).join('\n') + '\nnot valid json{{{\n'
   }
@@ -1028,30 +1052,37 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter.readTrace(已发现 rollout 
     await fs.writeFile(rolloutFile, sampleRolloutJsonl(rolloutUuid), 'utf-8')
 
     const { events, nextCursor } = await adapter.readTrace(h)
-    expect(events).toHaveLength(7)
-    expect(events[0]).toMatchObject({ kind: 'lifecycle', role: 'system' })
-    expect(events[1]).toMatchObject({ kind: 'message', role: 'user' })
-    expect(events[1].summary).toContain('这个函数为什么会抛 TypeError?')
-    expect(events[2]).toMatchObject({ kind: 'tool_call', role: 'assistant' })
-    expect(events[2].summary).toContain('shell')
-    expect(events[3]).toMatchObject({ kind: 'tool_result' })
-    expect(events[3].summary).toContain('文件内容摘要')
-    expect(events[3].role).toBeUndefined()
-    expect(events[4]).toMatchObject({ kind: 'thinking', role: 'assistant' })
-    expect(events[4].summary).toContain('先看文件再判断')
-    expect(events[5]).toMatchObject({ kind: 'message', role: 'assistant' })
-    expect(events[5].summary).toContain('问题在于第 12 行没有判空。')
-    expect(events[6]).toMatchObject({ kind: 'lifecycle', role: 'system', summary: 'turn_complete' })
-    // 原始行数是 10(7 条产生事件 + turn_context/web_search_call 两条未识别子类型跳过 +
-    // 1 条坏 JSON 跳过),nextCursor 必须计入被跳过的行,不能等于 events.length。
-    expect(nextCursor.offset).toBe(10)
+    // 11 行原始数据(session_meta/turn_context/developer msg/user msg/function_call/
+    // function_call_output/reasoning/assistant msg/event_msg/world_state/web_search_call)
+    // + 1 条坏 JSON = 12 行;turn_context/world_state/web_search_call(未识别子类型)/坏
+    // JSON 四条跳过,产生 8 条事件。
+    expect(events).toHaveLength(8)
+    expect(events[0]).toMatchObject({ kind: 'lifecycle', role: 'system', ts: '2026-07-30T01:00:00Z' })
+    expect(events[0].summary).toContain(rolloutUuid)
+    expect(events[0].summary).toContain('0.144.1')
+    // developer role 映射为协议允许的 'system'(NormalizedTraceEvent.role 不含 'developer')。
+    expect(events[1]).toMatchObject({ kind: 'message', role: 'system', ts: '2026-07-30T01:00:02Z' })
+    expect(events[1].summary).toBe('你是 crabot 的 worker。')
+    expect(events[2]).toMatchObject({ kind: 'message', role: 'user' })
+    expect(events[2].summary).toContain('这个函数为什么会抛 TypeError?')
+    expect(events[3]).toMatchObject({ kind: 'tool_call', role: 'assistant' })
+    expect(events[3].summary).toContain('shell')
+    expect(events[4]).toMatchObject({ kind: 'tool_result' })
+    expect(events[4].summary).toContain('文件内容摘要')
+    expect(events[4].role).toBeUndefined()
+    expect(events[5]).toMatchObject({ kind: 'thinking', role: 'assistant' })
+    expect(events[5].summary).toContain('先看文件再判断')
+    expect(events[6]).toMatchObject({ kind: 'message', role: 'assistant' })
+    expect(events[6].summary).toContain('问题在于第 12 行没有判空。')
+    expect(events[7]).toMatchObject({ kind: 'lifecycle', role: 'system', summary: 'turn_complete', ts: '2026-07-30T01:00:08Z' })
+    expect(nextCursor.offset).toBe(12)
 
-    const partial = await adapter.readTrace(h, { offset: 4 })
+    const partial = await adapter.readTrace(h, { offset: 6 })
     expect(partial.events).toHaveLength(3)
     expect(partial.events[0].kind).toBe('thinking')
     expect(partial.events[1].kind).toBe('message')
     expect(partial.events[2].kind).toBe('lifecycle')
-    expect(partial.nextCursor.offset).toBe(10)
+    expect(partial.nextCursor.offset).toBe(12)
 
     await adapter.kill(h)
   }, 15000)

--- a/crabot-agent/tests/workers/codex-adapter.test.ts
+++ b/crabot-agent/tests/workers/codex-adapter.test.ts
@@ -346,6 +346,42 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter (tmux + mock CLI)', () => {
   )
 
   it(
+    'session 发现:rollout 文件内容里的 session_meta.payload.session_id 优先于文件名解析出的 uuid(实测更权威,见 adapter.ts 头注释)',
+    async () => {
+      // 不用 provisionedAdapter 的 withRollout(mock CLI 自己落的 rollout 文件内容里没有
+      // session_id 字段,只用来验证文件名兜底路径)——这里手动在发现窗口内把一个"文件名嵌
+      // uuidA、内容 session_meta.payload.session_id 却是 uuidB"的 rollout 文件放进
+      // sessions 目录,模拟真实 codex 落盘的权威内容,验证 adapter 采信内容而不是文件名。
+      const { adapter, workerId } = await provisionedAdapter([{ output: '第一段输出', emitStop: true }])
+      const uuidFromFilename = randomUUID()
+      const uuidFromContent = randomUUID()
+
+      const spawnPromise = adapter.spawn(makeSpec(workerId, '你好'))
+
+      const now = new Date()
+      const pad = (n: number) => String(n).padStart(2, '0')
+      const datePath = path.join(String(now.getFullYear()), pad(now.getMonth() + 1), pad(now.getDate()))
+      const sessionsDir = path.join(workspaceRoot, '.codex', 'sessions', datePath)
+      await fs.mkdir(sessionsDir, { recursive: true })
+      await fs.writeFile(
+        path.join(sessionsDir, rolloutFileNameFor(uuidFromFilename)),
+        JSON.stringify({ type: 'session_meta', payload: { session_id: uuidFromContent, timestamp: new Date().toISOString(), cwd: workspaceRoot } }) + '\n',
+        'utf-8',
+      )
+
+      const h = await spawnPromise
+      await waitForState(adapter, h, 'idle')
+
+      const meta = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8')) as { session_id: string; session_discovery?: string }
+      expect(meta.session_id).toBe(uuidFromContent)
+      expect(meta.session_id).not.toBe(uuidFromFilename)
+      expect(meta.session_discovery).toBe('discovered')
+      expect(h.session_ref).toBe(uuidFromContent)
+    },
+    15000,
+  )
+
+  it(
     'session 发现:轮询超时降级时输出 console.warn 日志',
     async () => {
       const { adapter, workerId } = await provisionedAdapter([{ output: '第一段输出', emitStop: true }])
@@ -386,6 +422,58 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter (tmux + mock CLI)', () => {
       ).rejects.toThrow(/already resumed/)
 
       await adapter.kill(h2)
+    },
+    15000,
+  )
+
+  it(
+    'spawn 命令行携带 --skip-git-repo-check(m2 实测:worker workspace 非受信目录会报 "Not inside a trusted directory")',
+    async () => {
+      const channel = new CliEventChannel(eventsFilePath({ root: workspaceRoot }))
+      const stopHookCmd = channel.hookCommand('stop')
+      const argvFile = path.join(dataDir, 'spawn-argv.jsonl')
+      const codexBin = codexBinFor([{ output: '第一段输出', emitStop: true }], stopHookCmd, { argvFile })
+      const adapter = new CodexWorkerAdapter({ dataDir, tmux, codexBin, sessionDiscoveryTimeoutMs: 500 })
+      await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
+      const workerId = `codextest-${randomUUID().slice(0, 8)}`
+      const h = await adapter.spawn({ worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } })
+      await waitForState(adapter, h, 'idle')
+
+      const argv: string[] = JSON.parse((await fs.readFile(argvFile, 'utf-8')).trim().split('\n')[0])
+      expect(argv).toContain('--skip-git-repo-check')
+
+      await adapter.kill(h)
+    },
+    15000,
+  )
+
+  it(
+    'resume 命令行把 --skip-git-repo-check/--ask-for-approval/--sandbox 放在 resume 子命令之前(放后面 codex 报 usage 错、exit=2,m2 实测)',
+    async () => {
+      const channel = new CliEventChannel(eventsFilePath({ root: workspaceRoot }))
+      const stopHookCmd = channel.hookCommand('stop')
+      const argvFile = path.join(dataDir, 'resume-argv.jsonl')
+      const codexBin = codexBinFor([{ output: '主线输出', exit: true }], stopHookCmd, { argvFile })
+      const adapter = new CodexWorkerAdapter({ dataDir, tmux, codexBin, sessionDiscoveryTimeoutMs: 500 })
+      await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
+      const workerId = `codextest-${randomUUID().slice(0, 8)}`
+      const h1 = await adapter.spawn({ worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } })
+      await waitForState(adapter, h1, 'exited')
+
+      const meta1 = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8')) as { session_id: string }
+      const h2 = await adapter.resume({ worker_id: workerId, seq: 1, session_ref: meta1.session_id }, '继续')
+      await waitForState(adapter, h2, 'exited')
+
+      const lines = (await fs.readFile(argvFile, 'utf-8')).trim().split('\n')
+      // 第一行是 spawn 主线的 argv,第二行才是 resume 触发的调用。
+      const argv: string[] = JSON.parse(lines[1])
+      const resumeIdx = argv.indexOf('resume')
+      expect(resumeIdx).toBeGreaterThan(-1)
+      for (const flag of ['--skip-git-repo-check', '--ask-for-approval', '--sandbox']) {
+        const idx = argv.indexOf(flag)
+        expect(idx).toBeGreaterThan(-1)
+        expect(idx).toBeLessThan(resumeIdx)
+      }
     },
     15000,
   )
@@ -624,6 +712,41 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter — spawn 提交纪律', () 
     },
     15000,
   )
+
+  it(
+    'spawn/resume 经 tmux 拉起子进程时,PATH 前置了 codexBin 解析出的真实目录(nvm 部署陷阱:tmux server 自身环境可能解析不到 codex 的 node,m2 实测踩到 "env: node: No such file or directory")',
+    async () => {
+      class RecordingTmuxDriver extends TmuxDriver {
+        lastEnv?: Record<string, string>
+        async newSession(spec: TmuxSessionSpec): Promise<void> {
+          this.lastEnv = spec.env
+          return super.newSession(spec)
+        }
+      }
+      const toolDir = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-adapter-pathcheck-'))
+      const codexPath = path.join(toolDir, 'codex')
+      // 内容不重要——tmux new-session 本身不校验命令是否存在/能跑,只要 resolveBinDir 能
+      // fs.realpath 出这个文件即可,这里放个立即退出的 sh 脚本。
+      await fs.writeFile(codexPath, '#!/bin/sh\nexit 0\n', { mode: 0o755 })
+
+      const tmux = new RecordingTmuxDriver()
+      const adapter = new CodexWorkerAdapter({ dataDir, tmux, codexBin: codexPath, sessionDiscoveryTimeoutMs: 200 })
+      await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
+      const workerId = `codextest-${randomUUID().slice(0, 8)}`
+      const spec: SpawnSpec = { worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } }
+
+      // 会话内的假 codex 立即退出,首条 sendText 大概率落空(会话已死)——只关心 newSession
+      // 拿到的 env,spawn 本身是否 reject 不是这条用例的断言点。
+      await adapter.spawn(spec).catch(() => {})
+
+      expect(tmux.lastEnv).toBeDefined()
+      expect(tmux.lastEnv!.PATH).toBe(`${toolDir}:${process.env.PATH ?? ''}`)
+      expect(tmux.lastEnv!.CODEX_HOME).toBe(path.join(workspaceRoot, '.codex'))
+
+      await fs.rm(toolDir, { recursive: true, force: true }).catch(() => {})
+    },
+    15000,
+  )
 })
 
 describe('CodexWorkerAdapter.detect', () => {
@@ -644,7 +767,7 @@ describe('CodexWorkerAdapter.detect', () => {
     return `env FAKE_CODEX_VERSION=${shQuote(version)} node ${shQuote(FAKE_CODEX_VERSION)}`
   }
 
-  it('codex 二进制不存在/不可执行 → installed:false, activated:false', async () => {
+  it('codex 二进制不存在/不可执行 → installed:false, activated:false, detail 说"没装"', async () => {
     const adapter = new CodexWorkerAdapter({
       dataDir,
       codexBin: '/nonexistent/codex-bin-does-not-exist-crabot-test',
@@ -652,7 +775,29 @@ describe('CodexWorkerAdapter.detect', () => {
     const result = await adapter.detect()
     expect(result.installed).toBe(false)
     expect(result.activated).toBe(false)
+    expect(result.detail).toContain('not found')
   })
+
+  it(
+    'codex 二进制存在但执行失败(如 shebang 解释器不可解析,nvm 部署形态的常见故障)→ detail 区分"装了但跑不起来",不是"没装"',
+    async () => {
+      const brokenBinDir = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-adapter-broken-bin-'))
+      const brokenBin = path.join(brokenBinDir, 'codex')
+      await fs.writeFile(brokenBin, '#!/nonexistent-interpreter-xyz-crabot-test\necho hi\n', { mode: 0o755 })
+
+      const adapter = new CodexWorkerAdapter({ dataDir, codexBin: brokenBin })
+      const result = await adapter.detect()
+      expect(result.installed).toBe(false)
+      expect(result.activated).toBe(false)
+      // 区分点在消息前缀,不是"是否含 not found"——底层 shell 报错本身可能也含这个短语
+      // (如 dash 对坏 shebang 报 "not found" 而不是 bash 的 "bad interpreter"),不能拿它
+      // 当区分依据。
+      expect(result.detail).toMatch(/^codex binary found at .+ but failed to execute/)
+      expect(result.detail).toMatch(/node interpreter|unresolved/i)
+
+      await fs.rm(brokenBinDir, { recursive: true, force: true }).catch(() => {})
+    },
+  )
 
   it('codex 已安装且 codexHomeSource 下有 auth.json → installed:true, activated:true', async () => {
     await fs.writeFile(path.join(home, 'auth.json'), '{}', 'utf-8')
@@ -833,6 +978,10 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter.readTrace(已发现 rollout 
     await fs.rm(workspaceRoot, { recursive: true, force: true }).catch(() => {})
   })
 
+  // 按 m2 真机实测(codex-cli 0.144.1)的 rollout 信封结构手写:每行 {type, timestamp,
+  // payload},timestamp 在信封顶层(不是嵌进 payload 里)。覆盖五种顶层 type 中的
+  // session_meta/event_msg/response_item/world_state/turn_context,其中后两种应被
+  // readTrace 跳过(不产生事件,但仍计入 nextCursor)。
   function sampleRolloutJsonl(sessionId: string): string {
     const lines = [
       { type: 'session_meta', payload: { timestamp: '2026-07-29T01:00:00Z', cwd: workspaceRoot, id: sessionId } },

--- a/crabot-agent/tests/workers/codex-adapter.test.ts
+++ b/crabot-agent/tests/workers/codex-adapter.test.ts
@@ -149,6 +149,18 @@ describe('CodexWorkerAdapter.provision', () => {
     await expect(adapter.provision({ root: ws }, { skills: [], mcp_servers: [] })).resolves.toBeUndefined()
     await expect(fs.access(path.join(ws, '.codex/auth.json'))).rejects.toThrow()
   })
+
+  it('provision 把 workspace 写成受信任目录(config.toml 的 [projects."<realpath>"] trust_level = "trusted",替代不存在的 --skip-git-repo-check flag)', async () => {
+    const adapter = new CodexWorkerAdapter({ dataDir: ws, codexHomeSource })
+    await adapter.provision({ root: ws }, { skills: [], mcp_servers: [] })
+
+    const realRoot = await fs.realpath(ws)
+    const configToml = await fs.readFile(path.join(ws, '.codex/config.toml'), 'utf-8')
+    expect(configToml).toContain(`[projects."${realRoot}"]`)
+    expect(configToml).toContain('trust_level = "trusted"')
+    // TOML 根级 key(notify)必须出现在 [projects...] 表头之前。
+    expect(configToml.indexOf('notify =')).toBeLessThan(configToml.indexOf('[projects.'))
+  })
 })
 
 describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter (tmux + mock CLI)', () => {
@@ -427,7 +439,7 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter (tmux + mock CLI)', () => {
   )
 
   it(
-    'spawn 命令行携带 --skip-git-repo-check(m2 实测:worker workspace 非受信目录会报 "Not inside a trusted directory")',
+    'spawn 命令行不携带 --skip-git-repo-check(该 flag 只注册在 codex exec 子解析器上,m2 实测顶层交互式 codex 没有这个 Option,传了会被 clap usage 错误拒绝),--ask-for-approval/--sandbox 取值合法',
     async () => {
       const channel = new CliEventChannel(eventsFilePath({ root: workspaceRoot }))
       const stopHookCmd = channel.hookCommand('stop')
@@ -440,7 +452,13 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter (tmux + mock CLI)', () => {
       await waitForState(adapter, h, 'idle')
 
       const argv: string[] = JSON.parse((await fs.readFile(argvFile, 'utf-8')).trim().split('\n')[0])
-      expect(argv).toContain('--skip-git-repo-check')
+      expect(argv).not.toContain('--skip-git-repo-check')
+      const approvalIdx = argv.indexOf('--ask-for-approval')
+      expect(approvalIdx).toBeGreaterThan(-1)
+      expect(argv[approvalIdx + 1]).toBe('never')
+      const sandboxIdx = argv.indexOf('--sandbox')
+      expect(sandboxIdx).toBeGreaterThan(-1)
+      expect(['read-only', 'workspace-write', 'danger-full-access']).toContain(argv[sandboxIdx + 1])
 
       await adapter.kill(h)
     },
@@ -448,7 +466,7 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter (tmux + mock CLI)', () => {
   )
 
   it(
-    'resume 命令行把 --skip-git-repo-check/--ask-for-approval/--sandbox 放在 resume 子命令之前(放后面 codex 报 usage 错、exit=2,m2 实测)',
+    'resume 命令行不携带 --skip-git-repo-check,--ask-for-approval/--sandbox 放在 resume 子命令之前(放后面 codex 报 usage 错、exit=2,m2 实测)',
     async () => {
       const channel = new CliEventChannel(eventsFilePath({ root: workspaceRoot }))
       const stopHookCmd = channel.hookCommand('stop')
@@ -467,9 +485,10 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter (tmux + mock CLI)', () => {
       const lines = (await fs.readFile(argvFile, 'utf-8')).trim().split('\n')
       // 第一行是 spawn 主线的 argv,第二行才是 resume 触发的调用。
       const argv: string[] = JSON.parse(lines[1])
+      expect(argv).not.toContain('--skip-git-repo-check')
       const resumeIdx = argv.indexOf('resume')
       expect(resumeIdx).toBeGreaterThan(-1)
-      for (const flag of ['--skip-git-repo-check', '--ask-for-approval', '--sandbox']) {
+      for (const flag of ['--ask-for-approval', '--sandbox']) {
         const idx = argv.indexOf(flag)
         expect(idx).toBeGreaterThan(-1)
         expect(idx).toBeLessThan(resumeIdx)
@@ -978,10 +997,6 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter.readTrace(已发现 rollout 
     await fs.rm(workspaceRoot, { recursive: true, force: true }).catch(() => {})
   })
 
-  // 按 m2 真机实测(codex-cli 0.144.1)的 rollout 信封结构手写:每行 {type, timestamp,
-  // payload},timestamp 在信封顶层(不是嵌进 payload 里)。覆盖五种顶层 type 中的
-  // session_meta/event_msg/response_item/world_state/turn_context,其中后两种应被
-  // readTrace 跳过(不产生事件,但仍计入 nextCursor)。
   // 按 m2 真机实测(codex-cli 0.144.1)的 rollout 信封结构手写:每行 {type, timestamp,
   // payload},timestamp 在信封顶层(不是嵌进 payload 里)。覆盖五种顶层 type 中的
   // session_meta/event_msg/response_item/world_state/turn_context,其中后两种应被


### PR DESCRIPTION
## 概述

P2 的 codex adapter 此前是"照文档/源码实现",留了 8 项待真机校准。本次在部署机 **m2** 上用**隔离 `CODEX_HOME` 探针**实测 codex-cli **0.144.1**,据实修正 adapter。探针不动生产实例、不改用户 `~/.codex`,目录已全部清理。

## 修复四项

1. **session 发现优先信内容**:找到候选 rollout 后先读首行 `session_meta.payload.session_id`(权威),文件名解析退为兜底;
2. **nvm 部署陷阱**(实测踩到):codex 常是 nvm 装的 node 脚本(shebang `env node`),adapter 经 tmux 拉起时若 env 不含其 node 的 bin 目录,必报 `env: node: No such file or directory`。改为解析 `codexBin` 真实路径并把所在目录前置进 PATH(通用,不硬编码 nvm);`detect()` 区分"没装"与"装了但 node 不可解析";
3. **交互态命令参数校正**:不再传 `--skip-git-repo-check`(**顶层 `codex` 不支持,它只在 `exec` 子解析器**),`-s/-a` 置于 `resume` 之前;"受信目录"改用 config.toml 的 `[projects."<realpath>"] trust_level = "trusted"`;
4. **readTrace 按真实 rollout 结构校准**:统一信封 `{type,timestamp,payload}`,五类 type;消息在 `response_item` 按 `payload.role` 分(assistant `output_text` / user `input_text`),`developer` 映射为 `system`;`ts` 取信封顶层 `timestamp`。fixture 用真实字段名。

## 两次自我纠错(过程记录,值得看)

- **中途引入过一个会打挂真机的回归**:把 `codex exec` 路径的实测结论套用到交互式顶层命令,给 spawn/resume 加了顶层不存在的 flag——真机会 100% usage 错误退出。评审拦下后回 m2 用 `--help` 确证顶层选项全清单(`-c/-i/-m/-p/-s/-C/-a/-h/-V`),改正并改用 trust_level 授信;
- **曾误报"P2 fork 判错了"**:看到 `codex fork` 子命令存在就下结论,实测证明 `exec resume` 无论加不加 `--ephemeral` 都续写原会话(rollout 持续增长、总数不变),codex 确无 headless fork——`capabilities().fork = false` 原本就对,协议无需改。

## 协议

§6.1 新增已知限制:codex 的 session 发现是限时轮询,超时退化为占位 id 会使该化身的 `resume`/`readTrace` 不可用(crabot-docs 1e520f7)。

## 验证

tests/workers **349** 用例全绿;`tsc --noEmit` 干净;无 tmux/`/tmp` 残留。argv 断言用真实 `process.argv` 捕获(非拼串);provision 产物经 `tomllib` 实测可解析(含空格/引号/中文路径)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)