### PR TITLE
feat: Manager/Worker 拆分 P7/C——manager 的 messaging 工具面

### DIFF
--- a/crabot-agent/src/manager/tools/tool-face.ts
+++ b/crabot-agent/src/manager/tools/tool-face.ts
@@ -19,8 +19,7 @@ import type { ToolDefinition, ToolCallResult } from '../../engine/index.js'
 import type { McpServer } from '../../mcp/mcp-helpers.js'
 import { mcpServerToToolDefinitions } from '../../agent/mcp-tool-bridge.js'
 import { buildMessagingTools } from '../../mcp/crab-messaging.js'
-import type { CrabMessagingDeps, MessagingTool, TaskContext } from '../../mcp/crab-messaging.js'
-import { HumanMessageQueue } from '../../engine/human-message-queue.js'
+import type { CrabMessagingDeps, MessagingTool, MessagingToolSet } from '../../mcp/crab-messaging.js'
 import { buildWorkerTools } from './worker-tools.js'
 import type { WorkerHarness } from '../../workers/harness/harness'
 import { buildCrabotInfoTools } from './crabot-info.js'
@@ -67,6 +66,23 @@ const MESSAGING_BASE_WHITELIST: readonly string[] = [
 /** 仅 isSystemThread===true 时额外暴露。 */
 const MESSAGING_SYSTEM_EXTRA: readonly string[] = ['send_master_private', 'send_private_message']
 
+/**
+ * manager 交给 `buildMessagingTools` 的显式工具集声明。
+ *
+ * manager 不是任务执行者——它没有 TaskContext，也不该有；这里直接声明要哪些工具，
+ * 由 crab-messaging 照单构造。`allowAskHuman:false`：ask_human 是 worker 侧概念，
+ * manager 的 `send_message` 连 `intent` 参数都被去掉了（见 `messagingToolToDefinition`）。
+ */
+function managerMessagingToolSet(isSystemThread: boolean): MessagingToolSet {
+  return {
+    tools: new Set<string>([
+      ...MESSAGING_BASE_WHITELIST,
+      ...(isSystemThread ? MESSAGING_SYSTEM_EXTRA : []),
+    ]),
+    allowAskHuman: false,
+  }
+}
+
 /** 白名单内只读的子集（其余——发送类——一律 isReadOnly:false）。 */
 const MESSAGING_READ_ONLY = new Set([
   'get_history',
@@ -78,42 +94,6 @@ const MESSAGING_READ_ONLY = new Set([
   'list_group_members',
   'fetch_media',
 ])
-
-/**
- * isSystemThread===true 时，`buildMessagingTools` 内部的 `resolveMessagingToolProfile`
- * 必须判成 'scheduled'（而非缺省的 'human_message'）——send_master_private /
- * send_private_message 的可见性完全由 `taskCtx.triggerType` 决定（crab-messaging.ts），
- * 没有第二条口子。因此这里用一个最小 stub `TaskContext` 覆盖
- * `deps.messagingDeps.getTaskContext`，仅为解锁这两个工具在 `buildMessagingTools` 返回
- * 数组里的可见性、以及它们运行时 `requireScheduledShortcutContext` 检查（读的是同一个
- * `getTaskContext`）的通过。
- *
- * 隐式语义审查（CLAUDE.md「语义边界与复用审查」）：
- * - `hasGoal` 固定 false —— 不会触发 goal-mode 的 outboundBuffer 缓冲分支（该分支要求
- *   `hasGoal()===true` 才生效），manager 的 send_message 因此总是立即发送，语义不受影响；
- * - manager 侧 `send_message` 的 `intent` 参数已被本模块整体去除（见 `messagingToolToDefinition`），
- *   唯一读 `humanQueue`/`taskId` 的 `intent==='ask_human'` 分支因此永远不会被触发，stub 的
- *   `taskId`/`humanQueue` 只用于满足 `TaskContext` 的类型要求，不承载真实语义；
- * - 不影响非系统线程 manager：`isSystemThread===false` 时 `getTaskContext` 原样透传
- *   `deps.messagingDeps`，不做任何覆盖。
- */
-function buildSystemThreadTaskContext(): TaskContext {
-  return {
-    taskId: 'manager-system-thread',
-    humanQueue: new HumanMessageQueue(),
-    triggerType: 'scheduled',
-    hasGoal: () => false,
-  }
-}
-
-function resolveEffectiveMessagingDeps(deps: ToolFaceDeps): CrabMessagingDeps {
-  if (!deps.isSystemThread) return deps.messagingDeps
-  const systemThreadContext = buildSystemThreadTaskContext()
-  return {
-    ...deps.messagingDeps,
-    getTaskContext: () => systemThreadContext,
-  }
-}
 
 /**
  * 把裸 `MessagingTool`（crab-messaging 的内部工具形状：`schema` 是 zod 原始 shape，
@@ -164,13 +144,8 @@ function messagingToolToDefinition(tool: MessagingTool): ToolDefinition {
 }
 
 function buildMessagingFace(deps: ToolFaceDeps): ToolDefinition[] {
-  const effectiveMessagingDeps = resolveEffectiveMessagingDeps(deps)
-  const rawTools = buildMessagingTools(effectiveMessagingDeps)
-  const whitelist = new Set<string>([
-    ...MESSAGING_BASE_WHITELIST,
-    ...(deps.isSystemThread ? MESSAGING_SYSTEM_EXTRA : []),
-  ])
-  return rawTools.filter((tool) => whitelist.has(tool.name)).map(messagingToolToDefinition)
+  const toolSet = managerMessagingToolSet(deps.isSystemThread)
+  return buildMessagingTools(deps.messagingDeps, () => toolSet).map(messagingToolToDefinition)
 }
 
 // ============================================================================

--- a/crabot-agent/src/manager/tools/tool-face.ts
+++ b/crabot-agent/src/manager/tools/tool-face.ts
@@ -48,11 +48,18 @@ export interface ToolFaceDeps {
 // ============================================================================
 
 /**
- * 普通 manager 的 messaging 白名单（9 项，完整通讯能力含跨 session 投递，
- * protocol-agent-v3.md §4.3 明确不裁）。
+ * 普通 manager 的 messaging 白名单（完整通讯能力含跨 session 投递，
+ * protocol-agent-v3.md §4.3 明确不裁）。逐行对齐 protocol-crab-messaging.md §1 的两张可见性表。
+ *
+ * 末尾三个 channel 透传只读工具（§2.10.1–§2.10.3）**仅当存在飞书 channel 实例时才真的出现**：
+ * `deps.messagingDeps.enableFeishuDocTool` 为 falsy 时 crab-messaging 压根不构造它们，
+ * 而 `MessagingToolSet.tools` 是交集语义（声明 ≠ 存在）。**`feishu_write`（§2.10.4）不在此列**
+ * ——任意写 API 透传、无逐操作确认、无 undo，而 manager 是人类原文的唯一入口，
+ * 是最容易被 prompt 注入的一环（protocol-crab-messaging.md §1 的 note）。
  */
 const MESSAGING_BASE_WHITELIST: readonly string[] = [
   'send_message',
+  'send_private_message',
   'get_history',
   'get_message',
   'lookup_friend',
@@ -61,10 +68,16 @@ const MESSAGING_BASE_WHITELIST: readonly string[] = [
   'list_groups',
   'list_group_members',
   'fetch_media',
+  'read_feishu_document',
+  'feishu_raw_get',
+  'feishu_download_file',
 ]
 
-/** 仅 isSystemThread===true 时额外暴露。 */
-const MESSAGING_SYSTEM_EXTRA: readonly string[] = ['send_master_private', 'send_private_message']
+/**
+ * 仅 isSystemThread===true 时额外暴露：`send_master_private` 的 reach_master 语义只属于
+ * 系统线程（protocol-crab-messaging.md §1 投递类可见性表）。
+ */
+const MESSAGING_SYSTEM_EXTRA: readonly string[] = ['send_master_private']
 
 /**
  * manager 交给 `buildMessagingTools` 的显式工具集声明。
@@ -93,6 +106,11 @@ const MESSAGING_READ_ONLY = new Set([
   'list_groups',
   'list_group_members',
   'fetch_media',
+  // channel 透传只读三件套：都不改飞书数据（`feishu_download_file` 只把 token 登记成
+  // media handle，落盘要再走 fetch_media），可与其它读工具并行成批。
+  'read_feishu_document',
+  'feishu_raw_get',
+  'feishu_download_file',
 ])
 
 /**

--- a/crabot-agent/src/mcp/crab-messaging.ts
+++ b/crabot-agent/src/mcp/crab-messaging.ts
@@ -108,6 +108,36 @@ function resolveMessagingToolProfile(
 }
 
 // ============================================================================
+// 工具集声明 —— 由装配层显式给出，buildMessagingTools 不再自己从 TaskContext 推断
+// ============================================================================
+
+/**
+ * 一次 messaging 装配要暴露的能力声明。装配层给出（worker 侧 = `buildWorkerMessagingTools`，
+ * manager 侧 = `manager/tools/tool-face.ts`），`buildMessagingTools` 只照单执行。
+ *
+ * 它同时是**可见性**与**运行时门**的唯一来源：`tools` 决定构建哪些工具，两处旁路门
+ * （scheduled 私聊捷径 / `send_message` 的 ask_human）也读同一份声明——两边共用一个来源，
+ * 才不会出现"工具可见但调用被拦"这种极难排查的错位。
+ *
+ * `tools` 是**交集**语义：声明了但当前 deps 没构造的工具（如 `enableFeishuDocTool=false`
+ * 时的飞书工具）自然不出现。新增工具时须同时登记进 `ALL_MESSAGING_TOOL_NAMES`。
+ */
+export interface MessagingToolSet {
+  /** 要暴露的工具名集合。 */
+  readonly tools: ReadonlySet<string>
+  /** `send_message` 是否允许 `intent='ask_human'`（要求存在一个同步的人类应答方）。 */
+  readonly allowAskHuman: boolean
+}
+
+/**
+ * 声明的读取入口。取 **getter 而非定值**：worker 侧的声明由 `deps.getTaskContext()` 推出，
+ * 而 TaskContext 是活的，构建时的快照未必等于调用那一刻的上下文；运行时门要的是**调用那一刻**
+ * 的声明（回归用例：`tests/mcp/crab-messaging-send-master-private.test.ts`「构建后切到 message
+ * context 时拒绝且零 RPC」）。manager 侧声明是常量，getter 原样返回即可。
+ */
+export type MessagingToolSetProvider = () => MessagingToolSet
+
+// ============================================================================
 // 路径映射类型（实现已抽到 ../agent/outbound-flush.ts 与 flush 路径共享，本文件仅重导出）
 // ============================================================================
 
@@ -183,11 +213,17 @@ function wrapText(payload: unknown, opts?: { isError?: boolean }) {
   return opts?.isError ? { ...base, isError: true } : base
 }
 
-function requireScheduledShortcutContext(
-  deps: CrabMessagingDeps,
+/**
+ * 私聊捷径的运行时门：读装配层声明，未声明即拒绝。
+ *
+ * 与可见性同源（`buildMessagingTools` 用同一份声明过滤工具数组），因此"能看见的一定能调、
+ * 看不见的一定调不动"是构造上的不变量，而非两处规则碰巧一致。
+ */
+function requireDeclaredShortcut(
+  getToolSet: MessagingToolSetProvider,
   toolName: 'send_private_message' | 'send_master_private',
 ): ReturnType<typeof wrapText> | null {
-  if (deps.getTaskContext?.()?.triggerType === 'scheduled') return null
+  if (getToolSet().tools.has(toolName)) return null
   return wrapText({
     error_code: 'SCHEDULED_ONLY_TOOL',
     error: `${toolName} is only available in scheduled tasks`,
@@ -200,8 +236,30 @@ function clampPageSize(n: number, max = 100): number {
 }
 
 // ============================================================================
-// buildMessagingTools — 可单测的纯函数，返回 8 个工具数组
+// buildMessagingTools — 可单测的纯函数，按装配层声明返回工具数组
 // ============================================================================
+
+/**
+ * 本文件构造的全部 messaging 工具名。装配层拿它做基准裁剪，**新增工具时必须同步登记**
+ * （漏登记 = worker 侧拿不到新工具；`tests/mcp/crab-messaging-tool-set.test.ts` 有守卫用例）。
+ */
+export const ALL_MESSAGING_TOOL_NAMES: readonly string[] = [
+  'lookup_friend',
+  'list_contacts',
+  'list_groups',
+  'list_sessions',
+  'list_group_members',
+  'send_private_message',
+  'send_master_private',
+  'send_message',
+  'get_history',
+  'get_message',
+  'fetch_media',
+  'read_feishu_document',
+  'feishu_raw_get',
+  'feishu_download_file',
+  'feishu_write',
+]
 
 /**
  * daily-reflection 任务允许的 messaging 工具白名单。
@@ -219,7 +277,7 @@ function clampPageSize(n: number, max = 100): number {
  * 其他 scheduled 任务（如用户自建的 GitHub 新闻推送 / 群通报巡检）**不受此白名单影响**，
  * 走完整 messaging 工具集——它们本来就是要往群里发的合理用途。
  */
-const DAILY_REFLECTION_ALLOWED_TOOLS = new Set([
+const DAILY_REFLECTION_ALLOWED_TOOLS: ReadonlySet<string> = new Set([
   'send_master_private',
   'get_history',
   'get_message',
@@ -227,6 +285,46 @@ const DAILY_REFLECTION_ALLOWED_TOOLS = new Set([
   'feishu_raw_get',
   'feishu_download_file',
 ])
+
+/** scheduled 任务（非 daily_reflection）：完整工具集；无同步应答方，禁 ask_human。 */
+const SCHEDULED_TOOL_SET: MessagingToolSet = {
+  tools: new Set(ALL_MESSAGING_TOOL_NAMES),
+  allowAskHuman: false,
+}
+
+/** daily_reflection：白名单封死对外通道（见上方注释）。 */
+const DAILY_REFLECTION_TOOL_SET: MessagingToolSet = {
+  tools: DAILY_REFLECTION_ALLOWED_TOOLS,
+  allowAskHuman: false,
+}
+
+/** message 触发的任务 / front：不给 scheduled 专属的两个私聊捷径；有人类在对面，可 ask_human。 */
+const HUMAN_MESSAGE_TOOL_SET: MessagingToolSet = {
+  tools: new Set(ALL_MESSAGING_TOOL_NAMES.filter(
+    name => name !== 'send_private_message' && name !== 'send_master_private',
+  )),
+  allowAskHuman: true,
+}
+
+/**
+ * worker/front 装配路径：按 TaskContext 算出工具集声明。
+ *
+ * 这是 `resolveMessagingToolProfile` 唯一的消费点——它的语义不变（仍是"按任务上下文裁剪"），
+ * 只是从 `buildMessagingTools` 内部搬到了装配路径上。PR J 摘除 worker 侧 messaging 时，
+ * 本函数与 profile 一并删除。
+ */
+export function workerMessagingToolSet(
+  taskCtx: Pick<TaskContext, 'triggerType' | 'taskType'> | null,
+): MessagingToolSet {
+  switch (resolveMessagingToolProfile(taskCtx)) {
+    case 'scheduled_daily_reflection':
+      return DAILY_REFLECTION_TOOL_SET
+    case 'scheduled':
+      return SCHEDULED_TOOL_SET
+    case 'human_message':
+      return HUMAN_MESSAGE_TOOL_SET
+  }
+}
 
 // ============================================================================
 // 工具 schema（必须是模块级常量，只构建一次）
@@ -343,13 +441,18 @@ const FETCH_MEDIA_SCHEMA = {
   handle: z.string().describe('媒体下载句柄（消息标记里的 handle=fm_xxx）'),
 }
 
+/**
+ * 按装配层给出的**显式声明**构造 messaging 工具数组。
+ *
+ * 本函数不再自己从 TaskContext 推断该给哪些工具——那是装配层的事（worker 侧
+ * `buildWorkerMessagingTools`，manager 侧 `manager/tools/tool-face.ts`）。
+ */
 export function buildMessagingTools(
   deps: CrabMessagingDeps,
+  getToolSet: MessagingToolSetProvider,
   sandboxPathMappingsRef?: { current: PathMapping[] },
 ): MessagingTool[] {
   const { rpcClient, moduleId, getAdminPort, resolveChannelPort } = deps
-  const taskCtx = deps.getTaskContext?.() ?? null
-  const toolProfile = resolveMessagingToolProfile(taskCtx)
 
   // 解析飞书 channel port 的公共 helper（供 read_feishu_document / feishu_raw_get / feishu_download_file 共用）
   async function resolveFeishuChannelPort(args: Record<string, unknown>): Promise<
@@ -616,7 +719,7 @@ export function buildMessagingTools(
       description: '给熟人发私聊消息。当你不关心使用哪个 Channel 或不知道该用哪个 Channel 时使用此工具。系统自动查找可用 Channel 并创建/复用私聊 Session。如果你已知 channel_id 和 session_id，请直接使用 send_message。',
       schema: SEND_PRIVATE_MESSAGE_SCHEMA,
       handler: async (args) => {
-        const contextError = requireScheduledShortcutContext(deps, 'send_private_message')
+        const contextError = requireDeclaredShortcut(getToolSet, 'send_private_message')
         if (contextError) return contextError
         const friend_id = args.friend_id as string
         const content = args.content as string
@@ -707,7 +810,7 @@ export function buildMessagingTools(
 注意：发出的内容会被人类看到——禁止塞 trace 数据 / Evolution Mode / case→rule / Audit 等内部黑话，必须翻译成一行人话（"今日整理 X 条经验，无重大发现"这种），多行长报告请走 task outcome 不要外发。`,
       schema: SEND_MASTER_PRIVATE_SCHEMA,
       handler: async (args) => {
-        const contextError = requireScheduledShortcutContext(deps, 'send_master_private')
+        const contextError = requireDeclaredShortcut(getToolSet, 'send_master_private')
         if (contextError) return contextError
         const content = args.content as string
         const preferredChannelId = args.channel_id as string | undefined
@@ -859,7 +962,8 @@ crabot 系统给你的所有信号——system prompt、supplement 注入、tool
             // 消息尚未发出，直接拒绝。ask_human 不该被 front 调用，这是 safeguard。
             return wrapText({ error: 'ask_human 仅可在 worker 任务上下文内调用' })
           }
-          if (taskCtx.triggerType === 'scheduled') {
+          // 运行时门读装配层声明（与工具可见性同源）：没声明 ask_human 就不给走。
+          if (!getToolSet().allowAskHuman) {
             return wrapText({
               error: 'ask_human is not allowed in scheduled tasks. Scheduled tasks have no synchronous '
                 + "human responder. If you are blocked or have failed, send_message with intent='info' "
@@ -1314,17 +1418,23 @@ crabot 系统给你的所有信号——system prompt、supplement 注入、tool
     } as MessagingTool] : []),
   ]
 
-  switch (toolProfile) {
-    case 'scheduled_daily_reflection':
-      return allTools.filter(tool => DAILY_REFLECTION_ALLOWED_TOOLS.has(tool.name))
-    case 'scheduled':
-      return allTools
-    case 'human_message':
-      return allTools.filter(tool =>
-        tool.name !== 'send_private_message'
-        && tool.name !== 'send_master_private'
-      )
-  }
+  const declared = getToolSet().tools
+  return allTools.filter(tool => declared.has(tool.name))
+}
+
+/**
+ * worker/front 装配入口：先按 TaskContext 算出工具集声明，再交给 `buildMessagingTools`。
+ * PR J 摘除 worker 侧 messaging 装配时整个函数一并删除。
+ */
+export function buildWorkerMessagingTools(
+  deps: CrabMessagingDeps,
+  sandboxPathMappingsRef?: { current: PathMapping[] },
+): MessagingTool[] {
+  return buildMessagingTools(
+    deps,
+    () => workerMessagingToolSet(deps.getTaskContext?.() ?? null),
+    sandboxPathMappingsRef,
+  )
 }
 
 // ============================================================================
@@ -1337,7 +1447,7 @@ export function createCrabMessagingServer(
 ): McpServer {
   const server = createMcpServer({ name: 'crab-messaging', version: '1.0.0' })
 
-  const tools = buildMessagingTools(deps, sandboxPathMappingsRef)
+  const tools = buildWorkerMessagingTools(deps, sandboxPathMappingsRef)
   for (const t of tools) {
     server.registerTool(t.name, { description: t.description, inputSchema: t.schema }, t.handler as never)
   }

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -487,6 +487,8 @@ export class UnifiedAgent extends ModuleBase {
    * `.superpowers/sdd/progress.md` Task 1 条目）。这里给一个半成品反而会掩盖它。
    */
   private initializeManagerStack(): void {
+    // messagingDeps 里的 getter 需要拿到本实例（getter 内的 `this` 是那个对象字面量）。
+    const self = this
     this.managerStack = buildManagerStack({
       dataRoot: getDataRootDir(),
       now: () => new Date().toISOString(),
@@ -501,6 +503,13 @@ export class UnifiedAgent extends ModuleBase {
         moduleId: this.config.moduleId,
         getAdminPort: () => this.getAdminPort(),
         resolveChannelPort: (channelId) => this.getChannelPort(channelId),
+        // channel 透传只读三件套（protocol-crab-messaging §2.10）"仅当存在飞书 channel 实例
+        // 时才注入"——取值来源与 worker 侧 `createMcpConfigs` 完全一致（同一个
+        // `feishuChannelAvailable`，由 `detectFeishuChannel()` 探测）。
+        // **必须是 getter**：本对象在构造函数里就建好了（`initializeManagerStack`），而探测跑在
+        // `onStart()` 里；写成定值就永远快照到探测前的 false。worker 侧没这个问题是因为
+        // `createMcpConfigs` 本身是每个 task 现调的工厂。
+        get enableFeishuDocTool(): boolean { return self.feishuChannelAvailable },
       },
       // crab-memory：manager 没有 task 上下文，visibility/scopes 取 agent-handler 在缺配置时
       // 用的同一组缺省值（'public' / []），sourceType 记 'system'（不是某次对话的产物）。

--- a/crabot-agent/tests/agent/crab-messaging-list.test.ts
+++ b/crabot-agent/tests/agent/crab-messaging-list.test.ts
@@ -2,9 +2,9 @@ import { describe, it, expect, vi } from 'vitest'
 import { RpcCallError } from 'crabot-shared'
 
 // MCP server.tool 注册的 handler 没法直接外部调用。我们用一个轻量 helper：
-// 改用 buildMessagingTools 纯函数（实现一并 export）来测试。
+// 改用 buildWorkerMessagingTools 纯函数（实现一并 export）来测试。
 // 这要求实现侧把工具构造从 server.tool 注入流程里抽出来。
-import { buildMessagingTools } from '../../src/mcp/crab-messaging.js'
+import { buildWorkerMessagingTools } from '../../src/mcp/crab-messaging.js'
 
 type MockRpcClient = { call: ReturnType<typeof vi.fn> }
 
@@ -24,7 +24,7 @@ function makeDeps(): TestDeps {
   }
 }
 
-function findTool(tools: ReturnType<typeof buildMessagingTools>, name: string) {
+function findTool(tools: ReturnType<typeof buildWorkerMessagingTools>, name: string) {
   const t = tools.find((x: (typeof tools)[number]) => x.name === name)
   if (!t) throw new Error(`tool ${name} not found`)
   return t
@@ -42,7 +42,7 @@ describe('crab-messaging list_groups 工具', () => {
       pagination: { page: 1, page_size: 50, total_items: 187, total_pages: 4 },
     })
 
-    const tools = buildMessagingTools(deps as never)
+    const tools = buildWorkerMessagingTools(deps as never)
     const out = await findTool(tools, 'list_groups').handler({ channel_id: 'wechat-x', search: '工作' })
 
     expect(deps.rpcClient.call).toHaveBeenCalledWith(
@@ -65,7 +65,7 @@ describe('crab-messaging list_groups 工具', () => {
     deps.rpcClient.call = vi.fn().mockRejectedValue(
       new RpcCallError('CHANNEL_LIST_GROUPS_NOT_SUPPORTED', 'tg 不支持'),
     )
-    const tools = buildMessagingTools(deps as never)
+    const tools = buildWorkerMessagingTools(deps as never)
     const out = await findTool(tools, 'list_groups').handler({ channel_id: 'tg-x' })
     const parsed = parseToolResult(out)
     expect(parsed.error_code).toBe('CHANNEL_LIST_GROUPS_NOT_SUPPORTED')
@@ -78,7 +78,7 @@ describe('crab-messaging list_groups 工具', () => {
       items: [],
       pagination: { page: 1, page_size: 100, total_items: 200, total_pages: 2 },
     })
-    const tools = buildMessagingTools(deps as never)
+    const tools = buildWorkerMessagingTools(deps as never)
     const out = await findTool(tools, 'list_groups').handler({ channel_id: 'wechat-x', page_size: 100 })
     const parsed = parseToolResult(out)
     expect(parsed.pagination).toMatchObject({ default_page_size_applied: false, page_size: 100 })
@@ -91,7 +91,7 @@ describe('crab-messaging list_contacts 工具', () => {
     deps.rpcClient.call = vi.fn().mockRejectedValue(
       new RpcCallError('PERMISSION_DENIED', '缺 scope', { missing_scope: 'contact:user.base:readonly' }),
     )
-    const tools = buildMessagingTools(deps as never)
+    const tools = buildWorkerMessagingTools(deps as never)
     const out = await findTool(tools, 'list_contacts').handler({ channel_id: 'feishu-x' })
     const parsed = parseToolResult(out)
     expect(parsed.error_code).toBe('PERMISSION_DENIED')
@@ -104,7 +104,7 @@ describe('crab-messaging list_contacts 工具', () => {
       items: [{ platform_user_id: 'wxid_a', display_name: '老李' }],
       pagination: { page: 1, page_size: 50, total_items: 1, total_pages: 1 },
     })
-    const tools = buildMessagingTools(deps as never)
+    const tools = buildWorkerMessagingTools(deps as never)
     const out = await findTool(tools, 'list_contacts').handler({ channel_id: 'wechat-x' })
     const parsed = parseToolResult(out)
     expect(parsed.pagination).toMatchObject({ has_more: false, next_page: null })
@@ -118,7 +118,7 @@ describe('crab-messaging list_sessions 工具', () => {
       items: [{ session_id: 's1', type: 'group', title: 'X', participant_count: 5 }],
       pagination: { page: 1, page_size: 20, total_items: 80, total_pages: 4 },
     })
-    const tools = buildMessagingTools(deps as never)
+    const tools = buildWorkerMessagingTools(deps as never)
     const out = await findTool(tools, 'list_sessions').handler({ channel_id: 'wechat-x' })
     const parsed = parseToolResult(out)
     expect(parsed.pagination).toMatchObject({ has_more: true, next_page: 2 })

--- a/crabot-agent/tests/manager/p5-integration.test.ts
+++ b/crabot-agent/tests/manager/p5-integration.test.ts
@@ -28,7 +28,7 @@ import { SYSTEM_TASKS_MANAGER_KEY } from '../../src/manager/registry.js'
 import { dialogObjectIdForPrivate, type DialogObjectId, type LedgerWorker } from '../../src/workers/harness/ledger-types.js'
 import type { ManagerKey } from '../../src/manager/types.js'
 import type { ManagerStack } from '../../src/manager/bootstrap.js'
-import type { LLMAdapter } from '../../src/engine/index.js'
+import type { LLMAdapter, ToolDefinition } from '../../src/engine/index.js'
 import type {
   UnifiedAgentConfig,
   OrchestrationConfig,
@@ -170,6 +170,7 @@ interface AgentInternals {
   managerStack?: ManagerStack
   rpcClient: { publishEvent: (e: Event, source: ModuleId) => Promise<number> }
   adminPort?: number
+  feishuChannelAvailable: boolean
   onStart(): Promise<void>
   onStop(): Promise<void>
 }
@@ -251,6 +252,46 @@ describe('P5 集成：manager 栈启动接线（Task 6）', () => {
 
     expect(detectSpy).not.toHaveBeenCalled()
     await expect(fs.access(join(tmpRoot, 'data', 'agent', 'ledgers'))).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  /**
+   * `enableFeishuDocTool` 的接线自证（PR C 第 2 步）。
+   *
+   * 只断言"白名单里有这三个名字"证明不了任何事——manager 的 `messagingDeps` 一度**根本没传**
+   * 这个开关，工具压根不会被构造。这里走真实构造函数装出来的真工具面：探测前后各取一次，
+   * 只有开关真的接到 `feishuChannelAvailable` 上，第二次才会多出那三个。
+   *
+   * 顺带钉住两条：① 它必须是 getter——本对象在构造函数里就建好了，而探测跑在 `onStart()` 里，
+   * 写成定值就永远是探测前的 false；② "仅当存在飞书 channel 实例时可见"（protocol-crab-messaging
+   * §2.10）的实现方式就是这个开关，没有实例时三件套不出现。
+   */
+  it('manager 工具面接 enableFeishuDocTool：无飞书实例时三件套不出现，探测到实例后出现，feishu_write 始终不出现', () => {
+    boot()
+    const registryDeps = (internals.managerStack as unknown as {
+      registry: { deps: { toolFace: (k: ManagerKey, sys: boolean, onErr: () => void) => ReadonlyArray<ToolDefinition> } }
+    }).registry.deps
+    const namesNow = (): string[] =>
+      registryDeps.toolFace('wechat::sess-1' as ManagerKey, false, () => {}).map((t) => t.name)
+
+    const feishuReadOnly = ['read_feishu_document', 'feishu_raw_get', 'feishu_download_file']
+
+    // detectFeishuChannel 还没跑（构造函数阶段）→ 一个都不该有
+    const before = namesNow()
+    for (const name of [...feishuReadOnly, 'feishu_write']) {
+      expect(before, `探测前不应出现 ${name}`).not.toContain(name)
+    }
+
+    // 模拟 detectFeishuChannel 命中 channel-feishu 实例
+    internals.feishuChannelAvailable = true
+
+    const after = namesNow()
+    for (const name of feishuReadOnly) {
+      expect(after, `探测到飞书实例后应出现 ${name}`).toContain(name)
+    }
+    expect(after, 'feishu_write 绝不进 manager 工具面').not.toContain('feishu_write')
+    // 投递类补齐同样走真实装配路径
+    expect(after).toContain('send_private_message')
+    expect(after).not.toContain('send_master_private')
   })
 
   // --- ⑤ §11 manager slot 与降级路径 ---

--- a/crabot-agent/tests/manager/tool-face.test.ts
+++ b/crabot-agent/tests/manager/tool-face.test.ts
@@ -2,11 +2,13 @@
  * manager 封闭工具面装配测试 —— protocol-agent-v3.md §4.3。
  *
  * 覆盖：
- * - 普通 manager 工具名集合精确匹配预期清单
- * - 系统线程（isSystemThread）多出 send_master_private / send_private_message，其余不变
+ * - 普通 manager 工具名集合精确匹配预期清单（含 send_private_message，protocol-crab-messaging §1）
+ * - 系统线程（isSystemThread）多出 send_master_private，其余不变
+ * - 飞书 channel 存在时多出 §2.10 的只读三件套，且**任何情况下都不含 feishu_write**
  * - 运行时护栏对注入的违规工具（通用文件系统工具 / 外装 mcp__ 工具）抛错，crab-memory 前缀放行
  * - isReadOnly 标记正确（messaging 只读子集 / worker 六件套 / crabot-info 六件套）
  * - send_message 暴露给 LLM 的 inputSchema 不含 intent，调用底层 handler 时也不透传 intent
+ * - 可见性门与运行时门同源：可见的 send_private_message 真调一次不被 requireDeclaredShortcut 拦
  */
 import { describe, it, expect, vi } from 'vitest'
 import { buildManagerToolFace, assertClosedToolFace, type ToolFaceDeps } from '../../src/manager/tools/tool-face'
@@ -14,8 +16,13 @@ import { createCrabMemoryServer } from '../../src/mcp/crab-memory'
 import type { WorkerHarness } from '../../src/workers/harness/harness'
 import type { ToolDefinition } from '../../src/engine/index'
 
+/**
+ * 普通 manager 的 messaging 工具（无飞书 channel 实例时）。
+ * `send_private_message` 在列——protocol-crab-messaging.md §1 投递类可见性表「普通 manager = 是」。
+ */
 const MESSAGING_NORMAL = [
   'send_message',
+  'send_private_message',
   'get_history',
   'get_message',
   'lookup_friend',
@@ -25,6 +32,9 @@ const MESSAGING_NORMAL = [
   'list_group_members',
   'fetch_media',
 ]
+
+/** protocol-crab-messaging.md §2.10 的 channel 透传只读三件套（仅当存在飞书 channel 实例）。 */
+const FEISHU_READ_ONLY_TOOLS = ['read_feishu_document', 'feishu_raw_get', 'feishu_download_file']
 
 const WORKER_TOOLS = ['spawn_worker', 'send_to_worker', 'query_worker', 'read_worker_output', 'list_workers', 'kill_worker']
 
@@ -52,6 +62,16 @@ function makeMemoryServer() {
   )
 }
 
+function makeMessagingDeps(extra: Partial<ToolFaceDeps['messagingDeps']> = {}): ToolFaceDeps['messagingDeps'] {
+  return {
+    rpcClient: { call: vi.fn() } as never,
+    moduleId: 'manager-test',
+    getAdminPort: async () => 19001,
+    resolveChannelPort: async () => 19009,
+    ...extra,
+  }
+}
+
 function makeDeps(overrides: Partial<ToolFaceDeps> = {}): ToolFaceDeps {
   return {
     harness: {} as unknown as WorkerHarness,
@@ -60,12 +80,7 @@ function makeDeps(overrides: Partial<ToolFaceDeps> = {}): ToolFaceDeps {
       managerKey: 'manager-1',
       reportTo: { channel_id: 'ch-1', session_id: 'sess-1' },
     }),
-    messagingDeps: {
-      rpcClient: { call: vi.fn() } as never,
-      moduleId: 'manager-test',
-      getAdminPort: async () => 19001,
-      resolveChannelPort: async () => 19009,
-    },
+    messagingDeps: makeMessagingDeps(),
     memoryServer: makeMemoryServer(),
     callAdmin: vi.fn(async () => ({})) as unknown as ToolFaceDeps['callAdmin'],
     isSystemThread: false,
@@ -88,25 +103,53 @@ describe('buildManagerToolFace', () => {
     )
     // crab-memory 原样全给，不裁（§4.3），至少有 A 组 6 个
     expect(memoryToolNames(tools).length).toBeGreaterThanOrEqual(6)
-    // 系统线程专属工具不应出现
+    // 投递类：send_private_message 在（§1 表「普通 manager = 是」），系统线程专属的不在
+    expect(names).toContain('send_private_message')
     expect(names).not.toContain('send_master_private')
-    expect(names).not.toContain('send_private_message')
+    // 没有飞书 channel 实例（enableFeishuDocTool falsy）→ §2.10 那一组一个都不出现
+    for (const name of [...FEISHU_READ_ONLY_TOOLS, 'feishu_write']) {
+      expect(names, `无飞书实例时不应出现 ${name}`).not.toContain(name)
+    }
   })
 
-  it('系统线程多出 send_master_private / send_private_message，其余相同', () => {
+  it('系统线程只多出 send_master_private，其余相同', () => {
     const normalNames = buildManagerToolFace(makeDeps({ isSystemThread: false })).map((t) => t.name).sort()
     const systemNames = buildManagerToolFace(makeDeps({ isSystemThread: true })).map((t) => t.name).sort()
 
-    expect(systemNames).toEqual(
-      [...normalNames, 'send_master_private', 'send_private_message'].sort(),
-    )
+    expect(systemNames).toEqual([...normalNames, 'send_master_private'].sort())
+  })
+
+  it('存在飞书 channel 实例时：两类 manager 都多出 §2.10 只读三件套，都不含 feishu_write', () => {
+    for (const isSystemThread of [false, true]) {
+      const tools = buildManagerToolFace(makeDeps({
+        isSystemThread,
+        messagingDeps: makeMessagingDeps({ enableFeishuDocTool: true }),
+      }))
+      const names = tools.map((t) => t.name)
+      const nonMemoryNames = names.filter((n) => !n.startsWith('mcp__crab-memory__'))
+
+      expect(nonMemoryNames.sort(), `isSystemThread=${isSystemThread}`).toEqual(
+        [
+          ...MESSAGING_NORMAL,
+          ...FEISHU_READ_ONLY_TOOLS,
+          ...(isSystemThread ? ['send_master_private'] : []),
+          ...WORKER_TOOLS,
+          ...CRABOT_INFO_TOOLS,
+        ].sort(),
+      )
+      // 任意写 API 透传绝不进 manager 工具面（protocol-crab-messaging.md §1 note）
+      expect(names, `isSystemThread=${isSystemThread} 不得含 feishu_write`).not.toContain('feishu_write')
+    }
   })
 
   it('isReadOnly 标记正确', () => {
-    const tools = buildManagerToolFace(makeDeps({ isSystemThread: true }))
+    const tools = buildManagerToolFace(makeDeps({
+      isSystemThread: true,
+      messagingDeps: makeMessagingDeps({ enableFeishuDocTool: true }),
+    }))
     const byName = new Map(tools.map((t) => [t.name, t]))
 
-    const readOnly = ['get_history', 'get_message', 'lookup_friend', 'list_sessions', 'list_contacts', 'list_groups', 'list_group_members', 'fetch_media', 'read_worker_output', 'list_workers', ...CRABOT_INFO_TOOLS]
+    const readOnly = ['get_history', 'get_message', 'lookup_friend', 'list_sessions', 'list_contacts', 'list_groups', 'list_group_members', 'fetch_media', ...FEISHU_READ_ONLY_TOOLS, 'read_worker_output', 'list_workers', ...CRABOT_INFO_TOOLS]
     for (const name of readOnly) {
       expect(byName.get(name)?.isReadOnly, `${name} 应为 isReadOnly:true`).toBe(true)
     }
@@ -144,6 +187,35 @@ describe('buildManagerToolFace', () => {
     // manager 没有 task 上下文；若 intent 被透传，这里会因缺 taskCtx 而报错/行为异常）
     expect(result.isError).toBe(false)
     void capturedArgsByHandler
+  })
+
+  it('普通 manager 真调一次 send_private_message：不被 requireDeclaredShortcut 拦，RPC 真的打出去', async () => {
+    const call = vi.fn(async (_port: number, method: string) => {
+      switch (method) {
+        case 'get_friend':
+          return { friend: { display_name: 'Alice', channel_identities: [{ channel_id: 'ch-1', platform_user_id: 'u-1' }] } }
+        case 'find_or_create_private_session':
+          return { session: { id: 'sess-9' }, created: false }
+        case 'send_message':
+          return { platform_message_id: 'pm-1', sent_at: '2026-08-01T00:00:00.000Z' }
+        default:
+          throw new Error(`未预期的 RPC: ${method}`)
+      }
+    })
+    const tools = buildManagerToolFace(makeDeps({
+      isSystemThread: false,
+      messagingDeps: makeMessagingDeps({ rpcClient: { call } as never }),
+    }))
+    const sendPrivate = tools.find((t) => t.name === 'send_private_message')!
+
+    const result = await sendPrivate.call({ friend_id: 'f-1', content: 'hi' }, {} as never)
+
+    // 运行时门若拒绝，会返回 isError + SCHEDULED_ONLY_TOOL 且**零 RPC**——这两条一起钉住
+    // 「可见性门与运行时门同源」，而不只是「工具出现在列表里」。
+    expect(result.isError).toBe(false)
+    expect(result.output).not.toContain('SCHEDULED_ONLY_TOOL')
+    expect(JSON.parse(result.output)).toMatchObject({ channel_id: 'ch-1', session_id: 'sess-9', platform_message_id: 'pm-1' })
+    expect(call.mock.calls.map((c) => c[1])).toEqual(['get_friend', 'find_or_create_private_session', 'send_message'])
   })
 
   it('护栏拦截注入的通用文件系统工具（bash/read/write/edit/glob/grep/delegate_task）', () => {

--- a/crabot-agent/tests/mcp/crab-messaging-ask-human-terminal-guard.test.ts
+++ b/crabot-agent/tests/mcp/crab-messaging-ask-human-terminal-guard.test.ts
@@ -6,17 +6,17 @@
  * 不让 worker 带着死任务继续跑（历史上它会发出用户看不懂的进度消息，再撞状态机拒绝）。
  */
 import { describe, it, expect, vi } from 'vitest'
-import { buildMessagingTools } from '../../src/mcp/crab-messaging.js'
+import { buildWorkerMessagingTools } from '../../src/mcp/crab-messaging.js'
 import { HumanMessageQueue } from '../../src/engine/human-message-queue.js'
 
-function findTool(tools: ReturnType<typeof buildMessagingTools>, name: string) {
+function findTool(tools: ReturnType<typeof buildWorkerMessagingTools>, name: string) {
   const t = tools.find((x) => x.name === name)
   if (!t) throw new Error(`tool ${name} not found`)
   return t
 }
 
 function buildTools(queue: HumanMessageQueue, abortIfTaskTerminal: () => Promise<void>) {
-  return buildMessagingTools({
+  return buildWorkerMessagingTools({
     rpcClient: {
       call: vi.fn().mockResolvedValue({ platform_message_id: 'm', sent_at: '' }),
     } as never,

--- a/crabot-agent/tests/mcp/crab-messaging-ask-human.test.ts
+++ b/crabot-agent/tests/mcp/crab-messaging-ask-human.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi } from 'vitest'
-import { buildMessagingTools } from '../../src/mcp/crab-messaging.js'
+import { buildWorkerMessagingTools } from '../../src/mcp/crab-messaging.js'
 import { HumanMessageQueue } from '../../src/engine/human-message-queue.js'
 
-function findTool(tools: ReturnType<typeof buildMessagingTools>, name: string) {
+function findTool(tools: ReturnType<typeof buildWorkerMessagingTools>, name: string) {
   const t = tools.find((x) => x.name === name)
   if (!t) throw new Error(`tool ${name} not found`)
   return t
@@ -14,7 +14,7 @@ describe('send_message intent=ask_human', () => {
     const rpcCalls: Array<{ method: string; params: unknown }> = []
     const callOrder: string[] = []
 
-    const tools = buildMessagingTools({
+    const tools = buildWorkerMessagingTools({
       rpcClient: {
         call: vi.fn().mockImplementation(async (_port: number, method: string, params: unknown) => {
           rpcCalls.push({ method, params })
@@ -58,7 +58,7 @@ describe('send_message intent=ask_human', () => {
   it('sets barrier on humanQueue after ask_human', async () => {
     const queue = new HumanMessageQueue()
 
-    const tools = buildMessagingTools({
+    const tools = buildWorkerMessagingTools({
       rpcClient: {
         call: vi.fn().mockResolvedValue({ platform_message_id: 'm', sent_at: '' }),
       } as never,
@@ -82,7 +82,7 @@ describe('send_message intent=ask_human', () => {
   })
 
   it('returns error when getTaskContext is null', async () => {
-    const tools = buildMessagingTools({
+    const tools = buildWorkerMessagingTools({
       rpcClient: { call: vi.fn() } as never,
       moduleId: 'front',
       getAdminPort: async () => 19001,
@@ -106,7 +106,7 @@ describe('send_message intent=ask_human', () => {
     const queue = new HumanMessageQueue()
     const rpcMethods: string[] = []
 
-    const tools = buildMessagingTools({
+    const tools = buildWorkerMessagingTools({
       rpcClient: {
         call: vi.fn().mockImplementation(async (_port: number, method: string) => {
           rpcMethods.push(method)
@@ -132,7 +132,7 @@ describe('send_message intent=ask_human', () => {
   it('scheduled 任务调用 ask_human 时返回拒绝错误，错误消息含明确指引', async () => {
     const queue = new HumanMessageQueue()
 
-    const tools = buildMessagingTools({
+    const tools = buildWorkerMessagingTools({
       rpcClient: { call: vi.fn() } as never,
       moduleId: 'worker-test',
       getAdminPort: async () => 19001,
@@ -160,7 +160,7 @@ describe('send_message intent=ask_human', () => {
     // 其他 scheduled 任务（用户自建的群推送 / 巡检）不受此白名单影响——它们走 triggerType='scheduled' 但 taskType 不是 'daily_reflection'。
     const queue = new HumanMessageQueue()
 
-    const tools = buildMessagingTools({
+    const tools = buildWorkerMessagingTools({
       rpcClient: { call: vi.fn() } as never,
       moduleId: 'worker-test',
       getAdminPort: async () => 19001,
@@ -183,7 +183,7 @@ describe('send_message intent=ask_human', () => {
   it('非 daily_reflection 的 scheduled 任务（用户自建推送等）保留完整 messaging 工具集', async () => {
     const queue = new HumanMessageQueue()
 
-    const tools = buildMessagingTools({
+    const tools = buildWorkerMessagingTools({
       rpcClient: { call: vi.fn() } as never,
       moduleId: 'worker-test',
       getAdminPort: async () => 19001,
@@ -206,7 +206,7 @@ describe('send_message intent=ask_human', () => {
   it('message 任务调用 ask_human 不在 scheduled 闸门被拒（仍可走后续流程）', async () => {
     const queue = new HumanMessageQueue()
 
-    const tools = buildMessagingTools({
+    const tools = buildWorkerMessagingTools({
       rpcClient: {
         call: vi.fn().mockImplementation(async (_port: number, method: string) => {
           if (method === 'update_task_status') return { task: { id: 't1', status: 'waiting_human' } }
@@ -239,7 +239,7 @@ describe('send_message intent=ask_human', () => {
   it('does NOT set barrier if update_task_status fails (transient admin failure — spec §5.3)', async () => {
     const queue = new HumanMessageQueue()
 
-    const tools = buildMessagingTools({
+    const tools = buildWorkerMessagingTools({
       rpcClient: {
         call: vi.fn().mockImplementation(async (_port: number, method: string) => {
           if (method === 'update_task_status') throw new Error('admin unavailable')
@@ -279,7 +279,7 @@ describe('send_message intent=ask_human', () => {
     let simulatedStatus: 'pending' | 'planning' | 'executing' | 'waiting_human' = 'pending'
     const transitionCalls: Array<{ status: string; pending_question?: string | null }> = []
 
-    const tools = buildMessagingTools({
+    const tools = buildWorkerMessagingTools({
       rpcClient: {
         call: vi.fn().mockImplementation(async (_port: number, method: string, params: Record<string, unknown>) => {
           if (method === 'send_message') return { platform_message_id: 'm1', sent_at: '' }
@@ -339,7 +339,7 @@ describe('send_message intent=ask_human', () => {
     const queue = new HumanMessageQueue()
     const transitionCalls: string[] = []
     // 仿真：task 已 completed（终结态），所有 transition 都会被拒
-    const tools = buildMessagingTools({
+    const tools = buildWorkerMessagingTools({
       rpcClient: {
         call: vi.fn().mockImplementation(async (_port: number, method: string, params: Record<string, unknown>) => {
           if (method === 'send_message') return { platform_message_id: 'm1', sent_at: '' }

--- a/crabot-agent/tests/mcp/crab-messaging-feishu-passthrough.test.ts
+++ b/crabot-agent/tests/mcp/crab-messaging-feishu-passthrough.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect, vi } from 'vitest'
-import { buildMessagingTools } from '../../src/mcp/crab-messaging.js'
+import { buildWorkerMessagingTools } from '../../src/mcp/crab-messaging.js'
 
-function findTool(tools: ReturnType<typeof buildMessagingTools>, name: string) {
+function findTool(tools: ReturnType<typeof buildWorkerMessagingTools>, name: string) {
   const t = tools.find((x) => x.name === name)
   if (!t) throw new Error(`tool ${name} not found`)
   return t
 }
 
-function parse(out: Awaited<ReturnType<ReturnType<typeof buildMessagingTools>[number]['handler']>>) {
+function parse(out: Awaited<ReturnType<ReturnType<typeof buildWorkerMessagingTools>[number]['handler']>>) {
   return JSON.parse((out as { content: Array<{ text: string }> }).content[0].text)
 }
 
@@ -29,21 +29,21 @@ function makeDeps(opts: {
 
 describe('feishu_raw_get / feishu_download_file 门控', () => {
   it('enableFeishuDocTool=true → feishu_raw_get 与 feishu_download_file 出现在工具列表', () => {
-    const tools = buildMessagingTools(makeDeps({ enableFeishuDocTool: true }))
+    const tools = buildWorkerMessagingTools(makeDeps({ enableFeishuDocTool: true }))
     expect(tools.find(t => t.name === 'feishu_raw_get')).toBeDefined()
     expect(tools.find(t => t.name === 'feishu_download_file')).toBeDefined()
     expect(tools.find(t => t.name === 'read_feishu_document')).toBeDefined()
   })
 
   it('enableFeishuDocTool=false → feishu_raw_get 与 feishu_download_file 都不出现', () => {
-    const tools = buildMessagingTools(makeDeps({ enableFeishuDocTool: false }))
+    const tools = buildWorkerMessagingTools(makeDeps({ enableFeishuDocTool: false }))
     expect(tools.find(t => t.name === 'feishu_raw_get')).toBeUndefined()
     expect(tools.find(t => t.name === 'feishu_download_file')).toBeUndefined()
     expect(tools.find(t => t.name === 'read_feishu_document')).toBeUndefined()
   })
 
   it('enableFeishuDocTool 未传 (undefined) → 飞书工具不出现', () => {
-    const tools = buildMessagingTools({
+    const tools = buildWorkerMessagingTools({
       rpcClient: { call: vi.fn() } as never,
       moduleId: 'agent-test',
       getAdminPort: async () => 19001,
@@ -65,7 +65,7 @@ describe('feishu_raw_get handler', () => {
         return {}
       },
     )
-    const tools = buildMessagingTools(makeDeps({ rpcCall, enableFeishuDocTool: true }))
+    const tools = buildWorkerMessagingTools(makeDeps({ rpcCall, enableFeishuDocTool: true }))
     const out = await findTool(tools, 'feishu_raw_get').handler({
       path: '/open-apis/wiki/v2/spaces/get_node',
       query: { token: 'abc123' },
@@ -96,7 +96,7 @@ describe('feishu_raw_get handler', () => {
         return {}
       },
     )
-    const tools = buildMessagingTools(makeDeps({ rpcCall, enableFeishuDocTool: true }))
+    const tools = buildWorkerMessagingTools(makeDeps({ rpcCall, enableFeishuDocTool: true }))
     const out = await findTool(tools, 'feishu_raw_get').handler({
       path: '/open-apis/im/v1/messages',
       channel_id: 'feishu-1',
@@ -128,7 +128,7 @@ describe('feishu_raw_get handler', () => {
         return {}
       },
     )
-    const tools = buildMessagingTools(makeDeps({ rpcCall, enableFeishuDocTool: true }))
+    const tools = buildWorkerMessagingTools(makeDeps({ rpcCall, enableFeishuDocTool: true }))
     await findTool(tools, 'feishu_raw_get').handler({ path: '/open-apis/foo/bar' })
     // 调 feishu_get 时 params 不含 query 键
     const feishuGetCall = rpcCall.mock.calls.find((c: unknown[]) => c[1] === 'feishu_get')
@@ -148,7 +148,7 @@ describe('feishu_download_file handler', () => {
         return {}
       },
     )
-    const tools = buildMessagingTools(makeDeps({ rpcCall, enableFeishuDocTool: true }))
+    const tools = buildWorkerMessagingTools(makeDeps({ rpcCall, enableFeishuDocTool: true }))
     const out = await findTool(tools, 'feishu_download_file').handler({
       file_token: 'boxTokABC',
       filename: 'report.pdf',
@@ -174,7 +174,7 @@ describe('feishu_download_file handler', () => {
         return {}
       },
     )
-    const tools = buildMessagingTools(makeDeps({ rpcCall, enableFeishuDocTool: true }))
+    const tools = buildWorkerMessagingTools(makeDeps({ rpcCall, enableFeishuDocTool: true }))
     await findTool(tools, 'feishu_download_file').handler({ file_token: 'boxTok' })
     const downloadCall = rpcCall.mock.calls.find((c: unknown[]) => c[1] === 'feishu_download')
     expect(downloadCall).toBeDefined()
@@ -184,12 +184,12 @@ describe('feishu_download_file handler', () => {
 
 describe('feishu_write 门控', () => {
   it('enableFeishuDocTool=true → feishu_write 出现在工具列表', () => {
-    const tools = buildMessagingTools(makeDeps({ enableFeishuDocTool: true }))
+    const tools = buildWorkerMessagingTools(makeDeps({ enableFeishuDocTool: true }))
     expect(tools.find(t => t.name === 'feishu_write')).toBeDefined()
   })
 
   it('enableFeishuDocTool=false → feishu_write 不出现', () => {
-    const tools = buildMessagingTools(makeDeps({ enableFeishuDocTool: false }))
+    const tools = buildWorkerMessagingTools(makeDeps({ enableFeishuDocTool: false }))
     expect(tools.find(t => t.name === 'feishu_write')).toBeUndefined()
   })
 })
@@ -205,7 +205,7 @@ describe('feishu_write handler', () => {
         return {}
       },
     )
-    const tools = buildMessagingTools(makeDeps({ rpcCall, enableFeishuDocTool: true }))
+    const tools = buildWorkerMessagingTools(makeDeps({ rpcCall, enableFeishuDocTool: true }))
     const out = await findTool(tools, 'feishu_write').handler({
       method: 'POST',
       path: '/open-apis/im/v1/messages',
@@ -237,7 +237,7 @@ describe('feishu_write handler', () => {
         return {}
       },
     )
-    const tools = buildMessagingTools(makeDeps({ rpcCall, enableFeishuDocTool: true }))
+    const tools = buildWorkerMessagingTools(makeDeps({ rpcCall, enableFeishuDocTool: true }))
     await findTool(tools, 'feishu_write').handler({
       method: 'DELETE',
       path: '/open-apis/im/v1/messages/msg_abc',
@@ -251,7 +251,7 @@ describe('feishu_write handler', () => {
 describe('feishu_write 不在 DAILY_REFLECTION_ALLOWED_TOOLS', () => {
   it('daily_reflection 任务中 feishu_write 不出现', () => {
     const rpcCall = vi.fn()
-    const tools = buildMessagingTools({
+    const tools = buildWorkerMessagingTools({
       rpcClient: { call: rpcCall } as never,
       moduleId: 'agent-test',
       getAdminPort: async () => 19001,
@@ -279,7 +279,7 @@ describe('resolveFeishuChannelPort 错误分支（通过 feishu_raw_get 触发�
         return {}
       },
     )
-    const tools = buildMessagingTools(makeDeps({ rpcCall, enableFeishuDocTool: true }))
+    const tools = buildWorkerMessagingTools(makeDeps({ rpcCall, enableFeishuDocTool: true }))
     const out = await findTool(tools, 'feishu_raw_get').handler({ path: '/open-apis/wiki/v2/spaces' })
     const result = parse(out)
     expect(result.error_code).toBe('CHANNEL_UNAVAILABLE')
@@ -293,7 +293,7 @@ describe('resolveFeishuChannelPort 错误分支（通过 feishu_raw_get 触发�
         return {}
       },
     )
-    const tools = buildMessagingTools(makeDeps({ rpcCall, enableFeishuDocTool: true }))
+    const tools = buildWorkerMessagingTools(makeDeps({ rpcCall, enableFeishuDocTool: true }))
     const out = await findTool(tools, 'feishu_raw_get').handler({ path: '/open-apis/foo' })
     const result = parse(out)
     expect(result.error_code).toBe('CHANNEL_UNAVAILABLE')
@@ -313,7 +313,7 @@ describe('resolveFeishuChannelPort 错误分支（通过 feishu_raw_get 触发�
         return {}
       },
     )
-    const tools = buildMessagingTools(makeDeps({ rpcCall, enableFeishuDocTool: true }))
+    const tools = buildWorkerMessagingTools(makeDeps({ rpcCall, enableFeishuDocTool: true }))
     const out = await findTool(tools, 'feishu_raw_get').handler({ path: '/open-apis/wiki/v2/spaces' })
     const result = parse(out)
     expect(result.error_code).toBe('AMBIGUOUS')
@@ -323,7 +323,7 @@ describe('resolveFeishuChannelPort 错误分支（通过 feishu_raw_get 触发�
   })
 
   it('channel_id 指定但 resolveChannelPort 抛错 → error_code: CHANNEL_UNAVAILABLE', async () => {
-    const tools = buildMessagingTools(makeDeps({
+    const tools = buildWorkerMessagingTools(makeDeps({
       rpcCall: vi.fn(),
       resolveChannelPort: async () => { throw new Error('port not found') },
       enableFeishuDocTool: true,

--- a/crabot-agent/tests/mcp/crab-messaging-fetch-media.test.ts
+++ b/crabot-agent/tests/mcp/crab-messaging-fetch-media.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect, vi } from 'vitest'
-import { buildMessagingTools } from '../../src/mcp/crab-messaging.js'
+import { buildWorkerMessagingTools } from '../../src/mcp/crab-messaging.js'
 
-function findTool(tools: ReturnType<typeof buildMessagingTools>, name: string) {
+function findTool(tools: ReturnType<typeof buildWorkerMessagingTools>, name: string) {
   const t = tools.find((x) => x.name === name)
   if (!t) throw new Error(`tool ${name} not found`)
   return t
 }
 
-function parse(out: Awaited<ReturnType<ReturnType<typeof buildMessagingTools>[number]['handler']>>) {
+function parse(out: Awaited<ReturnType<ReturnType<typeof buildWorkerMessagingTools>[number]['handler']>>) {
   return JSON.parse((out as { content: Array<{ text: string }> }).content[0].text)
 }
 
@@ -27,7 +27,7 @@ describe('fetch_media 工具', () => {
       file_path: '/data/media/om_f.pdf',
       mime_type: 'application/pdf',
     })
-    const tools = buildMessagingTools(makeDeps(call))
+    const tools = buildWorkerMessagingTools(makeDeps(call))
     const out = await findTool(tools, 'fetch_media').handler({
       channel_id: 'feishu-1',
       handle: 'fm_abc',
@@ -39,7 +39,7 @@ describe('fetch_media 工具', () => {
   })
 
   it('channel 不可用 → 结构化错误', async () => {
-    const tools = buildMessagingTools(makeDeps(vi.fn()))
+    const tools = buildWorkerMessagingTools(makeDeps(vi.fn()))
     const out = await findTool(tools, 'fetch_media').handler({
       channel_id: 'unknown',
       handle: 'fm_x',
@@ -52,7 +52,7 @@ describe('fetch_media 工具', () => {
       status: 'failed',
       error: 'unknown media handle',
     })
-    const tools = buildMessagingTools(makeDeps(call))
+    const tools = buildWorkerMessagingTools(makeDeps(call))
     const out = await findTool(tools, 'fetch_media').handler({
       channel_id: 'feishu-1',
       handle: 'fm_bad',
@@ -64,7 +64,7 @@ describe('fetch_media 工具', () => {
 
   it('status=fetching → 结果含调用 wait_for_signal 的提示', async () => {
     const call = vi.fn().mockResolvedValue({ status: 'fetching' })
-    const tools = buildMessagingTools(makeDeps(call))
+    const tools = buildWorkerMessagingTools(makeDeps(call))
     const out = await findTool(tools, 'fetch_media').handler({ channel_id: 'feishu-1', handle: 'fm_big' })
     const parsed = parse(out)
     expect(parsed.status).toBe('fetching')

--- a/crabot-agent/tests/mcp/crab-messaging-send-master-private.test.ts
+++ b/crabot-agent/tests/mcp/crab-messaging-send-master-private.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { buildMessagingTools } from '../../src/mcp/crab-messaging.js'
+import { buildWorkerMessagingTools } from '../../src/mcp/crab-messaging.js'
 import { HumanMessageQueue } from '../../src/engine/human-message-queue.js'
 import type { Friend } from '../../src/types.js'
 
@@ -18,7 +18,7 @@ function makeMaster(channels: Array<{ channel_id: string; platform_user_id: stri
   }
 }
 
-function findTool(tools: ReturnType<typeof buildMessagingTools>, name: string) {
+function findTool(tools: ReturnType<typeof buildWorkerMessagingTools>, name: string) {
   return tools.find(t => t.name === name)
 }
 
@@ -28,7 +28,7 @@ function parsePayload(result: { content: Array<{ text: string }> }): Record<stri
 
 describe('daily_reflection task messaging tool whitelist', () => {
   it('daily_reflection 任务只暴露 send_master_private + 只读分析工具', () => {
-    const tools = buildMessagingTools({
+    const tools = buildWorkerMessagingTools({
       rpcClient: { call: vi.fn() } as never,
       moduleId: 'worker',
       getAdminPort: async () => 19001,
@@ -55,7 +55,7 @@ describe('daily_reflection task messaging tool whitelist', () => {
   })
 
   it('其他 scheduled 任务（如 news_briefing 群推送）不受白名单影响，保留全部工具', () => {
-    const tools = buildMessagingTools({
+    const tools = buildWorkerMessagingTools({
       rpcClient: { call: vi.fn() } as never,
       moduleId: 'worker',
       getAdminPort: async () => 19001,
@@ -78,7 +78,7 @@ describe('daily_reflection task messaging tool whitelist', () => {
   })
 
   it('无 task context 时不暴露 scheduled 私聊捷径', () => {
-    const tools = buildMessagingTools({
+    const tools = buildWorkerMessagingTools({
       rpcClient: { call: vi.fn() } as never,
       moduleId: 'front',
       getAdminPort: async () => 19001,
@@ -91,7 +91,7 @@ describe('daily_reflection task messaging tool whitelist', () => {
   })
 
   it('message task 只保留精确 send_message，不暴露 scheduled 私聊捷径', () => {
-    const tools = buildMessagingTools({
+    const tools = buildWorkerMessagingTools({
       rpcClient: { call: vi.fn() } as never,
       moduleId: 'worker',
       getAdminPort: async () => 19001,
@@ -119,7 +119,7 @@ describe('scheduled-only shortcut runtime guard', () => {
     async (toolName) => {
       let triggerType: 'scheduled' | 'message' = 'scheduled'
       const rpcCall = vi.fn()
-      const tools = buildMessagingTools({
+      const tools = buildWorkerMessagingTools({
         rpcClient: { call: rpcCall } as never,
         moduleId: 'worker',
         getAdminPort: async () => 19001,
@@ -152,7 +152,7 @@ describe('scheduled-only shortcut runtime guard', () => {
 
 describe('send_master_private', () => {
   it('returns error when no master friend configured', async () => {
-    const tools = buildMessagingTools({
+    const tools = buildWorkerMessagingTools({
       rpcClient: {
         call: vi.fn().mockImplementation(async (_port, method) => {
           if (method === 'find_master_friend') return { friend: null }
@@ -184,7 +184,7 @@ describe('send_master_private', () => {
     ])
     const calls: Array<{ port: number; method: string; params: unknown }> = []
 
-    const tools = buildMessagingTools({
+    const tools = buildWorkerMessagingTools({
       rpcClient: {
         call: vi.fn().mockImplementation(async (port, method, params) => {
           calls.push({ port, method, params })
@@ -231,7 +231,7 @@ describe('send_master_private', () => {
       { channel_id: 'feishu-001', platform_user_id: 'ou_x' },
     ])
 
-    const tools = buildMessagingTools({
+    const tools = buildWorkerMessagingTools({
       rpcClient: {
         call: vi.fn().mockImplementation(async (_port, method) => {
           if (method === 'find_master_friend') return { friend: master }
@@ -267,7 +267,7 @@ describe('send_master_private', () => {
     ])
     const calls: Array<{ method: string; params: Record<string, unknown> }> = []
 
-    const tools = buildMessagingTools({
+    const tools = buildWorkerMessagingTools({
       rpcClient: {
         call: vi.fn().mockImplementation(async (_port, method, params) => {
           calls.push({ method, params: params as Record<string, unknown> })

--- a/crabot-agent/tests/mcp/crab-messaging-system-session.test.ts
+++ b/crabot-agent/tests/mcp/crab-messaging-system-session.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi } from 'vitest'
-import { buildMessagingTools } from '../../src/mcp/crab-messaging.js'
+import { buildWorkerMessagingTools } from '../../src/mcp/crab-messaging.js'
 import { HumanMessageQueue } from '../../src/engine/human-message-queue.js'
 
-function findTool(tools: ReturnType<typeof buildMessagingTools>, name: string) {
+function findTool(tools: ReturnType<typeof buildWorkerMessagingTools>, name: string) {
   const t = tools.find((x) => x.name === name)
   if (!t) throw new Error(`tool ${name} not found`)
   return t
@@ -11,7 +11,7 @@ function findTool(tools: ReturnType<typeof buildMessagingTools>, name: string) {
 describe('send_message rejects SYSTEM_SESSION sentinel', () => {
   it('returns error when channel_id is the system sentinel', async () => {
     const callMock = vi.fn()
-    const tools = buildMessagingTools({
+    const tools = buildWorkerMessagingTools({
       rpcClient: { call: callMock } as never,
       moduleId: 'worker-test',
       getAdminPort: async () => 19001,
@@ -39,7 +39,7 @@ describe('send_message rejects SYSTEM_SESSION sentinel', () => {
 
   it('returns error when session_id is the system sentinel', async () => {
     const callMock = vi.fn()
-    const tools = buildMessagingTools({
+    const tools = buildWorkerMessagingTools({
       rpcClient: { call: callMock } as never,
       moduleId: 'worker-test',
       getAdminPort: async () => 19001,
@@ -67,7 +67,7 @@ describe('send_message rejects SYSTEM_SESSION sentinel', () => {
 
   it('passes through when both channel_id and session_id are real', async () => {
     const callMock = vi.fn().mockResolvedValue({ platform_message_id: 'm1', sent_at: '2026-06-05T00:00:00Z' })
-    const tools = buildMessagingTools({
+    const tools = buildWorkerMessagingTools({
       rpcClient: { call: callMock } as never,
       moduleId: 'worker-test',
       getAdminPort: async () => 19001,

--- a/crabot-agent/tests/mcp/crab-messaging-tool-set.test.ts
+++ b/crabot-agent/tests/mcp/crab-messaging-tool-set.test.ts
@@ -1,0 +1,121 @@
+/**
+ * worker 侧 messaging 工具集快照 —— 三种 profile 各自的**完整**工具名清单。
+ *
+ * 既有用例只逐个断言"某工具在/不在"，没有一处把整份清单钉死；工具集的决定权从
+ * `buildMessagingTools` 内部提到装配层（PR C 第 1 步）时，这类局部断言不足以证明
+ * "行为逐字不变"。本文件补上三份精确快照（飞书开/关各一组），任何一项多给或少给都会挂。
+ *
+ * daily_reflection 那份尤其重要：它是 2026-05-30 反思报告误发群事故的防线
+ * （见 crab-messaging.ts 的 DAILY_REFLECTION_ALLOWED_TOOLS 注释）。
+ */
+import { describe, it, expect, vi } from 'vitest'
+import {
+  ALL_MESSAGING_TOOL_NAMES,
+  buildMessagingTools,
+  buildWorkerMessagingTools,
+} from '../../src/mcp/crab-messaging.js'
+import { HumanMessageQueue } from '../../src/engine/human-message-queue.js'
+import type { TaskContext } from '../../src/mcp/crab-messaging.js'
+
+const BARE_DEPS = {
+  rpcClient: { call: vi.fn() } as never,
+  moduleId: 'worker-test',
+  getAdminPort: async () => 19001,
+  resolveChannelPort: async () => 19009,
+}
+
+function toolNames(
+  taskCtx: Pick<TaskContext, 'triggerType' | 'taskType'> | null,
+  enableFeishuDocTool: boolean,
+): string[] {
+  const tools = buildWorkerMessagingTools({
+    rpcClient: { call: vi.fn() } as never,
+    moduleId: 'worker-test',
+    getAdminPort: async () => 19001,
+    resolveChannelPort: async () => 19009,
+    enableFeishuDocTool,
+    ...(taskCtx
+      ? {
+          getTaskContext: () => ({
+            taskId: 't1',
+            humanQueue: new HumanMessageQueue(),
+            hasGoal: () => false,
+            ...taskCtx,
+          }),
+        }
+      : {}),
+  })
+  return tools.map(t => t.name).sort()
+}
+
+const FEISHU_READ = ['feishu_download_file', 'feishu_raw_get', 'read_feishu_document']
+const FEISHU_ALL = [...FEISHU_READ, 'feishu_write']
+
+const HUMAN_MESSAGE_BASE = [
+  'fetch_media',
+  'get_history',
+  'get_message',
+  'list_contacts',
+  'list_group_members',
+  'list_groups',
+  'list_sessions',
+  'lookup_friend',
+  'send_message',
+]
+
+const SCHEDULED_BASE = [...HUMAN_MESSAGE_BASE, 'send_master_private', 'send_private_message']
+
+const DAILY_REFLECTION_BASE = ['get_history', 'get_message', 'send_master_private']
+
+describe('worker messaging 工具集快照', () => {
+  it('human_message（message 任务）', () => {
+    expect(toolNames({ triggerType: 'message' }, false)).toEqual(HUMAN_MESSAGE_BASE.sort())
+    expect(toolNames({ triggerType: 'message' }, true))
+      .toEqual([...HUMAN_MESSAGE_BASE, ...FEISHU_ALL].sort())
+  })
+
+  it('human_message（front：无 task context）与 message 任务同集合', () => {
+    expect(toolNames(null, false)).toEqual(HUMAN_MESSAGE_BASE.sort())
+    expect(toolNames(null, true)).toEqual([...HUMAN_MESSAGE_BASE, ...FEISHU_ALL].sort())
+  })
+
+  it('human_message：taskType=daily_reflection 但 triggerType=message 时不套白名单', () => {
+    expect(toolNames({ triggerType: 'message', taskType: 'daily_reflection' }, false))
+      .toEqual(HUMAN_MESSAGE_BASE.sort())
+  })
+
+  it('scheduled（非 daily_reflection）', () => {
+    expect(toolNames({ triggerType: 'scheduled', taskType: 'news_briefing' }, false))
+      .toEqual(SCHEDULED_BASE.sort())
+    expect(toolNames({ triggerType: 'scheduled', taskType: 'news_briefing' }, true))
+      .toEqual([...SCHEDULED_BASE, ...FEISHU_ALL].sort())
+    // taskType 缺省的 scheduled 任务同集合
+    expect(toolNames({ triggerType: 'scheduled' }, false)).toEqual(SCHEDULED_BASE.sort())
+  })
+
+  it('scheduled_daily_reflection：唯一对外通道 send_master_private + 只读分析工具', () => {
+    expect(toolNames({ triggerType: 'scheduled', taskType: 'daily_reflection' }, false))
+      .toEqual(DAILY_REFLECTION_BASE.sort())
+    // 飞书三件只读工具在白名单内；feishu_write 不在
+    expect(toolNames({ triggerType: 'scheduled', taskType: 'daily_reflection' }, true))
+      .toEqual([...DAILY_REFLECTION_BASE, ...FEISHU_READ].sort())
+  })
+})
+
+describe('装配层声明', () => {
+  it('buildMessagingTools 只给声明里的工具，多声明的名字不会凭空造出工具', () => {
+    const tools = buildMessagingTools(
+      { ...BARE_DEPS, enableFeishuDocTool: true },
+      () => ({ tools: new Set(['get_history', 'send_message', '不存在的工具']), allowAskHuman: false }),
+    )
+    expect(tools.map(t => t.name).sort()).toEqual(['get_history', 'send_message'])
+  })
+
+  it('ALL_MESSAGING_TOOL_NAMES 与实际构造的工具一一对应（登记漏了 / 名字写错都会挂）', () => {
+    const tools = buildMessagingTools(
+      { ...BARE_DEPS, enableFeishuDocTool: true },
+      () => ({ tools: new Set(ALL_MESSAGING_TOOL_NAMES), allowAskHuman: false }),
+    )
+    expect(tools.map(t => t.name).sort()).toEqual([...ALL_MESSAGING_TOOL_NAMES].sort())
+  })
+})

--- a/crabot-agent/tests/mcp/send-message-buffer.test.ts
+++ b/crabot-agent/tests/mcp/send-message-buffer.test.ts
@@ -11,11 +11,11 @@
  */
 
 import { describe, it, expect, vi } from 'vitest'
-import { buildMessagingTools } from '../../src/mcp/crab-messaging.js'
+import { buildWorkerMessagingTools } from '../../src/mcp/crab-messaging.js'
 import { HumanMessageQueue } from '../../src/engine/human-message-queue.js'
 import type { OutboundBufferEntry } from '../../src/agent/outbound-flush.js'
 
-function findTool(tools: ReturnType<typeof buildMessagingTools>, name: string) {
+function findTool(tools: ReturnType<typeof buildWorkerMessagingTools>, name: string) {
   const t = tools.find((x) => x.name === name)
   if (!t) throw new Error(`tool ${name} not found`)
   return t
@@ -30,7 +30,7 @@ describe('send_message buffering (goal mode)', () => {
     const buffer: BufferEntry[] = []
     const rpcMethods: string[] = []
 
-    const tools = buildMessagingTools({
+    const tools = buildWorkerMessagingTools({
       rpcClient: {
         call: vi.fn().mockImplementation(async (_port: number, method: string) => {
           rpcMethods.push(method)
@@ -74,7 +74,7 @@ describe('send_message buffering (goal mode)', () => {
     const buffer: BufferEntry[] = []
     const rpcMethods: string[] = []
 
-    const tools = buildMessagingTools({
+    const tools = buildWorkerMessagingTools({
       rpcClient: {
         call: vi.fn().mockImplementation(async (_port: number, method: string) => {
           rpcMethods.push(method)
@@ -128,7 +128,7 @@ describe('send_message buffering (goal mode)', () => {
     const buffer: BufferEntry[] = []
     const rpcMethods: string[] = []
 
-    const tools = buildMessagingTools({
+    const tools = buildWorkerMessagingTools({
       rpcClient: {
         call: vi.fn().mockImplementation(async (_port: number, method: string) => {
           rpcMethods.push(method)
@@ -172,7 +172,7 @@ describe('send_message buffering (goal mode)', () => {
     const buffer: BufferEntry[] = []
     const rpcMethods: string[] = []
 
-    const tools = buildMessagingTools({
+    const tools = buildWorkerMessagingTools({
       rpcClient: {
         call: vi.fn().mockImplementation(async (_port: number, method: string) => {
           rpcMethods.push(method)
@@ -215,7 +215,7 @@ describe('send_message buffering (goal mode)', () => {
     const queue = new HumanMessageQueue()
     const buffer: BufferEntry[] = []
 
-    const tools = buildMessagingTools({
+    const tools = buildWorkerMessagingTools({
       rpcClient: { call: vi.fn() } as never,
       moduleId: 'worker-test',
       getAdminPort: async () => 19001,
@@ -268,7 +268,7 @@ describe('send_message buffering (goal mode)', () => {
     const queue = new HumanMessageQueue()
     const rpcMethods: string[] = []
 
-    const tools = buildMessagingTools({
+    const tools = buildWorkerMessagingTools({
       rpcClient: {
         call: vi.fn().mockImplementation(async (_port: number, method: string) => {
           rpcMethods.push(method)
@@ -304,7 +304,7 @@ describe('send_message buffering (goal mode)', () => {
     const queue = new HumanMessageQueue()
     const buffer: BufferEntry[] = []
 
-    const tools = buildMessagingTools({
+    const tools = buildWorkerMessagingTools({
       rpcClient: { call: vi.fn() } as never,
       moduleId: 'worker-test',
       getAdminPort: async () => 19001,
@@ -341,7 +341,7 @@ describe('send_message buffering (goal mode)', () => {
     const queue = new HumanMessageQueue()
     const buffer: BufferEntry[] = []
 
-    const tools = buildMessagingTools({
+    const tools = buildWorkerMessagingTools({
       rpcClient: { call: vi.fn() } as never,
       moduleId: 'worker-test',
       getAdminPort: async () => 19001,


### PR DESCRIPTION
## P7 / PR C:manager 的 messaging 工具面

spec:`crabot-docs/superpowers/specs/2026-07-31-manager-tool-visibility-design.md`
协议(先行,已 push):`protocol-crab-messaging.md` v0.3.0(`0692b14`)

### 起因:一段没理顺的逻辑

P4 的 `buildManagerToolFace` **伪造了一个 `triggerType:'scheduled'` 的 TaskContext**,去骗过 `resolveMessagingToolProfile`。

根源不是缺一个开关,而是 **manager 被迫走了一个为 worker 写的函数**——那个函数的语义是"根据**任务上下文**裁剪工具",而 manager 不是任务执行者,它没有 TaskContext,也不该有。让它去满足一个本质上不具备的前提,只能靠编造。

> 早先的方案是"加一个 `exposeDirectSendTools` 开关",后来否掉了:那只是给伪造换了个体面的名字,manager 依然在走那个裁剪函数,臭味的根源没动。

### 做法:把工具集的决定权提到装配层

```ts
interface MessagingToolSet {
  readonly tools: ReadonlySet<string>   // 交集语义:deps 没构造的自然不出现
  readonly allowAskHuman: boolean
}
buildMessagingTools(deps, getToolSet: () => MessagingToolSet, ...)
```

- **worker 侧**:调用前先用 `resolveMessagingToolProfile(taskContext)` 算出工具集再传进去——该函数语义不变,继续服务它本来的场景(PR J 摘掉 worker 侧装配时一并删);
- **manager 侧**:直接声明自己要哪些,**一行 TaskContext 都不需要**;
- **两处旁路运行时门同步改**(`requireScheduledShortcutContext` → `requireDeclaredShortcut`、ask_human 拒绝改读 `allowAskHuman`)——只改可见性不改运行时门会变成"工具可见但调用被拦",更难排查。

**为什么是 getter 不是定值**:worker 的声明源自活的 `getTaskContext()`,运行时门要读**调用那一刻**的声明;定值会让既有回归用例「构建后切到 message context 时拒绝且零 RPC」失效。

### 分两个 commit,中间有个可验证的干净点

**`fec6655e` 纯重构** —— 行为逐字不变。自证:

```
$ git diff -- crabot-agent/tests | grep -E '^[+-]' | grep -v '^[+-][+-]' \
    | grep -v 'buildWorkerMessagingTools\|buildMessagingTools'
(空)
```

既有测试里被改的每一行都只是函数名 `buildMessagingTools` → `buildWorkerMessagingTools`。**断言的期望值一条都没动。** 重构前还先补了 7 条快照用例(三档 profile 的**完整**工具清单,飞书开/关各一组)——既有用例只逐个断言"某工具在/不在",没有一处把整份清单钉死。

**`86e4d217` 行为变更** —— manager 侧补齐工具。

### manager 拿到什么

`send_private_message`(协议 §1 早就写着"普通 manager = 是",实现里一直放在系统线程专属集里)+ 飞书**只读**三件套 + `fetch_media`。

**不给 `feishu_write`**:任意写 API、无逐操作确认、无 undo;m2 现网 channel 配置无 `allow_write` 键 → 按 `allow_write !== false` 判定,**生产上写透传是开着的**。cutover 后 manager 直接吃群消息原文,把不可回滚的任意写接在最容易被 prompt 注入的一环;而它在 m2 上 7-01 起 7777 条 trace 里**零调用**。

**给只读三件套的决定性理由**是这条真实链路:

```
get_history → feishu_raw_get(/open-apis/im/v1/messages) → get_message
            → feishu_download_file → fetch_media
```

`raw_get` 在这里打的是 **IM 消息端点**,是对话层的逃生门。v3 的 worker 不持有任何 messaging 工具,连"是哪条消息"都定位不到;而 handle 兑换器 `fetch_media` 本就只在 manager 白名单里,**链子只在 manager 侧闭合**。

### 一个只改白名单会踩空的坑

manager 的 `messagingDeps` **根本没传 `enableFeishuDocTool`** —— 不接这个开关,工具压根不会被构造,白名单里写了也没用。

接法是 **getter**(`get enableFeishuDocTool(){ return self.feishuChannelAvailable }`),不能是定值:`initializeManagerStack()` 在构造函数里跑,而 `detectFeishuChannel()` 在 `onStart()` 里;manager 的 `messagingDeps` 是建好就长期持有、每个 episode 复用的对象,写成定值会永远快照到探测前的 `false`。worker 侧无此问题是因为它的 `createMcpConfigs` 是每 task 现调的工厂。

"仅当存在飞书 channel 实例才可见"就落在这个开关上,没有额外分支——`tools` 是**交集**语义,开关 falsy 时三件套压根不被构造,白名单写了也过滤不出东西。

### 验收(spec 6 条,逐条自证)

| # | 自证方式 |
|---|---|
| 1 | 普通 manager 工具名集合**精确匹配**预期清单;系统线程**只**多出 `send_master_private` |
| 2 | **端到端**真的 `await tool.call(...)`,断言 RPC 序列 `['get_friend','find_or_create_private_session','send_message']` —— 门若拒绝会在任何 RPC 之前返回,序列会是空的 |
| 3 | `grep -rn "TaskContext" src/manager/` → 唯一命中是注释里"manager 没有 TaskContext,也不该有"那句 |
| 4 | `git diff -- tests/mcp tests/agent tests/engine \| wc -l` → `0` |
| 5 | 走**真实** `new UnifiedAgent()` 构造出的真实 `toolFace()`:探测前取一次(三件套不在)→ 置 `feishuChannelAvailable=true` → 再取一次(三件套在、`feishu_write` 仍不在) |
| 6 | 见下 |

### 变异验证

| 变异 | 结果 |
|---|---|
| 去掉 `send_private_message` | 5 failed / 15 passed |
| **加上 `feishu_write`** | 2 failed / 18 passed |
| 删掉 `enableFeishuDocTool` | 1 failed / 10 passed |
| **getter 退化成定值** | 1 failed / 10 passed —— 证明"接了"不够,必须是活的 |

### 验证

- 全量 **2334 passed | 2 skipped**,零失败(基线 2331 + 3 条新用例);`tsc --noEmit` 干净
- `src/mcp/crab-messaging.ts` 在第 2 步零改动

### 发现但未改

1. `feishuChannelAvailable` 只在 `onStart()` 探测一次,运行期新增/删除飞书 channel 实例不会反映到工具面(manager 与 worker 皆然,既有行为);
2. **移交 PR J**:4 个飞书工具只活在 crab-messaging 内部,J 摘掉 worker 侧装配后 worker 的"执行取数"场景会真空。本 PR 补上了对话层那一半;
3. 协议里另发现 `list_group_members` 同样是"实现私货"(已在 manager 白名单但 §2 从未定义),不在本次范围。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
