### PR TITLE
feat: Manager/Worker 拆分 P5——Scheduler 路由与 Admin 读代理

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,6 +1,18 @@
 # Crabot 项目进度
 
-> 最后更新：2026-07-30 — Manager/Worker 拆分 P4：manager loop（分支 feat/mw-p4-manager-loop，未合并 main）
+> 最后更新：2026-07-31 — Manager/Worker 拆分 P5：scheduler 路由与 Admin 读代理（分支 feat/mw-p5-scheduler-readmodel，未合并 main）
+
+## 2026-07-31 — Manager/Worker 拆分 P5：scheduler 路由与 Admin 只读代理（生产链路仍未切换）
+
+- 计划：`crabot-docs/superpowers/plans/2026-07-31-mw-p5-scheduler-readmodel.md`。交付 protocol-agent-v3 §8.2/§8.3/§9.2/§10.3：agent 侧 `trigger_schedule` + 读模型四件套 RPC、`agent.task_status_changed` 事件、manager 栈的**生产装配点**；admin 侧只**新增** `/api/agent/workers*` 四个只读 REST 端点。
+- **与 roadmap 的一处有意偏离**：roadmap P5 原写"admin 侧改调用点"，本阶段**不改**——切过去会让 scheduled 任务走 manager 而人类消息仍走 dispatcher，构成 spec 明确排除的混合运行态，且 P7 两个阻塞项会在这条路上产生用户可见错误。调用点切换与 SYSTEM_SESSION 哨兵退役一并移入 P7 cutover。
+- 六个 task：① `manager/bootstrap.ts` 栈装配（严格照 harness 四步接线契约，O(1) 纯构造、启动路径不探测子进程/不扫盘）；② `manager/events.ts` 对外事件（harness 化身级事件 → 任务级事件的翻译与去重）；③ `manager/read-model.ts` 读模型纯逻辑（过滤/排序/分页，`updated_at desc` + `worker_id asc` 兜底，越界返空不报错）；④ `unified-agent.ts` 五个 RPC handler（`trigger_schedule` 写成同步方法，"受理即返回"体现在签名上；权限身份经 WakeEvent 下传到 `origin.creator_friend_id`）；⑤ admin 先抽 `proxyAgentRpc` 样板再加四个端点（抽之前先写 11 条特征化用例钉住既有 4 个 `/api/agent/*`）；⑥ 启动接线 + 集成测试 + 零现网影响自证。
+- **评审拦下并根治的一个缺陷**：事件发布方原来现读台账取 `new_status`，而 `LedgerStore.findWorker` 不进互斥锁——读晚于下一次落账就把中间状态整条吞掉，PoC 里终态 `completed` 一次都没发出去（cutover 后表现为"任务永远显示 running"）。根治 = `HarnessEvent` 自带落账后的 `task_status`（23 个调用点逐个分类：8 个 task 级迁移点带、15 个化身级/纯记录点不带），缺字段退回现读台账而不是跳过（跳过会把"缺字段"变成新的静默丢事件路径）。
+- 启动接线的三个决定（Task 6）：装配放**构造函数**（RPC 一旦注册，取件口就必须就绪）；启动对账放 `onStart()` 里**不 await**、失败仅 warn（对账要逐个问 adapter 化身死活，会起子进程，启动不能挂在它上面；空台账开销 = 一次 ENOENT readdir + 一次 `mkdir -p ledgers` + 一次空 readdir）；LLM 解析放 thunk 里（§11 `manager ?? powerful`）——**现网此刻并没有配 manager slot，放装配期解析会让 agent 直接起不来**，放 thunk 最坏只是某次路由在 episode 内抛错被 catch，读模型四件套照常可用。
+- **P7 cutover 前必须补的四项**（前两项 P4 已记，后两项 P5 新增）：① `processStateChange` 对自然结束硬编码 `endReason='completed'`，失败 worker 的 `task.status` 失真，读模型的 status 在修掉前不可信；② `spawn_worker` 不传 `SpawnSpec.builtin`，而 bootstrap 的 `defaultImpl='builtin'`，manager 第一次走缺省派工必挂；③ `dialogObjectIdFor` 目前一律派生成 `group:<channel>:<session>`——私聊按 `friend:<id>` 跨 channel 聚合需要 admin 的 friend 解析，而该依赖是同步签名、agent 侧唯一知情处是入站链路（P5 明令零改动）；④ admin 调用点切到 `trigger_schedule` 时，`last_task_id` 与 `admin.schedule_triggered` 载荷需改造（`{accepted:true}` 不回 task_id）。
+- **零现网影响自证**（逐条实证，非"看起来干净"）：`unified-agent.ts` 相对 base 只有一行删除（`data-paths` 那行 import 加了个 `getDataRootDir`），`handleMessageReceived`/`processDirectBatch`/`processGroupLaneBatch`/`handleProcessMessage` 四个入站函数体与 base **逐字节相同**；`crab-messaging.ts`/`agent-handler.ts`/`engine/**`/`orchestration/**`/`dispatcher/**` 零改动；admin 的 `upsertTask`/`applyStatusTransition`/`runReconciliation`/`handleCancelTask` 函数体逐字节相同（只多了 JSDoc 弃用注记）；admin scheduler 调用点仍是 `create_task_from_schedule`，全仓无任何生产调用方引用 `trigger_schedule`。
+- **一条不能回避的坦白**：对入站链路做的变异（改坏群聊分流、改坏 batch 合并）**全量测试一条都没抓到**——`unified-agent.ts` 的入站链路目前几乎没有直接单测（`tests/agent/unified-loop-private.test.ts` 只断言方法存在）。所以"入站链路未受影响"这个结论**只由 diff 证据支撑，不由测试支撑**；P7 cutover 真要改这条链路时，必须先补覆盖。
+- 验证：`crabot-agent` 196 files / 2216 passed | 2 skipped（基线 2209 + 本次集成 8 - 1 已知 flaky `bg-entities/trace.test.ts`，单跑 50 全绿）；`crabot-admin` 122 files / 1068 tests 全绿；两侧 `tsc --noEmit` 干净；`tmux ls` 无新增会话、`/tmp` 无残留。
 
 ## 2026-07-30 — Manager/Worker 拆分 P4：manager loop（纯新增未激活）
 
@@ -29,18 +41,13 @@
 - 评审沉淀（10 个 task + 全分支终审，多轮 PoC 实证）：fork 化身劫持主线、drain 与 in-flight 双投、workspace 软链绕过、revive 不回填旧化身终态、handoff 死结、主线守卫漏 impl、kill 与 in-flight 竞态复活 cancelled——均已修复并有回归测试；顺带修掉 cc/codex `state()` 无 runtime 时不探活（曾使"tmux worker 存活→重连接管"对 CLI worker 失效）。
 - 已知限制（入协议或执行记录）：化身 seq 非跨实例全局唯一（(impl,seq) 末条匹配已缓解）、`isAlive=true` 时 state 精度限于 meta 快照、tsconfig 排除 tests 致测试从未被类型检查（另开小 PR）。
 
-## 2026-07-29 — Manager/Worker 拆分 P2：tmux 驱动与外部 CLI adapter
+## 2026-07-29 — Manager/Worker 拆分 P1 + P2（均已合并，PR #47 / #48）
 
-- P1（PR #47）当日四轮 auto review 后合并。P2 交付（纯新增未激活）：tmux 驱动层（new-session+pipe-pane 批处理防首输出竞态、send-keys -l 防键名解释）、CLI hook 事件文件通道（纯 POSIX printf 追加 + fs.watch/轮询,无 HTTP 端点）、provision 物化基建（skill 复制/mcp 双格式渲染含 TOML quoted-key/自述文件）、claude-code adapter（--session-id 预知 session_ref、Stop hook 通知、无头 -p --fork-session 侧问、readTrace 解析 projects JSONL）、codex adapter（文档语义实现：CODEX_HOME 隔离、rollout 文件名 session 发现、fork 定案不支持 [openai/codex#11750/#17568]）、契约套件复跑（cc/codex 各 10 例,mock CLI 走真实 tmux）。tests/workers 163 用例。
-- 评审沉淀：P1 锁纪律在 cc adapter 的两处回归被抓（syncState 全段入锁、spawn 提交后置）；安全审查修 session_ref 注入（UUID 边界校验+shQuote 双层）；codex auth.json 0600+gitignore。
-- 已知限制：本机无 codex,其 adapter 待真机校准（8 项清单见执行记录）；协议已同步修正（codex fork=false、通知为事件文件通道,crabot-docs 5e95b20）。
+> 已被 P3–P5 覆盖，压缩保留；细节见 `crabot-docs/superpowers/plans/2026-07-28-manager-worker-split-roadmap.md` 与同目录执行记录。
 
-## 2026-07-29 — Manager/Worker 拆分 P1：worker 契约与内置 adapter
-
-- 背景：manager/worker 双 agent 拆分立项。总体架构 spec `crabot-docs/superpowers/specs/2026-07-28-manager-worker-agent-split-design.md` 已确认；协议落地 protocol-agent-v3（v2 标记 Superseded，admin task 域退役为读模型，TaskStatus 精简，crab-messaging 收窄为 manager 持有）；实施路线图 P1–P8 见 `crabot-docs/superpowers/plans/2026-07-28-manager-worker-split-roadmap.md`。
-- P1 交付（本 PR，纯新增未激活，现网零影响）：`crabot-agent/src/workers/` —— 契约类型（与 protocol-agent-v3 §3/§6.1 逐字对齐）、append-only session 树（任意节点分支，取代 ResumeCheckpoint 的方向）、OutputLog 游标增量读（UTF-8 边界安全）、builtin adapter（burst 状态机：spawn/sendInput/resume/fork/kill/scanOrphans，per-worker 互斥）、可复用契约一致性套件（P2 的 claude-code/codex adapter 直接复跑）。tests/workers 47 用例。
-- 评审沉淀：四轮并发竞态修复（sendInput 双发、收尾窗口、catch 锁外判死、kill 交接窗口 killRequested 闭环）；burst 显式 disableCompaction（压缩与 session 树协同留 P7）；resume 幂等提交次序（append→writeMeta→注册+标记）。
-- 待办：P2（tmux 驱动 + claude-code/codex adapter）起手前先写细化 plan；终审裁决"留"的 Minor 清单见 roadmap 同目录执行记录。
+- 立项背景：架构 spec `crabot-docs/superpowers/specs/2026-07-28-manager-worker-agent-split-design.md`；协议落地 protocol-agent-v3（v2 标记 Superseded，admin task 域退役为读模型，TaskStatus 精简，crab-messaging 收窄为 manager 持有）。
+- P1（纯新增未激活，47 用例）：`crabot-agent/src/workers/` worker 契约类型、append-only session 树（取代 ResumeCheckpoint 方向）、OutputLog 游标增量读、builtin adapter burst 状态机、可复用契约一致性套件。评审沉淀：四轮并发竞态修复 + resume 幂等提交次序。
+- P2（纯新增未激活，163 用例）：tmux 驱动层、CLI hook 事件文件通道（纯 POSIX printf + fs.watch，无 HTTP 端点）、provision 物化基建、claude-code adapter、codex adapter。评审沉淀：cc adapter 两处锁纪律回归、session_ref 注入（UUID 校验 + shQuote 双层）、codex auth.json 0600。codex adapter 的真机校准见 2026-07-30 条目。
 
 ## 2026-07-27 — 任务终态与 worker 生命周期对齐（issue #43 下半）
 

--- a/crabot-admin/src/admin-web-api.test.ts
+++ b/crabot-admin/src/admin-web-api.test.ts
@@ -1775,7 +1775,16 @@ describe('Admin Web API', () => {
       expect(response.body.error).toBe('Worker not found: w-404')
     })
 
