### PR TITLE
fix: Manager/Worker 拆分 P7/D——修 mailbox 停滞与回收丢失窗口

### DIFF
--- a/crabot-agent/src/manager/loop.ts
+++ b/crabot-agent/src/manager/loop.ts
@@ -135,6 +135,11 @@ export class ManagerLoop {
    *   `pending`(见 human-message-queue.ts push() 实现),下次 wakeUp() 顶部的
    *   drainPending() 会把它们和本次唤醒事件一起拼进新 episode 的 initialMessages——
    *   "至少一次投递"对两种时机是同一套代码路径,不需要再维护一份独立的 pending 队列。
+   *
+   * 但"下次唤醒"未必会到来:注入若落在 engine 最后一次 drain 之后(query-loop 在 end_turn
+   * 收口前的那次 drainPending),内容就会一直躺在这里。这个停滞窗口由 `ManagerRegistry`
+   * 在 episode 收口时按 `hasPendingMailbox` 自唤醒(`drainMailbox`)兜底,并由 `evictIdle`
+   * 拒绝回收 mailbox 非空的实例保证它不会先被回收掉(P7 阻塞项 #5)。
    */
   private readonly mailbox = new HumanMessageQueue()
   /**
@@ -165,6 +170,28 @@ export class ManagerLoop {
     return this.mutex.run(() => this.runEpisode(event))
   }
 
+  /**
+   * 自唤醒入口(`ManagerRegistry` 专用):不带新唤醒事件,只把 mailbox 里的残留跑一个 episode
+   * 处理掉。用途见 registry.ts `maybeSelfWake`——engine 在 end_turn 收口前做最后一次
+   * `drainPending`,落在那之后的 `enqueueDuringEpisode` 内容没有任何消费者在等,若不自唤醒
+   * 就会一直躺在内存 mailbox 里。
+   *
+   * mailbox 为空(残留已被别的 episode 顺带 drain 走)时是 no-op:不调 LLM、不写盘、不记
+   * episode 日志——否则会拿一份没有任何新内容的上下文再问一次 LLM,凭空多出一次回复。
+   */
+  async drainMailbox(): Promise<EpisodeResult> {
+    return this.mutex.run(() => this.runEpisode(undefined))
+  }
+
+  /**
+   * mailbox 里是否还有尚未投递给 LLM 的内容。`ManagerRegistry` 用它做两件事:
+   * ① episode 收口后判断要不要自唤醒;② `evictIdle` 判断该实例能不能回收——mailbox 是这些
+   * 内容**唯一**的存放处(盘上 state 没有它们,正因为还没被消费),回收即永久丢失。
+   */
+  get hasPendingMailbox(): boolean {
+    return this.mailbox.hasPending
+  }
+
   /** episode 进行中到达的新事件:渲染成文本推进内部邮箱,由 engine 的 humanMessageQueue
    *  在 turn 间隙注入;episode 不在跑时同样入队,行为见 `mailbox` 字段注释。 */
   enqueueDuringEpisode(event: WakeEvent): void {
@@ -173,12 +200,18 @@ export class ManagerLoop {
     this.currentEpisodeInjected?.push(text)
   }
 
-  private async runEpisode(event: WakeEvent): Promise<EpisodeResult> {
+  /** `event === undefined` ⇒ 自唤醒(见 `drainMailbox`):只处理 mailbox 残留,不渲染唤醒事件。 */
+  private async runEpisode(event: WakeEvent | undefined): Promise<EpisodeResult> {
     const episodeId = randomUUID()
     const carriedTexts = this.mailbox.drainPending().map(toText)
-    const eventText = renderWakeEvent(event)
+    if (event === undefined && carriedTexts.length === 0) {
+      // 自唤醒但 mailbox 已空(残留被排在前面的另一个 episode 顺带 drain 走了)——
+      // 没有任何新内容,直接空转返回,不开 episode(见 drainMailbox 注释)。
+      return { episodeId, outcome: 'completed', turns: 0, consumedEvents: true }
+    }
+    const eventText = event === undefined ? undefined : renderWakeEvent(event)
     this.currentEpisodeInjected = []
-    this.currentWakeEvent = event
+    this.currentWakeEvent = event ?? null
 
     try {
       return await this.runEpisodeBody(episodeId, carriedTexts, eventText)
@@ -194,7 +227,7 @@ export class ManagerLoop {
       // 绕过"至少一次投递"(见文件头)。
       this.mailbox.drainPending()
       for (const t of carriedTexts) this.mailbox.push(t)
-      this.mailbox.push(eventText)
+      if (eventText !== undefined) this.mailbox.push(eventText)
       for (const t of this.currentEpisodeInjected ?? []) this.mailbox.push(t)
       throw err
     } finally {
@@ -206,7 +239,7 @@ export class ManagerLoop {
   private async runEpisodeBody(
     episodeId: string,
     carriedTexts: ReadonlyArray<string>,
-    eventText: string,
+    eventText: string | undefined,
   ): Promise<EpisodeResult> {
     // §11 热更语义:整个 episode(含下面的 max_tokens 兜底重试)只在这里解析一次 adapter/
     // model,固定用这份快照——即使两次解析之间 admin config 已经变了,当前 episode 也不换。
@@ -229,7 +262,7 @@ export class ManagerLoop {
     const tailMessages: EngineMessage[] = [
       ...state.recent,
       ...carriedTexts.map((t) => createUserMessage(t)),
-      createUserMessage(eventText),
+      ...(eventText === undefined ? [] : [createUserMessage(eventText)]),
     ]
 
     let attempt = await this.runAttempt(state, tailMessages, adapter, model)
@@ -298,7 +331,7 @@ export class ManagerLoop {
       // 不清空会和下面的整体重投重复),再按到达顺序整体重投,保证至少一次投递、不丢失、不重复。
       this.mailbox.drainPending()
       for (const t of carriedTexts) this.mailbox.push(t)
-      this.mailbox.push(eventText)
+      if (eventText !== undefined) this.mailbox.push(eventText)
       for (const t of this.currentEpisodeInjected ?? []) this.mailbox.push(t)
     }
 

--- a/crabot-agent/src/manager/registry.ts
+++ b/crabot-agent/src/manager/registry.ts
@@ -14,6 +14,10 @@
  * `getOrCreate` 重新建一个新的 `ManagerLoop` 实例,而它构造时 `ManagerLoop.runEpisodeBody`
  * 顶部的 `store.load(key)` 会原样读回历史——对调用方完全透明。
  *
+ * **例外:mailbox 非空的实例不可回收**——那些内容只存在于内存 mailbox,盘上没有(见
+ * `evictIdle`);与之配套的是 episode 收口时的自唤醒兜底(见 `maybeSelfWake`)。两者合起来
+ * 关掉 P7 阻塞项 #5 的"停滞 + 回收丢失"窗口。
+ *
  * ## 系统线程(§4.4)
  *
  * `SYSTEM_TASKS_MANAGER_KEY` 是协议保留的"系统任务"线程:未指定目标 session 的 scheduled
@@ -58,6 +62,18 @@ import type { ChannelMessage } from '../types'
 
 /** §4.4 保留线程:未配置目标 session 的 scheduled 触发 / 台账查不到监护 session 的 worker 事件落此。 */
 export const SYSTEM_TASKS_MANAGER_KEY = 'admin-web::system-tasks' as ManagerKey
+
+/**
+ * 连锁自唤醒的上限(见 `ManagerRegistry.maybeSelfWake`)。
+ *
+ * 自唤醒本身可能再产生新的 mailbox 内容(自唤醒 episode 期间又有注入到达),不设上限就是
+ * 一条"episode → 注入 → episode"的无限链:注入源若是稳定复发的故障(如某 worker 上
+ * `query_worker` 恒失败,每个 episode 都触发一次 onAsyncError),链条永不收敛,烧的是真钱。
+ * 取 3:够把"收口瞬间才到达"这类一次性尾巴处理干净,又不至于替一个稳定故障源无限重开
+ * episode。到顶后残留**不丢**——它留在 mailbox 里,受 `evictIdle` 的非空保护,由下一次
+ * 真实唤醒(人类消息 / worker 事件 / schedule)顺带 drain 走,仍满足 §4.1 至少一次投递。
+ */
+export const MAX_SELF_WAKE_CHAIN = 3
 
 /** `query_worker` 异步失败(Task 4 `WorkerToolsDeps.onAsyncError`)的信息形状,逐字对齐该接口。 */
 export interface AsyncToolErrorInfo {
@@ -233,14 +249,27 @@ export class ManagerRegistry {
   }
 
   /**
-   * 空闲实例回收:回收 `nowMs - 最后活跃时间 > idleMs` 且当前无 episode 在跑的实例。
-   * 只删内存里的 `ManagerLoop` 引用,不碰 `ManagerSessionStore` 的盘上状态——回收后同一 key
-   * 再次唤醒会经 `getOrCreate` 重建实例并从盘上恢复历史(见文件头说明)。返回本次回收数量。
+   * 空闲实例回收:回收 `nowMs - 最后活跃时间 > idleMs`、当前无 episode 在跑、且 **mailbox 为空**
+   * 的实例。只删内存里的 `ManagerLoop` 引用,不碰 `ManagerSessionStore` 的盘上状态——回收后
+   * 同一 key 再次唤醒会经 `getOrCreate` 重建实例并从盘上恢复历史(见文件头说明)。
+   * 返回本次回收数量。
+   *
+   * **mailbox 非空必须跳过**(P7 阻塞项 #5):mailbox 里的内容是"已经收到、但还没被投递给
+   * LLM"的事件——盘上 state 里没有它们(正因为还没消费),`ManagerLoop` 实例是它们唯一的
+   * 存放处。回收即永久丢失,直接违反 §4.1"至少一次投递";cutover 之后这条路径上跑的是**人类
+   * 消息**(episode 失败会把整批人类消息推回 mailbox 等下次唤醒重投),丢的就是人类消息。
+   *
+   * 代价是这类实例可能长期不被回收(极端情况:一个 key 的 mailbox 一直非空 → 永不回收)。
+   * 这是有意的取舍,且边界可控:①内存占用是一个 `ManagerLoop` 外壳 + 若干条待投递文本,
+   * 会话历史本来就在盘上;②mailbox 非空只有两种来路——episode 失败推回(下次唤醒即消费)、
+   * 收口后到达的注入(episode 收口时自唤醒消费,见 `maybeSelfWake`),两条都自带收敛路径,
+   * "永不回收"意味着"这个 key 确实还欠着一条没投递的消息",此时保住实例正是我们要的。
    */
   evictIdle(idleMs: number, nowMs: number): number {
     let evicted = 0
-    for (const key of this.loops.keys()) {
+    for (const [key, loop] of this.loops) {
       if (this.isEpisodeActive(key)) continue
+      if (loop.hasPendingMailbox) continue
       const lastActive = this.lastActiveAtMs.get(key) ?? 0
       if (nowMs - lastActive <= idleMs) continue
       this.loops.delete(key)
@@ -267,17 +296,65 @@ export class ManagerRegistry {
     return (this.activeEpisodes.get(key) ?? 0) > 0
   }
 
-  /** getOrCreate + 维护 activeEpisodes 引用计数的公共路径,所有 routeXxx / onAsyncError 都走这里。 */
-  private async runWake(key: ManagerKey, event: WakeEvent): Promise<EpisodeResult> {
+  /**
+   * getOrCreate + 维护 activeEpisodes 引用计数的公共路径,所有 routeXxx / onAsyncError /
+   * 自唤醒都走这里。`event === undefined` ⇒ 自唤醒(只处理 mailbox 残留,见
+   * `ManagerLoop.drainMailbox`);`selfWakeChain` 是当前连锁自唤醒的深度,真实唤醒恒为 0。
+   */
+  private async runWake(key: ManagerKey, event: WakeEvent | undefined, selfWakeChain = 0): Promise<EpisodeResult> {
     const loop = this.getOrCreate(key)
     this.activeEpisodes.set(key, (this.activeEpisodes.get(key) ?? 0) + 1)
+    let result: EpisodeResult | undefined
     try {
-      return await loop.wakeUp(event)
+      result = await (event === undefined ? loop.drainMailbox() : loop.wakeUp(event))
+      return result
     } finally {
       const remaining = (this.activeEpisodes.get(key) ?? 1) - 1
       if (remaining <= 0) this.activeEpisodes.delete(key)
       else this.activeEpisodes.set(key, remaining)
+      // 必须与上面的引用计数递减处在**同一个同步块**里(中间不 await):否则会出现
+      // "计数已归零、自唤醒尚未登记"的窗口,`evictIdle` 恰在此时跑就会把实例连同 mailbox
+      // 一起回收掉。`maybeSelfWake` 内部的 `runWake` 在第一个 await 之前就完成了 +1。
+      this.maybeSelfWake(key, loop, result, selfWakeChain)
     }
+  }
+
+  /**
+   * episode 收口后的 mailbox 兜底(P7 阻塞项 #5):engine 在 end_turn 收口前做最后一次
+   * `drainPending`,落在那之后的 `enqueueDuringEpisode` 内容没有任何消费者在等,不自唤醒
+   * 就会一直停滞在内存 mailbox 里(cutover 后这条路径上会跑人类消息 → 表现为"机器人收到了
+   * 但永远不回")。这里在 episode 刚收口、引用计数刚归零的同步窗口里补一次自唤醒。
+   *
+   * 四道门,缺一不可:
+   * 1. `result?.consumedEvents === true` —— **只在成功收口后自唤醒**。episode 失败
+   *    (含直接抛错,此时 `result` 是 undefined)会把整批输入原样推回 mailbox,那是 §4.1
+   *    "下次唤醒重投"的既有语义;若在这里自唤醒,LLM 持续故障时就变成"失败→立刻重试→再
+   *    失败"的热循环,把重投语义变成无限重试。失败留下的残留由 `evictIdle` 的非空保护守住,
+   *    等下一次真实唤醒重投。
+   * 2. `loop.hasPendingMailbox` —— 没有残留就没有要处理的东西(绝大多数 episode 走这条)。
+   * 3. `!isEpisodeActive(key)` —— 同 key 还有别的在途 episode 时不插队:它要么已经在
+   *    turn 间隙 drain 掉这批残留,要么在自己收口时走这同一段逻辑。
+   * 4. `selfWakeChain < MAX_SELF_WAKE_CHAIN` —— 防无限自唤醒(见该常量注释)。
+   */
+  private maybeSelfWake(
+    key: ManagerKey,
+    loop: ManagerLoop,
+    result: EpisodeResult | undefined,
+    selfWakeChain: number
+  ): void {
+    if (result?.consumedEvents !== true) return
+    if (!loop.hasPendingMailbox) return
+    if (this.isEpisodeActive(key)) return
+    if (selfWakeChain >= MAX_SELF_WAKE_CHAIN) {
+      console.warn(
+        `[ManagerRegistry] manager '${key}' 连锁自唤醒达到上限 ${MAX_SELF_WAKE_CHAIN},` +
+          `剩余 mailbox 内容留待下次唤醒投递(实例不会被 evictIdle 回收)`
+      )
+      return
+    }
+    void this.runWake(key, undefined, selfWakeChain + 1).catch((err) => {
+      console.error(`[ManagerRegistry] manager '${key}' 自唤醒失败:`, err)
+    })
   }
 }
 

--- a/crabot-agent/tests/manager/loop.test.ts
+++ b/crabot-agent/tests/manager/loop.test.ts
@@ -699,6 +699,49 @@ describe('ManagerLoop', () => {
     expect(state.rollingSummary).toBeUndefined() // 没发生过折叠
   })
 
+  // --- drainMailbox(自唤醒入口,P7 阻塞项 #5) ---
+
+  it('drainMailbox: mailbox 为空时是 no-op——不调 LLM、不写盘(否则会拿没有新内容的上下文凭空多问一次)', async () => {
+    const { adapter, calls } = makeAdapter()
+    const loop = new ManagerLoop(baseDeps({ store, adapter }))
+
+    expect(loop.hasPendingMailbox).toBe(false)
+    const result = await loop.drainMailbox()
+
+    expect(result.turns).toBe(0)
+    expect(result.consumedEvents).toBe(true)
+    expect(calls.length).toBe(0)
+    const state = await store.load(KEY)
+    expect(state.recent.length).toBe(0)
+  })
+
+  it('drainMailbox: 只投递 mailbox 残留,不额外渲染唤醒事件;投递后 mailbox 清空、内容进历史(至少一次且不重复)', async () => {
+    const { adapter, queue, calls } = makeAdapter()
+    queue.push({ text: '处理完残留', stopReason: 'end_turn' })
+    queue.push({ text: '下一次唤醒的回复', stopReason: 'end_turn' })
+
+    const loop = new ManagerLoop(baseDeps({ store, adapter }))
+    loop.enqueueDuringEpisode({ kind: 'schedule', scheduleId: 'sched-residue', title: '巡检', description: '收口后才到达的残留' })
+    expect(loop.hasPendingMailbox).toBe(true)
+
+    const result = await loop.drainMailbox()
+    expect(result.outcome).toBe('completed')
+    expect(result.consumedEvents).toBe(true)
+    expect(loop.hasPendingMailbox).toBe(false)
+
+    // 喂给 LLM 的只有残留本身,没有为"自唤醒"这件事凭空造出一条唤醒事件文本。
+    const firstCallMessages = JSON.stringify(calls[0].messages)
+    expect(firstCallMessages).toContain('收口后才到达的残留')
+    expect(firstCallMessages).not.toContain('[人类消息]')
+
+    // 已消费进持久历史,下次真实唤醒不会重复投递。
+    const afterDrain = await loop.wakeUp({ kind: 'human_messages', messages: [makeChannelMessage('新的话')] })
+    expect(afterDrain.outcome).toBe('completed')
+    const state = await store.load(KEY)
+    const occurrences = (JSON.stringify(state.recent).match(/sched-residue/g) ?? []).length
+    expect(occurrences).toBe(1)
+  })
+
   it('session 永不 finalize:连续 5 次 wakeUp 后仍能正常继续工作', async () => {
     const { adapter, queue } = makeAdapter()
     for (let i = 0; i < 5; i++) queue.push({ text: `回复${i}`, stopReason: 'end_turn' })

--- a/crabot-agent/tests/manager/registry.test.ts
+++ b/crabot-agent/tests/manager/registry.test.ts
@@ -6,6 +6,7 @@ import { join } from 'path'
 import {
   ManagerRegistry,
   SYSTEM_TASKS_MANAGER_KEY,
+  MAX_SELF_WAKE_CHAIN,
   type ManagerRegistryDeps,
   type OnAsyncError,
 } from '../../src/manager/registry.js'
@@ -394,6 +395,164 @@ describe('ManagerRegistry', () => {
     // 两个都结束后引用计数应归零——此时才真正允许回收。
     const evictedAfterBothDone = registry.evictIdle(-1, Date.parse('2026-01-01T00:00:00.000Z'))
     expect(evictedAfterBothDone).toBe(1)
+  })
+
+  // --- mailbox 停滞窗口 / 回收丢失窗口（P7 阻塞项 #5） ---
+
+  it('mailbox 停滞：注入落在 engine 最后一次 drain 之后（episode 仍在途）→ episode 收口时必须自唤醒把它处理掉，不得躺在 mailbox 无人问津', async () => {
+    const key = 'wechat::sess-stall' as ManagerKey
+    const { adapter, queue } = makeAdapter()
+    queue.push({ text: '第一个 episode 收口', stopReason: 'end_turn' })
+    queue.push({ text: '自唤醒 episode 的回复', stopReason: 'end_turn' })
+
+    let capturedOnAsyncError: OnAsyncError | undefined
+    const registry = new ManagerRegistry(
+      baseRegistryDeps({
+        adapter,
+        toolFace: (_key, _isSystemThread, onAsyncError) => {
+          capturedOnAsyncError = onAsyncError
+          return []
+        },
+      })
+    )
+
+    // 复现窗口：query-loop 在 end_turn 收口前做**最后一次** drainPending（query-loop.ts:551），
+    // 此后到达的注入没有任何消费者在等。这里用 store.appendEpisodeLog 作确定性锚点——它在
+    // runEngine 已经返回之后、wakeUp 尚未 resolve 之前被调用（loop.ts runEpisodeBody），
+    // 此刻 registry 仍把该 key 计为在途（activeEpisodes > 0），因此走的正是生产路径
+    // handleAsyncToolError 的 enqueueDuringEpisode 分支（真实触发者是 query_worker 那条
+    // 游离 promise 恰好在最后一次 drain 之后才 reject）。不靠定时器猜时间窗口。
+    const origAppend = store.appendEpisodeLog.bind(store)
+    let injected = false
+    vi.spyOn(store, 'appendEpisodeLog').mockImplementation(async (k, episodeId, messages) => {
+      await origAppend(k, episodeId, messages)
+      if (!injected) {
+        injected = true
+        capturedOnAsyncError?.({ tool: 'query_worker', worker_id: 'w-late', error: 'fork failed' })
+      }
+    })
+
+    await registry.routeHumanMessages('wechat', 'sess-stall', [makeChannelMessage('侧问一下 worker')])
+    expect(injected).toBe(true)
+
+    // 语义不变量（§4.1 至少一次投递）：这条注入必须最终被投递给 LLM 并落进持久历史，
+    // 且只投递一次。旧实现里它永远停在 mailbox 里等一个不会到来的下次唤醒。
+    await vi.waitFor(
+      async () => {
+        const state = await store.load(key)
+        expect(JSON.stringify(state.recent)).toContain('query_failed')
+      },
+      { timeout: 2000, interval: 10 }
+    )
+    const occurrences = (JSON.stringify((await store.load(key)).recent).match(/query_failed/g) ?? []).length
+    expect(occurrences).toBe(1)
+  })
+
+  it('回收丢失：episode 失败把人类消息推回 mailbox 后，evictIdle 不得回收该实例——回收即永久丢失（§4.1 至少一次投递）', async () => {
+    const key = 'wechat::sess-evict-loss' as ManagerKey
+    let failNext = true
+    const adapter: LLMAdapter = {
+      async *stream() {
+        if (failNext) throw new Error('boom: simulated non-retryable failure')
+        yield* chunksFromContent([{ type: 'text', text: '收到' }], 'end_turn', { inputTokens: 10, outputTokens: 5 })
+      },
+      updateConfig: () => {},
+    }
+    let nowMs = Date.parse('2026-01-01T00:00:00.000Z')
+    const registry = new ManagerRegistry(baseRegistryDeps({ adapter, now: () => new Date(nowMs) }))
+
+    // episode 失败 → consumedEvents=false → 这条人类消息被推回 mailbox 等下次唤醒重投。
+    const first = await registry.routeHumanMessages('wechat', 'sess-evict-loss', [makeChannelMessage('救命，这条不能丢')])
+    expect(first.consumedEvents).toBe(false)
+    const loopBefore = registry.getOrCreate(key)
+
+    // 此时实例空闲（无 episode 在跑）且已超过 idleMs：旧实现会连同 mailbox 一起丢掉，
+    // 而 mailbox 是这条人类消息**唯一**的存放处（盘上 state 没有它——正因为没消费）。
+    nowMs += 10 * 60 * 1000
+    const evicted = registry.evictIdle(5 * 60 * 1000, nowMs)
+
+    // 先断"内容还在"这条语义不变量（而不是先断计数）：修复被移除时最先挂的是这一条，
+    // 它证明的是**人类消息永久丢失**，而不只是"回收计数不对"。
+    failNext = false
+    const second = await registry.routeHumanMessages('wechat', 'sess-evict-loss', [makeChannelMessage('还在吗')])
+    expect(second.consumedEvents).toBe(true)
+    const serialized = JSON.stringify((await store.load(key)).recent)
+    expect(serialized).toContain('救命，这条不能丢')
+    expect(serialized).toContain('还在吗')
+
+    // 机制层面：没被回收，仍是同一个实例（mailbox 就在它身上）。
+    expect(evicted).toBe(0)
+    expect(registry.getOrCreate(key)).toBe(loopBefore)
+  })
+
+  it('自唤醒不覆盖失败路径：episode 失败把内容推回 mailbox 后不得立即重开 episode（否则 LLM 持续故障时变成热循环重试）', async () => {
+    let streamCalls = 0
+    const adapter: LLMAdapter = {
+      async *stream() {
+        streamCalls++
+        if (streamCalls > 0) throw new Error('boom: LLM 持续故障') // 恒真;写成条件只为让它仍是合法 generator
+        yield* chunksFromContent([{ type: 'text', text: '不可达' }], 'end_turn')
+      },
+      updateConfig: () => {},
+    }
+    const registry = new ManagerRegistry(baseRegistryDeps({ adapter }))
+
+    const result = await registry.routeHumanMessages('wechat', 'sess-no-hot-retry', [makeChannelMessage('你好')])
+    expect(result.consumedEvents).toBe(false)
+
+    // 给自唤醒足够的宏任务窗口去发生（如果它错误地覆盖了失败路径的话）。
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    expect(streamCalls).toBe(1) // 只有那一次失败的 episode，没有自动重试
+
+    // 内容仍在 mailbox 里等下次唤醒重投（§4.1），因此实例也不允许被回收。
+    expect(registry.evictIdle(-1, Date.parse('2026-01-01T00:00:00.000Z'))).toBe(0)
+  })
+
+  it('自唤醒有上限：每个 episode 都产生新残留时，连锁自唤醒最多 MAX_SELF_WAKE_CHAIN 次；到顶后残留不丢（不被回收 + 下次真实唤醒投递）', async () => {
+    const key = 'wechat::sess-chain' as ManagerKey
+    const { adapter, calls } = makeAdapter()
+
+    let capturedOnAsyncError: OnAsyncError | undefined
+    const registry = new ManagerRegistry(
+      baseRegistryDeps({
+        adapter,
+        toolFace: (_key, _isSystemThread, onAsyncError) => {
+          capturedOnAsyncError = onAsyncError
+          return []
+        },
+      })
+    )
+
+    // 病态注入源：**每个** episode 收口后都再产生一条注入（模拟某 worker 上 query_worker
+    // 恒失败这类稳定复发故障）。没有上限的话这就是一条无限的 episode 链。
+    let keepInjecting = true
+    let injections = 0
+    const origAppend = store.appendEpisodeLog.bind(store)
+    vi.spyOn(store, 'appendEpisodeLog').mockImplementation(async (k, episodeId, messages) => {
+      await origAppend(k, episodeId, messages)
+      if (keepInjecting) {
+        injections++
+        capturedOnAsyncError?.({ tool: 'query_worker', worker_id: `w-${injections}`, error: 'fork failed' })
+      }
+    })
+
+    await registry.routeHumanMessages('wechat', 'sess-chain', [makeChannelMessage('开始')])
+
+    // 1 次真实唤醒 + 至多 MAX_SELF_WAKE_CHAIN 次连锁自唤醒，然后必须停下。
+    await vi.waitFor(() => expect(calls.length).toBe(1 + MAX_SELF_WAKE_CHAIN), { timeout: 2000, interval: 10 })
+    await new Promise((resolve) => setTimeout(resolve, 80))
+    expect(calls.length).toBe(1 + MAX_SELF_WAKE_CHAIN) // 停住了，没有继续滚
+    expect(injections).toBe(1 + MAX_SELF_WAKE_CHAIN)
+
+    // 到顶时最后一条注入仍留在 mailbox：不丢、不被回收，由下一次真实唤醒顺带投递。
+    const loopBefore = registry.getOrCreate(key)
+    expect(registry.evictIdle(-1, Date.parse('2026-01-01T00:00:00.000Z'))).toBe(0)
+    expect(registry.getOrCreate(key)).toBe(loopBefore)
+
+    keepInjecting = false
+    await registry.routeHumanMessages('wechat', 'sess-chain', [makeChannelMessage('还在吗')])
+    const lastCall = calls[calls.length - 1]
+    expect(JSON.stringify(lastCall.messages)).toContain(`w-${1 + MAX_SELF_WAKE_CHAIN}`)
   })
 
   // --- onAsyncError 接线（Task 4 遗留出口） ---


### PR DESCRIPTION
## P7 / PR D:修 mailbox 停滞与回收丢失窗口(阻塞项 #5)

**为什么现在修**:`enqueueDuringEpisode` 目前唯一的生产触发者是 `handleAsyncToolError`,影响面还小。但 P7 cutover 会把 **mid-episode 的人类消息**接到这个入口——那时这两个窗口就从"丢一条工具错误通知"升级为"**丢人类消息**"。**修在接线之前是对的顺序。**

本次只做阻塞项 #5。动态块位置(#4)需要 engine 提供"消息尾部注入口",触碰 engine,另行评估。

### 两个缺陷都先复现再修

**停滞窗口**:注入落在 episode 最后一次 `drainPending`(`query-loop.ts:551`,end_turn 收口前那次)之后,内容躺在内存 mailbox 无人唤醒。复现测试全程走生产路径——从 registry 的 `toolFace` 工厂捕获它按 key 绑定的真实 `onAsyncError`,用 `store.appendEpisodeLog` 作确定性锚点触发,**不靠 `setTimeout` 猜窗口**。

**回收丢失**:纯生产路径、零测试专用注入点——adapter 首次抛错 → `consumedEvents=false` → 整批**人类消息**被推回 mailbox → 推进时钟越过 `idleMs` → `evictIdle` 回收 → 永久丢失。断言顺序特意是"先断内容还在、再断回收计数",所以修复被移除时最先挂的是 `toContain('救命,这条不能丢')`——证明的是**人类消息永久丢失**,而不只是计数不对。

### 修法:自唤醒放在 registry,不放在 loop

这是本 PR 唯一有实质取舍的决定。自唤醒**必须占用 `activeEpisodes` 引用计数**,否则 registry 不知情、计数为 0,`evictIdle` 会在自唤醒 episode 运行期间回收 `this.loops` 引用 → 新事件 `getOrCreate` 出第二个独立 mutex 的 loop 并发写同一份 session store——**正是 P4 Task 8 裁决过的 split-brain**。走 `runWake` 则复用既有的引用计数纪律(`Map<key,number>` 一行未改)。

配套一条同步窗口纪律:`maybeSelfWake` 与引用计数递减在**同一同步块、中间不 await**,否则存在"计数已归零、自唤醒未登记"的窗口给 `evictIdle` 钻。

**没有新增 `WakeEvent` 变体** —— 自唤醒不是事件,给它造渲染文本等于往上下文塞一条 LLM 从没收到过的假消息。

### 两个边界

**无限自唤醒**:四道门 —— ① 只在 `consumedEvents===true` 后自唤醒(失败路径维持 §4.1"下次唤醒重投";在这里自唤醒会让 LLM 持续故障变成**热循环重试**);② mailbox 非空;③ 同 key 无其它在途 episode;④ 连锁深度 < 3。另有 `drainMailbox` 在 mailbox 已空时 no-op,堵住"拿没有新内容的上下文再问一次 LLM"。到顶不等于丢:残留受非空保护,由下次真实唤醒 drain 走,有断言。

**永不回收**:确实会发生,**是有意取舍**。mailbox 非空 ⇔ 该 key 还欠一条未投递消息,此时保住实例正是目的;代价只是一个 loop 外壳 + 若干文本(会话历史本就在盘上);两条来路都自带收敛路径。持久化 mailbox 会改持久化格式,超出小改动边界。

### 变异验证(5 处全抓,已还原)

| 变异 | 结果 |
|---|---|
| 删 evict 守卫 | 3 挂,**首挂即"人类消息丢失"** |
| 删 `maybeSelfWake` 调用 | 2 挂 |
| 让失败路径也自唤醒 | `expected 4 to be 1`——热重试确实发生 |
| 去掉链上限 | `expected 389 to be 4`——80ms 滚了 389 个 episode |
| 去掉 no-op 短路 | 凭空多一次 LLM 调用 |

未做变异覆盖的一处:`!isEpisodeActive(key)` 那道门——删掉不构成正确性故障(退化成 no-op episode),故未单造用例。

### 验证

- 基线(main)**2318 passed | 2 skipped**;改动后 **2324** 非跳过(= 2318 + 新增 6),**零回归**
- 唯一 failed 是已登记 flaky `bg-entities/bg-shell`,单跑 14 passed
- `tests/manager/` 定向 15 files / 210 passed;`tsc --noEmit` 干净

### 发现但**未修**的问题

1. **失败 episode 的残留没有自愈时机**(需单独评估):本次保证它**不丢**(不被回收),但若此后再无任何真实唤醒,它会一直等着——现实表现就是"**人类发一条 → episode 失败 → 已读不回**"。给失败路径加自动重试会与 §4.1"下次唤醒重投"的协议语义冲突,且需要退避策略,属设计决策,建议 cutover 前单独评估。
2. mailbox 是**纯内存**的,进程崩溃/重启丢掉所有未投递内容(P1–P5 既有设计,改它要改持久化格式 → 独立 spec)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
