### PR TITLE
test: Manager/Worker 拆分 P7/A——入站链路测试网

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,6 +1,18 @@
 # Crabot 项目进度
 
-> 最后更新：2026-07-31 — Manager/Worker 拆分 P5：scheduler 路由与 Admin 读代理（分支 feat/mw-p5-scheduler-readmodel，未合并 main）
+> 最后更新：2026-07-31 — Manager/Worker 拆分 P7 / PR A：入站链路测试网（分支 feat/mw-p7a-inbound-test-net，未合并 main）
+
+## 2026-07-31 — Manager/Worker 拆分 P7 / PR A：入站链路测试网（只加测试，生产代码零改动）
+
+- 计划：`crabot-docs/superpowers/plans/2026-07-31-mw-p7-a-inbound-test-net.md`（roadmap Phase 0 PR A，阻塞项 #8）。**它是所有 P7 后续的前置**：上一条 P5 记录里那句"对入站链路做变异，全量 2216 个用例一条都没抓到"就是本 PR 要还的债——cutover（PR J）要重写的正是这条人类消息的唯一通路。
+- 交付 4 个测试文件 98 例（`crabot-agent/tests/inbound/`）：`handle-message-received`（14，分流/未配置早退/lane key）、`process-direct-batch`（22，侦察 §A.2 的 8 件事 + 顺序）、`process-group-lane-batch`（34，barrier + memory 两档 fallback + 退避反馈）、`process-admin-chat-message`（28，RPC 路由 + admin chat "三不"）。**生产代码零改动**（每次变异/改写后 `git status` 核空）。
+- **12 处变异逐个植入实测，全部被抓**（M12 拆成误入 lane / 误入 attention / 注入 reaction 三变体）：M1(14 挂) M2(4) M3(2) M4(4) M5(2) M6(3) M7(1) M8(2) M9(6) M10(1) M11(6) M12a(4) M12b(4) M12c(3)。**旧网基线实测：除 M11 有一条执行器层单测外，其余全部 0 命中**——群聊入站链路此前完全裸奔（删掉整条退避反馈、把 batch 合并改成只取第一条、把入站改成同步等 worker，2256 个用例一条都察觉不到）。
+- **反向验证同样做了**（防止测试写成"实现的镜像"）：三类等价改写——提取局部变量（`processDirectBatch` 的 sessionId/channelId/lastMessage）、抽出纯函数 helper（memory 档位派生，跨私聊+群聊两处、穿过 M5 变异锚点）、调换无依赖语句 + 上提纯计算（`handleMessageReceived` 的两个缓存写入互换、laneKey 提到分流之前、穿过 M1 变异锚点）——三次 `tests/inbound/` 98 例**全绿**且 `tsc` 干净。网够密，同时不是刺猬。
+- 手法定调（Task 1 结论，后三个 task 沿用）：**用真实构造函数 `new UnifiedAgent(roles: [])` 而不是 `Object.create(prototype)`**——分流语义的一半在构造函数的 lane/attention 接线里，造壳等于把接线抄进测试，变异就只能靠参数透传断言去抓。唯一打破"纯真实装配"的地方是 `vi.mock` 模块级 `dispatch`（LLM 入口，无实例注入口），**`executeDispatchActions` 保留真件**——M8/M11/supplement 三分支的语义恰恰长在执行器里。全链路零 `setTimeout`、零 fake timer。
+- 断言落在语义不变量而非参数透传：M4/M9 的落点分别是 `getToolPermissionConfig()` 的输出与 `AttentionScheduler.getCurrentIntervalMs()` 的退避档位毫秒值（×5 / 逐级累积 / 封顶 / 出声拉回 min），M10 用 promise 闸门断"本批已返回而 worker 还在跑"，M7 在 fake dispatch 里跑真实 `prefetchQuotedMessages` 断引用原文真的取得回来。
+- **`handleProcessMessage` 的 `channel` 分支证实为死代码**，按 plan **不给它写测试**：① 全仓（含 4 个 channel 仓）grep RPC `process_message`，唯一生产调用方 `crabot-admin/src/chat-manager.ts:220` 固定传 `source_type:'admin_chat'`；② `setPendingRequest` 全仓无调用方 → `:1588` 取代检查恒真 → 该分支即使被调用也永远空转返回。已连同 `SessionManager.setPendingRequest/getPendingRequest`、`assembleFrontContext` 的死形参 `_memoryPermissions` 一起记入 **PR L 退役清单**（`.superpowers/sdd/progress.md`）。
+- **发现但未修的生产问题 O1–O8**（本 PR 只加测试，不修；台账在 `.superpowers/sdd/progress.md`）：O1 群聊两条早退与 catch 都不调 `reportResult`（`!sdkEnvWorker` 早退还漏 `clearAllBarriers`）；O2 `setPendingRequest` 无调用方；O3 admin chat 的 `!sdkEnvWorker` 早退不发 `chat_callback`（Master Chat 界面静默卡住）；O4 `currentResolvedPerms` 并发 race（作者已自标）；O5 `tests/manager/events.test.ts` 是新发现的 flaky；O6 `assembleFrontContext` 第三参完全没用；O7 `AttentionScheduler.reportResult` 无条件 `scheduleCheck` 覆盖已有 timer → 泄漏的旧 timer 先触发、退避被绕过、`stopAll` 也清不掉；O8 群聊路径从不 `updateLastMessageTime` → `get_status` 的活跃会话数永不含群聊。
+- 验证：`crabot-agent` 全量 `2318 passed | 2 skipped`（203 文件），基线（新文件移出实测）`2290 | 2`（202 文件），差值 = 新增 28，**零回归**；`tsc --noEmit` 干净；`tests/inbound/` 98 例连跑 3 次全绿。已知 flaky（判定变异命中前必须单跑复核）：`tests/engine/bg-entities/*`、`tests/manager/events.test.ts`、`harness-integration` 的 tmux 用例。
 
 ## 2026-07-31 — Manager/Worker 拆分 P5：scheduler 路由与 Admin 只读代理（生产链路仍未切换）
 

--- a/crabot-agent/tests/inbound/handle-message-received.test.ts
+++ b/crabot-agent/tests/inbound/handle-message-received.test.ts
@@ -29,95 +29,19 @@
  * 因此断言不依赖任何真实定时器，也不需要轮询等待。
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { promises as fs } from 'fs'
-import { tmpdir } from 'os'
-import { join } from 'path'
 
 import { UnifiedAgent } from '../../src/unified-agent.js'
-import type {
-  ChannelMessage,
-  Friend,
-  LLMConnectionInfo,
-  ModuleId,
-  OrchestrationConfig,
-  UnifiedAgentConfig,
-} from '../../src/types.js'
+import type { ChannelMessage, Friend, ModuleId } from '../../src/types.js'
 import type { BufferedMessage } from '../../src/orchestration/attention-scheduler.js'
 import type { Event } from 'crabot-shared'
-
-// ============================================================================
-// fixtures
-// ============================================================================
-
-const ORCHESTRATION: OrchestrationConfig = {
-  front_context_recent_messages_window_hours: 24,
-  front_context_recent_messages_max_cap: 50,
-  front_context_short_term_memory_window_hours: 24,
-  front_context_short_term_memory_max_cap: 20,
-  worker_recent_messages_window_hours: 24,
-  worker_recent_messages_max_cap: 50,
-  worker_short_term_memory_window_hours: 24,
-  worker_short_term_memory_max_cap: 20,
-  worker_long_term_memory_limit: 10,
-  front_agent_timeout: 60,
-  session_state_ttl: 3600,
-  worker_config_refresh_interval: 300,
-  front_agent_queue_max_length: 10,
-  front_agent_queue_timeout: 60,
-}
-
-const CONFIGURED_MODELS: Record<string, LLMConnectionInfo> = {
-  powerful: { endpoint: 'https://example.invalid', apikey: 'k', model_id: 'm-x', format: 'anthropic' },
-}
-
-function makeFriend(id: string): Friend {
-  return {
-    id,
-    display_name: `好友 ${id}`,
-    permission: 'normal',
-    channel_identities: [],
-    created_at: '2026-01-01T00:00:00.000Z',
-    updated_at: '2026-01-01T00:00:00.000Z',
-  }
-}
-
-function makeMessage(p: {
-  id: string
-  channelId?: string
-  sessionId?: string
-  type: 'private' | 'group'
-  text?: string
-  mention?: boolean
-}): ChannelMessage {
-  return {
-    platform_message_id: p.id,
-    session: {
-      session_id: (p.sessionId ?? 'sess-1') as string,
-      channel_id: (p.channelId ?? 'wechat') as ModuleId,
-      type: p.type,
-    },
-    sender: { friend_id: 'f-1', platform_user_id: 'u-1', platform_display_name: '张三' },
-    content: { type: 'text', text: p.text ?? '你好' },
-    features: { is_mention_crab: p.mention ?? false },
-    platform_timestamp: '2026-07-31T00:00:00.000Z',
-  }
-}
-
-/** 与 `crabot-admin/src/index.ts:4114-4130` 的 payload 逐字段对齐。 */
-function authorizedEvent(payload: {
-  message: ChannelMessage
-  friend: Friend
-  crab_display_name?: string
-  crab_self_handle?: string
-}): Event {
-  return {
-    id: 'evt-1',
-    type: 'channel.message_authorized',
-    source: 'admin' as ModuleId,
-    payload: { channel_id: payload.message.session.channel_id, ...payload },
-    timestamp: '2026-07-31T00:00:00.000Z',
-  }
-}
+import {
+  authorizedEvent,
+  makeAgentConfig,
+  makeFriend,
+  makeMessage,
+  useTmpDataDir,
+  type DataDirGuard,
+} from './harness.js'
 
 // ============================================================================
 // harness