-    it('GET /api/agent/workers/:id/output → read_worker_output_admin（seq 必填、cursor 可选）', async () => {
+    /**
+     * `?seq=` 缺省时**不下发该字段**（与 cursor 同一纪律）：化身 seq 从 1 起编号，admin 侧
+     * 任何硬编码缺省都是错的——0 在台账里恒不存在（agent 侧 findIncarnationBySeq 抛错 → 500），
+     * 1 则锁死在最早那个化身上（worker 经 revive/handoff 后主线早已不是它）。唯一正确的缺省
+     * 是"主线化身"，只有持台账的 agent 侧算得出来。
+     *
+     * 这两条只钉住"admin 转发的载荷长什么样"；"这个载荷打到真实 agent 上确实读到主线化身"
+     * 由 crabot-agent `tests/manager/p5-integration.test.ts` 经真实 RPC + 真实台账验证。
+     */
+    it('GET /api/agent/workers/:id/output → read_worker_output_admin（seq 缺省不下发，由 agent 取主线化身）', async () => {
       const token = await loginAndGetToken()
       const spy = spyAgentRpc().mockResolvedValue({ chunk: 'hello', next_cursor: '133', eof: false })
 
@@ -1790,10 +1799,17 @@ describe('Admin Web API', () => {
       expect(spy).toHaveBeenCalledWith('read_worker_output_admin', { worker_id: 'w-1', seq: 2, cursor: '128' })
 
       await makeWebRequest(TEST_WEB_PORT, '/api/agent/workers/w-1/output', 'GET', null, token)
-      expect(spy).toHaveBeenLastCalledWith('read_worker_output_admin', { worker_id: 'w-1', seq: 0 })
+      expect(spy).toHaveBeenLastCalledWith('read_worker_output_admin', { worker_id: 'w-1' })
+      // toHaveBeenCalledWith 把 `{ seq: undefined }` 视同缺席，这里显式钉住 key 真的不在载荷里。
+      expect('seq' in (spy.mock.lastCall![1] as object)).toBe(false)
+
+      // 脏值同样不下发（不回落成某个具体化身），与 list 端点"脏分页 → 回落默认值"的区别在于
+      // seq 根本没有安全的默认值可回落。
+      await makeWebRequest(TEST_WEB_PORT, '/api/agent/workers/w-1/output?seq=abc', 'GET', null, token)
+      expect(spy).toHaveBeenLastCalledWith('read_worker_output_admin', { worker_id: 'w-1' })
     })
 
-    it('GET /api/agent/workers/:id/trace → get_worker_trace（seq 必填、cursor 可选）', async () => {
+    it('GET /api/agent/workers/:id/trace → get_worker_trace（seq 缺省不下发，由 agent 取主线化身）', async () => {
       const token = await loginAndGetToken()
       const spy = spyAgentRpc().mockResolvedValue({ events: [], next_cursor: '0' })
 
@@ -1808,7 +1824,8 @@ describe('Admin Web API', () => {
       expect(spy).toHaveBeenCalledWith('get_worker_trace', { worker_id: 'w-1', seq: 1, cursor: '3' })
 
       await makeWebRequest(TEST_WEB_PORT, '/api/agent/workers/w-1/trace', 'GET', null, token)
-      expect(spy).toHaveBeenLastCalledWith('get_worker_trace', { worker_id: 'w-1', seq: 0 })
+      expect(spy).toHaveBeenLastCalledWith('get_worker_trace', { worker_id: 'w-1' })
+      expect('seq' in (spy.mock.lastCall![1] as object)).toBe(false)
     })
 
     it('GET /api/agent/workers/:id/trace：worker 不存在 → 404', async () => {

--- a/crabot-admin/src/admin-web-api.test.ts
+++ b/crabot-admin/src/admin-web-api.test.ts
@@ -1759,20 +1759,49 @@ describe('Admin Web API', () => {
       expect(spy).toHaveBeenCalledWith('get_worker_detail', { worker_id: 'w-1' })
     })
 
-    it('GET /api/agent/workers/:id：worker 不存在 → 404', async () => {
+    /**
+     * 三个按 worker_id 读的端点对**同一个**不存在的 id 必须给同一个状态码——P6 前端要靠状态码
+     * 区分"worker 不存在"与"agent 侧真错"。
+     *
+     * agent 侧两条路径的文案大小写**不一致**（下表 message 列逐字取自 agent 源码）：
+     * detail/trace 由 `unified-agent.ts` 的 handler 显式抛（大写 W），output 由
+     * `harness.ts` 的 `WorkerNotFoundError` 抛（小写 w）。修复前 output 端点匹配不上
+     * `'Worker not found'` → 落 500。故三处共用同一个大小写无关的谓词。
+     */
+    it.each([
+      ['/api/agent/workers/w-404', 'Worker not found: w-404'],
+      ['/api/agent/workers/w-404/trace', 'Worker not found: w-404'],
+      ['/api/agent/workers/w-404/output', 'worker not found: w-404'],
+    ])('GET %s：worker 不存在 → 404（agent 侧文案 %s）', async (path, agentMessage) => {
       const token = await loginAndGetToken()
-      spyAgentRpc().mockRejectedValue(new Error('Worker not found: w-404'))
+      spyAgentRpc().mockRejectedValue(new Error(agentMessage))
 
-      const response = await makeWebRequest<{ error: string }>(
-        TEST_WEB_PORT,
-        '/api/agent/workers/w-404',
-        'GET',
-        null,
-        token,
-      )
+      const response = await makeWebRequest<{ error: string }>(TEST_WEB_PORT, path, 'GET', null, token)
 
       expect(response.statusCode).toBe(404)
-      expect(response.body.error).toBe('Worker not found: w-404')
+      expect(response.body.error).toBe(agentMessage)
+    })
+
+    /**
+     * 谓词只认"worker 不存在"，agent 侧其它真错仍是 500——否则前端会把"这个化身不存在"
+     * 或"这个 agent build 还没有这个方法"当成"这个 worker 不存在"。三条 message 都逐字取自
+     * 源码：前两条来自 `harness.readWorkerOutput` / `handleGetWorkerTrace` 的 seq 校验，
+     * 第三条来自 crabot-core 的 JSON-RPC 分发（未注册方法，滚动升级期真实可达；由
+     * `reject(new Error(response.error.message))` 原样送到这里）。
+     * 它们都含 "not found" 却不含 "worker not found"——谓词故意不放宽到前者。
+     */
+    it.each([
+      ['/api/agent/workers/w-1/output?seq=9', 'WorkerHarness.readWorkerOutput: no incarnation with seq=9 found for worker w-1'],
+      ['/api/agent/workers/w-1/trace?seq=9', 'get_worker_trace: no incarnation with seq=9 found for worker w-1'],
+      ['/api/agent/workers/w-1/output', 'Method "read_worker_output_admin" not found'],
+    ])('GET %s：不是 worker 不存在 → 500', async (path, agentMessage) => {
+      const token = await loginAndGetToken()
+      spyAgentRpc().mockRejectedValue(new Error(agentMessage))
+
+      const response = await makeWebRequest<{ error: string }>(TEST_WEB_PORT, path, 'GET', null, token)
+
+      expect(response.statusCode).toBe(500)
+      expect(response.body.error).toBe(agentMessage)
     })
 
     /**
@@ -1826,22 +1855,6 @@ describe('Admin Web API', () => {
       await makeWebRequest(TEST_WEB_PORT, '/api/agent/workers/w-1/trace', 'GET', null, token)
       expect(spy).toHaveBeenLastCalledWith('get_worker_trace', { worker_id: 'w-1' })
       expect('seq' in (spy.mock.lastCall![1] as object)).toBe(false)
-    })
-
-    it('GET /api/agent/workers/:id/trace：worker 不存在 → 404', async () => {
-      const token = await loginAndGetToken()
-      spyAgentRpc().mockRejectedValue(new Error('Worker not found: w-404'))
-
-      const response = await makeWebRequest<{ error: string }>(
-        TEST_WEB_PORT,
-        '/api/agent/workers/w-404/trace',
-        'GET',
-        null,
-        token,
-      )
-
-      expect(response.statusCode).toBe(404)
-      expect(response.body.error).toBe('Worker not found: w-404')
     })
   })
 })

--- a/crabot-admin/src/admin-web-api.test.ts
+++ b/crabot-admin/src/admin-web-api.test.ts
@@ -1476,6 +1476,158 @@ describe('Admin Web API', () => {
       expect(response.body.sources.session_template_id).toBe('group_default')
     })
   })
+
+  // ==========================================================================
+  // 既有 /api/agent/* 转发端点的特征化测试（P5 Task 5 第一步）
+  //
+  // 这四个 handler 各自重复同一段 503/500 样板，本组用例在抽 proxyAgentRpc **之前**
+  // 就写下它们当前的行为（method / params / 状态码 / body），抽完之后必须逐条照旧通过——
+  // 这是"纯重构、行为一字不变"的证据，而不是靠肉眼比对。
+  // ==========================================================================
+  describe('既有 /api/agent/* 转发端点（重构护栏）', () => {
+    const spyAgentRpc = () =>
+      vi.spyOn(
+        admin as unknown as { callAgentRpc: (...args: unknown[]) => Promise<unknown> },
+        'callAgentRpc',
+      )
+
+    it('GET /api/agent/traces 转发 get_traces（默认 limit/offset，status 缺省为 undefined）', async () => {
+      const token = await loginAndGetToken()
+      const spy = spyAgentRpc().mockResolvedValue({ traces: [], total: 0 })
+
+      const response = await makeWebRequest(TEST_WEB_PORT, '/api/agent/traces', 'GET', null, token)
+
+      expect(response.statusCode).toBe(200)
+      expect(spy).toHaveBeenCalledWith('get_traces', { limit: 20, offset: 0, status: undefined })
+    })
+
+    it('GET /api/agent/traces 透传 limit/offset/status', async () => {
+      const token = await loginAndGetToken()
+      const spy = spyAgentRpc().mockResolvedValue({ traces: [], total: 0 })
+
+      await makeWebRequest(TEST_WEB_PORT, '/api/agent/traces?limit=5&offset=10&status=completed', 'GET', null, token)
+
+      expect(spy).toHaveBeenCalledWith('get_traces', { limit: 5, offset: 10, status: 'completed' })
+    })
+
+    it('GET /api/agent/traces：agent 不可达 → 503 + 固定文案', async () => {
+      const token = await loginAndGetToken()
+      spyAgentRpc().mockRejectedValue(new Error('Agent not available'))
+
+      const response = await makeWebRequest<{ error: string }>(TEST_WEB_PORT, '/api/agent/traces', 'GET', null, token)
+
+      expect(response.statusCode).toBe(503)
+      expect(response.body.error).toBe('Agent not available')
+    })
+
+    it('GET /api/agent/traces：其他错误 → 500 + 原始 message', async () => {
+      const token = await loginAndGetToken()
+      spyAgentRpc().mockRejectedValue(new Error('boom'))
+
+      const response = await makeWebRequest<{ error: string }>(TEST_WEB_PORT, '/api/agent/traces', 'GET', null, token)
+
+      expect(response.statusCode).toBe(500)
+      expect(response.body.error).toBe('boom')
+    })
+
+    it('GET /api/agent/traces/:traceId 转发 get_trace', async () => {
+      const token = await loginAndGetToken()
+      const spy = spyAgentRpc().mockResolvedValue({ trace: { trace_id: 't-1' } })
+
+      const response = await makeWebRequest(TEST_WEB_PORT, '/api/agent/traces/t-1', 'GET', null, token)
+
+      expect(response.statusCode).toBe(200)
+      expect(spy).toHaveBeenCalledWith('get_trace', { trace_id: 't-1' })
+    })
+
+    it('GET /api/agent/traces/:traceId：not found → 404 + 原始 message（该端点独有分支）', async () => {
+      const token = await loginAndGetToken()
+      spyAgentRpc().mockRejectedValue(new Error('Trace not found: t-404'))
+
+      const response = await makeWebRequest<{ error: string }>(TEST_WEB_PORT, '/api/agent/traces/t-404', 'GET', null, token)
+
+      expect(response.statusCode).toBe(404)
+      expect(response.body.error).toBe('Trace not found: t-404')
+    })
+
+    it('GET /api/agent/traces/:traceId：ECONNREFUSED → 503', async () => {
+      const token = await loginAndGetToken()
+      spyAgentRpc().mockRejectedValue(new Error('connect ECONNREFUSED 127.0.0.1:19000'))
+
+      const response = await makeWebRequest<{ error: string }>(TEST_WEB_PORT, '/api/agent/traces/t-1', 'GET', null, token)
+
+      expect(response.statusCode).toBe(503)
+      expect(response.body.error).toBe('Agent not available')
+    })
+
+    it('DELETE /api/agent/traces 转发 clear_traces（带 body / 空 body）', async () => {
+      const token = await loginAndGetToken()
+      const spy = spyAgentRpc().mockResolvedValue({ cleared_count: 3 })
+
+      const withBody = await makeWebRequest(
+        TEST_WEB_PORT,
+        '/api/agent/traces',
+        'DELETE',
+        { before: '2026-01-01T00:00:00.000Z' },
+        token,
+      )
+      expect(withBody.statusCode).toBe(200)
+      expect(spy).toHaveBeenCalledWith('clear_traces', { before: '2026-01-01T00:00:00.000Z' })
+
+      await makeWebRequest(TEST_WEB_PORT, '/api/agent/traces', 'DELETE', null, token)
+      expect(spy).toHaveBeenLastCalledWith('clear_traces', {})
+    })
+
+    it('DELETE /api/agent/traces：agent 不可达 → 503', async () => {
+      const token = await loginAndGetToken()
+      spyAgentRpc().mockRejectedValue(new Error('connect failed'))
+
+      const response = await makeWebRequest<{ error: string }>(TEST_WEB_PORT, '/api/agent/traces', 'DELETE', null, token)
+
+      expect(response.statusCode).toBe(503)
+      expect(response.body.error).toBe('Agent not available')
+    })
+
+    it('GET /api/agent/traces/search 转发 search_traces（time_range 需 start+end 同时存在）', async () => {
+      const token = await loginAndGetToken()
+      const spy = spyAgentRpc().mockResolvedValue({ traces: [], total: 0 })
+
+      await makeWebRequest(
+        TEST_WEB_PORT,
+        '/api/agent/traces/search?task_id=task-1&keyword=needle&status=completed&start=2026-01-01&end=2026-02-01&limit=3&offset=1',
+        'GET',
+        null,
+        token,
+      )
+      expect(spy).toHaveBeenCalledWith('search_traces', {
+        task_id: 'task-1',
+        keyword: 'needle',
+        status: 'completed',
+        time_range: { start: '2026-01-01', end: '2026-02-01' },
+        limit: 3,
+        offset: 1,
+      })
+
+      await makeWebRequest(TEST_WEB_PORT, '/api/agent/traces/search?start=2026-01-01', 'GET', null, token)
+      expect(spy).toHaveBeenLastCalledWith('search_traces', { limit: 20, offset: 0 })
+    })
+
+    it('GET /api/agent/traces/search：agent 不可达 → 503', async () => {
+      const token = await loginAndGetToken()
+      spyAgentRpc().mockRejectedValue(new Error('Agent not available'))
+
+      const response = await makeWebRequest<{ error: string }>(
+        TEST_WEB_PORT,
+        '/api/agent/traces/search',
+        'GET',
+        null,
+        token,
+      )
+
+      expect(response.statusCode).toBe(503)
+      expect(response.body.error).toBe('Agent not available')
+    })
+  })
 })
 
 // Helper functions

--- a/crabot-admin/src/admin-web-api.test.ts
+++ b/crabot-admin/src/admin-web-api.test.ts
@@ -1628,6 +1628,205 @@ describe('Admin Web API', () => {
       expect(response.body.error).toBe('Agent not available')
     })
   })
+
+  // ==========================================================================
+  // Worker 只读 REST 代理（protocol-agent-v3 §10.3 / §8.3，P5 Task 5 第二步）
+  //
+  // 本阶段生产链路无人调用这四个端点（web 切换在 P6、cutover 在 P7），所以用例只钉两件事：
+  // 鉴权走既有 /api/* 中间件、query → RPC 参数按 §8.3 逐字段映射。
+  // **不写**"worker 失败 → 返回 failed"这类断言：台账 status 目前被 P7 阻塞项 #1 污染。
+  // ==========================================================================
+  describe('GET /api/agent/workers*（§10.3 只读代理）', () => {
+    const spyAgentRpc = () =>
+      vi.spyOn(
+        admin as unknown as { callAgentRpc: (...args: unknown[]) => Promise<unknown> },
+        'callAgentRpc',
+      )
+
+    it.each([
+      '/api/agent/workers',
+      '/api/agent/workers/w-1',
+      '/api/agent/workers/w-1/output',
+      '/api/agent/workers/w-1/trace',
+    ])('%s 未带 token → 401', async (path) => {
+      const response = await makeWebRequest(TEST_WEB_PORT, path, 'GET', null, null)
+      expect(response.statusCode).toBe(401)
+    })
+
+    it('GET /api/agent/workers 无 query → list_workers_admin 只带默认分页', async () => {
+      const token = await loginAndGetToken()
+      const spy = spyAgentRpc().mockResolvedValue({
+        items: [],
+        pagination: { page: 1, page_size: 20, total_items: 0, total_pages: 0 },
+      })
+
+      const response = await makeWebRequest(TEST_WEB_PORT, '/api/agent/workers', 'GET', null, token)
+
+      expect(response.statusCode).toBe(200)
+      expect(spy).toHaveBeenCalledWith('list_workers_admin', { pagination: { page: 1, page_size: 20 } })
+    })
+
+    it('GET /api/agent/workers 全量 query → 逐字段映射（status 重复出现即数组）', async () => {
+      const token = await loginAndGetToken()
+      const spy = spyAgentRpc().mockResolvedValue({
+        items: [],
+        pagination: { page: 2, page_size: 5, total_items: 0, total_pages: 0 },
+      })
+
+      await makeWebRequest(
+        TEST_WEB_PORT,
+        '/api/agent/workers?status=executing&status=waiting&dialog_object_id=telegram-001%3Aprivate-42'
+          + '&start=2026-07-01T00%3A00%3A00.000Z&end=2026-07-31T00%3A00%3A00.000Z&page=2&page_size=5',
+        'GET',
+        null,
+        token,
+      )
+
+      expect(spy).toHaveBeenCalledWith('list_workers_admin', {
+        status: ['executing', 'waiting'],
+        dialog_object_id: 'telegram-001:private-42',
+        time_range: { start: '2026-07-01T00:00:00.000Z', end: '2026-07-31T00:00:00.000Z' },
+        pagination: { page: 2, page_size: 5 },
+      })
+    })
+
+    it('GET /api/agent/workers 单个 status → 单值而非数组（§8.3 是联合类型）', async () => {
+      const token = await loginAndGetToken()
+      const spy = spyAgentRpc().mockResolvedValue({
+        items: [],
+        pagination: { page: 1, page_size: 20, total_items: 0, total_pages: 0 },
+      })
+
+      await makeWebRequest(TEST_WEB_PORT, '/api/agent/workers?status=completed', 'GET', null, token)
+
+      expect(spy).toHaveBeenCalledWith('list_workers_admin', {
+        status: 'completed',
+        pagination: { page: 1, page_size: 20 },
+      })
+    })
+
+    it('GET /api/agent/workers 只给 start → time_range 只带 start（TimeRange 两端各自可选）', async () => {
+      const token = await loginAndGetToken()
+      const spy = spyAgentRpc().mockResolvedValue({
+        items: [],
+        pagination: { page: 1, page_size: 20, total_items: 0, total_pages: 0 },
+      })
+
+      await makeWebRequest(TEST_WEB_PORT, '/api/agent/workers?start=2026-07-01T00%3A00%3A00.000Z', 'GET', null, token)
+
+      expect(spy).toHaveBeenCalledWith('list_workers_admin', {
+        time_range: { start: '2026-07-01T00:00:00.000Z' },
+        pagination: { page: 1, page_size: 20 },
+      })
+    })
+
+    it('GET /api/agent/workers 脏分页参数 → 回落默认值', async () => {
+      const token = await loginAndGetToken()
+      const spy = spyAgentRpc().mockResolvedValue({
+        items: [],
+        pagination: { page: 1, page_size: 20, total_items: 0, total_pages: 0 },
+      })
+
+      await makeWebRequest(TEST_WEB_PORT, '/api/agent/workers?page=abc&page_size=', 'GET', null, token)
+
+      expect(spy).toHaveBeenCalledWith('list_workers_admin', { pagination: { page: 1, page_size: 20 } })
+    })
+
+    it('GET /api/agent/workers：agent 不可达 → 503', async () => {
+      const token = await loginAndGetToken()
+      spyAgentRpc().mockRejectedValue(new Error('Agent not available'))
+
+      const response = await makeWebRequest<{ error: string }>(TEST_WEB_PORT, '/api/agent/workers', 'GET', null, token)
+
+      expect(response.statusCode).toBe(503)
+      expect(response.body.error).toBe('Agent not available')
+    })
+
+    it('GET /api/agent/workers/:id → get_worker_detail', async () => {
+      const token = await loginAndGetToken()
+      const spy = spyAgentRpc().mockResolvedValue({ worker: { worker_id: 'w-1' } })
+
+      const response = await makeWebRequest<{ worker: { worker_id: string } }>(
+        TEST_WEB_PORT,
+        '/api/agent/workers/w-1',
+        'GET',
+        null,
+        token,
+      )
+
+      expect(response.statusCode).toBe(200)
+      expect(response.body.worker.worker_id).toBe('w-1')
+      expect(spy).toHaveBeenCalledWith('get_worker_detail', { worker_id: 'w-1' })
+    })
+
+    it('GET /api/agent/workers/:id：worker 不存在 → 404', async () => {
+      const token = await loginAndGetToken()
+      spyAgentRpc().mockRejectedValue(new Error('Worker not found: w-404'))
+
+      const response = await makeWebRequest<{ error: string }>(
+        TEST_WEB_PORT,
+        '/api/agent/workers/w-404',
+        'GET',
+        null,
+        token,
+      )
+
+      expect(response.statusCode).toBe(404)
+      expect(response.body.error).toBe('Worker not found: w-404')
+    })
+
+    it('GET /api/agent/workers/:id/output → read_worker_output_admin（seq 必填、cursor 可选）', async () => {
+      const token = await loginAndGetToken()
+      const spy = spyAgentRpc().mockResolvedValue({ chunk: 'hello', next_cursor: '133', eof: false })
+
+      const response = await makeWebRequest(
+        TEST_WEB_PORT,
+        '/api/agent/workers/w-1/output?seq=2&cursor=128',
+        'GET',
+        null,
+        token,
+      )
+      expect(response.statusCode).toBe(200)
+      expect(spy).toHaveBeenCalledWith('read_worker_output_admin', { worker_id: 'w-1', seq: 2, cursor: '128' })
+
+      await makeWebRequest(TEST_WEB_PORT, '/api/agent/workers/w-1/output', 'GET', null, token)
+      expect(spy).toHaveBeenLastCalledWith('read_worker_output_admin', { worker_id: 'w-1', seq: 0 })
+    })
+
+    it('GET /api/agent/workers/:id/trace → get_worker_trace（seq 必填、cursor 可选）', async () => {
+      const token = await loginAndGetToken()
+      const spy = spyAgentRpc().mockResolvedValue({ events: [], next_cursor: '0' })
+
+      const response = await makeWebRequest(
+        TEST_WEB_PORT,
+        '/api/agent/workers/w-1/trace?seq=1&cursor=3',
+        'GET',
+        null,
+        token,
+      )
+      expect(response.statusCode).toBe(200)
+      expect(spy).toHaveBeenCalledWith('get_worker_trace', { worker_id: 'w-1', seq: 1, cursor: '3' })
+
+      await makeWebRequest(TEST_WEB_PORT, '/api/agent/workers/w-1/trace', 'GET', null, token)
+      expect(spy).toHaveBeenLastCalledWith('get_worker_trace', { worker_id: 'w-1', seq: 0 })
+    })
+
+    it('GET /api/agent/workers/:id/trace：worker 不存在 → 404', async () => {
+      const token = await loginAndGetToken()
+      spyAgentRpc().mockRejectedValue(new Error('Worker not found: w-404'))
+
+      const response = await makeWebRequest<{ error: string }>(
+        TEST_WEB_PORT,
+        '/api/agent/workers/w-404/trace',
+        'GET',
+        null,
+        token,
+      )
+
+      expect(response.statusCode).toBe(404)
+      expect(response.body.error).toBe('Worker not found: w-404')
+    })
+  })
 })
 
 // Helper functions

--- a/crabot-admin/src/index.ts
+++ b/crabot-admin/src/index.ts
@@ -387,6 +387,20 @@ function parseIntParam(raw: string | null, fallback: number): number {
   return Number.isFinite(parsed) ? parsed : fallback
 }
 
+/**
+ * 没有合理 fallback 的整数参数（`?seq=`）：缺省或非法一律返回 undefined，由调用方**不下发
+ * 该字段**，让 agent 侧走它自己的缺省语义。
+ *
+ * 不能像 page/page_size 那样回落到一个具体数字：化身 seq 从 1 开始编号，回落 0 在台账里
+ * 永远不存在（output 端点因此 500、trace 端点静默返回空），回落 1 则锁死在**最早**那个
+ * 化身上——worker 经历 revive/handoff 后主线早已不是 seq=1。唯一正确的缺省是"主线化身"，
+ * 而那只有 agent 侧（持台账）算得出来。
+ */
+function parseOptionalIntParam(raw: string | null): number | undefined {
+  const parsed = Number.parseInt(raw ?? '', 10)
+  return Number.isFinite(parsed) ? parsed : undefined
+}
+
 function sendJson(res: ServerResponse, status: number, body: unknown): void {
   res.writeHead(status, { 'Content-Type': 'application/json' })
   res.end(JSON.stringify(body))
@@ -9841,13 +9855,15 @@ export class AdminModule extends ModuleBase {
     url: URL,
   ): Promise<void> {
     const cursor = url.searchParams.get('cursor') || undefined
+    // seq = 化身序号（从 1 起）。没给就**不下发该字段**，由 agent 侧取主线化身
+    // （harness.readWorkerOutput 的既有缺省，见 parseOptionalIntParam 注释）——与 cursor 同一纪律。
+    const seq = parseOptionalIntParam(url.searchParams.get('seq'))
     await this.proxyAgentRpc<
-      { worker_id: string; seq: number; cursor?: string },
+      { worker_id: string; seq?: number; cursor?: string },
       { chunk: string; next_cursor: string; eof: boolean }
     >(res, 'read_worker_output_admin', {
       worker_id: workerId,
-      // seq = 化身序号；§8.3 里必填，缺省取第一个化身。
-      seq: parseIntParam(url.searchParams.get('seq'), 0),
+      ...(seq !== undefined ? { seq } : {}),
       ...(cursor ? { cursor } : {}),
     })
   }
@@ -9860,15 +9876,17 @@ export class AdminModule extends ModuleBase {
     url: URL,
   ): Promise<void> {
     const cursor = url.searchParams.get('cursor') || undefined
+    // 同 output 端点：没给 seq 就不下发，agent 侧取主线化身，两个端点缺省落在同一个化身上。
+    const seq = parseOptionalIntParam(url.searchParams.get('seq'))
     await this.proxyAgentRpc<
-      { worker_id: string; seq: number; cursor?: string },
+      { worker_id: string; seq?: number; cursor?: string },
       { events: unknown[]; next_cursor?: string; unavailable_reason?: string }
     >(
       res,
       'get_worker_trace',
       {
         worker_id: workerId,
-        seq: parseIntParam(url.searchParams.get('seq'), 0),
+        ...(seq !== undefined ? { seq } : {}),
         ...(cursor ? { cursor } : {}),
       },
       (msg) => msg.includes('Worker not found'),

--- a/crabot-admin/src/index.ts
+++ b/crabot-admin/src/index.ts
@@ -401,6 +401,23 @@ function parseOptionalIntParam(raw: string | null): number | undefined {
   return Number.isFinite(parsed) ? parsed : undefined
 }
 
+/**
+ * `/api/agent/workers*` 三个按 worker_id 读的端点统一的"worker 不存在 → 404"判定。
+ *
+ * agent 侧同一件事有两处文案，大小写不同：`unified-agent.ts` 的 handler 显式抛
+ * `Worker not found: <id>`（detail / trace），`harness.ts` 的 `WorkerNotFoundError` 抛
+ * `worker not found: <id>`（output 走 `harness.readWorkerOutput`）。各端点各写各的匹配串时，
+ * output 端点对同一个不存在的 id 落 500 而另外两个落 404（P5 review 修复第二轮）。
+ * 抽成一个谓词共用，是为了不让这种不对称再次悄悄漂移出来。
+ *
+ * 只做大小写归一、不放宽到 `includes('not found')`：agent 侧其它真错（如
+ * `no incarnation with seq=N found for worker <id>` —— 化身不存在而非 worker 不存在）必须
+ * 继续落 500，否则前端分不清"这个 worker 没了"和"这个化身没了"。
+ */
+function isWorkerNotFoundError(message: string): boolean {
+  return message.toLowerCase().includes('worker not found')
+}
+
 function sendJson(res: ServerResponse, status: number, body: unknown): void {
   res.writeHead(status, { 'Content-Type': 'application/json' })
   res.end(JSON.stringify(body))
@@ -9841,9 +9858,8 @@ export class AdminModule extends ModuleBase {
       res,
       'get_worker_detail',
       { worker_id: workerId },
-      // agent 侧对不存在的 worker 抛 `Worker not found: <id>`（unified-agent.ts）；映射成 404
-      // 与相邻的 `/api/agent/traces/:traceId` 一致。
-      (msg) => msg.includes('Worker not found'),
+      // 404 与相邻的 `/api/agent/traces/:traceId` 一致；判定见 isWorkerNotFoundError。
+      isWorkerNotFoundError,
     )
   }
 
@@ -9861,11 +9877,16 @@ export class AdminModule extends ModuleBase {
     await this.proxyAgentRpc<
       { worker_id: string; seq?: number; cursor?: string },
       { chunk: string; next_cursor: string; eof: boolean }
-    >(res, 'read_worker_output_admin', {
-      worker_id: workerId,
-      ...(seq !== undefined ? { seq } : {}),
-      ...(cursor ? { cursor } : {}),
-    })
+    >(
+      res,
+      'read_worker_output_admin',
+      {
+        worker_id: workerId,
+        ...(seq !== undefined ? { seq } : {}),
+        ...(cursor ? { cursor } : {}),
+      },
+      isWorkerNotFoundError,
+    )
   }
 
   /** §10.3 `GET /api/agent/workers/:id/trace` → `get_worker_trace`（§8.3）。 */
@@ -9889,7 +9910,7 @@ export class AdminModule extends ModuleBase {
         ...(seq !== undefined ? { seq } : {}),
         ...(cursor ? { cursor } : {}),
       },
-      (msg) => msg.includes('Worker not found'),
+      isWorkerNotFoundError,
     )
   }
 

--- a/crabot-admin/src/index.ts
+++ b/crabot-admin/src/index.ts
@@ -9564,6 +9564,38 @@ export class AdminModule extends ModuleBase {
     }
   }
 
+  /**
+   * `/api/agent/*` 转发端点的统一样板：调 agent RPC → 200 回传结果；失败按 agent 可达性
+   * 映射 503（agent 不可达，固定文案）/ 500（其余，回传原始 message）。
+   *
+   * 抽自 handleGetAgentTracesApi / handleGetAgentTraceApi / handleClearAgentTracesApi /
+   * handleSearchAgentTracesApi 四处**逐字相同**的 catch 块（P5 Task 5，纯重构）。
+   * `notFoundWhen` 只为保留 handleGetAgentTraceApi 独有的 404 分支——不传时行为与抽取前
+   * 完全一致；该分支优先于 503/500 判定，与原实现的判定顺序相同。
+   */
+  private async proxyAgentRpc<P, R>(
+    res: ServerResponse,
+    method: string,
+    params: P,
+    notFoundWhen?: (message: string) => boolean,
+  ): Promise<void> {
+    try {
+      const result = await this.callAgentRpc<P, R>(method, params)
+      sendJson(res, 200, result)
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error)
+      if (notFoundWhen?.(msg)) {
+        sendJson(res, 404, { error: msg })
+        return
+      }
+      const isUnreachable =
+        msg.includes('Agent not available') ||
+        msg.includes('ECONNREFUSED') ||
+        msg.includes('connect failed')
+      sendJson(res, isUnreachable ? 503 : 500, { error: isUnreachable ? 'Agent not available' : msg })
+    }
+  }
+
   private memoryModules: Array<{ module_id: string; port: number; name: string }> = []
 
   /**
@@ -9609,25 +9641,13 @@ export class AdminModule extends ModuleBase {
     res: ServerResponse,
     url: URL
   ): Promise<void> {
-    try {
-      const limit = parseInt(url.searchParams.get('limit') ?? '20', 10)
-      const offset = parseInt(url.searchParams.get('offset') ?? '0', 10)
-      const status = url.searchParams.get('status') ?? undefined
-      const result = await this.callAgentRpc<
-        { limit?: number; offset?: number; status?: string },
-        { traces: unknown[]; total: number }
-      >('get_traces', { limit, offset, status })
-      res.writeHead(200, { 'Content-Type': 'application/json' })
-      res.end(JSON.stringify(result))
-    } catch (error) {
-      const msg = error instanceof Error ? error.message : String(error)
-      const isUnreachable =
-        msg.includes('Agent not available') ||
-        msg.includes('ECONNREFUSED') ||
-        msg.includes('connect failed')
-      res.writeHead(isUnreachable ? 503 : 500, { 'Content-Type': 'application/json' })
-      res.end(JSON.stringify({ error: isUnreachable ? 'Agent not available' : msg }))
-    }
+    const limit = parseInt(url.searchParams.get('limit') ?? '20', 10)
+    const offset = parseInt(url.searchParams.get('offset') ?? '0', 10)
+    const status = url.searchParams.get('status') ?? undefined
+    await this.proxyAgentRpc<
+      { limit?: number; offset?: number; status?: string },
+      { traces: unknown[]; total: number }
+    >(res, 'get_traces', { limit, offset, status })
   }
 
   private async handleGetAgentTraceApi(
@@ -9635,55 +9655,36 @@ export class AdminModule extends ModuleBase {
     res: ServerResponse,
     traceId: string
   ): Promise<void> {
-    try {
-      const result = await this.callAgentRpc<
-        { trace_id: string },
-        { trace: unknown }
-      >('get_trace', { trace_id: traceId })
-      res.writeHead(200, { 'Content-Type': 'application/json' })
-      res.end(JSON.stringify(result))
-    } catch (error) {
-      const msg = error instanceof Error ? error.message : String(error)
-      if (msg.includes('not found') || msg.includes('Trace not found')) {
-        res.writeHead(404, { 'Content-Type': 'application/json' })
-        res.end(JSON.stringify({ error: msg }))
-      } else {
-        const isUnreachable =
-          msg.includes('Agent not available') ||
-          msg.includes('ECONNREFUSED') ||
-          msg.includes('connect failed')
-        res.writeHead(isUnreachable ? 503 : 500, { 'Content-Type': 'application/json' })
-        res.end(JSON.stringify({ error: isUnreachable ? 'Agent not available' : msg }))
-      }
-    }
+    await this.proxyAgentRpc<{ trace_id: string }, { trace: unknown }>(
+      res,
+      'get_trace',
+      { trace_id: traceId },
+      (msg) => msg.includes('not found') || msg.includes('Trace not found'),
+    )
   }
 
   private async handleClearAgentTracesApi(
     req: IncomingMessage,
     res: ServerResponse
   ): Promise<void> {
+    let params: { before?: string; trace_ids?: string[] }
     try {
       const body = await new Promise<string>((resolve) => {
         let data = ''
         req.on('data', (chunk) => { data += chunk })
         req.on('end', () => resolve(data))
       })
-      const params = body ? (JSON.parse(body) as { before?: string; trace_ids?: string[] }) : {}
-      const result = await this.callAgentRpc<
-        { before?: string; trace_ids?: string[] },
-        { cleared_count: number }
-      >('clear_traces', params)
-      res.writeHead(200, { 'Content-Type': 'application/json' })
-      res.end(JSON.stringify(result))
+      params = body ? (JSON.parse(body) as { before?: string; trace_ids?: string[] }) : {}
     } catch (error) {
-      const msg = error instanceof Error ? error.message : String(error)
-      const isUnreachable =
-        msg.includes('Agent not available') ||
-        msg.includes('ECONNREFUSED') ||
-        msg.includes('connect failed')
-      res.writeHead(isUnreachable ? 503 : 500, { 'Content-Type': 'application/json' })
-      res.end(JSON.stringify({ error: isUnreachable ? 'Agent not available' : msg }))
+      // body 不是合法 JSON：抽 proxyAgentRpc 之前 JSON.parse 的异常落在同一个 catch 里，
+      // 走的是"非不可达 → 500 + 原始 message"分支。这里显式保留该分支，避免重构改行为。
+      sendJson(res, 500, { error: error instanceof Error ? error.message : String(error) })
+      return
     }
+    await this.proxyAgentRpc<
+      { before?: string; trace_ids?: string[] },
+      { cleared_count: number }
+    >(res, 'clear_traces', params)
   }
 
   private async handleSearchAgentTracesApi(
@@ -9691,35 +9692,23 @@ export class AdminModule extends ModuleBase {
     res: ServerResponse,
     url: URL
   ): Promise<void> {
-    try {
-      const params: Record<string, unknown> = {}
-      const taskId = url.searchParams.get('task_id')
-      if (taskId) params.task_id = taskId
-      const keyword = url.searchParams.get('keyword')
-      if (keyword) params.keyword = keyword
-      const status = url.searchParams.get('status')
-      if (status) params.status = status
-      const start = url.searchParams.get('start')
-      const end = url.searchParams.get('end')
-      if (start && end) params.time_range = { start, end }
-      params.limit = parseInt(url.searchParams.get('limit') ?? '20', 10)
-      params.offset = parseInt(url.searchParams.get('offset') ?? '0', 10)
+    const params: Record<string, unknown> = {}
+    const taskId = url.searchParams.get('task_id')
+    if (taskId) params.task_id = taskId
+    const keyword = url.searchParams.get('keyword')
+    if (keyword) params.keyword = keyword
+    const status = url.searchParams.get('status')
+    if (status) params.status = status
+    const start = url.searchParams.get('start')
+    const end = url.searchParams.get('end')
+    if (start && end) params.time_range = { start, end }
+    params.limit = parseInt(url.searchParams.get('limit') ?? '20', 10)
+    params.offset = parseInt(url.searchParams.get('offset') ?? '0', 10)
 
-      const result = await this.callAgentRpc<
-        Record<string, unknown>,
-        { traces: unknown[]; total: number }
-      >('search_traces', params)
-      res.writeHead(200, { 'Content-Type': 'application/json' })
-      res.end(JSON.stringify(result))
-    } catch (error) {
-      const msg = error instanceof Error ? error.message : String(error)
-      const isUnreachable =
-        msg.includes('Agent not available') ||
-        msg.includes('ECONNREFUSED') ||
-        msg.includes('connect failed')
-      res.writeHead(isUnreachable ? 503 : 500, { 'Content-Type': 'application/json' })
-      res.end(JSON.stringify({ error: isUnreachable ? 'Agent not available' : msg }))
-    }
+    await this.proxyAgentRpc<
+      Record<string, unknown>,
+      { traces: unknown[]; total: number }
+    >(res, 'search_traces', params)
   }
 
   private async handleDeleteTaskApi(

--- a/crabot-admin/src/index.ts
+++ b/crabot-admin/src/index.ts
@@ -376,6 +376,17 @@ function normalizeSceneProfileTextField(
  */
 const CRABOT_HOME = process.env.CRABOT_HOME ?? path.resolve(__dirname, '../..')
 
+/**
+ * query string 里的整数参数。缺省或非法（`?page=abc` / `?page_size=`）一律回落到 fallback。
+ *
+ * 与既有端点惯用的裸 `parseInt(x ?? '20', 10)` 的差别只在于挡住了 NaN——`/api/agent/workers*`
+ * 的 page/page_size/seq 会原样进入 agent 侧的 slice/filter，NaN 会静默返回空结果而不报错。
+ */
+function parseIntParam(raw: string | null, fallback: number): number {
+  const parsed = Number.parseInt(raw ?? '', 10)
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
 function sendJson(res: ServerResponse, status: number, body: unknown): void {
   res.writeHead(status, { 'Content-Type': 'application/json' })
   res.end(JSON.stringify(body))
@@ -2175,6 +2186,27 @@ export class AdminModule extends ModuleBase {
       const agentTraceDetailMatch = pathname.match(/^\/api\/agent\/traces\/([^/]+)$/)
       if (agentTraceDetailMatch && req.method === 'GET') {
         await this.handleGetAgentTraceApi(req, res, agentTraceDetailMatch[1])
+        return
+      }
+
+      // Worker 只读代理（protocol-agent-v3 §10.3）。子路径先于 :id 匹配。
+      if (pathname === '/api/agent/workers' && req.method === 'GET') {
+        await this.handleListWorkersApi(req, res, url)
+        return
+      }
+      const workerOutputMatch = pathname.match(/^\/api\/agent\/workers\/([^/]+)\/output$/)
+      if (workerOutputMatch && req.method === 'GET') {
+        await this.handleReadWorkerOutputApi(req, res, workerOutputMatch[1], url)
+        return
+      }
+      const workerTraceMatch = pathname.match(/^\/api\/agent\/workers\/([^/]+)\/trace$/)
+      if (workerTraceMatch && req.method === 'GET') {
+        await this.handleGetWorkerTraceApi(req, res, workerTraceMatch[1], url)
+        return
+      }
+      const workerDetailMatch = pathname.match(/^\/api\/agent\/workers\/([^/]+)$/)
+      if (workerDetailMatch && req.method === 'GET') {
+        await this.handleGetWorkerDetailApi(req, res, workerDetailMatch[1])
         return
       }
 
@@ -4424,6 +4456,11 @@ export class AdminModule extends ModuleBase {
   /**
    * 写入 task 的统一入口：set + 落盘原子绑定，杜绝"改了内存忘了落盘"。
    * 所有 handler*Task / handle*TaskGoal / handleCancelTask 都走这里。
+   *
+   * @deprecated **P7 cutover 时删除**（protocol-agent-v3 §7）。v3 把 task 的真相源从 admin 的
+   * `tasks.json` 迁到 agent 的台账（`LedgerStore`），admin 退化成只读代理，不再有 task 写路径。
+   * 替代者：agent 侧 `LedgerStore` 的写入（由 `WorkerHarness` 的状态迁移驱动）。
+   * P5 只加注记、**行为不变**——本阶段 admin 仍是 task 的写真相源。
    */
   private async upsertTask(task: Task): Promise<void> {
     this.tasks.set(task.id, task)
@@ -5086,6 +5123,12 @@ export class AdminModule extends ModuleBase {
     return { items }
   }
 
+  /**
+   * P7 cutover 注记（本次不改行为）：本方法体内的 `admin.task_status_changed` 发布点是
+   * v3 要退役的两处 task 事件发布点之一——替代者是 agent 侧的 `agent.task_status_changed`
+   * （protocol-agent-v3 §9.2，发布方从 admin 变为 agent）。cutover 时随 admin 侧 task
+   * 写路径一并删除。
+   */
   private async handleReviveTaskForSupplement(
     params: ReviveTaskForSupplementParams,
   ): Promise<ReviveTaskForSupplementResult> {
@@ -5179,6 +5222,13 @@ export class AdminModule extends ModuleBase {
     }
   }
 
+  /**
+   * @deprecated **P7 cutover 时删除**（protocol-agent-v3 §5.2 / §9.2）。task 状态机在 v3 里
+   * 属于 agent 台账，替代者是 `WorkerHarness` 的状态迁移（写台账 + 由 agent 发
+   * `agent.task_status_changed`）。本方法体内的 `admin.task_status_changed` 发布点即 v3 要
+   * 退役的两处 task 事件发布点之二（另一处在 `handleReviveTaskForSupplement`）。
+   * P5 只加注记、**行为不变**。
+   */
   private applyStatusTransition(
     task: Task,
     newStatus: TaskStatus,
@@ -5636,6 +5686,11 @@ export class AdminModule extends ModuleBase {
    * applyStatusTransition 路径，保留派生字段维护和事件发布。
    *
    * 失败容忍：单条 patch apply 失败只 log + 跳过，不影响其他 patch；下轮 reconciliation 继续重试。
+   *
+   * @deprecated **P7 cutover 时删除**（protocol-agent-v3 §7）。这层兜底的存在前提是"admin 的
+   * task 状态与 agent 的 trace 是两份可能 drift 的数据"；v3 把真相源收敛到 agent 台账后该前提
+   * 消失，且它依赖的 `get_trace_tree` 已随 §10.1 退役。替代者：agent 侧的启动对账
+   * `reconcileManagerStack`（台账 vs 实际存活化身）。P5 只加注记、**行为不变**。
    */
   async runReconciliation(): Promise<void> {
     if (!this.dataLoaded) return  // 启动早期 loadData 未完不跑
@@ -5734,6 +5789,11 @@ export class AdminModule extends ModuleBase {
     }
   }
 
+  /**
+   * @deprecated **P7 cutover 时删除**（protocol-agent-v3 §8.5：`cancel_task` 与 `abort_worker`
+   * 均已列入退役接口）。v3 里 admin 不再单方面判死任务，取消由 manager 的 `kill_worker` 执行。
+   * 替代者：manager 工具面的 `kill_worker`（§4.3）。P5 只加注记、**行为不变**。
+   */
   private async handleCancelTask(params: CancelTaskParams): Promise<{ task: Task; cancelled: boolean }> {
     const task = this.tasks.get(params.task_id)
     if (!task) {
@@ -9709,6 +9769,110 @@ export class AdminModule extends ModuleBase {
       Record<string, unknown>,
       { traces: unknown[]; total: number }
     >(res, 'search_traces', params)
+  }
+
+  // ============================================================================
+  // Worker 只读 REST 代理（protocol-agent-v3 §10.3，转发 §8.3 的读模型 RPC）
+  //
+  // 纯转发：鉴权由 `/api/*` 的统一中间件负责，错误映射由 proxyAgentRpc 负责，本段只做
+  // query string → RPC 参数的翻译。**本阶段生产链路无人调用**（web 切到 worker 视图在 P6、
+  // 真相源 cutover 在 P7），先落端点是为了让 P6 只改前端。
+  //
+  // 台账 status 目前被 P7 阻塞项 #1（harness.processStateChange 硬编码 completed）污染，
+  // 这里原样透传、不做任何补偿——修复在 agent 侧的 harness，不在代理层。
+  // ============================================================================
+
+  /** §10.3 `GET /api/agent/workers` → `list_workers_admin`（§8.3）。 */
+  private async handleListWorkersApi(
+    _req: IncomingMessage,
+    res: ServerResponse,
+    url: URL,
+  ): Promise<void> {
+    // §8.3 的 status 是 `TaskStatus | TaskStatus[]`：重复出现 `?status=a&status=b` 即数组，
+    // 单个即单值（沿用 parseAccessibleScopes 的 getAll 惯例，不另发明逗号分隔语法）。
+    const statuses = url.searchParams.getAll('status').filter(Boolean)
+    const dialogObjectId = url.searchParams.get('dialog_object_id') || undefined
+    // base-protocol §5.7 的 TimeRange 两端各自可选（start 闭、end 开），故任一存在即下发；
+    // 这点与 search_traces 端点"start+end 必须同时给"的旧写法不同——那是它自己的历史约定。
+    const start = url.searchParams.get('start') || undefined
+    const end = url.searchParams.get('end') || undefined
+
+    await this.proxyAgentRpc<
+      {
+        status?: string | string[]
+        dialog_object_id?: string
+        time_range?: { start?: string; end?: string }
+        pagination?: { page: number; page_size: number }
+      },
+      { items: unknown[]; pagination: { page: number; page_size: number; total_items: number; total_pages: number } }
+    >(res, 'list_workers_admin', {
+      ...(statuses.length === 1 ? { status: statuses[0] } : {}),
+      ...(statuses.length > 1 ? { status: statuses } : {}),
+      ...(dialogObjectId ? { dialog_object_id: dialogObjectId } : {}),
+      ...(start || end ? { time_range: { ...(start ? { start } : {}), ...(end ? { end } : {}) } } : {}),
+      pagination: {
+        page: parseIntParam(url.searchParams.get('page'), 1),
+        page_size: parseIntParam(url.searchParams.get('page_size'), 20),
+      },
+    })
+  }
+
+  /** §10.3 `GET /api/agent/workers/:id` → `get_worker_detail`（§8.3）。 */
+  private async handleGetWorkerDetailApi(
+    _req: IncomingMessage,
+    res: ServerResponse,
+    workerId: string,
+  ): Promise<void> {
+    await this.proxyAgentRpc<{ worker_id: string }, { worker: unknown }>(
+      res,
+      'get_worker_detail',
+      { worker_id: workerId },
+      // agent 侧对不存在的 worker 抛 `Worker not found: <id>`（unified-agent.ts）；映射成 404
+      // 与相邻的 `/api/agent/traces/:traceId` 一致。
+      (msg) => msg.includes('Worker not found'),
+    )
+  }
+
+  /** §10.3 `GET /api/agent/workers/:id/output` → `read_worker_output_admin`（§8.3）。 */
+  private async handleReadWorkerOutputApi(
+    _req: IncomingMessage,
+    res: ServerResponse,
+    workerId: string,
+    url: URL,
+  ): Promise<void> {
+    const cursor = url.searchParams.get('cursor') || undefined
+    await this.proxyAgentRpc<
+      { worker_id: string; seq: number; cursor?: string },
+      { chunk: string; next_cursor: string; eof: boolean }
+    >(res, 'read_worker_output_admin', {
+      worker_id: workerId,
+      // seq = 化身序号；§8.3 里必填，缺省取第一个化身。
+      seq: parseIntParam(url.searchParams.get('seq'), 0),
+      ...(cursor ? { cursor } : {}),
+    })
+  }
+
+  /** §10.3 `GET /api/agent/workers/:id/trace` → `get_worker_trace`（§8.3）。 */
+  private async handleGetWorkerTraceApi(
+    _req: IncomingMessage,
+    res: ServerResponse,
+    workerId: string,
+    url: URL,
+  ): Promise<void> {
+    const cursor = url.searchParams.get('cursor') || undefined
+    await this.proxyAgentRpc<
+      { worker_id: string; seq: number; cursor?: string },
+      { events: unknown[]; next_cursor?: string; unavailable_reason?: string }
+    >(
+      res,
+      'get_worker_trace',
+      {
+        worker_id: workerId,
+        seq: parseIntParam(url.searchParams.get('seq'), 0),
+        ...(cursor ? { cursor } : {}),
+      },
+      (msg) => msg.includes('Worker not found'),
+    )
   }
 
   private async handleDeleteTaskApi(

--- a/crabot-agent/src/manager/bootstrap.ts
+++ b/crabot-agent/src/manager/bootstrap.ts
@@ -221,18 +221,21 @@ export function buildManagerStack(deps: BootstrapDeps): ManagerStack {
     model: deps.managerModel,
     now: () => new Date(deps.now()),
     dialogObjectIdFor: deps.dialogObjectIdFor,
-    toolFace: (key, isSystemThread, onAsyncError) =>
+    toolFace: (key, isSystemThread, onAsyncError, scheduleIdentity) =>
       buildManagerToolFace({
         harness,
         workerContext: () => ({
           dialogObjectId: deps.dialogObjectIdFor(key),
           managerKey: key,
           reportTo: channelSessionFromManagerKey(key),
-          // 系统线程(未指定目标 session 的 scheduled 触发 / 查不到监护 session 的 worker
-          // 事件)派出去的 worker 记 'system';其余按人类消息触发记 'message'。
-          // 'scheduled'(有目标 session 的定时触发)由 P5 Task 4 的 trigger_schedule 路径
-          // 补,那时才有"本次唤醒是不是 schedule"这个信息。
-          triggerType: isSystemThread ? 'system' : 'message',
+          // 权限身份(§4.4"权限按 Schedule.creator_friend_id 解析(is_builtin 按 master
+          // 等价)"):内置 schedule 不以任何 friend 的名义执行,显式留空——空 creator 正是
+          // admin 侧既有的 master 等价规则(protocol-admin §"is_builtin=true 或
+          // creator_friend_id 为空 → master_private"),所以这里丢弃而不是改写成某个 id。
+          creatorFriendId: scheduleIdentity?.isBuiltin ? undefined : scheduleIdentity?.creatorFriendId,
+          // scheduled 触发(不论有无目标 session)记 'scheduled';系统线程的其余唤醒
+          // (查不到监护 session 的 worker 事件)记 'system';人类消息记 'message'。
+          triggerType: scheduleIdentity ? 'scheduled' : isSystemThread ? 'system' : 'message',
         }),
         messagingDeps: deps.messagingDeps,
         memoryServer: deps.memoryServer,

--- a/crabot-agent/src/manager/bootstrap.ts
+++ b/crabot-agent/src/manager/bootstrap.ts
@@ -43,6 +43,7 @@ import type { SpawnSpec, WorkerAdapter, WorkerImplId } from '../workers/types.js
 
 import { ManagerRegistry } from './registry.js'
 import { ManagerSessionStore } from './session-store.js'
+import { makeTaskStatusEventBridge, type AgentEventPublisher } from './events.js'
 import { shouldWakeOnHarnessEvent } from './inbound-adapters.js'
 import { buildManagerToolFace } from './tools/tool-face.js'
 import type { CompactionPolicy } from './compaction.js'
@@ -112,6 +113,12 @@ export interface BootstrapDeps {
   readonly dialogObjectIdFor: (key: ManagerKey) => DialogObjectId
   /** handoff 目标为 builtin 时的 LLM 注入缺省值,原样透传给 `HarnessDeps.builtinSpawnDefaults`。 */
   readonly builtinSpawnDefaults?: () => SpawnSpec['builtin']
+  /**
+   * 对外事件发布口(§9.2 `agent.task_status_changed`),由 `makeAgentEventPublisher` 构造。
+   * 可选:P5 阶段这套栈没有生产调用方,注入真实 rpcClient 是 P5 Task 6 的事;不注入则本栈
+   * 只维护台账、不对外发事件。
+   */
+  readonly publishEvent?: AgentEventPublisher
 }
 
 /** `ManagerKey` → `{channel_id, session_id}`。按**第一个** `::` 切,session_id 里再含 `::` 也不会被截断。 */
@@ -147,6 +154,12 @@ export function buildManagerStack(deps: BootstrapDeps): ManagerStack {
   // 见文件头"与 registry 的环形依赖"。
   let registry: ManagerRegistry | undefined
 
+  // harness 事件 → 对外的 `agent.task_status_changed`(§9.2)。翻译与去重都在 events.ts 里,
+  // 这里只负责把口子接上。
+  const publishTaskStatusChanged = deps.publishEvent
+    ? makeTaskStatusEventBridge({ ledger, publish: deps.publishEvent })
+    : undefined
+
   // --- 四步接线契约 step 1:先建空壳 Map ---
   const adapters = new Map<WorkerImplId, WorkerAdapter>()
 
@@ -162,6 +175,12 @@ export function buildManagerStack(deps: BootstrapDeps): ManagerStack {
     // 工具调用里同步拿到结果)。fire-and-forget,必须 .catch():路由失败绝不能反噬 harness 的
     // 状态机推进,更不能变成 unhandledRejection 打崩 agent 进程。
     onEvent: (event) => {
+      // 对外事件走在唤醒过滤之前,且不共用下面那个门:`shouldWakeOnHarnessEvent` 答的是"要不
+      // 要唤醒 manager"(input_sent 不唤醒),`!registry` 答的是"manager 侧接线好了没"——两者
+      // 都与"task 状态有没有变"无关,拿它们当对外事件的门,等于把 §9.2 的正确性挂在别的模块
+      // 的过滤规则上。对外事件自己的去重按 task.status 做,在 events.ts 里。
+      publishTaskStatusChanged?.(event)
+
       if (!registry || !shouldWakeOnHarnessEvent(event)) return
       void registry.routeWorkerEvent(event).catch((err) => {
         console.error(`[manager-bootstrap] routeWorkerEvent 失败 (worker=${event.worker_id}, kind=${event.kind}):`, err)

--- a/crabot-agent/src/manager/bootstrap.ts
+++ b/crabot-agent/src/manager/bootstrap.ts
@@ -1,0 +1,248 @@
+/**
+ * manager 栈装配 —— protocol-agent-v3.md §4/§5/§6/§7(P5 Task 1)。
+ *
+ * P4 之前,`LedgerStore` / `WorkspaceManager` / `WorkerHarness` / 三个 `WorkerAdapter` /
+ * `ManagerRegistry` 只在测试里被完整装配过(`tests/manager/manager-integration.test.ts` 的
+ * 私有 `setupAssembly`,以及 `tests/workers/harness/*` 里五份重复的 `makeHarness`)——生产
+ * 侧没有任何装配入口。本文件是第一个:把那套只存在于测试里的接线固化成生产代码,
+ * `unified-agent.ts`(P5 Task 6)持有它,其余调用方一律经 `ManagerStack` 取件,不再各自 new。
+ *
+ * ## 两条硬边界
+ *
+ * 1. **`buildManagerStack` 无 I/O 副作用**:只 new 对象、只接回调。不调 `adapter.detect()`
+ *    (会起 `claude --version` / `codex --version` / `tmux -V` 子进程)、不调
+ *    `ledger.init()`(会 `mkdir -p` 并扫整个台账目录)、不碰 workspace。理由:它在 agent
+ *    启动路径上被调用,而 P5 阶段这套栈**没有任何生产调用方**——装配本身的现网影响必须
+ *    近似为零。需要探测/对账时由调用方显式调下面的 `reconcileManagerStack`。
+ * 2. **`harness.ts` 文件头的四步接线契约**:空 Map → `new WorkerHarness({adapters})` →
+ *    构造三个 adapter 时传 `onStateChange: harness.handleStateChange` → `adapters.set(...)`
+ *    回**同一个** Map。顺序写错(比如先构造 adapter 再构造 harness、或 set 进另一个 Map)
+ *    的后果是静默的:adapter 的状态变化到不了 harness,台账永远停在旧状态。
+ *
+ * ## 与 registry 的环形依赖
+ *
+ * `HarnessDeps.onEvent` 要把 harness 事件路由给 manager(`registry.routeWorkerEvent`),而
+ * `ManagerRegistryDeps.harness` 又要求 harness 先存在。用一个 `let` 闭包变量打破环:harness
+ * 构造时 registry 还是 undefined,但 `onEvent` 只在真有事件发生时才读它,那时 registry 早已
+ * 赋值。这与四步接线契约里"Map 引用先给、内容后填"是同一种解法。
+ *
+ * @see crabot-docs/protocols/protocol-agent-v3.md §4、§5、§6、§7
+ * @see crabot-agent/src/workers/harness/harness.ts 文件头"onStateChange 接线契约"
+ */
+
+import { join, resolve } from 'path'
+
+import { WorkerHarness, type HarnessDeps, type ReconcileReport } from '../workers/harness/harness'
+import { LedgerStore } from '../workers/harness/ledger-store'
+import { WorkspaceManager } from '../workers/harness/workspace-manager'
+import type { DialogObjectId } from '../workers/harness/ledger-types'
+import { BuiltinWorkerAdapter } from '../workers/builtin/adapter.js'
+import { ClaudeCodeAdapter } from '../workers/claude-code/adapter.js'
+import { CodexWorkerAdapter } from '../workers/codex/adapter.js'
+import type { SpawnSpec, WorkerAdapter, WorkerImplId } from '../workers/types.js'
+
+import { ManagerRegistry } from './registry.js'
+import { ManagerSessionStore } from './session-store.js'
+import { shouldWakeOnHarnessEvent } from './inbound-adapters.js'
+import { buildManagerToolFace } from './tools/tool-face.js'
+import type { CompactionPolicy } from './compaction.js'
+import type { ManagerKey } from './types.js'
+
+// 与 `unified-agent.ts` 同款引用路径:这两个常量没有从 `engine/index.ts` 转出,直接引子模块
+// (engine 本阶段零改动,不为此新增 barrel 导出)。
+import { ContextManager, DEFAULT_COMPACT_THRESHOLD } from '../engine/context-manager.js'
+import { DEFAULT_MAX_CONTEXT_TOKENS } from '../engine/query-loop.js'
+import type { LLMAdapter } from '../engine/index.js'
+import type { CrabMessagingDeps } from '../mcp/crab-messaging.js'
+import type { McpServer } from '../mcp/mcp-helpers.js'
+
+/**
+ * 全局缺省 worker 实现(§6.4"实现选择":人类显式指定 > manager 按偏好选择 > 全局默认)。
+ * 取 builtin:它是唯一不依赖外部 CLI 安装/登录态的实现,`detect()` 恒 true,不会因为开发机
+ * 没装 claude/codex 就让 `spawn_worker` 在缺省路径上直接失败。
+ */
+const DEFAULT_WORKER_IMPL: WorkerImplId = 'builtin'
+
+/**
+ * manager 会话压缩参数(§4.2"参数经 extra 配置"——尚无配置入口,这里给一份可用缺省)。
+ * - `keepRecent`:唤醒边界之外保留的原始消息条数,取 20(manager 的一轮 episode 常有
+ *   数条工具调用往返,留太少会把同一件事的上下文折断);
+ * - `cacheTtlMs`:prompt 缓存热判定窗口,取 5 分钟——与 provider 侧 prompt cache 的常见
+ *   TTL 一致,超过它再压缩不会浪费一次已经失效的缓存前缀;
+ * - `foldTokenThreshold`:唤醒边界折叠的历史 token 门槛;
+ * - `hardCapTokens`:热态强压兜底,直接复用 engine 自己的比例常量
+ *   `DEFAULT_COMPACT_THRESHOLD` × 默认上下文窗口,不另定一个数。
+ */
+export const DEFAULT_MANAGER_COMPACTION_POLICY: CompactionPolicy = {
+  keepRecent: 20,
+  cacheTtlMs: 5 * 60_000,
+  foldTokenThreshold: 20_000,
+  hardCapTokens: Math.floor(DEFAULT_MAX_CONTEXT_TOKENS * DEFAULT_COMPACT_THRESHOLD),
+}
+
+export interface ManagerStack {
+  readonly ledger: LedgerStore
+  readonly harness: WorkerHarness
+  readonly registry: ManagerRegistry
+  readonly adapters: Map<WorkerImplId, WorkerAdapter>
+  /**
+   * builtin adapter 的私有 dataDir。`reconcileManagerStack` 需要它跑
+   * `BuiltinWorkerAdapter.scanOrphans`——见该函数注释里的顺序契约。放在 stack 上而不是
+   * 让调用方自己推,是为了让"路径怎么派生"这件事只有 `buildManagerStack` 一处真相。
+   */
+  readonly builtinDataDir: string
+}
+
+export interface BootstrapDeps {
+  /** 存储根(= `getDataRootDir()`,即 `$DATA_DIR`);台账/事件流/manager 会话都按 §7 派生自它。 */
+  readonly dataRoot: string
+  /** ISO 时间注入(harness 用);registry 需要的 `() => Date` 由本模块从它派生,保持单一时间源。 */
+  readonly now: () => string
+  /** manager 的 LLM 来源(model_config.manager ?? powerful),thunk 以支持热更 */
+  readonly managerAdapter: () => LLMAdapter
+  readonly managerModel: () => string
+  readonly messagingDeps: CrabMessagingDeps
+  readonly memoryServer: McpServer
+  readonly callAdmin: <P, R>(m: string, p: P) => Promise<R>
+  /**
+   * `ManagerKey`(channel::session)→ 台账聚合键 `DialogObjectId`。必须由调用方注入:
+   * 私聊要解析成 `friend:<friend_id>`(跨 channel 聚合),这一步依赖 admin 的 friend 解析,
+   * 本模块拿不到,而 `ManagerRegistryDeps.dialogObjectIdFor` 又是同步签名,不能在这里现查。
+   */
+  readonly dialogObjectIdFor: (key: ManagerKey) => DialogObjectId
+  /** handoff 目标为 builtin 时的 LLM 注入缺省值,原样透传给 `HarnessDeps.builtinSpawnDefaults`。 */
+  readonly builtinSpawnDefaults?: () => SpawnSpec['builtin']
+}
+
+/** `ManagerKey` → `{channel_id, session_id}`。按**第一个** `::` 切,session_id 里再含 `::` 也不会被截断。 */
+function channelSessionFromManagerKey(key: ManagerKey): { channel_id: string; session_id: string } {
+  const sep = key.indexOf('::')
+  return sep < 0
+    ? { channel_id: key, session_id: '' }
+    : { channel_id: key.slice(0, sep), session_id: key.slice(sep + 2) }
+}
+
+/**
+ * worker workspace 根。与 `core/data-paths.ts` 的 `getWorkspacesRootDir()` 语义一致
+ * (`WORKER_WORKSPACES_DIR` 覆盖 > `<dataRoot>/workspaces`),但根从注入的 `dataRoot` 派生
+ * 而不是从进程 env 推导——bootstrap 的所有路径都必须可被调用方/测试完全决定。
+ */
+function resolveWorkspacesRoot(dataRoot: string): string {
+  return process.env.WORKER_WORKSPACES_DIR ? resolve(process.env.WORKER_WORKSPACES_DIR) : join(dataRoot, 'workspaces')
+}
+
+/**
+ * 只构造对象与接线,不做探测/不扫盘/不建目录;可安全在启动路径调用(见文件头"两条硬边界")。
+ */
+export function buildManagerStack(deps: BootstrapDeps): ManagerStack {
+  const agentDir = join(deps.dataRoot, 'agent')
+  // 三个 adapter 各自的私有 dataDir(存 meta-<seq>.json / 运行时目录 / session 树),与 §7 的
+  // `agent/workers/<worker_id>/`(harness 亲历事件流与输出)是两个互不相干的目录。
+  const adapterDataDir = (impl: WorkerImplId): string => join(agentDir, 'worker-adapters', impl)
+  const builtinDataDir = adapterDataDir('builtin')
+
+  const ledger = new LedgerStore(join(agentDir, 'ledgers'))
+  const workspaces = new WorkspaceManager(resolveWorkspacesRoot(deps.dataRoot))
+
+  // 见文件头"与 registry 的环形依赖"。
+  let registry: ManagerRegistry | undefined
+
+  // --- 四步接线契约 step 1:先建空壳 Map ---
+  const adapters = new Map<WorkerImplId, WorkerAdapter>()
+
+  const harnessDeps: HarnessDeps = {
+    adapters,
+    defaultImpl: DEFAULT_WORKER_IMPL,
+    ledger,
+    workspaces,
+    workersDir: join(agentDir, 'workers'),
+    now: deps.now,
+    // harness 事件 → 该 worker 的监护 manager(§4.4)。过滤复用 P4 的
+    // `shouldWakeOnHarnessEvent`(input_sent 不唤醒:manager 发起 send_to_worker 时已在同一次
+    // 工具调用里同步拿到结果)。fire-and-forget,必须 .catch():路由失败绝不能反噬 harness 的
+    // 状态机推进,更不能变成 unhandledRejection 打崩 agent 进程。
+    onEvent: (event) => {
+      if (!registry || !shouldWakeOnHarnessEvent(event)) return
+      void registry.routeWorkerEvent(event).catch((err) => {
+        console.error(`[manager-bootstrap] routeWorkerEvent 失败 (worker=${event.worker_id}, kind=${event.kind}):`, err)
+      })
+    },
+    builtinSpawnDefaults: deps.builtinSpawnDefaults,
+  }
+
+  // --- step 2:把空壳 Map 交给 harness ---
+  const harness = new WorkerHarness(harnessDeps)
+
+  // --- step 3 + 4:构造三个 adapter 时传 harness.handleStateChange,再 set 回同一个 Map ---
+  adapters.set(
+    'builtin',
+    new BuiltinWorkerAdapter({ dataDir: builtinDataDir, onStateChange: harness.handleStateChange }),
+  )
+  adapters.set(
+    'claude-code',
+    new ClaudeCodeAdapter({ dataDir: adapterDataDir('claude-code'), onStateChange: harness.handleStateChange }),
+  )
+  adapters.set(
+    'codex',
+    new CodexWorkerAdapter({ dataDir: adapterDataDir('codex'), onStateChange: harness.handleStateChange }),
+  )
+
+  // token 估算复用 engine 既有的 `ContextManager.estimateTotalTokens`(chars/4 + 每条消息
+  // 固定开销 + 图片按固定 token 折算),与 `unified-agent.ts` 里同款用法一致——不另写一版
+  // 估算器,避免"重造版本漏掉原版有的条件"。
+  const tokenEstimator = new ContextManager({ maxContextTokens: DEFAULT_MAX_CONTEXT_TOKENS })
+
+  registry = new ManagerRegistry({
+    store: new ManagerSessionStore(join(agentDir, 'managers')),
+    policy: DEFAULT_MANAGER_COMPACTION_POLICY,
+    estimateTokens: (msgs) => tokenEstimator.estimateTotalTokens(msgs),
+    harness,
+    ledger,
+    adapter: deps.managerAdapter,
+    model: deps.managerModel,
+    now: () => new Date(deps.now()),
+    dialogObjectIdFor: deps.dialogObjectIdFor,
+    toolFace: (key, isSystemThread, onAsyncError) =>
+      buildManagerToolFace({
+        harness,
+        workerContext: () => ({
+          dialogObjectId: deps.dialogObjectIdFor(key),
+          managerKey: key,
+          reportTo: channelSessionFromManagerKey(key),
+          // 系统线程(未指定目标 session 的 scheduled 触发 / 查不到监护 session 的 worker
+          // 事件)派出去的 worker 记 'system';其余按人类消息触发记 'message'。
+          // 'scheduled'(有目标 session 的定时触发)由 P5 Task 4 的 trigger_schedule 路径
+          // 补,那时才有"本次唤醒是不是 schedule"这个信息。
+          triggerType: isSystemThread ? 'system' : 'message',
+        }),
+        messagingDeps: deps.messagingDeps,
+        memoryServer: deps.memoryServer,
+        callAdmin: deps.callAdmin,
+        isSystemThread,
+        // 这一行是本文件存在的理由之一:registry 按 key 绑定好的 onAsyncError 必须一路传到
+        // `buildWorkerTools`,否则 codex worker 上 `query_worker`(fork 能力恒 false)的失败
+        // 只会 console.error,manager 永远等不到回音(P4 Task 8 留给本 task 的验证点)。
+        onAsyncError,
+      }),
+    // system prompt 的动态段素材(对话对象档案 / 待处理通知)目前没有解析入口,给空对象;
+    // prompt.ts 对两者缺省都有处理,不会因此少渲染任何必需段落。
+    promptInputs: () => ({}),
+  })
+
+  return { ledger, harness, registry, adapters, builtinDataDir }
+}
+
+/**
+ * 显式的启动对账入口(§12),与构造分离——由调用方决定何时调(建议:启动后异步跑一次,
+ * 失败仅 warn)。
+ *
+ * 两步顺序不可换,理由见 `harness.reconcileOnStartup` 的方法注释:`scanOrphans` 修的是
+ * builtin adapter 自己 dataDir 下 meta 文件那份"进程内存活状态"私有真相(进程重启后
+ * state==='running' 的 meta 必是孤儿),必须先把它改写成 exited(crashed);否则
+ * `reconcileOnStartup` 调 `builtin.state()` 时会读到过期的 'running',把已经不存在的化身
+ * 误判进 revived 桶。
+ */
+export async function reconcileManagerStack(stack: ManagerStack): Promise<ReconcileReport> {
+  await BuiltinWorkerAdapter.scanOrphans(stack.builtinDataDir)
+  return stack.harness.reconcileOnStartup()
+}

--- a/crabot-agent/src/manager/events.ts
+++ b/crabot-agent/src/manager/events.ts
@@ -1,0 +1,158 @@
+/**
+ * agent 对外事件 —— protocol-agent-v3.md §9.2(P5 Task 2)。
+ *
+ * v3 把 task 的真相源从 admin 迁到 agent,`admin.task_status_changed` 随之由
+ * `agent.task_status_changed` 取代(发布方从 admin 变为 agent)。agent 侧此前**没有任何
+ * 事件发布口**(全仓零 `publishEvent` 调用),本文件是第一个。
+ *
+ * ## 两件事,两个函数
+ *
+ * 1. `makeAgentEventPublisher`:信封 + 投递。形状照抄 admin 的 `publishAdminEvent`
+ *    (`crabot-admin/src/index.ts:6151`):`{id: generateId(), type, source: moduleId,
+ *    payload, timestamp}` → `rpcClient.publishEvent(event, moduleId)`,fire-and-forget
+ *    且 `.catch()` 记日志。**唯一有意的偏离**:多包一层 try/catch,连 `publishEvent` 的
+ *    同步抛错(如 rpcClient 尚未就绪)也吃掉——admin 的版本只 catch 了 rejection,而本模块
+ *    的调用点在 harness 的状态机推进路径上(`appendEvent` 内),任何反噬都会污染 worker 主
+ *    流程,不能只防一半。
+ * 2. `makeTaskStatusEventBridge`:harness 事件 → task 状态事件的**翻译与去重**。
+ *
+ * ## 为什么必须去重(不能一对一映射)
+ *
+ * `HarnessEvent` 是**化身级**的(`{ts, kind, worker_id, seq, detail?}`,见 worker-events.ts):
+ * 一次 `send_to_worker` 会落 `input_sent`,一次 fork 会落 `state_changed{kind:'fork'}`,
+ * 投递到已取消 task 会落 `state_changed{kind:'dead_letter'}`——这些**都不改 task.status**。
+ * 而 `agent.task_status_changed` 是**任务级**的,只在 task 真的迁移时才该发。
+ *
+ * ## old_status 从哪来
+ *
+ * `HarnessEvent` 不带 from/to(`state_changed` 的 detail 只有 `{to: <化身契约状态>}`),协议
+ * 也没有别的出口,所以只能由本模块维护一份 `worker_id → 上一次已见 task.status`。新状态则
+ * 现读台账:harness 的所有状态迁移都是"先 `upsertWorker` 落账、后 `appendEvent`"(见
+ * harness.ts 的 spawnWorker / processStateChange / killWorker),事件到达时台账已是迁移后的
+ * 真值。
+ *
+ * 这份 map 的三条边界(选择的代价,调用方需知情):
+ * - **首次观测的兜底是 `'queued'`**(§5.2:task 建账即 queued)。worker 在本进程内 spawn 的
+ *   主路径因此是准的(spawnWorker 建 queued → 迁 running → 落 `spawned` 事件,翻译出
+ *   queued→running);但**agent 重启后**遗留的在途 worker,其第一条事件的 `old_status` 会退化
+ *   成 `'queued'`(`new_status` 始终准确,取自台账)。
+ * - **两次迁移之间没有事件时,中间态被折叠**。已知的一例是 spawn 失败路径:台账上是
+ *   queued→running→failed 两跳,但只落一条 `exited` 事件,翻译出 queued→failed。端点正确,
+ *   中间的 running 丢失。
+ * - **终态不清理条目**:§5.3 的透明接续(`reviveTask`)会把终态 task 拉回 running,清理掉就
+ *   会让那次迁移的 old_status 退化成 'queued'。代价是每个进程生命周期内见过的 worker 各留
+ *   一条 `worker_id → 状态字符串`(~百字节);worker 是重量级实体(一个 CLI/tmux 会话 + 一个
+ *   workspace 目录),单进程内的实际数量在百量级,不值得为此引入淘汰策略再换回错误的
+ *   old_status。
+ *
+ * @see crabot-docs/protocols/protocol-agent-v3.md §9.2、§5.2、§5.3
+ * @see crabot-admin/src/index.ts 的 `publishAdminEvent`(信封与 fire-and-forget 的既有范式)
+ */
+
+import { generateId, type Event, type ModuleId, type RpcClient } from 'crabot-shared'
+
+import type { LedgerStore } from '../workers/harness/ledger-store.js'
+import type { DialogObjectId, TaskStatus } from '../workers/harness/ledger-types.js'
+import type { HarnessEvent } from '../workers/harness/harness.js'
+import type { TaskId } from '../types.js'
+
+/** protocol-agent-v3 §9.2 `agent.task_status_changed` 载荷(字段逐字对齐,不增不减)。 */
+export interface AgentTaskStatusChangedPayload {
+  worker_id: string
+  task_id: TaskId
+  old_status: TaskStatus
+  new_status: TaskStatus
+  dialog_object_id: DialogObjectId
+}
+
+/** 对外事件发布口。同步返回(fire-and-forget),失败只记日志。 */
+export type AgentEventPublisher = (
+  type: 'agent.task_status_changed',
+  payload: AgentTaskStatusChangedPayload,
+) => void
+
+/**
+ * 信封 + 投递,照 admin `publishAdminEvent` 的做法(见文件头)。
+ *
+ * `rpcClient` 用 `Pick<RpcClient, 'publishEvent'>` 而不是整个 `RpcClient`:本模块只需要这一个
+ * 方法,窄依赖同时让测试不必伪造整个 RpcClient。
+ */
+export function makeAgentEventPublisher(deps: {
+  rpcClient: Pick<RpcClient, 'publishEvent'>
+  moduleId: ModuleId
+  now: () => string
+}): AgentEventPublisher {
+  return (type, payload) => {
+    const event: Event = {
+      id: generateId(),
+      type,
+      source: deps.moduleId,
+      payload,
+      timestamp: deps.now(),
+    }
+    // 事件发布绝不能反噬调用方(见文件头):rejection 与同步抛错都在这里终结。
+    try {
+      deps.rpcClient.publishEvent(event, deps.moduleId).catch((err: unknown) => {
+        console.error(`[agent-events] 发布事件失败 ${type}:`, err)
+      })
+    } catch (err) {
+      console.error(`[agent-events] 发布事件失败 ${type}:`, err)
+    }
+  }
+}
+
+/** 台账里 task 的建账初始状态(§5.2),即"没见过这个 worker"时 old_status 的兜底值。 */
+const INITIAL_TASK_STATUS: TaskStatus = 'queued'
+
+/**
+ * harness 事件 → `agent.task_status_changed`。返回的函数直接挂在 `HarnessDeps.onEvent` 上
+ * (由 bootstrap 接线),同步返回、内部 fire-and-forget。
+ *
+ * 每个 worker 一条 promise 链:`onEvent` 是同步回调,而翻译要异步读台账,不串行的话两条紧邻
+ * 事件的台账读会交叉完成,先到的事件可能后发布,`old_status`/`new_status` 直接错位(甚至倒
+ * 着报一条不存在的迁移)。链跑空即从 map 里摘掉,不留残条目。
+ */
+export function makeTaskStatusEventBridge(deps: {
+  ledger: Pick<LedgerStore, 'findWorker'>
+  publish: AgentEventPublisher
+}): (event: HarnessEvent) => void {
+  const lastKnownStatus = new Map<string, TaskStatus>()
+  const chains = new Map<string, Promise<void>>()
+
+  const translate = async (workerId: string): Promise<void> => {
+    const found = await deps.ledger.findWorker(workerId)
+    // worker 不在台账(如 query_failed 的 worker_not_found 分支):没有 task,无从谈状态迁移。
+    if (!found) return
+
+    const newStatus = found.worker.task.status
+    const oldStatus = lastKnownStatus.get(workerId) ?? INITIAL_TASK_STATUS
+    // 去重的落点:化身级事件与同状态重复回调都停在这里,一条对外事件都不发。
+    if (oldStatus === newStatus) return
+
+    lastKnownStatus.set(workerId, newStatus)
+    deps.publish('agent.task_status_changed', {
+      worker_id: workerId,
+      task_id: found.worker.task.id,
+      old_status: oldStatus,
+      new_status: newStatus,
+      dialog_object_id: found.dialogObjectId,
+    })
+  }
+
+  return (event: HarnessEvent) => {
+    const workerId = event.worker_id
+    const prev = chains.get(workerId) ?? Promise.resolve()
+    const next = prev
+      .then(() => translate(workerId))
+      .catch((err: unknown) => {
+        console.error(
+          `[agent-events] task 状态事件翻译失败 (worker=${workerId}, kind=${event.kind}):`,
+          err,
+        )
+      })
+      .finally(() => {
+        if (chains.get(workerId) === next) chains.delete(workerId)
+      })
+    chains.set(workerId, next)
+  }
+}

--- a/crabot-agent/src/manager/events.ts
+++ b/crabot-agent/src/manager/events.ts
@@ -23,27 +23,50 @@
  * 投递到已取消 task 会落 `state_changed{kind:'dead_letter'}`——这些**都不改 task.status**。
  * 而 `agent.task_status_changed` 是**任务级**的,只在 task 真的迁移时才该发。
  *
- * ## old_status 从哪来
+ * ## new_status / old_status 从哪来
  *
- * `HarnessEvent` 不带 from/to(`state_changed` 的 detail 只有 `{to: <化身契约状态>}`),协议
- * 也没有别的出口,所以只能由本模块维护一份 `worker_id → 上一次已见 task.status`。新状态则
- * 现读台账:harness 的所有状态迁移都是"先 `upsertWorker` 落账、后 `appendEvent`"(见
- * harness.ts 的 spawnWorker / processStateChange / killWorker),事件到达时台账已是迁移后的
- * 真值。
+ * **`new_status` 由事件自带**(`HarnessEvent.task_status`,harness 在 `appendEvent` 时把
+ * `upsertWorker` 落账后的 `task.status` 钉在事件上)。
+ *
+ * 这里曾经是**现读台账**(`ledger.findWorker(worker_id).worker.task.status`),被独立评审的
+ * PoC 证伪:`LedgerStore.findWorker` 不进互斥锁、读的永远是最新已提交文件,只要这次读发生
+ * 在**下一次落账之后**,那个中间状态就被整条吞掉——PoC 里 `completed` 这个订阅方最关心的
+ * 终态**一次都没发出去**(spawned/exited/resumed 三条事件,exited 的读晚于 §5.3 透明接续把
+ * task 拉回 running 的那次落账)。把值钉在事件上,读取时刻与落账时刻就此解耦。
+ *
+ * **台账读没有全部消失**,但读的只剩 `task_id` 与 `dialog_object_id` 两个字段——它们在一个
+ * worker 的整个生命周期内不变(`task.id` 建账即等于 `worker_id`,`dialog_object_id` 是台账的
+ * 聚合键),读晚了也读不出别的值,不存在"被下一次落账折叠"的问题。会随时间变化的只有
+ * `status`,而它已经不再现读。
+ *
+ * **`old_status`**:`HarnessEvent` 只描述"这次迁移之后",协议没有别的出口,所以仍由本模块
+ * 维护一份 `worker_id → 上一次已见 task.status`。
  *
  * 这份 map 的三条边界(选择的代价,调用方需知情):
  * - **首次观测的兜底是 `'queued'`**(§5.2:task 建账即 queued)。worker 在本进程内 spawn 的
  *   主路径因此是准的(spawnWorker 建 queued → 迁 running → 落 `spawned` 事件,翻译出
  *   queued→running);但**agent 重启后**遗留的在途 worker,其第一条事件的 `old_status` 会退化
- *   成 `'queued'`(`new_status` 始终准确,取自台账)。
+ *   成 `'queued'`(`new_status` 始终准确)。
  * - **两次迁移之间没有事件时,中间态被折叠**。已知的一例是 spawn 失败路径:台账上是
- *   queued→running→failed 两跳,但只落一条 `exited` 事件,翻译出 queued→failed。端点正确,
- *   中间的 running 丢失。
+ *   queued→running→failed 两跳,但只落一条 `exited` 事件(带 `task_status:'failed'`),翻译出
+ *   queued→failed。端点正确,中间的 running 丢失。这是"没有事件"造成的折叠,与上面修掉的
+ *   "有事件但读晚了"是两回事,后者已经不存在。
+ *   由此推论并明确记一句:**对外事件的 `old→new` 只保证端点正确,不保证是状态机合法边**
+ *   (`VALID_TRANSITIONS['queued']` 只有 `['running','cancelled']`,不含 failed)。任何对
+ *   订阅到的迁移做合法性校验的消费者都会被这条打挂,P7 接线时必须知情。
  * - **终态不清理条目**:§5.3 的透明接续(`reviveTask`)会把终态 task 拉回 running,清理掉就
  *   会让那次迁移的 old_status 退化成 'queued'。代价是每个进程生命周期内见过的 worker 各留
  *   一条 `worker_id → 状态字符串`(~百字节);worker 是重量级实体(一个 CLI/tmux 会话 + 一个
  *   workspace 目录),单进程内的实际数量在百量级,不值得为此引入淘汰策略再换回错误的
  *   old_status。
+ *
+ * ## 事件没带 task_status 怎么办 —— 退回现读台账
+ *
+ * `task_status` 是 additive 可选字段:化身级事件点不带它(它们本来就没有迁移),老事件日志
+ * 文件里的事件也不带。缺席时**退回修复前的行为**(现读台账取状态),而不是当成"无迁移"跳过。
+ * 理由:跳过会把"字段缺席"变成一条**新的静默丢事件路径**——只要 harness 将来新增一个迁移点
+ * 忘了带这个参数,或者某处分类判断错了,那条迁移就永远发不出去且无声无息;而退回现读台账
+ * 最差也只是退化成修复前那套(端点仍会被后续事件纠正),严格不劣于现状。
  *
  * @see crabot-docs/protocols/protocol-agent-v3.md §9.2、§5.2、§5.3
  * @see crabot-admin/src/index.ts 的 `publishAdminEvent`(信封与 fire-and-forget 的既有范式)
@@ -108,9 +131,13 @@ const INITIAL_TASK_STATUS: TaskStatus = 'queued'
  * harness 事件 → `agent.task_status_changed`。返回的函数直接挂在 `HarnessDeps.onEvent` 上
  * (由 bootstrap 接线),同步返回、内部 fire-and-forget。
  *
- * 每个 worker 一条 promise 链:`onEvent` 是同步回调,而翻译要异步读台账,不串行的话两条紧邻
- * 事件的台账读会交叉完成,先到的事件可能后发布,`old_status`/`new_status` 直接错位(甚至倒
- * 着报一条不存在的迁移)。链跑空即从 map 里摘掉,不留残条目。
+ * 每个 worker 一条 promise 链——`new_status` 改由事件自带之后这条链**仍然是必需的**,原因有二:
+ * 1. 台账读还在(取 `task_id` / `dialog_object_id`,见文件头),`onEvent` 却是同步回调:不串行
+ *    的话两条紧邻事件的读会交叉完成,发布顺序被打乱,订阅方最后落到的会是**较早**那个状态
+ *    (对 admin 就是"任务永远显示 running");
+ * 2. `lastKnownStatus` 的读与写跨了那个 await,不串行就会出现两条事件读到同一个 old_status、
+ *    互相覆盖,倒着报一条根本不存在的迁移。
+ * 链跑空即从 map 里摘掉,不留残条目。
  */
 export function makeTaskStatusEventBridge(deps: {
   ledger: Pick<LedgerStore, 'findWorker'>
@@ -119,12 +146,15 @@ export function makeTaskStatusEventBridge(deps: {
   const lastKnownStatus = new Map<string, TaskStatus>()
   const chains = new Map<string, Promise<void>>()
 
-  const translate = async (workerId: string): Promise<void> => {
+  const translate = async (event: HarnessEvent): Promise<void> => {
+    const workerId = event.worker_id
+    // 只为拿两个**不随时间变化**的字段:task_id 与 dialog_object_id(见文件头)。状态不从这里取。
     const found = await deps.ledger.findWorker(workerId)
     // worker 不在台账(如 query_failed 的 worker_not_found 分支):没有 task,无从谈状态迁移。
     if (!found) return
 
-    const newStatus = found.worker.task.status
+    // 事件自带的落账后状态优先;缺席时退回现读台账(见文件头"事件没带 task_status 怎么办")。
+    const newStatus = event.task_status ?? found.worker.task.status
     const oldStatus = lastKnownStatus.get(workerId) ?? INITIAL_TASK_STATUS
     // 去重的落点:化身级事件与同状态重复回调都停在这里,一条对外事件都不发。
     if (oldStatus === newStatus) return
@@ -143,7 +173,7 @@ export function makeTaskStatusEventBridge(deps: {
     const workerId = event.worker_id
     const prev = chains.get(workerId) ?? Promise.resolve()
     const next = prev
-      .then(() => translate(workerId))
+      .then(() => translate(event))
       .catch((err: unknown) => {
         console.error(
           `[agent-events] task 状态事件翻译失败 (worker=${workerId}, kind=${event.kind}):`,

--- a/crabot-agent/src/manager/loop.ts
+++ b/crabot-agent/src/manager/loop.ts
@@ -59,7 +59,20 @@ import type { ChannelMessage } from '../types'
 export type WakeEvent =
   | { readonly kind: 'human_messages'; readonly messages: ReadonlyArray<ChannelMessage> }
   | { readonly kind: 'worker_event'; readonly event: HarnessEvent }
-  | { readonly kind: 'schedule'; readonly scheduleId: string; readonly title: string; readonly description: string }
+  | {
+      readonly kind: 'schedule'
+      readonly scheduleId: string
+      readonly title: string
+      readonly description: string
+      /**
+       * P5 Task 4 additive:本次调度触发的**权限身份**(protocol-agent-v3 §8.2
+       * `creator_friend_id` / `is_builtin`,§4.4"权限按 Schedule.creator_friend_id 解析")。
+       * 只在唤醒事件上随行,不进 manager 的对话上下文(`renderWakeEvent` 不渲染它):它的
+       * 用途是让本 episode 派出去的 worker 记对 `origin.creator_friend_id`,不是给 LLM 看的。
+       */
+      readonly creatorFriendId?: string
+      readonly isBuiltin?: boolean
+    }
   | { readonly kind: 'attention_flush'; readonly messages: ReadonlyArray<ChannelMessage> }
 
 export interface EpisodeResult {
@@ -93,8 +106,14 @@ export interface ManagerLoopDeps {
   readonly model: () => string
   readonly maxTurns?: number
   readonly contextWindowTokens?: number
-  /** 工具面提供者(thunk):每轮重算,由调用方决定要不要按最新状态重建。 */
-  readonly toolFace: () => ReadonlyArray<ToolDefinition>
+  /**
+   * 工具面提供者(thunk):每轮重算,由调用方决定要不要按最新状态重建。
+   *
+   * P5 Task 4 additive:入参是**本 episode 的唤醒事件**,让调用方能按"这次是被什么唤醒的"
+   * 装配工具面(当前唯一用途:scheduled 触发的权限身份 → `spawn_worker` 的
+   * `origin.creator_friend_id`)。可选参数,既有调用方 `() => [...]` 无需改动。
+   */
+  readonly toolFace: (wakeEvent?: WakeEvent) => ReadonlyArray<ToolDefinition>
   /** system prompt 里除动态台账/时间外的其余输入(档案、待处理通知),每轮重算。 */
   readonly promptInputs: () => { readonly dialogProfile?: string; readonly pendingNotes?: ReadonlyArray<string> }
   readonly harness: WorkerHarness
@@ -128,6 +147,14 @@ export class ManagerLoop {
    * 不记录——那时 mailbox 只是普通 pending 队列,靠下次 wakeUp 顶部的 drainPending 自然带走。
    */
   private currentEpisodeInjected: string[] | null = null
+  /**
+   * P5 Task 4 additive:本 episode 的唤醒事件,供 `deps.toolFace(wakeEvent)` 按"这次是被
+   * 什么唤醒的"装配工具面(见 `ManagerLoopDeps.toolFace`)。与 `currentEpisodeInjected`
+   * 同一套生命周期纪律(runEpisode 进入时置、finally 清),因此天然是**每 episode 精确**的
+   * ——同一 loop 的 episode 由 `wakeUp` 的 mutex 串行,不会有两个 episode 的唤醒事件交叠;
+   * 这正是不把它做成 registry 侧 `Map<ManagerKey, …>` 的原因(那样并发唤醒会串身份)。
+   */
+  private currentWakeEvent: WakeEvent | null = null
 
   constructor(deps: ManagerLoopDeps) {
     this.deps = deps
@@ -151,6 +178,7 @@ export class ManagerLoop {
     const carriedTexts = this.mailbox.drainPending().map(toText)
     const eventText = renderWakeEvent(event)
     this.currentEpisodeInjected = []
+    this.currentWakeEvent = event
 
     try {
       return await this.runEpisodeBody(episodeId, carriedTexts, eventText)
@@ -171,6 +199,7 @@ export class ManagerLoop {
       throw err
     } finally {
       this.currentEpisodeInjected = null
+      this.currentWakeEvent = null
     }
   }
 
@@ -355,7 +384,7 @@ export class ManagerLoop {
         },
       })
     }
-    const tools = (): ReadonlyArray<ToolDefinition> => this.deps.toolFace()
+    const tools = (): ReadonlyArray<ToolDefinition> => this.deps.toolFace(this.currentWakeEvent ?? undefined)
 
     const options: EngineOptions = {
       systemPrompt,

--- a/crabot-agent/src/manager/read-model.ts
+++ b/crabot-agent/src/manager/read-model.ts
@@ -76,7 +76,13 @@ export interface GetWorkerDetailResult {
  */
 export interface ReadWorkerOutputAdminParams {
   worker_id: string
-  seq: number
+  /**
+   * 化身序号(从 1 起)。**可选**:缺省 = 主线化身(`mainlineIncarnation`,即排除侧问 fork
+   * 之后的最新化身),沿用 `WorkerHarness.readWorkerOutput` 的既有缺省语义。调用方(admin
+   * REST `?seq=` 缺省时)拿不到台账,算不出主线是哪个化身,只有不下发这个字段才落在正确的
+   * 化身上——填 0 台账里恒不存在,填 1 则锁死在最早那个化身上。
+   */
+  seq?: number
   cursor?: string
 }
 
@@ -89,7 +95,8 @@ export interface ReadWorkerOutputAdminResult {
 /** §8.3 get_worker_trace:结构化时间线(两层信息源见 §10.2) */
 export interface GetWorkerTraceParams {
   worker_id: string
-  seq: number
+  /** 化身序号(从 1 起)。**可选**:缺省 = 主线化身,与 `ReadWorkerOutputAdminParams.seq` 同一缺省。 */
+  seq?: number
   cursor?: string
 }
 

--- a/crabot-agent/src/manager/read-model.ts
+++ b/crabot-agent/src/manager/read-model.ts
@@ -30,6 +30,7 @@
 
 import type { PaginationParams, PaginatedResult } from 'crabot-shared'
 import type { DialogObjectId, LedgerWorker, TaskStatus } from '../workers/harness/ledger-types.js'
+import type { NormalizedTraceEvent } from '../workers/types.js'
 
 /**
  * base-protocol §5.7 TimeRange。`crabot-shared` 目前没有导出它(只在协议文档和各 channel
@@ -63,6 +64,39 @@ export interface GetWorkerDetailParams {
 
 export interface GetWorkerDetailResult {
   worker: LedgerWorker
+}
+
+/**
+ * §8.3 read_worker_output_admin:按化身增量读终端输出。
+ *
+ * 实现是 harness 直读(`WorkerHarness.readWorkerOutput`),没有可抽出的纯逻辑,所以本文件
+ * 只放类型——让 §8.3 四组 Params/Result 集中在一处便于逐字核对协议(P5 Task 3 报告的交接项)。
+ * 注意协议这里的 `cursor` / `next_cursor` 是**字符串**,而 harness/adapter 侧是
+ * `OutputCursor { offset: number }`,两者的互转在 RPC 壳里(unified-agent.ts)。
+ */
+export interface ReadWorkerOutputAdminParams {
+  worker_id: string
+  seq: number
+  cursor?: string
+}
+
+export interface ReadWorkerOutputAdminResult {
+  chunk: string
+  next_cursor: string
+  eof: boolean
+}
+
+/** §8.3 get_worker_trace:结构化时间线(两层信息源见 §10.2) */
+export interface GetWorkerTraceParams {
+  worker_id: string
+  seq: number
+  cursor?: string
+}
+
+export interface GetWorkerTraceResult {
+  events: NormalizedTraceEvent[]
+  next_cursor?: string
+  unavailable_reason?: string
 }
 
 /**

--- a/crabot-agent/src/manager/read-model.ts
+++ b/crabot-agent/src/manager/read-model.ts
@@ -1,0 +1,168 @@
+/**
+ * task 读模型的纯逻辑 —— protocol-agent-v3.md §8.3(P5 Task 3)。
+ *
+ * v3 把 task 的真相源从 admin 迁到 agent,admin 退化成只读代理。本文件是 `list_workers_admin`
+ * / `get_worker_detail` 两个读端点的**纯计算部分**:只接收已经取出来的台账数据,不读盘、不碰
+ * LedgerStore / WorkerHarness 实例。RPC 壳(取数、错误码、fire-and-forget)在 P5 Task 4。
+ * 这样切是为了让过滤/排序/分页的边界语义能被确定性地测出来,不必造文件系统。
+ *
+ * ## 复用而非重造
+ *
+ * - `PaginationParams` / `PaginatedResult<T>` 直接用 `crabot-shared` 的导出(base-protocol §5.6),
+ *   不在本文件另立形状相近的类型;
+ * - 过滤 → 排序 → 分页的写法沿用 admin 既有 list 处理器的范式(`handleListTasks`
+ *   `crabot-admin/src/index.ts`、`AgentManager.listImplementations`):status 单值/数组归一后
+ *   `includes`、时间用 ISO 8601 字符串直接比较、`page ?? 1` / `page_size ?? 20` +
+ *   `Math.ceil(total / pageSize)` + `slice((page-1)*pageSize, ...)`;
+ * - `page_size` 的 100 上限沿用 agent 侧既有范式(`src/agent/find-task-tool.ts` 的
+ *   `Math.min(page_size ?? 20, 100)`),admin 侧的处理器没有夹紧,这里以 base-protocol
+ *   §5.6 注释("默认 20,最大 100")为准。
+ *
+ * ## 已知的读模型污染源(不要据此写断言)
+ *
+ * harness 的 `processStateChange` 目前硬编码把化身退出记成 `completed`(P7 阻塞项 #1),
+ * 也就是说**台账里的 `task.status` 对失败的 worker 是失真的**。本文件只忠实反映台账,
+ * 不做任何补偿;修复在 P7 的 harness 侧,不在读模型这一层。
+ *
+ * @see crabot-docs/protocols/protocol-agent-v3.md §8.3、§7
+ * @see crabot-docs/protocols/base-protocol.md §5.6(分页)、§5.7(TimeRange)
+ */
+
+import type { PaginationParams, PaginatedResult } from 'crabot-shared'
+import type { DialogObjectId, LedgerWorker, TaskStatus } from '../workers/harness/ledger-types.js'
+
+/**
+ * base-protocol §5.7 TimeRange。`crabot-shared` 目前没有导出它(只在协议文档和各 channel
+ * 模块的本地 types.ts 里各写各的),这里按协议原样声明,待上游补齐后再收敛为复用——
+ * 与 ledger-types.ts 处理 `TaskPriority` 的做法一致。
+ *
+ * 注意各 channel 模块本地的 `TimeRange { before?, after? }` 是另一套形状(历史偏离),
+ * 本文件以 base-protocol 为准。
+ */
+export interface TimeRange {
+  /** 起始时间,ISO 8601,**包含** */
+  start?: string
+  /** 结束时间,ISO 8601,**不包含** */
+  end?: string
+}
+
+/** §8.3 list_workers_admin:跨对话对象扁平查询 */
+export interface ListWorkersAdminParams {
+  status?: TaskStatus | TaskStatus[]
+  dialog_object_id?: DialogObjectId
+  time_range?: TimeRange
+  pagination?: PaginationParams
+}
+
+export interface ListWorkersAdminResult extends PaginatedResult<LedgerWorker> {}
+
+/** §8.3 get_worker_detail:单 worker 全量(台账条目 + 化身链) */
+export interface GetWorkerDetailParams {
+  worker_id: string
+}
+
+export interface GetWorkerDetailResult {
+  worker: LedgerWorker
+}
+
+/**
+ * 台账条目 + 它所属的对话对象 —— `LedgerStore.listAllWorkers()` / `findWorker()` 的返回元素形状。
+ * `dialogObjectId` 只用于过滤,不出现在协议返回体里(§8.3 的 items 是 `LedgerWorker`)。
+ */
+export interface LedgerWorkerEntry {
+  dialogObjectId: DialogObjectId
+  worker: LedgerWorker
+}
+
+/** base-protocol §5.6:每页数量默认 20,最大 100 */
+const DEFAULT_PAGE_SIZE = 20
+const MAX_PAGE_SIZE = 100
+
+/** 页码/每页数量归一:非正数、非有限数、缺失一律退回默认值(读端点不该因为参数脏就报错) */
+function normalizePositive(value: number | undefined, fallback: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 1) return fallback
+  return Math.floor(value)
+}
+
+/**
+ * 过滤 → 排序 → 分页。纯函数:不修改入参数组。
+ *
+ * **排序 `updated_at desc`**:台账的每次状态迁移都会刷新 `updated_at`(harness 的
+ * upsertWorker 路径),而 `task.created_at` 只反映建账时刻。admin 的 worker 列表是运维视角的
+ * "最近发生了什么",按最近活动排序才能让在途/刚变更的 worker 浮到首页;若按 created_at 排,
+ * 一个跑了三天仍在推进的 worker 会沉底。§8.3 未开放排序参数,故此处固定不可配。
+ *
+ * **同 `updated_at` 的兜底次序**:按 `worker_id` 升序。不依赖 `Array.prototype.sort` 的稳定性,
+ * 因为输入顺序本身不确定(`listAllWorkers` 按 Map/Set 的迭代序拼装,受台账文件扫描顺序影响),
+ * 稳定排序只能保证"保持输入序",保证不了"跨调用一致"——而分页要求全序确定,否则同一批数据
+ * 翻页会出现漏项/重项。
+ *
+ * **`time_range` 边界**:base-protocol §5.7 —— `start` 闭(含)、`end` 开(不含),即 `[start, end)`;
+ * 比较的是 `task.created_at`(创建时间落在窗口内),与 admin 既有 `list_tasks` 的
+ * `created_after`/`created_before` 语义一致。ISO 8601 UTC 串按字典序比较即时间序。
+ *
+ * **越界分页**:返回空 items,`pagination` 原样回显请求的 page,不报错(§8.3 没有定义越界错误码,
+ * 且列表在并发删改下天然可能翻到空页,报错只会让 admin UI 更难用)。
+ */
+export function filterAndPageWorkers(
+  all: ReadonlyArray<LedgerWorkerEntry>,
+  params: ListWorkersAdminParams
+): ListWorkersAdminResult {
+  const statuses =
+    params.status === undefined
+      ? undefined
+      : Array.isArray(params.status)
+        ? params.status
+        : [params.status]
+  const range = params.time_range
+  const hasRange = range !== undefined && (range.start !== undefined || range.end !== undefined)
+
+  // filter 总是产出新数组,后面的 sort 不会污染入参
+  const matched = all.filter((entry) => {
+    if (statuses && !statuses.includes(entry.worker.task.status)) return false
+    if (params.dialog_object_id && entry.dialogObjectId !== params.dialog_object_id) return false
+    if (hasRange) {
+      // created_at 缺失(脏台账)时无法证明落在窗口内,按不命中处理
+      const createdAt = entry.worker.task.created_at
+      if (!createdAt) return false
+      if (range!.start !== undefined && createdAt < range!.start) return false
+      if (range!.end !== undefined && createdAt >= range!.end) return false
+    }
+    return true
+  })
+
+  matched.sort((a, b) => {
+    const byUpdatedDesc = (b.worker.updated_at ?? '').localeCompare(a.worker.updated_at ?? '')
+    if (byUpdatedDesc !== 0) return byUpdatedDesc
+    return a.worker.worker_id.localeCompare(b.worker.worker_id)
+  })
+
+  const page = normalizePositive(params.pagination?.page, 1)
+  const pageSize = Math.min(
+    normalizePositive(params.pagination?.page_size, DEFAULT_PAGE_SIZE),
+    MAX_PAGE_SIZE
+  )
+  const totalItems = matched.length
+  const offset = (page - 1) * pageSize
+
+  return {
+    items: matched.slice(offset, offset + pageSize).map((entry) => entry.worker),
+    pagination: {
+      page,
+      page_size: pageSize,
+      total_items: totalItems,
+      total_pages: Math.ceil(totalItems / pageSize),
+    },
+  }
+}
+
+/**
+ * 台账条目 → §8.3 的 `GetWorkerDetailResult`。
+ *
+ * 详情就是台账条目本身(含完整化身链),不做任何计算或裁剪——v3 里 agent 即真相源,台账结构
+ * (§3)本身就是对外契约。这里只负责剥掉 `LedgerStore.findWorker` 附带的 `dialogObjectId`
+ * 包装:它是查找的副产物,不在协议返回体里(调用方要用的话自己留着)。
+ */
+export function buildWorkerDetail(found: LedgerWorkerEntry): GetWorkerDetailResult {
+  return { worker: found.worker }
+}

--- a/crabot-agent/src/manager/registry.ts
+++ b/crabot-agent/src/manager/registry.ts
@@ -68,6 +68,22 @@ export interface AsyncToolErrorInfo {
 
 export type OnAsyncError = (info: AsyncToolErrorInfo) => void
 
+/**
+ * scheduled 唤醒随行的**权限身份**(protocol-agent-v3 §8.2 的 `creator_friend_id` /
+ * `is_builtin`;§4.4"scheduled 任务约束……权限按 `Schedule.creator_friend_id` 解析
+ * (`is_builtin` 按 master 等价)")。
+ *
+ * **过渡形态,P7 收敛**:v2 的 admin 在自己那侧把 schedule 解析成 `resolved_permissions`
+ * 再下发;v3 改成 agent 侧按 `origin.creator_friend_id` 解析。P5 的 `trigger_schedule`
+ * 已按 v3 协议接收身份并一路透到 `SpawnWorkerParams.origin.creator_friend_id`,但 admin
+ * 调用点尚未切换(P5 Global Constraints:不激活生产链路),真正的"以此身份解析工具权限"
+ * 在 P7 cutover 时才接上。
+ */
+export interface ScheduleIdentity {
+  readonly creatorFriendId?: string
+  readonly isBuiltin?: boolean
+}
+
 export interface ManagerRegistryDeps {
   readonly store: ManagerSessionStore
   readonly policy: CompactionPolicy
@@ -98,8 +114,17 @@ export interface ManagerRegistryDeps {
    * 工具面工厂:调用方据 key/isSystemThread 装配 `buildManagerToolFace` 的完整依赖并返回
    * 工具面数组;`onAsyncError` 由本 registry 按 key 绑定好传入,调用方负责把它接进
    * `WorkerToolsDeps.onAsyncError`(见文件头说明)。
+   *
+   * P5 Task 4 additive:第四个参数是**本 episode 若由 scheduled 触发**时随行的权限身份
+   * (非 schedule 唤醒为 undefined),调用方据它填 `WorkerToolsContext.creatorFriendId` /
+   * `triggerType`。可选参数,既有三参调用点无需改动。
    */
-  readonly toolFace: (key: ManagerKey, isSystemThread: boolean, onAsyncError: OnAsyncError) => ReadonlyArray<ToolDefinition>
+  readonly toolFace: (
+    key: ManagerKey,
+    isSystemThread: boolean,
+    onAsyncError: OnAsyncError,
+    scheduleIdentity?: ScheduleIdentity
+  ) => ReadonlyArray<ToolDefinition>
   /** system prompt 动态段素材(档案/待处理通知),每轮重算,由调用方决定要不要按最新状态重建。 */
   readonly promptInputs: (key: ManagerKey) => { readonly dialogProfile?: string; readonly pendingNotes?: ReadonlyArray<string> }
 }
@@ -143,7 +168,9 @@ export class ManagerRegistry {
       model: this.deps.model,
       maxTurns: this.deps.maxTurns,
       contextWindowTokens: this.deps.contextWindowTokens,
-      toolFace: () => this.deps.toolFace(key, isSystemThread, onAsyncError),
+      // 唤醒事件由 ManagerLoop 按 episode 传入(见 ManagerLoopDeps.toolFace);schedule 之外
+      // 的唤醒不带身份,工具面照旧。
+      toolFace: (wakeEvent) => this.deps.toolFace(key, isSystemThread, onAsyncError, scheduleIdentityOf(wakeEvent)),
       promptInputs: () => this.deps.promptInputs(key),
       harness: this.deps.harness,
       now: this.deps.now,
@@ -177,17 +204,32 @@ export class ManagerRegistry {
     return this.runWake(key, { kind: 'worker_event', event })
   }
 
-  /** scheduled 触发(§4.4):有 target_session → 该 manager;无 → 系统线程 manager。 */
+  /**
+   * scheduled 触发(§4.4):有 target_session → 该 manager;无 → 系统线程 manager。
+   *
+   * P5 Task 4 additive:`creatorFriendId` / `isBuiltin`(§8.2 权限身份)随唤醒事件下传,
+   * 供本 episode 的工具面把它填进 `SpawnWorkerParams.origin.creator_friend_id`;两者都不传
+   * 时行为与之前逐字相同(既有调用点无需改动)。
+   */
   async routeSchedule(p: {
     scheduleId: string
     title: string
     description: string
     targetSession?: { channel_id: string; session_id: string }
+    creatorFriendId?: string
+    isBuiltin?: boolean
   }): Promise<EpisodeResult> {
     const key = p.targetSession
       ? (`${p.targetSession.channel_id}::${p.targetSession.session_id}` as ManagerKey)
       : SYSTEM_TASKS_MANAGER_KEY
-    return this.runWake(key, { kind: 'schedule', scheduleId: p.scheduleId, title: p.title, description: p.description })
+    return this.runWake(key, {
+      kind: 'schedule',
+      scheduleId: p.scheduleId,
+      title: p.title,
+      description: p.description,
+      creatorFriendId: p.creatorFriendId,
+      isBuiltin: p.isBuiltin,
+    })
   }
 
   /**
@@ -237,6 +279,12 @@ export class ManagerRegistry {
       else this.activeEpisodes.set(key, remaining)
     }
   }
+}
+
+/** 唤醒事件 → 随行的 scheduled 权限身份;非 schedule 唤醒没有身份(undefined)。 */
+function scheduleIdentityOf(wakeEvent: WakeEvent | undefined): ScheduleIdentity | undefined {
+  if (wakeEvent?.kind !== 'schedule') return undefined
+  return { creatorFriendId: wakeEvent.creatorFriendId, isBuiltin: wakeEvent.isBuiltin }
 }
 
 /** query_worker 异步失败 → 借用既有 `worker_event`/`query_failed` kind 包装成 WakeEvent(见文件头)。 */

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -84,7 +84,7 @@ import {
 } from './manager/read-model.js'
 import type { NormalizedTraceEvent } from './workers/types.js'
 import type { HarnessEvent } from './workers/harness/worker-events.js'
-import { mainlineIncarnation } from './workers/harness/harness.js'
+import { findIncarnationBySeq, mainlineIncarnation } from './workers/harness/harness.js'
 
 const BARRIER_TIMEOUT_MS = 8_000
 
@@ -3275,6 +3275,11 @@ export class UnifiedAgent extends ModuleBase {
    * `mainlineIncarnation`），保证两个端点在同一次"不带 seq"的调用下描述的是同一个化身。
    * 缺这个分支时 `event.seq === undefined` 恒为 false，会静默返回空 events，与"该化身确实
    * 还没有事件"无法区分（P5 review 修复）。
+   *
+   * 同理，**显式**给的 seq 在化身链里不存在时抛错而非返回空 events（P5 review 修复第二轮）：
+   * 化身链的存在性只能问台账，不能问事件流——"这个化身不存在"与"这个化身确实还没产生
+   * 事件"在 events.jsonl 上是同一个结果（都是空），只有先查台账才分得开。判定与错误文案
+   * 与 `harness.readWorkerOutput` 同形状（共用 `findIncarnationBySeq`），让 admin 侧统一映射。
    */
   private async handleGetWorkerTrace(params: GetWorkerTraceParams): Promise<GetWorkerTraceResult> {
     const stack = this.requireManagerStack()
@@ -3284,9 +3289,13 @@ export class UnifiedAgent extends ModuleBase {
     if (!found) {
       throw new Error(`Worker not found: ${params.worker_id}`)
     }
-    const seq = params.seq ?? mainlineIncarnation(found.worker).seq
+    const incarnation =
+      params.seq === undefined ? mainlineIncarnation(found.worker) : findIncarnationBySeq(found.worker, params.seq)
+    if (!incarnation) {
+      throw new Error(`get_worker_trace: no incarnation with seq=${params.seq} found for worker ${params.worker_id}`)
+    }
     const ofIncarnation = (await stack.harness.readWorkerEvents(params.worker_id)).filter(
-      (event) => event.seq === seq
+      (event) => event.seq === incarnation.seq
     )
     const offset = parseOffsetCursor(params.cursor)
     return {

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -529,15 +529,25 @@ export class UnifiedAgent extends ModuleBase {
   /**
    * `ManagerKey`（`channel_id::session_id`）→ 台账聚合键 `DialogObjectId`（§3）。
    *
-   * ⚠️ **P7 cutover 前必须修**：协议要求私聊聚合成 `friend:<friend_id>`（同一 friend 跨 channel
-   * 共享一份台账），但那需要 admin 的 friend 解析，而 `ManagerRegistryDeps.dialogObjectIdFor`
-   * 是**同步**签名，这里没有任何可同步查到 session 类型/friend 的入口——agent 侧唯一知道
-   * "这个 session 是私聊且对端是谁"的地方是入站消息链路，而 P5 明令该链路零改动。
-   * 因此本阶段一律派生成 `group:<channel_id>:<session_id>`。
+   * ⚠️ **P7 cutover 前必须修**。本阶段一律派生成 `group:<channel_id>:<session_id>`，
+   * 有**两处**归档错误：
+   *
+   * 1. **私聊**：协议要求聚合成 `friend:<friend_id>`（同一 friend 跨 channel 共享一份台账），
+   *    但那需要 admin 的 friend 解析，而 `ManagerRegistryDeps.dialogObjectIdFor` 是**同步**签名，
+   *    这里没有任何可同步查到 session 类型/friend 的入口——agent 侧唯一知道"这个 session 是
+   *    私聊且对端是谁"的地方是入站消息链路，而 P5 明令该链路零改动。
+   * 2. **系统任务线程**：§4.4 要求未配置 `target_session` 的 scheduled 触发**台账归 master
+   *    对话对象**（`friend:<master_id>`），但 `SYSTEM_TASKS_MANAGER_KEY`（`admin-web::system-tasks`）
+   *    在这里会派生成 `group:admin-web:system-tasks`。后果不只是归档键难看：master 在私聊里
+   *    问进度时，其 manager 按 `friend:<master_id>` 查台账**看不到**系统线程派出的 worker，
+   *    §4.4 "人类在哪个 session 回话、该 session 的 manager 凭共享台账接办"就断了。
    *
    * 现阶段无害：P5 没有任何生产调用方经这套栈 spawn worker（admin 的 scheduler 调用点未切换），
-   * 台账上不会出现被归错档的条目。切换调用点之前必须先解决它，二选一：把签名改成异步，
-   * 或在入站链路上维护一份 `ManagerKey → DialogObjectId` 缓存。
+   * 台账上不会出现被归错档的条目。
+   *
+   * 切换调用点之前必须先解决。**只有"把签名改成异步"这一条路能同时覆盖两种情况**——
+   * "在入站链路上维护 `ManagerKey → DialogObjectId` 缓存"对系统线程**天然无效**：它根本
+   * 没有入站消息，缓存永远不会被填充。
    */
   private dialogObjectIdForManagerKey(key: ManagerKey): DialogObjectId {
     const sep = key.indexOf('::')

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -84,6 +84,7 @@ import {
 } from './manager/read-model.js'
 import type { NormalizedTraceEvent } from './workers/types.js'
 import type { HarnessEvent } from './workers/harness/worker-events.js'
+import { mainlineIncarnation } from './workers/harness/harness.js'
 
 const BARRIER_TIMEOUT_MS = 8_000
 
@@ -3268,6 +3269,12 @@ export class UnifiedAgent extends ModuleBase {
    * `unavailable_reason` 明示。
    *
    * 游标是"该化身已返回的事件条数"：事件流 append-only，条数即稳定位点。
+   *
+   * `params.seq` 缺省（admin REST 的 `?seq=` 没给）时取**主线化身**——与
+   * `read_worker_output_admin` 走的 `harness.readWorkerOutput` 缺省逐字同源（共用
+   * `mainlineIncarnation`），保证两个端点在同一次"不带 seq"的调用下描述的是同一个化身。
+   * 缺这个分支时 `event.seq === undefined` 恒为 false，会静默返回空 events，与"该化身确实
+   * 还没有事件"无法区分（P5 review 修复）。
    */
   private async handleGetWorkerTrace(params: GetWorkerTraceParams): Promise<GetWorkerTraceResult> {
     const stack = this.requireManagerStack()
@@ -3277,8 +3284,9 @@ export class UnifiedAgent extends ModuleBase {
     if (!found) {
       throw new Error(`Worker not found: ${params.worker_id}`)
     }
+    const seq = params.seq ?? mainlineIncarnation(found.worker).seq
     const ofIncarnation = (await stack.harness.readWorkerEvents(params.worker_id)).filter(
-      (event) => event.seq === params.seq
+      (event) => event.seq === seq
     )
     const offset = parseOffsetCursor(params.cursor)
     return {

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -23,6 +23,8 @@ import type {
   ToolAccessConfig,
   TaskId,
   FriendId,
+  ScheduleId,
+  SessionId,
   Friend,
   LLMRoleRequirement,
   GetConfigResult,
@@ -63,6 +65,21 @@ import { isResumable, redactCheckpoint } from './core/resume-checkpoint.js'
 import { AGENT_VERSION } from './constants.js'
 import { ContextManager, DEFAULT_COMPACT_THRESHOLD } from './engine/context-manager.js'
 import { DEFAULT_MAX_CONTEXT_TOKENS } from './engine/query-loop.js'
+import type { ManagerStack } from './manager/bootstrap.js'
+import {
+  filterAndPageWorkers,
+  buildWorkerDetail,
+  type ListWorkersAdminParams,
+  type ListWorkersAdminResult,
+  type GetWorkerDetailParams,
+  type GetWorkerDetailResult,
+  type ReadWorkerOutputAdminParams,
+  type ReadWorkerOutputAdminResult,
+  type GetWorkerTraceParams,
+  type GetWorkerTraceResult,
+} from './manager/read-model.js'
+import type { NormalizedTraceEvent } from './workers/types.js'
+import type { HarnessEvent } from './workers/harness/worker-events.js'
 
 const BARRIER_TIMEOUT_MS = 8_000
 
@@ -128,6 +145,68 @@ export function resolveTimeoutSeconds(value: number | undefined): number {
 export function resolveOverdueReminder(value: boolean | undefined): boolean {
   return value ?? true
 }
+
+/**
+ * protocol-agent-v3 §8.2 trigger_schedule —— 调度触发（替代 create_task_from_schedule）。
+ * 字段与协议逐字一致；`resolved_permissions` 是**唯一的额外字段**，见下方注释。
+ */
+export interface TriggerScheduleParams {
+  schedule_id: ScheduleId
+  title: string
+  description: string
+  target_session?: { channel_id: ModuleId; session_id: SessionId }
+  creator_friend_id?: FriendId
+  is_builtin?: boolean
+  /**
+   * 过渡期兼容字段（**不在 §8.2 里**，P7 cutover 后删）：v2 的 admin 在自己那侧把 schedule
+   * 的权限解析成 `resolved_permissions` 再下发（见 handleCreateTaskFromSchedule / protocol-admin
+   * §"is_builtin=true 或 creator_friend_id 为空 → master_private"）。v3 改为 agent 侧按
+   * `origin.creator_friend_id` 解析，因此本 handler **不消费**它——声明在这里只是为了让过渡期
+   * 里仍在下发该字段的调用方不至于类型不匹配，避免 admin 侧被迫与 agent 同步切换。
+   */
+  resolved_permissions?: ResolvedPermissions
+}
+
+/** §8.2：同步受理即返回（是否派 worker、如何执行由被唤醒的 manager 决定）。 */
+export interface TriggerScheduleResult {
+  accepted: true
+}
+
+/**
+ * §8.3 的 `cursor` / `next_cursor` 是字符串（REST 友好的不透明游标），harness/adapter 侧是
+ * `{ offset: number }`。这里做两侧互转：脏值 / 缺省一律从头读（读端点不因参数脏就报错）。
+ */
+function parseOffsetCursor(cursor: string | undefined): number {
+  if (cursor === undefined) return 0
+  const parsed = Number(cursor)
+  return Number.isFinite(parsed) && parsed >= 0 ? Math.floor(parsed) : 0
+}
+
+/** trace summary 的截断长度（§10.2：summary 是"截断摘要"，原始结构留在 detail 里）。 */
+const TRACE_SUMMARY_MAX_CHARS = 200
+
+/**
+ * harness 亲历事件（§10.2 第一层）→ `NormalizedTraceEvent`。
+ * 生命周期事件没有会话角色，故一律 `kind: 'lifecycle'` 且不填 `role`；`detail` 原样透传。
+ */
+function normalizeHarnessEvent(event: HarnessEvent): NormalizedTraceEvent {
+  const detailText = event.detail === undefined ? '' : ` ${JSON.stringify(event.detail)}`
+  const summary = `${event.kind}${detailText}`
+  return {
+    ts: event.ts,
+    kind: 'lifecycle',
+    summary: summary.length > TRACE_SUMMARY_MAX_CHARS ? `${summary.slice(0, TRACE_SUMMARY_MAX_CHARS)}…` : summary,
+    detail: event.detail,
+  }
+}
+
+/**
+ * §8.3 `get_worker_trace` 的第二层（adapter `readTrace()` 懒解析，§10.2）在本阶段未接线，
+ * 用协议规定的 `unavailable_reason` 明说，而不是静默只给第一层。
+ */
+const WORKER_TRACE_LAYER2_UNAVAILABLE =
+  '实现原生 trace（adapter readTrace 懒解析，protocol-agent-v3 §10.2 第二层）尚未接入本端点，' +
+  '当前仅返回 harness 亲历的生命周期事件（第一层）'
 
 export class UnifiedAgent extends ModuleBase {
   // 编排层组件
@@ -197,6 +276,14 @@ export class UnifiedAgent extends ModuleBase {
    * 用于 dispatcher / worker prompt 区分多 bot 群里"哪个 @ 是我"。
    */
   private crabSelfHandles: Map<ModuleId, string> = new Map()
+
+  /**
+   * Manager/Worker 栈（protocol-agent-v3 §4-§7）。**P5 Task 4 阶段没有生产注入点**：
+   * 启动路径上的构造与接线（`buildManagerStack` + 事件出口 + 启动对账）是 P5 Task 6 的事，
+   * 本 task 只留字段与取件口，让 §8.2/§8.3 的 RPC handler 能被测试注入。
+   * 未装配时读端点 fail-fast 报错，不返回空结果——空结果会被 admin 误读成"没有 worker"。
+   */
+  private managerStack?: ManagerStack
 
   // Trace 存储
   private traceStore: TraceStore
@@ -492,6 +579,15 @@ export class UnifiedAgent extends ModuleBase {
     this.registerMethod('list_bg_entities', this.handleListBgEntities.bind(this))
     this.registerMethod('kill_bg_entity', this.handleKillBgEntity.bind(this))
     this.registerMethod('get_bg_entity_log', this.handleGetBgEntityLog.bind(this))
+
+    // Manager/Worker（v3）接口：§8.2 调度触发 + §8.3 task 读模型四件套。
+    // P5 阶段没有任何生产调用方（admin 的 scheduler 仍走 create_task_from_schedule，
+    // 只读 REST 代理是 P5 Task 5、启动接线是 Task 6），注册本身不改变现网行为。
+    this.registerMethod('trigger_schedule', this.handleTriggerSchedule.bind(this))
+    this.registerMethod('list_workers_admin', this.handleListWorkersAdmin.bind(this))
+    this.registerMethod('get_worker_detail', this.handleGetWorkerDetail.bind(this))
+    this.registerMethod('read_worker_output_admin', this.handleReadWorkerOutputAdmin.bind(this))
+    this.registerMethod('get_worker_trace', this.handleGetWorkerTrace.bind(this))
   }
 
   // ============================================================================
@@ -2996,6 +3092,113 @@ export class UnifiedAgent extends ModuleBase {
   }> {
     if (!this.agentHandler) throw new Error('Worker handler not initialized')
     return this.agentHandler.getBgEntityLog(params.entity_id, params)
+  }
+
+  // ============================================================================
+  // Manager/Worker RPC 方法（protocol-agent-v3 §8.2 / §8.3，P5 Task 4）
+  //
+  // 已知读模型污染源：harness 的 processStateChange 目前把化身退出一律记成 completed
+  // （P7 阻塞项 #1），因此台账里失败 worker 的 task.status 是失真的。这几个读端点只忠实
+  // 反映台账、不做补偿，修复在 harness 侧。
+  // ============================================================================
+
+  /** manager 栈取件口：未装配即 fail-fast（P5 阶段启动路径尚未接线，见字段注释）。 */
+  private requireManagerStack(): ManagerStack {
+    if (!this.managerStack) throw new Error('Manager stack not initialized')
+    return this.managerStack
+  }
+
+  /**
+   * §8.2：按 §4.4 路由唤醒对应 manager（有 target_session → 该会话的 manager；无 → 系统
+   * 线程 manager），**受理即返回**。
+   *
+   * 路由是 fire-and-forget：`routeSchedule` 要跑完整个 manager episode（LLM 往返 + 工具
+   * 调用），await 它等于把调用方（admin 的 scheduler tick）阻塞在一整个 episode 上，与
+   * §8.2 的"同步（受理即返回）"直接冲突。游离 promise 必须 `.catch()`——路由失败不能变成
+   * unhandledRejection 打崩 agent 进程。
+   *
+   * 权限身份（`creator_friend_id` / `is_builtin`）随唤醒事件下传，最终落到本次 episode 派出
+   * 的 worker 的 `origin.creator_friend_id`（§4.4）。这是过渡形态：admin 调用点仍走
+   * `create_task_from_schedule` 并自行下发 `resolved_permissions`，P7 cutover 时收敛。
+   */
+  private handleTriggerSchedule(params: TriggerScheduleParams): TriggerScheduleResult {
+    const { registry } = this.requireManagerStack()
+    void registry
+      .routeSchedule({
+        scheduleId: params.schedule_id,
+        title: params.title,
+        description: params.description,
+        targetSession: params.target_session,
+        creatorFriendId: params.creator_friend_id,
+        isBuiltin: params.is_builtin,
+      })
+      .catch((error) => {
+        const message = error instanceof Error ? error.message : String(error)
+        console.error(
+          `[${this.config.moduleId}] trigger_schedule 路由失败 (schedule=${params.schedule_id}):`,
+          message
+        )
+      })
+    return { accepted: true }
+  }
+
+  /** §8.3 list_workers_admin：跨对话对象扁平查询（过滤/排序/分页语义见 manager/read-model.ts）。 */
+  private async handleListWorkersAdmin(params: ListWorkersAdminParams): Promise<ListWorkersAdminResult> {
+    const all = await this.requireManagerStack().ledger.listAllWorkers()
+    return filterAndPageWorkers(all, params ?? {})
+  }
+
+  /** §8.3 get_worker_detail：单 worker 全量（台账条目 + 化身链）；不存在抛错，不返回空对象。 */
+  private async handleGetWorkerDetail(params: GetWorkerDetailParams): Promise<GetWorkerDetailResult> {
+    const found = await this.requireManagerStack().ledger.findWorker(params.worker_id)
+    if (!found) {
+      throw new Error(`Worker not found: ${params.worker_id}`)
+    }
+    return buildWorkerDetail(found)
+  }
+
+  /**
+   * §8.3 read_worker_output_admin：按化身增量读终端输出。
+   *
+   * `eof` 的口径：本次已读到**当前**输出末尾（chunk 为空）。它**不**表示化身已经终结——
+   * worker 仍在跑时会继续追加，调用方据 `next_cursor` 继续轮询即可；要判断"再也不会有
+   * 新输出"应看 `get_worker_detail` 里该化身的 state/ended_reason。
+   */
+  private async handleReadWorkerOutputAdmin(
+    params: ReadWorkerOutputAdminParams
+  ): Promise<ReadWorkerOutputAdminResult> {
+    const { chunk, nextCursor } = await this.requireManagerStack().harness.readWorkerOutput(
+      params.worker_id,
+      { offset: parseOffsetCursor(params.cursor) },
+      { seq: params.seq }
+    )
+    return { chunk, next_cursor: String(nextCursor.offset), eof: chunk.length === 0 }
+  }
+
+  /**
+   * §8.3 get_worker_trace：结构化时间线。本阶段只有 §10.2 的**第一层**（harness 亲历的
+   * `events.jsonl`），第二层（adapter `readTrace()` 懒解析）留给 P6，缺席以
+   * `unavailable_reason` 明示。
+   *
+   * 游标是"该化身已返回的事件条数"：事件流 append-only，条数即稳定位点。
+   */
+  private async handleGetWorkerTrace(params: GetWorkerTraceParams): Promise<GetWorkerTraceResult> {
+    const stack = this.requireManagerStack()
+    // 先确认 worker 存在：否则事件流缺席（目录不存在）会被 readAll 归一成空数组，
+    // 让"worker 不存在"与"这个化身还没产生任何事件"在返回值上无法区分。
+    const found = await stack.ledger.findWorker(params.worker_id)
+    if (!found) {
+      throw new Error(`Worker not found: ${params.worker_id}`)
+    }
+    const ofIncarnation = (await stack.harness.readWorkerEvents(params.worker_id)).filter(
+      (event) => event.seq === params.seq
+    )
+    const offset = parseOffsetCursor(params.cursor)
+    return {
+      events: ofIncarnation.slice(offset).map(normalizeHarnessEvent),
+      next_cursor: String(ofIncarnation.length),
+      unavailable_reason: WORKER_TRACE_LAYER2_UNAVAILABLE,
+    }
   }
 
   // ============================================================================

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -56,7 +56,7 @@ import { McpConnector } from './agent/mcp-connector.js'
 import { createCrabMessagingServer, type PathMapping, type TaskContext } from './mcp/crab-messaging.js'
 import { toImageConnInfo, type ImageConnInfo } from './mcp/crab-image.js'
 import { TraceStore } from './core/trace-store.js'
-import { getAgentTraceDir, getAgentLogsDir, getWorkspaceDir } from './core/data-paths.js'
+import { getAgentTraceDir, getAgentLogsDir, getWorkspaceDir, getDataRootDir } from './core/data-paths.js'
 import { PromptManager } from './prompt-manager.js'
 import { createLSPManager, type LSPManager } from './lsp/lsp-manager.js'
 import type { BgEntityRecord, BgEntityStatus, BgEntityType } from './engine/bg-entities/types.js'
@@ -65,7 +65,11 @@ import { isResumable, redactCheckpoint } from './core/resume-checkpoint.js'
 import { AGENT_VERSION } from './constants.js'
 import { ContextManager, DEFAULT_COMPACT_THRESHOLD } from './engine/context-manager.js'
 import { DEFAULT_MAX_CONTEXT_TOKENS } from './engine/query-loop.js'
-import type { ManagerStack } from './manager/bootstrap.js'
+import { buildManagerStack, reconcileManagerStack, type ManagerStack } from './manager/bootstrap.js'
+import { makeAgentEventPublisher } from './manager/events.js'
+import { resolveManagerModelConfig } from './manager/model-slot.js'
+import { createCrabMemoryServer } from './mcp/crab-memory.js'
+import { dialogObjectIdForGroup, type DialogObjectId, type ManagerKey } from './workers/harness/ledger-types.js'
 import {
   filterAndPageWorkers,
   buildWorkerDetail,
@@ -278,9 +282,9 @@ export class UnifiedAgent extends ModuleBase {
   private crabSelfHandles: Map<ModuleId, string> = new Map()
 
   /**
-   * Manager/Worker 栈（protocol-agent-v3 §4-§7）。**P5 Task 4 阶段没有生产注入点**：
-   * 启动路径上的构造与接线（`buildManagerStack` + 事件出口 + 启动对账）是 P5 Task 6 的事，
-   * 本 task 只留字段与取件口，让 §8.2/§8.3 的 RPC handler 能被测试注入。
+   * Manager/Worker 栈（protocol-agent-v3 §4-§7）。构造函数里由 `initializeManagerStack()`
+   * 装配（P5 Task 6），启动对账在 `onStart()` 里异步跑。
+   * 仍是可选字段：既有测试用 `Object.create(prototype)` 造壳、只塞 handler 用到的字段，
    * 未装配时读端点 fail-fast 报错，不返回空结果——空结果会被 admin 误读成"没有 worker"。
    */
   private managerStack?: ManagerStack
@@ -388,6 +392,9 @@ export class UnifiedAgent extends ModuleBase {
       this.initializeAgentLayer(this.agentConfig)
     }
 
+    // 装配 Manager/Worker 栈（见方法注释：为什么在构造函数里、为什么不依赖 agentConfig）
+    this.initializeManagerStack()
+
     // 注册 RPC 方法
     this.registerMethods()
   }
@@ -456,6 +463,86 @@ export class UnifiedAgent extends ModuleBase {
         )
       }
     }
+  }
+
+  /**
+   * 装配 Manager/Worker 栈（protocol-agent-v3 §4-§7，P5 Task 6）。
+   *
+   * **为什么在构造函数里而不是 `onStart()`**：`buildManagerStack` 是 O(1) 的纯构造——不探测
+   * 子进程、不扫盘、不建目录（bootstrap.ts 文件头的第一条硬边界，有专门用例钉住）；而
+   * §8.2/§8.3 的五个 RPC 在 `registerMethods()` 里无条件注册，方法一旦可被调用，取件口就必须
+   * 已经就绪，否则 admin 的只读 REST 会在"进程已起、onStart 未跑完"这段窗口里返回 500。
+   *
+   * **为什么不挂在 `agentConfig` 的有无上**：LLM 只在 manager episode 真的要跑时才解析（下面
+   * 两个 thunk，§11 的 `manager` slot → 回退 `powerful`）。现网此刻并没有配 `manager` slot，
+   * 把解析放在装配期会让 agent 直接起不来；放在 thunk 里则最坏只是某次 `trigger_schedule`
+   * 的路由在 episode 内抛错，被 handler 的 `.catch()` 记成一行日志，而**读模型四件套照常可用**
+   * （它们只读台账，与 LLM 无关）。thunk 同时顺带满足 §11 的热更语义：manager 的 model 于
+   * 下一个 episode 生效。
+   *
+   * **本阶段刻意不提供 `builtinSpawnDefaults`**：它要的是 builtin worker 的完整 LLM + 工具面
+   * 注入，而 `spawnWorker` 目前压根不读它（只有 `handoffIncarnation` 消费），补上去也补不掉
+   * "manager 走缺省 `spawn_worker` 必挂"这个缺口——那是 P7 cutover 前必须修的一项（见
+   * `.superpowers/sdd/progress.md` Task 1 条目）。这里给一个半成品反而会掩盖它。
+   */
+  private initializeManagerStack(): void {
+    this.managerStack = buildManagerStack({
+      dataRoot: getDataRootDir(),
+      now: () => new Date().toISOString(),
+      // §11：manager slot → 回退 powerful。两个 thunk 每个 episode 各解析一次，
+      // 未配置时抛出的错误信息由 model-slot.ts 给出（明确指出缺哪两个 slot）。
+      managerAdapter: () => adapterFromSdkEnv(this.buildSdkEnv(resolveManagerModelConfig(this.agentConfig?.model_config))),
+      managerModel: () => resolveManagerModelConfig(this.agentConfig?.model_config).model_id,
+      // crab-messaging：与 `createMcpConfigs` 同款依赖，但不传 `getTaskContext`——manager 不是
+      // task，且 tool-face 已把 `send_message` 的 intent 去掉，ask_human 路径对 manager 不存在。
+      messagingDeps: {
+        rpcClient: this.rpcClient,
+        moduleId: this.config.moduleId,
+        getAdminPort: () => this.getAdminPort(),
+        resolveChannelPort: (channelId) => this.getChannelPort(channelId),
+      },
+      // crab-memory：manager 没有 task 上下文，visibility/scopes 取 agent-handler 在缺配置时
+      // 用的同一组缺省值（'public' / []），sourceType 记 'system'（不是某次对话的产物）。
+      // manager 的记忆权限档位目前没有解析入口，P6/P7 接 §4.3 权限时再收敛。
+      memoryServer: createCrabMemoryServer(
+        {
+          rpcClient: this.rpcClient,
+          moduleId: this.config.moduleId,
+          getMemoryPort: () => this.getMemoryPort(),
+        },
+        { visibility: 'public', scopes: [], sourceType: 'system', isMasterPrivate: false },
+      ),
+      callAdmin: async <P, R>(method: string, params: P): Promise<R> =>
+        this.rpcClient.call<P, R>(await this.getAdminPort(), method, params, this.config.moduleId),
+      dialogObjectIdFor: (key) => this.dialogObjectIdForManagerKey(key),
+      // 对外事件出口（§9.2 `agent.task_status_changed`）：真实 rpcClient 注入。
+      // 翻译与去重在 manager/events.ts，这里只负责把口子接上。
+      publishEvent: makeAgentEventPublisher({
+        rpcClient: this.rpcClient,
+        moduleId: this.config.moduleId,
+        now: () => new Date().toISOString(),
+      }),
+    })
+  }
+
+  /**
+   * `ManagerKey`（`channel_id::session_id`）→ 台账聚合键 `DialogObjectId`（§3）。
+   *
+   * ⚠️ **P7 cutover 前必须修**：协议要求私聊聚合成 `friend:<friend_id>`（同一 friend 跨 channel
+   * 共享一份台账），但那需要 admin 的 friend 解析，而 `ManagerRegistryDeps.dialogObjectIdFor`
+   * 是**同步**签名，这里没有任何可同步查到 session 类型/friend 的入口——agent 侧唯一知道
+   * "这个 session 是私聊且对端是谁"的地方是入站消息链路，而 P5 明令该链路零改动。
+   * 因此本阶段一律派生成 `group:<channel_id>:<session_id>`。
+   *
+   * 现阶段无害：P5 没有任何生产调用方经这套栈 spawn worker（admin 的 scheduler 调用点未切换），
+   * 台账上不会出现被归错档的条目。切换调用点之前必须先解决它，二选一：把签名改成异步，
+   * 或在入站链路上维护一份 `ManagerKey → DialogObjectId` 缓存。
+   */
+  private dialogObjectIdForManagerKey(key: ManagerKey): DialogObjectId {
+    const sep = key.indexOf('::')
+    return sep < 0
+      ? dialogObjectIdForGroup(key, '')
+      : dialogObjectIdForGroup(key.slice(0, sep), key.slice(sep + 2))
   }
 
   /**
@@ -3321,6 +3408,7 @@ export class UnifiedAgent extends ModuleBase {
     // 探測是否有飛書 channel，決定是否注入 read_feishu_document 工具
     this.detectFeishuChannel().catch(() => {/* 探测失败不影响启动 */})
     this.sessionManager.startCleanup()
+    this.startManagerStackReconciliation()
 
     // Connect to external MCP servers (Admin-configured)
     if (this.agentConfig?.mcp_servers && this.agentConfig.mcp_servers.length > 0) {
@@ -3352,6 +3440,36 @@ export class UnifiedAgent extends ModuleBase {
         }
       } catch { /* best effort */ }
     }, ONE_DAY_MS)
+  }
+
+  /**
+   * manager 栈的启动对账（§12），`onStart()` 里发一次，**不 await**。
+   *
+   * **为什么不 await**：对账要向三个 adapter 逐个问在途化身的死活（CLI 实现会起子进程），
+   * 台账非空时耗时不可控；agent 的启动不能挂在它上面——`start()` 返回晚了，MM 的健康探测
+   * 会把 agent 当成起不来。失败只 warn：对账修的是"进程重启后台账里残留的 running 化身"，
+   * 修不成最坏是这些条目继续显示为 running，不影响任何新任务。
+   *
+   * **台账为空时（现网此刻的真实状态）的开销**：`scanOrphans` 一次 readdir 撞 ENOENT 直接返回，
+   * `reconcileOnStartup` 走 `LedgerStore.init()` → 一次 `mkdir -p <dataRoot>/agent/ledgers`
+   * 加一次空目录 readdir，随后零 worker 可对账。唯一的可观测副作用就是那个空目录被建出来。
+   */
+  private startManagerStackReconciliation(): void {
+    const stack = this.managerStack
+    if (!stack) return
+    void reconcileManagerStack(stack)
+      .then((report) => {
+        // 空台账（现网常态）不打日志，避免每次启动都刷一行没有信息量的 0/0/0。
+        if (report.revived.length === 0 && report.failed.length === 0) return
+        console.log(
+          `[${this.config.moduleId}] manager 栈启动对账完成：` +
+          `revived=${report.revived.length} failed=${report.failed.length} unchanged=${report.unchanged.length}`
+        )
+      })
+      .catch((error) => {
+        const message = error instanceof Error ? error.message : String(error)
+        console.warn(`[${this.config.moduleId}] manager 栈启动对账失败（不影响启动）:`, message)
+      })
   }
 
   protected override async onStop(): Promise<void> {

--- a/crabot-agent/src/workers/harness/harness.ts
+++ b/crabot-agent/src/workers/harness/harness.ts
@@ -270,7 +270,7 @@ export class WorkerHarness {
         spawnedHandle = await adapter.spawn(spec)
       } catch (err) {
         const now = this.deps.now()
-        await this.deps.ledger.upsertWorker(p.dialogObjectId, workerId, (prev) => {
+        const failed = await this.deps.ledger.upsertWorker(p.dialogObjectId, workerId, (prev) => {
           if (!prev) return undefined
           // VALID_TRANSITIONS 里 queued 没有直达 failed 的边(只能到 running/cancelled)。
           // spawn 尝试确实发生过(我们已经调用了 provision/spawn),用 queued→running→failed
@@ -287,10 +287,17 @@ export class WorkerHarness {
           })
           return { ...prev, task: nextTask, incarnations, updated_at: now }
         })
-        await this.appendEvent(workerId, 1, 'exited', {
-          reason: 'spawn_failed',
-          message: err instanceof Error ? err.message : String(err),
-        })
+        // 台账上是 queued→running→failed 两跳,但这里只落一条事件,事件带的是**落账后的
+        // 终点** failed;中间的 running 没有对应事件,订阅方看到的仍是 queued→failed(不是
+        // 状态机合法边)。这属于"两次迁移之间没有事件 → 中间态折叠",不是订阅方读晚了造成
+        // 的——后者已由 task_status 修掉。见 manager/events.ts 文件头的边界说明。
+        await this.appendEvent(
+          workerId,
+          1,
+          'exited',
+          { reason: 'spawn_failed', message: err instanceof Error ? err.message : String(err) },
+          failed?.task.status
+        )
         throw err
       }
 
@@ -304,7 +311,7 @@ export class WorkerHarness {
         const incarnations = patchIncarnationBySeq(prev.incarnations, impl, 1, { session_ref: spawnedHandle.session_ref })
         return { ...prev, task: nextTask, incarnations, updated_at: now }
       })
-      await this.appendEvent(workerId, 1, 'spawned', { impl })
+      await this.appendEvent(workerId, 1, 'spawned', { impl }, spawned?.task.status)
       return spawned as LedgerWorker
     })
   }
@@ -565,7 +572,7 @@ export class WorkerHarness {
     const newHandle = await adapter.resume(prevRef, text)
 
     const now = this.deps.now()
-    await this.deps.ledger.upsertWorker(dialogObjectId, worker.worker_id, (prev) => {
+    const revived = await this.deps.ledger.upsertWorker(dialogObjectId, worker.worker_id, (prev) => {
       if (!prev) return undefined
       const newIncarnation: Incarnation = {
         seq: newHandle.seq,
@@ -595,7 +602,7 @@ export class WorkerHarness {
       const nextTask = reopenTaskForContinuation(prev.task, now)
       return { ...prev, task: nextTask, incarnations: [...incarnations, newIncarnation], updated_at: now }
     })
-    await this.appendEvent(worker.worker_id, newHandle.seq, 'resumed', { from_seq: mainline.seq })
+    await this.appendEvent(worker.worker_id, newHandle.seq, 'resumed', { from_seq: mainline.seq }, revived?.task.status)
   }
 
   /**
@@ -711,7 +718,7 @@ export class WorkerHarness {
 
     // 4. 化身链 +1,task 重新回到 running(见 reopenTaskForContinuation 注释)。
     const now = this.deps.now()
-    await this.deps.ledger.upsertWorker(dialogObjectId, worker.worker_id, (prev) => {
+    const handedOff = await this.deps.ledger.upsertWorker(dialogObjectId, worker.worker_id, (prev) => {
       if (!prev) return undefined
       const newIncarnation: Incarnation = {
         seq: newHandle.seq,
@@ -726,7 +733,13 @@ export class WorkerHarness {
     })
     // 与 reviveIncarnation 收尾时发 'resumed' 事件对称——交接产出的新化身同样是一次"开工",
     // 缺了这个事件会让事件流看不到 handoff 之后新主线是何时、以何种 impl 建起来的。
-    await this.appendEvent(worker.worker_id, newHandle.seq, 'spawned', { impl: targetImpl, from_seq: source.seq })
+    await this.appendEvent(
+      worker.worker_id,
+      newHandle.seq,
+      'spawned',
+      { impl: targetImpl, from_seq: source.seq },
+      handedOff?.task.status
+    )
   }
 
   /**
@@ -908,7 +921,7 @@ export class WorkerHarness {
     detailReason: string
   ): Promise<void> {
     const now = this.deps.now()
-    await this.deps.ledger.upsertWorker(dialogObjectId, worker.worker_id, (prev) => {
+    const crashed = await this.deps.ledger.upsertWorker(dialogObjectId, worker.worker_id, (prev) => {
       if (!prev) return undefined
       const nextTask = transitionTaskTo(prev.task, 'failed', { error: detailReason, now })
       const incarnations = patchIncarnationBySeq(prev.incarnations, mainline.impl, mainline.seq, {
@@ -918,7 +931,13 @@ export class WorkerHarness {
       })
       return { ...prev, task: nextTask, incarnations, updated_at: now }
     })
-    await this.appendEvent(worker.worker_id, mainline.seq, 'exited', { reason: 'crashed', message: detailReason })
+    await this.appendEvent(
+      worker.worker_id,
+      mainline.seq,
+      'exited',
+      { reason: 'crashed', message: detailReason },
+      crashed?.task.status
+    )
   }
 
   /**
@@ -943,7 +962,7 @@ export class WorkerHarness {
     if (!stateChanged && !statusChanged) return
 
     const now = this.deps.now()
-    await this.deps.ledger.upsertWorker(dialogObjectId, worker.worker_id, (prev) => {
+    const realigned = await this.deps.ledger.upsertWorker(dialogObjectId, worker.worker_id, (prev) => {
       if (!prev) return undefined
       const nextTask = statusChanged ? transitionTaskTo(prev.task, nextStatus, { now }) : prev.task
       const incarnations = stateChanged
@@ -951,7 +970,15 @@ export class WorkerHarness {
         : prev.incarnations
       return { ...prev, task: nextTask, incarnations, updated_at: now }
     })
-    await this.appendEvent(worker.worker_id, mainline.seq, 'state_changed', { to: observed, source: 'reconcile' })
+    // 这条事件可能只改了化身 state 而没动 task.status(stateChanged 单独成立);带上落账后的
+    // 状态是无害的——订阅方拿它与上次已知状态比对,相同即静默。
+    await this.appendEvent(
+      worker.worker_id,
+      mainline.seq,
+      'state_changed',
+      { to: observed, source: 'reconcile' },
+      realigned?.task.status
+    )
   }
 
   async killWorker(workerId: string, reason?: string): Promise<void> {
@@ -978,7 +1005,7 @@ export class WorkerHarness {
       }
 
       const now = this.deps.now()
-      await this.deps.ledger.upsertWorker(dialogObjectId, workerId, (prev) => {
+      const cancelled = await this.deps.ledger.upsertWorker(dialogObjectId, workerId, (prev) => {
         if (!prev) return undefined
         const nextTask = applyStatusTransition(prev.task, 'cancelled', { now })
         // 按 (impl, seq) 精确定位主线化身条目,不假设它是数组最后一个(fork 之后数组末尾是
@@ -990,7 +1017,7 @@ export class WorkerHarness {
         })
         return { ...prev, task: nextTask, incarnations, updated_at: now }
       })
-      await this.appendEvent(workerId, incarnation.seq, 'killed', reason ? { reason } : undefined)
+      await this.appendEvent(workerId, incarnation.seq, 'killed', reason ? { reason } : undefined, cancelled?.task.status)
 
       // 清空信箱残留:此刻队列里的条目是 kill 之前已入队、deliver 还没轮到的消息(kill 之后
       // 的 sendToWorker 会命中上面已落定的 cancelled 直接拒绝,不会再有新条目挤进来——入队
@@ -1232,7 +1259,7 @@ export class WorkerHarness {
       const waitingInput = state === 'idle' ? true : undefined
       const nextStatus: TaskStatus = taskStatusFromIncarnation(state, endReason, waitingInput)
 
-      await this.deps.ledger.upsertWorker(dialogObjectId, h.worker_id, (prev) => {
+      const committed = await this.deps.ledger.upsertWorker(dialogObjectId, h.worker_id, (prev) => {
         if (!prev) return undefined
         // 同状态重复回调(如 adapter 偶发对同一次转变重复通知)不是合法状态机边(VALID_TRANSITIONS
         // 没有自环),会被 applyStatusTransition 当非法转换抛错——那样 upsertWorker 直接
@@ -1251,7 +1278,10 @@ export class WorkerHarness {
         )
         return { ...prev, task: nextTask, incarnations, updated_at: now }
       })
-      await this.appendEvent(h.worker_id, h.seq, 'state_changed', { to: state })
+      // 主线分支是 task 状态机的主要推进点——事件必须自带落账后的状态,否则订阅方现读台账
+      // 时若已经有下一次落账(如 §5.3 透明接续把终态拉回 running),这次迁移(含 completed
+      // 这类终态)会被整条吞掉。见 worker-events.ts `HarnessEvent.task_status`。
+      await this.appendEvent(h.worker_id, h.seq, 'state_changed', { to: state }, committed?.task.status)
     })
   }
 
@@ -1282,14 +1312,33 @@ export class WorkerHarness {
     return log
   }
 
+  /**
+   * `taskStatus`:只有**真正伴随一次 task 状态迁移**的调用点才传,值取自那次
+   * `ledger.upsertWorker` 的返回值(`committed?.task.status`)——即真正写进台账的那份
+   * worker,不是 harness 另算一遍,保证事件里的值与盘上的值同源。见 worker-events.ts
+   * `HarnessEvent.task_status` 的字段注释(为什么必须由事件自带,以及缺席时的语义)。
+   *
+   * 本文件里带这个参数的调用点(8 处,均为 task 级迁移):spawnWorker 的失败/成功收尾、
+   * reviveIncarnation 的 `resumed`、handoffIncarnation 第 4 步的 `spawned`、markCrashed 的
+   * `exited`、realignAliveIncarnation 的 `state_changed`、killWorker 的 `killed`、
+   * processStateChange 主线分支的 `state_changed`。其余调用点(化身级事件:input_sent /
+   * fork 分支 state_changed / query_failed / dead-letter / superseded / handoff_started …)
+   * 都不动 task.status,一律不传。
+   *
+   * upsert 的 mutator 返回 undefined(worker 已不在台账)时 `committed` 是 undefined,这里
+   * 原样落成"不带该字段",订阅方退回现读台账兜底,不构造假状态。
+   */
   private async appendEvent(
     workerId: string,
     seq: number,
     kind: HarnessEventKind,
-    detail?: Record<string, unknown>
+    detail?: Record<string, unknown>,
+    taskStatus?: TaskStatus
   ): Promise<void> {
     const ts = this.deps.now()
-    const event: HarnessEvent = detail !== undefined ? { ts, kind, worker_id: workerId, seq, detail } : { ts, kind, worker_id: workerId, seq }
+    const base: HarnessEvent = { ts, kind, worker_id: workerId, seq }
+    const withDetail: HarnessEvent = detail !== undefined ? { ...base, detail } : base
+    const event: HarnessEvent = taskStatus !== undefined ? { ...withDetail, task_status: taskStatus } : withDetail
     await this.getEventLog(workerId).append(event)
     this.deps.onEvent?.(event)
   }

--- a/crabot-agent/src/workers/harness/harness.ts
+++ b/crabot-agent/src/workers/harness/harness.ts
@@ -1420,8 +1420,12 @@ function findIncarnation(worker: LedgerWorker, impl: WorkerImplId, seq: number):
  * adapter 实例),不会产生跨 impl 撞号的歧义——唯一的例外是该 worker 曾经历跨实现切换
  * 且新旧 adapter 实例恰好在 seq 计数上撞号(protocol-agent-v3 §6.1 已知限制),这种边缘
  * 情况下"取最后一条"与本文件其它同类查找函数保持一致的降级行为,不单独处理。
+ *
+ * P5 review 修复(第二轮)additive:导出给 `get_worker_trace` 的 handler 复用——两个按化身读的
+ * 端点(output/trace)对"显式给的 seq 存不存在"必须用同一份判定,否则 trace 侧自己写一遍
+ * 就会与 readWorkerOutput 的"取最后一条匹配"原则漂移。纯可见性变更,零行为改动。
  */
-function findIncarnationBySeq(worker: LedgerWorker, seq: number): Incarnation | undefined {
+export function findIncarnationBySeq(worker: LedgerWorker, seq: number): Incarnation | undefined {
   let lastMatch: Incarnation | undefined
   for (const inc of worker.incarnations) {
     if (inc.seq === seq) lastMatch = inc

--- a/crabot-agent/src/workers/harness/harness.ts
+++ b/crabot-agent/src/workers/harness/harness.ts
@@ -767,6 +767,16 @@ export class WorkerHarness {
   }
 
   /**
+   * P5 Task 4 additive:harness 亲历事件流全量读——protocol-agent-v3 §10.2 worker trace 的
+   * **第一层**信息源(`events.jsonl`),供 §8.3 `get_worker_trace` 使用。事件流本来就只经
+   * `getEventLog` 这一个入口访问(带实例缓存),对外只补一个只读出口,不让调用方自己按
+   * `workersDir` 拼路径另建 `WorkerEventLog`——那会让"事件流文件在哪"出现第二处真相。
+   */
+  async readWorkerEvents(workerId: string): Promise<HarnessEvent[]> {
+    return this.getEventLog(workerId).readAll()
+  }
+
+  /**
    * 崩溃恢复对账(protocol-agent-v3 §12,替代 admin 的一刀切自愈)。agent 进程重启后调用
    * 一次:巡检台账里所有非终态 worker 的主线化身,凭 adapter.state() 判定它到底是"进程
    * 没了、化身也没了"(判死)还是"化身独立于 agent 进程,可能还活着"(如 tmux worker),

--- a/crabot-agent/src/workers/harness/harness.ts
+++ b/crabot-agent/src/workers/harness/harness.ts
@@ -1352,8 +1352,13 @@ export class WorkerHarness {
  * sendToWorker/killWorker 都 target 到 fork 的 seq,而不是主线 seq)。
  *
  * 前提:worker.incarnations 非空(每个已注册的 worker 至少有 spawn 落下的 seq=1 主线化身)。
+ *
+ * P5 review 修复 additive:导出给 `get_worker_trace` 的 handler 复用——§8.3 两个按化身读的
+ * 端点(output/trace)在调用方没给 seq 时必须落在**同一个**化身上,而 output 那条路
+ * (`readWorkerOutput`)本来就是用本函数取缺省。trace 侧若自己再写一遍"排除 forked_from
+ * 取最后一条",就会让"主线是哪个化身"出现第二处真相。
  */
-function mainlineIncarnation(worker: LedgerWorker): Incarnation {
+export function mainlineIncarnation(worker: LedgerWorker): Incarnation {
   const mainline = worker.incarnations.filter((inc) => inc.forked_from === undefined)
   return mainline[mainline.length - 1]
 }

--- a/crabot-agent/src/workers/harness/worker-events.ts
+++ b/crabot-agent/src/workers/harness/worker-events.ts
@@ -12,6 +12,7 @@
 import { promises as fs } from 'fs'
 import { join, basename } from 'path'
 import { AsyncMutex } from '../async-mutex'
+import type { TaskStatus } from './ledger-types'
 
 export type HarnessEventKind =
   | 'spawned'
@@ -40,6 +41,25 @@ export interface HarnessEvent {
   readonly worker_id: string
   readonly seq: number
   readonly detail?: Record<string, unknown>
+  /**
+   * 本条事件**所伴随的那次 task 状态迁移落账后**的 task.status。
+   *
+   * 为什么必须由事件自带(P5 修复):`HarnessEvent` 本身是**化身级**的,订阅方(见
+   * manager/events.ts 的 `makeTaskStatusEventBridge`)要把它翻译成任务级的
+   * `agent.task_status_changed`,就得知道"这次迁移之后 task 是什么状态"。此前订阅方是拿
+   * `worker_id` **现读台账**取这个值——而 `LedgerStore.findWorker` 不进互斥锁、读的永远是
+   * 最新已提交文件,只要这次读发生在**下一次落账之后**,中间那个状态(含 `completed` 这类
+   * 终态)就被整条吞掉,订阅方一次都收不到。把值钉在事件上,读取时刻就与落账时刻解耦。
+   *
+   * 取值来源:`LedgerStore.upsertWorker` 的返回值(即真正写进台账的那份 worker)的
+   * `task.status`,不是 harness 自己另算一遍——保证事件里的值与盘上的值同源。
+   *
+   * **可选**,只有真正发生 task 状态迁移的事件点才带(见 harness.ts `appendEvent` 的调用点
+   * 分类):化身级事件(`input_sent`、fork 分支的 `state_changed`、`query_failed`、
+   * dead-letter 等)与纯记录事件不带。缺席时订阅方退回现读台账(即修复前的行为),
+   * 不当作"无迁移"静默丢弃。
+   */
+  readonly task_status?: TaskStatus
 }
 
 function parseLine(line: string): HarnessEvent | null {
@@ -55,12 +75,16 @@ function parseLine(line: string): HarnessEvent | null {
       typeof parsed.worker_id === 'string' &&
       typeof parsed.seq === 'number'
     ) {
-      const event: HarnessEvent = {
+      // task_status 是 P5 additive 字段:老日志文件里没有,读回来就是没有(与在线事件缺席
+      // 时同一含义,见字段注释)。按字符串校验后原样带回,不让往返读丢字段。
+      const base: HarnessEvent = {
         ts: parsed.ts,
         kind: parsed.kind,
         worker_id: parsed.worker_id,
         seq: parsed.seq,
       }
+      const event: HarnessEvent =
+        typeof parsed.task_status === 'string' ? { ...base, task_status: parsed.task_status } : base
       return 'detail' in parsed ? { ...event, detail: parsed.detail } : event
     }
     return null

--- a/crabot-agent/tests/manager/bootstrap.test.ts
+++ b/crabot-agent/tests/manager/bootstrap.test.ts
@@ -2,7 +2,8 @@
  * manager 栈装配(P5 Task 1)—— `src/manager/bootstrap.ts`。
  *
  * 四条不变量:
- * ① `buildManagerStack` 无 I/O 副作用(不探测子进程、不扫盘、不建目录);
+ * ① `buildManagerStack` 无 I/O 副作用(不探测子进程、不扫盘、不建目录)——证据强度与残留缺口
+ *    见该用例内的注释;
  * ② harness.ts 文件头的四步接线契约成立(空 Map → harness → adapter 拿 handleStateChange →
  *    set 回同一 Map),且 adapter 的状态回调真的能被 harness 收到并落账;
  * ③ `onAsyncError` 经 registry 的 toolFace 工厂端到端接到 worker-tools 的 `query_worker`;
@@ -114,9 +115,6 @@ async function waitUntil(cond: () => Promise<boolean> | boolean, timeoutMs = 400
   throw new Error('waitUntil timed out')
 }
 
-const FS_MUTATING_OR_SCANNING: ReadonlyArray<'mkdir' | 'readdir' | 'readFile' | 'writeFile' | 'access' | 'stat' | 'rename' | 'rm'> =
-  ['mkdir', 'readdir', 'readFile', 'writeFile', 'access', 'stat', 'rename', 'rm']
-
 describe('manager bootstrap（P5 Task 1）', () => {
   let tmpRoot: string
   /** 刻意指向一个不存在的子目录:任何"顺手建目录"的 I/O 都会在盘上留下痕迹被用例抓住。 */
@@ -161,15 +159,25 @@ describe('manager bootstrap（P5 Task 1）', () => {
       vi.spyOn(LedgerStore.prototype, 'listAllWorkers'),
       vi.spyOn(LedgerStore.prototype, 'findWorker'),
     ]
-    // 直接盯住 fs.promises 本身:比"没报错"强得多——任何一次真实的建目录/扫目录/读写都会被记到。
-    const fsSpies = FS_MUTATING_OR_SCANNING.map((name) => vi.spyOn(fs, name))
+    // 这里曾经还有一组 `vi.spyOn(fs, 'mkdir' | 'readdir' | …)`(fs.promises 上的八个方法),
+    // **已删**:它拦不住被测代码。生产侧一律 `import * as fs from 'node:fs/promises'`——ESM
+    // 命名空间导入的绑定在模块求值时就固化了,事后 patch `require('fs').promises` 的属性对它
+    // 无效;而且那组 spy 也没覆盖 `appendFile` / `fs.watch` / `child_process`,即使拦得住也不
+    // 是"零 I/O"的充分条件。留着只会给人虚假安全感。
+    //
+    // **真正兜住"零 I/O"结论的是下面两条**:
+    // (a) 行为口的 spy —— detect / scanOrphans / LedgerStore.{init,listAllWorkers,findWorker}
+    //     是这套栈里所有子进程探测与扫盘的**入口**,零调用即没有从这几个口子出去过;
+    // (b) 盘上自证 —— `dataRoot` 整棵子树在装配后仍是 ENOENT,任何一次顺手的建目录/写文件
+    //     都会留下痕迹。
+    // 残留缺口(如实记):对 `dataRoot` **之外**已存在文件的纯读取,这两条都看不见。评审
+    // (review-p5-task12.md)按逐个通读 9 个构造函数补上了这一段。
 
     const stack = buildManagerStack(makeDeps())
 
     for (const spy of detectSpies) expect(spy).not.toHaveBeenCalled()
     expect(scanOrphansSpy).not.toHaveBeenCalled()
     for (const spy of ledgerSpies) expect(spy).not.toHaveBeenCalled()
-    for (const spy of fsSpies) expect(spy, `fs.${spy.getMockName()} 不应在装配期被调用`).not.toHaveBeenCalled()
 
     vi.restoreAllMocks()
 

--- a/crabot-agent/tests/manager/bootstrap.test.ts
+++ b/crabot-agent/tests/manager/bootstrap.test.ts
@@ -1,0 +1,288 @@
+/**
+ * manager 栈装配(P5 Task 1)—— `src/manager/bootstrap.ts`。
+ *
+ * 四条不变量:
+ * ① `buildManagerStack` 无 I/O 副作用(不探测子进程、不扫盘、不建目录);
+ * ② harness.ts 文件头的四步接线契约成立(空 Map → harness → adapter 拿 handleStateChange →
+ *    set 回同一 Map),且 adapter 的状态回调真的能被 harness 收到并落账;
+ * ③ `onAsyncError` 经 registry 的 toolFace 工厂端到端接到 worker-tools 的 `query_worker`;
+ * ④ `reconcileManagerStack` 对空台账快速返回空三桶。
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { promises as fs } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+import { buildManagerStack, reconcileManagerStack, type BootstrapDeps } from '../../src/manager/bootstrap.js'
+import { LedgerStore } from '../../src/workers/harness/ledger-store.js'
+import { BuiltinWorkerAdapter } from '../../src/workers/builtin/adapter.js'
+import { ClaudeCodeAdapter } from '../../src/workers/claude-code/adapter.js'
+import { CodexWorkerAdapter } from '../../src/workers/codex/adapter.js'
+import { CapabilityNotSupportedError } from '../../src/workers/errors.js'
+import { dialogObjectIdForPrivate, type DialogObjectId, type LedgerWorker } from '../../src/workers/harness/ledger-types.js'
+import type { WorkerAdapter, WorkerImplId, IncarnationHandle, WorkerContractState } from '../../src/workers/types.js'
+import type { ManagerKey } from '../../src/manager/types.js'
+import type { LLMAdapter, LLMStreamParams } from '../../src/engine/index.js'
+import type { ChannelMessage } from '../../src/types.js'
+import { createCrabMemoryServer } from '../../src/mcp/crab-memory.js'
+import { chunksFromContent } from '../engine/helpers/mock-stream.js'
+
+// ============================================================================
+// helpers
+// ============================================================================
+
+/** 最小 crab-memory server(照抄 tests/manager/registry.test.ts)。 */
+function makeMemoryServer() {
+  return createCrabMemoryServer(
+    { rpcClient: { call: vi.fn() } as never, moduleId: 'manager-bootstrap-test', getMemoryPort: async () => 19100 },
+    { visibility: 'internal', scopes: [], isMasterPrivate: false },
+  )
+}
+
+/** 最小 crab-messaging 依赖桩(照抄 tests/manager/registry.test.ts)。 */
+function makeMessagingDeps() {
+  return {
+    rpcClient: { call: vi.fn() } as never,
+    moduleId: 'manager-bootstrap-test',
+    getAdminPort: async () => 19001,
+    resolveChannelPort: async () => 19009,
+  }
+}
+
+function makeChannelMessage(text: string): ChannelMessage {
+  return {
+    platform_message_id: `pm-${Math.random().toString(36).slice(2)}`,
+    session: { session_id: 'sess-boot', channel_id: 'wechat', type: 'private' },
+    sender: { platform_user_id: 'u1', platform_display_name: '测试用户' },
+    content: { type: 'text', text },
+    features: { is_mention_crab: false },
+    platform_timestamp: new Date().toISOString(),
+  }
+}
+
+function silentAdapter(): LLMAdapter {
+  return {
+    async *stream() {
+      yield* chunksFromContent([{ type: 'text', text: '(默认回复)' }], 'end_turn', { inputTokens: 10, outputTokens: 5 })
+    },
+    updateConfig: () => {},
+  }
+}
+
+/**
+ * 读出 adapter 构造时收到的 `onStateChange`——三个 adapter 都把构造 deps 存成私有字段
+ * `deps`,这里刻意穿透私有性:本用例要验证的正是"构造时传进去的那个引用是不是 harness 的
+ * handleStateChange",没有别的观测口。
+ */
+function capturedOnStateChange(
+  adapter: WorkerAdapter | undefined,
+): ((h: IncarnationHandle, s: WorkerContractState) => void) | undefined {
+  return (adapter as unknown as { deps?: { onStateChange?: (h: IncarnationHandle, s: WorkerContractState) => void } })
+    ?.deps?.onStateChange
+}
+
+function makeLedgerWorker(p: {
+  workerId: string
+  impl: WorkerImplId
+  spawnedBySession: ManagerKey
+}): LedgerWorker {
+  return {
+    worker_id: p.workerId,
+    task: { id: p.workerId, title: 't', status: 'running', created_at: '2026-01-01T00:00:00.000Z' },
+    origin: { spawned_by_session: p.spawnedBySession, trigger_type: 'message' },
+    report_to: { channel_id: 'wechat', session_id: 'sess-boot' },
+    incarnations: [
+      {
+        seq: 1,
+        impl: p.impl,
+        state: 'running',
+        workspace: '/tmp/ws-not-used',
+        session_ref: `${p.workerId}-ref`,
+        started_at: '2026-01-01T00:00:00.000Z',
+      },
+    ],
+    updated_at: '2026-01-01T00:00:00.000Z',
+  }
+}
+
+async function waitUntil(cond: () => Promise<boolean> | boolean, timeoutMs = 4000, intervalMs = 20): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (await cond()) return
+    await new Promise((resolve) => setTimeout(resolve, intervalMs))
+  }
+  throw new Error('waitUntil timed out')
+}
+
+const FS_MUTATING_OR_SCANNING: ReadonlyArray<'mkdir' | 'readdir' | 'readFile' | 'writeFile' | 'access' | 'stat' | 'rename' | 'rm'> =
+  ['mkdir', 'readdir', 'readFile', 'writeFile', 'access', 'stat', 'rename', 'rm']
+
+describe('manager bootstrap（P5 Task 1）', () => {
+  let tmpRoot: string
+  /** 刻意指向一个不存在的子目录:任何"顺手建目录"的 I/O 都会在盘上留下痕迹被用例抓住。 */
+  let dataRoot: string
+  const dialogObjectIdFor = (key: ManagerKey): DialogObjectId => dialogObjectIdForPrivate(`friend-of-${key}`)
+
+  beforeEach(async () => {
+    tmpRoot = await fs.mkdtemp(join(tmpdir(), 'manager-bootstrap-'))
+    dataRoot = join(tmpRoot, 'data-root-not-created-yet')
+  })
+
+  afterEach(async () => {
+    vi.restoreAllMocks()
+    await fs.rm(tmpRoot, { recursive: true, force: true })
+  })
+
+  function makeDeps(overrides: Partial<BootstrapDeps> = {}): BootstrapDeps {
+    return {
+      dataRoot,
+      now: () => new Date().toISOString(),
+      managerAdapter: () => silentAdapter(),
+      managerModel: () => 'test-manager-model',
+      messagingDeps: makeMessagingDeps(),
+      memoryServer: makeMemoryServer(),
+      callAdmin: async () => ({}) as never,
+      dialogObjectIdFor,
+      ...overrides,
+    }
+  }
+
+  // --- ① 无 I/O 副作用 ---
+
+  it('buildManagerStack 不触发任何子进程探测 / 台账扫描 / 文件系统写读，盘上不留痕迹', async () => {
+    const detectSpies = [
+      vi.spyOn(BuiltinWorkerAdapter.prototype, 'detect'),
+      vi.spyOn(ClaudeCodeAdapter.prototype, 'detect'),
+      vi.spyOn(CodexWorkerAdapter.prototype, 'detect'),
+    ]
+    const scanOrphansSpy = vi.spyOn(BuiltinWorkerAdapter, 'scanOrphans')
+    const ledgerSpies = [
+      vi.spyOn(LedgerStore.prototype, 'init'),
+      vi.spyOn(LedgerStore.prototype, 'listAllWorkers'),
+      vi.spyOn(LedgerStore.prototype, 'findWorker'),
+    ]
+    // 直接盯住 fs.promises 本身:比"没报错"强得多——任何一次真实的建目录/扫目录/读写都会被记到。
+    const fsSpies = FS_MUTATING_OR_SCANNING.map((name) => vi.spyOn(fs, name))
+
+    const stack = buildManagerStack(makeDeps())
+
+    for (const spy of detectSpies) expect(spy).not.toHaveBeenCalled()
+    expect(scanOrphansSpy).not.toHaveBeenCalled()
+    for (const spy of ledgerSpies) expect(spy).not.toHaveBeenCalled()
+    for (const spy of fsSpies) expect(spy, `fs.${spy.getMockName()} 不应在装配期被调用`).not.toHaveBeenCalled()
+
+    vi.restoreAllMocks()
+
+    // 盘上自证:dataRoot 整棵子树都还不存在。
+    await expect(fs.access(dataRoot)).rejects.toMatchObject({ code: 'ENOENT' })
+
+    // 装配结果本身仍然是完整的
+    expect(stack.adapters.size).toBe(3)
+    expect([...stack.adapters.keys()].sort()).toEqual(['builtin', 'claude-code', 'codex'])
+  })
+
+  // --- ② 四步接线契约 ---
+
+  it('四步接线契约成立：三个 adapter 都拿到同一个 harness.handleStateChange，回调能落账；harness 看得到构造后才 set 进 Map 的 adapter', async () => {
+    const stack = buildManagerStack(makeDeps())
+
+    // step 3：构造 adapter 时传的就是 harness 那个绑定好 this 的箭头函数字段本身
+    for (const impl of ['builtin', 'claude-code', 'codex'] as const) {
+      expect(capturedOnStateChange(stack.adapters.get(impl)), `${impl} 的 onStateChange`).toBe(
+        stack.harness.handleStateChange,
+      )
+    }
+
+    // step 1/2/4：走 adapter 手里那份回调引用，验证 harness 真的收到了并落账
+    const dialogObjectId = dialogObjectIdForPrivate('friend-wiring')
+    await stack.ledger.upsertWorker(dialogObjectId, 'w-builtin-1', () =>
+      makeLedgerWorker({ workerId: 'w-builtin-1', impl: 'builtin', spawnedBySession: 'wechat::sess-boot' as ManagerKey }),
+    )
+
+    // onEvent 出口把 harness 事件路由给监护 manager，是 fire-and-forget：这里把返回的
+    // promise 捞出来，既顺带验证接线，也保证用例收尾前把它们 await 干净（否则会漏进
+    // afterEach 的清理，和 rm 打架）。
+    const routeSpy = vi.spyOn(stack.registry, 'routeWorkerEvent')
+
+    const onStateChange = capturedOnStateChange(stack.adapters.get('builtin'))
+    expect(onStateChange).toBeDefined()
+    onStateChange!({ worker_id: 'w-builtin-1', seq: 1, impl: 'builtin', session_ref: 'w-builtin-1-ref' }, 'exited')
+
+    await waitUntil(async () => (await stack.ledger.findWorker('w-builtin-1'))?.worker.task.status === 'completed')
+    const after = await stack.ledger.findWorker('w-builtin-1')
+    expect(after?.worker.incarnations[0].state).toBe('exited')
+
+    // step 4 的另一面：harness 按需从同一个底层 Map 取 adapter——codex 是构造 harness 之后才
+    // set 进去的，能命中它自己的 capabilities().fork===false 分支，就证明 Map 引用是共享的
+    // （若没共享，抛的会是 "no adapter registered for impl 'codex'"）。
+    await stack.ledger.upsertWorker(dialogObjectId, 'w-codex-1', () =>
+      makeLedgerWorker({ workerId: 'w-codex-1', impl: 'codex', spawnedBySession: 'wechat::sess-boot' as ManagerKey }),
+    )
+    await expect(stack.harness.queryWorker('w-codex-1', '进展如何？')).rejects.toBeInstanceOf(CapabilityNotSupportedError)
+
+    // onEvent → registry.routeWorkerEvent 确实接上了（state_changed 与 query_failed 各一条）
+    await waitUntil(() => routeSpy.mock.calls.length >= 2)
+    expect(routeSpy.mock.calls.map(([e]) => e.kind)).toEqual(['state_changed', 'query_failed'])
+    await Promise.allSettled(routeSpy.mock.results.map((r) => r.value as Promise<unknown>))
+  })
+
+  // --- ③ onAsyncError 端到端 ---
+
+  it('onAsyncError 端到端：经 bootstrap 装配的真实工具面调用 query_worker（worker 不存在→游离 promise reject）→ registry 按 key 绑定的回调被触发 → episode 内 enqueueDuringEpisode', async () => {
+    let triggered = false
+    const managerLLM: LLMAdapter = {
+      async *stream(params: LLMStreamParams) {
+        if (!triggered) {
+          triggered = true
+          // 从真实 LLMStreamParams.tools 里取生产链路上真正会喂给 LLM 的那个 query_worker
+          const queryWorkerTool = params.tools.find((t) => t.name === 'query_worker')
+          expect(queryWorkerTool).toBeDefined()
+          const result = await queryWorkerTool!.call({ worker_id: 'w-not-in-ledger', question: '进展如何？' }, {} as never)
+          // fire-and-forget：调用本身不因后台失败而报错
+          expect(result.isError).toBe(false)
+          // 给游离 promise 一个宏任务窗口 reject → .catch() → onAsyncError（此刻 episode 仍在跑）
+          await new Promise((resolve) => setTimeout(resolve, 40))
+        }
+        yield* chunksFromContent([{ type: 'text', text: '收到' }], 'end_turn', { inputTokens: 10, outputTokens: 5 })
+      },
+      updateConfig: () => {},
+    }
+
+    const stack = buildManagerStack(makeDeps({ managerAdapter: () => managerLLM }))
+    const key = 'wechat::sess-boot' as ManagerKey
+    const loop = stack.registry.getOrCreate(key)
+    const enqueueSpy = vi.spyOn(loop, 'enqueueDuringEpisode')
+
+    const result = await stack.registry.routeHumanMessages('wechat', 'sess-boot', [makeChannelMessage('侧问一下 worker')])
+
+    expect(result.outcome).toBe('completed')
+    expect(enqueueSpy).toHaveBeenCalledTimes(1)
+    expect(JSON.stringify(enqueueSpy.mock.calls[0][0])).toContain('query_failed')
+  })
+
+  // --- ④ 空台账对账 ---
+
+  it('reconcileManagerStack 对空台账快速返回空三桶，且不探测任何 adapter', async () => {
+    const stack = buildManagerStack(makeDeps())
+
+    const detectSpies = [
+      vi.spyOn(BuiltinWorkerAdapter.prototype, 'detect'),
+      vi.spyOn(ClaudeCodeAdapter.prototype, 'detect'),
+      vi.spyOn(CodexWorkerAdapter.prototype, 'detect'),
+    ]
+    const stateSpies = [
+      vi.spyOn(BuiltinWorkerAdapter.prototype, 'state'),
+      vi.spyOn(ClaudeCodeAdapter.prototype, 'state'),
+      vi.spyOn(CodexWorkerAdapter.prototype, 'state'),
+    ]
+
+    const startedAt = Date.now()
+    const report = await reconcileManagerStack(stack)
+    const elapsed = Date.now() - startedAt
+
+    expect(report).toEqual({ revived: [], failed: [], unchanged: [] })
+    expect(elapsed).toBeLessThan(1000)
+    for (const spy of detectSpies) expect(spy).not.toHaveBeenCalled()
+    for (const spy of stateSpies) expect(spy).not.toHaveBeenCalled()
+  })
+})

--- a/crabot-agent/tests/manager/events.test.ts
+++ b/crabot-agent/tests/manager/events.test.ts
@@ -1,0 +1,469 @@
+/**
+ * agent 对外事件(P5 Task 2)—— `src/manager/events.ts` + bootstrap 的 onEvent 接线。
+ *
+ * 五条不变量:
+ * ① `agent.task_status_changed` 载荷与 protocol-agent-v3 §9.2 逐字一致(字段名/字段集);
+ * ② 事件信封形状与既有模块(admin `publishAdminEvent`)一致:id/type/source/payload/timestamp;
+ * ③ 发布失败(reject 与同步抛)都被 catch,不抛给调用方、不产生 unhandledRejection;
+ * ④ 化身级事件(task.status 没动)不触发 task 级事件;
+ * ⑤ 同状态重复事件静默;并发事件按 worker 串行,old/new 不会错位。
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { promises as fs } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+import {
+  makeAgentEventPublisher,
+  makeTaskStatusEventBridge,
+  type AgentTaskStatusChangedPayload,
+} from '../../src/manager/events.js'
+import { buildManagerStack, type BootstrapDeps } from '../../src/manager/bootstrap.js'
+import {
+  dialogObjectIdForPrivate,
+  type DialogObjectId,
+  type LedgerWorker,
+  type TaskStatus,
+} from '../../src/workers/harness/ledger-types.js'
+import type { HarnessEvent } from '../../src/workers/harness/harness.js'
+import type { LedgerStore } from '../../src/workers/harness/ledger-store.js'
+import type { WorkerAdapter, WorkerImplId, IncarnationHandle, WorkerContractState } from '../../src/workers/types.js'
+import type { ManagerKey } from '../../src/manager/types.js'
+import type { LLMAdapter } from '../../src/engine/index.js'
+import type { Event, ModuleId, RpcClient } from 'crabot-shared'
+import { createCrabMemoryServer } from '../../src/mcp/crab-memory.js'
+import { chunksFromContent } from '../engine/helpers/mock-stream.js'
+
+// ============================================================================
+// helpers
+// ============================================================================
+
+const DIALOG_OBJECT_ID = dialogObjectIdForPrivate('friend-evt')
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+function makeLedgerWorker(p: {
+  workerId: string
+  status: TaskStatus
+  taskId?: string
+  impl?: WorkerImplId
+}): LedgerWorker {
+  return {
+    worker_id: p.workerId,
+    task: { id: p.taskId ?? `task-of-${p.workerId}`, title: 't', status: p.status, created_at: '2026-01-01T00:00:00.000Z' },
+    origin: { spawned_by_session: 'wechat::sess-evt' as ManagerKey, trigger_type: 'message' },
+    report_to: { channel_id: 'wechat', session_id: 'sess-evt' },
+    incarnations: [
+      {
+        seq: 1,
+        impl: p.impl ?? 'builtin',
+        state: 'running',
+        workspace: '/tmp/ws-not-used',
+        session_ref: `${p.workerId}-ref`,
+        started_at: '2026-01-01T00:00:00.000Z',
+      },
+    ],
+    updated_at: '2026-01-01T00:00:00.000Z',
+  }
+}
+
+/** 台账桩:按调用序返回状态(模拟 harness 落账后的真实读)。 */
+function makeLedgerStub(
+  script: Array<{ status: TaskStatus; delayMs?: number } | undefined>,
+  opts: { taskId?: string; workerId?: string } = {},
+): { ledger: Pick<LedgerStore, 'findWorker'>; calls: () => number } {
+  let n = 0
+  const ledger = {
+    findWorker: async (workerId: string) => {
+      const step = script[Math.min(n, script.length - 1)]
+      n += 1
+      if (!step) return undefined
+      if (step.delayMs) await new Promise((resolve) => setTimeout(resolve, step.delayMs))
+      return {
+        dialogObjectId: DIALOG_OBJECT_ID,
+        worker: makeLedgerWorker({ workerId: opts.workerId ?? workerId, status: step.status, taskId: opts.taskId }),
+      }
+    },
+  } as Pick<LedgerStore, 'findWorker'>
+  return { ledger, calls: () => n }
+}
+
+function harnessEvent(overrides: Partial<HarnessEvent> = {}): HarnessEvent {
+  return {
+    ts: '2026-07-31T00:00:00.000Z',
+    kind: 'state_changed',
+    worker_id: 'w-1',
+    seq: 1,
+    ...overrides,
+  }
+}
+
+/** 等待 bridge 内部的 fire-and-forget 链跑完(宏任务窗口足够,链上只有内存桩)。 */
+async function flush(times = 6): Promise<void> {
+  for (let i = 0; i < times; i += 1) await new Promise((resolve) => setTimeout(resolve, 5))
+}
+
+async function waitUntil(cond: () => Promise<boolean> | boolean, timeoutMs = 4000, intervalMs = 20): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (await cond()) return
+    await new Promise((resolve) => setTimeout(resolve, intervalMs))
+  }
+  throw new Error('waitUntil timed out')
+}
+
+// --- bootstrap 接线用(最小依赖桩,与 tests/manager/bootstrap.test.ts 同款) ---
+
+function makeMemoryServer() {
+  return createCrabMemoryServer(
+    { rpcClient: { call: vi.fn() } as never, moduleId: 'manager-events-test', getMemoryPort: async () => 19100 },
+    { visibility: 'internal', scopes: [], isMasterPrivate: false },
+  )
+}
+
+function makeMessagingDeps() {
+  return {
+    rpcClient: { call: vi.fn() } as never,
+    moduleId: 'manager-events-test',
+    getAdminPort: async () => 19001,
+    resolveChannelPort: async () => 19009,
+  }
+}
+
+function silentAdapter(): LLMAdapter {
+  return {
+    async *stream() {
+      yield* chunksFromContent([{ type: 'text', text: '(默认回复)' }], 'end_turn', { inputTokens: 10, outputTokens: 5 })
+    },
+    updateConfig: () => {},
+  }
+}
+
+function capturedOnStateChange(
+  adapter: WorkerAdapter | undefined,
+): ((h: IncarnationHandle, s: WorkerContractState) => void) | undefined {
+  return (adapter as unknown as { deps?: { onStateChange?: (h: IncarnationHandle, s: WorkerContractState) => void } })
+    ?.deps?.onStateChange
+}
+
+// ============================================================================
+
+describe('agent 对外事件（P5 Task 2）', () => {
+  let unhandled: unknown[]
+  const onUnhandled = (err: unknown): void => {
+    unhandled.push(err)
+  }
+
+  beforeEach(() => {
+    unhandled = []
+    process.on('unhandledRejection', onUnhandled)
+  })
+
+  afterEach(() => {
+    process.off('unhandledRejection', onUnhandled)
+    vi.restoreAllMocks()
+  })
+
+  // --- ② 事件信封 ---
+
+  describe('makeAgentEventPublisher', () => {
+    it('信封形状与既有模块一致：自动补 id(uuid) / source / timestamp，payload 原样透传', () => {
+      const publishEvent = vi.fn(async () => 1)
+      const publish = makeAgentEventPublisher({
+        rpcClient: { publishEvent } as Pick<RpcClient, 'publishEvent'>,
+        moduleId: 'agent-1' as ModuleId,
+        now: () => '2026-07-31T12:00:00.000Z',
+      })
+
+      const payload: AgentTaskStatusChangedPayload = {
+        worker_id: 'w-1',
+        task_id: 'task-1',
+        old_status: 'running',
+        new_status: 'completed',
+        dialog_object_id: DIALOG_OBJECT_ID,
+      }
+      publish('agent.task_status_changed', payload)
+
+      expect(publishEvent).toHaveBeenCalledTimes(1)
+      const [event, source] = publishEvent.mock.calls[0] as unknown as [Event, ModuleId]
+      expect(source).toBe('agent-1')
+      expect(Object.keys(event).sort()).toEqual(['id', 'payload', 'source', 'timestamp', 'type'])
+      expect(event.type).toBe('agent.task_status_changed')
+      expect(event.source).toBe('agent-1')
+      expect(event.timestamp).toBe('2026-07-31T12:00:00.000Z')
+      expect(event.id).toMatch(UUID_RE)
+      expect(event.payload).toEqual(payload)
+    })
+
+    // --- ③ 发布失败不反噬调用方 ---
+
+    it('rpcClient reject 被 catch：调用方不抛、无 unhandledRejection', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const publish = makeAgentEventPublisher({
+        rpcClient: { publishEvent: async () => Promise.reject(new Error('module manager 不可达')) } as Pick<
+          RpcClient,
+          'publishEvent'
+        >,
+        moduleId: 'agent-1' as ModuleId,
+        now: () => '2026-07-31T12:00:00.000Z',
+      })
+
+      expect(() =>
+        publish('agent.task_status_changed', {
+          worker_id: 'w-1',
+          task_id: 'task-1',
+          old_status: 'running',
+          new_status: 'failed',
+          dialog_object_id: DIALOG_OBJECT_ID,
+        }),
+      ).not.toThrow()
+
+      await flush()
+      expect(unhandled).toEqual([])
+      expect(consoleSpy).toHaveBeenCalled()
+    })
+
+    it('rpcClient 同步抛错也被 catch：调用方不抛', () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const publish = makeAgentEventPublisher({
+        rpcClient: {
+          publishEvent: () => {
+            throw new Error('rpcClient 未初始化')
+          },
+        } as unknown as Pick<RpcClient, 'publishEvent'>,
+        moduleId: 'agent-1' as ModuleId,
+        now: () => '2026-07-31T12:00:00.000Z',
+      })
+
+      expect(() =>
+        publish('agent.task_status_changed', {
+          worker_id: 'w-1',
+          task_id: 'task-1',
+          old_status: 'queued',
+          new_status: 'running',
+          dialog_object_id: DIALOG_OBJECT_ID,
+        }),
+      ).not.toThrow()
+      expect(consoleSpy).toHaveBeenCalled()
+    })
+  })
+
+  // --- ①④⑤ harness 事件 → task 状态事件的翻译与去重 ---
+
+  describe('makeTaskStatusEventBridge', () => {
+    it('①载荷与 §9.2 逐字：worker_id / task_id / old_status / new_status / dialog_object_id，无多余字段', async () => {
+      const publish = vi.fn()
+      const { ledger } = makeLedgerStub([{ status: 'running' }], { taskId: 'task-42' })
+      const bridge = makeTaskStatusEventBridge({ ledger, publish })
+
+      bridge(harnessEvent({ kind: 'spawned', worker_id: 'w-42' }))
+      await flush()
+
+      expect(publish).toHaveBeenCalledTimes(1)
+      const [type, payload] = publish.mock.calls[0] as [string, AgentTaskStatusChangedPayload]
+      expect(type).toBe('agent.task_status_changed')
+      expect(Object.keys(payload).sort()).toEqual([
+        'dialog_object_id',
+        'new_status',
+        'old_status',
+        'task_id',
+        'worker_id',
+      ])
+      expect(payload).toEqual({
+        worker_id: 'w-42',
+        task_id: 'task-42',
+        // 台账里的 task 初始状态是 queued（harness.spawnWorker 先建 queued 再迁 running）
+        old_status: 'queued',
+        new_status: 'running',
+        dialog_object_id: DIALOG_OBJECT_ID,
+      })
+    })
+
+    it('④化身级事件不触发 task 事件：task.status 一直是 running 时，state_changed / input_sent 一条都不发', async () => {
+      const publish = vi.fn()
+      const { ledger } = makeLedgerStub([{ status: 'running' }])
+      const bridge = makeTaskStatusEventBridge({ ledger, publish })
+
+      // 第一条把 task 从初始 queued 带到 running（这是真实迁移，应发）
+      bridge(harnessEvent({ kind: 'spawned' }))
+      await flush()
+      expect(publish).toHaveBeenCalledTimes(1)
+
+      // 后续全是化身级跳动：input_sent / state_changed(fork) / state_changed(dead_letter)
+      bridge(harnessEvent({ kind: 'input_sent', detail: { text_len: 3 } }))
+      bridge(harnessEvent({ kind: 'state_changed', seq: 2, detail: { kind: 'fork', from_seq: 1 } }))
+      bridge(harnessEvent({ kind: 'state_changed', detail: { kind: 'dead_letter', reason: 'task_cancelled' } }))
+      bridge(harnessEvent({ kind: 'query_failed', detail: { reason: 'capability_not_supported' } }))
+      await flush()
+
+      expect(publish).toHaveBeenCalledTimes(1)
+    })
+
+    it('⑤同状态重复事件静默；状态真的变了才发，且 old_status 取上一次已知值', async () => {
+      const publish = vi.fn()
+      const { ledger } = makeLedgerStub([
+        { status: 'running' },
+        { status: 'running' },
+        { status: 'waiting_input' },
+        { status: 'waiting_input' },
+        { status: 'completed' },
+      ])
+      const bridge = makeTaskStatusEventBridge({ ledger, publish })
+
+      for (let i = 0; i < 5; i += 1) {
+        bridge(harnessEvent({ kind: 'state_changed' }))
+        await flush(2)
+      }
+      await flush()
+
+      expect(publish.mock.calls.map(([, p]) => [p.old_status, p.new_status])).toEqual([
+        ['queued', 'running'],
+        ['running', 'waiting_input'],
+        ['waiting_input', 'completed'],
+      ])
+    })
+
+    it('同一 worker 的并发事件按序处理：先到的台账读慢一拍也不会让 old/new 错位', async () => {
+      const publish = vi.fn()
+      const { ledger } = makeLedgerStub([
+        { status: 'running', delayMs: 40 }, // 第一条读得慢
+        { status: 'completed' }, // 第二条读得快
+      ])
+      const bridge = makeTaskStatusEventBridge({ ledger, publish })
+
+      bridge(harnessEvent({ kind: 'spawned' }))
+      bridge(harnessEvent({ kind: 'exited' }))
+      await flush(20)
+
+      expect(publish.mock.calls.map(([, p]) => [p.old_status, p.new_status])).toEqual([
+        ['queued', 'running'],
+        ['running', 'completed'],
+      ])
+    })
+
+    it('worker 不在台账（如 query_failed:worker_not_found）→ 不发事件、不抛', async () => {
+      const publish = vi.fn()
+      const { ledger } = makeLedgerStub([undefined])
+      const bridge = makeTaskStatusEventBridge({ ledger, publish })
+
+      expect(() => bridge(harnessEvent({ kind: 'query_failed', detail: { reason: 'worker_not_found' } }))).not.toThrow()
+      await flush()
+
+      expect(publish).not.toHaveBeenCalled()
+      expect(unhandled).toEqual([])
+    })
+
+    it('台账读失败 → 记日志、不发事件、不抛、无 unhandledRejection', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const publish = vi.fn()
+      const ledger = {
+        findWorker: async () => {
+          throw new Error('台账文件损坏')
+        },
+      } as unknown as Pick<LedgerStore, 'findWorker'>
+      const bridge = makeTaskStatusEventBridge({ ledger, publish })
+
+      expect(() => bridge(harnessEvent())).not.toThrow()
+      await flush()
+
+      expect(publish).not.toHaveBeenCalled()
+      expect(unhandled).toEqual([])
+      expect(consoleSpy).toHaveBeenCalled()
+    })
+  })
+
+  // --- 接线:bootstrap 的 onEvent 出口 ---
+
+  describe('bootstrap onEvent 接线', () => {
+    let tmpRoot: string
+
+    beforeEach(async () => {
+      tmpRoot = await fs.mkdtemp(join(tmpdir(), 'manager-events-'))
+    })
+
+    afterEach(async () => {
+      await fs.rm(tmpRoot, { recursive: true, force: true })
+    })
+
+    function makeDeps(overrides: Partial<BootstrapDeps> = {}): BootstrapDeps {
+      return {
+        dataRoot: join(tmpRoot, 'data'),
+        now: () => new Date().toISOString(),
+        managerAdapter: () => silentAdapter(),
+        managerModel: () => 'test-manager-model',
+        messagingDeps: makeMessagingDeps(),
+        memoryServer: makeMemoryServer(),
+        callAdmin: async () => ({}) as never,
+        dialogObjectIdFor: (): DialogObjectId => DIALOG_OBJECT_ID,
+        ...overrides,
+      }
+    }
+
+    it('真实 harness 状态迁移（adapter 回调 → 落账 → onEvent）会发出 agent.task_status_changed', async () => {
+      const published: Array<[string, AgentTaskStatusChangedPayload]> = []
+      const stack = buildManagerStack(
+        makeDeps({
+          publishEvent: (type, payload) => {
+            published.push([type, payload])
+          },
+        }),
+      )
+
+      await stack.ledger.upsertWorker(DIALOG_OBJECT_ID, 'w-wired', () =>
+        makeLedgerWorker({ workerId: 'w-wired', status: 'running', taskId: 'task-wired' }),
+      )
+
+      const onStateChange = capturedOnStateChange(stack.adapters.get('builtin'))
+      expect(onStateChange).toBeDefined()
+      // 注：这里 exited 落成 completed 是 P7 阻塞项 #1（processStateChange 硬编码
+      // endReason='completed'）的直接后果，本用例只验证"事件发得出来"，不验证 completed 的正确性。
+      onStateChange!({ worker_id: 'w-wired', seq: 1, impl: 'builtin', session_ref: 'w-wired-ref' }, 'exited')
+
+      await waitUntil(() => published.length >= 1)
+      expect(published[0][0]).toBe('agent.task_status_changed')
+      expect(published[0][1]).toEqual({
+        worker_id: 'w-wired',
+        task_id: 'task-wired',
+        old_status: 'queued',
+        new_status: 'completed',
+        dialog_object_id: DIALOG_OBJECT_ID,
+      })
+    })
+
+    it('对外事件不受 manager 唤醒过滤（shouldWakeOnHarnessEvent）与 registry 就绪与否影响：input_sent 也要能翻译出状态迁移', async () => {
+      const published: Array<[string, AgentTaskStatusChangedPayload]> = []
+      const stack = buildManagerStack(
+        makeDeps({
+          publishEvent: (type, payload) => {
+            published.push([type, payload])
+          },
+        }),
+      )
+
+      await stack.ledger.upsertWorker(DIALOG_OBJECT_ID, 'w-filtered', () =>
+        makeLedgerWorker({ workerId: 'w-filtered', status: 'running', taskId: 'task-filtered' }),
+      )
+
+      // 直取 harness 拿到的那个 onEvent：这是 bootstrap 开的唯一出口，也是本用例要验证的对象
+      // （input_sent 在 NO_WAKE_KINDS 里，真实 harness 只有在活 worker 上投递才会落，
+      // 这里用同一个回调直接喂，验证的是接线顺序本身）。
+      const onEvent = (stack.harness as unknown as { deps: { onEvent?: (e: HarnessEvent) => void } }).deps.onEvent
+      expect(onEvent).toBeDefined()
+      onEvent!(harnessEvent({ kind: 'input_sent', worker_id: 'w-filtered', detail: { text_len: 3 } }))
+
+      await waitUntil(() => published.length >= 1)
+      expect(published[0][1].new_status).toBe('running')
+      expect(published[0][1].worker_id).toBe('w-filtered')
+    })
+
+    it('未注入 publishEvent 时装配照常工作（P5 阶段无生产调用方）', async () => {
+      const stack = buildManagerStack(makeDeps())
+      await stack.ledger.upsertWorker(DIALOG_OBJECT_ID, 'w-nopub', () =>
+        makeLedgerWorker({ workerId: 'w-nopub', status: 'running' }),
+      )
+      const onStateChange = capturedOnStateChange(stack.adapters.get('builtin'))
+      onStateChange!({ worker_id: 'w-nopub', seq: 1, impl: 'builtin', session_ref: 'w-nopub-ref' }, 'exited')
+      await waitUntil(async () => (await stack.ledger.findWorker('w-nopub'))?.worker.task.status === 'completed')
+      expect(unhandled).toEqual([])
+    })
+  })
+})

--- a/crabot-agent/tests/manager/events.test.ts
+++ b/crabot-agent/tests/manager/events.test.ts
@@ -340,6 +340,79 @@ describe('agent 对外事件（P5 Task 2）', () => {
       ])
     })
 
+    // --- ⑥ 终态不得被"读晚一步"吞掉（评审 PoC (B) 的复现 + 修复）---
+
+    it('⑥读晚于下一次落账时，终态 completed 仍必须发出（事件自带 task_status）', async () => {
+      const publish = vi.fn()
+      // 真实 LedgerStore.findWorker 的语义：不进互斥锁、读到的永远是**最新已提交**的那份。
+      // 这里用一个可变量模拟"盘上现状"，在事件之间推进它，就能精确制造"bridge 的台账读
+      // 晚于下一次落账"的时序——评审 PoC (B) 的构造手法。
+      let onDisk: TaskStatus = 'running'
+      const ledger = {
+        findWorker: async (workerId: string) => ({
+          dialogObjectId: DIALOG_OBJECT_ID,
+          worker: makeLedgerWorker({ workerId, status: onDisk, taskId: 'task-swallow' }),
+        }),
+      } as unknown as Pick<LedgerStore, 'findWorker'>
+      const bridge = makeTaskStatusEventBridge({ ledger, publish })
+
+      // ① spawn：台账落 running，事件带 running
+      bridge(harnessEvent({ kind: 'spawned', worker_id: 'w-swallow', task_status: 'running' }))
+      await flush()
+
+      // ② 化身自然结束：台账落 completed、harness 发 exited……
+      onDisk = 'completed'
+      const exited = harnessEvent({ kind: 'exited', worker_id: 'w-swallow', task_status: 'completed' })
+      // ……但在 bridge 真正去读台账之前，§5.3 透明接续已经把 task 拉回 running 并落了账。
+      // 修复前：bridge 现读台账只看得到 running，old===new，completed 被整条吞掉，一次都不发。
+      onDisk = 'running'
+      bridge(exited)
+      await flush()
+
+      // ③ 接续产出新化身
+      bridge(harnessEvent({ kind: 'resumed', worker_id: 'w-swallow', task_status: 'running' }))
+      await flush()
+
+      expect(publish.mock.calls.map(([, p]) => [p.old_status, p.new_status])).toEqual([
+        ['queued', 'running'],
+        ['running', 'completed'],
+        ['completed', 'running'],
+      ])
+      // 身份字段仍取自台账（它们在 worker 生命周期内不变，读晚了也读不出别的值）
+      expect(publish.mock.calls[1][1]).toMatchObject({ worker_id: 'w-swallow', task_id: 'task-swallow', dialog_object_id: DIALOG_OBJECT_ID })
+    })
+
+    it('⑥事件带 task_status 时，new_status 一律以事件为准，不再受台账现状影响', async () => {
+      const publish = vi.fn()
+      // 台账故意一直报 running（模拟读永远晚一步）
+      const { ledger } = makeLedgerStub([{ status: 'running' }])
+      const bridge = makeTaskStatusEventBridge({ ledger, publish })
+
+      bridge(harnessEvent({ kind: 'killed', worker_id: 'w-evt', task_status: 'cancelled' }))
+      await flush()
+
+      expect(publish.mock.calls.map(([, p]) => [p.old_status, p.new_status])).toEqual([['queued', 'cancelled']])
+    })
+
+    it('⑥向后兼容：事件没带 task_status（老事件日志 / 化身级事件点）时退回现读台账，不静默丢弃', async () => {
+      const publish = vi.fn()
+      const { ledger, calls } = makeLedgerStub([{ status: 'running' }, { status: 'completed' }])
+      const bridge = makeTaskStatusEventBridge({ ledger, publish })
+
+      // 两条都不带 task_status —— 必须仍能翻译出迁移（这正是修复前的行为，缺字段不得变成
+      // 一条新的静默丢事件路径）。
+      bridge(harnessEvent({ kind: 'state_changed', worker_id: 'w-legacy' }))
+      await flush(2)
+      bridge(harnessEvent({ kind: 'state_changed', worker_id: 'w-legacy' }))
+      await flush()
+
+      expect(publish.mock.calls.map(([, p]) => [p.old_status, p.new_status])).toEqual([
+        ['queued', 'running'],
+        ['running', 'completed'],
+      ])
+      expect(calls()).toBe(2) // 确实是靠现读台账兜底的
+    })
+
     it('worker 不在台账（如 query_failed:worker_not_found）→ 不发事件、不抛', async () => {
       const publish = vi.fn()
       const { ledger } = makeLedgerStub([undefined])

--- a/crabot-agent/tests/manager/p5-integration.test.ts
+++ b/crabot-agent/tests/manager/p5-integration.test.ts
@@ -473,8 +473,78 @@ describe('P5 集成：manager 栈启动接线（Task 6）', () => {
     expect(defaultTrace.next_cursor).toBe('2')
     // 不是 #1 的那条、也不是 fork #3 的那条
     expect((await rpc<{ events: unknown[] }>('get_worker_trace', { worker_id: 'w-main', seq: 1 })).events).toHaveLength(1)
-    // 修复前 admin 下发的 seq=0：静默返回空 events，与"该化身还没有事件"无法区分
-    expect((await rpc<{ events: unknown[] }>('get_worker_trace', { worker_id: 'w-main', seq: 0 })).events).toEqual([])
+    // 修复前 admin 下发的 seq=0：静默返回空 events，与"该化身还没有事件"无法区分；
+    // 现在与 output 路径同形状抛错（见下一条用例）。
+    await expect(rpc('get_worker_trace', { worker_id: 'w-main', seq: 0 })).rejects.toThrow(
+      /no incarnation with seq=0/,
+    )
+  })
+
+  /**
+   * get_worker_trace 显式给了 seq 时的两种"空"必须可区分（P5 review 修复第二轮）：
+   *
+   * - 化身**不存在** → 抛错（文案与 `read_worker_output_admin` 同形状，admin 侧统一映射 500）；
+   * - 化身**存在但还没产生事件** → 照常 200 + 空 events，**不能**误判成错误。
+   *
+   * 前者修复前是静默返回空 events，与后者在返回值上完全一样——正是上一轮已修的
+   * "静默返空"同一形状的第二个入口。
+   */
+  it('get_worker_trace 显式 seq：化身不存在 → 抛错；化身存在但无事件 → 200 空 events', async () => {
+    boot()
+    const stack = internals.managerStack!
+    vi.spyOn(stack.registry, 'routeWorkerEvent').mockResolvedValue(undefined)
+    vi.spyOn(internals.rpcClient, 'publishEvent').mockResolvedValue(1)
+
+    const dialogObjectId = dialogObjectIdForPrivate('friend-seq-probe')
+    const base = makeLedgerWorker({ workerId: 'w-seq' })
+    await stack.ledger.upsertWorker(dialogObjectId, 'w-seq', () => ({
+      ...base,
+      incarnations: [
+        {
+          seq: 1,
+          impl: 'builtin',
+          state: 'exited',
+          workspace: '/tmp/ws-not-used',
+          session_ref: 'ref-1',
+          started_at: '2026-03-01T00:00:00.000Z',
+          ended_at: '2026-03-01T00:01:00.000Z',
+          ended_reason: 'completed',
+        },
+        // 主线的当前化身：确实存在于台账，但一条事件都还没落盘
+        {
+          seq: 2,
+          impl: 'builtin',
+          state: 'running',
+          workspace: '/tmp/ws-not-used',
+          session_ref: 'ref-2',
+          started_at: '2026-03-01T00:02:00.000Z',
+        },
+      ],
+    }))
+
+    const appendEvent = (
+      stack.harness as unknown as {
+        appendEvent: (w: string, seq: number, kind: string, detail?: Record<string, unknown>) => Promise<void>
+      }
+    ).appendEvent.bind(stack.harness)
+    await appendEvent('w-seq', 1, 'spawned', { impl: 'builtin' })
+
+    // ① 化身存在但无事件：200 + 空 events（显式 seq 与缺省取主线两条路都要成立）
+    const explicitEmpty = await rpc<{ events: unknown[]; next_cursor?: string }>('get_worker_trace', {
+      worker_id: 'w-seq',
+      seq: 2,
+    })
+    expect(explicitEmpty.events).toEqual([])
+    expect(explicitEmpty.next_cursor).toBe('0')
+    expect((await rpc<{ events: unknown[] }>('get_worker_trace', { worker_id: 'w-seq' })).events).toEqual([])
+
+    // ② 化身不存在：抛错，不再与①的返回值混同
+    await expect(rpc('get_worker_trace', { worker_id: 'w-seq', seq: 99 })).rejects.toThrow(
+      /no incarnation with seq=99 found for worker w-seq/,
+    )
+
+    // ③ 有事件的化身照常返回（防止校验写成"一律抛错"）
+    expect((await rpc<{ events: unknown[] }>('get_worker_trace', { worker_id: 'w-seq', seq: 1 })).events).toHaveLength(1)
   })
 
   // --- ④ agent.task_status_changed ---

--- a/crabot-agent/tests/manager/p5-integration.test.ts
+++ b/crabot-agent/tests/manager/p5-integration.test.ts
@@ -1,0 +1,446 @@
+/**
+ * P5 集成（Task 6）—— manager 栈的**启动接线**。
+ *
+ * 与 `rpc-handlers.test.ts`（Task 4）的分工：那里用 `Object.create(prototype)` 造壳、直接调私有
+ * handler，验的是 handler 自身的语义；本文件反过来——**走真实构造函数把栈装配出来，再经真实的
+ * RPC 分发路径**（`ModuleBase.methodHandlers`，即 HTTP 入口 `handleRequest` 用的那张表）打进去，
+ * 验的是"接线到底通没通"：
+ *
+ * ① 五个 §8.2/§8.3 方法都注册了，且调用不再抛 `Manager stack not initialized`；
+ * ② `trigger_schedule` 真的唤醒了系统线程 manager（mock LLM）；
+ * ③ 三个读端点对**真实台账 / 真实输出日志**返回正确数据；
+ * ④ 真实状态迁移会发出 `agent.task_status_changed`，载荷逐字对齐 §9.2；
+ * ⑤ §11 的 manager slot 解析与"没配 manager slot 也必须能启动"的降级路径；
+ * ⑥ `onStart()` 里的启动对账真的跑了。
+ *
+ * **唯一被替换的生产件是 manager 的 LLM**：`BootstrapDeps.managerAdapter` 那个 thunk 会经
+ * `adapterFromSdkEnv` 建出真会发 HTTP 的 adapter，测试里换成脚本化的 mock（换法见
+ * `overrideManagerLLM`）。其余（栈装配、事件出口、台账、harness、工具面、RPC 注册与分发）
+ * 全部是生产代码装出来的真件。
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { promises as fs } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+import { UnifiedAgent } from '../../src/unified-agent.js'
+import { SYSTEM_TASKS_MANAGER_KEY } from '../../src/manager/registry.js'
+import { dialogObjectIdForPrivate, type DialogObjectId, type LedgerWorker } from '../../src/workers/harness/ledger-types.js'
+import type { ManagerKey } from '../../src/manager/types.js'
+import type { ManagerStack } from '../../src/manager/bootstrap.js'
+import type { LLMAdapter } from '../../src/engine/index.js'
+import type {
+  UnifiedAgentConfig,
+  OrchestrationConfig,
+  LLMConnectionInfo,
+  ModuleId,
+} from '../../src/types.js'
+import type { IncarnationHandle, WorkerAdapter, WorkerContractState } from '../../src/workers/types.js'
+import type { Event } from 'crabot-shared'
+import { chunksFromContent } from '../engine/helpers/mock-stream.js'
+
+// ============================================================================
+// helpers
+// ============================================================================
+
+const ORCHESTRATION: OrchestrationConfig = {
+  front_context_recent_messages_window_hours: 24,
+  front_context_recent_messages_max_cap: 50,
+  front_context_short_term_memory_window_hours: 24,
+  front_context_short_term_memory_max_cap: 20,
+  worker_recent_messages_window_hours: 24,
+  worker_recent_messages_max_cap: 50,
+  worker_short_term_memory_window_hours: 24,
+  worker_short_term_memory_max_cap: 20,
+  worker_long_term_memory_limit: 10,
+  front_agent_timeout: 60,
+  session_state_ttl: 3600,
+  worker_config_refresh_interval: 300,
+  front_agent_queue_max_length: 10,
+  front_agent_queue_timeout: 60,
+}
+
+function connInfo(modelId: string): LLMConnectionInfo {
+  return { endpoint: 'https://example.invalid', apikey: 'k', model_id: modelId, format: 'anthropic' }
+}
+
+/**
+ * `roles: []` 是刻意的：带 'worker' 角色会让 `initializeAgentLayer` 建 AgentHandler 并
+ * `lspManager.start()`（起 LSP 子进程），与本文件要验的接线无关。manager 栈的装配**不看**
+ * roles，正是本文件要钉住的性质之一。
+ */
+function makeConfig(modelConfig: Record<string, LLMConnectionInfo>): UnifiedAgentConfig {
+  return {
+    module_id: 'p5-integration-agent' as ModuleId,
+    module_type: 'agent',
+    version: '0.0.0-test',
+    protocol_version: '1.0',
+    port: 19999,
+    orchestration: ORCHESTRATION,
+    agent_config: {
+      instance_id: 'p5-int',
+      roles: [],
+      system_prompt: '你是测试用 Crabot',
+      model_config: modelConfig,
+    },
+  }
+}
+
+/** 脚本化 manager LLM（照 `tests/manager/rpc-handlers.test.ts` 的 makeManagerLLM）。 */
+function makeManagerLLM(
+  scripts: ReadonlyArray<{
+    text?: string
+    toolCalls?: ReadonlyArray<{ name: string; id: string; input: Record<string, unknown> }>
+    stopReason: 'end_turn' | 'tool_use'
+  }>,
+): LLMAdapter {
+  let i = 0
+  return {
+    async *stream() {
+      const r = scripts[i++] ?? { text: '(收工)', stopReason: 'end_turn' as const }
+      const content: unknown[] = []
+      if (r.text) content.push({ type: 'text', text: r.text })
+      for (const tc of r.toolCalls ?? []) content.push({ type: 'tool_use', id: tc.id, name: tc.name, input: tc.input })
+      yield* chunksFromContent(content, r.stopReason, { inputTokens: 10, outputTokens: 5 })
+    },
+    updateConfig: () => {},
+  }
+}
+
+/**
+ * 换掉 manager 的 LLM 来源。`BootstrapDeps.managerAdapter` 被 bootstrap 原样交给
+ * `ManagerRegistryDeps.adapter`，registry 只在 `getOrCreate` 首次建 loop 时读它——所以在第一次
+ * 唤醒之前改这一个字段，就等于换掉整条链路上唯一的 LLM 入口，其余全是生产装配的真件。
+ * （穿透私有字段的手法与 `bootstrap.test.ts` 的 `capturedOnStateChange` 同源：没有别的注入口。）
+ */
+function overrideManagerLLM(stack: ManagerStack, llm: LLMAdapter): void {
+  ;(stack.registry as unknown as { deps: { adapter: () => LLMAdapter } }).deps.adapter = () => llm
+}
+
+/** 读出 adapter 构造时收到的 `onStateChange`（同 bootstrap.test.ts）。 */
+function capturedOnStateChange(
+  adapter: WorkerAdapter | undefined,
+): ((h: IncarnationHandle, s: WorkerContractState) => void) | undefined {
+  return (adapter as unknown as { deps?: { onStateChange?: (h: IncarnationHandle, s: WorkerContractState) => void } })
+    ?.deps?.onStateChange
+}
+
+function makeLedgerWorker(p: {
+  workerId: string
+  status?: LedgerWorker['task']['status']
+  updatedAt?: string
+  incarnationState?: WorkerContractState
+}): LedgerWorker {
+  return {
+    worker_id: p.workerId,
+    task: {
+      id: p.workerId,
+      title: `任务 ${p.workerId}`,
+      status: p.status ?? 'running',
+      created_at: '2026-01-01T00:00:00.000Z',
+    },
+    origin: { spawned_by_session: 'wechat::sess-1' as ManagerKey, trigger_type: 'message' },
+    report_to: { channel_id: 'wechat' as ModuleId, session_id: 'sess-1' },
+    incarnations: [
+      {
+        seq: 1,
+        impl: 'builtin',
+        state: p.incarnationState ?? 'running',
+        workspace: '/tmp/ws-not-used',
+        session_ref: `${p.workerId}-ref`,
+        started_at: '2026-01-01T00:00:00.000Z',
+      },
+    ],
+    updated_at: p.updatedAt ?? '2026-01-01T00:00:00.000Z',
+  }
+}
+
+async function waitUntil(cond: () => boolean | Promise<boolean>, timeoutMs = 6000, intervalMs = 20): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (await cond()) return
+    await new Promise((resolve) => setTimeout(resolve, intervalMs))
+  }
+  throw new Error('waitUntil timed out')
+}
+
+/** UnifiedAgent 的私有件在测试里的视图（TS 私有性只在编译期）。 */
+interface AgentInternals {
+  methodHandlers: Map<string, (params: unknown) => unknown>
+  managerStack?: ManagerStack
+  rpcClient: { publishEvent: (e: Event, source: ModuleId) => Promise<number> }
+  adminPort?: number
+  onStart(): Promise<void>
+  onStop(): Promise<void>
+}
+
+// ============================================================================
+
+describe('P5 集成：manager 栈启动接线（Task 6）', () => {
+  let tmpRoot: string
+  let prevDataDir: string | undefined
+  let prevAgentDataDir: string | undefined
+  let agent: UnifiedAgent
+  let internals: AgentInternals
+
+  /** 经真实 RPC 分发表调用——不是直接调私有 handler。 */
+  async function rpc<R>(method: string, params: unknown): Promise<R> {
+    const handler = internals.methodHandlers.get(method)
+    if (!handler) throw new Error(`RPC 方法未注册: ${method}`)
+    return (await handler(params)) as R
+  }
+
+  function boot(modelConfig: Record<string, LLMConnectionInfo> = { manager: connInfo('manager-model-x') }): void {
+    agent = new UnifiedAgent(makeConfig(modelConfig))
+    internals = agent as unknown as AgentInternals
+    // 端口解析预置：避免 onStart 里的 detectFeishuChannel 去 resolve 一个不存在的 MM。
+    internals.adminPort = 1
+  }
+
+  beforeEach(async () => {
+    tmpRoot = await fs.mkdtemp(join(tmpdir(), 'p5-integration-'))
+    prevDataDir = process.env.DATA_DIR
+    prevAgentDataDir = process.env.CRABOT_AGENT_DATA_DIR
+    delete process.env.CRABOT_AGENT_DATA_DIR
+    process.env.DATA_DIR = join(tmpRoot, 'data')
+  })
+
+  afterEach(async () => {
+    vi.restoreAllMocks()
+    if (prevDataDir === undefined) delete process.env.DATA_DIR
+    else process.env.DATA_DIR = prevDataDir
+    if (prevAgentDataDir === undefined) delete process.env.CRABOT_AGENT_DATA_DIR
+    else process.env.CRABOT_AGENT_DATA_DIR = prevAgentDataDir
+    await fs.rm(tmpRoot, { recursive: true, force: true })
+  })
+
+  // --- ① 接线自证 ---
+
+  it('构造函数装配 manager 栈：五个 v3 RPC 经真实分发表调用不再抛 "Manager stack not initialized"', async () => {
+    boot()
+
+    for (const m of [
+      'trigger_schedule',
+      'list_workers_admin',
+      'get_worker_detail',
+      'read_worker_output_admin',
+      'get_worker_trace',
+    ]) {
+      expect(internals.methodHandlers.has(m), `${m} 应已注册`).toBe(true)
+    }
+
+    // 这条是本 task 的变异靶：去掉 initializeManagerStack() 的调用，它就会抛
+    // 'Manager stack not initialized'。
+    const result = await rpc<{ items: unknown[]; pagination: { total_items: number } }>('list_workers_admin', {})
+    expect(result.items).toEqual([])
+    expect(result.pagination.total_items).toBe(0)
+
+    // 台账根按 §7 从 $DATA_DIR 派生（不是从别处推的）
+    const stack = internals.managerStack
+    expect(stack).toBeDefined()
+    expect(stack!.builtinDataDir).toBe(join(tmpRoot, 'data', 'agent', 'worker-adapters', 'builtin'))
+  })
+
+  it('装配是 O(1) 纯构造：构造函数不探测任何 adapter，$DATA_DIR/agent/ledgers 在启动对账之前不存在', async () => {
+    const detectSpy = vi.spyOn(
+      await import('../../src/workers/builtin/adapter.js').then((m) => m.BuiltinWorkerAdapter.prototype),
+      'detect',
+    )
+
+    boot()
+
+    expect(detectSpy).not.toHaveBeenCalled()
+    await expect(fs.access(join(tmpRoot, 'data', 'agent', 'ledgers'))).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  // --- ⑤ §11 manager slot 与降级路径 ---
+
+  it('§11 manager slot：manager 优先，缺失回退 powerful', () => {
+    boot({ manager: connInfo('manager-model-x'), powerful: connInfo('powerful-model-y') })
+    const withManager = internals.managerStack as unknown as { registry: { deps: { model: () => string } } }
+    expect(withManager.registry.deps.model()).toBe('manager-model-x')
+
+    boot({ powerful: connInfo('powerful-model-y') })
+    const fallback = internals.managerStack as unknown as { registry: { deps: { model: () => string } } }
+    expect(fallback.registry.deps.model()).toBe('powerful-model-y')
+  })
+
+  it('降级：两个 slot 都没配（现网此刻的状态）时 agent 照常构造，读模型四件套照常可用，只有 LLM 解析在被用到时才抛', async () => {
+    boot({})
+
+    expect(internals.managerStack).toBeDefined()
+    await expect(rpc('list_workers_admin', {})).resolves.toBeDefined()
+
+    const deps = (internals.managerStack as unknown as { registry: { deps: { model: () => string } } }).registry.deps
+    expect(() => deps.model()).toThrow(/model_config 缺少 'manager' 与 'powerful'/)
+  })
+
+  // --- ② trigger_schedule → 系统线程 manager ---
+
+  it('trigger_schedule 经真实分发表 → 唤醒系统线程 manager，派出的 worker 记在 admin-web::system-tasks 名下', async () => {
+    boot()
+    const stack = internals.managerStack!
+    overrideManagerLLM(
+      stack,
+      makeManagerLLM([
+        { toolCalls: [{ name: 'spawn_worker', id: 'tc-1', input: { title: '巡检子任务', prompt: '去巡检' } }], stopReason: 'tool_use' },
+        { text: '已派发', stopReason: 'end_turn' },
+      ]),
+    )
+    const spawnSpy = vi.spyOn(stack.harness, 'spawnWorker').mockResolvedValue(makeLedgerWorker({ workerId: 'w-spawned' }))
+    const routeSpy = vi.spyOn(stack.registry, 'routeSchedule')
+
+    const accepted = await rpc('trigger_schedule', {
+      schedule_id: 'sc-sys',
+      title: '系统巡检',
+      description: '无目标会话',
+      creator_friend_id: 'friend-42',
+    })
+
+    expect(accepted).toEqual({ accepted: true })
+    // 受理即返回：这一刻 episode 还没跑到派发
+    expect(spawnSpy).not.toHaveBeenCalled()
+
+    await waitUntil(() => spawnSpy.mock.calls.length > 0)
+    const params = spawnSpy.mock.calls[0][0]
+    expect(params.origin.spawned_by_session).toBe(SYSTEM_TASKS_MANAGER_KEY)
+    expect(params.origin.trigger_type).toBe('scheduled')
+    expect(params.origin.creator_friend_id).toBe('friend-42')
+
+    await Promise.allSettled(routeSpy.mock.results.map((r) => r.value as Promise<unknown>))
+  })
+
+  // --- ③ 三个读端点对真实台账 ---
+
+  it('list_workers_admin / get_worker_detail / read_worker_output_admin 对真实台账与真实输出日志返回正确数据', async () => {
+    boot()
+    const stack = internals.managerStack!
+    const alice = dialogObjectIdForPrivate('alice')
+    const bob = dialogObjectIdForPrivate('bob')
+
+    await stack.ledger.upsertWorker(alice, 'w-a1', () =>
+      makeLedgerWorker({ workerId: 'w-a1', status: 'running', updatedAt: '2026-02-02T00:00:00.000Z' }),
+    )
+    await stack.ledger.upsertWorker(alice, 'w-a2', () =>
+      makeLedgerWorker({ workerId: 'w-a2', status: 'completed', updatedAt: '2026-02-03T00:00:00.000Z' }),
+    )
+    await stack.ledger.upsertWorker(bob, 'w-b1', () =>
+      makeLedgerWorker({ workerId: 'w-b1', status: 'running', updatedAt: '2026-02-01T00:00:00.000Z' }),
+    )
+
+    // 全量：updated_at desc
+    const all = await rpc<{ items: Array<{ worker_id: string }>; pagination: { total_items: number } }>(
+      'list_workers_admin',
+      {},
+    )
+    expect(all.items.map((w) => w.worker_id)).toEqual(['w-a2', 'w-a1', 'w-b1'])
+    expect(all.pagination.total_items).toBe(3)
+
+    // 按 dialog_object_id + status 过滤
+    const scoped = await rpc<{ items: Array<{ worker_id: string }> }>('list_workers_admin', {
+      dialog_object_id: alice,
+      status: 'running',
+    })
+    expect(scoped.items.map((w) => w.worker_id)).toEqual(['w-a1'])
+
+    // 详情（§8.3 的返回只有 worker 本体，不带 dialog_object_id）
+    const detail = await rpc<{ worker: LedgerWorker }>('get_worker_detail', { worker_id: 'w-b1' })
+    expect(detail.worker.worker_id).toBe('w-b1')
+    expect(detail.worker.task.status).toBe('running')
+    expect(detail.worker.incarnations).toHaveLength(1)
+
+    await expect(rpc('get_worker_detail', { worker_id: 'w-nope' })).rejects.toThrow(/Worker not found: w-nope/)
+
+    // 输出：真实 builtin adapter 的 output-<seq>.log
+    const outDir = join(stack.builtinDataDir, 'w-a1')
+    await fs.mkdir(outDir, { recursive: true })
+    await fs.writeFile(join(outDir, 'output-1.log'), '第一段输出\n第二段输出\n', 'utf-8')
+
+    const head = await rpc<{ chunk: string; next_cursor: string; eof: boolean }>('read_worker_output_admin', {
+      worker_id: 'w-a1',
+      seq: 1,
+    })
+    expect(head.chunk).toBe('第一段输出\n第二段输出\n')
+    expect(head.eof).toBe(false)
+
+    const tail = await rpc<{ chunk: string; eof: boolean }>('read_worker_output_admin', {
+      worker_id: 'w-a1',
+      seq: 1,
+      cursor: head.next_cursor,
+    })
+    expect(tail.chunk).toBe('')
+    expect(tail.eof).toBe(true)
+  })
+
+  // --- ④ agent.task_status_changed ---
+
+  it('真实状态迁移 → 经生产事件出口发出 agent.task_status_changed，载荷逐字对齐 §9.2', async () => {
+    boot()
+    const stack = internals.managerStack!
+    // 事件出口的终点是 agent 自己那个 RpcClient 实例——spy 在实例上即可拦到生产链路。
+    const publishSpy = vi.spyOn(internals.rpcClient, 'publishEvent').mockResolvedValue(1)
+    // 同一个 onEvent 的另一条支路（唤醒监护 manager）挡掉：它要跑 LLM，不是本用例的对象；
+    // 顺带断言它确实接着（两条支路互不干扰）。
+    const routeSpy = vi.spyOn(stack.registry, 'routeWorkerEvent').mockResolvedValue(undefined)
+
+    const dialogObjectId = dialogObjectIdForPrivate('friend-evt')
+    await stack.ledger.upsertWorker(dialogObjectId, 'w-evt', () => makeLedgerWorker({ workerId: 'w-evt' }))
+
+    // 用 adapter 手里那份回调触发真实迁移：handleStateChange → processStateChange →
+    // upsertWorker（落 completed）→ appendEvent（带 task_status）→ onEvent → 事件出口
+    const onStateChange = capturedOnStateChange(stack.adapters.get('builtin'))
+    expect(onStateChange).toBeDefined()
+    onStateChange!({ worker_id: 'w-evt', seq: 1, impl: 'builtin', session_ref: 'w-evt-ref' }, 'exited')
+
+    await waitUntil(() => publishSpy.mock.calls.length > 0)
+
+    const [event, source] = publishSpy.mock.calls[0]
+    expect(source).toBe('p5-integration-agent')
+    expect(event.type).toBe('agent.task_status_changed')
+    expect(event.source).toBe('p5-integration-agent')
+    expect(typeof event.id).toBe('string')
+    expect(typeof event.timestamp).toBe('string')
+    expect(event.payload).toEqual({
+      worker_id: 'w-evt',
+      task_id: 'w-evt',
+      // 首次观测的兜底（events.ts 文件头三条边界之一）
+      old_status: 'queued',
+      // 台账落账值；P7 阻塞项 #1 未修前，"退出即 completed" 是 harness 的既有行为，
+      // 本断言只钉"事件值 == 台账值"，不对语义正确性背书。
+      new_status: (await stack.ledger.findWorker('w-evt'))!.worker.task.status,
+      dialog_object_id: dialogObjectId,
+    })
+    expect(routeSpy).toHaveBeenCalled()
+  })
+
+  // --- ⑥ onStart 的启动对账 ---
+
+  it('onStart() 异步跑一次启动对账：台账里残留的 running 化身被对账掉，且不阻塞 onStart 返回', async () => {
+    boot()
+    const stack = internals.managerStack!
+    // 对账把化身判死会落 `exited` 事件，onEvent 的另一条支路会去唤醒监护 manager（要跑 LLM）。
+    // 那条路由本身由 bootstrap.test.ts 覆盖，这里挡掉，免得用例结束后还留着一个在重试的 LLM 请求。
+    const routeSpy = vi.spyOn(stack.registry, 'routeWorkerEvent').mockResolvedValue(undefined)
+    // 对账判死同样会发 §9.2 事件（下一条用例专门验它）；这里挡住投递，免得没有 MM 的测试环境
+    // 刷一屏 ECONNREFUSED——注意 publisher 本身把失败吃掉了，不挡也不会让用例失败。
+    vi.spyOn(internals.rpcClient, 'publishEvent').mockResolvedValue(1)
+    const dialogObjectId = dialogObjectIdForPrivate('friend-recon')
+    await stack.ledger.upsertWorker(dialogObjectId, 'w-stale', () =>
+      makeLedgerWorker({ workerId: 'w-stale', status: 'running', incarnationState: 'running' }),
+    )
+
+    await internals.onStart()
+    try {
+      // 进程里没有这个化身的任何痕迹（builtin adapter 的 dataDir 下无 meta）→ 对账判定它已死
+      await waitUntil(async () => {
+        const found = await stack.ledger.findWorker('w-stale')
+        return found?.worker.incarnations[0].state === 'exited'
+      })
+      const after = await stack.ledger.findWorker('w-stale')
+      expect(after!.worker.task.status).toBe('failed')
+      expect(routeSpy).toHaveBeenCalled()
+    } finally {
+      await internals.onStop()
+    }
+  })
+})

--- a/crabot-agent/tests/manager/p5-integration.test.ts
+++ b/crabot-agent/tests/manager/p5-integration.test.ts
@@ -372,6 +372,111 @@ describe('P5 集成：manager 栈启动接线（Task 6）', () => {
     expect(tail.eof).toBe(true)
   })
 
+  /**
+   * P5 review 修复的端到端回归：admin 的 `/output`、`/trace` 在 `?seq=` 缺省时**不下发 seq**
+   * （载荷形状由 crabot-admin `admin-web-api.test.ts` 钉住），本用例把**那个载荷原样**打进真实
+   * RPC + 真实台账，验它确实落在主线化身上。
+   *
+   * 为什么非得端到端验一遍：原实现两端各自"看着对"——admin 填了个 seq、agent 按 seq 过滤，
+   * 只断言参数透传的测试全绿，但缺省值 0 在台账里恒不存在，output 抛错落 500、trace 静默返回
+   * 空 events。缺省语义的正确性只在"真实台账 + 真实化身链"上才可判定。
+   *
+   * 台账形状取自真实演化路径：builtin#1 自然结束 → send_to_worker 触发 revive 产出 builtin#2
+   * 入主线链（`reviveIncarnation` 不填 forked_from）；期间 query_worker 从主线 fork 出 #3
+   * （forked_from=2）。于是三个候选缺省互不相同：主线=#2、"第一个化身"=#1、"数组最后一条"=#3。
+   */
+  it('admin 缺 seq 的转发载荷经真实 RPC → output/trace 都落在主线化身（不是 #1、不是 fork）', async () => {
+    boot()
+    const stack = internals.managerStack!
+    // appendEvent 的 onEvent 支路会去唤醒监护 manager（要跑 LLM）并发事件，与本用例无关，挡掉。
+    vi.spyOn(stack.registry, 'routeWorkerEvent').mockResolvedValue(undefined)
+    vi.spyOn(internals.rpcClient, 'publishEvent').mockResolvedValue(1)
+
+    const dialogObjectId = dialogObjectIdForPrivate('friend-mainline')
+    const base = makeLedgerWorker({ workerId: 'w-main' })
+    await stack.ledger.upsertWorker(dialogObjectId, 'w-main', () => ({
+      ...base,
+      incarnations: [
+        {
+          seq: 1,
+          impl: 'builtin',
+          state: 'exited',
+          workspace: '/tmp/ws-not-used',
+          session_ref: 'ref-1',
+          started_at: '2026-03-01T00:00:00.000Z',
+          ended_at: '2026-03-01T00:01:00.000Z',
+          ended_reason: 'completed',
+        },
+        {
+          seq: 2,
+          impl: 'builtin',
+          state: 'running',
+          workspace: '/tmp/ws-not-used',
+          session_ref: 'ref-2',
+          started_at: '2026-03-01T00:02:00.000Z',
+        },
+        {
+          seq: 3,
+          impl: 'builtin',
+          state: 'exited',
+          workspace: '/tmp/ws-not-used',
+          session_ref: 'ref-3',
+          started_at: '2026-03-01T00:03:00.000Z',
+          forked_from: 2,
+        },
+      ],
+    }))
+
+    // 真实 builtin adapter 的 output-<seq>.log，三个化身各一份
+    const outDir = join(stack.builtinDataDir, 'w-main')
+    await fs.mkdir(outDir, { recursive: true })
+    await fs.writeFile(join(outDir, 'output-1.log'), '旧主线 #1 的输出\n', 'utf-8')
+    await fs.writeFile(join(outDir, 'output-2.log'), '当前主线 #2 的输出\n', 'utf-8')
+    await fs.writeFile(join(outDir, 'output-3.log'), '侧问 fork #3 的输出\n', 'utf-8')
+
+    // ① output：不带 seq == 主线 #2
+    const defaultOut = await rpc<{ chunk: string }>('read_worker_output_admin', { worker_id: 'w-main' })
+    expect(defaultOut.chunk).toBe('当前主线 #2 的输出\n')
+    // 显式 seq 仍按 seq 走（也证明缺省确实不等于 1、不等于"最后一条"）
+    expect((await rpc<{ chunk: string }>('read_worker_output_admin', { worker_id: 'w-main', seq: 1 })).chunk).toBe(
+      '旧主线 #1 的输出\n',
+    )
+    expect((await rpc<{ chunk: string }>('read_worker_output_admin', { worker_id: 'w-main', seq: 3 })).chunk).toBe(
+      '侧问 fork #3 的输出\n',
+    )
+    // 修复前 admin 下发的就是 seq=0：台账里恒不存在 → 抛错 → proxyAgentRpc 落 500
+    await expect(rpc('read_worker_output_admin', { worker_id: 'w-main', seq: 0 })).rejects.toThrow(
+      /no incarnation with seq=0/,
+    )
+
+    // ② trace：经 harness 自己的事件写入口落真实 events.jsonl（private，穿透手法同本文件其它用例）
+    const appendEvent = (
+      stack.harness as unknown as {
+        appendEvent: (w: string, seq: number, kind: string, detail?: Record<string, unknown>) => Promise<void>
+      }
+    ).appendEvent.bind(stack.harness)
+    await appendEvent('w-main', 1, 'spawned', { impl: 'builtin' })
+    await appendEvent('w-main', 2, 'resumed', { from_seq: 1 })
+    await appendEvent('w-main', 2, 'input_sent')
+    await appendEvent('w-main', 3, 'state_changed', { to: 'exited' })
+
+    const defaultTrace = await rpc<{ events: Array<{ detail?: unknown }>; next_cursor?: string }>('get_worker_trace', {
+      worker_id: 'w-main',
+    })
+    const mainlineTrace = await rpc<{ events: Array<{ detail?: unknown }> }>('get_worker_trace', {
+      worker_id: 'w-main',
+      seq: 2,
+    })
+    expect(defaultTrace.events).toEqual(mainlineTrace.events)
+    expect(defaultTrace.events).toHaveLength(2)
+    expect(defaultTrace.events[0].detail).toEqual({ from_seq: 1 })
+    expect(defaultTrace.next_cursor).toBe('2')
+    // 不是 #1 的那条、也不是 fork #3 的那条
+    expect((await rpc<{ events: unknown[] }>('get_worker_trace', { worker_id: 'w-main', seq: 1 })).events).toHaveLength(1)
+    // 修复前 admin 下发的 seq=0：静默返回空 events，与"该化身还没有事件"无法区分
+    expect((await rpc<{ events: unknown[] }>('get_worker_trace', { worker_id: 'w-main', seq: 0 })).events).toEqual([])
+  })
+
   // --- ④ agent.task_status_changed ---
 
   it('真实状态迁移 → 经生产事件出口发出 agent.task_status_changed，载荷逐字对齐 §9.2', async () => {

--- a/crabot-agent/tests/manager/read-model.test.ts
+++ b/crabot-agent/tests/manager/read-model.test.ts
@@ -1,0 +1,429 @@
+/**
+ * task 读模型纯逻辑(P5 Task 3)—— `src/manager/read-model.ts`。
+ *
+ * 钉住的语义不变量:
+ * ① 过滤:status 单值/数组、dialog_object_id、time_range 三者可组合,且 total_items
+ *    统计的是**过滤后**的总数;
+ * ② time_range 边界 = base-protocol §5.7:`start` 闭(含)、`end` 开(不含);
+ * ③ 排序:`updated_at desc`,同 updated_at 时按 `worker_id` 升序兜底 —— 与输入顺序无关;
+ * ④ 分页越界返回空 items 而不报错;page/page_size 非法值归一,page_size 上限 100;
+ * ⑤ 纯函数:不修改入参数组、items 是 `LedgerWorker`(不泄漏 dialogObjectId);
+ * ⑥ `buildWorkerDetail` 逐字段透传台账条目(含化身链),返回体只有 `worker`(§8.3)。
+ */
+import { describe, it, expect } from 'vitest'
+
+import {
+  filterAndPageWorkers,
+  buildWorkerDetail,
+  type LedgerWorkerEntry,
+} from '../../src/manager/read-model.js'
+import {
+  dialogObjectIdForPrivate,
+  dialogObjectIdForGroup,
+  type DialogObjectId,
+  type LedgerWorker,
+  type TaskStatus,
+} from '../../src/workers/harness/ledger-types.js'
+
+const ALICE = dialogObjectIdForPrivate('alice')
+const BOB = dialogObjectIdForPrivate('bob')
+const GROUP = dialogObjectIdForGroup('telegram', 'g-1')
+
+function mkWorker(
+  workerId: string,
+  opts: {
+    status?: TaskStatus
+    createdAt?: string
+    updatedAt?: string
+  } = {}
+): LedgerWorker {
+  return {
+    worker_id: workerId,
+    task: {
+      id: `task-${workerId}`,
+      title: `title-${workerId}`,
+      status: opts.status ?? 'running',
+      created_at: opts.createdAt ?? '2026-07-01T00:00:00.000Z',
+    },
+    origin: {
+      spawned_by_session: 'telegram::s-1',
+      trigger_type: 'message',
+    },
+    report_to: { channel_id: 'telegram', session_id: 's-1' },
+    incarnations: [],
+    updated_at: opts.updatedAt ?? '2026-07-01T00:00:00.000Z',
+  }
+}
+
+function entry(
+  dialogObjectId: DialogObjectId,
+  workerId: string,
+  opts?: Parameters<typeof mkWorker>[1]
+): LedgerWorkerEntry {
+  return { dialogObjectId, worker: mkWorker(workerId, opts) }
+}
+
+describe('filterAndPageWorkers', () => {
+  it('空输入返回空 items 且分页字段完整', () => {
+    const result = filterAndPageWorkers([], {})
+    expect(result.items).toEqual([])
+    expect(result.pagination).toEqual({
+      page: 1,
+      page_size: 20,
+      total_items: 0,
+      total_pages: 0,
+    })
+  })
+
+  it('items 是 LedgerWorker 本身,不泄漏 dialogObjectId 包装', () => {
+    const e = entry(ALICE, 'w-1')
+    const result = filterAndPageWorkers([e], {})
+    expect(result.items).toEqual([e.worker])
+    expect(result.items[0]).not.toHaveProperty('dialogObjectId')
+    expect(result.items[0]).not.toHaveProperty('worker')
+  })
+
+  it('不修改入参数组(纯函数)', () => {
+    const all = [
+      entry(ALICE, 'w-old', { updatedAt: '2026-07-01T00:00:00.000Z' }),
+      entry(ALICE, 'w-new', { updatedAt: '2026-07-09T00:00:00.000Z' }),
+    ]
+    const snapshot = all.map((e) => e.worker.worker_id)
+    filterAndPageWorkers(all, {})
+    expect(all.map((e) => e.worker.worker_id)).toEqual(snapshot)
+  })
+
+  describe('status 过滤', () => {
+    const all = [
+      entry(ALICE, 'w-running', { status: 'running' }),
+      entry(ALICE, 'w-queued', { status: 'queued' }),
+      entry(ALICE, 'w-failed', { status: 'failed' }),
+      entry(ALICE, 'w-completed', { status: 'completed' }),
+    ]
+
+    it('单值形态', () => {
+      const result = filterAndPageWorkers(all, { status: 'queued' })
+      expect(result.items.map((w) => w.worker_id)).toEqual(['w-queued'])
+      expect(result.pagination.total_items).toBe(1)
+    })
+
+    it('数组形态', () => {
+      const result = filterAndPageWorkers(all, { status: ['queued', 'failed'] })
+      expect(result.items.map((w) => w.worker_id).sort()).toEqual(['w-failed', 'w-queued'])
+      expect(result.pagination.total_items).toBe(2)
+    })
+
+    it('空数组表示"不匹配任何状态",返回空', () => {
+      const result = filterAndPageWorkers(all, { status: [] })
+      expect(result.items).toEqual([])
+      expect(result.pagination.total_items).toBe(0)
+    })
+
+    it('不传 status 时全量返回', () => {
+      expect(filterAndPageWorkers(all, {}).pagination.total_items).toBe(4)
+    })
+  })
+
+  describe('dialog_object_id 过滤', () => {
+    const all = [
+      entry(ALICE, 'w-a1'),
+      entry(ALICE, 'w-a2'),
+      entry(BOB, 'w-b1'),
+      entry(GROUP, 'w-g1'),
+    ]
+
+    it('私聊对话对象', () => {
+      const result = filterAndPageWorkers(all, { dialog_object_id: ALICE })
+      expect(result.items.map((w) => w.worker_id).sort()).toEqual(['w-a1', 'w-a2'])
+    })
+
+    it('群聊对话对象', () => {
+      const result = filterAndPageWorkers(all, { dialog_object_id: GROUP })
+      expect(result.items.map((w) => w.worker_id)).toEqual(['w-g1'])
+    })
+
+    it('无匹配返回空而不报错', () => {
+      const result = filterAndPageWorkers(all, {
+        dialog_object_id: dialogObjectIdForPrivate('nobody'),
+      })
+      expect(result.items).toEqual([])
+      expect(result.pagination.total_items).toBe(0)
+    })
+  })
+
+  describe('time_range 边界(base-protocol §5.7:start 闭、end 开;比较 task.created_at)', () => {
+    const all = [
+      entry(ALICE, 'w-before', { createdAt: '2026-07-01T23:59:59.999Z' }),
+      entry(ALICE, 'w-on-start', { createdAt: '2026-07-02T00:00:00.000Z' }),
+      entry(ALICE, 'w-inside', { createdAt: '2026-07-03T00:00:00.000Z' }),
+      entry(ALICE, 'w-on-end', { createdAt: '2026-07-04T00:00:00.000Z' }),
+      entry(ALICE, 'w-after', { createdAt: '2026-07-05T00:00:00.000Z' }),
+    ]
+
+    it('start 是闭区间:等于 start 的条目被包含', () => {
+      const result = filterAndPageWorkers(all, {
+        time_range: { start: '2026-07-02T00:00:00.000Z' },
+      })
+      expect(result.items.map((w) => w.worker_id).sort()).toEqual([
+        'w-after',
+        'w-inside',
+        'w-on-end',
+        'w-on-start',
+      ])
+    })
+
+    it('end 是开区间:等于 end 的条目被排除', () => {
+      const result = filterAndPageWorkers(all, {
+        time_range: { end: '2026-07-04T00:00:00.000Z' },
+      })
+      expect(result.items.map((w) => w.worker_id).sort()).toEqual([
+        'w-before',
+        'w-inside',
+        'w-on-start',
+      ])
+    })
+
+    it('start + end = [start, end)', () => {
+      const result = filterAndPageWorkers(all, {
+        time_range: { start: '2026-07-02T00:00:00.000Z', end: '2026-07-04T00:00:00.000Z' },
+      })
+      expect(result.items.map((w) => w.worker_id).sort()).toEqual(['w-inside', 'w-on-start'])
+    })
+
+    it('过滤的是 task.created_at 而非 updated_at', () => {
+      const only = [
+        entry(ALICE, 'w-x', {
+          createdAt: '2026-07-01T00:00:00.000Z',
+          updatedAt: '2026-07-09T00:00:00.000Z',
+        }),
+      ]
+      // 窗口只覆盖 updated_at,不覆盖 created_at → 不命中
+      expect(
+        filterAndPageWorkers(only, {
+          time_range: { start: '2026-07-08T00:00:00.000Z' },
+        }).items
+      ).toEqual([])
+      // 窗口覆盖 created_at → 命中
+      expect(
+        filterAndPageWorkers(only, {
+          time_range: { start: '2026-07-01T00:00:00.000Z', end: '2026-07-02T00:00:00.000Z' },
+        }).items.map((w) => w.worker_id)
+      ).toEqual(['w-x'])
+    })
+
+    it('空的 time_range({} / 两端都缺)不过滤任何条目', () => {
+      expect(filterAndPageWorkers(all, { time_range: {} }).pagination.total_items).toBe(5)
+    })
+
+    it('created_at 缺失的脏条目在 time_range 生效时被排除,不生效时保留', () => {
+      const dirty = entry(ALICE, 'w-dirty')
+      delete (dirty.worker.task as { created_at?: string }).created_at
+      const input = [dirty, entry(ALICE, 'w-ok', { createdAt: '2026-07-03T00:00:00.000Z' })]
+
+      expect(
+        filterAndPageWorkers(input, {
+          time_range: { start: '2026-07-01T00:00:00.000Z' },
+        }).items.map((w) => w.worker_id)
+      ).toEqual(['w-ok'])
+      expect(filterAndPageWorkers(input, {}).pagination.total_items).toBe(2)
+    })
+  })
+
+  describe('排序:updated_at desc,同值按 worker_id 升序', () => {
+    it('按 updated_at 倒序', () => {
+      const all = [
+        entry(ALICE, 'w-mid', { updatedAt: '2026-07-05T00:00:00.000Z' }),
+        entry(ALICE, 'w-new', { updatedAt: '2026-07-09T00:00:00.000Z' }),
+        entry(ALICE, 'w-old', { updatedAt: '2026-07-01T00:00:00.000Z' }),
+      ]
+      expect(filterAndPageWorkers(all, {}).items.map((w) => w.worker_id)).toEqual([
+        'w-new',
+        'w-mid',
+        'w-old',
+      ])
+    })
+
+    it('同 updated_at 时次序确定,且与输入顺序无关', () => {
+      const same = '2026-07-05T00:00:00.000Z'
+      const forward = [
+        entry(ALICE, 'w-a', { updatedAt: same }),
+        entry(BOB, 'w-b', { updatedAt: same }),
+        entry(ALICE, 'w-c', { updatedAt: same }),
+      ]
+      const reversed = [...forward].reverse()
+      const expected = ['w-a', 'w-b', 'w-c']
+
+      expect(filterAndPageWorkers(forward, {}).items.map((w) => w.worker_id)).toEqual(expected)
+      expect(filterAndPageWorkers(reversed, {}).items.map((w) => w.worker_id)).toEqual(expected)
+    })
+
+    it('updated_at 缺失的脏条目排在最后,不影响其余次序', () => {
+      const dirty = entry(ALICE, 'w-dirty')
+      delete (dirty.worker as { updated_at?: string }).updated_at
+      const all = [
+        dirty,
+        entry(ALICE, 'w-new', { updatedAt: '2026-07-09T00:00:00.000Z' }),
+        entry(ALICE, 'w-old', { updatedAt: '2026-07-01T00:00:00.000Z' }),
+      ]
+      expect(filterAndPageWorkers(all, {}).items.map((w) => w.worker_id)).toEqual([
+        'w-new',
+        'w-old',
+        'w-dirty',
+      ])
+    })
+  })
+
+  describe('分页', () => {
+    // updated_at 递减 → 排序后即 w-1..w-5
+    const all = [1, 2, 3, 4, 5].map((n) =>
+      entry(ALICE, `w-${n}`, { updatedAt: `2026-07-0${9 - n}T00:00:00.000Z` })
+    )
+
+    it('首页', () => {
+      const result = filterAndPageWorkers(all, { pagination: { page: 1, page_size: 2 } })
+      expect(result.items.map((w) => w.worker_id)).toEqual(['w-1', 'w-2'])
+      expect(result.pagination).toEqual({
+        page: 1,
+        page_size: 2,
+        total_items: 5,
+        total_pages: 3,
+      })
+    })
+
+    it('末页(不足一页)', () => {
+      const result = filterAndPageWorkers(all, { pagination: { page: 3, page_size: 2 } })
+      expect(result.items.map((w) => w.worker_id)).toEqual(['w-5'])
+      expect(result.pagination.total_pages).toBe(3)
+    })
+
+    it('越界页返回空数组而不报错,page 原样回显', () => {
+      const result = filterAndPageWorkers(all, { pagination: { page: 99, page_size: 2 } })
+      expect(result.items).toEqual([])
+      expect(result.pagination).toEqual({
+        page: 99,
+        page_size: 2,
+        total_items: 5,
+        total_pages: 3,
+      })
+    })
+
+    it('total_items 反映过滤后的总数,而非全量', () => {
+      const mixed = [
+        entry(ALICE, 'w-1', { status: 'running' }),
+        entry(ALICE, 'w-2', { status: 'failed' }),
+        entry(ALICE, 'w-3', { status: 'failed' }),
+      ]
+      const result = filterAndPageWorkers(mixed, {
+        status: 'failed',
+        pagination: { page: 1, page_size: 1 },
+      })
+      expect(result.pagination.total_items).toBe(2)
+      expect(result.pagination.total_pages).toBe(2)
+      expect(result.items).toHaveLength(1)
+    })
+
+    it('page_size 上限 100', () => {
+      const result = filterAndPageWorkers(all, { pagination: { page: 1, page_size: 500 } })
+      expect(result.pagination.page_size).toBe(100)
+      expect(result.items).toHaveLength(5)
+    })
+
+    it('非法的 page / page_size 归一为默认值', () => {
+      const zeroed = filterAndPageWorkers(all, {
+        pagination: { page: 0, page_size: 0 },
+      })
+      expect(zeroed.pagination.page).toBe(1)
+      expect(zeroed.pagination.page_size).toBe(20)
+      expect(zeroed.items).toHaveLength(5)
+
+      const negative = filterAndPageWorkers(all, {
+        pagination: { page: -3, page_size: -1 },
+      })
+      expect(negative.pagination.page).toBe(1)
+      expect(negative.pagination.page_size).toBe(20)
+    })
+
+    it('缺失 pagination 时用默认 page=1 / page_size=20', () => {
+      const result = filterAndPageWorkers(all, {})
+      expect(result.pagination.page).toBe(1)
+      expect(result.pagination.page_size).toBe(20)
+    })
+  })
+
+  it('三种过滤条件可组合', () => {
+    const all = [
+      entry(ALICE, 'w-hit', { status: 'failed', createdAt: '2026-07-03T00:00:00.000Z' }),
+      entry(ALICE, 'w-status-miss', { status: 'running', createdAt: '2026-07-03T00:00:00.000Z' }),
+      entry(BOB, 'w-dialog-miss', { status: 'failed', createdAt: '2026-07-03T00:00:00.000Z' }),
+      entry(ALICE, 'w-time-miss', { status: 'failed', createdAt: '2026-07-09T00:00:00.000Z' }),
+    ]
+    const result = filterAndPageWorkers(all, {
+      status: ['failed', 'cancelled'],
+      dialog_object_id: ALICE,
+      time_range: { start: '2026-07-01T00:00:00.000Z', end: '2026-07-04T00:00:00.000Z' },
+    })
+    expect(result.items.map((w) => w.worker_id)).toEqual(['w-hit'])
+  })
+})
+
+describe('buildWorkerDetail', () => {
+  it('返回体只有 worker 一个字段(§8.3),不带 dialog_object_id', () => {
+    const found = entry(ALICE, 'w-1')
+    const detail = buildWorkerDetail(found)
+    expect(Object.keys(detail)).toEqual(['worker'])
+    expect(detail).not.toHaveProperty('dialog_object_id')
+    expect(detail).not.toHaveProperty('dialogObjectId')
+  })
+
+  it('台账条目逐字段透传(含全部可选字段与化身链)', () => {
+    const worker: LedgerWorker = {
+      worker_id: 'w-full',
+      task: {
+        id: 'task-1',
+        title: '标题',
+        status: 'completed',
+        priority: 'high',
+        goal: '目标',
+        outcome: '结果',
+        created_at: '2026-07-01T00:00:00.000Z',
+        completed_at: '2026-07-02T00:00:00.000Z',
+        error: 'boom',
+      },
+      origin: {
+        spawned_by_session: 'telegram::s-1',
+        spawned_by_episode: 'trace-1',
+        creator_friend_id: 'friend-1',
+        trigger_type: 'scheduled',
+      },
+      report_to: { channel_id: 'telegram', session_id: 's-1' },
+      incarnations: [
+        {
+          seq: 1,
+          impl: 'claude-code',
+          state: 'exited',
+          workspace: '/ws/w-full',
+          session_ref: 'sess-1',
+          tmux_session: 'crabot-w-full-1',
+          started_at: '2026-07-01T00:00:00.000Z',
+          ended_at: '2026-07-01T01:00:00.000Z',
+          ended_reason: 'completed',
+        },
+        {
+          seq: 2,
+          impl: 'builtin',
+          state: 'running',
+          workspace: '/ws/w-full',
+          session_ref: 'node-2',
+          started_at: '2026-07-02T00:00:00.000Z',
+          forked_from: 1,
+        },
+      ],
+      updated_at: '2026-07-02T00:00:00.000Z',
+    }
+
+    const detail = buildWorkerDetail({ dialogObjectId: ALICE, worker })
+    expect(detail.worker).toEqual(worker)
+    expect(detail.worker.incarnations).toHaveLength(2)
+    expect(detail.worker.incarnations[1].forked_from).toBe(1)
+  })
+})

--- a/crabot-agent/tests/manager/rpc-handlers.test.ts
+++ b/crabot-agent/tests/manager/rpc-handlers.test.ts
@@ -1,0 +1,517 @@
+/**
+ * agent 侧五个 v3 RPC handler(P5 Task 4)—— protocol-agent-v3.md §8.2 / §8.3。
+ *
+ * 手法照 `tests/unified-agent-resume-task.test.ts`:`Object.create(UnifiedAgent.prototype)`
+ * 绕过构造函数,只塞 handler 真正会用到的字段(这里是 `managerStack`),直接调私有 handler。
+ * 需要断言"语义不变量而不只是参数透传"的两条(trigger_schedule 的路由归属、权限身份落到
+ * `origin.creator_friend_id`)另外走**真实** `buildManagerStack` + mock LLM 的端到端路径。
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { promises as fs } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+import { UnifiedAgent } from '../../src/unified-agent.js'
+import { buildManagerStack, type BootstrapDeps, type ManagerStack } from '../../src/manager/bootstrap.js'
+import { SYSTEM_TASKS_MANAGER_KEY } from '../../src/manager/registry.js'
+import { dialogObjectIdForPrivate, type DialogObjectId, type LedgerWorker } from '../../src/workers/harness/ledger-types.js'
+import type { ManagerKey } from '../../src/manager/types.js'
+import type { HarnessEvent } from '../../src/workers/harness/worker-events.js'
+import type { LLMAdapter } from '../../src/engine/index.js'
+import { createCrabMemoryServer } from '../../src/mcp/crab-memory.js'
+import { chunksFromContent } from '../engine/helpers/mock-stream.js'
+import type {
+  ListWorkersAdminParams,
+  ListWorkersAdminResult,
+  GetWorkerDetailParams,
+  GetWorkerDetailResult,
+  ReadWorkerOutputAdminParams,
+  ReadWorkerOutputAdminResult,
+  GetWorkerTraceParams,
+  GetWorkerTraceResult,
+} from '../../src/manager/read-model.js'
+import type { TriggerScheduleParams, TriggerScheduleResult } from '../../src/unified-agent.js'
+
+// ============================================================================
+// helpers
+// ============================================================================
+
+/** 被测的五个私有 handler 的公开视图(TS 私有性只在编译期,运行时照常可调)。 */
+interface AgentUnderTest {
+  managerStack?: unknown
+  handleTriggerSchedule(p: TriggerScheduleParams): TriggerScheduleResult
+  handleListWorkersAdmin(p: ListWorkersAdminParams): Promise<ListWorkersAdminResult>
+  handleGetWorkerDetail(p: GetWorkerDetailParams): Promise<GetWorkerDetailResult>
+  handleReadWorkerOutputAdmin(p: ReadWorkerOutputAdminParams): Promise<ReadWorkerOutputAdminResult>
+  handleGetWorkerTrace(p: GetWorkerTraceParams): Promise<GetWorkerTraceResult>
+}
+
+function buildAgent(managerStack?: unknown): AgentUnderTest {
+  const agent = Object.create(UnifiedAgent.prototype) as Record<string, unknown>
+  agent.config = { moduleId: 'test-agent' }
+  if (managerStack !== undefined) agent.managerStack = managerStack
+  return agent as unknown as AgentUnderTest
+}
+
+function makeLedgerWorker(p: {
+  workerId: string
+  status?: LedgerWorker['task']['status']
+  createdAt?: string
+  updatedAt?: string
+}): LedgerWorker {
+  return {
+    worker_id: p.workerId,
+    task: {
+      id: p.workerId,
+      title: `任务 ${p.workerId}`,
+      status: p.status ?? 'running',
+      created_at: p.createdAt ?? '2026-01-01T00:00:00.000Z',
+    },
+    origin: { spawned_by_session: 'wechat::sess-1' as ManagerKey, trigger_type: 'message' },
+    report_to: { channel_id: 'wechat', session_id: 'sess-1' },
+    incarnations: [],
+    updated_at: p.updatedAt ?? '2026-01-01T00:00:00.000Z',
+  }
+}
+
+/** 最小 crab-memory server(照抄 tests/manager/bootstrap.test.ts)。 */
+function makeMemoryServer() {
+  return createCrabMemoryServer(
+    { rpcClient: { call: vi.fn() } as never, moduleId: 'rpc-handlers-test', getMemoryPort: async () => 19100 },
+    { visibility: 'internal', scopes: [], isMasterPrivate: false },
+  )
+}
+
+/** 最小 crab-messaging 依赖桩(照抄 tests/manager/bootstrap.test.ts)。 */
+function makeMessagingDeps() {
+  return {
+    rpcClient: { call: vi.fn() } as never,
+    moduleId: 'rpc-handlers-test',
+    getAdminPort: async () => 19001,
+    resolveChannelPort: async () => 19009,
+  }
+}
+
+/** 脚本化 manager LLM(照抄 tests/manager/manager-integration.test.ts 的 makeWorkerLLM 约定)。 */
+function makeManagerLLM(
+  scripts: ReadonlyArray<{
+    text?: string
+    toolCalls?: ReadonlyArray<{ name: string; id: string; input: Record<string, unknown> }>
+    stopReason: 'end_turn' | 'tool_use'
+  }>,
+): LLMAdapter {
+  let i = 0
+  return {
+    async *stream() {
+      const r = scripts[i++] ?? { text: '(收工)', stopReason: 'end_turn' as const }
+      const content: unknown[] = []
+      if (r.text) content.push({ type: 'text', text: r.text })
+      for (const tc of r.toolCalls ?? []) content.push({ type: 'tool_use', id: tc.id, name: tc.name, input: tc.input })
+      yield* chunksFromContent(content, r.stopReason, { inputTokens: 10, outputTokens: 5 })
+    },
+    updateConfig: () => {},
+  }
+}
+
+async function waitUntil(cond: () => boolean, timeoutMs = 6000, intervalMs = 20): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (cond()) return
+    await new Promise((resolve) => setTimeout(resolve, intervalMs))
+  }
+  throw new Error('waitUntil timed out')
+}
+
+// ============================================================================
+// §8.2 trigger_schedule
+// ============================================================================
+
+describe('trigger_schedule(§8.2)', () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('受理即返回 {accepted:true}——routeSchedule 永不 resolve 也不阻塞 handler', () => {
+    let routeCalls = 0
+    const stack = {
+      registry: {
+        routeSchedule: () => {
+          routeCalls++
+          return new Promise<never>(() => {
+            /* 永不 resolve:handler 若 await 它就永远回不来 */
+          })
+        },
+      },
+    }
+    const agent = buildAgent(stack)
+
+    // handler 是同步返回的:拿到返回值这件事本身就证明它没有等待路由完成
+    const result = agent.handleTriggerSchedule({ schedule_id: 'sc-1', title: '巡检', description: '每日巡检' })
+
+    expect(result).toEqual({ accepted: true })
+    expect(routeCalls).toBe(1)
+  })
+
+  it('routeSchedule 抛错不产生 unhandledRejection(游离 promise 必须 .catch)', async () => {
+    const unhandled: unknown[] = []
+    const onUnhandled = (reason: unknown): void => {
+      unhandled.push(reason)
+    }
+    process.on('unhandledRejection', onUnhandled)
+    try {
+      const stack = {
+        registry: { routeSchedule: () => Promise.reject(new Error('路由炸了')) },
+      }
+      const agent = buildAgent(stack)
+
+      expect(agent.handleTriggerSchedule({ schedule_id: 'sc-1', title: 't', description: 'd' })).toEqual({
+        accepted: true,
+      })
+
+      // 给 node 若干次事件循环回合去判定 unhandledRejection
+      await new Promise((resolve) => setTimeout(resolve, 50))
+      expect(unhandled).toEqual([])
+      // 失败仍要留痕(诊断日志)
+      expect(errorSpy).toHaveBeenCalled()
+    } finally {
+      process.off('unhandledRejection', onUnhandled)
+    }
+  })
+
+  it('参数按 §8.2 原样透传给 registry.routeSchedule(含 target_session / 权限身份)', () => {
+    const calls: unknown[] = []
+    const agent = buildAgent({ registry: { routeSchedule: (p: unknown) => { calls.push(p); return Promise.resolve() } } })
+
+    agent.handleTriggerSchedule({
+      schedule_id: 'sc-9',
+      title: '标题',
+      description: '描述',
+      target_session: { channel_id: 'wechat', session_id: 'sess-1' },
+      creator_friend_id: 'friend-42',
+      is_builtin: false,
+    })
+
+    expect(calls[0]).toEqual({
+      scheduleId: 'sc-9',
+      title: '标题',
+      description: '描述',
+      targetSession: { channel_id: 'wechat', session_id: 'sess-1' },
+      creatorFriendId: 'friend-42',
+      isBuiltin: false,
+    })
+  })
+
+  it('manager 栈未装配时抛明确错误(P5 阶段启动路径尚未接线)', () => {
+    const agent = buildAgent()
+    expect(() => agent.handleTriggerSchedule({ schedule_id: 'sc', title: 't', description: 'd' })).toThrow(
+      /Manager stack not initialized/,
+    )
+  })
+})
+
+// ============================================================================
+// §8.2 端到端:双路由 + 权限身份真的落到 origin.creator_friend_id
+// ============================================================================
+
+describe('trigger_schedule 端到端(真实 manager 栈 + mock LLM)', () => {
+  let tmpRoot: string
+  const dialogObjectIdFor = (key: ManagerKey): DialogObjectId => dialogObjectIdForPrivate(`friend-of-${key}`)
+
+  beforeEach(async () => {
+    tmpRoot = await fs.mkdtemp(join(tmpdir(), 'rpc-handlers-'))
+  })
+
+  afterEach(async () => {
+    vi.restoreAllMocks()
+    await fs.rm(tmpRoot, { recursive: true, force: true })
+  })
+
+  function makeStack(llm: LLMAdapter): ManagerStack {
+    const deps: BootstrapDeps = {
+      dataRoot: join(tmpRoot, 'data'),
+      now: () => new Date().toISOString(),
+      managerAdapter: () => llm,
+      managerModel: () => 'test-manager-model',
+      messagingDeps: makeMessagingDeps(),
+      memoryServer: makeMemoryServer(),
+      callAdmin: async () => ({}) as never,
+      dialogObjectIdFor,
+    }
+    return buildManagerStack(deps)
+  }
+
+  /** 第一轮调 spawn_worker、第二轮收工的 manager 脚本。 */
+  function spawnScript(): LLMAdapter {
+    return makeManagerLLM([
+      {
+        toolCalls: [{ name: 'spawn_worker', id: 'tc-1', input: { title: '巡检子任务', prompt: '去巡检' } }],
+        stopReason: 'tool_use',
+      },
+      { text: '已派发', stopReason: 'end_turn' },
+    ])
+  }
+
+  it('无 target_session → 系统线程 manager;creator_friend_id 落到 origin.creator_friend_id,trigger_type=scheduled', async () => {
+    const stack = makeStack(spawnScript())
+    const spawnSpy = vi
+      .spyOn(stack.harness, 'spawnWorker')
+      .mockResolvedValue(makeLedgerWorker({ workerId: 'w-spawned' }))
+    const routeSpy = vi.spyOn(stack.registry, 'routeSchedule')
+    const agent = buildAgent(stack)
+
+    const result = agent.handleTriggerSchedule({
+      schedule_id: 'sc-sys',
+      title: '系统巡检',
+      description: '无目标会话',
+      creator_friend_id: 'friend-42',
+    })
+
+    expect(result).toEqual({ accepted: true })
+    // fire-and-forget 的另一面自证:受理返回那一刻 episode 还没跑到派发 worker
+    expect(spawnSpy).not.toHaveBeenCalled()
+
+    await waitUntil(() => spawnSpy.mock.calls.length > 0)
+    const params = spawnSpy.mock.calls[0][0]
+    expect(params.origin.spawned_by_session).toBe(SYSTEM_TASKS_MANAGER_KEY)
+    expect(params.origin.creator_friend_id).toBe('friend-42')
+    expect(params.origin.trigger_type).toBe('scheduled')
+
+    await Promise.allSettled(routeSpy.mock.results.map((r) => r.value as Promise<unknown>))
+  })
+
+  it('有 target_session → 该会话的 manager', async () => {
+    const stack = makeStack(spawnScript())
+    const spawnSpy = vi
+      .spyOn(stack.harness, 'spawnWorker')
+      .mockResolvedValue(makeLedgerWorker({ workerId: 'w-spawned' }))
+    const routeSpy = vi.spyOn(stack.registry, 'routeSchedule')
+    const agent = buildAgent(stack)
+
+    agent.handleTriggerSchedule({
+      schedule_id: 'sc-sess',
+      title: '会话内巡检',
+      description: '有目标会话',
+      target_session: { channel_id: 'wechat', session_id: 'sess-1' },
+      creator_friend_id: 'friend-7',
+    })
+
+    await waitUntil(() => spawnSpy.mock.calls.length > 0)
+    const params = spawnSpy.mock.calls[0][0]
+    expect(params.origin.spawned_by_session).toBe('wechat::sess-1')
+    expect(params.origin.creator_friend_id).toBe('friend-7')
+    expect(params.origin.trigger_type).toBe('scheduled')
+
+    await Promise.allSettled(routeSpy.mock.results.map((r) => r.value as Promise<unknown>))
+  })
+
+  it('is_builtin=true → 不以任何 friend 身份执行(creator_friend_id 留空,按 §4.4「master 等价」的既有空值规则)', async () => {
+    const stack = makeStack(spawnScript())
+    const spawnSpy = vi
+      .spyOn(stack.harness, 'spawnWorker')
+      .mockResolvedValue(makeLedgerWorker({ workerId: 'w-spawned' }))
+    const routeSpy = vi.spyOn(stack.registry, 'routeSchedule')
+    const agent = buildAgent(stack)
+
+    agent.handleTriggerSchedule({
+      schedule_id: 'sc-builtin',
+      title: '内置巡检',
+      description: '系统内置',
+      is_builtin: true,
+      creator_friend_id: 'friend-should-be-ignored',
+    })
+
+    await waitUntil(() => spawnSpy.mock.calls.length > 0)
+    expect(spawnSpy.mock.calls[0][0].origin.creator_friend_id).toBeUndefined()
+
+    await Promise.allSettled(routeSpy.mock.results.map((r) => r.value as Promise<unknown>))
+  })
+
+  it('非 schedule 唤醒(人类消息)不受影响:trigger_type 仍是 message,不带 creator_friend_id', async () => {
+    const stack = makeStack(spawnScript())
+    const spawnSpy = vi
+      .spyOn(stack.harness, 'spawnWorker')
+      .mockResolvedValue(makeLedgerWorker({ workerId: 'w-spawned' }))
+
+    await stack.registry.routeHumanMessages('wechat', 'sess-1', [
+      {
+        platform_message_id: 'pm-1',
+        session: { session_id: 'sess-1', channel_id: 'wechat', type: 'private' },
+        sender: { platform_user_id: 'u1', platform_display_name: '测试用户' },
+        content: { type: 'text', text: '帮我跑个活' },
+        features: { is_mention_crab: false },
+        platform_timestamp: new Date().toISOString(),
+      },
+    ])
+
+    await waitUntil(() => spawnSpy.mock.calls.length > 0)
+    const params = spawnSpy.mock.calls[0][0]
+    expect(params.origin.trigger_type).toBe('message')
+    expect(params.origin.creator_friend_id).toBeUndefined()
+  })
+})
+
+// ============================================================================
+// §8.3 读模型四件套
+// ============================================================================
+
+describe('list_workers_admin(§8.3)', () => {
+  it('取全量台账 → filterAndPageWorkers(status 过滤 + 分页回显)', async () => {
+    const entries = [
+      { dialogObjectId: dialogObjectIdForPrivate('f1'), worker: makeLedgerWorker({ workerId: 'w-1', status: 'running', updatedAt: '2026-01-03T00:00:00.000Z' }) },
+      { dialogObjectId: dialogObjectIdForPrivate('f1'), worker: makeLedgerWorker({ workerId: 'w-2', status: 'completed', updatedAt: '2026-01-02T00:00:00.000Z' }) },
+      { dialogObjectId: dialogObjectIdForPrivate('f2'), worker: makeLedgerWorker({ workerId: 'w-3', status: 'running', updatedAt: '2026-01-01T00:00:00.000Z' }) },
+    ]
+    const agent = buildAgent({ ledger: { listAllWorkers: async () => entries } })
+
+    const all = await agent.handleListWorkersAdmin({})
+    expect(all.items.map((w) => w.worker_id)).toEqual(['w-1', 'w-2', 'w-3'])
+    expect(all.pagination).toEqual({ page: 1, page_size: 20, total_items: 3, total_pages: 1 })
+
+    const running = await agent.handleListWorkersAdmin({ status: 'running' })
+    expect(running.items.map((w) => w.worker_id)).toEqual(['w-1', 'w-3'])
+
+    const scoped = await agent.handleListWorkersAdmin({ dialog_object_id: dialogObjectIdForPrivate('f2') })
+    expect(scoped.items.map((w) => w.worker_id)).toEqual(['w-3'])
+  })
+
+  it('params 缺省(admin 不带任何查询参数)也能工作', async () => {
+    const agent = buildAgent({ ledger: { listAllWorkers: async () => [] } })
+    const result = await agent.handleListWorkersAdmin(undefined as unknown as ListWorkersAdminParams)
+    expect(result.items).toEqual([])
+    expect(result.pagination.total_items).toBe(0)
+  })
+})
+
+describe('get_worker_detail(§8.3)', () => {
+  it('存在 → 返回台账条目本身(剥掉 dialogObjectId 包装)', async () => {
+    const worker = makeLedgerWorker({ workerId: 'w-1' })
+    const agent = buildAgent({
+      ledger: { findWorker: async () => ({ dialogObjectId: dialogObjectIdForPrivate('f1'), worker }) },
+    })
+    await expect(agent.handleGetWorkerDetail({ worker_id: 'w-1' })).resolves.toEqual({ worker })
+  })
+
+  it('不存在 → 抛带 worker_id 的明确错误', async () => {
+    const agent = buildAgent({ ledger: { findWorker: async () => undefined } })
+    await expect(agent.handleGetWorkerDetail({ worker_id: 'w-missing' })).rejects.toThrow(/w-missing/)
+  })
+})
+
+describe('read_worker_output_admin(§8.3)', () => {
+  it('cursor 字符串 ↔ harness 的 OutputCursor 互转,seq 原样下传', async () => {
+    const calls: unknown[][] = []
+    const agent = buildAgent({
+      harness: {
+        readWorkerOutput: async (...args: unknown[]) => {
+          calls.push(args)
+          return { chunk: 'hello', nextCursor: { offset: 105 } }
+        },
+      },
+    })
+
+    const result = await agent.handleReadWorkerOutputAdmin({ worker_id: 'w-1', seq: 2, cursor: '100' })
+
+    expect(calls[0]).toEqual(['w-1', { offset: 100 }, { seq: 2 }])
+    expect(result).toEqual({ chunk: 'hello', next_cursor: '105', eof: false })
+  })
+
+  it('无 cursor → 从 0 读起;空 chunk → eof=true(已读到当前末尾)', async () => {
+    const calls: unknown[][] = []
+    const agent = buildAgent({
+      harness: {
+        readWorkerOutput: async (...args: unknown[]) => {
+          calls.push(args)
+          return { chunk: '', nextCursor: { offset: 7 } }
+        },
+      },
+    })
+
+    const result = await agent.handleReadWorkerOutputAdmin({ worker_id: 'w-1', seq: 1 })
+
+    expect(calls[0]).toEqual(['w-1', { offset: 0 }, { seq: 1 }])
+    expect(result).toEqual({ chunk: '', next_cursor: '7', eof: true })
+  })
+
+  it('harness 抛错(worker/化身不存在)原样冒泡,不吞成空 chunk', async () => {
+    const agent = buildAgent({
+      harness: {
+        readWorkerOutput: async () => {
+          throw new Error('no incarnation with seq=9')
+        },
+      },
+    })
+    await expect(agent.handleReadWorkerOutputAdmin({ worker_id: 'w-1', seq: 9 })).rejects.toThrow(/seq=9/)
+  })
+})
+
+describe('get_worker_trace(§8.3 + §10.2)', () => {
+  const events: HarnessEvent[] = [
+    { ts: '2026-01-01T00:00:00.000Z', kind: 'spawned', worker_id: 'w-1', seq: 1, detail: { impl: 'builtin' } },
+    { ts: '2026-01-01T00:00:01.000Z', kind: 'input_sent', worker_id: 'w-1', seq: 1 },
+    { ts: '2026-01-01T00:00:02.000Z', kind: 'spawned', worker_id: 'w-1', seq: 2 },
+  ]
+
+  function agentWithEvents() {
+    return buildAgent({
+      ledger: {
+        findWorker: async () => ({
+          dialogObjectId: dialogObjectIdForPrivate('f1'),
+          worker: makeLedgerWorker({ workerId: 'w-1' }),
+        }),
+      },
+      harness: { readWorkerEvents: async () => events },
+    })
+  }
+
+  it('第一层(harness 亲历事件流)按 seq 过滤并归一化为 NormalizedTraceEvent', async () => {
+    const result = await agentWithEvents().handleGetWorkerTrace({ worker_id: 'w-1', seq: 1 })
+
+    expect(result.events.map((e) => e.ts)).toEqual(['2026-01-01T00:00:00.000Z', '2026-01-01T00:00:01.000Z'])
+    expect(result.events.every((e) => e.kind === 'lifecycle')).toBe(true)
+    expect(result.events[0].summary).toContain('spawned')
+    expect(result.events[0].detail).toEqual({ impl: 'builtin' })
+  })
+
+  it('第二层(adapter readTrace 懒解析)本阶段未接线 → unavailable_reason 说明', async () => {
+    const result = await agentWithEvents().handleGetWorkerTrace({ worker_id: 'w-1', seq: 1 })
+    expect(result.unavailable_reason).toBeTruthy()
+    expect(result.unavailable_reason).toContain('readTrace')
+  })
+
+  it('cursor 增量读:next_cursor 回位后再读拿到剩余事件,读完为空', async () => {
+    const agent = agentWithEvents()
+    const first = await agent.handleGetWorkerTrace({ worker_id: 'w-1', seq: 1, cursor: '1' })
+    expect(first.events.map((e) => e.ts)).toEqual(['2026-01-01T00:00:01.000Z'])
+    expect(first.next_cursor).toBe('2')
+
+    const second = await agent.handleGetWorkerTrace({ worker_id: 'w-1', seq: 1, cursor: first.next_cursor })
+    expect(second.events).toEqual([])
+    expect(second.next_cursor).toBe('2')
+  })
+
+  it('worker 不存在 → 抛明确错误,而不是返回空时间线', async () => {
+    const agent = buildAgent({
+      ledger: { findWorker: async () => undefined },
+      harness: { readWorkerEvents: async () => [] },
+    })
+    await expect(agent.handleGetWorkerTrace({ worker_id: 'w-missing', seq: 1 })).rejects.toThrow(/w-missing/)
+  })
+})
+
+describe('读模型 handler 的 manager 栈前置门', () => {
+  it('未装配 manager 栈时四个读端点都抛明确错误', async () => {
+    const agent = buildAgent()
+    await expect(agent.handleListWorkersAdmin({})).rejects.toThrow(/Manager stack not initialized/)
+    await expect(agent.handleGetWorkerDetail({ worker_id: 'w' })).rejects.toThrow(/Manager stack not initialized/)
+    await expect(agent.handleReadWorkerOutputAdmin({ worker_id: 'w', seq: 1 })).rejects.toThrow(
+      /Manager stack not initialized/,
+    )
+    await expect(agent.handleGetWorkerTrace({ worker_id: 'w', seq: 1 })).rejects.toThrow(/Manager stack not initialized/)
+  })
+})

--- a/crabot-agent/tests/manager/rpc-handlers.test.ts
+++ b/crabot-agent/tests/manager/rpc-handlers.test.ts
@@ -457,12 +457,27 @@ describe('get_worker_trace(§8.3 + §10.2)', () => {
     { ts: '2026-01-01T00:00:02.000Z', kind: 'spawned', worker_id: 'w-1', seq: 2 },
   ]
 
+  /**
+   * 台账里必须真有 seq=1/2 两个化身：handler 现在先按台账校验显式给的 seq 存不存在
+   * （P5 review 修复第二轮），"化身不存在"与"化身没事件"要可区分。makeLedgerWorker 的
+   * `incarnations: []` 缺省对本组用例不成立——有事件却没有对应化身的 worker 在真实台账里
+   * 不存在（每个化身至少由 spawn 落一条）。
+   */
+  const incarnation = (seq: number) => ({
+    seq,
+    impl: 'builtin' as const,
+    state: 'exited' as const,
+    workspace: '/tmp/ws-not-used',
+    session_ref: `ref-${seq}`,
+    started_at: '2026-01-01T00:00:00.000Z',
+  })
+
   function agentWithEvents() {
     return buildAgent({
       ledger: {
         findWorker: async () => ({
           dialogObjectId: dialogObjectIdForPrivate('f1'),
-          worker: makeLedgerWorker({ workerId: 'w-1' }),
+          worker: { ...makeLedgerWorker({ workerId: 'w-1' }), incarnations: [incarnation(1), incarnation(2)] },
         }),
       },
       harness: { readWorkerEvents: async () => events },
@@ -493,6 +508,15 @@ describe('get_worker_trace(§8.3 + §10.2)', () => {
     const second = await agent.handleGetWorkerTrace({ worker_id: 'w-1', seq: 1, cursor: first.next_cursor })
     expect(second.events).toEqual([])
     expect(second.next_cursor).toBe('2')
+  })
+
+  /**
+   * 与 read_worker_output_admin 的 `seq=9 → rejects(/seq=9/)` 对称（见上一个 describe）：
+   * 显式给的化身不存在时报错，而不是与"该化身还没有事件"（seq=2 只有 1 条、cursor 读完
+   * 返回空——上面两条用例）在返回值上混同。
+   */
+  it('显式 seq 在化身链里不存在 → 抛错,而不是静默返回空 events', async () => {
+    await expect(agentWithEvents().handleGetWorkerTrace({ worker_id: 'w-1', seq: 9 })).rejects.toThrow(/seq=9/)
   })
 
   it('worker 不存在 → 抛明确错误,而不是返回空时间线', async () => {

--- a/crabot-agent/tests/workers/harness/harness-continuation.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-continuation.test.ts
@@ -1521,3 +1521,62 @@ describe('WorkerHarness — 三轮 review PoC 回归：handoff 目标是该 work
     expect(events.filter((e) => e.kind === 'handoff_started')).toHaveLength(0)
   })
 })
+
+/**
+ * P5 修复:`HarnessEvent.task_status` —— §5.3 接续路径上的两个 task 级迁移点
+ * (reviveIncarnation 的 `resumed`、handoffIncarnation 第 4 步的 `spawned`)。这两处是把
+ * **终态 task 拉回 running** 的唯一合法出边(§5.2 接续例外),也正是评审 PoC 里让"读晚一步"
+ * 吞掉终态 `completed` 的那次落账;事件自带状态之后,终态与这次复活各发各的,不再互相覆盖。
+ * 同一条路径上的纯记录事件(handoff_started / superseded)不动 task.status,一律不带。
+ */
+describe('HarnessEvent.task_status —— 透明接续的迁移点', () => {
+  it('revive:终态化身之上接续 → resumed 带 running(与台账落账值一致)', async () => {
+    const { harness, adaptersMap } = await makeHarness()
+    const fake = new FakeAdapter({ caps: { revive: true }, onStateChange: harness.handleStateChange })
+    adaptersMap.set('builtin', fake)
+
+    const worker = await harness.spawnWorker(spawnParams())
+    fake.emitStateChange({ worker_id: worker.worker_id, seq: 1, impl: 'builtin', session_ref: `ref-${worker.worker_id}#1` }, 'exited')
+    await waitUntil(async () => {
+      const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+      return w.task.status === 'completed'
+    })
+    // 终态那一跳自己也带了状态(processStateChange 主线分支)
+    const exitedStateEvent = events.filter((e) => e.kind === 'state_changed').pop()!
+    expect(exitedStateEvent.task_status).toBe('completed')
+    events.length = 0
+
+    await harness.sendToWorker(worker.worker_id, '还有件事要办')
+
+    const resumed = events.filter((e) => e.kind === 'resumed')
+    expect(resumed).toHaveLength(1)
+    expect(resumed[0].task_status).toBe('running')
+    const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    expect(w.task.status).toBe('running')
+  })
+
+  it('handoff:交接产出新化身 → spawned 带 running;handoff_started / superseded 不带', async () => {
+    const { harness, adaptersMap } = await makeHarness()
+    const fake = new FakeAdapter({
+      caps: { revive: false },
+      onStateChange: harness.handleStateChange,
+      sendInputBehavior: (h) => {
+        throw new WorkerExitedError(h.worker_id, h.seq)
+      },
+    })
+    adaptersMap.set('builtin', fake)
+    adaptersMap.set('claude-code', new FakeAdapter({ implId: 'claude-code', onStateChange: harness.handleStateChange }))
+
+    const worker = await harness.spawnWorker(spawnParams())
+    events.length = 0
+
+    await harness.sendToWorker(worker.worker_id, '接着把剩下的做完')
+
+    const spawned = events.filter((e) => e.kind === 'spawned')
+    expect(spawned).toHaveLength(1)
+    expect(spawned[0].task_status).toBe('running')
+
+    expect(events.filter((e) => e.kind === 'handoff_started')[0].task_status).toBeUndefined()
+    expect(events.filter((e) => e.kind === 'superseded')[0].task_status).toBeUndefined()
+  })
+})

--- a/crabot-agent/tests/workers/harness/harness-lifecycle.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-lifecycle.test.ts
@@ -828,6 +828,122 @@ describe('WorkerHarness.handleStateChange — 同状态重复回调', () => {
   })
 })
 
+/**
+ * P5 修复:`HarnessEvent.task_status` —— 事件自带"这次迁移落账后的 task 状态"。
+ *
+ * 分类不变量(见 harness.ts `appendEvent` 注释):**只有真正发生 task 状态迁移的事件点**带这
+ * 个字段,化身级/纯记录事件一律不带。下面按分类逐点钉住;剩余的迁移点(resumed / handoff 的
+ * spawned / markCrashed 的 exited / reconcile 的 state_changed)在 harness-continuation /
+ * harness-recovery 两个文件里由各自的夹具覆盖。
+ */
+describe('HarnessEvent.task_status —— 事件自带落账后的 task 状态', () => {
+  it('迁移点:spawn 成功 → spawned 带 running(与台账落账值一致)', async () => {
+    const { harness } = await makeHarness()
+    const worker = await harness.spawnWorker(spawnParams())
+
+    const spawned = events.filter((e) => e.kind === 'spawned')
+    expect(spawned).toHaveLength(1)
+    expect(spawned[0].task_status).toBe('running')
+    expect(spawned[0].task_status).toBe(worker.task.status)
+  })
+
+  it('迁移点:spawn 失败 → exited 带 failed(端点正确;中间的 running 无事件,仍折叠)', async () => {
+    const { harness } = await makeHarness({ spawnShouldFail: new Error('spawn 炸了') })
+    await expect(harness.spawnWorker(spawnParams())).rejects.toThrow('spawn 炸了')
+
+    const exited = events.filter((e) => e.kind === 'exited')
+    expect(exited).toHaveLength(1)
+    expect(exited[0].task_status).toBe('failed')
+  })
+
+  it('迁移点:主线状态回调 → state_changed 带落账后的 waiting_input / completed', async () => {
+    const { harness, fake } = await makeHarness()
+    const worker = await harness.spawnWorker(spawnParams())
+    const handle = { worker_id: worker.worker_id, seq: 1, impl: 'builtin' as WorkerImplId, session_ref: `ref-${worker.worker_id}#1` }
+    events.length = 0
+
+    fake.emitStateChange(handle, 'idle')
+    await waitUntil(async () => events.some((e) => e.kind === 'state_changed'))
+    expect(events.filter((e) => e.kind === 'state_changed')[0].task_status).toBe('waiting_input')
+
+    fake.emitStateChange(handle, 'exited')
+    await waitUntil(async () => events.filter((e) => e.kind === 'state_changed').length >= 2)
+    expect(events.filter((e) => e.kind === 'state_changed')[1].task_status).toBe('completed')
+  })
+
+  it('迁移点:killWorker → killed 带 cancelled', async () => {
+    const { harness } = await makeHarness()
+    const worker = await harness.spawnWorker(spawnParams())
+    events.length = 0
+
+    await harness.killWorker(worker.worker_id, '用户要求终止')
+
+    const killed = events.filter((e) => e.kind === 'killed')
+    expect(killed).toHaveLength(1)
+    expect(killed[0].task_status).toBe('cancelled')
+  })
+
+  it('非迁移点:input_sent 不带 task_status(投递不动 task 状态)', async () => {
+    const { harness } = await makeHarness()
+    const worker = await harness.spawnWorker(spawnParams())
+    events.length = 0
+
+    await harness.sendToWorker(worker.worker_id, '继续干活')
+
+    const inputSent = events.filter((e) => e.kind === 'input_sent')
+    expect(inputSent).toHaveLength(1)
+    expect(inputSent[0].task_status).toBeUndefined()
+  })
+
+  it('非迁移点:kill 后 drain 出的 dead_letter 不带 task_status(kill 的迁移由 killed 事件承载)', async () => {
+    const { harness } = await makeHarness({
+      // 让第一条卡在投递里,第二条就会留在队列上等 killWorker 去 drain
+      sendInputBehavior: () => new Promise((resolve) => setTimeout(resolve, 30)),
+    })
+    const worker = await harness.spawnWorker(spawnParams())
+    events.length = 0
+
+    const inFlight = harness.sendToWorker(worker.worker_id, '第一条')
+    const queued = harness.sendToWorker(worker.worker_id, '第二条').catch(() => undefined)
+    await harness.killWorker(worker.worker_id)
+    await inFlight.catch(() => undefined)
+    await queued
+
+    const deadLetters = events.filter((e) => e.kind === 'state_changed' && e.detail?.kind === 'dead_letter')
+    expect(deadLetters.length).toBeGreaterThan(0)
+    for (const e of deadLetters) expect(e.task_status).toBeUndefined()
+    // 同一次 kill 落的 killed 事件才是那次迁移的载体
+    expect(events.filter((e) => e.kind === 'killed')[0].task_status).toBe('cancelled')
+  })
+
+  it('非迁移点:query_failed 不带 task_status', async () => {
+    const { harness } = await makeHarness({ caps: { fork: false } })
+    const worker = await harness.spawnWorker(spawnParams())
+    events.length = 0
+
+    await expect(harness.queryWorker(worker.worker_id, '侧问')).rejects.toThrow(CapabilityNotSupportedError)
+
+    const queryFailed = events.filter((e) => e.kind === 'query_failed')
+    expect(queryFailed).toHaveLength(1)
+    expect(queryFailed[0].task_status).toBeUndefined()
+  })
+
+  it('非迁移点:fork 化身的落账事件不带 task_status(§5.3 fork 不影响主线)', async () => {
+    const { harness } = await makeHarness({ caps: { fork: true } })
+    const worker = await harness.spawnWorker(spawnParams())
+    events.length = 0
+
+    await harness.queryWorker(worker.worker_id, '侧问')
+
+    const forkEvents = events.filter((e) => e.seq === 2)
+    expect(forkEvents.length).toBeGreaterThan(0)
+    for (const e of forkEvents) expect(e.task_status).toBeUndefined()
+    // 台账确实没动主线 task.status——事件不带这个字段与台账事实一致
+    const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    expect(w.task.status).toBe('running')
+  })
+})
+
 async function waitUntil(cond: () => Promise<boolean>, timeoutMs = 2000, intervalMs = 10): Promise<void> {
   const deadline = Date.now() + timeoutMs
   while (Date.now() < deadline) {

--- a/crabot-agent/tests/workers/harness/harness-recovery.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-recovery.test.ts
@@ -362,3 +362,39 @@ describe('WorkerHarness.reconcileOnStartup — 幂等', () => {
     expect(afterSecond).toEqual(afterFirst) // 台账没有被第二次改写
   })
 })
+
+/**
+ * P5 修复:`HarnessEvent.task_status` —— 对账路径上的两个 task 级迁移点
+ * (markCrashed 的 `exited`、realignAliveIncarnation 的 `state_changed`)必须自带落账后的
+ * 状态,订阅方不再现读台账。分类总表见 harness.ts `appendEvent` 注释。
+ */
+describe('HarnessEvent.task_status —— reconcileOnStartup 的迁移点', () => {
+  it('判死(markCrashed)的 exited 事件带 failed', async () => {
+    const { harness, ledger, adaptersMap } = await makeHarness()
+    const fake = new FakeAdapter('builtin')
+    adaptersMap.set('builtin', fake)
+    await seed(ledger, DIALOG, makeWorker('w-crash'))
+    fake.setState({ worker_id: 'w-crash', seq: 1 }, 'exited')
+
+    await harness.reconcileOnStartup()
+
+    const exited = events.filter((e) => e.kind === 'exited' && e.worker_id === 'w-crash')
+    expect(exited).toHaveLength(1)
+    expect(exited[0].task_status).toBe('failed')
+    expect(exited[0].task_status).toBe((await getWorker(ledger, 'w-crash')).task.status)
+  })
+
+  it('存活对齐(realignAliveIncarnation)的 state_changed 事件带 waiting_input', async () => {
+    const { harness, ledger, adaptersMap } = await makeHarness()
+    const fake = new FakeAdapter('builtin')
+    adaptersMap.set('builtin', fake)
+    await seed(ledger, DIALOG, makeWorker('w-realign'))
+    fake.setState({ worker_id: 'w-realign', seq: 1 }, 'idle')
+
+    await harness.reconcileOnStartup()
+
+    const stateEvents = events.filter((e) => e.kind === 'state_changed' && e.worker_id === 'w-realign')
+    expect(stateEvents).toHaveLength(1)
+    expect(stateEvents[0].task_status).toBe('waiting_input')
+  })
+})


### PR DESCRIPTION
## P5:Scheduler 路由与 Admin 读代理

落地 protocol-agent-v3 §8.2/§8.3/§9.2/§10.3 的 agent 侧实现与 admin 侧只读 REST 代理。

**生产链路仍无人调用,cutover 在 P7** —— 这是本 PR 最重要的性质:admin 的 scheduler 调用点未切换(仍走 `create_task_from_schedule`),新增的四个 REST 端点没有前端消费方,`trigger_schedule` 全仓无生产调用方。

plan:`crabot-docs/superpowers/plans/2026-07-31-mw-p5-scheduler-readmodel.md`

### 改了什么

| commit | 内容 |
|---|---|
| `e7bfd7fd` | `manager/bootstrap.ts` —— manager 栈装配,严格按 harness 四步接线契约 |
| `07b6b1b2` | `manager/events.ts` —— `agent.task_status_changed` 对外事件 |
| `3b1d9f6a` | `manager/read-model.ts` —— 过滤/分页/详情纯逻辑 |
| `a5428b73` | `unified-agent.ts` 新增五个 RPC(`trigger_schedule` + 读模型四件套) |
| `cf5706c7` | admin 抽 `proxyAgentRpc` 转发样板(纯重构,行为不变) |
| `a78a744b` | admin 新增 `/api/agent/workers*` 四个只读端点 + 弃用注记 |
| `a05cdc5d` | 评审发现的正确性缺陷修复(见下) |
| `ac427ace` | 启动接线 + 集成测试 + 零现网影响自证 |

### 零现网影响自证(逐条实证,非声明)

- `unified-agent.ts` 全分支只删 1 行(`data-paths` import 加了 `getDataRootDir`);**入站四函数**(`handleMessageReceived`/`processDirectBatch`/`processGroupLaneBatch`/`handleProcessMessage`)按签名截取函数体与 base **逐字节比对相同** —— 没有满足于"diff 无删除行",因为新增可以插在函数体中间;
- `crab-messaging.ts`/`agent-handler.ts`/`engine/**`/`orchestration/**`/`dispatcher/**` 零改动;
- admin 四个写路径(`upsertTask`/`applyStatusTransition`/`handleCancelTask`/`runReconciliation`)函数体逐字节相同,只多了 JSDoc 弃用注记。`admin/src/index.ts` 的删除行**不为空**,已逐段核对,全部来自 `proxyAgentRpc` 重构;
- 唯一新增生产副作用:启动对账会建出一个空的 `$DATA_DIR/agent/ledgers` 目录。

### 评审发现并已修复的正确性缺陷

Task 1+2 的独立评审用 PoC 实测发现:事件发布器的 `new_status` 现读台账,而 `findWorker` 不进互斥锁、读的是最新文件 —— 只要该读发生在**下一次落账之后**,那个状态就被整条吞掉,**PoC 里终态 `completed` 一次都没发出去**。

这条没有留到 P7:cutover 后 admin 靠该事件更新任务状态,丢终态表现为"任务永远显示 running",属用户可见错误。根治方式是让 `HarnessEvent` 携带迁移后的 `task_status`(该类型不在任何协议文档中,已 grep 确认)。23 处 `appendEvent` 调用点按"紧邻的上一次 `upsertWorker` 有没有改 `task.status`"逐个分类,8 处 task 级迁移点带字段、15 处化身级/纯记录不带。缺字段时**退回现读台账**而非跳过 —— 跳过会把"缺字段"变成新的静默丢事件路径,正是本缺陷换个入口复发。

### 两处协议落差的过渡处理(P7 收敛)

1. **权限身份**:RPC 按协议收 `creator_friend_id`/`is_builtin`,`resolved_permissions` 只声明不消费(`ResolvedPermissions` 里没有 friend id,无法反推身份)。身份经 `WakeEvent(schedule)` → `ManagerLoop.currentWakeEvent`(per-episode + mutex 串行)→ `origin.creator_friend_id`,端到端测试钉住。**"按 creator_friend_id 解析 worker 工具权限"本阶段未实现**,身份只是被正确记账;
2. `{accepted:true}` vs admin 依赖 `task_id`:本阶段 admin 调用点未改故无冲突,切换时 `last_task_id` 与 `admin.schedule_triggered` 载荷需改造。

### 需要 reviewer 特别看的两条坦白

1. **入站链路"未受影响"只由 diff 证据支撑,不由测试支撑。** 对入站链路做的两处变异(改坏群聊分流、改坏 batch 合并)**全量测试一条都没抓到** —— `unified-agent.ts` 的入站链路几乎没有直接单测。P5 确实一字节没动它,但 P7 cutover 改这条链路前必须先补覆盖。
2. **`dialogObjectIdFor` 是半成品**,代码里已标 ⚠️ P7 阻塞:一律派生 `group:<ch>:<sess>`。私聊要 `friend:<id>` 跨 channel 聚合,但该 dep 是同步签名而 agent 侧唯一知情处是入站链路(本阶段零改动)。刻意**不做**"缓存+异步预取":预取在第一次调用(spawn 那次)上仍然是错的,复杂度买不到正确性,只造假象。

同理刻意**不提供** `builtinSpawnDefaults` —— `spawnWorker` 根本不读它,补上也补不掉"manager 缺省派工必挂",给半成品只会掩盖 P7 阻塞项。

### 三个启动期决定

- 装配放**构造函数**(RPC 无条件注册,取件口必须先就绪,否则 REST 在 `onStart` 跑完前 500);
- 对账放 `onStart` **不 await**、失败仅 warn(对账要起子进程问化身死活,启动不能挂它上面);
- **LLM 解析整个推进 thunk** —— 现网此刻没配 manager slot,装配期解析会让 agent 直接起不来。

### 验证

- agent:2216 passed | 2 skipped(基线 2209 + 8),既有测试一条未改;`tsc --noEmit` 干净
- admin:122 files / 1068 tests 全绿(基线 1042);`tsc --noEmit` 干净
- 各 task 均做了变异验证(删掉实现关键行确认对应测试会挂),累计 20 处,除入站链路那两处外全部被抓
- 已知 flaky:`bg-entities/*`、`harness-integration` 的 tmux 用例,单跑通过

### 已知不可信项(勿据此断言)

P7 阻塞项 #1(`processStateChange` 硬编码 `endReason='completed'`)未修,**读模型返回的 status 在失败路径上本身就是错的**。本 PR 所有测试都没有"worker 失败 → 返回 failed"这类断言,集成测试只断言"事件值 == 台账落账值",不对语义正确性背书。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