@@ -141,9 +65,7 @@ interface AgentInternals {
 }
 
 describe('handleMessageReceived —— 入站分流（P7/PR A 测试网 ①）', () => {
-  let tmpRoot: string
-  let prevDataDir: string | undefined
-  let prevAgentDataDir: string | undefined
+  let dataDir: DataDirGuard
   let agent: UnifiedAgent
   let internals: AgentInternals
   /** 落点序列：断言"最终进了哪条处理路径"用的唯一事实来源。 */
@@ -154,25 +76,10 @@ describe('handleMessageReceived —— 入站分流（P7/PR A 测试网 ①）',
   let gate: Promise<void> | undefined
 
   function boot(opts: { configured: boolean; attentionMinMs?: number }): void {
-    const config: UnifiedAgentConfig = {
-      module_id: 'inbound-test-agent' as ModuleId,
-      module_type: 'agent',
-      version: '0.0.0-test',
-      protocol_version: '1.0',
-      port: 19998,
-      orchestration: ORCHESTRATION,
-      // roles: [] —— 不建 AgentHandler、不起 LSP 子进程；分流不看 roles。
-      agent_config: {
-        instance_id: 'inbound-test',
-        roles: [],
-        system_prompt: '你是测试用 Crabot',
-        model_config: opts.configured ? CONFIGURED_MODELS : {},
-      },
-      ...(opts.attentionMinMs !== undefined
-        ? { extra: { group_attention_min_ms: opts.attentionMinMs } }
-        : {}),
-    }
-    agent = new UnifiedAgent(config)
+    // roles: [] —— 不建 AgentHandler、不起 LSP 子进程；分流不看 roles。
+    agent = new UnifiedAgent(
+      makeAgentConfig({ ...opts, moduleId: 'inbound-test-agent', port: 19998 }),
+    )
     internals = agent as unknown as AgentInternals
 
     // 两个 lane handler 换成录制器。构造函数把它们接成
@@ -200,21 +107,13 @@ describe('handleMessageReceived —— 入站分流（P7/PR A 测试网 ①）',
     landings = []
     rpcCalls = []
     gate = undefined
-    tmpRoot = await fs.mkdtemp(join(tmpdir(), 'inbound-hmr-'))
-    prevDataDir = process.env.DATA_DIR
-    prevAgentDataDir = process.env.CRABOT_AGENT_DATA_DIR
-    delete process.env.CRABOT_AGENT_DATA_DIR
-    process.env.DATA_DIR = join(tmpRoot, 'data')
+    dataDir = await useTmpDataDir('inbound-hmr-')
   })
 
   afterEach(async () => {
     internals?.attentionScheduler.stopAll()
     vi.restoreAllMocks()
-    if (prevDataDir === undefined) delete process.env.DATA_DIR
-    else process.env.DATA_DIR = prevDataDir
-    if (prevAgentDataDir === undefined) delete process.env.CRABOT_AGENT_DATA_DIR
-    else process.env.CRABOT_AGENT_DATA_DIR = prevAgentDataDir
-    await fs.rm(tmpRoot, { recursive: true, force: true })
+    await dataDir.restore()
   })
 
   // --- 入口 ---

--- a/crabot-agent/tests/inbound/handle-message-received.test.ts
+++ b/crabot-agent/tests/inbound/handle-message-received.test.ts
@@ -1,0 +1,465 @@
+/**
+ * 入站链路测试网 ①：`handleMessageReceived`（P7 / PR A Task 1）。
+ *
+ * 计划：`crabot-docs/superpowers/plans/2026-07-31-mw-p7-a-inbound-test-net.md`
+ * 侦察：`.superpowers/sdd/p7-recon.md` §A.1 / §A.2
+ *
+ * ## 为什么走真实构造函数而不是 `Object.create(prototype)`
+ *
+ * `rpc-handlers.test.ts` 的造壳手法适合"handler 自身语义"——被测函数的依赖是它自己读的字段。
+ * 但本文件要钉的是**分流**：群消息必须最终落到 `processGroupLaneBatch`、私聊必须落到
+ * `processDirectBatch`。这条路径的一半在**构造函数的接线**里
+ * （`unified-agent.ts:375-389`：attentionScheduler.flushCallback → groupLaneRegistry；
+ * directLaneRegistry → processDirectBatch）。造壳就得在测试里把这段接线抄一遍，
+ * 抄出来的接线永远是对的，M1 那类变异就只能靠"某个函数被调用了"这种参数透传断言去抓——
+ * 恰恰是 CLAUDE.md 明令禁止的。
+ *
+ * 所以这里照 `tests/manager/p5-integration.test.ts` 走**真实构造函数**（`roles: []`，
+ * 不建 AgentHandler / 不起 LSP），只把两个 lane handler 换成录制器：
+ * 从事件入口到"落到哪条处理路径"整条链全是生产装配。
+ *
+ * ## 确定性
+ *
+ * 全链路无 `setTimeout`：
+ * - `@mention` 群消息 → `AttentionScheduler.flushNow` 同步触发；
+ * - 非 `@mention` 群消息 → 用 `group_attention_min_ms: 0` 让 `scheduleCheck` 算出
+ *   `remaining <= 0`，同样走 `flushNow`；
+ * - `SessionLane.enqueue` → `kick()` 在第一个 `await` 之前就同步调 handler。
+ *
+ * 因此断言不依赖任何真实定时器，也不需要轮询等待。
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { promises as fs } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+import { UnifiedAgent } from '../../src/unified-agent.js'
+import type {
+  ChannelMessage,
+  Friend,
+  LLMConnectionInfo,
+  ModuleId,
+  OrchestrationConfig,
+  UnifiedAgentConfig,
+} from '../../src/types.js'
+import type { BufferedMessage } from '../../src/orchestration/attention-scheduler.js'
+import type { Event } from 'crabot-shared'
+
+// ============================================================================
+// fixtures
+// ============================================================================
+
+const ORCHESTRATION: OrchestrationConfig = {
+  front_context_recent_messages_window_hours: 24,
+  front_context_recent_messages_max_cap: 50,
+  front_context_short_term_memory_window_hours: 24,
+  front_context_short_term_memory_max_cap: 20,
+  worker_recent_messages_window_hours: 24,
+  worker_recent_messages_max_cap: 50,
+  worker_short_term_memory_window_hours: 24,
+  worker_short_term_memory_max_cap: 20,
+  worker_long_term_memory_limit: 10,
+  front_agent_timeout: 60,
+  session_state_ttl: 3600,
+  worker_config_refresh_interval: 300,
+  front_agent_queue_max_length: 10,
+  front_agent_queue_timeout: 60,
+}
+
+const CONFIGURED_MODELS: Record<string, LLMConnectionInfo> = {
+  powerful: { endpoint: 'https://example.invalid', apikey: 'k', model_id: 'm-x', format: 'anthropic' },
+}
+
+function makeFriend(id: string): Friend {
+  return {
+    id,
+    display_name: `好友 ${id}`,
+    permission: 'normal',
+    channel_identities: [],
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+  }
+}
+
+function makeMessage(p: {
+  id: string
+  channelId?: string
+  sessionId?: string
+  type: 'private' | 'group'
+  text?: string
+  mention?: boolean
+}): ChannelMessage {
+  return {
+    platform_message_id: p.id,
+    session: {
+      session_id: (p.sessionId ?? 'sess-1') as string,
+      channel_id: (p.channelId ?? 'wechat') as ModuleId,
+      type: p.type,
+    },
+    sender: { friend_id: 'f-1', platform_user_id: 'u-1', platform_display_name: '张三' },
+    content: { type: 'text', text: p.text ?? '你好' },
+    features: { is_mention_crab: p.mention ?? false },
+    platform_timestamp: '2026-07-31T00:00:00.000Z',
+  }
+}
+
+/** 与 `crabot-admin/src/index.ts:4114-4130` 的 payload 逐字段对齐。 */
+function authorizedEvent(payload: {
+  message: ChannelMessage
+  friend: Friend
+  crab_display_name?: string
+  crab_self_handle?: string
+}): Event {
+  return {
+    id: 'evt-1',
+    type: 'channel.message_authorized',
+    source: 'admin' as ModuleId,
+    payload: { channel_id: payload.message.session.channel_id, ...payload },
+    timestamp: '2026-07-31T00:00:00.000Z',
+  }
+}
+
+// ============================================================================
+// harness
+// ============================================================================
+
+/** 一次"落到某条处理路径"的记录。 */
+type Landing =
+  | { path: 'direct'; batch: ReadonlyArray<{ message: ChannelMessage; friend: Friend }> }
+  | { path: 'group'; batch: ReadonlyArray<{ messages: BufferedMessage[]; sessionId: string }> }
+
+interface AgentInternals {
+  onEvent(event: Event): Promise<void>
+  processDirectBatch(batch: ReadonlyArray<{ message: ChannelMessage; friend: Friend }>): Promise<void>
+  processGroupLaneBatch(batch: ReadonlyArray<{ messages: BufferedMessage[]; sessionId: string }>): Promise<void>
+  attentionScheduler: { getBufferSize(sessionId: string): number; stopAll(): void }
+  channelPorts: Map<string, number>
+  crabDisplayNames: Map<string, string>
+  crabSelfHandles: Map<string, string>
+  rpcClient: { call: (...args: unknown[]) => Promise<unknown> }
+  config: { subscriptions?: string[] }
+}
+
+describe('handleMessageReceived —— 入站分流（P7/PR A 测试网 ①）', () => {
+  let tmpRoot: string
+  let prevDataDir: string | undefined
+  let prevAgentDataDir: string | undefined
+  let agent: UnifiedAgent
+  let internals: AgentInternals
+  /** 落点序列：断言"最终进了哪条处理路径"用的唯一事实来源。 */
+  let landings: Landing[]
+  /** 出站 RPC 序列（未配置提示语走这里）。 */
+  let rpcCalls: Array<{ port: number; method: string; params: unknown }>
+  /** lane handler 的放行闸：默认立即放行；需要观察串行/合并时挂起它。 */
+  let gate: Promise<void> | undefined
+
+  function boot(opts: { configured: boolean; attentionMinMs?: number }): void {
+    const config: UnifiedAgentConfig = {
+      module_id: 'inbound-test-agent' as ModuleId,
+      module_type: 'agent',
+      version: '0.0.0-test',
+      protocol_version: '1.0',
+      port: 19998,
+      orchestration: ORCHESTRATION,
+      // roles: [] —— 不建 AgentHandler、不起 LSP 子进程；分流不看 roles。
+      agent_config: {
+        instance_id: 'inbound-test',
+        roles: [],
+        system_prompt: '你是测试用 Crabot',
+        model_config: opts.configured ? CONFIGURED_MODELS : {},
+      },
+      ...(opts.attentionMinMs !== undefined
+        ? { extra: { group_attention_min_ms: opts.attentionMinMs } }
+        : {}),
+    }
+    agent = new UnifiedAgent(config)
+    internals = agent as unknown as AgentInternals
+
+    // 两个 lane handler 换成录制器。构造函数把它们接成
+    // `(batch) => this.processDirectBatch(batch)` 的闭包（读取时才解引用），
+    // 因此实例上覆盖同名方法不破坏任何生产接线。
+    internals.processDirectBatch = async (batch) => {
+      landings.push({ path: 'direct', batch })
+      if (gate) await gate
+    }
+    internals.processGroupLaneBatch = async (batch) => {
+      landings.push({ path: 'group', batch })
+      if (gate) await gate
+    }
+
+    // 出站：预置 channel 端口，绕开 MM resolve；rpcClient.call 只记录。
+    internals.channelPorts.set('wechat', 18001)
+    internals.channelPorts.set('telegram', 18002)
+    internals.rpcClient.call = async (port, method, params) => {
+      rpcCalls.push({ port: port as number, method: method as string, params })
+      return {}
+    }
+  }
+
+  beforeEach(async () => {
+    landings = []
+    rpcCalls = []
+    gate = undefined
+    tmpRoot = await fs.mkdtemp(join(tmpdir(), 'inbound-hmr-'))
+    prevDataDir = process.env.DATA_DIR
+    prevAgentDataDir = process.env.CRABOT_AGENT_DATA_DIR
+    delete process.env.CRABOT_AGENT_DATA_DIR
+    process.env.DATA_DIR = join(tmpRoot, 'data')
+  })
+
+  afterEach(async () => {
+    internals?.attentionScheduler.stopAll()
+    vi.restoreAllMocks()
+    if (prevDataDir === undefined) delete process.env.DATA_DIR
+    else process.env.DATA_DIR = prevDataDir
+    if (prevAgentDataDir === undefined) delete process.env.CRABOT_AGENT_DATA_DIR
+    else process.env.CRABOT_AGENT_DATA_DIR = prevAgentDataDir
+    await fs.rm(tmpRoot, { recursive: true, force: true })
+  })
+
+  // --- 入口 ---
+
+  describe('事件入口', () => {
+    it('agent 订阅的是 admin 鉴权后的 channel.message_authorized，而不是 channel 原始事件', () => {
+      boot({ configured: true })
+      expect(internals.config.subscriptions).toContain('channel.message_authorized')
+      expect(internals.config.subscriptions).not.toContain('channel.message_received')
+    })
+
+    it('非入站事件不会误入分流（走错 case 会把无关事件当消息处理）', async () => {
+      boot({ configured: true })
+      await internals.onEvent({
+        id: 'evt-x',
+        type: 'admin.friend_updated',
+        source: 'admin' as ModuleId,
+        payload: { friend_id: 'f-1' },
+        timestamp: '2026-07-31T00:00:00.000Z',
+      })
+      expect(landings).toEqual([])
+    })
+  })
+
+  // --- M1：群/私分流 ---
+
+  describe('群/私分流（变异靶 M1）', () => {
+    it('私聊消息最终落到私聊处理路径，且完全不经过群聊注意力调度', async () => {
+      boot({ configured: true })
+      const message = makeMessage({ id: 'pm-1', type: 'private' })
+
+      await internals.onEvent(authorizedEvent({ message, friend: makeFriend('f-1') }))
+
+      expect(landings).toHaveLength(1)
+      const landing = landings[0]
+      expect(landing.path).toBe('direct')
+      if (landing.path !== 'direct') throw new Error('unreachable')
+      // 落到私聊路径的是**这条消息本身**（不是空批、不是别的消息）
+      expect(landing.batch.map((b) => b.message.platform_message_id)).toEqual(['pm-1'])
+      expect(landing.batch[0].friend.id).toBe('f-1')
+      // 私聊绕开注意力调度：调度器里不该留下任何缓冲
+      expect(internals.attentionScheduler.getBufferSize('sess-1')).toBe(0)
+    })
+
+    it('群聊 @ 消息最终落到群聊处理路径，私聊路径零命中', async () => {
+      boot({ configured: true })
+      const message = makeMessage({ id: 'gm-1', type: 'group', sessionId: 'group-1', mention: true })
+
+      await internals.onEvent(authorizedEvent({ message, friend: makeFriend('f-1') }))
+
+      expect(landings).toHaveLength(1)
+      const landing = landings[0]
+      expect(landing.path).toBe('group')
+      if (landing.path !== 'group') throw new Error('unreachable')
+      expect(landing.batch).toHaveLength(1)
+      expect(landing.batch[0].sessionId).toBe('group-1')
+      expect(landing.batch[0].messages.map((m) => m.message.platform_message_id)).toEqual(['gm-1'])
+      expect(landing.batch[0].messages[0].friend.id).toBe('f-1')
+      // 已被取走：调度器缓冲清空
+      expect(internals.attentionScheduler.getBufferSize('group-1')).toBe(0)
+    })
+
+    it('群聊非 @ 消息同样只走群聊路径（巡检到点即 flush）', async () => {
+      boot({ configured: true, attentionMinMs: 0 })
+      const message = makeMessage({ id: 'gm-2', type: 'group', sessionId: 'group-2', mention: false })
+
+      await internals.onEvent(authorizedEvent({ message, friend: makeFriend('f-1') }))
+
+      expect(landings.map((l) => l.path)).toEqual(['group'])
+    })
+
+    it('群、私两条消息交错到达时各走各的路，互不串台', async () => {
+      boot({ configured: true })
+      const priv = makeMessage({ id: 'pm-2', type: 'private', sessionId: 'sess-a' })
+      const grp = makeMessage({ id: 'gm-3', type: 'group', sessionId: 'group-a', mention: true })
+
+      await internals.onEvent(authorizedEvent({ message: priv, friend: makeFriend('f-1') }))
+      await internals.onEvent(authorizedEvent({ message: grp, friend: makeFriend('f-2') }))
+
+      expect(landings.map((l) => l.path)).toEqual(['direct', 'group'])
+      const first = landings[0]
+      const second = landings[1]
+      if (first.path !== 'direct' || second.path !== 'group') throw new Error('unreachable')
+      expect(first.batch[0].message.platform_message_id).toBe('pm-2')
+      expect(second.batch[0].messages[0].message.platform_message_id).toBe('gm-3')
+    })
+  })
+
+  // --- M3：未配置早退 ---
+
+  describe('未配置早退（变异靶 M3）', () => {
+    it('未配置 LLM 时私聊消息不进任何处理路径，只回一条提示', async () => {
+      boot({ configured: false })
+      const message = makeMessage({ id: 'pm-3', type: 'private' })
+
+      await internals.onEvent(authorizedEvent({ message, friend: makeFriend('f-1') }))
+
+      expect(landings).toEqual([])
+      const sends = rpcCalls.filter((c) => c.method === 'send_message')
+      expect(sends).toHaveLength(1)
+      expect(sends[0].port).toBe(18001)
+      const reply = (sends[0].params as { message: ChannelMessage }).message
+      expect(reply.content.text).toContain('尚未配置')
+      // 提示必须回到原会话，不能串到别的会话
+      expect(reply.session.session_id).toBe('sess-1')
+      expect(reply.session.channel_id).toBe('wechat')
+    })
+
+    it('未配置 LLM 时群聊消息既不进群聊路径，也不留在注意力调度里', async () => {
+      boot({ configured: false })
+      const message = makeMessage({ id: 'gm-4', type: 'group', sessionId: 'group-3', mention: true })
+
+      await internals.onEvent(authorizedEvent({ message, friend: makeFriend('f-1') }))
+
+      expect(landings).toEqual([])
+      expect(internals.attentionScheduler.getBufferSize('group-3')).toBe(0)
+      expect(rpcCalls.filter((c) => c.method === 'send_message')).toHaveLength(1)
+    })
+
+    it('配置齐备时不发"未配置"提示（早退不能反过来误伤正常消息）', async () => {
+      boot({ configured: true })
+      await internals.onEvent(
+        authorizedEvent({ message: makeMessage({ id: 'pm-4', type: 'private' }), friend: makeFriend('f-1') }),
+      )
+      expect(rpcCalls.filter((c) => c.method === 'send_message')).toHaveLength(0)
+      expect(landings.map((l) => l.path)).toEqual(['direct'])
+    })
+  })
+
+  // --- lane key：串行化边界 ---
+
+  describe('私聊 lane key = channel + session', () => {
+    it('同一会话连发：第二条不与第一条并发，等第一批处理完后合并成新一批', async () => {
+      boot({ configured: true })
+      let release: () => void = () => {}
+      gate = new Promise<void>((resolve) => {
+        release = resolve
+      })
+
+      const friend = makeFriend('f-1')
+      await internals.onEvent(authorizedEvent({ message: makeMessage({ id: 'a1', type: 'private' }), friend }))
+      // 第一批还卡在 gate 上
+      expect(landings).toHaveLength(1)
+
+      await internals.onEvent(authorizedEvent({ message: makeMessage({ id: 'a2', type: 'private' }), friend }))
+      await internals.onEvent(authorizedEvent({ message: makeMessage({ id: 'a3', type: 'private' }), friend }))
+      // 串行化：处理中不得再起第二次 handler
+      expect(landings).toHaveLength(1)
+
+      gate = undefined
+      release()
+      await new Promise((resolve) => process.nextTick(resolve))
+
+      expect(landings).toHaveLength(2)
+      const second = landings[1]
+      if (second.path !== 'direct') throw new Error('unreachable')
+      // a2/a3 合并进同一批（合并语义本身的完整覆盖在 processDirectBatch 测试里）
+      expect(second.batch.map((b) => b.message.platform_message_id)).toEqual(['a2', 'a3'])
+    })
+
+    it('session_id 相同但 channel_id 不同 → 两条独立 lane，不互相阻塞', async () => {
+      boot({ configured: true })
+      let release: () => void = () => {}
+      gate = new Promise<void>((resolve) => {
+        release = resolve
+      })
+
+      const friend = makeFriend('f-1')
+      await internals.onEvent(
+        authorizedEvent({ message: makeMessage({ id: 'w1', type: 'private', channelId: 'wechat' }), friend }),
+      )
+      await internals.onEvent(
+        authorizedEvent({ message: makeMessage({ id: 't1', type: 'private', channelId: 'telegram' }), friend }),
+      )
+
+      // 若 lane key 只用 session_id，t1 会被 w1 的 lane 挡住，这里只有 1 条落点
+      expect(landings).toHaveLength(2)
+      expect(
+        landings.map((l) => (l.path === 'direct' ? l.batch[0].message.session.channel_id : '?')),
+      ).toEqual(['wechat', 'telegram'])
+
+      gate = undefined
+      release()
+      await new Promise((resolve) => process.nextTick(resolve))
+    })
+  })
+
+  // --- 昵称 / self-handle 缓存 ---
+
+  describe('crab 昵称与 self-handle 缓存', () => {
+    it('按 channel 分桶缓存，多渠道互不覆盖', async () => {
+      boot({ configured: true })
+      const friend = makeFriend('f-1')
+      await internals.onEvent(
+        authorizedEvent({
+          message: makeMessage({ id: 'c1', type: 'private', channelId: 'wechat' }),
+          friend,
+          crab_display_name: '小蟹',
+          crab_self_handle: '@crabot_wx',
+        }),
+      )
+      await internals.onEvent(
+        authorizedEvent({
+          message: makeMessage({ id: 'c2', type: 'private', channelId: 'telegram' }),
+          friend,
+          crab_display_name: 'Crabot',
+          crab_self_handle: '@crabot_tg',
+        }),
+      )
+
+      expect(internals.crabDisplayNames.get('wechat')).toBe('小蟹')
+      expect(internals.crabDisplayNames.get('telegram')).toBe('Crabot')
+      expect(internals.crabSelfHandles.get('wechat')).toBe('@crabot_wx')
+      expect(internals.crabSelfHandles.get('telegram')).toBe('@crabot_tg')
+    })
+
+    it('后续消息不带这两个字段时保留已缓存值（不能被 undefined 抹掉）', async () => {
+      boot({ configured: true })
+      const friend = makeFriend('f-1')
+      await internals.onEvent(
+        authorizedEvent({
+          message: makeMessage({ id: 'c3', type: 'private' }),
+          friend,
+          crab_display_name: '小蟹',
+          crab_self_handle: '@crabot_wx',
+        }),
+      )
+      await internals.onEvent(
+        authorizedEvent({ message: makeMessage({ id: 'c4', type: 'private' }), friend }),
+      )
+
+      expect(internals.crabDisplayNames.get('wechat')).toBe('小蟹')
+      expect(internals.crabSelfHandles.get('wechat')).toBe('@crabot_wx')
+    })
+
+    it('未配置早退发生在缓存之后：提示消息不影响昵称缓存被写入', async () => {
+      boot({ configured: false })
+      await internals.onEvent(
+        authorizedEvent({
+          message: makeMessage({ id: 'c5', type: 'private' }),
+          friend: makeFriend('f-1'),
+          crab_self_handle: '@crabot_wx',
+        }),
+      )
+      expect(internals.crabSelfHandles.get('wechat')).toBe('@crabot_wx')
+    })
+  })
+})

--- a/crabot-agent/tests/inbound/harness.ts
+++ b/crabot-agent/tests/inbound/harness.ts
@@ -115,7 +115,12 @@ export function makeAgentConfig(opts: {
   moduleId: string
   port: number
   attentionMinMs?: number
+  attentionMaxMs?: number
 }): UnifiedAgentConfig {
+  const attentionExtra = {
+    ...(opts.attentionMinMs !== undefined ? { group_attention_min_ms: opts.attentionMinMs } : {}),
+    ...(opts.attentionMaxMs !== undefined ? { group_attention_max_ms: opts.attentionMaxMs } : {}),
+  }
   return {
     module_id: opts.moduleId as ModuleId,
     module_type: 'agent',
@@ -129,9 +134,7 @@ export function makeAgentConfig(opts: {
       system_prompt: '你是测试用 Crabot',
       model_config: opts.configured ? CONFIGURED_MODELS : {},
     },
-    ...(opts.attentionMinMs !== undefined
-      ? { extra: { group_attention_min_ms: opts.attentionMinMs } }
-      : {}),
+    ...(Object.keys(attentionExtra).length > 0 ? { extra: attentionExtra } : {}),
   }
 }
 

--- a/crabot-agent/tests/inbound/harness.ts
+++ b/crabot-agent/tests/inbound/harness.ts
@@ -1,0 +1,163 @@
+/**
+ * 入站链路测试网的共享装配（P7 / PR A）。
+ *
+ * 计划：`crabot-docs/superpowers/plans/2026-07-31-mw-p7-a-inbound-test-net.md`
+ *
+ * 这里只放**纯 fixture 与环境装配**：消息 / friend / 事件 payload 的构造，
+ * `UnifiedAgentConfig` 的组装，以及 tmp `DATA_DIR` 的开关。
+ * 各个测试文件自己决定要覆盖哪些实例字段——那部分是每个被测函数的语义边界，不共享。
+ */
+import { promises as fs } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+import type {
+  ChannelMessage,
+  Friend,
+  LLMConnectionInfo,
+  ModuleId,
+  OrchestrationConfig,
+  UnifiedAgentConfig,
+} from '../../src/types.js'
+import type { Event } from 'crabot-shared'
+
+export const ORCHESTRATION: OrchestrationConfig = {
+  front_context_recent_messages_window_hours: 24,
+  front_context_recent_messages_max_cap: 50,
+  front_context_short_term_memory_window_hours: 24,
+  front_context_short_term_memory_max_cap: 20,
+  worker_recent_messages_window_hours: 24,
+  worker_recent_messages_max_cap: 50,
+  worker_short_term_memory_window_hours: 24,
+  worker_long_term_memory_limit: 10,
+  worker_short_term_memory_max_cap: 20,
+  front_agent_timeout: 60,
+  session_state_ttl: 3600,
+  worker_config_refresh_interval: 300,
+  front_agent_queue_max_length: 10,
+  front_agent_queue_timeout: 60,
+}
+
+export const CONFIGURED_MODELS: Record<string, LLMConnectionInfo> = {
+  powerful: { endpoint: 'https://example.invalid', apikey: 'k', model_id: 'm-x', format: 'anthropic' },
+}
+
+export function makeFriend(id: string, overrides: Partial<Friend> = {}): Friend {
+  return {
+    id,
+    display_name: `好友 ${id}`,
+    permission: 'normal',
+    channel_identities: [],
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+export function makeMessage(p: {
+  id: string
+  channelId?: string
+  sessionId?: string
+  type: 'private' | 'group'
+  text?: string
+  mention?: boolean
+  /** 发言人（不传则统一 u-1 / 张三） */
+  senderId?: string
+  senderName?: string
+  friendId?: string
+  /** features.reply_to_message_id：引用预取用 */
+  replyTo?: string
+  timestamp?: string
+}): ChannelMessage {
+  return {
+    platform_message_id: p.id,
+    session: {
+      session_id: (p.sessionId ?? 'sess-1') as string,
+      channel_id: (p.channelId ?? 'wechat') as ModuleId,
+      type: p.type,
+    },
+    sender: {
+      friend_id: p.friendId ?? 'f-1',
+      platform_user_id: p.senderId ?? 'u-1',
+      platform_display_name: p.senderName ?? '张三',
+    },
+    content: { type: 'text', text: p.text ?? '你好' },
+    features: {
+      is_mention_crab: p.mention ?? false,
+      ...(p.replyTo ? { reply_to_message_id: p.replyTo } : {}),
+    },
+    platform_timestamp: p.timestamp ?? '2026-07-31T00:00:00.000Z',
+  }
+}
+
+/** 与 `crabot-admin/src/index.ts:4114-4130` 的 payload 逐字段对齐。 */
+export function authorizedEvent(payload: {
+  message: ChannelMessage
+  friend: Friend
+  crab_display_name?: string
+  crab_self_handle?: string
+}): Event {
+  return {
+    id: 'evt-1',
+    type: 'channel.message_authorized',
+    source: 'admin' as ModuleId,
+    payload: { channel_id: payload.message.session.channel_id, ...payload },
+    timestamp: '2026-07-31T00:00:00.000Z',
+  }
+}
+
+/**
+ * 真实构造函数用的配置。`roles: []` → 不建 AgentHandler、不起 LSP 子进程；
+ * 需要 handler 的测试自己往实例上塞桩。
+ */
+export function makeAgentConfig(opts: {
+  configured: boolean
+  moduleId: string
+  port: number
+  attentionMinMs?: number
+}): UnifiedAgentConfig {
+  return {
+    module_id: opts.moduleId as ModuleId,
+    module_type: 'agent',
+    version: '0.0.0-test',
+    protocol_version: '1.0',
+    port: opts.port,
+    orchestration: ORCHESTRATION,
+    agent_config: {
+      instance_id: opts.moduleId,
+      roles: [],
+      system_prompt: '你是测试用 Crabot',
+      model_config: opts.configured ? CONFIGURED_MODELS : {},
+    },
+    ...(opts.attentionMinMs !== undefined
+      ? { extra: { group_attention_min_ms: opts.attentionMinMs } }
+      : {}),
+  }
+}
+
+export interface DataDirGuard {
+  root: string
+  restore(): Promise<void>
+}
+
+/**
+ * 把 `DATA_DIR` 指向一个 tmp 目录（TraceStore / manager 栈构造时会建目录），
+ * 返回的 `restore()` 负责还原环境变量并删目录。
+ */
+export async function useTmpDataDir(prefix: string): Promise<DataDirGuard> {
+  const root = await fs.mkdtemp(join(tmpdir(), prefix))
+  const prevDataDir = process.env.DATA_DIR
+  const prevAgentDataDir = process.env.CRABOT_AGENT_DATA_DIR
+  delete process.env.CRABOT_AGENT_DATA_DIR
+  process.env.DATA_DIR = join(root, 'data')
+  return {
+    root,
+    async restore() {
+      if (prevDataDir === undefined) delete process.env.DATA_DIR
+      else process.env.DATA_DIR = prevDataDir
+      if (prevAgentDataDir === undefined) delete process.env.CRABOT_AGENT_DATA_DIR
+      else process.env.CRABOT_AGENT_DATA_DIR = prevAgentDataDir
+      await fs.rm(root, { recursive: true, force: true })
+    },
+  }
+}

--- a/crabot-agent/tests/inbound/process-admin-chat-message.test.ts
+++ b/crabot-agent/tests/inbound/process-admin-chat-message.test.ts
@@ -1,0 +1,930 @@
+/**
+ * 入站链路测试网 ④：`processAdminChatMessage` + `handleProcessMessage` 路由
+ * （P7 / PR A Task 4）。
+ *
+ * 计划：`crabot-docs/superpowers/plans/2026-07-31-mw-p7-a-inbound-test-net.md`
+ * 被测单元：`unified-agent.ts:1522-1607`（RPC 入口路由）、`:1617-1918`（admin chat 处理）
+ *
+ * ## 本文件的核心：admin chat 的"三不"（变异靶 M12）
+ *
+ * Master Chat 是 admin REST 串行串发的伪 channel（spec 2026-06-10 §4），
+ * 与 IM 入站是**两套语义**。三条边界必须钉死，否则 cutover 时很容易被"统一入站"顺手抹平：
+ *
+ * | 不 | 为什么 | 断言落点 |
+ * |---|---|---|
+ * | 不进 lane | admin 侧前端 fetch 等响应才发下一条，天然单线；进 lane 会让 RPC 响应与处理解耦 | 两个 `SessionLaneRegistry` 零命中（既没建过 lane，两个 batch handler 也没被调过） |
+ * | 不进 attention | 注意力调度是群聊"该不该插话"的机制；master 直连对话每条都必须处理 | `attentionScheduler.getCurrentIntervalMs('admin-chat') === undefined`——连 session state 都不该建（比 `getBufferSize === 0` 强：后者在 enqueue 过又被 flush 掉时同样是 0） |
+ * | 无 reaction | admin-web 没有 channel 侧 platform message，无处可打（`:1778` 注释） | 全程零 `add_reaction` RPC |
+ *
+ * ## `handleProcessMessage` 的 `channel` 分支：已证实为死代码，不写测试
+ *
+ * 两重证据（`p7a-task1-report.md` §2.4）：
+ * 1. 全仓（含 4 个 channel 仓）grep RPC `process_message`，唯一生产调用方
+ *    `crabot-admin/src/chat-manager.ts:220`，固定传 `source_type:'admin_chat'`；
+ * 2. `setPendingRequest` 全仓无调用方 → `:1588` 的取代检查恒真 → 该分支即使被调用
+ *    也永远返回 `{decision_types: []}`。
+ *
+ * 按 plan："不给死代码写测试——那会让它看起来是活的，cutover 时反而不敢删。"
+ * 本文件只覆盖**活的**那条路由（`admin_chat` + `callback_info`）与静默丢弃分支。
+ *
+ * ## 明确不写成断言的现状（`p7a-task1-report.md` §6 O3）
+ *
+ * `!sdkEnvWorker` 早退**不发** `chat_callback`（另外两条早退都发），前端静默卡住。
+ * 那是已登记的 bug 不是契约，所以该用例只钉"trace 记失败 + 不进 dispatcher"，
+ * 不去断言"没有回执"——将来修 bug 补上回执时本用例不该被误挂。
+ *
+ * ## 手法
+ *
+ * 沿用测试网 ①②③：真实构造函数（`roles: []`）+ 只换外部边界桩 + 只 mock 模块级
+ * `dispatch`（`executeDispatchActions` 用真件）+ 真实 `traceStore`（tmp `DATA_DIR`）
+ * + 单一 `calls` 序列做顺序断言 + 零 `setTimeout` / 零 fake timer。
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+import { UnifiedAgent } from '../../src/unified-agent.js'
+import { prefetchQuotedMessages } from '../../src/agent/quoted-message-prefetcher.js'
+import type { QuotedMessageEntry } from '../../src/prompt-manager.js'
+import type {
+  AgentTrace,
+  ChannelMessage,
+  Friend,
+  MemoryPermissions,
+  ResolvedPermissions,
+  TaskSummary,
+  ToolAccessConfig,
+} from '../../src/types.js'
+import type { DispatchAction, DispatchContext } from '../../src/dispatcher/dispatcher-types.js'
+import type { DispatchDeps } from '../../src/dispatcher/dispatcher.js'
+import { makeAgentConfig, makeMessage, useTmpDataDir, type DataDirGuard } from './harness.js'
+
+// dispatch 是模块级 import，没有实例注入口——本文件唯一 mock 掉的生产模块。
+vi.mock('../../src/dispatcher/dispatcher.js', () => ({ dispatch: vi.fn() }))
+import { dispatch } from '../../src/dispatcher/dispatcher.js'
+
+const dispatchMock = vi.mocked(dispatch)
+
+// ============================================================================
+// fixtures
+// ============================================================================
+
+const ADMIN_PORT = 18200
+const ADMIN_CHAT_SESSION = 'admin-chat'
+const REQUEST_ID = 'req-42'
+
+/** master 身份解析出来的工具面：file_io 开、remote_exec 关（用来做正反对照）。 */
+const MASTER_TOOL_ACCESS: ToolAccessConfig = {
+  memory: true,
+  messaging: true,
+  task: true,
+  mcp_skill: true,
+  file_io: true,
+  browser: true,
+  shell: true,
+  remote_exec: false,
+  desktop: false,
+}
+
+const MASTER_PERMS: ResolvedPermissions = {
+  tool_access: MASTER_TOOL_ACCESS,
+  cli_access: {} as ResolvedPermissions['cli_access'],
+  storage: null,
+  memory_scopes: ['master-scope'],
+}
+
+/** admin chat 固定用的 master 记忆档位（`unified-agent.ts:1677-1682`）。 */
+const MASTER_MEM_PERMS: MemoryPermissions = {
+  write_visibility: 'private',
+  write_scopes: [],
+  read_min_visibility: 'private',
+  read_accessible_scopes: undefined,
+}
+
+const HISTORY_MESSAGE = makeMessage({
+  id: 'hist-a1',
+  type: 'private',
+  channelId: 'admin-web',
+  sessionId: ADMIN_CHAT_SESSION,
+  text: '上一轮我说的那个报表',
+  timestamp: '2026-07-30T10:00:00.000Z',
+})
+
+const SCENE_PROFILE = {
+  label: 'Master 直连',
+  content: 'master 喜欢直接给结论',
+  source: { scene: { type: 'friend' as const, friend_id: 'master' } },
+}
+
+const ACTIVE_TASK: TaskSummary = {
+  task_id: 'task-admin-active',
+  title: '在跑的任务',
+  status: 'executing',
+  priority: 'normal',
+}
+
+const SCHEDULED_TASK: TaskSummary = {
+  task_id: 'task-admin-scheduled',
+  title: '定时任务',
+  status: 'executing',
+  priority: 'normal',
+  trigger_type: 'scheduled',
+}
+
+/**
+ * admin chat 的入参消息：session 里带的是**别的**渠道/会话，
+ * 用来证明处理端固定用 `admin-web` / `admin-chat`，不看消息自带的 session。
+ */
+function amsg(p: { id: string; text?: string; replyTo?: string; friendId?: string } = { id: 'a-1' }): ChannelMessage {
+  return makeMessage({
+    ...p,
+    type: 'private',
+    channelId: 'wechat',
+    sessionId: 'some-other-session',
+    ...(p.friendId !== undefined ? { friendId: p.friendId } : {}),
+  })
+}
+
+const CALLBACK_INFO = { source_module_id: 'admin', request_id: REQUEST_ID }
+
+interface AssembleCall {
+  params: {
+    channel_id: string
+    session_id: string
+    sender_id: string
+    message: string
+    friend_id: string
+    session_type: string
+  }
+  friend: Friend | undefined
+  memPerms: MemoryPermissions
+}
+
+interface SpawnCall {
+  messages: ReadonlyArray<ChannelMessage>
+  activeTasks: ReadonlyArray<TaskSummary>
+  isGroup: boolean
+  senderFriend: Friend
+  memoryPermissions: MemoryPermissions
+  resolvedPermissions: ResolvedPermissions
+  channelId: string
+  sessionId: string
+  frontContext: { recent_messages: ChannelMessage[]; scene_profile?: unknown }
+  sceneProfile?: unknown
+}
+
+interface Internals {
+  handleProcessMessage(params: {
+    message: ChannelMessage
+    source_type?: 'channel' | 'admin_chat'
+    callback_info?: { source_module_id: string; request_id: string }
+  }): Promise<{ decision_types: string[]; task_ids?: string[] }>
+  processDirectBatch(batch: unknown): Promise<void>
+  processGroupLaneBatch(batch: unknown): Promise<void>
+  directLaneRegistry: { getOrCreate(key: string): unknown; size(): number }
+  groupLaneRegistry: { getOrCreate(key: string): unknown; size(): number }
+  sessionManager: {
+    getSession(sessionId: string): { message_count: number } | undefined
+  }
+  traceStore: {
+    getTraces(limit?: number): { traces: AgentTrace[] }
+    startTrace(params: { trigger: { type: string } }): { trace_id: string }
+  }
+  contextAssembler: unknown
+  agentHandler: unknown
+  sdkEnvWorker: unknown
+  attentionScheduler: {
+    stopAll(): void
+    getCurrentIntervalMs(sessionId: string): number | undefined
+    getBufferSize(sessionId: string): number
+  }
+  rpcClient: {
+    call: (port: number, method: string, params: unknown, from?: string) => Promise<unknown>
+    resolve: (filter: unknown, from?: string) => Promise<unknown[]>
+  }
+}
+
+describe('processAdminChatMessage —— admin chat 入站（P7/PR A 测试网 ④）', () => {
+  let dataDir: DataDirGuard
+  let agent: UnifiedAgent
+  let internals: Internals
+
+  /** 唯一的顺序事实来源。 */
+  let calls: string[]
+  let rpcCalls: Array<{ port: number; method: string; params: Record<string, unknown> }>
+  let assembleCalls: AssembleCall[]
+  let spawnCalls: SpawnCall[]
+  let deliverCalls: Array<{ taskId: string; messages: ReadonlyArray<ChannelMessage> }>
+  /** "不进 lane" 的两处观测点：registry 有没有被建过 lane、两个 batch handler 有没有被跑过。 */
+  let laneKeysCreated: string[]
+  let laneBatchRuns: string[]
+  /** `handleProcessMessage` 的 channel 分支出口（死代码），录来做反向断言。 */
+  let executeTriggerCalls: number
+  let capturedCtx: DispatchContext | undefined
+  let capturedDeps: DispatchDeps | undefined
+
+  // 可按测试改写的响应
+  let permsResponse: ResolvedPermissions | null | 'throw'
+  let supplementCandidates: TaskSummary[]
+  let activeTasks: TaskSummary[]
+  let recentMessages: ChannelMessage[]
+  let hasActiveTaskResult: boolean
+  /** worker loop 的放行闸：默认立即完成；M10 用它把 worker 挂住。 */
+  let workerGate: Promise<void> | undefined
+  let workerSettled: boolean
+
+  function boot(opts: { configured?: boolean; withHandler?: boolean; withSdkEnv?: boolean } = {}): void {
+    agent = new UnifiedAgent(
+      makeAgentConfig({
+        configured: opts.configured !== false,
+        moduleId: 'admin-chat-agent',
+        port: 19995,
+      }),
+    )
+    internals = agent as unknown as Internals
+
+    internals.rpcClient.resolve = async () => [
+      { module_id: 'admin', module_type: 'admin', host: 'localhost', port: ADMIN_PORT, status: 'running' },
+    ]
+    internals.rpcClient.call = async (port, method, params) => {
+      rpcCalls.push({ port, method, params: params as Record<string, unknown> })
+      switch (method) {
+        case 'resolve_principal_permissions':
+          calls.push('resolve_permissions')
+          if (permsResponse === 'throw') throw new Error('admin unreachable')
+          return { resolved: permsResponse, sources: {} }
+        case 'chat_callback':
+          calls.push(`chat_callback:${(params as { reply_type: string }).reply_type}`)
+          return { received: true }
+        case 'add_reaction':
+          calls.push('add_reaction')
+          return {}
+        case 'get_message':
+          calls.push('get_message')
+          return {
+            platform_message_id: (params as { platform_message_id: string }).platform_message_id,
+            sender: { platform_user_id: 'master', platform_display_name: 'Master' },
+            content: { type: 'text', text: '这是被引用的原文' },
+            features: {},
+            platform_timestamp: '2026-07-20T00:00:00.000Z',
+          }
+        default:
+          return {}
+      }
+    }
+
+    const realStartTrace = internals.traceStore.startTrace.bind(internals.traceStore)
+    internals.traceStore.startTrace = (params) => {
+      calls.push(`start_trace:${params.trigger.type}`)
+      return realStartTrace(params)
+    }
+
+    // 「不进 lane」观测点。构造函数存的是 `(batch) => this.processXxxBatch(batch)`
+    // （调用时才解引用），所以实例上换成录制器不破坏生产接线。
+    for (const [name, registry] of [
+      ['direct', internals.directLaneRegistry],
+      ['group', internals.groupLaneRegistry],
+    ] as const) {
+      const realGetOrCreate = registry.getOrCreate.bind(registry)
+      registry.getOrCreate = (key: string) => {
+        laneKeysCreated.push(`${name}:${key}`)
+        return realGetOrCreate(key)
+      }
+    }
+    internals.processDirectBatch = async () => {
+      laneBatchRuns.push('direct')
+    }
+    internals.processGroupLaneBatch = async () => {
+      laneBatchRuns.push('group')
+    }
+
+    internals.contextAssembler = {
+      assembleFrontContext: async (
+        params: AssembleCall['params'],
+        friend: Friend | undefined,
+        memPerms: MemoryPermissions,
+      ) => {
+        calls.push('assemble_front_context')
+        assembleCalls.push({ params, friend, memPerms })
+        return {
+          sender_friend: friend,
+          recent_messages: recentMessages,
+          short_term_memories: [],
+          active_tasks: activeTasks,
+          available_tools: [],
+          scene_profile: SCENE_PROFILE,
+          time_windows: { recent_messages_window_hours: 24, short_term_memory_window_hours: 24 },
+          supplement_candidates: supplementCandidates,
+        }
+      },
+    }
+
+    if (opts.withHandler !== false) {
+      internals.agentHandler = {
+        hasActiveTask: () => hasActiveTaskResult,
+        deliverHumanResponse: (taskId: string, messages: ReadonlyArray<ChannelMessage>) => {
+          calls.push('deliver_human_response')
+          deliverCalls.push({ taskId, messages })
+        },
+        getTaskPrincipal: () => undefined,
+        updateTaskPermissions: () => {},
+        getInflightSnapshot: () => [],
+        executeTriggerMessage: async () => {
+          executeTriggerCalls += 1
+          return { outcome: 'completed', finalText: '', sentMessage: true }
+        },
+        registerTriggerAndActivate: async (params: SpawnCall) => {
+          calls.push('register_trigger')
+          spawnCalls.push(params)
+          return {
+            taskId: 'task-admin-new',
+            registered: true,
+            task: {},
+            context: {},
+            taskTitle: '新建的 master 任务',
+          }
+        },
+        runTriggerWorkerLoop: async () => {
+          calls.push('worker_loop')
+          if (workerGate) await workerGate
+          workerSettled = true
+          return { outcome: 'completed', finalText: '搞定', sentMessage: true }
+        },
+      }
+    }
+
+    if (opts.withSdkEnv !== false) {
+      internals.sdkEnvWorker = {
+        modelId: 'worker-model',
+        format: 'anthropic',
+        env: { LLM_BASE_URL: 'https://example.invalid', LLM_API_KEY: 'k' },
+      }
+    }
+  }
+
+  function setDispatchActions(actions: DispatchAction[]): void {
+    dispatchMock.mockImplementation(async (ctx, deps) => {
+      calls.push('dispatch')
+      capturedCtx = ctx
+      capturedDeps = deps
+      return { actions }
+    })
+  }
+
+  /** 走真实 RPC 入口（`handleProcessMessage`），不直接调私有方法。 */
+  function runAdminChat(
+    message: ChannelMessage = amsg({ id: 'a-1' }),
+  ): Promise<{ decision_types: string[]; task_ids?: string[] }> {
+    return internals.handleProcessMessage({
+      message,
+      source_type: 'admin_chat',
+      callback_info: CALLBACK_INFO,
+    })
+  }
+
+  function dispatchTrace(): AgentTrace {
+    const t = internals.traceStore.getTraces(50).traces.find((x) => x.trigger.type === 'message')
+    if (!t) throw new Error('dispatch trace not found')
+    return t
+  }
+
+  function callbacksOf(replyType: string): Array<Record<string, unknown>> {
+    return rpcCalls.filter((c) => c.method === 'chat_callback' && c.params.reply_type === replyType).map((c) => c.params)
+  }
+
+  /** 三不：不进 lane、不进 attention、无 reaction。 */
+  function expectThreeNots(): void {
+    expect(laneKeysCreated).toEqual([])
+    expect(laneBatchRuns).toEqual([])
+    expect(internals.directLaneRegistry.size()).toBe(0)
+    expect(internals.groupLaneRegistry.size()).toBe(0)
+    expect(internals.attentionScheduler.getCurrentIntervalMs(ADMIN_CHAT_SESSION)).toBeUndefined()
+    expect(internals.attentionScheduler.getBufferSize(ADMIN_CHAT_SESSION)).toBe(0)
+    expect(rpcCalls.find((c) => c.method === 'add_reaction')).toBeUndefined()
+    expect(calls).not.toContain('add_reaction')
+  }
+
+  beforeEach(async () => {
+    calls = []
+    rpcCalls = []
+    assembleCalls = []
+    spawnCalls = []
+    deliverCalls = []
+    laneKeysCreated = []
+    laneBatchRuns = []
+    executeTriggerCalls = 0
+    capturedCtx = undefined
+    capturedDeps = undefined
+    permsResponse = MASTER_PERMS
+    supplementCandidates = [ACTIVE_TASK]
+    activeTasks = [ACTIVE_TASK]
+    recentMessages = [HISTORY_MESSAGE]
+    hasActiveTaskResult = true
+    workerGate = undefined
+    workerSettled = false
+    dispatchMock.mockReset()
+    setDispatchActions([{ kind: 'new_task' }])
+    dataDir = await useTmpDataDir('inbound-pacm-')
+  })
+
+  afterEach(async () => {
+    internals?.attentionScheduler.stopAll()
+    vi.restoreAllMocks()
+    await dataDir.restore()
+  })
+
+  // ==========================================================================
+  // RPC 入口路由（handleProcessMessage）
+  // ==========================================================================
+
+  describe('RPC 入口路由（handleProcessMessage）', () => {
+    it('带回执信息的 admin_chat 消息走 master 对话路径，固定落在 admin-web / admin-chat', async () => {
+      boot()
+      await runAdminChat(amsg({ id: 'a-1', text: '帮我看下季度报表' }))
+
+      // 处理端不看消息自带的 session（入参故意给了 wechat / some-other-session）
+      const trace = dispatchTrace()
+      expect(trace.trigger.source).toBe('admin-web')
+      expect(trace.trigger.summary).toBe('帮我看下季度报表')
+      expect(spawnCalls[0].channelId).toBe('admin-web')
+      expect(spawnCalls[0].sessionId).toBe(ADMIN_CHAT_SESSION)
+      expect(spawnCalls[0].isGroup).toBe(false)
+      // 会话活跃度推进的是固定的 admin-chat 会话
+      expect(internals.sessionManager.getSession(ADMIN_CHAT_SESSION)?.message_count).toBe(1)
+      expect(internals.sessionManager.getSession('some-other-session')).toBeUndefined()
+    })
+
+    it('admin_chat 但缺回执信息：静默丢弃，不建 trace、不碰 worker', async () => {
+      boot()
+      const result = await internals.handleProcessMessage({
+        message: amsg({ id: 'a-1' }),
+        source_type: 'admin_chat',
+      })
+
+      expect(result).toEqual({ decision_types: [] })
+      expect(calls).toEqual([])
+      expect(internals.traceStore.getTraces(50).traces).toHaveLength(0)
+      expect(dispatchMock).not.toHaveBeenCalled()
+      expect(executeTriggerCalls).toBe(0)
+      expect(rpcCalls).toEqual([])
+    })
+  })
+
+  // ==========================================================================
+  // 三不语义（变异靶 M12）
+  // ==========================================================================
+
+  describe('admin chat 的"三不"语义（变异靶 M12）', () => {
+    it('不进 lane：一轮 master 对话全程不碰任何会话 lane（admin REST 天然单线）', async () => {
+      boot()
+      setDispatchActions([{ kind: 'new_task', immediate_reply: '收到' }])
+      await runAdminChat()
+
+      expect(laneKeysCreated).toEqual([])
+      expect(laneBatchRuns).toEqual([])
+      expect(internals.directLaneRegistry.size()).toBe(0)
+      expect(internals.groupLaneRegistry.size()).toBe(0)
+      // 反向锚点：这轮确实处理了（不是因为早退才没碰 lane）
+      expect(spawnCalls).toHaveLength(1)
+    })
+
+    it('不进注意力调度：admin-chat 连注意力状态都不该被建出来', async () => {
+      boot()
+      setDispatchActions([{ kind: 'stay_silent' }])
+      await runAdminChat()
+
+      // 建了 state 就意味着 master 的话可能被"注意力渐远"推迟甚至跳过
+      expect(internals.attentionScheduler.getCurrentIntervalMs(ADMIN_CHAT_SESSION)).toBeUndefined()
+      expect(internals.attentionScheduler.getBufferSize(ADMIN_CHAT_SESSION)).toBe(0)
+      expect(dispatchMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('不打"已读"回应：admin-web 没有 channel 侧消息可回应', async () => {
+      boot()
+      setDispatchActions([{ kind: 'new_task', immediate_reply: '收到' }])
+      await runAdminChat()
+
+      expect(rpcCalls.find((c) => c.method === 'add_reaction')).toBeUndefined()
+      expect(calls).not.toContain('add_reaction')
+      // 反向锚点：回执确实走了 chat_callback 这条通道
+      expect(callbacksOf('direct_reply')).toHaveLength(1)
+    })
+
+    it('三不在 new_task / supplement / stay_silent 三条路径上同样成立', async () => {
+      boot()
+
+      setDispatchActions([{ kind: 'new_task', immediate_reply: '收到' }])
+      await runAdminChat(amsg({ id: 'a-1' }))
+      expectThreeNots()
+
+      setDispatchActions([{ kind: 'supplement', target_task_id: 'task-admin-active' }])
+      await runAdminChat(amsg({ id: 'a-2' }))
+      expectThreeNots()
+
+      setDispatchActions([{ kind: 'stay_silent' }])
+      await runAdminChat(amsg({ id: 'a-3' }))
+      expectThreeNots()
+
+      // 三轮都真的跑到了 dispatcher
+      expect(dispatchMock).toHaveBeenCalledTimes(3)
+      expect(spawnCalls).toHaveLength(1)
+      expect(deliverCalls).toHaveLength(1)
+    })
+  })
+
+  // ==========================================================================
+  // master 身份与记忆档位
+  // ==========================================================================
+
+  describe('master 身份与记忆档位', () => {
+    it('按 master 身份解析权限，结果决定这轮 worker 的工具面', async () => {
+      boot()
+      await runAdminChat()
+
+      const resolveCall = rpcCalls.find((c) => c.method === 'resolve_principal_permissions')
+      expect(resolveCall!.port).toBe(ADMIN_PORT)
+      expect(resolveCall!.params).toMatchObject({
+        sender_friend_id: 'master',
+        session_id: ADMIN_CHAT_SESSION,
+        session_type: 'private',
+      })
+
+      expect(spawnCalls[0].resolvedPermissions.tool_access.file_io).toBe(true)
+      expect(spawnCalls[0].resolvedPermissions.tool_access.remote_exec).toBe(false)
+      expect(
+        agent.getToolPermissionConfig([
+          { name: 'write_file', description: '', inputSchema: {}, category: 'file_io' },
+        ]),
+      ).toEqual({ mode: 'bypass' })
+      expect(
+        agent.getToolPermissionConfig([
+          { name: 'ssh_exec', description: '', inputSchema: {}, category: 'remote_exec' },
+        ]),
+      ).toEqual({ mode: 'denyList', toolNames: ['ssh_exec'] })
+    })
+
+    it('dispatcher 看到的是 master 本人（permission=master），不是普通好友', async () => {
+      boot()
+      await runAdminChat()
+
+      expect(capturedCtx!.senderFriend.id).toBe('master')
+      expect(capturedCtx!.senderFriend.permission).toBe('master')
+      expect(capturedCtx!.sessionType).toBe('admin_chat')
+      expect(capturedCtx!.channelId).toBe('admin-web')
+      expect(capturedCtx!.sessionId).toBe(ADMIN_CHAT_SESSION)
+      expect(spawnCalls[0].senderFriend.permission).toBe('master')
+    })
+
+    it('记忆档位是 master 私有档：私有可见性 + 不做 scope 过滤，且不随身份解析结果变化', async () => {
+      boot()
+      permsResponse = { ...MASTER_PERMS, memory_scopes: ['某个群 scope'] }
+      await runAdminChat()
+
+      // master 直连对话读写的是自己的私有记忆，既不是 public 也不受群 scope 限制
+      expect(assembleCalls[0].memPerms).toEqual(MASTER_MEM_PERMS)
+      expect(spawnCalls[0].memoryPermissions).toEqual(MASTER_MEM_PERMS)
+      expect(spawnCalls[0].memoryPermissions.write_visibility).not.toBe('public')
+      expect(spawnCalls[0].memoryPermissions.read_accessible_scopes).toBeUndefined()
+    })
+
+    it('身份解析失败时不覆盖会话身份，仍 fail-closed（只剩 messaging）', async () => {
+      boot()
+      permsResponse = 'throw'
+      await runAdminChat()
+
+      expect(
+        agent.getToolPermissionConfig([
+          { name: 'bash', description: '', inputSchema: {}, category: 'shell' },
+          { name: 'send_message', description: '', inputSchema: {}, category: 'messaging' },
+        ]),
+      ).toEqual({ mode: 'denyList', toolNames: ['bash'] })
+      // 解析失败不阻断这一轮：master 的话仍然被处理
+      expect(spawnCalls).toHaveLength(1)
+    })
+  })
+
+  // ==========================================================================
+  // 上下文装配与引用预取
+  // ==========================================================================
+
+  describe('上下文装配与引用预取', () => {
+    it('装配请求按 admin-web / admin-chat / private 语义发出，master 身份进装配', async () => {
+      boot()
+      await runAdminChat(amsg({ id: 'a-1', text: '继续昨天那个' }))
+
+      expect(assembleCalls[0].params).toEqual({
+        channel_id: 'admin-web',
+        session_id: ADMIN_CHAT_SESSION,
+        sender_id: 'master',
+        message: '继续昨天那个',
+        friend_id: 'f-1',
+        session_type: 'private',
+      })
+      expect(assembleCalls[0].friend?.permission).toBe('master')
+      // context_assembly span 挂在本轮 dispatch trace 上
+      const span = dispatchTrace().spans.find((s) => s.type === 'context_assembly')
+      expect(span?.status).toBe('completed')
+      expect(span?.details).toMatchObject({ context_type: 'front', channel_id: 'admin-web', session_id: ADMIN_CHAT_SESSION })
+    })
+
+    it('装配结果进 dispatcher 与 worker，触发消息不被重复渲染成历史', async () => {
+      boot()
+      const trigger = amsg({ id: 'a-1', text: '看下这个' })
+      recentMessages = [HISTORY_MESSAGE, trigger]
+      await runAdminChat(trigger)
+
+      expect(capturedCtx!.recentMessages.map((m) => m.platform_message_id)).toEqual(['hist-a1', 'a-1'])
+      expect(capturedCtx!.activeTasks.map((t) => t.task_id)).toEqual(['task-admin-active'])
+      expect(capturedCtx!.sceneProfile).toEqual(SCENE_PROFILE)
+      // worker 侧：触发消息只在 messages 里出现一次，不在历史里重复
+      expect(spawnCalls[0].messages.map((m) => m.platform_message_id)).toEqual(['a-1'])
+      expect(spawnCalls[0].frontContext.recent_messages.map((m) => m.platform_message_id)).toEqual(['hist-a1'])
+      expect(spawnCalls[0].sceneProfile).toEqual(SCENE_PROFILE)
+      expect(spawnCalls[0].activeTasks.map((t) => t.task_id)).toEqual(['task-admin-active'])
+    })
+
+    it('dispatcher 拿到的预取依赖真的能把引用原文取回来（走 admin 伪 channel 端口）', async () => {
+      boot()
+      let prefetched: ReadonlyMap<string, QuotedMessageEntry> | undefined
+      dispatchMock.mockImplementation(async (ctx, deps) => {
+        calls.push('dispatch')
+        capturedDeps = deps
+        if (deps.quotedPrefetchDeps) {
+          prefetched = await prefetchQuotedMessages(
+            ctx.messages,
+            ctx.recentMessages,
+            ctx.channelId,
+            ctx.sessionId,
+            'private',
+            deps.quotedPrefetchDeps,
+            () => 'master',
+          )
+        }
+        return { actions: [{ kind: 'stay_silent' }] }
+      })
+
+      await runAdminChat(amsg({ id: 'a-1', text: '这条怎么说', replyTo: 'quoted-origin-a1' }))
+
+      expect(prefetched?.get('quoted-origin-a1')?.msg.content.text).toBe('这是被引用的原文')
+      const fetch = rpcCalls.find((c) => c.method === 'get_message')
+      expect(fetch!.port).toBe(ADMIN_PORT)
+      expect(fetch!.params).toMatchObject({ session_id: ADMIN_CHAT_SESSION, platform_message_id: 'quoted-origin-a1' })
+      expect(capturedDeps!.timezone).toBeTruthy()
+    })
+  })
+
+  // ==========================================================================
+  // 回执通道与顺序
+  // ==========================================================================
+
+  describe('回执通道与顺序', () => {
+    it('一轮新建任务的固定顺序：决策 → 预回复回执 → 注册任务 → 任务卡回执 → 起 worker', async () => {
+      boot()
+      setDispatchActions([{ kind: 'new_task', immediate_reply: '收到，我看一下' }])
+
+      await runAdminChat()
+
+      expect(calls).toEqual([
+        'start_trace:message',
+        'resolve_permissions',
+        'assemble_front_context',
+        'dispatch',
+        'chat_callback:direct_reply',
+        'register_trigger',
+        'chat_callback:task_created',
+        'start_trace:task',
+        'worker_loop',
+      ])
+    })
+
+    it('预回复走 chat_callback 并合成 ack 元数据进 worker 上下文（admin-web 没有真实 platform_message_id）', async () => {
+      boot()
+      setDispatchActions([{ kind: 'new_task', immediate_reply: '收到，我看一下' }])
+
+      await runAdminChat()
+
+      const direct = callbacksOf('direct_reply')
+      expect(direct).toHaveLength(1)
+      expect(direct[0]).toMatchObject({ request_id: REQUEST_ID, content: '收到，我看一下' })
+
+      const history = spawnCalls[0].frontContext.recent_messages
+      const ack = history[history.length - 1]
+      expect(ack.content.text).toBe('收到，我看一下')
+      expect(ack.sender.platform_user_id).toBe('self')
+      expect(ack.platform_message_id).toMatch(/^dispatcher-ack-/)
+      // ack 必须挂在 admin chat 会话上
+      expect(ack.session.channel_id).toBe('admin-web')
+      expect(ack.session.session_id).toBe(ADMIN_CHAT_SESSION)
+      expect(ack.session.type).toBe('private')
+    })
+
+    it('没有预回复时不发 direct_reply 回执，也不往 worker 上下文里塞 ack', async () => {
+      boot()
+      setDispatchActions([{ kind: 'new_task' }])
+
+      await runAdminChat()
+
+      expect(callbacksOf('direct_reply')).toHaveLength(0)
+      expect(spawnCalls[0].frontContext.recent_messages.map((m) => m.platform_message_id)).toEqual(['hist-a1'])
+    })
+
+    it('任务注册后立刻回一张任务卡（带 task_id 与标题），前端据此显示任务状态', async () => {
+      boot()
+      await runAdminChat()
+
+      const created = callbacksOf('task_created')
+      expect(created).toHaveLength(1)
+      expect(created[0]).toEqual({
+        request_id: REQUEST_ID,
+        reply_type: 'task_created',
+        content: '已创建任务：新建的 master 任务',
+        task_id: 'task-admin-new',
+      })
+      // 本轮 dispatch trace 关联到新建的任务
+      expect(dispatchTrace().related_task_id).toBe('task-admin-new')
+    })
+  })
+
+  // ==========================================================================
+  // 返回值（RPC 响应）
+  // ==========================================================================
+
+  describe('返回值（RPC 响应）', () => {
+    it('新建任务 → decision_types 报 create_task', async () => {
+      boot()
+      setDispatchActions([{ kind: 'new_task' }, { kind: 'new_task' }])
+
+      const result = await runAdminChat()
+
+      expect(result.decision_types).toEqual(['create_task', 'create_task'])
+      expect(result.task_ids).toBeUndefined()
+    })
+
+    it('往在跑的任务补充 → 回报目标任务 id，不报 create_task', async () => {
+      boot()
+      setDispatchActions([{ kind: 'supplement', target_task_id: 'task-admin-active' }])
+
+      const result = await runAdminChat()
+
+      expect(result.decision_types).toEqual([])
+      expect(result.task_ids).toEqual(['task-admin-active'])
+      expect(deliverCalls).toHaveLength(1)
+    })
+
+    it('dispatcher 一个动作都不给 → 空返回，trace 记 silent', async () => {
+      boot()
+      setDispatchActions([])
+
+      const result = await runAdminChat()
+
+      expect(result).toEqual({ decision_types: [], task_ids: undefined })
+      expect(dispatchTrace().status).toBe('completed')
+      expect(dispatchTrace().outcome?.summary).toBe('silent')
+      expect(spawnCalls).toHaveLength(0)
+    })
+  })
+
+  // ==========================================================================
+  // supplement 分支
+  // ==========================================================================
+
+  describe('补充投递（supplement）', () => {
+    it('投递前先回一条带 task_id 的回执，再把消息交给目标任务', async () => {
+      boot()
+      setDispatchActions([{ kind: 'supplement', target_task_id: 'task-admin-active' }])
+
+      await runAdminChat(amsg({ id: 'a-1', text: '再补一句：只要中文' }))
+
+      const cb = callbacksOf('direct_reply')
+      expect(cb).toHaveLength(1)
+      expect(cb[0]).toMatchObject({ content: '收到，正在调整。', task_id: 'task-admin-active' })
+      expect(calls.indexOf('chat_callback:direct_reply')).toBeLessThan(calls.indexOf('deliver_human_response'))
+
+      expect(deliverCalls[0].taskId).toBe('task-admin-active')
+      // 投递的是 master 身份的合成消息，内容是本轮原文
+      const delivered = deliverCalls[0].messages[0]
+      expect(delivered.content.text).toBe('再补一句：只要中文')
+      expect(delivered.sender.platform_user_id).toBe('master')
+      expect(delivered.session.channel_id).toBe('admin-web')
+      expect(delivered.session.session_id).toBe(ADMIN_CHAT_SESSION)
+      expect(spawnCalls).toHaveLength(0)
+    })
+
+    it('目标任务已经不在跑 → 回落成新建任务，不静默丢掉这句话', async () => {
+      boot()
+      hasActiveTaskResult = false
+      setDispatchActions([{ kind: 'supplement', target_task_id: 'task-admin-active' }])
+
+      await runAdminChat()
+
+      expect(deliverCalls).toHaveLength(0)
+      expect(spawnCalls).toHaveLength(1)
+    })
+
+    it('定时任务不接受补充 → 同样回落成新建任务', async () => {
+      boot()
+      activeTasks = [SCHEDULED_TASK]
+      supplementCandidates = [SCHEDULED_TASK]
+      setDispatchActions([{ kind: 'supplement', target_task_id: 'task-admin-scheduled' }])
+
+      await runAdminChat()
+
+      expect(deliverCalls).toHaveLength(0)
+      expect(spawnCalls).toHaveLength(1)
+    })
+  })
+
+  // ==========================================================================
+  // worker 不阻塞 RPC（变异靶 M10 在 admin chat 路径）
+  // ==========================================================================
+
+  describe('worker 不阻塞 RPC 响应（变异靶 M10）', () => {
+    it('worker 还在跑时 RPC 就已返回（长任务不该撑爆 process_message 超时）', async () => {
+      boot()
+      let release: () => void = () => {}
+      workerGate = new Promise<void>((resolve) => {
+        release = resolve
+      })
+
+      const result = await runAdminChat()
+
+      // 到这里 handleProcessMessage 已经返回——改成同步等 worker 时这一行永远到不了
+      expect(calls).toContain('worker_loop')
+      expect(workerSettled).toBe(false)
+      expect(result.decision_types).toEqual(['create_task'])
+      expect(dispatchTrace().status).toBe('completed')
+      expect(dispatchTrace().outcome?.summary).toBe('dispatched (1 actions)')
+
+      release()
+      await new Promise((resolve) => process.nextTick(resolve))
+      expect(workerSettled).toBe(true)
+    }, 5000)
+  })
+
+  // ==========================================================================
+  // 早退与异常
+  // ==========================================================================
+
+  describe('早退与异常', () => {
+    it('未配置 LLM：回一条提示、trace 记失败，不进 dispatcher', async () => {
+      boot({ configured: false })
+
+      const result = await runAdminChat()
+
+      expect(result).toEqual({ decision_types: [] })
+      expect(callbacksOf('direct_reply')[0]).toMatchObject({
+        request_id: REQUEST_ID,
+        content: 'Crabot 尚未配置 LLM 模型。请在全局设置中完成配置后重试。',
+      })
+      expect(dispatchTrace().status).toBe('failed')
+      expect(dispatchTrace().outcome?.summary).toBe('Agent not configured')
+      expect(dispatchMock).not.toHaveBeenCalled()
+      expectThreeNots()
+    })
+
+    it('没有 worker handler：回"系统暂时不可用"、trace 记失败', async () => {
+      boot({ withHandler: false })
+      internals.agentHandler = undefined
+
+      const result = await runAdminChat()
+
+      expect(result).toEqual({ decision_types: [] })
+      expect(callbacksOf('direct_reply')[0]).toMatchObject({ content: '系统暂时不可用' })
+      expect(dispatchTrace().status).toBe('failed')
+      expect(dispatchTrace().outcome?.summary).toBe('No worker handler configured')
+      expect(dispatchMock).not.toHaveBeenCalled()
+    })
+
+    it('没有 worker LLM 环境：早退发生在解析身份与装配上下文之前（不做白工）', async () => {
+      boot({ withSdkEnv: false })
+      internals.sdkEnvWorker = undefined
+
+      const result = await runAdminChat()
+
+      // 注：这条早退当前**不发** chat_callback（另外两条都发），前端会静默卡住——
+      //     那是已登记的 bug（p7a-task1-report.md §6 O3）不是契约，所以这里不断言"没有回执"，
+      //     将来补上回执时本用例不该被误挂。
+      expect(result).toEqual({ decision_types: [] })
+      expect(dispatchTrace().status).toBe('failed')
+      expect(dispatchTrace().outcome?.summary).toBe('sdkEnvWorker missing')
+      expect(dispatchMock).not.toHaveBeenCalled()
+      // 与私聊/群聊不同：admin chat 的这条早退在 resolve/assemble **之前**
+      // （`unified-agent.ts:1671` vs 私聊 `:857`），所以既不解析身份也不装配上下文
+      expect(calls).toEqual(['start_trace:message'])
+      expect(assembleCalls).toEqual([])
+    })
+
+    it('处理中抛错：trace 记失败并把错误抛回 RPC 调用方（与 channel 入站的吞错不同）', async () => {
+      boot()
+      dispatchMock.mockImplementation(async () => {
+        calls.push('dispatch')
+        throw new Error('dispatch boom')
+      })
+
+      await expect(runAdminChat()).rejects.toThrow('dispatch boom')
+
+      expect(dispatchTrace().status).toBe('failed')
+      expect(dispatchTrace().outcome?.error).toBe('dispatch boom')
+      expect(spawnCalls).toHaveLength(0)
+      expectThreeNots()
+    })
+  })
+})

--- a/crabot-agent/tests/inbound/process-direct-batch.test.ts
+++ b/crabot-agent/tests/inbound/process-direct-batch.test.ts
@@ -1,0 +1,796 @@
+/**
+ * 入站链路测试网 ②：`processDirectBatch`（P7 / PR A Task 2）。
+ *
+ * 计划：`crabot-docs/superpowers/plans/2026-07-31-mw-p7-a-inbound-test-net.md`
+ * 侦察：`.superpowers/sdd/p7-recon.md` §A.2 —— "processDirectBatch 在 dispatcher 之前做的 8 件事"
+ *
+ * ## 覆盖的 8 个动作（含顺序）
+ *
+ * | 动作 | 生产位置 |
+ * |---|---|
+ * | `sessionManager.updateLastMessageTime` | `unified-agent.ts:786` |
+ * | `traceStore.startTrace(trigger.type='message')` | `:789-799` |
+ * | `resolvePrincipalPermissions` → `ResolvedPermissions` | `:807` |
+ * | memory 权限档位（按 friend 的 memory_scopes） | `:809-816` |
+ * | `contextAssembler.assembleFrontContext` | `:831-845` |
+ * | `buildQuotedPrefetchDeps()`（引用预取） | `:887` |
+ * | `sendErrorToUser` / `sendImmediateReply` | `:865-882` |
+ * | `reactToTriggerMessage` | `:913` |
+ *
+ * ## 手法（沿用 Task 1 的结论）
+ *
+ * - **真实构造函数**（`roles: []`，不建 AgentHandler / 不起 LSP），只在实例上换掉
+ *   `agentHandler` / `contextAssembler` / `sdkEnvWorker` / `rpcClient` 这几个外部边界；
+ * - **只 mock 模块级 `dispatch`**（LLM 入口，无实例注入口），
+ *   **`executeDispatchActions` 用真件**——M8（reaction）/ M11（预回复 vs spawn 顺序）/
+ *   supplement 三分支的语义恰恰长在执行器里，把执行器也 mock 掉就只剩参数透传可断言；
+ * - **`traceStore` 用真实的**（tmp `DATA_DIR`）：trace/span 是这条链路的可观测事实来源，
+ *   顺序、早退分支、supplement 走的哪条路都从 span 上读；
+ * - **顺序断言只用一条 `calls: string[]` 序列**，不用各自的 `toHaveBeenCalled`；
+ * - 全链路无 `setTimeout`，不引 fake timer（会和 TraceStore / manager 栈的内部 timer 打架）。
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+import { UnifiedAgent } from '../../src/unified-agent.js'
+import { prefetchQuotedMessages } from '../../src/agent/quoted-message-prefetcher.js'
+import type { QuotedMessageEntry } from '../../src/prompt-manager.js'
+import type {
+  AgentTrace,
+  ChannelMessage,
+  Friend,
+  MemoryPermissions,
+  ResolvedPermissions,
+  TaskSummary,
+  ToolAccessConfig,
+} from '../../src/types.js'
+import type { DispatchAction, DispatchContext } from '../../src/dispatcher/dispatcher-types.js'
+import type { DispatchDeps } from '../../src/dispatcher/dispatcher.js'
+import { makeAgentConfig, makeFriend, makeMessage, useTmpDataDir, type DataDirGuard } from './harness.js'
+
+// dispatch 是模块级 import，没有实例注入口——这是本文件唯一 mock 掉的生产模块。
+vi.mock('../../src/dispatcher/dispatcher.js', () => ({ dispatch: vi.fn() }))
+import { dispatch } from '../../src/dispatcher/dispatcher.js'
+
+const dispatchMock = vi.mocked(dispatch)
+
+// ============================================================================
+// fixtures
+// ============================================================================
+
+const ADMIN_PORT = 18000
+const WECHAT_PORT = 18001
+
+/** 该 friend 解析出的权限身份：shell 开、file_io 关，memory_scopes 是两个私聊专属 scope。 */
+const FRIEND_TOOL_ACCESS: ToolAccessConfig = {
+  memory: true,
+  messaging: true,
+  task: true,
+  mcp_skill: true,
+  file_io: false,
+  browser: false,
+  shell: true,
+  remote_exec: false,
+  desktop: false,
+}
+
+const FRIEND_PERMS: ResolvedPermissions = {
+  tool_access: FRIEND_TOOL_ACCESS,
+  cli_access: {} as ResolvedPermissions['cli_access'],
+  storage: null,
+  memory_scopes: ['friend-scope-a', 'friend-scope-b'],
+}
+
+/** 上下文装配吐出的历史消息（不属于当前触发批次）。 */
+const HISTORY_MESSAGE = makeMessage({
+  id: 'hist-1',
+  type: 'private',
+  text: '昨天说的那个 PDF',
+  timestamp: '2026-07-30T10:00:00.000Z',
+})
+
+const SCENE_PROFILE = {
+  label: '私聊场景',
+  content: '这个人喜欢直接给结论',
+  source: { scene: { type: 'friend' as const, friend_id: 'f-1' } },
+}
+
+const ACTIVE_TASK: TaskSummary = {
+  task_id: 'task-active-1',
+  title: '在跑的任务',
+  status: 'executing',
+  priority: 'normal',
+}
+
+/** 已终止的 supplement 候选——只可能来自 assembleFrontContext.supplement_candidates。 */
+const TERMINAL_CANDIDATE: TaskSummary = {
+  task_id: 'task-terminal-1',
+  title: '刚做完的任务',
+  status: 'completed',
+  priority: 'normal',
+  candidate_kind: 'recent_terminal',
+  completed_at: '2026-07-31T00:00:00.000Z',
+}
+
+interface AssembleCall {
+  params: {
+    channel_id: string
+    session_id: string
+    sender_id: string
+    message: string
+    friend_id: string
+    session_type: string
+    crab_self_handle?: string
+  }
+  friend: Friend | undefined
+  memPerms: MemoryPermissions
+}
+
+interface SpawnCall {
+  messages: ReadonlyArray<ChannelMessage>
+  activeTasks: ReadonlyArray<TaskSummary>
+  isGroup: boolean
+  senderFriend: Friend
+  memoryPermissions: MemoryPermissions
+  resolvedPermissions: ResolvedPermissions
+  channelId: string
+  sessionId: string
+  frontContext: { recent_messages: ChannelMessage[]; scene_profile?: unknown }
+  sceneProfile?: unknown
+}
+
+interface Internals {
+  processDirectBatch(batch: ReadonlyArray<{ message: ChannelMessage; friend: Friend }>): Promise<void>
+  sessionManager: {
+    updateLastMessageTime(sessionId: string): void
+    getSession(sessionId: string): { message_count: number; last_message_time: number } | undefined
+  }
+  traceStore: {
+    getTraces(limit?: number): { traces: AgentTrace[] }
+    startTrace(params: { trigger: { type: string } }): { trace_id: string }
+  }
+  contextAssembler: unknown
+  agentHandler: unknown
+  sdkEnvWorker: unknown
+  channelPorts: Map<string, number>
+  crabSelfHandles: Map<string, string>
+  attentionScheduler: { stopAll(): void }
+  rpcClient: {
+    call: (port: number, method: string, params: unknown, from?: string) => Promise<unknown>
+    resolve: (filter: unknown, from?: string) => Promise<unknown[]>
+  }
+}
+
+describe('processDirectBatch —— 私聊 lane handler（P7/PR A 测试网 ②）', () => {
+  let dataDir: DataDirGuard
+  let agent: UnifiedAgent
+  let internals: Internals
+
+  /** 唯一的顺序事实来源。 */
+  let calls: string[]
+  let rpcCalls: Array<{ port: number; method: string; params: Record<string, unknown> }>
+  let assembleCalls: AssembleCall[]
+  let spawnCalls: SpawnCall[]
+  let deliverCalls: Array<{ taskId: string; messages: ReadonlyArray<ChannelMessage> }>
+  let capturedCtx: DispatchContext | undefined
+  let capturedDeps: DispatchDeps | undefined
+
+  // 可按测试改写的响应
+  let permsResponse: ResolvedPermissions | 'throw'
+  let sessionScopes: string[]
+  let supplementCandidates: TaskSummary[]
+  let activeTasks: TaskSummary[]
+  let recentMessages: ChannelMessage[]
+  let hasActiveTaskResult: boolean
+  /** worker loop 的放行闸：默认立即完成；M10 用它把 worker 挂住。 */
+  let workerGate: Promise<void> | undefined
+  let workerSettled: boolean
+
+  function boot(opts: { withHandler?: boolean; withSdkEnv?: boolean } = {}): void {
+    agent = new UnifiedAgent(makeAgentConfig({ configured: true, moduleId: 'direct-batch-agent', port: 19997 }))
+    internals = agent as unknown as Internals
+
+    internals.channelPorts.set('wechat', WECHAT_PORT)
+    internals.crabSelfHandles.set('wechat', '@crabot_wx')
+
+    internals.rpcClient.resolve = async () => [
+      { module_id: 'admin', module_type: 'admin', host: 'localhost', port: ADMIN_PORT, status: 'running' },
+    ]
+    internals.rpcClient.call = async (port, method, params) => {
+      rpcCalls.push({ port, method, params: params as Record<string, unknown> })
+      switch (method) {
+        case 'resolve_principal_permissions':
+          calls.push('resolve_permissions')
+          if (permsResponse === 'throw') throw new Error('admin unreachable')
+          return { resolved: permsResponse, sources: {} }
+        case 'get_session_config':
+          calls.push('get_session_config')
+          return { config: { memory_scopes: sessionScopes } }
+        case 'send_message':
+          calls.push('send_message')
+          return { platform_message_id: 'ack-1', sent_at: '2026-07-31T00:00:05.000Z' }
+        case 'add_reaction':
+          calls.push('add_reaction')
+          return {}
+        case 'get_message':
+          calls.push('get_message')
+          return {
+            platform_message_id: (params as { platform_message_id: string }).platform_message_id,
+            sender: { platform_user_id: 'u-1', platform_display_name: '张三' },
+            content: { type: 'text', text: '这是跨窗口引用的原文' },
+            features: {},
+            platform_timestamp: '2026-07-20T00:00:00.000Z',
+          }
+        case 'revive_task_for_supplement':
+          calls.push('revive_task_for_supplement')
+          return {}
+        default:
+          return {}
+      }
+    }
+
+    // trace 起点：按 trigger 类型区分 dispatch trace 与 task trace。
+    const realStartTrace = internals.traceStore.startTrace.bind(internals.traceStore)
+    internals.traceStore.startTrace = (params) => {
+      calls.push(`start_trace:${params.trigger.type}`)
+      return realStartTrace(params)
+    }
+
+    const realUpdate = internals.sessionManager.updateLastMessageTime.bind(internals.sessionManager)
+    internals.sessionManager.updateLastMessageTime = (sessionId: string) => {
+      calls.push('update_last_message_time')
+      realUpdate(sessionId)
+    }
+
+    internals.contextAssembler = {
+      assembleFrontContext: async (
+        params: AssembleCall['params'],
+        friend: Friend | undefined,
+        memPerms: MemoryPermissions,
+      ) => {
+        calls.push('assemble_front_context')
+        assembleCalls.push({ params, friend, memPerms })
+        return {
+          sender_friend: friend,
+          recent_messages: recentMessages,
+          short_term_memories: [],
+          active_tasks: activeTasks,
+          available_tools: [],
+          scene_profile: SCENE_PROFILE,
+          crab_self_handle: '@crabot_wx',
+          time_windows: { recent_messages_window_hours: 24, short_term_memory_window_hours: 24 },
+          supplement_candidates: supplementCandidates,
+        }
+      },
+    }
+
+    if (opts.withHandler !== false) {
+      internals.agentHandler = {
+        hasActiveTask: () => hasActiveTaskResult,
+        deliverHumanResponse: (taskId: string, messages: ReadonlyArray<ChannelMessage>) => {
+          calls.push('deliver_human_response')
+          deliverCalls.push({ taskId, messages })
+        },
+        getTaskPrincipal: () => undefined,
+        updateTaskPermissions: () => {},
+        getInflightSnapshot: () => [],
+        registerTriggerAndActivate: async (params: SpawnCall) => {
+          calls.push('register_trigger')
+          spawnCalls.push(params)
+          return {
+            taskId: 'task-new-1',
+            registered: true,
+            task: {},
+            context: {},
+            taskTitle: '新任务标题',
+          }
+        },
+        runTriggerWorkerLoop: async () => {
+          calls.push('worker_loop')
+          if (workerGate) await workerGate
+          workerSettled = true
+          return { outcome: 'completed', finalText: '搞定', sentMessage: true }
+        },
+      }
+    }
+
+    if (opts.withSdkEnv !== false) {
+      internals.sdkEnvWorker = {
+        modelId: 'worker-model',
+        format: 'anthropic',
+        env: { LLM_BASE_URL: 'https://example.invalid', LLM_API_KEY: 'k' },
+      }
+    }
+  }
+
+  /** 设定 dispatcher 的输出；同时录 ctx/deps 供引用预取等断言使用。 */
+  function setDispatchActions(actions: DispatchAction[]): void {
+    dispatchMock.mockImplementation(async (ctx, deps) => {
+      calls.push('dispatch')
+      capturedCtx = ctx
+      capturedDeps = deps
+      return { actions }
+    })
+  }
+
+  function batchOf(messages: ChannelMessage[], friend = makeFriend('f-1')) {
+    return messages.map((message) => ({ message, friend }))
+  }
+
+  function dispatchTrace(): AgentTrace {
+    const t = internals.traceStore.getTraces(50).traces.find((x) => x.trigger.type === 'message')
+    if (!t) throw new Error('dispatch trace not found')
+    return t
+  }
+
+  function actionSpanDetails(): Record<string, unknown> {
+    const span = dispatchTrace().spans.find((s) => s.type === 'dispatch_action')
+    if (!span) throw new Error('dispatch_action span not found')
+    return (span.details ?? {}) as Record<string, unknown>
+  }
+
+  beforeEach(async () => {
+    calls = []
+    rpcCalls = []
+    assembleCalls = []
+    spawnCalls = []
+    deliverCalls = []
+    capturedCtx = undefined
+    capturedDeps = undefined
+    permsResponse = FRIEND_PERMS
+    sessionScopes = ['session-scope-1']
+    supplementCandidates = [ACTIVE_TASK]
+    activeTasks = [ACTIVE_TASK]
+    recentMessages = [HISTORY_MESSAGE]
+    hasActiveTaskResult = true
+    workerGate = undefined
+    workerSettled = false
+    dispatchMock.mockReset()
+    setDispatchActions([{ kind: 'new_task' }])
+    dataDir = await useTmpDataDir('inbound-pdb-')
+  })
+
+  afterEach(async () => {
+    internals?.attentionScheduler.stopAll()
+    vi.restoreAllMocks()
+    await dataDir.restore()
+  })
+
+  // ==========================================================================
+  // 动作 1 / 2：会话状态与 trace 起点
+  // ==========================================================================
+
+  describe('会话状态与 trace 起点', () => {
+    it('整批只推进一次会话活跃时间（每条消息各推一次会把 TTL 语义算错）', async () => {
+      boot()
+      await internals.processDirectBatch(
+        batchOf([
+          makeMessage({ id: 'm-1', type: 'private', text: '第一条' }),
+          makeMessage({ id: 'm-2', type: 'private', text: '第二条' }),
+        ]),
+      )
+
+      const session = internals.sessionManager.getSession('sess-1')
+      expect(session).toBeDefined()
+      expect(session!.message_count).toBe(1)
+      expect(calls.filter((c) => c === 'update_last_message_time')).toHaveLength(1)
+    })
+
+    it('trace 记的是 message 触发、批内每条消息都进 summary、source 是来源 channel（变异靶 M2）', async () => {
+      boot()
+      await internals.processDirectBatch(
+        batchOf([
+          makeMessage({ id: 'm-1', type: 'private', text: '第一条' }),
+          makeMessage({ id: 'm-2', type: 'private', text: '第二条' }),
+        ]),
+      )
+
+      const trace = dispatchTrace()
+      expect(trace.trigger.type).toBe('message')
+      expect(trace.trigger.source).toBe('wechat')
+      expect(trace.trigger.summary).toBe('[private×2] 第一条 | 第二条')
+      expect(trace.module_id).toBe('direct-batch-agent')
+    })
+
+    it('空 batch 直接返回：不动会话、不建 trace', async () => {
+      boot()
+      await internals.processDirectBatch([])
+
+      expect(calls).toEqual([])
+      expect(internals.traceStore.getTraces(50).traces).toHaveLength(0)
+    })
+  })
+
+  // ==========================================================================
+  // 动作 3：权限身份解析（M4）
+  // ==========================================================================
+
+  describe('权限身份解析（变异靶 M4）', () => {
+    it('解析出的身份决定这轮之后 worker 能用哪些工具', async () => {
+      boot()
+      await internals.processDirectBatch(batchOf([makeMessage({ id: 'm-1', type: 'private' })]))
+
+      // 语义落点①：worker 拿到的执行身份
+      expect(spawnCalls).toHaveLength(1)
+      expect(spawnCalls[0].resolvedPermissions?.tool_access.shell).toBe(true)
+      expect(spawnCalls[0].resolvedPermissions?.tool_access.file_io).toBe(false)
+
+      // 语义落点②：会话级权限被记住——后续按此身份授权工具（shell 放行、file_io 拦）
+      expect(
+        agent.getToolPermissionConfig([
+          { name: 'bash', description: '', inputSchema: {}, category: 'shell' },
+        ]),
+      ).toEqual({ mode: 'bypass' })
+      expect(
+        agent.getToolPermissionConfig([
+          { name: 'write_file', description: '', inputSchema: {}, category: 'file_io' },
+        ]),
+      ).toEqual({ mode: 'denyList', toolNames: ['write_file'] })
+
+      // 解析请求打的是 admin，带的是这条私聊会话的身份三元组
+      const resolveCall = rpcCalls.find((c) => c.method === 'resolve_principal_permissions')
+      expect(resolveCall).toBeDefined()
+      expect(resolveCall!.port).toBe(ADMIN_PORT)
+      expect(resolveCall!.params).toMatchObject({
+        sender_friend_id: 'f-1',
+        session_id: 'sess-1',
+        session_type: 'private',
+      })
+    })
+
+    it('解析失败时 fail-closed（只剩 messaging），不是放开也不是沿用上一轮', async () => {
+      boot()
+      permsResponse = 'throw'
+      await internals.processDirectBatch(batchOf([makeMessage({ id: 'm-1', type: 'private' })]))
+
+      expect(
+        agent.getToolPermissionConfig([
+          { name: 'bash', description: '', inputSchema: {}, category: 'shell' },
+          { name: 'send_message', description: '', inputSchema: {}, category: 'messaging' },
+        ]),
+      ).toEqual({ mode: 'denyList', toolNames: ['bash'] })
+    })
+  })
+
+  // ==========================================================================
+  // 动作 4：memory 权限档位（M5）
+  // ==========================================================================
+
+  describe('memory 权限档位（变异靶 M5）', () => {
+    it('按该 friend 解析出的 memory_scopes 授权读写，不是 public/全局', async () => {
+      boot()
+      await internals.processDirectBatch(batchOf([makeMessage({ id: 'm-1', type: 'private' })]))
+
+      const expected: MemoryPermissions = {
+        write_visibility: 'internal',
+        write_scopes: ['friend-scope-a', 'friend-scope-b'],
+        read_min_visibility: 'internal',
+        read_accessible_scopes: ['friend-scope-a', 'friend-scope-b'],
+      }
+      // 语义落点：worker 这轮能读到 / 写进的记忆范围
+      expect(spawnCalls[0].memoryPermissions).toEqual(expected)
+      // 上下文装配用的是同一档位（读侧不得比写侧宽）
+      expect(assembleCalls[0].memPerms).toEqual(expected)
+      // 反向钉死：不能退化成"公开可见 + 无 scope 限制"
+      expect(spawnCalls[0].memoryPermissions.write_visibility).not.toBe('public')
+      expect(spawnCalls[0].memoryPermissions.write_scopes).not.toEqual([])
+    })
+
+    it('身份解析失败时档位回落到该 session 配置的 scopes（仍不是公开）', async () => {
+      boot()
+      permsResponse = 'throw'
+      sessionScopes = ['session-scope-1']
+      await internals.processDirectBatch(batchOf([makeMessage({ id: 'm-1', type: 'private' })]))
+
+      expect(spawnCalls[0].memoryPermissions).toEqual({
+        write_visibility: 'internal',
+        write_scopes: ['session-scope-1'],
+        read_min_visibility: 'internal',
+        read_accessible_scopes: ['session-scope-1'],
+      })
+      expect(calls).toContain('get_session_config')
+    })
+  })
+
+  // ==========================================================================
+  // 动作 5：前置上下文装配（M6）
+  // ==========================================================================
+
+  describe('前置上下文装配（变异靶 M6）', () => {
+    it('装配结果进入 dispatcher 的决策上下文（历史消息 / 场景画像 / 候选任务）', async () => {
+      boot()
+      setDispatchActions([{ kind: 'stay_silent' }])
+      await internals.processDirectBatch(batchOf([makeMessage({ id: 'm-1', type: 'private', text: '继续弄那个' })]))
+
+      expect(capturedCtx).toBeDefined()
+      expect(capturedCtx!.recentMessages.map((m) => m.platform_message_id)).toEqual(['hist-1'])
+      expect(capturedCtx!.activeTasks.map((t) => t.task_id)).toEqual(['task-active-1'])
+      expect(capturedCtx!.sceneProfile).toEqual(SCENE_PROFILE)
+      expect(capturedCtx!.crabSelfHandle).toBe('@crabot_wx')
+      expect(capturedCtx!.sessionType).toBe('private')
+      // 装配请求描述的是这次的会话与发言人
+      expect(assembleCalls[0].params).toMatchObject({
+        channel_id: 'wechat',
+        session_id: 'sess-1',
+        sender_id: 'u-1',
+        friend_id: 'f-1',
+        session_type: 'private',
+        message: '继续弄那个',
+        crab_self_handle: '@crabot_wx',
+      })
+    })
+
+    it('装配出的历史进 worker，且触发批次不被重复渲染成历史', async () => {
+      boot()
+      const trigger = makeMessage({ id: 'm-1', type: 'private' })
+      // 上下文里同时含有历史消息和这条触发消息的副本（真实 message-store 就是这样）
+      recentMessages = [HISTORY_MESSAGE, trigger]
+      await internals.processDirectBatch(batchOf([trigger]))
+
+      expect(spawnCalls[0].frontContext.recent_messages.map((m) => m.platform_message_id)).toEqual(['hist-1'])
+      expect(spawnCalls[0].activeTasks.map((t) => t.task_id)).toEqual(['task-active-1'])
+      expect(spawnCalls[0].sceneProfile).toEqual(SCENE_PROFILE)
+    })
+
+    it('只有装配结果里的候选任务才认得出"已终止任务"，从而走复活而不是往活任务里投递', async () => {
+      boot()
+      supplementCandidates = [TERMINAL_CANDIDATE]
+      setDispatchActions([{ kind: 'supplement', target_task_id: 'task-terminal-1' }])
+
+      await internals.processDirectBatch(batchOf([makeMessage({ id: 'm-1', type: 'private', text: '补一句' })]))
+
+      // 走的是终止任务复活路径
+      expect(calls).toContain('revive_task_for_supplement')
+      expect(actionSpanDetails().outcome).toBe('terminal_task_revived')
+      expect(actionSpanDetails().target_task_status).toBe('completed')
+      // 而不是把补充消息塞进某个"活着的"任务
+      expect(deliverCalls).toHaveLength(0)
+      // dispatch trace 归到目标任务名下（UI 按任务聚合靠它）
+      expect(dispatchTrace().related_task_id).toBe('task-terminal-1')
+    })
+  })
+
+  // ==========================================================================
+  // 动作 6：引用消息预取（M7）
+  // ==========================================================================
+
+  describe('引用消息预取（变异靶 M7）', () => {
+    it('dispatcher 拿到的预取依赖真的能把跨窗口引用的原文取回来', async () => {
+      boot()
+      let prefetched: ReadonlyMap<string, QuotedMessageEntry> | undefined
+      dispatchMock.mockImplementation(async (ctx, deps) => {
+        calls.push('dispatch')
+        capturedDeps = deps
+        // 用真实 prefetcher 跑一遍：验证的是"这组依赖可用"，不是"某个字段被传进来了"
+        if (deps.quotedPrefetchDeps) {
+          prefetched = await prefetchQuotedMessages(
+            ctx.messages,
+            ctx.recentMessages,
+            ctx.channelId,
+            ctx.sessionId,
+            'private',
+            deps.quotedPrefetchDeps,
+            () => 'friend',
+          )
+        }
+        return { actions: [{ kind: 'stay_silent' }] }
+      })
+
+      await internals.processDirectBatch(
+        batchOf([makeMessage({ id: 'm-1', type: 'private', text: '这个怎么办', replyTo: 'quoted-origin-1' })]),
+      )
+
+      expect(prefetched?.get('quoted-origin-1')?.msg.content.text).toBe('这是跨窗口引用的原文')
+      const fetch = rpcCalls.find((c) => c.method === 'get_message')
+      expect(fetch).toBeDefined()
+      expect(fetch!.port).toBe(WECHAT_PORT)
+      expect(fetch!.params).toMatchObject({ session_id: 'sess-1', platform_message_id: 'quoted-origin-1' })
+      // 时区也一并传给 dispatcher（消息时间戳本地化）
+      expect(capturedDeps!.timezone).toBeTruthy()
+    })
+  })
+
+  // ==========================================================================
+  // 动作 7 / 8：预回复、spawn 顺序与 reaction（M11 / M8 / M2）
+  // ==========================================================================
+
+  describe('预回复 / spawn / reaction 的顺序（变异靶 M11、M8）', () => {
+    it('8 件事按固定顺序发生：预回复必须在 worker 起来之前发出去', async () => {
+      boot()
+      setDispatchActions([{ kind: 'new_task', immediate_reply: '收到，我看一下' }])
+
+      await internals.processDirectBatch(batchOf([makeMessage({ id: 'm-1', type: 'private' })]))
+
+      expect(calls).toEqual([
+        'update_last_message_time',
+        'start_trace:message',
+        'resolve_permissions',
+        'assemble_front_context',
+        'dispatch',
+        'send_message',
+        'register_trigger',
+        'start_trace:task',
+        'worker_loop',
+        'add_reaction',
+      ])
+    })
+
+    it('预回复的落地元数据进 worker 的上下文（worker 因此知道自己已经 ack 过）', async () => {
+      boot()
+      setDispatchActions([{ kind: 'new_task', immediate_reply: '收到，我看一下' }])
+
+      await internals.processDirectBatch(batchOf([makeMessage({ id: 'm-1', type: 'private' })]))
+
+      const sent = rpcCalls.find((c) => c.method === 'send_message')
+      expect(sent!.port).toBe(WECHAT_PORT)
+      expect(sent!.params).toMatchObject({
+        session_id: 'sess-1',
+        content: { type: 'text', text: '收到，我看一下' },
+      })
+
+      const history = spawnCalls[0].frontContext.recent_messages
+      const ack = history[history.length - 1]
+      expect(ack.platform_message_id).toBe('ack-1')
+      expect(ack.content.text).toBe('收到，我看一下')
+      // sender=self → prompt 渲染时会被认成 assistant 自己发的
+      expect(ack.sender.platform_user_id).toBe('self')
+    })
+
+    it('接住消息后给批内最后一条打"已读"回应（变异靶 M2 / M8）', async () => {
+      boot()
+      await internals.processDirectBatch(
+        batchOf([
+          makeMessage({ id: 'm-1', type: 'private', text: '第一条' }),
+          makeMessage({ id: 'm-2', type: 'private', text: '第二条' }),
+        ]),
+      )
+
+      const reaction = rpcCalls.find((c) => c.method === 'add_reaction')
+      expect(reaction).toBeDefined()
+      expect(reaction!.port).toBe(WECHAT_PORT)
+      expect(reaction!.params).toEqual({
+        session_id: 'sess-1',
+        platform_message_id: 'm-2',
+        kind: 'acknowledged',
+      })
+    })
+
+    it('决定不回应时不打"已读"、不起 worker（reaction 不是无条件发的）', async () => {
+      boot()
+      setDispatchActions([{ kind: 'stay_silent', reason: '闲聊' }])
+
+      await internals.processDirectBatch(batchOf([makeMessage({ id: 'm-1', type: 'private' })]))
+
+      expect(rpcCalls.find((c) => c.method === 'add_reaction')).toBeUndefined()
+      expect(spawnCalls).toHaveLength(0)
+      expect(deliverCalls).toHaveLength(0)
+      expect(actionSpanDetails().outcome).toBe('silent_discard')
+      expect(dispatchTrace().status).toBe('completed')
+    })
+
+    it('dispatcher 一个动作都没给时 trace 记 silent', async () => {
+      boot()
+      setDispatchActions([])
+
+      await internals.processDirectBatch(batchOf([makeMessage({ id: 'm-1', type: 'private' })]))
+
+      expect(dispatchTrace().outcome?.summary).toBe('silent')
+      expect(rpcCalls.find((c) => c.method === 'add_reaction')).toBeUndefined()
+    })
+
+    it('整批消息都交给 dispatcher 和 worker，发起人取批内最后一条（变异靶 M2）', async () => {
+      boot()
+      const older = makeFriend('f-1')
+      const newer = makeFriend('f-2')
+      const batch = [
+        { message: makeMessage({ id: 'm-1', type: 'private', text: '第一条' }), friend: older },
+        { message: makeMessage({ id: 'm-2', type: 'private', text: '第二条' }), friend: newer },
+      ]
+
+      await internals.processDirectBatch(batch)
+
+      expect(capturedCtx!.messages.map((m) => m.platform_message_id)).toEqual(['m-1', 'm-2'])
+      expect(capturedCtx!.senderFriend.id).toBe('f-2')
+      expect(capturedDeps!.laneBatchSize).toBe(2)
+      expect(spawnCalls[0].messages.map((m) => m.platform_message_id)).toEqual(['m-1', 'm-2'])
+      expect(spawnCalls[0].senderFriend.id).toBe('f-2')
+      // 上下文装配按最后一条发言人的视角取
+      expect(assembleCalls[0].params.friend_id).toBe('f-2')
+      expect(assembleCalls[0].params.message).toBe('第一条\n第二条')
+    })
+
+    it('supplement 投递把整批消息交给目标任务（变异靶 M2）', async () => {
+      boot()
+      setDispatchActions([{ kind: 'supplement', target_task_id: 'task-active-1' }])
+
+      await internals.processDirectBatch(
+        batchOf([
+          makeMessage({ id: 'm-1', type: 'private', text: '第一条' }),
+          makeMessage({ id: 'm-2', type: 'private', text: '第二条' }),
+        ]),
+      )
+
+      expect(deliverCalls).toHaveLength(1)
+      expect(deliverCalls[0].taskId).toBe('task-active-1')
+      expect(deliverCalls[0].messages.map((m) => m.platform_message_id)).toEqual(['m-1', 'm-2'])
+      expect(spawnCalls).toHaveLength(0)
+    })
+  })
+
+  // ==========================================================================
+  // worker 不阻塞入站（M10）
+  // ==========================================================================
+
+  describe('worker 不阻塞入站 lane（变异靶 M10）', () => {
+    it('worker 还在跑时本批就已处理完，lane 可以接下一批', async () => {
+      boot()
+      let release: () => void = () => {}
+      workerGate = new Promise<void>((resolve) => {
+        release = resolve
+      })
+
+      await internals.processDirectBatch(batchOf([makeMessage({ id: 'm-1', type: 'private' })]))
+
+      // 到这里 processDirectBatch 已经返回——若改成同步等 worker，这一行永远到不了
+      expect(calls).toContain('worker_loop')
+      expect(workerSettled).toBe(false)
+      expect(dispatchTrace().status).toBe('completed')
+      expect(dispatchTrace().outcome?.summary).toBe('dispatched (1 actions)')
+
+      release()
+      await new Promise((resolve) => process.nextTick(resolve))
+      expect(workerSettled).toBe(true)
+    }, 5000)
+  })
+
+  // ==========================================================================
+  // 早退分支
+  // ==========================================================================
+
+  describe('早退分支', () => {
+    it('没有 worker handler：trace 记失败，后续 7 件事一件都不做', async () => {
+      boot({ withHandler: false })
+      internals.agentHandler = undefined
+
+      await internals.processDirectBatch(batchOf([makeMessage({ id: 'm-1', type: 'private' })]))
+
+      const trace = dispatchTrace()
+      expect(trace.status).toBe('failed')
+      expect(trace.outcome?.summary).toBe('No worker handler configured')
+      expect(calls).toEqual(['update_last_message_time', 'start_trace:message'])
+      expect(dispatchMock).not.toHaveBeenCalled()
+    })
+
+    it('没有 worker LLM 环境：早退发生在上下文装配之后（顺序敏感）', async () => {
+      boot({ withSdkEnv: false })
+      internals.sdkEnvWorker = undefined
+
+      await internals.processDirectBatch(batchOf([makeMessage({ id: 'm-1', type: 'private' })]))
+
+      const trace = dispatchTrace()
+      expect(trace.status).toBe('failed')
+      expect(trace.outcome?.summary).toBe('sdkEnvWorker missing')
+      expect(calls).toEqual([
+        'update_last_message_time',
+        'start_trace:message',
+        'resolve_permissions',
+        'assemble_front_context',
+      ])
+      expect(dispatchMock).not.toHaveBeenCalled()
+    })
+
+    it('dispatcher 抛错：trace 记 failed，不起 worker', async () => {
+      boot()
+      dispatchMock.mockImplementation(async () => {
+        calls.push('dispatch')
+        throw new Error('dispatch boom')
+      })
+
+      await internals.processDirectBatch(batchOf([makeMessage({ id: 'm-1', type: 'private' })]))
+
+      const trace = dispatchTrace()
+      expect(trace.status).toBe('failed')
+      expect(trace.outcome?.error).toBe('dispatch boom')
+      expect(spawnCalls).toHaveLength(0)
+    })
+  })
+})

--- a/crabot-agent/tests/inbound/process-group-lane-batch.test.ts
+++ b/crabot-agent/tests/inbound/process-group-lane-batch.test.ts
@@ -1,0 +1,1061 @@
+/**
+ * 入站链路测试网 ③：`processGroupLaneBatch`（P7 / PR A Task 3）。
+ *
+ * 计划：`crabot-docs/superpowers/plans/2026-07-31-mw-p7-a-inbound-test-net.md`
+ * 侦察：`.superpowers/sdd/p7-recon.md` §A.2 / §A.3
+ *
+ * ## 与私聊（测试网 ②）的关系
+ *
+ * 私聊那 8 件事在群聊路径上同样成立，但**不是同一段代码**（`unified-agent.ts:971-1190`
+ * 是与 `:779-962` 平行的另一份实现），所以这里逐条**在群聊路径上重新钉一遍**，
+ * 而不是复用私聊的断言。群聊多出来的三件事单独成节：
+ *
+ * | 群聊特有 | 生产位置 |
+ * |---|---|
+ * | barrier：@bot 时暂停本群在跑的 worker，处理完解除 | `:1012-1015` / `:1179` / `:1186` |
+ * | memory scopes 的**第二档 fallback**（空 scopes → `[sessionId]`，防跨群泄漏） | `:1019-1022` |
+ * | 退避反馈：`attentionScheduler.reportResult(sessionId, hasReply)` | `:1110-1111` / `:1180` |
+ *
+ * ## M9 断的是"退避档位"，不是"reportResult 被调用了"
+ *
+ * `AttentionScheduler` 的 `currentIntervalMs` 就是群聊打扰频率的调节旋钮
+ * （`attention-scheduler.ts:81-103`：回复 → 拉回 `min_ms`；没回复 → ×5 封顶 `max_ms`），
+ * 且它有现成的读口 `getCurrentIntervalMs`。所以退避相关的用例走**真实事件入口**
+ * （`channel.message_authorized` → 真实 AttentionScheduler → 真实群聊 lane →
+ * `processGroupLaneBatch`），处理完直接读这个档位。
+ * 注意：`reportResult` 在没有 session state 时是 no-op，直接调 handler 是读不出档位的——
+ * 这也是这几条必须走事件入口的原因。
+ *
+ * ## 明确不写成断言的现状（`p7a-task1-report.md` §6 O1）
+ *
+ * 两条早退与 catch 分支**都不调** `reportResult`，退避档位在故障期间不更新。
+ * 那是已登记的 bug（O1），不是契约，所以这里只钉"barrier 一定被解除"，
+ * 不去断言故障路径的退避行为。
+ *
+ * ## 确定性
+ *
+ * 零 `setTimeout`、零 fake timer：@mention 消息在 `AttentionScheduler.enqueue` 里同步
+ * `flushNow`；`SessionLane.enqueue` 在第一个 await 之前同步调 handler。
+ * 事件入口返回后用 `settleGroupLane()` 等 in-flight 的那次 handler，避免竞态。
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+import { UnifiedAgent } from '../../src/unified-agent.js'
+import { prefetchQuotedMessages } from '../../src/agent/quoted-message-prefetcher.js'
+import type { QuotedMessageEntry } from '../../src/prompt-manager.js'
+import type { BufferedMessage } from '../../src/orchestration/attention-scheduler.js'
+import type {
+  AgentTrace,
+  ChannelMessage,
+  Friend,
+  MemoryPermissions,
+  ResolvedPermissions,
+  TaskSummary,
+  ToolAccessConfig,
+} from '../../src/types.js'
+import type { DispatchAction, DispatchContext } from '../../src/dispatcher/dispatcher-types.js'
+import type { DispatchDeps } from '../../src/dispatcher/dispatcher.js'
+import type { Event } from 'crabot-shared'
+import { authorizedEvent, makeAgentConfig, makeFriend, makeMessage, useTmpDataDir, type DataDirGuard } from './harness.js'
+
+// dispatch 是模块级 import，没有实例注入口——本文件唯一 mock 掉的生产模块。
+vi.mock('../../src/dispatcher/dispatcher.js', () => ({ dispatch: vi.fn() }))
+import { dispatch } from '../../src/dispatcher/dispatcher.js'
+
+const dispatchMock = vi.mocked(dispatch)
+
+// ============================================================================
+// fixtures
+// ============================================================================
+
+const ADMIN_PORT = 18100
+const WECHAT_PORT = 18101
+const GROUP_SESSION = 'sess-group-1'
+
+const FRIEND_TOOL_ACCESS: ToolAccessConfig = {
+  memory: true,
+  messaging: true,
+  task: true,
+  mcp_skill: true,
+  file_io: false,
+  browser: false,
+  shell: true,
+  remote_exec: false,
+  desktop: false,
+}
+
+/** 群聊解析出的身份：shell 开、file_io 关，memory_scopes 是该群专属 scope。 */
+const GROUP_PERMS: ResolvedPermissions = {
+  tool_access: FRIEND_TOOL_ACCESS,
+  cli_access: {} as ResolvedPermissions['cli_access'],
+  storage: null,
+  memory_scopes: ['group-scope-a', 'group-scope-b'],
+}
+
+const HISTORY_MESSAGE = makeMessage({
+  id: 'hist-g1',
+  type: 'group',
+  sessionId: GROUP_SESSION,
+  text: '昨天群里说的那个方案',
+  timestamp: '2026-07-30T10:00:00.000Z',
+})
+
+const SCENE_PROFILE = {
+  label: '技术群',
+  content: '这个群喜欢直给结论',
+  source: { scene: { type: 'group_session' as const, channel_id: 'wechat', session_id: GROUP_SESSION } },
+}
+
+const ACTIVE_TASK: TaskSummary = {
+  task_id: 'task-group-active',
+  title: '群里在跑的任务',
+  status: 'executing',
+  priority: 'normal',
+}
+
+const TERMINAL_CANDIDATE: TaskSummary = {
+  task_id: 'task-group-terminal',
+  title: '群里刚做完的任务',
+  status: 'completed',
+  priority: 'normal',
+  candidate_kind: 'recent_terminal',
+  completed_at: '2026-07-31T00:00:00.000Z',
+}
+
+function gmsg(p: {
+  id: string
+  text?: string
+  mention?: boolean
+  senderId?: string
+  senderName?: string
+  friendId?: string
+  replyTo?: string
+}): ChannelMessage {
+  return makeMessage({ ...p, type: 'group', sessionId: GROUP_SESSION })
+}
+
+interface AssembleCall {
+  params: {
+    channel_id: string
+    session_id: string
+    sender_id: string
+    message: string
+    friend_id: string
+    session_type: string
+    crab_display_name?: string
+    crab_self_handle?: string
+  }
+  friend: Friend | undefined
+  memPerms: MemoryPermissions
+}
+
+interface SpawnCall {
+  messages: ReadonlyArray<ChannelMessage>
+  activeTasks: ReadonlyArray<TaskSummary>
+  isGroup: boolean
+  senderFriend: Friend
+  memoryPermissions: MemoryPermissions
+  resolvedPermissions: ResolvedPermissions
+  channelId: string
+  sessionId: string
+  frontContext: { recent_messages: ChannelMessage[]; scene_profile?: unknown }
+  sceneProfile?: unknown
+}
+
+type GroupBatch = ReadonlyArray<{ messages: BufferedMessage[]; sessionId: string }>
+
+interface Internals {
+  onEvent(event: Event): Promise<void>
+  processGroupLaneBatch(batch: GroupBatch): Promise<void>
+  traceStore: {
+    getTraces(limit?: number): { traces: AgentTrace[] }
+    startTrace(params: { trigger: { type: string } }): { trace_id: string }
+  }
+  contextAssembler: unknown
+  agentHandler: unknown
+  sdkEnvWorker: unknown
+  channelPorts: Map<string, number>
+  crabDisplayNames: Map<string, string>
+  crabSelfHandles: Map<string, string>
+  attentionScheduler: {
+    stopAll(): void
+    getCurrentIntervalMs(sessionId: string): number | undefined
+    getBufferSize(sessionId: string): number
+  }
+  rpcClient: {
+    call: (port: number, method: string, params: unknown, from?: string) => Promise<unknown>
+    resolve: (filter: unknown, from?: string) => Promise<unknown[]>
+  }
+}
+
+describe('processGroupLaneBatch —— 群聊 lane handler（P7/PR A 测试网 ③）', () => {
+  let dataDir: DataDirGuard
+  let agent: UnifiedAgent
+  let internals: Internals
+
+  /** 唯一的顺序事实来源。 */
+  let calls: string[]
+  let rpcCalls: Array<{ port: number; method: string; params: Record<string, unknown> }>
+  let assembleCalls: AssembleCall[]
+  let spawnCalls: SpawnCall[]
+  let deliverCalls: Array<{ taskId: string; messages: ReadonlyArray<ChannelMessage> }>
+  let barrierArmed: Array<{ taskId: string; timeoutMs: number }>
+  let barrierCleared: string[]
+  let originQueries: Array<{ channelId: string; sessionId: string }>
+  let capturedCtx: DispatchContext | undefined
+  let capturedDeps: DispatchDeps | undefined
+  /** 事件入口驱动时 in-flight 的群聊 handler。 */
+  let inflight: Promise<void>[]
+
+  // 可按测试改写的响应
+  let permsResponse: ResolvedPermissions | null | 'throw'
+  let sessionScopes: string[]
+  let supplementCandidates: TaskSummary[]
+  let activeTasks: TaskSummary[]
+  let recentMessages: ChannelMessage[]
+  let hasActiveTaskResult: boolean
+  /** getActiveTasksByOrigin 的返回；barrier arm 失败（已 park）的 task 放 parkedTasks。 */
+  let originTasks: string[]
+  let parkedTasks: string[]
+  /** worker loop 的放行闸：默认立即完成；M10 用它把 worker 挂住。 */
+  let workerGate: Promise<void> | undefined
+  let workerSettled: boolean
+
+  function boot(
+    opts: {
+      withHandler?: boolean
+      withSdkEnv?: boolean
+      attentionMinMs?: number
+      attentionMaxMs?: number
+    } = {},
+  ): void {
+    agent = new UnifiedAgent(
+      makeAgentConfig({
+        configured: true,
+        moduleId: 'group-batch-agent',
+        port: 19996,
+        ...(opts.attentionMinMs !== undefined ? { attentionMinMs: opts.attentionMinMs } : {}),
+        ...(opts.attentionMaxMs !== undefined ? { attentionMaxMs: opts.attentionMaxMs } : {}),
+      }),
+    )
+    internals = agent as unknown as Internals
+
+    internals.channelPorts.set('wechat', WECHAT_PORT)
+    internals.crabDisplayNames.set('wechat', '小蟹')
+    internals.crabSelfHandles.set('wechat', '@crabot_wx')
+
+    // 事件入口驱动时，lane 是同步 kick 的但 handler 内部有 await；
+    // 这里把 in-flight promise 记下来，测试用 settleGroupLane() 等它落地。
+    // 构造函数的接线是 `(batch) => this.processGroupLaneBatch(batch)`（调用时才解引用），
+    // 所以实例上包一层不破坏任何生产装配。
+    const realGroupBatch = (
+      Object.getPrototypeOf(agent) as { processGroupLaneBatch: (b: GroupBatch) => Promise<void> }
+    ).processGroupLaneBatch.bind(agent)
+    internals.processGroupLaneBatch = (batch: GroupBatch) => {
+      const p = realGroupBatch(batch)
+      inflight.push(p)
+      return p
+    }
+
+    internals.rpcClient.resolve = async () => [
+      { module_id: 'admin', module_type: 'admin', host: 'localhost', port: ADMIN_PORT, status: 'running' },
+    ]
+    internals.rpcClient.call = async (port, method, params) => {
+      rpcCalls.push({ port, method, params: params as Record<string, unknown> })
+      switch (method) {
+        case 'resolve_principal_permissions':
+          calls.push('resolve_permissions')
+          if (permsResponse === 'throw') throw new Error('admin unreachable')
+          return { resolved: permsResponse, sources: {} }
+        case 'get_session_config':
+          calls.push('get_session_config')
+          return { config: { memory_scopes: sessionScopes } }
+        case 'send_message':
+          calls.push('send_message')
+          return { platform_message_id: 'ack-g1', sent_at: '2026-07-31T00:00:05.000Z' }
+        case 'add_reaction':
+          calls.push('add_reaction')
+          return {}
+        case 'get_message':
+          calls.push('get_message')
+          return {
+            platform_message_id: (params as { platform_message_id: string }).platform_message_id,
+            sender: { platform_user_id: 'u-9', platform_display_name: '王五' },
+            content: { type: 'text', text: '这是群里被引用的原文' },
+            features: {},
+            platform_timestamp: '2026-07-20T00:00:00.000Z',
+          }
+        case 'revive_task_for_supplement':
+          calls.push('revive_task_for_supplement')
+          return {}
+        default:
+          return {}
+      }
+    }
+
+    const realStartTrace = internals.traceStore.startTrace.bind(internals.traceStore)
+    internals.traceStore.startTrace = (params) => {
+      calls.push(`start_trace:${params.trigger.type}`)
+      return realStartTrace(params)
+    }
+
+    internals.contextAssembler = {
+      assembleFrontContext: async (
+        params: AssembleCall['params'],
+        friend: Friend | undefined,
+        memPerms: MemoryPermissions,
+      ) => {
+        calls.push('assemble_front_context')
+        assembleCalls.push({ params, friend, memPerms })
+        return {
+          sender_friend: friend,
+          recent_messages: recentMessages,
+          short_term_memories: [],
+          active_tasks: activeTasks,
+          available_tools: [],
+          scene_profile: SCENE_PROFILE,
+          crab_self_handle: '@crabot_wx',
+          time_windows: { recent_messages_window_hours: 24, short_term_memory_window_hours: 24 },
+          supplement_candidates: supplementCandidates,
+        }
+      },
+    }
+
+    if (opts.withHandler !== false) {
+      internals.agentHandler = {
+        hasActiveTask: () => hasActiveTaskResult,
+        deliverHumanResponse: (taskId: string, messages: ReadonlyArray<ChannelMessage>) => {
+          calls.push('deliver_human_response')
+          deliverCalls.push({ taskId, messages })
+        },
+        getTaskPrincipal: () => undefined,
+        updateTaskPermissions: () => {},
+        getInflightSnapshot: () => [],
+        getActiveTasksByOrigin: (channelId: string, sessionId: string) => {
+          calls.push('get_active_tasks_by_origin')
+          originQueries.push({ channelId, sessionId })
+          return [...originTasks]
+        },
+        setBarrierForTask: (taskId: string, timeoutMs: number) => {
+          calls.push('set_barrier')
+          // 已 park（ask_human）的 task arm 失败——生产语义见 unified-agent.ts:1343-1345
+          if (parkedTasks.includes(taskId)) return false
+          barrierArmed.push({ taskId, timeoutMs })
+          return true
+        },
+        clearBarrierForTask: (taskId: string) => {
+          calls.push('clear_barrier')
+          barrierCleared.push(taskId)
+        },
+        registerTriggerAndActivate: async (params: SpawnCall) => {
+          calls.push('register_trigger')
+          spawnCalls.push(params)
+          return {
+            taskId: 'task-group-new',
+            registered: true,
+            task: {},
+            context: {},
+            taskTitle: '新群任务',
+          }
+        },
+        runTriggerWorkerLoop: async () => {
+          calls.push('worker_loop')
+          if (workerGate) await workerGate
+          workerSettled = true
+          return { outcome: 'completed', finalText: '搞定', sentMessage: true }
+        },
+      }
+    }
+
+    if (opts.withSdkEnv !== false) {
+      internals.sdkEnvWorker = {
+        modelId: 'worker-model',
+        format: 'anthropic',
+        env: { LLM_BASE_URL: 'https://example.invalid', LLM_API_KEY: 'k' },
+      }
+    }
+  }
+
+  function setDispatchActions(actions: DispatchAction[]): void {
+    dispatchMock.mockImplementation(async (ctx, deps) => {
+      calls.push('dispatch')
+      capturedCtx = ctx
+      capturedDeps = deps
+      return { actions }
+    })
+  }
+
+  /** 一个 attention 批次 = 一条 lane item。 */
+  function attentionBatch(messages: ChannelMessage[], friend = makeFriend('f-1')) {
+    return { messages: messages.map((message) => ({ message, friend })), sessionId: GROUP_SESSION }
+  }
+
+  /** 直接喂 handler：batch 形状完全可控（laneBatchSize / 跨 batch 合并）。 */
+  function runGroup(messages: ChannelMessage[], friend = makeFriend('f-1')): Promise<void> {
+    return internals.processGroupLaneBatch([attentionBatch(messages, friend)])
+  }
+
+  /** 走真实事件入口：@mention 消息在 AttentionScheduler 里同步 flushNow。 */
+  async function deliverMention(message: ChannelMessage, friend = makeFriend('f-1')): Promise<void> {
+    await internals.onEvent(authorizedEvent({ message, friend, crab_display_name: '小蟹', crab_self_handle: '@crabot_wx' }))
+    await settleGroupLane()
+  }
+
+  async function settleGroupLane(): Promise<void> {
+    while (inflight.length > 0) {
+      const batch = inflight.splice(0)
+      await Promise.all(batch)
+    }
+  }
+
+  function dispatchTrace(): AgentTrace {
+    const t = internals.traceStore.getTraces(50).traces.find((x) => x.trigger.type === 'message')
+    if (!t) throw new Error('dispatch trace not found')
+    return t
+  }
+
+  function actionSpanDetails(): Record<string, unknown> {
+    const span = dispatchTrace().spans.find((s) => s.type === 'dispatch_action')
+    if (!span) throw new Error('dispatch_action span not found')
+    return (span.details ?? {}) as Record<string, unknown>
+  }
+
+  beforeEach(async () => {
+    calls = []
+    rpcCalls = []
+    assembleCalls = []
+    spawnCalls = []
+    deliverCalls = []
+    barrierArmed = []
+    barrierCleared = []
+    originQueries = []
+    inflight = []
+    capturedCtx = undefined
+    capturedDeps = undefined
+    permsResponse = GROUP_PERMS
+    sessionScopes = ['session-scope-1']
+    supplementCandidates = [ACTIVE_TASK]
+    activeTasks = [ACTIVE_TASK]
+    recentMessages = [HISTORY_MESSAGE]
+    hasActiveTaskResult = true
+    originTasks = []
+    parkedTasks = []
+    workerGate = undefined
+    workerSettled = false
+    dispatchMock.mockReset()
+    setDispatchActions([{ kind: 'new_task' }])
+    dataDir = await useTmpDataDir('inbound-pglb-')
+  })
+
+  afterEach(async () => {
+    internals?.attentionScheduler.stopAll()
+    vi.restoreAllMocks()
+    await dataDir.restore()
+  })
+
+  // ==========================================================================
+  // 批合并与 trace 起点（变异靶 M2）
+  // ==========================================================================
+
+  describe('批合并与 trace 起点（变异靶 M2）', () => {
+    it('trace 记 message 触发、批内每条都进 summary、source 是来源 channel', async () => {
+      boot()
+      await runGroup([
+        gmsg({ id: 'g-1', text: '第一条', senderName: '张三' }),
+        gmsg({ id: 'g-2', text: '第二条', senderName: '李四' }),
+      ])
+
+      const trace = dispatchTrace()
+      expect(trace.trigger.type).toBe('message')
+      expect(trace.trigger.source).toBe('wechat')
+      expect(trace.trigger.summary).toBe('[group×2] 张三: 第一条 | 李四: 第二条')
+      expect(trace.module_id).toBe('group-batch-agent')
+    })
+
+    it('lane 攒下的多个 attention 批次合并成一轮处理，不丢任何一批', async () => {
+      boot()
+      const friend = makeFriend('f-1')
+      await internals.processGroupLaneBatch([
+        attentionBatch([gmsg({ id: 'g-1', text: '第一批' })], friend),
+        attentionBatch([gmsg({ id: 'g-2', text: '第二批甲' }), gmsg({ id: 'g-3', text: '第二批乙' })], friend),
+      ])
+
+      expect(capturedCtx!.messages.map((m) => m.platform_message_id)).toEqual(['g-1', 'g-2', 'g-3'])
+      expect(spawnCalls[0].messages.map((m) => m.platform_message_id)).toEqual(['g-1', 'g-2', 'g-3'])
+      // dispatcher 靠 laneBatchSize 知道这轮攒了几批（提示语用）
+      expect(capturedDeps!.laneBatchSize).toBe(2)
+      // 只起一轮 dispatch / 一个 trace
+      expect(dispatchMock).toHaveBeenCalledTimes(1)
+      expect(internals.traceStore.getTraces(50).traces.filter((t) => t.trigger.type === 'message')).toHaveLength(1)
+    })
+
+    it('整批交给 dispatcher 和 worker，发起人取批内最后一条', async () => {
+      boot()
+      const older = makeFriend('f-1')
+      const newer = makeFriend('f-2')
+      await internals.processGroupLaneBatch([
+        {
+          messages: [
+            { message: gmsg({ id: 'g-1', text: '第一条', senderId: 'u-1', friendId: 'f-1' }), friend: older },
+            { message: gmsg({ id: 'g-2', text: '第二条', senderId: 'u-2', friendId: 'f-2' }), friend: newer },
+          ],
+          sessionId: GROUP_SESSION,
+        },
+      ])
+
+      expect(capturedCtx!.messages.map((m) => m.platform_message_id)).toEqual(['g-1', 'g-2'])
+      expect(capturedCtx!.senderFriend.id).toBe('f-2')
+      expect(spawnCalls[0].messages.map((m) => m.platform_message_id)).toEqual(['g-1', 'g-2'])
+      expect(spawnCalls[0].senderFriend.id).toBe('f-2')
+      // 上下文装配按最后一条发言人的视角取，message 汇总整批
+      expect(assembleCalls[0].params.sender_id).toBe('u-2')
+      expect(assembleCalls[0].params.friend_id).toBe('f-2')
+      expect(assembleCalls[0].params.message).toBe('第一条\n第二条')
+    })
+
+    it('supplement 投递把整批消息交给目标任务（漏消息 = 静默吃掉群友输入）', async () => {
+      boot()
+      setDispatchActions([{ kind: 'supplement', target_task_id: 'task-group-active' }])
+
+      await runGroup([gmsg({ id: 'g-1', text: '第一条' }), gmsg({ id: 'g-2', text: '第二条' })])
+
+      expect(deliverCalls).toHaveLength(1)
+      expect(deliverCalls[0].taskId).toBe('task-group-active')
+      expect(deliverCalls[0].messages.map((m) => m.platform_message_id)).toEqual(['g-1', 'g-2'])
+      expect(spawnCalls).toHaveLength(0)
+    })
+
+    it('给批内最后一条打"已读"回应（群里只回应最新那条，不是第一条）', async () => {
+      boot()
+      await runGroup([gmsg({ id: 'g-1', text: '第一条' }), gmsg({ id: 'g-2', text: '第二条' })])
+
+      const reaction = rpcCalls.find((c) => c.method === 'add_reaction')
+      expect(reaction).toBeDefined()
+      expect(reaction!.port).toBe(WECHAT_PORT)
+      expect(reaction!.params).toEqual({
+        session_id: GROUP_SESSION,
+        platform_message_id: 'g-2',
+        kind: 'acknowledged',
+      })
+    })
+
+    it('空 batch / 批内无消息：不建 trace、不解析权限', async () => {
+      boot()
+      await internals.processGroupLaneBatch([])
+      await internals.processGroupLaneBatch([{ messages: [], sessionId: GROUP_SESSION }])
+
+      expect(calls).toEqual([])
+      expect(internals.traceStore.getTraces(50).traces).toHaveLength(0)
+    })
+  })
+
+  // ==========================================================================
+  // 群聊特有 ①：barrier
+  // ==========================================================================
+
+  describe('barrier：@bot 时暂停本群在跑的 worker（群聊特有）', () => {
+    it('@bot 消息在 dispatcher 决策之前就暂停本群在跑的 worker，处理完解除', async () => {
+      boot()
+      originTasks = ['task-a', 'task-b']
+
+      await runGroup([gmsg({ id: 'g-1', text: '@小蟹 帮我看下', mention: true })])
+
+      // 只暂停"本群本渠道"发起的任务——别的群的 worker 不受影响
+      expect(originQueries).toEqual([{ channelId: 'wechat', sessionId: GROUP_SESSION }])
+      expect(barrierArmed.map((b) => b.taskId)).toEqual(['task-a', 'task-b'])
+      // 暂停必须自带兜底超时：即使这轮崩了，worker 也不会被永久挂住
+      for (const armed of barrierArmed) {
+        expect(armed.timeoutMs).toBeGreaterThan(0)
+        expect(armed.timeoutMs).toBeLessThanOrEqual(60_000)
+      }
+      // 顺序：先暂停再决策（否则 worker 可能在决策期间继续往群里发言）
+      expect(calls.indexOf('set_barrier')).toBeLessThan(calls.indexOf('dispatch'))
+      // 处理完必须解除
+      expect(barrierCleared).toEqual(['task-a', 'task-b'])
+      expect(calls.lastIndexOf('clear_barrier')).toBeGreaterThan(calls.indexOf('dispatch'))
+    })
+
+    it('非 @bot 的普通群消息完全不打断在跑的 worker', async () => {
+      boot()
+      originTasks = ['task-a']
+
+      await runGroup([gmsg({ id: 'g-1', text: '你们中午吃啥' })])
+
+      expect(barrierArmed).toEqual([])
+      expect(barrierCleared).toEqual([])
+      expect(calls).not.toContain('get_active_tasks_by_origin')
+      // 但这条消息本身照常进 dispatcher 决策
+      expect(dispatchMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('批内只要有一条 @bot 就暂停（混合批次不按第一条判定）', async () => {
+      boot()
+      originTasks = ['task-a']
+
+      await runGroup([
+        gmsg({ id: 'g-1', text: '你们中午吃啥' }),
+        gmsg({ id: 'g-2', text: '@小蟹 你说呢', mention: true }),
+      ])
+
+      expect(barrierArmed.map((b) => b.taskId)).toEqual(['task-a'])
+    })
+
+    it('已 park 的任务（暂停未生效）不会在收尾时被误唤醒', async () => {
+      boot()
+      originTasks = ['task-live', 'task-parked']
+      parkedTasks = ['task-parked']
+
+      await runGroup([gmsg({ id: 'g-1', text: '@小蟹 在吗', mention: true })])
+
+      expect(barrierArmed.map((b) => b.taskId)).toEqual(['task-live'])
+      // 关键语义：ask_human 挂起的 task 不能被这轮的 clear 顺手唤醒
+      expect(barrierCleared).toEqual(['task-live'])
+      expect(barrierCleared).not.toContain('task-parked')
+    })
+
+    it('处理过程中抛错：暂停仍然被解除，不把 worker 悬在那里', async () => {
+      boot()
+      originTasks = ['task-a']
+      dispatchMock.mockImplementation(async () => {
+        calls.push('dispatch')
+        throw new Error('dispatch boom')
+      })
+
+      await runGroup([gmsg({ id: 'g-1', text: '@小蟹 炸了', mention: true })])
+
+      expect(barrierArmed.map((b) => b.taskId)).toEqual(['task-a'])
+      expect(barrierCleared).toEqual(['task-a'])
+      expect(dispatchTrace().status).toBe('failed')
+      expect(dispatchTrace().outcome?.error).toBe('dispatch boom')
+      expect(spawnCalls).toHaveLength(0)
+    })
+  })
+
+  // ==========================================================================
+  // 权限身份解析（变异靶 M4）
+  // ==========================================================================
+
+  describe('权限身份解析（变异靶 M4）', () => {
+    it('按群聊语义解析发起人身份，结果决定这轮 worker 能用哪些工具', async () => {
+      boot()
+      await runGroup([gmsg({ id: 'g-1', text: '帮我跑个脚本' })])
+
+      expect(spawnCalls[0].resolvedPermissions?.tool_access.shell).toBe(true)
+      expect(spawnCalls[0].resolvedPermissions?.tool_access.file_io).toBe(false)
+      expect(
+        agent.getToolPermissionConfig([
+          { name: 'bash', description: '', inputSchema: {}, category: 'shell' },
+        ]),
+      ).toEqual({ mode: 'bypass' })
+      expect(
+        agent.getToolPermissionConfig([
+          { name: 'write_file', description: '', inputSchema: {}, category: 'file_io' },
+        ]),
+      ).toEqual({ mode: 'denyList', toolNames: ['write_file'] })
+
+      const resolveCall = rpcCalls.find((c) => c.method === 'resolve_principal_permissions')
+      expect(resolveCall!.port).toBe(ADMIN_PORT)
+      expect(resolveCall!.params).toMatchObject({
+        sender_friend_id: 'f-1',
+        session_id: GROUP_SESSION,
+        session_type: 'group',
+      })
+    })
+
+    it('解析失败时 fail-closed（只剩 messaging），不是放开也不是沿用上一轮', async () => {
+      boot()
+      permsResponse = 'throw'
+      await runGroup([gmsg({ id: 'g-1' })])
+
+      expect(
+        agent.getToolPermissionConfig([
+          { name: 'bash', description: '', inputSchema: {}, category: 'shell' },
+          { name: 'send_message', description: '', inputSchema: {}, category: 'messaging' },
+        ]),
+      ).toEqual({ mode: 'denyList', toolNames: ['bash'] })
+    })
+  })
+
+  // ==========================================================================
+  // 群聊特有 ②：memory 档位的两档 fallback（变异靶 M5）
+  // ==========================================================================
+
+  describe('memory 权限档位 —— 群聊两档 fallback（变异靶 M5）', () => {
+    it('第一档：按解析出的 memory_scopes 授权读写，不是 public/全局', async () => {
+      boot()
+      await runGroup([gmsg({ id: 'g-1' })])
+
+      const expected: MemoryPermissions = {
+        write_visibility: 'internal',
+        write_scopes: ['group-scope-a', 'group-scope-b'],
+        read_min_visibility: 'internal',
+        read_accessible_scopes: ['group-scope-a', 'group-scope-b'],
+      }
+      expect(spawnCalls[0].memoryPermissions).toEqual(expected)
+      expect(assembleCalls[0].memPerms).toEqual(expected)
+      expect(spawnCalls[0].memoryPermissions.write_visibility).not.toBe('public')
+      expect(spawnCalls[0].memoryPermissions.write_scopes).not.toEqual([])
+    })
+
+    it('第二档（群聊专有）：解析成功但 scopes 为空时收敛到本群 session，不允许空 scope 越界', async () => {
+      boot()
+      permsResponse = { ...GROUP_PERMS, memory_scopes: [] }
+      await runGroup([gmsg({ id: 'g-1' })])
+
+      // 空 scope 会让记忆读写落到"无限定"档位，等于跨群泄漏；必须收敛到本群
+      expect(spawnCalls[0].memoryPermissions).toEqual({
+        write_visibility: 'internal',
+        write_scopes: [GROUP_SESSION],
+        read_min_visibility: 'internal',
+        read_accessible_scopes: [GROUP_SESSION],
+      })
+      expect(assembleCalls[0].memPerms.read_accessible_scopes).toEqual([GROUP_SESSION])
+      // 这一档没有去问 admin 要 session 配置——它是就地收敛，不是第三档
+      expect(calls).not.toContain('get_session_config')
+      // 同一份收敛结果也进了会话级身份（后续 supplement 热刷新按它走）
+      expect(spawnCalls[0].resolvedPermissions.memory_scopes).toEqual([GROUP_SESSION])
+    })
+
+    it('第三档：身份解析失败时回落到该 session 配置的 scopes（仍不是公开）', async () => {
+      boot()
+      permsResponse = 'throw'
+      sessionScopes = ['session-scope-1']
+      await runGroup([gmsg({ id: 'g-1' })])
+
+      expect(spawnCalls[0].memoryPermissions).toEqual({
+        write_visibility: 'internal',
+        write_scopes: ['session-scope-1'],
+        read_min_visibility: 'internal',
+        read_accessible_scopes: ['session-scope-1'],
+      })
+      expect(calls).toContain('get_session_config')
+    })
+  })
+
+  // ==========================================================================
+  // 前置上下文装配（变异靶 M6）
+  // ==========================================================================
+
+  describe('前置上下文装配（变异靶 M6）', () => {
+    it('装配结果进入 dispatcher 的群聊决策上下文（历史 / 群画像 / 自称 / 候选任务）', async () => {
+      boot()
+      setDispatchActions([{ kind: 'stay_silent' }])
+      await runGroup([gmsg({ id: 'g-1', text: '这事儿接着弄' })])
+
+      expect(capturedCtx!.sessionType).toBe('group')
+      expect(capturedCtx!.recentMessages.map((m) => m.platform_message_id)).toEqual(['hist-g1'])
+      expect(capturedCtx!.activeTasks.map((t) => t.task_id)).toEqual(['task-group-active'])
+      expect(capturedCtx!.sceneProfile).toEqual(SCENE_PROFILE)
+      // 多 bot 群里靠它判断哪一段 @ 是发给自己的
+      expect(capturedCtx!.crabSelfHandle).toBe('@crabot_wx')
+      expect(capturedCtx!.channelId).toBe('wechat')
+      expect(capturedCtx!.sessionId).toBe(GROUP_SESSION)
+    })
+
+    it('装配请求带的是群聊语义（session_type=group + 本渠道群昵称/自称）', async () => {
+      boot()
+      await runGroup([gmsg({ id: 'g-1', text: '继续' })])
+
+      expect(assembleCalls[0].params).toMatchObject({
+        channel_id: 'wechat',
+        session_id: GROUP_SESSION,
+        session_type: 'group',
+        crab_display_name: '小蟹',
+        crab_self_handle: '@crabot_wx',
+        message: '继续',
+      })
+    })
+
+    it('装配出的历史进 worker 且触发批次不被重复渲染成历史，worker 按群聊模式跑', async () => {
+      boot()
+      const trigger = gmsg({ id: 'g-1', text: '看下这个' })
+      recentMessages = [HISTORY_MESSAGE, trigger]
+      await runGroup([trigger])
+
+      expect(spawnCalls[0].isGroup).toBe(true)
+      expect(spawnCalls[0].frontContext.recent_messages.map((m) => m.platform_message_id)).toEqual(['hist-g1'])
+      expect(spawnCalls[0].activeTasks.map((t) => t.task_id)).toEqual(['task-group-active'])
+      expect(spawnCalls[0].sceneProfile).toEqual(SCENE_PROFILE)
+      expect(spawnCalls[0].channelId).toBe('wechat')
+      expect(spawnCalls[0].sessionId).toBe(GROUP_SESSION)
+    })
+
+    it('只有装配结果里的候选任务才认得出"已终止任务"，从而走复活而不是往活任务投递', async () => {
+      boot()
+      supplementCandidates = [TERMINAL_CANDIDATE]
+      setDispatchActions([{ kind: 'supplement', target_task_id: 'task-group-terminal' }])
+
+      await runGroup([gmsg({ id: 'g-1', text: '再补一句' })])
+
+      expect(calls).toContain('revive_task_for_supplement')
+      expect(actionSpanDetails().outcome).toBe('terminal_task_revived')
+      expect(deliverCalls).toHaveLength(0)
+      expect(dispatchTrace().related_task_id).toBe('task-group-terminal')
+    })
+  })
+
+  // ==========================================================================
+  // 引用消息预取（变异靶 M7）
+  // ==========================================================================
+
+  describe('引用消息预取（变异靶 M7）', () => {
+    it('dispatcher 拿到的预取依赖真的能把群里跨窗口引用的原文取回来', async () => {
+      boot()
+      let prefetched: ReadonlyMap<string, QuotedMessageEntry> | undefined
+      dispatchMock.mockImplementation(async (ctx, deps) => {
+        calls.push('dispatch')
+        capturedDeps = deps
+        if (deps.quotedPrefetchDeps) {
+          prefetched = await prefetchQuotedMessages(
+            ctx.messages,
+            ctx.recentMessages,
+            ctx.channelId,
+            ctx.sessionId,
+            'group',
+            deps.quotedPrefetchDeps,
+            () => 'friend',
+          )
+        }
+        return { actions: [{ kind: 'stay_silent' }] }
+      })
+
+      await runGroup([gmsg({ id: 'g-1', text: '这个怎么说', replyTo: 'quoted-origin-g1' })])
+
+      expect(prefetched?.get('quoted-origin-g1')?.msg.content.text).toBe('这是群里被引用的原文')
+      const fetch = rpcCalls.find((c) => c.method === 'get_message')
+      expect(fetch!.port).toBe(WECHAT_PORT)
+      expect(fetch!.params).toMatchObject({ session_id: GROUP_SESSION, platform_message_id: 'quoted-origin-g1' })
+      expect(capturedDeps!.timezone).toBeTruthy()
+    })
+  })
+
+  // ==========================================================================
+  // 预回复 / spawn / reaction 的顺序（变异靶 M11、M8）
+  // ==========================================================================
+
+  describe('预回复 / spawn / reaction 的顺序（变异靶 M11、M8）', () => {
+    it('群聊一轮的固定顺序：暂停 worker → 决策 → 预回复 → 起 worker → 解除暂停 → 打已读', async () => {
+      boot()
+      originTasks = ['task-a']
+      setDispatchActions([{ kind: 'new_task', immediate_reply: '收到，我看一下' }])
+
+      await runGroup([gmsg({ id: 'g-1', text: '@小蟹 帮个忙', mention: true })])
+
+      expect(calls).toEqual([
+        'start_trace:message',
+        'get_active_tasks_by_origin',
+        'set_barrier',
+        'resolve_permissions',
+        'assemble_front_context',
+        'dispatch',
+        'send_message',
+        'register_trigger',
+        'start_trace:task',
+        'worker_loop',
+        'add_reaction',
+        'clear_barrier',
+      ])
+    })
+
+    it('预回复的落地元数据进 worker 的上下文（worker 因此知道自己已经在群里 ack 过）', async () => {
+      boot()
+      setDispatchActions([{ kind: 'new_task', immediate_reply: '收到，我看一下' }])
+
+      await runGroup([gmsg({ id: 'g-1' })])
+
+      const sent = rpcCalls.find((c) => c.method === 'send_message')
+      expect(sent!.port).toBe(WECHAT_PORT)
+      expect(sent!.params).toMatchObject({
+        session_id: GROUP_SESSION,
+        content: { type: 'text', text: '收到，我看一下' },
+      })
+
+      const history = spawnCalls[0].frontContext.recent_messages
+      const ack = history[history.length - 1]
+      expect(ack.platform_message_id).toBe('ack-g1')
+      expect(ack.content.text).toBe('收到，我看一下')
+      expect(ack.sender.platform_user_id).toBe('self')
+      // 群聊 ack 必须挂在本群会话上，不能落到别的 session
+      expect(ack.session.session_id).toBe(GROUP_SESSION)
+      expect(ack.session.type).toBe('group')
+    })
+
+    it('dispatcher 一个动作都没给时 trace 记 silent、不打已读', async () => {
+      boot()
+      setDispatchActions([])
+
+      await runGroup([gmsg({ id: 'g-1' })])
+
+      expect(dispatchTrace().outcome?.summary).toBe('silent')
+      expect(rpcCalls.find((c) => c.method === 'add_reaction')).toBeUndefined()
+    })
+  })
+
+  // ==========================================================================
+  // worker 不阻塞入站（变异靶 M10）
+  // ==========================================================================
+
+  describe('worker 不阻塞群聊 lane（变异靶 M10）', () => {
+    it('worker 还在跑时本批就已处理完，barrier 已解除、lane 可以接下一批', async () => {
+      boot()
+      originTasks = ['task-a']
+      let release: () => void = () => {}
+      workerGate = new Promise<void>((resolve) => {
+        release = resolve
+      })
+
+      await runGroup([gmsg({ id: 'g-1', text: '@小蟹 慢慢来', mention: true })])
+
+      // 到这里 processGroupLaneBatch 已经返回——若改成同步等 worker，这一行永远到不了
+      expect(calls).toContain('worker_loop')
+      expect(workerSettled).toBe(false)
+      expect(barrierCleared).toEqual(['task-a'])
+      expect(dispatchTrace().status).toBe('completed')
+      expect(dispatchTrace().outcome?.summary).toBe('dispatched (1 actions)')
+
+      release()
+      await new Promise((resolve) => process.nextTick(resolve))
+      expect(workerSettled).toBe(true)
+    }, 5000)
+  })
+
+  // ==========================================================================
+  // 群聊特有 ③：退避反馈（变异靶 M9 —— 本 task 的核心）
+  // ==========================================================================
+
+  describe('退避反馈：群聊打扰频率（变异靶 M9）', () => {
+    it('判定这轮不该出声时，下次巡检间隔按 ×5 拉长（注意力渐远）', async () => {
+      boot({ attentionMinMs: 1000 })
+      setDispatchActions([{ kind: 'stay_silent', reason: '群友互相聊天' }])
+
+      expect(internals.attentionScheduler.getCurrentIntervalMs(GROUP_SESSION)).toBeUndefined()
+      await deliverMention(gmsg({ id: 'g-1', text: '@小蟹 你觉得呢', mention: true }))
+
+      // 退避档位（= 下次巡检最快间隔）被拉长
+      expect(internals.attentionScheduler.getCurrentIntervalMs(GROUP_SESSION)).toBe(5000)
+      // 且这轮确实没有任何出声动作
+      expect(rpcCalls.find((c) => c.method === 'add_reaction')).toBeUndefined()
+      expect(rpcCalls.find((c) => c.method === 'send_message')).toBeUndefined()
+      expect(spawnCalls).toHaveLength(0)
+      expect(deliverCalls).toHaveLength(0)
+      expect(dispatchTrace().status).toBe('completed')
+      expect(actionSpanDetails().outcome).toBe('silent_discard')
+    })
+
+    it('连续判定不出声时退避逐级累积（第二轮再 ×5）', async () => {
+      boot({ attentionMinMs: 1000 })
+      setDispatchActions([{ kind: 'stay_silent' }])
+
+      await deliverMention(gmsg({ id: 'g-1', mention: true }))
+      expect(internals.attentionScheduler.getCurrentIntervalMs(GROUP_SESSION)).toBe(5000)
+
+      await deliverMention(gmsg({ id: 'g-2', mention: true }))
+      expect(internals.attentionScheduler.getCurrentIntervalMs(GROUP_SESSION)).toBe(25000)
+    })
+
+    it('退避拉长有上限，不会一路退到永不理人', async () => {
+      boot({ attentionMinMs: 1000, attentionMaxMs: 3000 })
+      setDispatchActions([{ kind: 'stay_silent' }])
+
+      await deliverMention(gmsg({ id: 'g-1', mention: true }))
+
+      expect(internals.attentionScheduler.getCurrentIntervalMs(GROUP_SESSION)).toBe(3000)
+    })
+
+    it('这轮出声后注意力被拉回：退避档位从拉长状态回到最小间隔', async () => {
+      boot({ attentionMinMs: 1000 })
+
+      setDispatchActions([{ kind: 'stay_silent' }])
+      await deliverMention(gmsg({ id: 'g-1', mention: true }))
+      expect(internals.attentionScheduler.getCurrentIntervalMs(GROUP_SESSION)).toBe(5000)
+
+      setDispatchActions([{ kind: 'new_task' }])
+      await deliverMention(gmsg({ id: 'g-2', mention: true }))
+
+      expect(spawnCalls).toHaveLength(1)
+      expect(internals.attentionScheduler.getCurrentIntervalMs(GROUP_SESSION)).toBe(1000)
+    })
+
+    it('往在跑的任务投递补充也算"出声"（注意力同样拉回）', async () => {
+      boot({ attentionMinMs: 1000 })
+
+      setDispatchActions([{ kind: 'stay_silent' }])
+      await deliverMention(gmsg({ id: 'g-1', mention: true }))
+      expect(internals.attentionScheduler.getCurrentIntervalMs(GROUP_SESSION)).toBe(5000)
+
+      setDispatchActions([{ kind: 'supplement', target_task_id: 'task-group-active' }])
+      await deliverMention(gmsg({ id: 'g-2', mention: true }))
+
+      expect(deliverCalls).toHaveLength(1)
+      expect(internals.attentionScheduler.getCurrentIntervalMs(GROUP_SESSION)).toBe(1000)
+    })
+
+    it('批内混着沉默与出声动作时按"有出声"算，不按第一条动作算', async () => {
+      boot({ attentionMinMs: 1000 })
+
+      setDispatchActions([{ kind: 'stay_silent' }])
+      await deliverMention(gmsg({ id: 'g-1', mention: true }))
+      expect(internals.attentionScheduler.getCurrentIntervalMs(GROUP_SESSION)).toBe(5000)
+
+      setDispatchActions([{ kind: 'stay_silent' }, { kind: 'new_task' }])
+      await deliverMention(gmsg({ id: 'g-2', mention: true }))
+
+      expect(internals.attentionScheduler.getCurrentIntervalMs(GROUP_SESSION)).toBe(1000)
+    })
+
+    it('真实事件入口：@bot 群消息走完整条链（注意力 → 群 lane → dispatcher → worker）', async () => {
+      boot({ attentionMinMs: 1000 })
+
+      await deliverMention(gmsg({ id: 'g-1', text: '@小蟹 建个任务', mention: true }))
+
+      // 缓冲已被取空，消息确实是经注意力调度落到群聊处理路径的
+      expect(internals.attentionScheduler.getBufferSize(GROUP_SESSION)).toBe(0)
+      expect(dispatchTrace().trigger.summary).toBe('[group×1] 张三: @小蟹 建个任务')
+      expect(spawnCalls[0].isGroup).toBe(true)
+      expect(internals.attentionScheduler.getCurrentIntervalMs(GROUP_SESSION)).toBe(1000)
+    })
+  })
+
+  // ==========================================================================
+  // 早退分支
+  // ==========================================================================
+
+  describe('早退分支', () => {
+    it('没有 worker handler：trace 记失败，barrier 都不去碰', async () => {
+      boot({ withHandler: false })
+      internals.agentHandler = undefined
+      originTasks = ['task-a']
+
+      await runGroup([gmsg({ id: 'g-1', mention: true })])
+
+      const trace = dispatchTrace()
+      expect(trace.status).toBe('failed')
+      expect(trace.outcome?.summary).toBe('No worker handler configured')
+      expect(calls).toEqual(['start_trace:message'])
+      expect(dispatchMock).not.toHaveBeenCalled()
+    })
+
+    it('没有 worker LLM 环境：早退发生在上下文装配之后，且已 arm 的 barrier 不会泄漏', async () => {
+      boot({ withSdkEnv: false })
+      internals.sdkEnvWorker = undefined
+      originTasks = ['task-a']
+
+      await runGroup([gmsg({ id: 'g-1', mention: true })])
+
+      const trace = dispatchTrace()
+      expect(trace.status).toBe('failed')
+      expect(trace.outcome?.summary).toBe('sdkEnvWorker missing')
+      // 注：这条早退当前既不解除 barrier 也不更新退避档位（见 p7a-task1-report.md §6 O1
+      //     与本报告 O7）——那是已登记的 bug 不是契约。所以这里把 clear_barrier 过滤掉，
+      //     只钉"早退发生在装配之后"这一条真语义；将来修 bug 补上解除，本用例不该被误挂。
+      expect(calls.filter((c) => c !== 'clear_barrier')).toEqual([
+        'start_trace:message',
+        'get_active_tasks_by_origin',
+        'set_barrier',
+        'resolve_permissions',
+        'assemble_front_context',
+      ])
+      expect(dispatchMock).not.toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
## P7 / PR A:入站链路测试网

**本 PR 不改任何生产代码,只加测试。** 新增 98 个用例(`crabot-agent/tests/inbound/`),给 `unified-agent.ts` 的入站链路织一张**变异抓得住**的网。

plan:`crabot-docs/superpowers/plans/2026-07-31-mw-p7-a-inbound-test-net.md`

### 为什么需要它

P5 收尾时对入站链路做了两处变异(改坏群聊分流、改坏 batch 合并),**全量 2216 个用例一条都没抓到**。这条链路是人类消息的**唯一通路**,而 P7 的 cutover 要重写它——在没有测试网的情况下改它等于闭着眼睛动主动脉。

本 PR 逐条实测了旧网的空洞:**M2/M4/M5/M6/M7/M8/M10 在旧测试网下全部 0 命中**;只有 M11 有一条真命中,但它在**执行器层**,cutover 若自己拼 `ExecuteContext` 就照样绿。

### 验收:12 处变异逐个植入,全部被抓

| # | 变异 | 挂掉用例数 |
|---|---|---|
| M1 | 群/私分流反转 | 14 |
| M2 | batch 合并只取第一条 | 4 |
| M3 | 删掉未配置早退 | 2 |
| M4 | `resolvePrincipalPermissions` 恒 null | 4 |
| M5 | memory 档位恒 `{public,[]}` | 2 |
| M6 | `assembleFrontContext` 结果被丢弃 | 3 |
| M7 | 跳过引用预取 | 1 |
| M8 | 不注入 reaction | 2 |
| M9 | 群聊不调 `reportResult` | 6 |
| M10 | `awaitWorker` false→true | 1 |
| M11 | `sendImmediateReply` 挪到 spawn 之后 | 6 |
| M12a/b/c | admin chat 误入 lane / 误入 attention / 注入 reaction | 4 / 4 / 3 |

M12 拆成三个变体,因为 plan 一行里同时含"误入 lane / 误入 attention",而 `:1778` 注释指的是第三件——合成一条会掩盖另两条是否真被网住。

### 反向验证:网不是刺猬

变异验证保证"网够密",反向验证保证**无害重构不会挂一片**——否则 cutover 时测试网会成为负担而不是保护。三类等价改写,`tests/inbound/` 98 例**全绿**:

| # | 类型 | 备注 |
|---|---|---|
| R1 | 提取局部变量(`processDirectBatch` 提 3 个,替换 8 处引用) | |
| R2 | 抽纯函数 `memoryPermissionsFromScopes`,两处档位派生改调它 | **故意穿过 M5/M5G 锚点** |
| R3 | 两个独立缓存写入互换 + 纯计算的 `laneKey` 上提到分流之前 | **故意穿过 M1 锚点** |

后两条故意跨过变异锚点仍全绿,说明断言落在**行为**上而非代码形状上。

### 几个断言手法上的取舍

- **M9 不断"`reportResult` 被调用"**,而是走**真实事件入口**跑完后读 `getCurrentIntervalMs(sessionId)` 的退避档位毫秒值(不出声 → 5000 → 25000 逐级累积;出声后拉回 1000;`max` 封顶)。原因:`reportResult` 在没有 session state 时是 no-op,直接调 handler 读出来是 `undefined`,那样断言等于没断。
- **"不进 lane" 没有只用 `size()===0`** —— `SessionLane` 处理完会 `dispose` 自己,size 会退回 0,**误入 lane 照样是 0**。主断言改成"两个 registry 的 `getOrCreate` 一次都没被调过 + 两个 batch handler 零命中"。
- **不用 `Object.create(prototype)`** —— 分流逻辑有一半在构造函数接线里,造壳等于把接线抄进测试,M1 就只剩参数透传可断言。改用真实构造函数路子,只在实例上覆盖 lane handler。
- **只 mock 模块级 `dispatch`,保留真实 `executeDispatchActions`** —— M8/M11 的语义恰恰在执行器里。

### 诚实标注:哪些只断到参数层

- **M5**(memory 权限档位):下游 `assembleFrontContext` **压根忽略这个参数**(见下方 O6),只能断"交给 worker 的档位 = 该 friend 的 scopes"+ 反向断言"不是 public/空 scope";
- **M6 的数据流部分**:要断"prompt 里真看得见历史"需 mock `adapterFromSdkEnv` 跑真 dispatcher,超出"只 mock dispatch"的边界;
- **barrier 的最后一公里**:"worker 真被暂停"在 `agent-handler.humanQueue.setBarrier` 内部,本 PR 不建真 handler。

### `handleProcessMessage` 的 channel 分支 = 死代码(两重证据)

按 plan **不给死代码写测试**——那会让它看起来是活的,cutover 时反而不敢删。证据已固化并记入 PR L 退役清单:

1. **没有调用方**:全仓(主仓 + 4 个 channel 仓)grep RPC `process_message`,唯一生产调用方 `chat-manager.ts:220` 固定传 `source_type:'admin_chat'`;
2. **即使被调用也是空转**:`:1542` 生成 `requestId` 后从未 `setPendingRequest`,而该方法全仓只有定义无调用方 → `:1588` 的取代检查**恒真** → 分支永远在 `executeTriggerMessage` 白跑一整轮后返回空。

### 发现但**未修**的生产问题(8 项)

按 plan,本 PR 只加测试不修 bug——否则测试网就没有干净基线来证明它有效。

| # | 位置 | 问题 | 影响 |
|---|---|---|---|
| O1 | `unified-agent.ts:1006/1065/1186` | 群聊两条早退与 catch 都不调 `reportResult`;`!sdkEnvWorker` 早退还漏 `clearAllBarriers` | **中**:故障期退避不更新 → 群聊退化成"每条都巡检";barrier 多挂 8s |
| O2 | `:1588` + `session-manager.ts:44` | `setPendingRequest` 无调用方 | 低(死代码) |
| O3 | `:1669-1672` | admin chat `!sdkEnvWorker` 早退不发 `chat_callback` | 低频但用户可见:Master Chat 静默卡在 processing |
| O4 | `:247-255` | `currentResolvedPerms` 并发覆写 race | 作者 2026-05-20 已自标 |
| O5 | `tests/manager/events.test.ts` | 未登记的 flaky | 中:污染变异验证信噪比 |
| O6 | `context-assembler.ts:217` | `_memoryPermissions` 形参完全没用,而调用方每轮认真计算并传入 | 低但有误导性 |
| O7 | `attention-scheduler.ts:99-102` | `reportResult` 无条件 `scheduleCheck` 不查 `state.timer` → 旧 timer 泄漏且先触发、退避被绕过、`stopAll` 清不掉 | **低-中**:消息密集时退避形同虚设,正是 M9 想防的失控 |
| O8 | `:971-1190` | 群聊路径从不 `updateLastMessageTime`(私聊与 admin chat 都调) | 低:`get_status` 活跃会话永不含群聊 |

### 验证

- **2318 passed | 2 skipped**(203 文件);基线实测(把新目录移出)2290 passed,差值 28 = 新增数,**零回归**
- `tsc --noEmit` 干净
- `tests/inbound/` 98 例**连跑 3 次全绿**
- 12 次变异 + 3 次等价改写后逐次核对 `crabot-agent/src/` 干净;最终 `git status` 全仓 clean
- 已登记 flaky:`bg-entities/bg-shell`、`bg-entities/trace`、`manager/events`(单跑均全绿)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
