### PR TITLE
feat: Manager/Worker 拆分 P7/F——builtin worker 注入通道

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,6 +1,17 @@
 # Crabot 项目进度
 
-> 最后更新：2026-07-31 — Manager/Worker 拆分 P7 / PR A：入站链路测试网（分支 feat/mw-p7a-inbound-test-net，未合并 main）
+> 最后更新：2026-08-01 — Manager/Worker 拆分 P7 / PR F：builtin worker 注入通道（分支 feat/mw-p7f-builtin-injection，未合并 main）
+
+## 2026-08-01 — Manager/Worker 拆分 P7 / PR F：builtin worker 注入通道（manager 终于能派出一个能干活的 builtin worker）
+
+- spec：`crabot-docs/superpowers/specs/2026-08-01-builtin-worker-injection-design.md`。补的是 P4/P5 两次记录里都点名的那条阻塞项——`spawn_worker` 不传 `SpawnSpec.builtin`，而 `defaultImpl='builtin'`，**cutover 后 manager 第一次派活必挂**。
+- 第 1 步（管道 + adapter 侧）：`builtinSpawnDefaults` 从无参 thunk 改成带 per-worker 上下文的工厂 `(ctx:{worker_id,workspace,origin,goal}) => SpawnSpec['builtin']`（无参签名从根上装不下 workspace/权限身份这些 spawn 时才知道的维度）；`spawnWorker` 在缺 `builtin` 且目标是 builtin 时回退调它；adapter 每次起化身（spawn/resume/fork/idle→续 burst）**现取**运行配置，per-worker 上下文落 `context.json`——builtin worker 因此**跨进程重启也能 revive**，而 LLM 连接信息始终不落盘；runEngine 补齐 `hookRegistry`（CLI 权限闸 / skill 目录 fence / git 写 fence）+ 固定权限档位 `BUILTIN_WORKER_PERMISSIONS` + 模型参数；工具集守卫在每轮 resolve 时硬断言不得出现 `set_cwd` / `set_task_goal`。
+- 第 2 步（生产装配，本次）：`unified-agent.ts` 实现真实工厂 `buildBuiltinWorkerRuntime`——LLM 走与现网 worker 同一个 `model_config.powerful` slot，工具 = 内置文件/shell + skills、crab-memory（A 组）、外部 MCP、tmp-page、生图，systemPrompt = `assembleAgentPrompt`（goal 模式关）+ 一段 v3 worker 契约尾巴（工作目录固定为 workspace / 没有任何直接联系人类的工具 / `finish_task` 是唯一终态信号）。**不装**：全部 messaging、`set_cwd`、goal 相关、`delegate_task`、`todo`、`find_task`、`wait_for_signal`。
+- **"现取"是这次的核心不变量**：工厂以方法引用交给 bootstrap，配置（model slot / 人格 / skills / MCP / 生图 / 时区）一律在**被调用那一刻**读 `this`；`systemPrompt`/`tools` 再各包一层 thunk，engine 每轮 turn 重新 resolve。教训来自 PR C 的 `enableFeishuDocTool`：deps 对象被长期持有，任何在装配期就地求值的东西都会永久快照。变异实测：把 model 快照进闭包 → 验收 3 用例挂。
+- 权限身份用**显式常量档位**（所有 worker 同权限，干活面开、messaging/task/remote_exec/desktop 关、CLI 全 `none`），因为 `origin.creator_friend_id` 现网恒空。**PR J 的验收必须包含"worker 权限随发起人身份解析"**，否则 cutover 当天群里任何人都能让 worker 干 master 才该能干的事。这条写死，不得遗忘。
+- `tests/manager/manager-integration.test.ts` 的 `BuiltinAutoConfigAdapter` 垫片**退役**：它原本包一层 adapter 在 `spec.builtin` 缺失时补配置，现在改成给 `HarnessDeps.builtinSpawnDefaults` 一个按队列出配置的工厂——同样的语义，走的是生产回退路径本身（去掉该回退，这两个场景用例立刻挂）。
+- 已知能力缺口（spec 明列，不在本 PR）：**无上下文压缩**（`disableCompaction:true` 写死，长活 worker 撞窗口即 burst 失败）→ **PR F2，必须在 J 之前**；权限身份接线 → J；subagent / todo / `wait_for_signal` / `delegate_task` → 后续独立加法；builtin `readTrace` → P6。
+- 验证：`crabot-agent` 全量 `2357 passed | 2 skipped`（204 文件），基线 `2348 | 2`，差值 = 新增 9，**零回归**；`tsc --noEmit` 干净；4 类变异逐个植入实测（① 去掉工厂回退 → 9 挂，含 manager-integration 两个场景；② 去掉 `hookRegistry` → 3 挂；③ 配置改回 spawn 快照 → 4 挂；④ model 快照进闭包 → 验收 3 挂）。
 
 ## 2026-07-31 — Manager/Worker 拆分 P7 / PR A：入站链路测试网（只加测试，生产代码零改动）
 

--- a/crabot-agent/src/manager/bootstrap.ts
+++ b/crabot-agent/src/manager/bootstrap.ts
@@ -39,7 +39,8 @@ import type { DialogObjectId } from '../workers/harness/ledger-types'
 import { BuiltinWorkerAdapter } from '../workers/builtin/adapter.js'
 import { ClaudeCodeAdapter } from '../workers/claude-code/adapter.js'
 import { CodexWorkerAdapter } from '../workers/codex/adapter.js'
-import type { SpawnSpec, WorkerAdapter, WorkerImplId } from '../workers/types.js'
+import type { WorkerAdapter, WorkerImplId } from '../workers/types.js'
+import type { BuiltinRuntimeFactory } from '../workers/builtin/runtime.js'
 
 import { ManagerRegistry } from './registry.js'
 import { ManagerSessionStore } from './session-store.js'
@@ -111,8 +112,13 @@ export interface BootstrapDeps {
    * 本模块拿不到,而 `ManagerRegistryDeps.dialogObjectIdFor` 又是同步签名,不能在这里现查。
    */
   readonly dialogObjectIdFor: (key: ManagerKey) => DialogObjectId
-  /** handoff 目标为 builtin 时的 LLM 注入缺省值,原样透传给 `HarnessDeps.builtinSpawnDefaults`。 */
-  readonly builtinSpawnDefaults?: () => SpawnSpec['builtin']
+  /**
+   * builtin worker 的运行配置工厂(spawn 缺省注入 / handoff 目标为 builtin 时的注入)。
+   * 同一个工厂同时喂给 `HarnessDeps.builtinSpawnDefaults`(spawn/handoff 起化身)与
+   * `BuiltinWorkerAdapter.resolveRuntime`(resume/fork/续 burst 起化身)——两条路都要
+   * "起化身时现取",不能各持一份(spec 决策 2)。
+   */
+  readonly builtinSpawnDefaults?: BuiltinRuntimeFactory
   /**
    * 对外事件发布口(§9.2 `agent.task_status_changed`),由 `makeAgentEventPublisher` 构造。
    * 可选:P5 阶段这套栈没有生产调用方,注入真实 rpcClient 是 P5 Task 6 的事;不注入则本栈
@@ -195,7 +201,11 @@ export function buildManagerStack(deps: BootstrapDeps): ManagerStack {
   // --- step 3 + 4:构造三个 adapter 时传 harness.handleStateChange,再 set 回同一个 Map ---
   adapters.set(
     'builtin',
-    new BuiltinWorkerAdapter({ dataDir: builtinDataDir, onStateChange: harness.handleStateChange }),
+    new BuiltinWorkerAdapter({
+      dataDir: builtinDataDir,
+      onStateChange: harness.handleStateChange,
+      resolveRuntime: deps.builtinSpawnDefaults,
+    }),
   )
   adapters.set(
     'claude-code',

--- a/crabot-agent/src/manager/tools/worker-tools.ts
+++ b/crabot-agent/src/manager/tools/worker-tools.ts
@@ -126,32 +126,38 @@ export function buildWorkerTools(deps: WorkerToolsDeps): ToolDefinition[] {
   const { harness, context, onAsyncError } = deps
 
   // --- spawn_worker(异步:发起即返回,任务进展由事件唤醒) ---
+  //
+  // 刻意**不收** `goal`:没有任何 worker 实现装配 goal 模式(builtin 的工具集硬禁
+  // `set_task_goal`,见 `workers/builtin/runtime.ts` 的 `FORBIDDEN_WORKER_TOOLS`;
+  // cc/codex 的 `capabilities().goalMode` 本来就是 false)。再收这个参数只会让 manager
+  // 照着工具描述传、以为生效,实际静默落进台账哪儿都到不了。要 worker 目标驱动,就把目标
+  // 写进 `prompt`——protocol-agent-v3 §4.3 / §6.4。
   const spawnWorker = defineTool({
     name: 'spawn_worker',
     description:
       '派发一个新的 worker 去执行一项任务。异步语义:本工具在 worker 化身创建完成后即返回' +
       '(不等 worker 把任务做完),返回 worker_id;worker 的后续状态变化(idle/exited)会作为' +
-      '事件唤醒你,不需要主动轮询。impl 缺省按部署偏好选择;workspace 缺省新建;goal 仅对' +
-      'builtin 实现生效。',
+      '事件唤醒你,不需要主动轮询。impl 缺省按部署偏好选择;workspace 缺省新建。',
     inputSchema: {
       type: 'object',
       properties: {
         title: { type: 'string', description: '任务标题(简短)' },
-        prompt: { type: 'string', description: '交给 worker 的任务描述/初始输入' },
+        prompt: {
+          type: 'string',
+          description: '交给 worker 的任务描述/初始输入。要它目标驱动就把目标写在这里',
+        },
         impl: { type: 'string', enum: WORKER_IMPL_IDS as unknown as string[], description: 'worker 实现,缺省按部署偏好' },
         workspace: { type: 'string', description: '复用的 workspace 路径,缺省新建一个' },
-        goal: { type: 'string', description: '目标态描述,仅 builtin 实现使用' },
       },
       required: ['title', 'prompt'],
     },
     isReadOnly: false,
     call: async (input): Promise<ToolCallResult> => {
-      const { title, prompt, impl, workspace, goal } = input as {
+      const { title, prompt, impl, workspace } = input as {
         title?: string
         prompt?: string
         impl?: string
         workspace?: string
-        goal?: string
       }
       if (!title || typeof title !== 'string') return invalid('spawn_worker: title 必填且为字符串')
       if (!prompt || typeof prompt !== 'string') return invalid('spawn_worker: prompt 必填且为字符串')
@@ -176,7 +182,6 @@ export function buildWorkerTools(deps: WorkerToolsDeps): ToolDefinition[] {
           report_to: ctx.reportTo,
           impl,
           workspace,
-          goal,
         })
         return ok({ status: 'spawned', worker_id: worker.worker_id, impl: worker.incarnations[0]?.impl })
       } catch (error) {

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -156,24 +156,23 @@ function buildWorkerSkillListing(skills: ReadonlyArray<SkillConfig> | undefined)
 }
 
 /**
- * v3 worker 契约尾巴（protocol-agent-v3 §5）。只陈述协议已经规定的事实——worker 没有
- * crab-messaging / 没有 ask_human（§5.1）、判断与转述的责任全在 manager 侧（§5.1）、
- * workspace 是跨实现交接的唯一介质且要求中间产物落盘（§5.4）、`finish_task` 是 builtin
- * 的终态信号（§5.1 "finalize 即 exited"）——不额外承诺协议里没有的东西。
+ * v3 worker 契约尾巴（protocol-agent-v3 §5）。只讲干活需要知道的事：工作目录固定且是
+ * 跨实现交接的唯一介质（§5.4）、卡住时怎么收场、`finish_task` 是终态信号
+ * （§5.1 "finalize 即 exited"）。
+ *
+ * 刻意**不写** "你没有联系人类的工具"这类否定式说明：worker 的工具列表里本来就没有
+ * crab-messaging / ask_human（§5.1），提它反而把这个念头塞进上下文；"判断与转述的责任
+ * 在 manager 侧"同理——那是 manager 的规矩，对 worker 干活没有帮助。
  */
 function buildBuiltinWorkerContractPrompt(workspaceRoot: string): string {
   return [
-    '## 你的角色：worker',
-    '',
-    '你是一个 worker：由 manager 派活、向 manager 交付，不直接面对人类。',
+    '## 你的工作方式',
     '',
     `- **你的工作目录固定为 \`${workspaceRoot}\`，并且没有切换工作目录的工具。**`
     + '所有中间产物和最终产出都要落在这个目录里——它是交接的唯一介质：'
     + '你被换成另一个实现接手时，接手方只能看到这里留下的东西。',
-    '- **你没有任何直接联系人类的工具**（没有发消息、也没有向人类提问这类原语），不要去找。'
-    + '你对外只有两个出口：workspace 里的文件，和你自己的输出流。',
-    '- 需要人类拿主意、或者有话想让人类知道时，把它在输出里写清楚然后结束本轮。'
-    + '你会停下来等待；读你的输出、判断你是干完了还是在等输入、以及要不要把话转述给人类，都是 manager 的责任。',
+    '- 缺少继续所需的信息、或者需要有人拍板时，把情况和你的判断写清楚，然后结束本轮。'
+    + '你会停下来等待下一条输入。',
     '- 任务完成或确认失败时调用 `finish_task`（`outcome` 取 `completed` 或 `failed`，`summary` 一句话）。'
     + '这是你唯一的终态信号——不调用它，你只是停下来等下一条输入。',
   ].join('\n')

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -51,12 +51,16 @@ import { dispatch } from './dispatcher/dispatcher.js'
 import type { DispatchTraceCallback, ImmediateReplySentInfo } from './dispatcher/dispatcher-types.js'
 import { executeDispatchActions } from './dispatcher/dispatcher-executor.js'
 import type { ToolPermissionConfig, ToolDefinition as EngineToolDefinition } from './engine/types.js'
+import { filterToolsByPermission } from './engine/index.js'
+import { getConfiguredBuiltinTools, filterMcpToolsByConfig } from './engine/tools/index.js'
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { McpConnector } from './agent/mcp-connector.js'
+import { mcpServerToToolDefinitions } from './agent/mcp-tool-bridge.js'
+import { createTmpPageTools } from './agent/tmp-page-tools.js'
 import { createCrabMessagingServer, type PathMapping, type TaskContext } from './mcp/crab-messaging.js'
-import { toImageConnInfo, type ImageConnInfo } from './mcp/crab-image.js'
+import { toImageConnInfo, imageToolsFor, type ImageConnInfo } from './mcp/crab-image.js'
 import { TraceStore } from './core/trace-store.js'
-import { getAgentTraceDir, getAgentLogsDir, getWorkspaceDir, getDataRootDir } from './core/data-paths.js'
+import { getAgentTraceDir, getAgentLogsDir, getAgentDataDir, getWorkspaceDir, getDataRootDir } from './core/data-paths.js'
 import { PromptManager } from './prompt-manager.js'
 import { createLSPManager, type LSPManager } from './lsp/lsp-manager.js'
 import type { BgEntityRecord, BgEntityStatus, BgEntityType } from './engine/bg-entities/types.js'
@@ -68,7 +72,11 @@ import { DEFAULT_MAX_CONTEXT_TOKENS } from './engine/query-loop.js'
 import { buildManagerStack, reconcileManagerStack, type ManagerStack } from './manager/bootstrap.js'
 import { makeAgentEventPublisher } from './manager/events.js'
 import { resolveManagerModelConfig } from './manager/model-slot.js'
-import { createCrabMemoryServer } from './mcp/crab-memory.js'
+import { createCrabMemoryServer, filterMemoryToolsByProfile } from './mcp/crab-memory.js'
+import {
+  BUILTIN_WORKER_PERMISSIONS,
+  type BuiltinRuntimeContext,
+} from './workers/builtin/runtime.js'
 import { dialogObjectIdForGroup, type DialogObjectId, type ManagerKey } from './workers/harness/ledger-types.js'
 import {
   filterAndPageWorkers,
@@ -82,7 +90,7 @@ import {
   type GetWorkerTraceParams,
   type GetWorkerTraceResult,
 } from './manager/read-model.js'
-import type { NormalizedTraceEvent } from './workers/types.js'
+import type { NormalizedTraceEvent, SpawnSpec } from './workers/types.js'
 import type { HarnessEvent } from './workers/harness/worker-events.js'
 import { findIncarnationBySeq, mainlineIncarnation } from './workers/harness/harness.js'
 
@@ -124,6 +132,51 @@ function toToolPermissionConfig(
 
 function normalizeResumeTriggerType(triggerType: string | undefined): 'message' | 'scheduled' {
   return triggerType === 'scheduled' ? 'scheduled' : 'message'
+}
+
+/**
+ * builtin worker 的 skill catalog（Tier 1 渐进式披露：name + description）。Skill 工具的
+ * description 明写"当任务匹配 <available_skills> 里某个技能的描述时必须先调用本工具"，
+ * 不给这段清单，装了 Skill 工具的 worker 也不知道有哪些技能可用。
+ *
+ * 与 `AgentHandler.buildSkillListingSnapshot` 是同一份格式，**刻意并存**：那一份属于现网
+ * worker loop 的组装路径，本阶段对它零改动（PR J 收编 worker loop 时随它一并删除）。
+ */
+function buildWorkerSkillListing(skills: ReadonlyArray<SkillConfig> | undefined): string | undefined {
+  if (!skills || skills.length === 0) return undefined
+  const intro =
+    '\n\n以下技能为特定任务提供专业指引。当任务匹配某个技能的描述时，'
+    + '必须先调用 Skill 工具（输入技能名称）加载完整指引，然后按指引操作。'
+    + '这是强制要求——先加载技能，再执行任务。'
+  const body = skills.map((s) => {
+    const desc = s.description || s.name
+    return `<skill>\n<name>${s.name}</name>\n<description>${desc}</description>\n</skill>`
+  }).join('\n')
+  return `${intro}\n\n<available_skills>\n${body}\n</available_skills>`
+}
+
+/**
+ * v3 worker 契约尾巴（protocol-agent-v3 §5）。只陈述协议已经规定的事实——worker 没有
+ * crab-messaging / 没有 ask_human（§5.1）、判断与转述的责任全在 manager 侧（§5.1）、
+ * workspace 是跨实现交接的唯一介质且要求中间产物落盘（§5.4）、`finish_task` 是 builtin
+ * 的终态信号（§5.1 "finalize 即 exited"）——不额外承诺协议里没有的东西。
+ */
+function buildBuiltinWorkerContractPrompt(workspaceRoot: string): string {
+  return [
+    '## 你的角色：worker',
+    '',
+    '你是一个 worker：由 manager 派活、向 manager 交付，不直接面对人类。',
+    '',
+    `- **你的工作目录固定为 \`${workspaceRoot}\`，并且没有切换工作目录的工具。**`
+    + '所有中间产物和最终产出都要落在这个目录里——它是交接的唯一介质：'
+    + '你被换成另一个实现接手时，接手方只能看到这里留下的东西。',
+    '- **你没有任何直接联系人类的工具**（没有发消息、也没有向人类提问这类原语），不要去找。'
+    + '你对外只有两个出口：workspace 里的文件，和你自己的输出流。',
+    '- 需要人类拿主意、或者有话想让人类知道时，把它在输出里写清楚然后结束本轮。'
+    + '你会停下来等待；读你的输出、判断你是干完了还是在等输入、以及要不要把话转述给人类，都是 manager 的责任。',
+    '- 任务完成或确认失败时调用 `finish_task`（`outcome` 取 `completed` 或 `failed`，`summary` 一句话）。'
+    + '这是你唯一的终态信号——不调用它，你只是停下来等下一条输入。',
+  ].join('\n')
 }
 
 /**
@@ -481,10 +534,11 @@ export class UnifiedAgent extends ModuleBase {
    * （它们只读台账，与 LLM 无关）。thunk 同时顺带满足 §11 的热更语义：manager 的 model 于
    * 下一个 episode 生效。
    *
-   * **本阶段刻意不提供 `builtinSpawnDefaults`**：它要的是 builtin worker 的完整 LLM + 工具面
-   * 注入，而 `spawnWorker` 目前压根不读它（只有 `handoffIncarnation` 消费），补上去也补不掉
-   * "manager 走缺省 `spawn_worker` 必挂"这个缺口——那是 P7 cutover 前必须修的一项（见
-   * `.superpowers/sdd/progress.md` Task 1 条目）。这里给一个半成品反而会掩盖它。
+   * **`builtinSpawnDefaults` 传的是方法引用而不是预先算好的值**（PR F 第 2 步）：deps 对象在
+   * 构造函数里建好后被 harness / adapter 长期持有，任何在这里就地求值的东西都会永久快照到
+   * 构造那一刻——`messagingDeps.enableFeishuDocTool` 写成 getter 就是同一个理由。builtin
+   * worker 的运行配置（model slot / 人格 / skills / MCP / 生图能力）全部要在**起化身那一刻**
+   * 才解析（spec 决策 2），所以这里只交出 `buildBuiltinWorkerRuntime` 的调用口。
    */
   private initializeManagerStack(): void {
     // messagingDeps 里的 getter 需要拿到本实例（getter 内的 `this` 是那个对象字面量）。
@@ -525,6 +579,8 @@ export class UnifiedAgent extends ModuleBase {
       callAdmin: async <P, R>(method: string, params: P): Promise<R> =>
         this.rpcClient.call<P, R>(await this.getAdminPort(), method, params, this.config.moduleId),
       dialogObjectIdFor: (key) => this.dialogObjectIdForManagerKey(key),
+      // 起化身时现取（spec 决策 2）：箭头函数只捕获 `this`，配置一律在调用那一刻读。
+      builtinSpawnDefaults: (ctx) => this.buildBuiltinWorkerRuntime(ctx),
       // 对外事件出口（§9.2 `agent.task_status_changed`）：真实 rpcClient 注入。
       // 翻译与去重在 manager/events.ts，这里只负责把口子接上。
       publishEvent: makeAgentEventPublisher({
@@ -563,6 +619,141 @@ export class UnifiedAgent extends ModuleBase {
     return sep < 0
       ? dialogObjectIdForGroup(key, '')
       : dialogObjectIdForGroup(key.slice(0, sep), key.slice(sep + 2))
+  }
+
+  // ==========================================================================
+  // builtin worker 的运行配置注入（PR F）
+  // spec: crabot-docs/superpowers/specs/2026-08-01-builtin-worker-injection-design.md
+  // ==========================================================================
+
+  /**
+   * builtin worker 起化身时的运行配置工厂 —— `HarnessDeps.builtinSpawnDefaults`
+   * （spawn / handoff）与 `BuiltinWorkerAdapter.resolveRuntime`（resume / fork /
+   * idle→running 续 burst，含进程重启之后）共用的同一个入口。
+   *
+   * **本方法里的每一项都必须是"现取"**：它读的是**被调用那一刻** `this` 上的配置
+   * （model slot / 人格 / skills / 外部 MCP / 生图能力 / 时区）。任何一项若提到装配期
+   * （`initializeManagerStack`）算好塞进闭包，"改了配置下次起化身生效"就退化成"agent
+   * 重启才生效"，进程重启后的 revive 也会拿不到配置（spec 决策 2）。
+   *
+   * 缺 `powerful` slot 时**抛错，不降级**：harness 会把这次 spawn 如实落成一条 failed 台账
+   * 加一条 `spawn_failed` 事件，manager 的 `spawn_worker` 拿到错误文本。静默降级只会让
+   * manager 以为派活成功。
+   */
+  private buildBuiltinWorkerRuntime(ctx: BuiltinRuntimeContext): SpawnSpec['builtin'] {
+    // 与现网 worker loop 同一个 slot（`initializeAgentLayer` 的 `model_config.powerful`），
+    // 但取值时机不同：那边在装配期解析成 `sdkEnvWorker` 字段，这里每次起化身现读现解析。
+    const connInfo = this.agentConfig?.model_config?.powerful
+    if (!connInfo) {
+      throw new Error(
+        "[builtin-worker] model_config 缺少 'powerful' slot，无法解析 builtin worker 的 LLM 连接信息",
+      )
+    }
+    const sdkEnv = this.buildSdkEnv(connInfo)
+    return {
+      adapter: adapterFromSdkEnv(sdkEnv),
+      model: sdkEnv.modelId,
+      // systemPrompt / tools 都给 thunk：engine 每轮 turn 重新 resolve，admin 中途 push 的
+      // 人格 / skills / MCP 变更因此在同一个 burst 内即时生效（与现网 worker loop 的
+      // buildSystemPromptDynamic / buildToolsDynamic 同款语义）。
+      systemPrompt: () => this.buildBuiltinWorkerSystemPrompt(ctx),
+      tools: () => this.buildBuiltinWorkerTools(ctx),
+      timezone: resolveTimezone(this.agentConfig?.timezone),
+      ...(sdkEnv.supportsVision !== undefined ? { supportsVision: sdkEnv.supportsVision } : {}),
+      ...(sdkEnv.maxTokens !== undefined ? { maxTokens: sdkEnv.maxTokens } : {}),
+      ...(sdkEnv.contextWindow !== undefined ? { contextWindowTokens: sdkEnv.contextWindow } : {}),
+    }
+  }
+
+  /**
+   * builtin worker 的工具集（spec 决策 5）。
+   *
+   * **装**：内置文件/shell 工具 + skills、crab-memory、外部 MCP、tmp-page / 生图。
+   * **不装**：全部 messaging（v3 语义：worker 不直接跟人类说话）、`set_cwd`、goal 相关、
+   * `delegate_task`、`todo`、`find_task` / `get_task_progress`、`wait_for_signal`、
+   * subagent coordinator / `request_restart`。它们不是被过滤掉的，而是根本不组装进来。
+   */
+  private buildBuiltinWorkerTools(ctx: BuiltinRuntimeContext): ReadonlyArray<EngineToolDefinition> {
+    const tools: EngineToolDefinition[] = []
+    const workspaceRoot = ctx.workspace.root
+
+    // 内置文件 / shell 工具 + Skill。cwd 恒等于 workspace 且**不传 `setCwdCtx`**——worker 的
+    // 工作目录就是它的 workspace，不可中途切换（决策 3；adapter 侧 `guardTools` 硬断言）。
+    // 也不传 bgEntityCtx / bgToolDeps：bg-shell 的退出唤醒依赖 `wait_for_signal`（本阶段不装），
+    // 且 owner 归属在多 worker 并发下尚未定义（spec 未决 #3）。
+    tools.push(...getConfiguredBuiltinTools(
+      () => workspaceRoot,
+      this.agentConfig?.builtin_tool_config,
+      { availableSkills: this.agentConfig?.skills ?? [] },
+    ))
+
+    // crab-memory：A 组（普通对话档）。worker 没有会话身份，visibility/scopes 取与 manager
+    // 侧同一组缺省值（`initializeManagerStack` 的 memoryServer），sourceType 记 'system'。
+    // 记忆权限档位随会话身份解析是 spec 未决 #2，J 接真实身份时一并收敛。
+    tools.push(...filterMemoryToolsByProfile(
+      mcpServerToToolDefinitions(
+        createCrabMemoryServer(
+          {
+            rpcClient: this.rpcClient,
+            moduleId: this.config.moduleId,
+            getMemoryPort: () => this.getMemoryPort(),
+          },
+          {
+            taskId: ctx.worker_id,
+            visibility: 'public',
+            scopes: [],
+            sourceType: 'system',
+            isMasterPrivate: false,
+          },
+        ),
+        'crab-memory',
+      ),
+      'conversation',
+    ))
+
+    // 外部 MCP（admin 托管，McpConnector 在 onStart 连接）。
+    tools.push(...this.mcpConnector.getAllTools())
+
+    // 临时页面：`taskId` 用 worker_id（页面 meta.owner_task_id 与台账里的 worker 对得上）。
+    tools.push(...createTmpPageTools({
+      dataDir: getDataRootDir(),
+      getTmpPageBaseUrl: () => this.agentConfig?.tmp_page_base_url,
+      taskId: ctx.worker_id,
+    }))
+
+    // 生图（未配置 image_config 时 imageToolsFor 返回空数组）。
+    tools.push(...imageToolsFor(this.imageConnInfo, {
+      moduleId: this.config.moduleId,
+      outputDir: path.join(getAgentDataDir(), 'generated-images'),
+    }))
+
+    // disabled_tools 对 MCP 桥接工具的过滤（内置工具的同名过滤已在 getConfiguredBuiltinTools 内完成）。
+    const configFiltered = filterMcpToolsByConfig(tools, this.agentConfig?.builtin_tool_config)
+    // F 阶段固定权限档位过滤：adapter 的 `checkPermission` 是执行期的闸，这里守的是
+    // "没权限的工具不进 prompt"——外部 MCP 里可能混进 `desktop` 类工具（computer-use），
+    // 那一面在 F 阶段的档位下是关的。J 接真实身份后档位改为按 origin 解析。
+    return filterToolsByPermission(
+      configFiltered,
+      this.getToolPermissionConfig(configFiltered, BUILTIN_WORKER_PERMISSIONS),
+    )
+  }
+
+  /**
+   * builtin worker 的 system prompt = 现网那套 agent prompt（goal 模式关闭）+ 一段 v3 worker
+   * 契约尾巴。两段都在每轮 turn 现拼，admin 改人格 / skills 后下一轮即生效。
+   */
+  private buildBuiltinWorkerSystemPrompt(ctx: BuiltinRuntimeContext): string {
+    const skillListing = buildWorkerSkillListing(this.agentConfig?.skills)
+    const base = this.promptManager.assembleAgentPrompt({
+      // 决策 4：builtin worker 不装 goal 模式（既不给 goal 工具也不给 goal 缓冲），
+      // 需要目标驱动时由 manager 在派活 prompt 里用指令表达。
+      goalModeEnabled: false,
+      ...(this.agentConfig?.system_prompt ? { adminPersonality: this.agentConfig.system_prompt } : {}),
+      ...(skillListing ? { skillListing } : {}),
+      imageCapability: { available: this.imageCapability.available },
+      // availableSubAgents 不传：worker 不装 delegate_task。
+    })
+    return `${base}\n\n${buildBuiltinWorkerContractPrompt(ctx.workspace.root)}`
   }
 
   /**

--- a/crabot-agent/src/workers/builtin/adapter.ts
+++ b/crabot-agent/src/workers/builtin/adapter.ts
@@ -1,6 +1,17 @@
 /**
  * BuiltinWorkerAdapter — worker 契约的 builtin 实现（P1：spawn + burst 状态机 + sendInput/resume）。
  *
+ * 运行配置（LLM adapter / model / systemPrompt / tools）不是 adapter 自己造的，也不吃 spawn
+ * 那一刻的快照：**每次起化身（spawn / resume / fork / idle→running 续 burst）都调注入工厂
+ * 现取一次**（deps.resolveRuntime，spec 2026-08-01 决策 2）。per-worker 上下文（workspace /
+ * origin / goal）在 spawn 时落 <dataDir>/<worker_id>/context.json，工厂据此重建运行配置——
+ * 进程重启后 builtin worker 因此仍能 revive，而 LLM 连接信息始终不落盘。正在跑的 burst 用的
+ * 是它启动时那一份，改配置只影响下一次起化身（与 cc/codex 的语义对齐）。
+ *
+ * worker 的工作目录就是它的 workspace，不可中途切换：工具集里不给 `set_cwd`，也不给 goal
+ * 相关工具（决策 3/4），guardTools 在每轮 resolve 时硬断言。runEngine 每次都带上
+ * hookRegistry（CLI 权限闸 / skill 目录 fence / git 写 fence）与固定权限档位（决策 6）。
+ *
  * 每个 worker 落 <dataDir>/<worker_id>/session.jsonl（跨化身共享的 session 树）+
  * 每个化身独立的 output-<seq>.log / meta-<seq>.json。spawn 建目录、把 prompt 作为根
  * 节点 append 进 session 树、fire-and-forget 起一个 "burst"（一次 runEngine 调用），
@@ -46,6 +57,15 @@ import { SessionTree } from '../session-tree.js'
 import { OutputLog } from '../output-log.js'
 import { AsyncMutex } from '../async-mutex.js'
 import { WorkerExitedError } from '../errors.js'
+import {
+  BUILTIN_WORKER_PERMISSIONS,
+  FORBIDDEN_WORKER_TOOLS,
+  createBuiltinWorkerHookRegistry,
+  type BuiltinRuntimeContext,
+  type BuiltinRuntimeFactory,
+} from './runtime.js'
+import type { HookRegistry } from '../../hooks/hook-registry.js'
+import type { ToolPermissionConfig } from '../../engine/types.js'
 import type {
   AdapterCapabilities,
   CapabilityBundle,
@@ -62,6 +82,9 @@ import type {
 
 /** fork 是一次性侧问，maxTurns 取小值，避免侧问跑成一次完整任务。 */
 const FORK_MAX_TURNS = 8
+
+/** spawn 时落盘的 per-worker 上下文文件名（见 persistContext）。 */
+const CONTEXT_FILE = 'context.json'
 
 /** Re-export for backward compatibility and convenience. */
 export { WorkerExitedError }
@@ -143,8 +166,18 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
   readonly implId = 'builtin' as const
 
   private readonly instances = new Map<string, WorkerInstance>()
-  /** worker_id → spawn 时注入的 builtin 执行配置（adapter/model/tools），resume 与续 burst 复用。P1：仅内存，不跨重启持久。 */
+  /**
+   * worker_id → spawn 时注入的 builtin 执行配置（adapter/model/tools）。
+   *
+   * **仅在没有配置 `deps.resolveRuntime` 时才被当作运行配置来源**（契约套件 / 单测这类
+   * 直接把 `spec.builtin` 塞进来的调用方）。配置了工厂时，起化身一律现取（见 runtimeFor），
+   * 这张表只剩两个作用：spawn 的"已 spawn"守卫记忆，以及无工厂时的兜底。
+   */
   private readonly builtinConfigs = new Map<string, NonNullable<SpawnSpec['builtin']>>()
+  /** worker_id → spawn 时的 per-worker 上下文（workspace/origin/goal）。内存缓存，权威副本在 context.json。 */
+  private readonly spawnContexts = new Map<string, BuiltinRuntimeContext>()
+  /** 每个 adapter 实例一份 hook 注册表（无状态，可跨 worker / burst 共用）。 */
+  private readonly hookRegistry: HookRegistry = createBuiltinWorkerHookRegistry()
   /**
    * worker_id → 互斥锁，惰性创建。sendInput 全程、resume 全程、runBurst 的收尾段（判定
    * pendingInputs 到状态落定）都在同一把锁内串行执行——同一化身任意时刻至多一个 burst
@@ -157,6 +190,17 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     private readonly deps: {
       readonly dataDir: string
       readonly onStateChange?: (h: IncarnationHandle, state: WorkerContractState) => void
+      /**
+       * 运行配置工厂：**每次起化身现取一次**（spec 决策 2）。spawn 的那次由调用方
+       * （harness.spawnWorker / handoffIncarnation）调同一个工厂后放进 `spec.builtin`；
+       * resume / fork / idle→running 续 burst 没有 spec 可依，由 adapter 自己调它——
+       * 不再吃 spawn 那一刻的快照。
+       * 因此：(1) 进程重启后 builtin worker 仍能 revive（工厂挂在装配层，重启后还在；
+       * per-worker 上下文从 context.json 读回）；(2) 改了 model slot 下次起化身生效，正在跑的
+       * burst 用旧的；(3) LLM 连接信息不落盘。不配置时退化为 P1 行为（吃 spawn 时的内存快照，
+       * 跨重启不可用），供契约套件与单测使用。
+       */
+      readonly resolveRuntime?: BuiltinRuntimeFactory
     },
   ) {}
 
@@ -169,6 +213,17 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
   }
 
   async spawn(spec: SpawnSpec): Promise<IncarnationHandle> {
+    // per-worker 上下文：spawn 是它唯一的来源，后续所有化身（resume/fork/续 burst，含进程
+    // 重启之后）都从这里回喂给运行配置工厂。workspace 就是 worker 的工作目录，落盘之后
+    // 不再改变——worker 不可中途切 cwd（spec 决策 3，工具集里也不给 set_cwd，见 guardTools）。
+    const context: BuiltinRuntimeContext = {
+      worker_id: spec.worker_id,
+      workspace: spec.workspace,
+      ...(spec.origin !== undefined ? { origin: spec.origin } : {}),
+      ...(spec.goal !== undefined ? { goal: spec.goal } : {}),
+    }
+    // spawn 的注入由调用方给（harness.spawnWorker 在缺省时回退到同一个工厂）——这里不再兜
+    // 一次：两处回退会互相掩盖，缺了 harness 那条回退也看不出问题。缺失即 fail-loud，不降级。
     if (!spec.builtin) {
       throw new Error(`BuiltinWorkerAdapter.spawn: spec.builtin missing for worker ${spec.worker_id}`)
     }
@@ -217,8 +272,12 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
       // instances 命中 / 磁盘 meta-${seq}.json 存在）全部落空——writeMeta 还没成功过，没有
       // 一个会命中。调用方重试 spawn 因此不会被拦住，只会在 session.jsonl 里再 append 一个
       // 孤儿根节点（不被任何化身的 tip 引用，是良性的，不影响 pathTo）。
+      // context.json 与 meta 一样在提交前落盘：resume/fork 起新化身（含跨进程重启）要靠它
+      // 重建工厂 ctx，落盘失败就不该出现一个"已注册但事后起不了化身"的 worker。
+      await this.persistContext(dir, context)
       await this.writeMeta(newInstance)
       this.instances.set(instanceKey(spec.worker_id, seq), newInstance)
+      this.spawnContexts.set(spec.worker_id, context)
       this.builtinConfigs.set(spec.worker_id, builtin)
       return { instance: newInstance, handle: newHandle }
     })
@@ -231,10 +290,9 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
   }
 
   async resume(prev: IncarnationRef, wakeInput: string): Promise<IncarnationHandle> {
-    const builtin = this.builtinConfigs.get(prev.worker_id)
-    if (!builtin) {
-      throw new Error(`BuiltinWorkerAdapter.resume: no builtin config resident in memory for worker ${prev.worker_id} (P1: worker must have been spawned in this process)`)
-    }
+    // 起化身 → 现取运行配置（spec 决策 2）。这条正是"进程重启后 builtin worker 能不能
+    // revive"的分水岭：吃 spawn 时的内存快照时，重启后这里必然拿不到配置。
+    const builtin = await this.runtimeFor(prev.worker_id, 'resume')
 
     // assertExited + 重复 resume 检测 + newSeq 计算 + append + 实例注册整体在锁内原子完成：
     // 两次并发 resume 同一 prev 若不串行化，会各自往 prev.session_ref 上挂一个孩子——树分叉。
@@ -288,10 +346,8 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
   }
 
   async fork(prev: IncarnationRef, forkInput: string): Promise<IncarnationHandle> {
-    const builtin = this.builtinConfigs.get(prev.worker_id)
-    if (!builtin) {
-      throw new Error(`BuiltinWorkerAdapter.fork: no builtin config resident in memory for worker ${prev.worker_id} (P1: worker must have been spawned in this process)`)
-    }
+    // 同 resume：fork 也是起一个新化身，运行配置现取。
+    const builtin = await this.runtimeFor(prev.worker_id, 'fork')
 
     // fork 不要求 prev 处于任何特定状态——这就是侧问的意义：主线跑着的时候也能问。不像
     // resume 那样校验 assertExited。newSeq 用 nextSeq()，与 resume 共用同一分配逻辑、
@@ -351,17 +407,16 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
 
       if (instance.state === 'running') {
         instance.pendingInputs.push(text)
-        return false
+        return undefined
       }
 
       // idle → 追加新一轮用户消息，转 running。起 burst 留到锁外（见下）。
-      const builtin = this.builtinConfigs.get(h.worker_id)
-      if (!builtin) {
-        throw new Error(`BuiltinWorkerAdapter.sendInput: no builtin config resident in memory for worker ${h.worker_id}`)
-      }
+      // 运行配置现取：idle 态下没有 burst 在跑，重新解析一次不会干扰任何正在执行的东西，
+      // 语义与"起化身现取"一致（正在跑的 burst 用旧配置，见 runBurst 续 burst 路径）。
+      const builtin = await this.runtimeFor(h.worker_id, 'sendInput')
       instance.tip = await instance.sessionTree.append(instance.tip, createUserMessage(text))
       await this.transitionState(instance, h, 'running')
-      return true
+      return builtin
     })
 
     if (!startBurst) return
@@ -369,8 +424,7 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     // burst 的 runEngine 调用本身在锁外：否则并发 sendInput(running) 的入队会被这次
     // burst 的整个执行时长堵死。
     const instance = this.instances.get(instanceKey(h.worker_id, h.seq))!
-    const builtin = this.builtinConfigs.get(h.worker_id)!
-    this.runBurst(instance, h, builtin).catch((err) => this.safetyNetExit(instance, h, err, 'runBurst (sendInput continuation)'))
+    this.runBurst(instance, h, startBurst).catch((err) => this.safetyNetExit(instance, h, err, 'runBurst (sendInput continuation)'))
   }
 
   async readOutput(h: IncarnationHandle, cursor: OutputCursor): Promise<{ chunk: string; nextCursor: OutputCursor }> {
@@ -543,6 +597,7 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
         tools: this.combineTools(builtin.tools),
         model: builtin.model,
         ...(builtin.maxTurnsPerBurst !== undefined ? { maxTurns: builtin.maxTurnsPerBurst } : {}),
+        ...this.safetyOptions(builtin),
         // session 树以原始消息为真相源，burst 内禁用压缩。压缩与树的协同（折叠节点）是 P7 集成议题。
         disableCompaction: true,
         abortSignal: abortController.signal,
@@ -673,9 +728,12 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
       initialMessages,
       options: {
         systemPrompt: builtin.systemPrompt,
-        tools: builtin.tools,
+        // fork 不加 finish_task（一次性侧问），但工具集守卫与安全项与主线完全一致——
+        // 侧问同样是一次真实的 LLM + 工具执行，没有理由少一道闸。
+        tools: this.guardTools(builtin.tools),
         model: builtin.model,
         maxTurns: FORK_MAX_TURNS,
+        ...this.safetyOptions(builtin),
         disableCompaction: true,
         abortSignal: abortController.signal,
         onTurn: (event) => {
@@ -803,7 +861,145 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
   }
 
   private combineTools(tools: Resolvable<ReadonlyArray<ToolDefinition>>): Resolvable<ReadonlyArray<ToolDefinition>> {
-    return () => [...resolve(tools), FINISH_TASK_TOOL]
+    const guarded = this.guardTools(tools)
+    return () => [...resolve(guarded), FINISH_TASK_TOOL]
+  }
+
+  /**
+   * 工具集守卫（spec 决策 3 / 决策 4）：`set_cwd` / `set_task_goal` 绝不许出现在 builtin
+   * worker 的工具集里。放在 resolve 路径上而不是 spawn 一次性检查——`tools` 是 Resolvable，
+   * engine 每轮 turn 都会重新 resolve，装配层中途换出一份带 set_cwd 的工具表同样要被拦下。
+   * 违规是装配层的配置错误，fail-loud 抛错（burst 因此落 exited(crashed)，错误信息指名道姓），
+   * 不静默过滤——静默过滤会让"worker 悄悄换了工作目录"这类问题拖到线上才发现。
+   */
+  private guardTools(tools: Resolvable<ReadonlyArray<ToolDefinition>>): Resolvable<ReadonlyArray<ToolDefinition>> {
+    return () => {
+      const resolved = resolve(tools)
+      const forbidden = resolved.filter((t) => FORBIDDEN_WORKER_TOOLS.has(t.name)).map((t) => t.name)
+      if (forbidden.length > 0) {
+        throw new Error(
+          `[builtin-adapter] forbidden tool(s) in builtin worker toolset: ${forbidden.join(', ')}. ` +
+          'worker 的工作目录固定为它的 workspace（不可中途切换），且不装配 goal 模式；' +
+          '这两类工具不得注入（spec 2026-08-01-builtin-worker-injection-design 决策 3/4）。',
+        )
+      }
+      return resolved
+    }
+  }
+
+  /**
+   * 每次 runEngine 都要带上的安全项与模型参数（spec 决策 6）。
+   *
+   * `hookRegistry` 是其中唯一不能省的一项：工具面过滤只保证"工具不出现在列表里"，挡不住
+   * worker 在 Bash 里直接跑 `crabot` 写命令——CLI 闸口只有 PreToolUse hook 这一处。
+   * `permissionConfig` 用 checkPermission 动态判定而不是静态 denyList：`tools` 是 Resolvable，
+   * 静态清单会在装配层换工具表之后失真。
+   * timezone / supportsVision / maxTokens / contextWindowTokens 随 model 由注入工厂给出，
+   * adapter 自己无从知道；缺省则不传，由 engine 用它自己的默认值。
+   */
+  private safetyOptions(builtin: NonNullable<SpawnSpec['builtin']>): {
+    permissionConfig: ToolPermissionConfig
+    hookRegistry: HookRegistry
+    resolvedPermissions: typeof BUILTIN_WORKER_PERMISSIONS
+    senderIsMaster: boolean
+    maxTokens?: number
+    contextWindowTokens?: number
+    supportsVision?: boolean
+    timezone?: string
+  } {
+    return {
+      permissionConfig: this.workerPermissionConfig(builtin.tools),
+      hookRegistry: this.hookRegistry,
+      resolvedPermissions: BUILTIN_WORKER_PERMISSIONS,
+      // worker 不是任何人：F 阶段没有可信发起人身份（origin.creator_friend_id 现网恒空），
+      // 不能走 CLI 闸的 master 短路。J 接线真实身份后由 origin 解析（见 runtime.ts 注释）。
+      senderIsMaster: false,
+      ...(builtin.maxTokens !== undefined ? { maxTokens: builtin.maxTokens } : {}),
+      ...(builtin.contextWindowTokens !== undefined ? { contextWindowTokens: builtin.contextWindowTokens } : {}),
+      ...(builtin.supportsVision !== undefined ? { supportsVision: builtin.supportsVision } : {}),
+      ...(builtin.timezone !== undefined ? { timezone: builtin.timezone } : {}),
+    }
+  }
+
+  /**
+   * 按固定权限档位（BUILTIN_WORKER_PERMISSIONS.tool_access）过滤工具，映射方式与现网
+   * worker loop 一致：工具的 `category` 落在被关掉的面上即拒。`finish_task` 是契约的终态
+   * 信号（不是能力面），恒放行。
+   */
+  private workerPermissionConfig(tools: Resolvable<ReadonlyArray<ToolDefinition>>): ToolPermissionConfig {
+    const toolAccess = BUILTIN_WORKER_PERMISSIONS.tool_access
+    return {
+      // checkPermission 存在时覆盖一切静态判定（engine/permission-checker.ts），
+      // mode/toolNames 在这条路径上不参与决策。
+      mode: 'denyList',
+      toolNames: [],
+      checkPermission: async (toolName: string) => {
+        if (toolName === FINISH_TASK_TOOL.name) return { allowed: true }
+        const tool = resolve(tools).find((t) => t.name === toolName)
+        const category = tool?.category ?? 'mcp_skill'
+        if (toolAccess[category]) return { allowed: true }
+        return { allowed: false, reason: `builtin worker 权限档位未开放 ${category} 类工具（tool=${toolName}）` }
+      },
+    }
+  }
+
+  /**
+   * 起化身时现取运行配置（spec 决策 2）。配置了工厂就一律现取——ctx 从内存缓存或
+   * context.json 读回，因此进程重启后仍然可用（这是 builtin worker 能 revive 的前提）。
+   * 没配工厂时退化为 P1 的内存快照，仅供契约套件与单测。
+   */
+  private async runtimeFor(worker_id: string, op: string): Promise<NonNullable<SpawnSpec['builtin']>> {
+    if (this.deps.resolveRuntime) {
+      const context = await this.loadContext(worker_id)
+      if (!context) {
+        throw new Error(
+          `BuiltinWorkerAdapter.${op}: no spawn context for worker ${worker_id} ` +
+          `(${CONTEXT_FILE} missing — worker was never spawned through this adapter?)`,
+        )
+      }
+      const builtin = this.deps.resolveRuntime(context)
+      if (!builtin) {
+        throw new Error(`BuiltinWorkerAdapter.${op}: resolveRuntime returned no runtime config for worker ${worker_id}`)
+      }
+      return builtin
+    }
+    const resident = this.builtinConfigs.get(worker_id)
+    if (!resident) {
+      throw new Error(
+        `BuiltinWorkerAdapter.${op}: no builtin config resident in memory for worker ${worker_id} ` +
+        '(no resolveRuntime factory configured; worker must have been spawned in this process)',
+      )
+    }
+    return resident
+  }
+
+  /** spawn 时把 per-worker 上下文原子落盘（tmp + rename，与 writeMeta 同款）。 */
+  private async persistContext(dir: string, context: BuiltinRuntimeContext): Promise<void> {
+    const path = join(dir, CONTEXT_FILE)
+    const tmpPath = join(dir, `.${CONTEXT_FILE}.tmp-${randomUUID()}`)
+    await fs.writeFile(tmpPath, JSON.stringify(context), 'utf-8')
+    await fs.rename(tmpPath, path)
+  }
+
+  /** 读 per-worker 上下文：内存缓存优先，缺失时回落到磁盘（进程重启后走的就是这条）。 */
+  private async loadContext(worker_id: string): Promise<BuiltinRuntimeContext | undefined> {
+    const cached = this.spawnContexts.get(worker_id)
+    if (cached) return cached
+    const path = join(this.deps.dataDir, worker_id, CONTEXT_FILE)
+    let raw: string
+    try {
+      raw = await fs.readFile(path, 'utf-8')
+    } catch {
+      return undefined
+    }
+    let parsed: BuiltinRuntimeContext
+    try {
+      parsed = JSON.parse(raw) as BuiltinRuntimeContext
+    } catch {
+      return undefined
+    }
+    this.spawnContexts.set(worker_id, parsed)
+    return parsed
   }
 
   // 先落盘、再切内存态：state() 优先读内存，若顺序反过来，外部在 writeMeta 的

--- a/crabot-agent/src/workers/builtin/adapter.ts
+++ b/crabot-agent/src/workers/builtin/adapter.ts
@@ -521,7 +521,11 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
   }
 
   capabilities(): AdapterCapabilities {
-    return { fork: true, revive: true, goalMode: true, subagent: true, structuredTrace: true }
+    // goalMode=false：装配层不给 builtin worker 装 goal 模式，`guardTools` 更是把
+    // `set_task_goal` 列进 `FORBIDDEN_WORKER_TOOLS` 硬禁（runtime.ts）——声明 true 与这条
+    // 硬禁直接矛盾。今天还没有消费方读它，但 protocol-agent-v3 §6.5 的实现选择语义迟早会读，
+    // 届时按 true 选型会选出一个根本没有 goal 能力的载体。protocol-agent-v3 §6.4。
+    return { fork: true, revive: true, goalMode: false, subagent: true, structuredTrace: true }
   }
 
   /**

--- a/crabot-agent/src/workers/builtin/runtime.ts
+++ b/crabot-agent/src/workers/builtin/runtime.ts
@@ -1,0 +1,114 @@
+/**
+ * builtin worker 的运行环境契约(PR F 第 1 步)。
+ *
+ * 这里只放"harness / adapter 两侧都要认的东西":起化身时现取运行配置的工厂签名、
+ * F 阶段的固定权限档位、worker 必须装的 hook、以及 worker 工具集里绝对不许出现的工具。
+ * 真正的运行配置装配(LLM adapter / model / systemPrompt / tools)在生产侧由
+ * `unified-agent` 实现该工厂(PR F 第 2 步),本文件不关心它怎么造。
+ *
+ * @see crabot-docs/superpowers/specs/2026-08-01-builtin-worker-injection-design.md
+ */
+import type { ResolvedPermissions, ToolAccessConfig, CliAccessConfig, CliDomain } from '../../types.js'
+import { CLI_DOMAINS } from '../../types.js'
+import { HookRegistry } from '../../hooks/hook-registry.js'
+import {
+  createCliPermissionHook,
+  createSkillDirFenceHook,
+  createGitWriteFenceHook,
+} from '../../hooks/defaults.js'
+import type { SpawnSpec, Workspace } from '../types.js'
+import type { LedgerWorker } from '../harness/ledger-types.js'
+
+/**
+ * 起化身时喂给运行配置工厂的 per-worker 上下文(spec 决策 1)。
+ *
+ * 无参签名装不下 per-worker 维度:workspace 决定工具的 cwd、origin 决定(J 之后的)权限
+ * 身份、worker_id 决定 bg entity / tmp-page 等的归属——它们都是 spawn 时才知道的。
+ *
+ * `origin` 声明为可选:生产路径(harness.spawnWorker / handoffIncarnation)恒有值,直接
+ * 构造 `SpawnSpec` 的契约套件与单测可能没有台账语境。工厂实现须自行决定缺省时的行为。
+ */
+export interface BuiltinRuntimeContext {
+  readonly worker_id: string
+  readonly workspace: Workspace
+  readonly origin?: LedgerWorker['origin']
+  readonly goal?: string
+}
+
+/**
+ * 运行配置工厂:每次起化身现调一次(spec 决策 2)。
+ *
+ * 三个后果:(1) 工厂挂在装配层、跨进程重启仍在,builtin worker 因此能 revive;
+ * (2) 改了 model slot 下次起化身生效、正在跑的 burst 用旧的,与 cc/codex 的
+ * "下次起化身生效"对齐;(3) LLM 连接信息不落盘。
+ */
+export type BuiltinRuntimeFactory = (ctx: BuiltinRuntimeContext) => SpawnSpec['builtin']
+
+function cliAccess(perm: 'none' | 'read' | 'write'): CliAccessConfig {
+  return Object.fromEntries(CLI_DOMAINS.map((d: CliDomain) => [d, perm])) as CliAccessConfig
+}
+
+const WORKER_TOOL_ACCESS: ToolAccessConfig = {
+  // 干活必需:读写文件、跑 shell、用 skill / 外部 MCP、查记忆。
+  memory: true,
+  mcp_skill: true,
+  file_io: true,
+  shell: true,
+  browser: true,
+  // v3:worker 不直接跟人类说话(spec 决策 5),messaging 工具本就不装,这里再关一道。
+  messaging: false,
+  // admin task 域在 v3 由台账取代,worker 不该再写它。
+  task: false,
+  // 需要身份背书的高危面:没有可信发起人身份之前一律关。
+  remote_exec: false,
+  desktop: false,
+}
+
+/**
+ * F 阶段的固定权限档位(所有 builtin worker 同权限)。
+ *
+ * **J 必须接真实身份。** 现网系统派工(`handleStartTask` / scheduled)拿的是 admin 解析出的
+ * `master_private`——那条路径的发起人是系统自身,可信。v3 的 builtin worker 由 manager 代
+ * 任意会话发起人派活,而 `LedgerWorker.origin.creator_friend_id` 现网恒空(遗漏项 N1),
+ * 拿不到可信身份。因此这里**不照抄 master_private**:
+ *   - tool_access 只开"干活必需"的面,`remote_exec`/`desktop` 这类需要身份背书的一律关;
+ *   - cli_access 全 `none` —— 放开等于让任何人都能借 worker 改 crabot 自身配置;
+ *   - storage 为 null(agent 侧当前无消费方),memory_scopes 为空。
+ * cutover(PR J)必须改成按 `origin.creator_friend_id` 实时解析权限模板,并把
+ * "worker 权限随发起人身份解析"写进验收——否则群里任何人都能让 worker 干 master 才该
+ * 能干的事(spec §"权限身份 → J 必须接线")。
+ */
+export const BUILTIN_WORKER_PERMISSIONS: ResolvedPermissions = {
+  tool_access: WORKER_TOOL_ACCESS,
+  cli_access: cliAccess('none'),
+  storage: null,
+  memory_scopes: [],
+}
+
+/**
+ * worker 必须装的 hook(spec 决策 6)。
+ *
+ * **工具面过滤挡不住 worker 在 Bash 里直接跑 `crabot` 写命令** —— 权限过滤只保证"工具不
+ * 出现在列表里",CLI 是从 Bash 里调出去的,唯一的闸口是 PreToolUse hook。三条:
+ *   - cli-permission-gate:按 `cli_access` 判 `crabot` 子命令(--reveal / 未识别子命令一律拦);
+ *   - skill-dir-fence:禁止写 skill 目录;
+ *   - git-write-fence:git MCP 的写操作闸。
+ */
+export function createBuiltinWorkerHookRegistry(): HookRegistry {
+  const registry = new HookRegistry()
+  registry.registerAll([createCliPermissionHook(), createSkillDirFenceHook(), createGitWriteFenceHook()])
+  return registry
+}
+
+/**
+ * builtin worker 的工具集里绝对不许出现的工具(spec 决策 3 / 决策 4)。
+ *
+ * - `set_cwd`:worker 的工作目录就是它的 workspace,不可中途切换——否则 §5.4"workspace 是
+ *   跨实现交接的唯一介质"对 builtin 不成立(交接时拿到的 workspace 里可能什么都没有);
+ * - `set_task_goal`:v3 不给 builtin worker 装 goal 模式,目标驱动靠 prompt 指令表达。
+ *
+ * 二者在 engine 侧都是"不传上下文就不注册"的可选工具,正常装配根本不会出现;这里做成
+ * adapter 侧的硬断言,是因为装配层(PR F 第 2 步)与 adapter 分属两处,只靠约定会漂。
+ * engine 里这两个工具的代码**不删**——现网 worker loop 还在用。
+ */
+export const FORBIDDEN_WORKER_TOOLS: ReadonlySet<string> = new Set(['set_cwd', 'set_task_goal'])

--- a/crabot-agent/src/workers/harness/harness.ts
+++ b/crabot-agent/src/workers/harness/harness.ts
@@ -77,6 +77,7 @@ import type {
   CapabilityBundle,
   Workspace,
 } from '../types'
+import type { BuiltinRuntimeFactory } from '../builtin/runtime'
 import { CapabilityNotSupportedError, WorkerExitedError } from '../errors'
 import { AsyncMutex } from '../async-mutex'
 import type { DialogObjectId, Incarnation, LedgerWorker, TaskStatus } from './ledger-types'
@@ -158,8 +159,13 @@ export interface HarnessDeps {
    * 自动触发,调用方拿不到再传一次 builtin 注入的机会),因此在 HarnessDeps 这一级配置
    * 一份可复用的默认值。缺省时 handoffIncarnation 对 builtin 目标做 pre-flight 拒绝
    * (见该方法注释),不尝试传 `undefined` 让 `BuiltinWorkerAdapter.spawn` 自己再抛错。
+   *
+   * PR F:`spawnWorker` 在 `p.builtin` 缺失且目标实现是 builtin 时也回退调它——manager 的
+   * `spawn_worker` 工具不可能从 LLM 入参里拿到 LLMAdapter / tools 这类运行时对象,注入
+   * 只能来自装配层。工厂带 per-worker 上下文(worker_id / workspace / origin / goal),
+   * 无参签名装不下这些维度(见 `BuiltinRuntimeFactory`)。
    */
-  readonly builtinSpawnDefaults?: () => SpawnSpec['builtin']
+  readonly builtinSpawnDefaults?: BuiltinRuntimeFactory
 }
 
 export interface SpawnWorkerParams {
@@ -260,12 +266,28 @@ export class WorkerHarness {
       try {
         const caps = this.deps.capabilityBundle ? await this.deps.capabilityBundle() : EMPTY_CAPABILITY_BUNDLE
         await adapter.provision(workspace, caps)
+        // builtin 注入:调用方显式传了就用它;没传(manager 的 spawn_worker 工具就不可能传——
+        // LLMAdapter / tools 是运行时对象,不可能来自 LLM 入参)则回退到装配层注入的工厂,
+        // 与 handoffIncarnation 走同一个工厂。目标实现不是 builtin 时不调工厂:CLI adapter
+        // 忽略该字段,白解析一次 LLM 连接信息没有意义。工厂抛错走下面的 catch,如实落成一次
+        // 失败的 spawn 尝试(queued→running→failed),不静默。
+        const builtin =
+          p.builtin ??
+          (impl === 'builtin'
+            ? this.deps.builtinSpawnDefaults?.({
+                worker_id: workerId,
+                workspace,
+                origin: p.origin,
+                goal: p.goal,
+              })
+            : undefined)
         const spec: SpawnSpec = {
           worker_id: workerId,
           prompt: p.prompt,
           workspace,
           goal: p.goal,
-          builtin: p.builtin,
+          origin: p.origin,
+          builtin,
         }
         spawnedHandle = await adapter.spawn(spec)
       } catch (err) {
@@ -649,7 +671,15 @@ export class WorkerHarness {
     }
     let builtinInjection: SpawnSpec['builtin']
     if (targetImpl === 'builtin') {
-      builtinInjection = this.deps.builtinSpawnDefaults?.()
+      // 工厂签名带上了 per-worker 上下文(PR F),这里的语义不变:仍在 pre-flight 阶段调一次、
+      // 拿不到就在动源化身之前拒绝。ctx 取交接语境下的既有值——新化身沿用源化身的 workspace
+      // (§5.3 同 workspace 交接),origin/goal 取台账上这条 worker 自己的。
+      builtinInjection = this.deps.builtinSpawnDefaults?.({
+        worker_id: worker.worker_id,
+        workspace: { root: source.workspace },
+        origin: worker.origin,
+        goal: worker.task.goal,
+      })
       if (!builtinInjection) {
         throw new Error(
           `WorkerHarness.handoffIncarnation: handoff target impl is 'builtin' but no builtinSpawnDefaults ` +
@@ -713,6 +743,7 @@ export class WorkerHarness {
       prompt,
       workspace,
       goal: worker.task.goal,
+      origin: worker.origin,
       builtin: builtinInjection,
     })
 

--- a/crabot-agent/src/workers/types.ts
+++ b/crabot-agent/src/workers/types.ts
@@ -1,5 +1,7 @@
 import type { ToolDefinition, LLMAdapter } from '../engine/index.js'
 import type { Resolvable } from '../engine/types.js'
+// 纯类型引用(两侧都是 `import type`,编译后无运行时依赖,不构成模块环)。
+import type { LedgerWorker } from './harness/ledger-types.js'
 
 export type WorkerImplId = 'builtin' | 'claude-code' | 'codex'
 export type WorkerContractState = 'running' | 'idle' | 'exited'
@@ -28,6 +30,11 @@ export interface SpawnSpec {
   readonly prompt: string
   readonly workspace: Workspace
   readonly goal?: string
+  /**
+   * 台账 origin(派发来源与权限身份)。builtin adapter 把它与 workspace/goal 一起持久化,
+   * 起后续化身(resume/fork)时回喂给运行配置工厂——包括进程重启之后。外部 CLI adapter 忽略。
+   */
+  readonly origin?: LedgerWorker['origin']
   /** builtin 专用注入(外部 CLI adapter 忽略) */
   readonly builtin?: {
     readonly adapter: LLMAdapter
@@ -35,6 +42,12 @@ export interface SpawnSpec {
     readonly systemPrompt: Resolvable<string>
     readonly tools: Resolvable<ReadonlyArray<ToolDefinition>>
     readonly maxTurnsPerBurst?: number
+    /** 以下四项随 model 一起由注入工厂解析——adapter 自己无从知道模型能力/上限。 */
+    readonly maxTokens?: number
+    readonly contextWindowTokens?: number
+    readonly supportsVision?: boolean
+    /** IANA 时区名,用于 tool_result 时间戳渲染 */
+    readonly timezone?: string
   }
 }
 

--- a/crabot-agent/tests/manager/manager-integration.test.ts
+++ b/crabot-agent/tests/manager/manager-integration.test.ts
@@ -10,20 +10,18 @@
  * `harness.handleStateChange` → set 回同一 Map)+ 注入 `now()` + `events[]` 收集 +
  * `waitUntil` 轮询。
  *
- * ## 已知缺口:`spawn_worker` 工具当前不能让 impl='builtin' 的化身真正跑起来
+ * ## builtin worker 的运行配置从哪来
  *
- * `worker-tools.ts` 的 `spawn_worker` 调 `harness.spawnWorker(...)` 时不传 `builtin` 字段
- * (读代码确认,不是猜测)——`SpawnSpec.builtin`(worker 的 LLM adapter/model/systemPrompt/
- * tools 注入)在 P4 目前只有 `harness.handoffIncarnation` 经 `HarnessDeps.builtinSpawnDefaults`
- * 消费,`spawnWorker` 本身完全不读它。因此 `BuiltinWorkerAdapter.spawn` 会因
- * `spec.builtin missing` 直接抛错。这是 P4"纯新增未激活"阶段的真实缺口(manager 侧还没有
- * 拿到"builtin worker 该用哪个 LLM"的配置解析入口,大概率留给 P7 cutover 时补),不是本测试
- * 该修的东西。测试用 `BuiltinAutoConfigAdapter`(本文件私有,不改动任何生产代码)包一层
- * `BuiltinWorkerAdapter`,在 `spec.builtin` 缺失时用测试预先排好的脚本队列兜底填入
- * ——语义上等价于"外部调用方原本就该在 SpawnSpec 里带上 builtin 配置",与
- * `builtinSpawnDefaults` 给 handoff 场景做的事是同一件事,只是补在 spawn 这条路径上。
+ * `worker-tools.ts` 的 `spawn_worker` 调 `harness.spawnWorker(...)` 时**不传** `builtin` 字段
+ * ——`SpawnSpec.builtin`(worker 的 LLM adapter/model/systemPrompt/tools)是装配层注入的,
+ * 不可能来自 LLM 的工具入参。PR F 之前 `spawnWorker` 压根不读注入工厂(只有
+ * `handoffIncarnation` 消费),本文件为此包过一个私有的 `BuiltinAutoConfigAdapter` 垫片;
+ * PR F 第 1 步给 `spawnWorker` 补上了"缺 `builtin` 就回退调 `builtinSpawnDefaults(ctx)`"
+ * 的生产路径,垫片随之退役。现在测试只需给 `HarnessDeps.builtinSpawnDefaults` 一个按队列
+ * 出配置的工厂,spawn 走的就是生产回退路径本身。
  *
  * @see .superpowers/sdd/task-10-brief.md
+ * @see crabot-docs/superpowers/specs/2026-08-01-builtin-worker-injection-design.md
  * @see crabot-docs/protocols/protocol-agent-v3.md §4
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
@@ -44,8 +42,6 @@ import type {
   IncarnationHandle,
   IncarnationRef,
   SpawnSpec,
-  Workspace,
-  CapabilityBundle,
   DetectResult,
   WorkerContractState,
   OutputCursor,
@@ -172,48 +168,6 @@ function findWorkerExitedEvent(events: readonly HarnessEvent[], workerId: string
 }
 
 // ============================================================================
-// BuiltinAutoConfigAdapter —— 见文件头"已知缺口"说明
-// ============================================================================
-
-class BuiltinAutoConfigAdapter implements WorkerAdapter {
-  readonly implId: WorkerImplId = 'builtin'
-  constructor(
-    private readonly inner: BuiltinWorkerAdapter,
-    private readonly nextBuiltinConfig: () => NonNullable<SpawnSpec['builtin']>,
-  ) {}
-  detect(): Promise<DetectResult> {
-    return this.inner.detect()
-  }
-  provision(ws: Workspace, caps: CapabilityBundle): Promise<void> {
-    return this.inner.provision(ws, caps)
-  }
-  spawn(spec: SpawnSpec): Promise<IncarnationHandle> {
-    return this.inner.spawn({ ...spec, builtin: spec.builtin ?? this.nextBuiltinConfig() })
-  }
-  resume(prev: IncarnationRef, wakeInput: string): Promise<IncarnationHandle> {
-    return this.inner.resume(prev, wakeInput)
-  }
-  fork(prev: IncarnationRef, forkInput: string): Promise<IncarnationHandle> {
-    return this.inner.fork(prev, forkInput)
-  }
-  sendInput(h: IncarnationHandle, text: string, opts?: { raw?: boolean }): Promise<void> {
-    return this.inner.sendInput(h, text, opts)
-  }
-  readOutput(h: IncarnationHandle, cursor: OutputCursor): Promise<{ chunk: string; nextCursor: OutputCursor }> {
-    return this.inner.readOutput(h, cursor)
-  }
-  state(h: IncarnationHandle): Promise<WorkerContractState> {
-    return this.inner.state(h)
-  }
-  kill(h: IncarnationHandle): Promise<void> {
-    return this.inner.kill(h)
-  }
-  capabilities(): AdapterCapabilities {
-    return this.inner.capabilities()
-  }
-}
-
-// ============================================================================
 // ForklessStubAdapter —— 场景四专用:如实实现 capabilities().fork===false 的 worker 实现
 // (照 codex adapter 的真实声明,不是伪造;不驱动任何真实 CLI,provision/spawn/state 均为
 // 最小可用实现,唯一要紧的是 capabilities() 如实返回 fork:false,让 harness.queryWorker
@@ -297,6 +251,11 @@ async function setupAssembly(opts: AssemblyOptions): Promise<Assembly> {
     return new Date(harnessNowMs).toISOString()
   }
 
+  // 每次 builtin spawn 的运行配置由测试预置队列给出。PR F 之前这里包了一个私有的
+  // `BuiltinAutoConfigAdapter` 垫片在 `spec.builtin` 缺失时补配置;现在生产的 harness 自己
+  // 在缺失时回退到 `builtinSpawnDefaults`(spec 决策 1),垫片因此退役——语义完全一样
+  //(spawn_worker 工具不传 builtin,配置由装配层现取),但走的是生产回退路径。
+  const builtinConfigQueue: Array<NonNullable<SpawnSpec['builtin']>> = []
   const harnessDeps: HarnessDeps = {
     adapters: adaptersMap,
     defaultImpl: 'builtin',
@@ -305,19 +264,18 @@ async function setupAssembly(opts: AssemblyOptions): Promise<Assembly> {
     workersDir,
     now: harnessNow,
     onEvent: (e) => events.push(e),
+    builtinSpawnDefaults: () => {
+      const cfg = builtinConfigQueue.shift()
+      if (!cfg) throw new Error('测试装配缺口:没有为下一次 builtin spawn 预置 builtinConfigQueue 条目')
+      return cfg
+    },
   }
   // onStateChange 接线契约(harness.ts 文件头):先构造空 Map 传给 harness,harness 构造完成后
   // 把 handleStateChange 传给真实 adapter 的构造函数,再把 adapter 塞回同一个底层 Map——
   // 与 P4 真实接线顺序一致,不是手动模拟回调触发。
   const harness = new WorkerHarness(harnessDeps)
 
-  const builtinConfigQueue: Array<NonNullable<SpawnSpec['builtin']>> = []
-  const realBuiltinAdapter = new BuiltinWorkerAdapter({ dataDir: builtinDataDir, onStateChange: harness.handleStateChange })
-  const builtinAdapter = new BuiltinAutoConfigAdapter(realBuiltinAdapter, () => {
-    const cfg = builtinConfigQueue.shift()
-    if (!cfg) throw new Error('测试装配缺口:没有为下一次 builtin spawn 预置 builtinConfigQueue 条目')
-    return cfg
-  })
+  const builtinAdapter = new BuiltinWorkerAdapter({ dataDir: builtinDataDir, onStateChange: harness.handleStateChange })
   adaptersMap.set('builtin', builtinAdapter)
   for (const [implId, adapter] of opts.extraAdapters ?? []) adaptersMap.set(implId, adapter)
 

--- a/crabot-agent/tests/workers/builtin-injection.test.ts
+++ b/crabot-agent/tests/workers/builtin-injection.test.ts
@@ -1,0 +1,630 @@
+/**
+ * builtin worker 注入管道 + adapter 侧运行语义（PR F 第 1 步）。
+ *
+ * 覆盖 spec `2026-08-01-builtin-worker-injection-design.md` 的验收 1/2/3/5/6：
+ *   1. manager 侧不传 `builtin` 也能拉起一个真的能干活的 builtin worker（真实 harness +
+ *      真实 adapter + mock LLM，worker 真的执行一次工具调用）；
+ *   2. 进程重启（丢弃内存态）后仍能 revive；
+ *   3. 运行配置在每次起化身时现取——改了配置下次起化身生效，正在跑的 burst 用旧的；
+ *   5. worker 的工作目录 = `spec.workspace`，`set_cwd` / goal 工具不得出现在工具集里；
+ *   6. `hookRegistry` 确实生效——worker 在 Bash 里跑受禁 `crabot` 命令被拦下。
+ *
+ * 断的是语义不变量（worker 真的跑了/真的被拦了/真的用了新配置），不是"参数被透传了"。
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { promises as fs } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { randomUUID } from 'node:crypto'
+
+import { WorkerHarness, type HarnessDeps } from '../../src/workers/harness/harness'
+import { LedgerStore } from '../../src/workers/harness/ledger-store'
+import { WorkspaceManager } from '../../src/workers/harness/workspace-manager'
+import { dialogObjectIdForPrivate } from '../../src/workers/harness/ledger-types'
+import { BuiltinWorkerAdapter } from '../../src/workers/builtin/adapter.js'
+import {
+  BUILTIN_WORKER_PERMISSIONS,
+  type BuiltinRuntimeContext,
+  type BuiltinRuntimeFactory,
+} from '../../src/workers/builtin/runtime.js'
+import type {
+  WorkerImplId,
+  WorkerAdapter,
+  IncarnationHandle,
+  IncarnationRef,
+  SpawnSpec,
+  Workspace,
+  CapabilityBundle,
+  DetectResult,
+  WorkerContractState,
+  OutputCursor,
+  AdapterCapabilities,
+} from '../../src/workers/types'
+import type { LLMAdapter } from '../../src/engine/llm-adapter-types.js'
+import { defineTool } from '../../src/engine/index.js'
+import type { ToolDefinition } from '../../src/engine/index.js'
+import { createBashTool } from '../../src/engine/tools/bash-tool.js'
+import { createSetCwdTool } from '../../src/engine/tools/set-cwd-tool.js'
+import * as engineModule from '../../src/engine/query-loop.js'
+import { chunksFromContent } from '../engine/helpers/mock-stream.js'
+
+type Turn = {
+  text?: string
+  toolCalls?: Array<{ name: string; id: string; input: Record<string, unknown> }>
+  stopReason: 'end_turn' | 'tool_use'
+}
+
+function makeLLM(responses: Turn[]): LLMAdapter {
+  let i = 0
+  return {
+    stream: vi.fn(async function* () {
+      const r = responses[i++] ?? responses[responses.length - 1]
+      const content: unknown[] = []
+      if (r.text) content.push({ type: 'text', text: r.text })
+      for (const tc of r.toolCalls ?? []) {
+        content.push({ type: 'tool_use', id: tc.id, name: tc.name, input: tc.input })
+      }
+      yield* chunksFromContent(content, r.stopReason, { inputTokens: 100, outputTokens: 50 })
+    }),
+    updateConfig: () => {},
+  } as unknown as LLMAdapter
+}
+
+async function waitUntil(cond: () => Promise<boolean> | boolean, timeoutMs = 8000, intervalMs = 10): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (await cond()) return
+    await new Promise((r) => setTimeout(r, intervalMs))
+  }
+  throw new Error('waitUntil timed out')
+}
+
+async function waitState(
+  adapter: BuiltinWorkerAdapter,
+  h: IncarnationHandle,
+  target: WorkerContractState,
+): Promise<void> {
+  await waitUntil(async () => (await adapter.state(h)) === target)
+}
+
+/** 一个可探测的假工具，用于断言"worker 真的执行了一次工具调用"。 */
+function makeProbeTool(onCall: () => void): ToolDefinition {
+  return defineTool({
+    name: 'probe',
+    category: 'shell',
+    description: 'probe',
+    isReadOnly: true,
+    inputSchema: { type: 'object', properties: {} },
+    call: async () => {
+      onCall()
+      return { output: 'probe-ok', isError: false }
+    },
+  })
+}
+
+/**
+ * 模仿真实调用方（harness.spawnWorker / handoffIncarnation）的注入方式：**spawn 的运行配置
+ * 由调用方解析后放进 `spec.builtin`**，adapter 自己不再兜一次（两处回退会互相掩盖）。
+ * resume / fork / idle→running 续 burst 没有 spec 可依，才由 adapter 调 `resolveRuntime`。
+ */
+async function spawnWith(
+  adapter: BuiltinWorkerAdapter,
+  factory: BuiltinRuntimeFactory,
+  spec: Omit<SpawnSpec, 'builtin'>,
+): Promise<IncarnationHandle> {
+  const ctx: BuiltinRuntimeContext = {
+    worker_id: spec.worker_id,
+    workspace: spec.workspace,
+    ...(spec.origin !== undefined ? { origin: spec.origin } : {}),
+    ...(spec.goal !== undefined ? { goal: spec.goal } : {}),
+  }
+  return adapter.spawn({ ...spec, builtin: factory(ctx) })
+}
+
+const FINISH: Turn = {
+  toolCalls: [{ name: 'finish_task', id: 'fin', input: { outcome: 'completed', summary: '完事' } }],
+  stopReason: 'tool_use',
+}
+
+describe('builtin worker 注入管道（harness → 工厂回退）', () => {
+  let dataDir: string
+  let nowValue: number
+
+  function now(): string {
+    nowValue += 1000
+    return new Date(nowValue).toISOString()
+  }
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(join(tmpdir(), 'builtin-injection-'))
+    nowValue = Date.parse('2026-01-01T00:00:00.000Z')
+  })
+
+  afterEach(async () => {
+    vi.restoreAllMocks()
+    await fs.rm(dataDir, { recursive: true, force: true })
+  })
+
+  async function makeStack(factory: BuiltinRuntimeFactory) {
+    const workspacesRoot = join(dataDir, 'workspaces')
+    await fs.mkdir(workspacesRoot, { recursive: true })
+    const adaptersMap = new Map<WorkerImplId, WorkerAdapter>()
+    const deps: HarnessDeps = {
+      adapters: adaptersMap,
+      defaultImpl: 'builtin',
+      ledger: new LedgerStore(join(dataDir, 'ledgers')),
+      workspaces: new WorkspaceManager(workspacesRoot),
+      workersDir: join(dataDir, 'workers'),
+      now,
+      builtinSpawnDefaults: factory,
+    }
+    const harness = new WorkerHarness(deps)
+    const builtinAdapter = new BuiltinWorkerAdapter({
+      dataDir: join(dataDir, 'builtin-adapter'),
+      onStateChange: harness.handleStateChange,
+      resolveRuntime: factory,
+    })
+    adaptersMap.set('builtin', builtinAdapter)
+    return { harness, builtinAdapter, adaptersMap }
+  }
+
+  it('spawnWorker 不传 builtin → 回退到注入工厂，worker 真的跑起来并执行了一次工具调用', async () => {
+    let probeCalls = 0
+    const seen: BuiltinRuntimeContext[] = []
+    const factory: BuiltinRuntimeFactory = (ctx) => {
+      seen.push(ctx)
+      return {
+        adapter: makeLLM([
+          { toolCalls: [{ name: 'probe', id: 'c1', input: {} }], stopReason: 'tool_use' },
+          FINISH,
+        ]),
+        model: 'model-A',
+        systemPrompt: '你是 worker',
+        tools: [makeProbeTool(() => { probeCalls += 1 })],
+      }
+    }
+    const { harness } = await makeStack(factory)
+
+    const dialogObjectId = dialogObjectIdForPrivate('friend-f1')
+    const worker = await harness.spawnWorker({
+      dialogObjectId,
+      title: '干活',
+      prompt: '把活干完',
+      origin: { spawned_by_session: 'wechat::sess-1', trigger_type: 'message', creator_friend_id: 'friend-f1' },
+      report_to: { channel_id: 'wechat', session_id: 'sess-1' },
+      impl: 'builtin',
+      goal: '目标',
+      // 关键：不传 builtin —— manager 的 spawn_worker 工具就是这么调的。
+    })
+
+    expect(worker.task.status).toBe('running')
+    await waitUntil(async () => {
+      const [w] = await harness.listWorkers(dialogObjectId)
+      return w.task.status === 'completed'
+    })
+
+    // 语义不变量：worker 真的执行了工具调用、真的以 finish_task 收尾。
+    expect(probeCalls).toBe(1)
+    const [done] = await harness.listWorkers(dialogObjectId)
+    expect(done.incarnations[0].state).toBe('exited')
+    expect(done.incarnations[0].ended_reason).toBe('completed')
+
+    // 工厂拿到的是 per-worker 上下文，不是一个无参 thunk 能给的东西。
+    expect(seen).toHaveLength(1)
+    expect(seen[0].worker_id).toBe(worker.worker_id)
+    expect(seen[0].workspace.root).toBe(done.incarnations[0].workspace)
+    expect(seen[0].goal).toBe('目标')
+    expect(seen[0].origin).toEqual({
+      spawned_by_session: 'wechat::sess-1',
+      trigger_type: 'message',
+      creator_friend_id: 'friend-f1',
+    })
+  })
+
+  it('目标实现不是 builtin → 不调注入工厂（CLI adapter 忽略该字段）', async () => {
+    const factory = vi.fn(() => undefined) as unknown as BuiltinRuntimeFactory
+    const { harness, adaptersMap } = await makeStack(factory)
+
+    const fakeCli: WorkerAdapter = {
+      implId: 'claude-code',
+      detect: async (): Promise<DetectResult> => ({ installed: true, activated: true }),
+      provision: async (_ws: Workspace, _c: CapabilityBundle) => {},
+      spawn: async (spec: SpawnSpec): Promise<IncarnationHandle> => ({
+        worker_id: spec.worker_id, seq: 1, impl: 'claude-code', session_ref: 'sess',
+      }),
+      resume: async (prev: IncarnationRef): Promise<IncarnationHandle> => ({
+        worker_id: prev.worker_id, seq: 2, impl: 'claude-code', session_ref: 'sess',
+      }),
+      fork: async (prev: IncarnationRef): Promise<IncarnationHandle> => ({
+        worker_id: prev.worker_id, seq: 3, impl: 'claude-code', session_ref: 'sess',
+      }),
+      sendInput: async () => {},
+      readOutput: async (_h: IncarnationHandle, _c: OutputCursor) => ({ chunk: '', nextCursor: { offset: 0 } }),
+      state: async (): Promise<WorkerContractState> => 'running',
+      kill: async () => {},
+      capabilities: (): AdapterCapabilities => ({ fork: true, revive: false, goalMode: false, subagent: false, structuredTrace: false }),
+    }
+    adaptersMap.set('claude-code', fakeCli)
+
+    await harness.spawnWorker({
+      dialogObjectId: dialogObjectIdForPrivate('friend-f2'),
+      title: 'cc 干活',
+      prompt: '干',
+      origin: { spawned_by_session: 'wechat::s', trigger_type: 'message' },
+      report_to: { channel_id: 'wechat', session_id: 's' },
+      impl: 'claude-code',
+    })
+
+    expect(factory).not.toHaveBeenCalled()
+  })
+
+  it('注入工厂抛错 → spawn 如实落成一次失败尝试（task failed + spawn_failed 事件），不静默', async () => {
+    const factory: BuiltinRuntimeFactory = () => {
+      throw new Error('model slot 未配置')
+    }
+    const { harness } = await makeStack(factory)
+    const dialogObjectId = dialogObjectIdForPrivate('friend-f3')
+
+    await expect(
+      harness.spawnWorker({
+        dialogObjectId,
+        title: '干活',
+        prompt: '干',
+        origin: { spawned_by_session: 'wechat::s', trigger_type: 'message' },
+        report_to: { channel_id: 'wechat', session_id: 's' },
+        impl: 'builtin',
+      }),
+    ).rejects.toThrow(/model slot 未配置/)
+
+    const [w] = await harness.listWorkers(dialogObjectId)
+    expect(w.task.status).toBe('failed')
+    expect(w.incarnations[0].ended_reason).toBe('failed')
+  })
+})
+
+describe('builtin worker 运行配置在起化身时现取', () => {
+  let dataDir: string
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(join(tmpdir(), 'builtin-runtime-'))
+  })
+
+  afterEach(async () => {
+    vi.restoreAllMocks()
+    await fs.rm(dataDir, { recursive: true, force: true })
+  })
+
+  /** 工厂返回的 model 可变；每次被调用都记一笔 ctx。 */
+  function makeMutableFactory(initialModel: string, llm: () => LLMAdapter) {
+    const state = { model: initialModel, calls: [] as BuiltinRuntimeContext[] }
+    const factory: BuiltinRuntimeFactory = (ctx) => {
+      state.calls.push(ctx)
+      return { adapter: llm(), model: state.model, systemPrompt: '', tools: [] }
+    }
+    return { state, factory }
+  }
+
+  it('进程重启（丢弃内存态）后仍能 revive —— 新 adapter 实例从 context.json 重建 ctx 并现取配置', async () => {
+    const runEngineSpy = vi.spyOn(engineModule, 'runEngine')
+    const { state, factory } = makeMutableFactory('model-A', () => makeLLM([FINISH]))
+    const workerId = `w-${randomUUID()}`
+    const workspace = { root: join(dataDir, 'ws') }
+    await fs.mkdir(workspace.root, { recursive: true })
+
+    const first = new BuiltinWorkerAdapter({ dataDir, resolveRuntime: factory })
+    const h1 = await spawnWith(first, factory, {
+      worker_id: workerId,
+      prompt: '干活',
+      workspace,
+      origin: { spawned_by_session: 'wechat::s1', trigger_type: 'message' },
+    })
+    await waitState(first, h1, 'exited')
+
+    // ---- 模拟进程重启：换一个全新的 adapter 实例（内存 instances / 配置表全空），
+    //      只有磁盘和挂在装配层上的工厂还在。
+    state.model = 'model-B'
+    const restarted = new BuiltinWorkerAdapter({ dataDir, resolveRuntime: factory })
+    const meta1 = JSON.parse(await fs.readFile(join(dataDir, workerId, 'meta-1.json'), 'utf-8'))
+    const h2 = await restarted.resume(
+      { worker_id: workerId, seq: 1, session_ref: meta1.tip_node_id },
+      '接着干',
+    )
+    expect(h2.seq).toBe(2)
+    await waitState(restarted, h2, 'exited')
+
+    // 现取：revive 用的是工厂**当下**返回的配置，不是重启前那份快照。
+    const models = runEngineSpy.mock.calls.map((c) => c[0].options.model)
+    expect(models).toEqual(['model-A', 'model-B'])
+
+    // ctx 从 context.json 重建：workspace / origin 与 spawn 时一致。
+    const reviveCtx = state.calls[state.calls.length - 1]
+    expect(reviveCtx.worker_id).toBe(workerId)
+    expect(reviveCtx.workspace.root).toBe(workspace.root)
+    expect(reviveCtx.origin).toEqual({ spawned_by_session: 'wechat::s1', trigger_type: 'message' })
+  })
+
+  it('改了配置下次起化身生效，正在跑的 burst 用旧的（多轮 burst 内工厂只调一次）', async () => {
+    const runEngineSpy = vi.spyOn(engineModule, 'runEngine')
+    // 第一次 burst 两轮（工具调用 + end_turn），用于验证 burst 内不会反复现取。
+    const { state, factory } = makeMutableFactory('model-A', () =>
+      makeLLM([
+        { text: '第一轮', stopReason: 'end_turn' },
+        { text: '第二轮', stopReason: 'end_turn' },
+      ]),
+    )
+    const workerId = `w-${randomUUID()}`
+    const adapter = new BuiltinWorkerAdapter({ dataDir, resolveRuntime: factory })
+    const h = await spawnWith(adapter, factory, { worker_id: workerId, prompt: '干活', workspace: { root: dataDir } })
+    await waitState(adapter, h, 'idle')
+    expect(state.calls).toHaveLength(1)
+
+    // 改配置：不影响已经落定的这一化身当前 burst，下一次起 burst 才现取。
+    state.model = 'model-B'
+    await adapter.sendInput(h, '继续')
+    await waitState(adapter, h, 'idle')
+
+    expect(state.calls).toHaveLength(2)
+    const models = runEngineSpy.mock.calls.map((c) => c[0].options.model)
+    expect(models).toEqual(['model-A', 'model-B'])
+  })
+
+  it('fork 也现取运行配置', async () => {
+    const runEngineSpy = vi.spyOn(engineModule, 'runEngine')
+    const { state, factory } = makeMutableFactory('model-A', () => makeLLM([{ text: 'ok', stopReason: 'end_turn' }]))
+    const workerId = `w-${randomUUID()}`
+    const adapter = new BuiltinWorkerAdapter({ dataDir, resolveRuntime: factory })
+    const h = await spawnWith(adapter, factory, { worker_id: workerId, prompt: '干活', workspace: { root: dataDir } })
+    await waitState(adapter, h, 'idle')
+
+    state.model = 'model-B'
+    const forkHandle = await adapter.fork({ worker_id: workerId, seq: 1, session_ref: h.session_ref }, '侧问一句')
+    await waitState(adapter, forkHandle, 'exited')
+
+    const models = runEngineSpy.mock.calls.map((c) => c[0].options.model)
+    expect(models).toEqual(['model-A', 'model-B'])
+  })
+
+  it('未配置工厂时退化为 spawn 时的内存快照（契约套件/单测路径），但跨实例不可用', async () => {
+    const workerId = `w-${randomUUID()}`
+    const adapter = new BuiltinWorkerAdapter({ dataDir })
+    const h = await adapter.spawn({
+      worker_id: workerId,
+      prompt: '干活',
+      workspace: { root: dataDir },
+      builtin: { adapter: makeLLM([FINISH]), model: 'model-A', systemPrompt: '', tools: [] },
+    })
+    await waitState(adapter, h, 'exited')
+
+    const restarted = new BuiltinWorkerAdapter({ dataDir })
+    const meta1 = JSON.parse(await fs.readFile(join(dataDir, workerId, 'meta-1.json'), 'utf-8'))
+    await expect(
+      restarted.resume({ worker_id: workerId, seq: 1, session_ref: meta1.tip_node_id }, '接着干'),
+    ).rejects.toThrow(/no builtin config resident in memory/)
+  })
+})
+
+describe('builtin worker 的 workspace 与工具集守卫', () => {
+  let dataDir: string
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(join(tmpdir(), 'builtin-ws-'))
+  })
+
+  afterEach(async () => {
+    vi.restoreAllMocks()
+    await fs.rm(dataDir, { recursive: true, force: true })
+  })
+
+  it('工作目录 = spec.workspace，落 context.json；工具的 cwd 就是它', async () => {
+    const workspace = { root: join(dataDir, 'ws') }
+    await fs.mkdir(workspace.root, { recursive: true })
+    const workerId = `w-${randomUUID()}`
+    let seenCwd = ''
+    const factory: BuiltinRuntimeFactory = (ctx) => ({
+      adapter: makeLLM([{ toolCalls: [{ name: 'probe', id: 'c1', input: {} }], stopReason: 'tool_use' }, FINISH]),
+      model: 'm',
+      systemPrompt: '',
+      // 装配层用 ctx.workspace.root 作为工具的 cwd —— 这是"workspace 即 cwd"的落点。
+      tools: [
+        defineTool({
+          name: 'probe',
+          category: 'shell',
+          description: 'probe',
+          isReadOnly: true,
+          inputSchema: { type: 'object', properties: {} },
+          call: async () => {
+            seenCwd = ctx.workspace.root
+            return { output: 'ok', isError: false }
+          },
+        }),
+      ],
+    })
+
+    const adapter = new BuiltinWorkerAdapter({ dataDir, resolveRuntime: factory })
+    const h = await spawnWith(adapter, factory, { worker_id: workerId, prompt: '干活', workspace })
+    await waitState(adapter, h, 'exited')
+
+    expect(seenCwd).toBe(workspace.root)
+    const persisted = JSON.parse(await fs.readFile(join(dataDir, workerId, 'context.json'), 'utf-8'))
+    expect(persisted.workspace.root).toBe(workspace.root)
+  })
+
+  it('工具集里出现 set_cwd → fail-loud，化身落 exited(crashed)', async () => {
+    const workerId = `w-${randomUUID()}`
+    const errors: string[] = []
+    vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      errors.push(args.map((a) => (a instanceof Error ? a.message : String(a))).join(' '))
+    })
+    const factory: BuiltinRuntimeFactory = () => ({
+      adapter: makeLLM([FINISH]),
+      model: 'm',
+      systemPrompt: '',
+      tools: [createSetCwdTool({ getCwd: () => dataDir, setCwd: () => {} })],
+    })
+    const adapter = new BuiltinWorkerAdapter({ dataDir, resolveRuntime: factory })
+    const h = await spawnWith(adapter, factory, { worker_id: workerId, prompt: '干活', workspace: { root: dataDir } })
+    await waitState(adapter, h, 'exited')
+
+    const meta = JSON.parse(await fs.readFile(join(dataDir, workerId, 'meta-1.json'), 'utf-8'))
+    expect(meta.ended_reason).toBe('crashed')
+    expect(errors.join('\n')).toContain('set_cwd')
+  })
+
+  it('工具集里出现 goal 工具（set_task_goal）→ 同样 fail-loud', async () => {
+    const workerId = `w-${randomUUID()}`
+    const errors: string[] = []
+    vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      errors.push(args.map((a) => (a instanceof Error ? a.message : String(a))).join(' '))
+    })
+    const factory: BuiltinRuntimeFactory = () => ({
+      adapter: makeLLM([FINISH]),
+      model: 'm',
+      systemPrompt: '',
+      tools: [
+        defineTool({
+          name: 'set_task_goal',
+          description: 'goal',
+          isReadOnly: false,
+          inputSchema: { type: 'object', properties: {} },
+          call: async () => ({ output: '', isError: false }),
+        }),
+      ],
+    })
+    const adapter = new BuiltinWorkerAdapter({ dataDir, resolveRuntime: factory })
+    const h = await spawnWith(adapter, factory, { worker_id: workerId, prompt: '干活', workspace: { root: dataDir } })
+    await waitState(adapter, h, 'exited')
+
+    const meta = JSON.parse(await fs.readFile(join(dataDir, workerId, 'meta-1.json'), 'utf-8'))
+    expect(meta.ended_reason).toBe('crashed')
+    expect(errors.join('\n')).toContain('set_task_goal')
+  })
+})
+
+describe('builtin worker 的安全项（hookRegistry / 权限档位）', () => {
+  let dataDir: string
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(join(tmpdir(), 'builtin-safety-'))
+  })
+
+  afterEach(async () => {
+    vi.restoreAllMocks()
+    await fs.rm(dataDir, { recursive: true, force: true })
+  })
+
+  it('worker 在 Bash 里跑受禁的 crabot 命令 → 被 CLI 权限闸拦下，命令没有真的执行', async () => {
+    const workerId = `w-${randomUUID()}`
+    const marker = join(dataDir, 'should-not-exist.txt')
+    const factory: BuiltinRuntimeFactory = () => ({
+      adapter: makeLLM([
+        {
+          toolCalls: [{
+            name: 'Bash',
+            id: 'c1',
+            // 未识别的 crabot 子命令 → cli-permission-gate fail-closed 拦截。
+            // `&& touch` 是探针：命令若真的执行了，marker 文件会出现。
+            input: { command: `crabot zzz-not-a-real-subcommand && touch ${marker}` },
+          }],
+          stopReason: 'tool_use',
+        },
+        FINISH,
+      ]),
+      model: 'm',
+      systemPrompt: '',
+      tools: [createBashTool(() => dataDir)],
+    })
+
+    const adapter = new BuiltinWorkerAdapter({ dataDir, resolveRuntime: factory })
+    const h = await spawnWith(adapter, factory, { worker_id: workerId, prompt: '干活', workspace: { root: dataDir } })
+    await waitState(adapter, h, 'exited')
+
+    // 拦截结果进了会话（tool_result），worker 看得见被拒的理由。
+    const session = await fs.readFile(join(dataDir, workerId, 'session.jsonl'), 'utf-8')
+    expect(session).toContain('PERMISSION_DENIED')
+    // 且命令确实没跑起来。
+    await expect(fs.access(marker)).rejects.toThrow()
+  })
+
+  it('权限档位真的过滤工具：messaging 类被拒、shell 类放行、finish_task 恒放行', async () => {
+    const runEngineSpy = vi.spyOn(engineModule, 'runEngine')
+    const workerId = `w-${randomUUID()}`
+    const messagingTool = defineTool({
+      name: 'send_message',
+      category: 'messaging',
+      description: 'send',
+      isReadOnly: false,
+      inputSchema: { type: 'object', properties: {} },
+      call: async () => ({ output: 'sent', isError: false }),
+    })
+    const factory: BuiltinRuntimeFactory = () => ({
+      adapter: makeLLM([
+        { toolCalls: [{ name: 'send_message', id: 'c1', input: {} }], stopReason: 'tool_use' },
+        FINISH,
+      ]),
+      model: 'm',
+      systemPrompt: '',
+      tools: [messagingTool, makeProbeTool(() => {})],
+    })
+    const adapter = new BuiltinWorkerAdapter({ dataDir, resolveRuntime: factory })
+    const h = await spawnWith(adapter, factory, { worker_id: workerId, prompt: '干活', workspace: { root: dataDir } })
+    await waitState(adapter, h, 'exited')
+
+    // 语义不变量：worker 想说话 → 被权限档位挡下，会话里留下拒绝理由。
+    const session = await fs.readFile(join(dataDir, workerId, 'session.jsonl'), 'utf-8')
+    expect(session).toContain('Permission denied')
+
+    const permissionConfig = runEngineSpy.mock.calls[0][0].options.permissionConfig
+    expect(permissionConfig).toBeDefined()
+    const check = permissionConfig!.checkPermission!
+    expect((await check('send_message', {})).allowed).toBe(false)
+    expect((await check('probe', {})).allowed).toBe(true)
+    expect((await check('finish_task', {})).allowed).toBe(true)
+  })
+
+  it('runEngine 每次都带上 hookRegistry / 固定权限档位 / 模型参数（fork 的一次性 burst 也一样）', async () => {
+    const runEngineSpy = vi.spyOn(engineModule, 'runEngine')
+    const workerId = `w-${randomUUID()}`
+    const factory: BuiltinRuntimeFactory = () => ({
+      adapter: makeLLM([{ text: 'ok', stopReason: 'end_turn' }]),
+      model: 'm',
+      systemPrompt: '',
+      tools: [],
+      maxTokens: 4096,
+      contextWindowTokens: 123456,
+      supportsVision: true,
+      timezone: 'Asia/Shanghai',
+    })
+    const adapter = new BuiltinWorkerAdapter({ dataDir, resolveRuntime: factory })
+    const h = await spawnWith(adapter, factory, { worker_id: workerId, prompt: '干活', workspace: { root: dataDir } })
+    await waitState(adapter, h, 'idle')
+    const forkHandle = await adapter.fork({ worker_id: workerId, seq: 1, session_ref: h.session_ref }, '侧问')
+    await waitState(adapter, forkHandle, 'exited')
+
+    expect(runEngineSpy.mock.calls).toHaveLength(2)
+    for (const call of runEngineSpy.mock.calls) {
+      const options = call[0].options
+      expect(options.hookRegistry?.isEmpty()).toBe(false)
+      expect(options.resolvedPermissions).toBe(BUILTIN_WORKER_PERMISSIONS)
+      // F 阶段没有可信发起人身份，不能走 CLI 闸的 master 短路。
+      expect(options.senderIsMaster).toBe(false)
+      expect(options.maxTokens).toBe(4096)
+      expect(options.contextWindowTokens).toBe(123456)
+      expect(options.supportsVision).toBe(true)
+      expect(options.timezone).toBe('Asia/Shanghai')
+    }
+  })
+
+  it('固定权限档位：cli_access 全关、messaging/task/remote_exec/desktop 关、干活面开', () => {
+    expect(Object.values(BUILTIN_WORKER_PERMISSIONS.cli_access).every((v) => v === 'none')).toBe(true)
+    expect(BUILTIN_WORKER_PERMISSIONS.tool_access).toMatchObject({
+      messaging: false,
+      task: false,
+      remote_exec: false,
+      desktop: false,
+      file_io: true,
+      shell: true,
+      memory: true,
+      mcp_skill: true,
+    })
+  })
+})

--- a/crabot-agent/tests/workers/builtin-production-runtime.test.ts
+++ b/crabot-agent/tests/workers/builtin-production-runtime.test.ts
@@ -97,8 +97,20 @@ interface Turn {
   readonly stopReason: 'end_turn' | 'tool_use'
 }
 
-/** v3 worker 契约尾巴的首行；mock LLM 用它区分 worker burst 与 manager episode。 */
-const WORKER_PROMPT_MARKER = '## 你的角色：worker'
+/**
+ * mock LLM 区分 worker burst 与 manager episode 的锚点。
+ *
+ * 取 `finish_task` 而不是契约尾巴的某句措辞：措辞会被反复打磨（这个常量已经因此坏过一次），
+ * 但"`finish_task` 是 builtin worker 的终态信号、必须在 system prompt 里交代给它"是
+ * protocol-agent-v3 §5.1（finalize 即 exited）规定的不变量，而 manager 没有也不该有这个
+ * 工具（§4.3 的封闭白名单）。全仓 system prompt 里唯一写出这个词的地方就是 worker 契约
+ * 尾巴（`unified-agent.ts` 的 `buildBuiltinWorkerContractPrompt`）。
+ *
+ * 下面"systemPrompt = 现网 agent prompt + v3 worker 契约尾巴"那条用例复用同一个常量断言它
+ * 确实在 prompt 里——锚点一旦从 prompt 里消失，那条用例先炸，而不是靠本文件的脚本被
+ * manager 抢走这种间接症状去发现。
+ */
+const WORKER_PROMPT_MARKER = 'finish_task'
 
 const FINISH: Turn = {
   toolCalls: [{ name: 'finish_task', id: 'fin', input: { outcome: 'completed', summary: '完事' } }],
@@ -110,8 +122,8 @@ const FINISH: Turn = {
  *
  * **按 system prompt 分流**：harness 的事件会经 `onEvent` 唤醒真实的 manager loop（生产接线，
  * 不该为了测试拆掉），而 manager 与 builtin worker 走的是同一个 `adapterFromSdkEnv` 出口。
- * 不分流的话 manager 会抢走给 worker 排的脚本——worker 契约尾巴（`WORKER_PROMPT_MARKER`）
- * 是两者 system prompt 上稳定且语义正确的分界。manager 一律一句话收工，不干扰任何断言。
+ * 不分流的话 manager 会抢走给 worker 排的脚本——`WORKER_PROMPT_MARKER`（见其注释）是两者
+ * system prompt 上稳定且语义正确的分界。manager 一律一句话收工，不干扰任何断言。
  */
 function makeScriptedLLM(): { adapter: LLMAdapter; queue: Turn[] } {
   const queue: Turn[] = []
@@ -416,11 +428,24 @@ describe('builtin worker 生产装配（PR F 第 2 步）', () => {
     expect(prompt).toContain('demo-skill')
     // 决策 4：goal 模式关闭（GOAL_MODE_DETAILS 段不注入）。
     expect(prompt).not.toContain('## 目标模式详解')
-    // v3 worker 契约尾巴：workspace 是哪、不直接联系人类、finish_task 是终态信号。
-    expect(prompt).toContain('## 你的角色：worker')
-    expect(prompt).toContain(workspaceRoot)
-    expect(prompt).toContain('没有任何直接联系人类的工具')
-    expect(prompt).toContain('finish_task')
+
+    // v3 worker 契约尾巴接在最后，且交代了协议要求 worker 知道的两件事：
+    //   1. 它自己的 workspace 是哪（§5.4：workspace 是跨实现交接的唯一介质）；
+    //   2. `finish_task` 是它的终态信号（§5.1：finalize 即 exited）——同时也是本文件
+    //      mock LLM 的分流锚点，这里一并钉住。
+    // 刻意不断言尾巴的具体措辞（原先断 '## 你的角色：worker' / '没有任何直接联系人类的
+    // 工具'，措辞一改就整片挂掉，且断的是文案不是语义）。
+    const tailStart = prompt.indexOf(workspaceRoot)
+    expect(tailStart, '契约尾巴应点名这个 worker 的 workspace').toBeGreaterThan(-1)
+    const tail = prompt.slice(tailStart)
+    expect(tail).toContain(WORKER_PROMPT_MARKER)
+
+    // 尾巴不提"你没有联系人类的工具"这类否定式说明：worker 的工具集里本来就没有这些原语
+    // （上面"工具集逐项断言"那组用例钉的就是这一点），在 prompt 里点名它们反而把这个念头
+    // 塞进上下文。这条断言守的是这个设计决定，不是某句文案。
+    for (const forbidden of ['send_message', 'ask_human', 'crab-messaging', '人类']) {
+      expect(tail, `契约尾巴不该提 ${forbidden}`).not.toContain(forbidden)
+    }
   })
 
   // --- 缺配置时 fail-loud ---

--- a/crabot-agent/tests/workers/builtin-production-runtime.test.ts
+++ b/crabot-agent/tests/workers/builtin-production-runtime.test.ts
@@ -1,0 +1,438 @@
+/**
+ * builtin worker 的**生产装配**（PR F 第 2 步）——spec
+ * `2026-08-01-builtin-worker-injection-design.md`。
+ *
+ * 第 1 步（`builtin-injection.test.ts`）用测试自己造的 fake 工厂验管道；本文件反过来：走
+ * **真实 `UnifiedAgent` 构造函数装配出的 manager 栈**（真实 harness + 真实
+ * `BuiltinWorkerAdapter` + 真实注入工厂 `buildBuiltinWorkerRuntime` + 真实工具/prompt 组装），
+ * 只把 LLM 换成脚本化 mock（`adapterFromSdkEnv` 是整条链路上唯一的 LLM 入口）。
+ *
+ * 覆盖 spec 验收：
+ *   1. manager 侧不传 `builtin` → 真的拉起一个能干活的 builtin worker（真的执行工具调用）；
+ *   2. 进程重启（换一个 UnifiedAgent 实例，内存态全丢）后 revive 仍可用；
+ *   3. 改 model slot 后起的新化身用新配置，已经起好的化身不受影响；
+ *   4. worker 工具集不含 messaging / `set_cwd` / goal 相关（逐项断言）；
+ *   5. 工作目录 = `spec.workspace`，且没有任何切换工作目录的工具；
+ *   6. `hookRegistry` 生效——Bash 里跑受禁 `crabot` 命令被拦。
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { promises as fs } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+import { UnifiedAgent } from '../../src/unified-agent.js'
+import * as agentHandlerModule from '../../src/agent/agent-handler.js'
+import * as engineModule from '../../src/engine/query-loop.js'
+import { dialogObjectIdForPrivate, type DialogObjectId } from '../../src/workers/harness/ledger-types.js'
+import type { ManagerStack } from '../../src/manager/bootstrap.js'
+import type { LLMAdapter, ToolDefinition } from '../../src/engine/index.js'
+import type {
+  UnifiedAgentConfig,
+  OrchestrationConfig,
+  LLMConnectionInfo,
+  ModuleId,
+  SkillConfig,
+} from '../../src/types.js'
+import { BUILTIN_WORKER_PERMISSIONS, type BuiltinRuntimeContext } from '../../src/workers/builtin/runtime.js'
+import type { SpawnSpec } from '../../src/workers/types.js'
+import { chunksFromContent } from '../engine/helpers/mock-stream.js'
+
+// ============================================================================
+// helpers
+// ============================================================================
+
+const ORCHESTRATION: OrchestrationConfig = {
+  front_context_recent_messages_window_hours: 24,
+  front_context_recent_messages_max_cap: 50,
+  front_context_short_term_memory_window_hours: 24,
+  front_context_short_term_memory_max_cap: 20,
+  worker_recent_messages_window_hours: 24,
+  worker_recent_messages_max_cap: 50,
+  worker_short_term_memory_window_hours: 24,
+  worker_short_term_memory_max_cap: 20,
+  worker_long_term_memory_limit: 10,
+  front_agent_timeout: 60,
+  session_state_ttl: 3600,
+  worker_config_refresh_interval: 300,
+  front_agent_queue_max_length: 10,
+  front_agent_queue_timeout: 60,
+}
+
+function connInfo(modelId: string): LLMConnectionInfo {
+  return { endpoint: 'https://example.invalid', apikey: 'k', model_id: modelId, format: 'anthropic' }
+}
+
+/**
+ * `roles: []` 与 `p5-integration.test.ts` 同理：带 'worker' 角色会建 AgentHandler 并起 LSP
+ * 子进程，与 builtin worker 的注入通道无关。builtin 的运行配置工厂**不看 roles**，它直接读
+ * `model_config.powerful`——这也是本文件顺带钉住的性质。
+ */
+function makeConfig(p: {
+  modelConfig?: Record<string, LLMConnectionInfo>
+  systemPrompt?: string
+  skills?: SkillConfig[]
+  tmpPageBaseUrl?: string
+}): UnifiedAgentConfig {
+  return {
+    module_id: 'p7f-runtime-agent' as ModuleId,
+    module_type: 'agent',
+    version: '0.0.0-test',
+    protocol_version: '1.0',
+    port: 19998,
+    orchestration: ORCHESTRATION,
+    agent_config: {
+      instance_id: 'p7f',
+      roles: [],
+      system_prompt: p.systemPrompt ?? '你是测试用 Crabot',
+      model_config: p.modelConfig ?? { powerful: connInfo('model-A') },
+      ...(p.skills ? { skills: p.skills } : {}),
+      ...(p.tmpPageBaseUrl ? { tmp_page_base_url: p.tmpPageBaseUrl } : {}),
+    },
+  }
+}
+
+interface Turn {
+  readonly text?: string
+  readonly toolCalls?: ReadonlyArray<{ name: string; id: string; input: Record<string, unknown> }>
+  readonly stopReason: 'end_turn' | 'tool_use'
+}
+
+/** v3 worker 契约尾巴的首行；mock LLM 用它区分 worker burst 与 manager episode。 */
+const WORKER_PROMPT_MARKER = '## 你的角色：worker'
+
+const FINISH: Turn = {
+  toolCalls: [{ name: 'finish_task', id: 'fin', input: { outcome: 'completed', summary: '完事' } }],
+  stopReason: 'tool_use',
+}
+
+/**
+ * 队列驱动的 mock LLM：整条生产链路上唯一被替换的件。
+ *
+ * **按 system prompt 分流**：harness 的事件会经 `onEvent` 唤醒真实的 manager loop（生产接线，
+ * 不该为了测试拆掉），而 manager 与 builtin worker 走的是同一个 `adapterFromSdkEnv` 出口。
+ * 不分流的话 manager 会抢走给 worker 排的脚本——worker 契约尾巴（`WORKER_PROMPT_MARKER`）
+ * 是两者 system prompt 上稳定且语义正确的分界。manager 一律一句话收工，不干扰任何断言。
+ */
+function makeScriptedLLM(): { adapter: LLMAdapter; queue: Turn[] } {
+  const queue: Turn[] = []
+  const adapter = {
+    stream: vi.fn(async function* (params: { systemPrompt: string }) {
+      const isWorker = params.systemPrompt.includes(WORKER_PROMPT_MARKER)
+      const r = isWorker
+        ? queue.shift() ?? { text: '(没有脚本了)', stopReason: 'end_turn' as const }
+        : { text: '(manager 收到，无动作)', stopReason: 'end_turn' as const }
+      const content: unknown[] = []
+      if (r.text) content.push({ type: 'text', text: r.text })
+      for (const tc of r.toolCalls ?? []) content.push({ type: 'tool_use', id: tc.id, name: tc.name, input: tc.input })
+      yield* chunksFromContent(content, r.stopReason, { inputTokens: 10, outputTokens: 5 })
+    }),
+    updateConfig: () => {},
+  } as unknown as LLMAdapter
+  return { adapter, queue }
+}
+
+/** builtin worker 那一轮 burst 的 runEngine 调用（manager loop 的调用不带固定权限档位）。 */
+function workerBurstModels(spy: { mock: { calls: Array<[{ options: { model: string; resolvedPermissions?: unknown } }]> } }): string[] {
+  return spy.mock.calls
+    .filter((c) => c[0].options.resolvedPermissions === BUILTIN_WORKER_PERMISSIONS)
+    .map((c) => c[0].options.model)
+}
+
+async function waitUntil(cond: () => boolean | Promise<boolean>, timeoutMs = 8000, intervalMs = 20): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (await cond()) return
+    await new Promise((resolve) => setTimeout(resolve, intervalMs))
+  }
+  throw new Error('waitUntil timed out')
+}
+
+/** UnifiedAgent 私有件在测试里的视图（TS 私有性只在编译期）。 */
+interface AgentInternals {
+  managerStack?: ManagerStack
+  methodHandlers: Map<string, (params: unknown) => unknown>
+  adminPort?: number
+  buildBuiltinWorkerRuntime(ctx: BuiltinRuntimeContext): SpawnSpec['builtin']
+}
+
+function resolveTools(builtin: NonNullable<SpawnSpec['builtin']>): ReadonlyArray<ToolDefinition> {
+  const t = builtin.tools
+  return typeof t === 'function' ? t() : t
+}
+
+function resolvePrompt(builtin: NonNullable<SpawnSpec['builtin']>): string {
+  const p = builtin.systemPrompt
+  return typeof p === 'function' ? p() : p
+}
+
+// ============================================================================
+
+describe('builtin worker 生产装配（PR F 第 2 步）', () => {
+  let tmpRoot: string
+  let prevDataDir: string | undefined
+  let prevAgentDataDir: string | undefined
+  let llm: ReturnType<typeof makeScriptedLLM>
+
+  function boot(config: UnifiedAgentConfig = makeConfig({})): { agent: UnifiedAgent; internals: AgentInternals } {
+    const agent = new UnifiedAgent(config)
+    const internals = agent as unknown as AgentInternals
+    internals.adminPort = 1
+    return { agent, internals }
+  }
+
+  beforeEach(async () => {
+    tmpRoot = await fs.mkdtemp(join(tmpdir(), 'p7f-runtime-'))
+    prevDataDir = process.env.DATA_DIR
+    prevAgentDataDir = process.env.CRABOT_AGENT_DATA_DIR
+    delete process.env.CRABOT_AGENT_DATA_DIR
+    process.env.DATA_DIR = join(tmpRoot, 'data')
+    llm = makeScriptedLLM()
+    // 生产链路上唯一被替换的件：`adapterFromSdkEnv` 是 unified-agent 把 model slot 变成
+    // 真会发 HTTP 的 adapter 的唯一出口（manager 与 builtin worker 共用它）。
+    vi.spyOn(agentHandlerModule, 'adapterFromSdkEnv').mockReturnValue(llm.adapter as never)
+  })
+
+  afterEach(async () => {
+    vi.restoreAllMocks()
+    if (prevDataDir === undefined) delete process.env.DATA_DIR
+    else process.env.DATA_DIR = prevDataDir
+    if (prevAgentDataDir === undefined) delete process.env.CRABOT_AGENT_DATA_DIR
+    else process.env.CRABOT_AGENT_DATA_DIR = prevAgentDataDir
+    await fs.rm(tmpRoot, { recursive: true, force: true })
+  })
+
+  async function spawnBuiltin(
+    internals: AgentInternals,
+    dialogObjectId: DialogObjectId,
+    prompt = '把活干完',
+  ): Promise<{ workerId: string; workspace: string }> {
+    const harness = internals.managerStack!.harness
+    // 关键：**不传 `builtin`** —— manager 的 `spawn_worker` 工具就是这么调 harness 的。
+    const worker = await harness.spawnWorker({
+      dialogObjectId,
+      title: '干活',
+      prompt,
+      origin: { spawned_by_session: 'wechat::sess-1', trigger_type: 'message', creator_friend_id: 'friend-f1' },
+      report_to: { channel_id: 'wechat' as ModuleId, session_id: 'sess-1' },
+      impl: 'builtin',
+    })
+    return { workerId: worker.worker_id, workspace: worker.incarnations[0].workspace }
+  }
+
+  // --- 验收 1 + 5：端到端拉起 + 工作目录就是 workspace ---
+
+  it('验收 1/5：manager 不传 builtin → 真的拉起 worker，worker 真的执行了一次工具调用，且 cwd = spec.workspace', async () => {
+    const { internals } = boot()
+    llm.queue.push(
+      { toolCalls: [{ name: 'Bash', id: 'c1', input: { command: 'pwd > pwd.txt' } }], stopReason: 'tool_use' },
+      FINISH,
+    )
+
+    const dialogObjectId = dialogObjectIdForPrivate('friend-f1')
+    const { workspace } = await spawnBuiltin(internals, dialogObjectId)
+
+    await waitUntil(async () => {
+      const [w] = await internals.managerStack!.harness.listWorkers(dialogObjectId)
+      return w.task.status === 'completed'
+    })
+
+    // 语义不变量：工具真的执行了（文件真的被写出来），而且是在 workspace 里执行的。
+    const pwd = (await fs.readFile(join(workspace, 'pwd.txt'), 'utf-8')).trim()
+    expect(pwd).toBe(await fs.realpath(workspace))
+
+    const [done] = await internals.managerStack!.harness.listWorkers(dialogObjectId)
+    expect(done.incarnations[0].ended_reason).toBe('completed')
+  })
+
+  // --- 验收 6：hookRegistry 在生产路径上确实生效 ---
+
+  it('验收 6：worker 在 Bash 里跑受禁 crabot 命令 → 被 CLI 权限闸拦下，命令没有真的执行', async () => {
+    const { internals } = boot()
+    const marker = join(tmpRoot, 'should-not-exist.txt')
+    llm.queue.push(
+      {
+        // 未识别的 crabot 子命令 → cli-permission-gate fail-closed；`&& touch` 是探针。
+        toolCalls: [{ name: 'Bash', id: 'c1', input: { command: `crabot zzz-not-a-real-subcommand && touch ${marker}` } }],
+        stopReason: 'tool_use',
+      },
+      FINISH,
+    )
+
+    const dialogObjectId = dialogObjectIdForPrivate('friend-hook')
+    const { workerId } = await spawnBuiltin(internals, dialogObjectId)
+    await waitUntil(async () => {
+      const [w] = await internals.managerStack!.harness.listWorkers(dialogObjectId)
+      return w.task.status === 'completed'
+    })
+
+    const sessionPath = join(internals.managerStack!.builtinDataDir, workerId, 'session.jsonl')
+    expect(await fs.readFile(sessionPath, 'utf-8')).toContain('PERMISSION_DENIED')
+    await expect(fs.access(marker)).rejects.toThrow()
+  })
+
+  // --- 验收 4 + 5：工具集逐项断言 ---
+
+  describe('验收 4/5：worker 的工具集', () => {
+    const skills: SkillConfig[] = [{ name: 'demo-skill', description: '演示技能', skill_dir: '/tmp/skills/demo' }]
+
+    function toolNames(internals: AgentInternals, workspaceRoot: string): string[] {
+      const builtin = internals.buildBuiltinWorkerRuntime({
+        worker_id: 'w-tools',
+        workspace: { root: workspaceRoot },
+        origin: { spawned_by_session: 'wechat::s', trigger_type: 'message' },
+      })!
+      return resolveTools(builtin).map((t) => t.name)
+    }
+
+    it('装了干活必需的四类：文件/shell + skills、crab-memory、tmp-page（外部 MCP 未连接时为空）', () => {
+      const { internals } = boot(makeConfig({ skills, tmpPageBaseUrl: 'https://example.test' }))
+      const names = toolNames(internals, tmpRoot)
+
+      for (const n of ['Bash', 'Read', 'Write', 'Edit', 'Glob', 'Grep', 'Skill']) {
+        expect(names, `应装 ${n}`).toContain(n)
+      }
+      expect(names).toContain('mcp__crab-memory__store_memory')
+      expect(names).toContain('mcp__crab-memory__search_memory')
+      expect(names).toContain('tmp_page_create')
+    })
+
+    it('不含 messaging / set_cwd / goal 相关，也不含本阶段明确排除的那几个（逐项断言）', () => {
+      const { internals } = boot(makeConfig({ skills }))
+      const names = toolNames(internals, tmpRoot)
+
+      // messaging 整面（v3：worker 不直接跟人类说话）
+      for (const n of [
+        'mcp__crab-messaging__send_message',
+        'mcp__crab-messaging__get_message',
+        'mcp__crab-messaging__read_feishu_document',
+        'send_message',
+      ]) {
+        expect(names, `不该装 ${n}`).not.toContain(n)
+      }
+      expect(names.filter((n) => n.startsWith('mcp__crab-messaging__'))).toEqual([])
+      // 工作目录不可中途切换（决策 3）
+      expect(names).not.toContain('set_cwd')
+      // goal 相关（决策 4）
+      expect(names).not.toContain('set_task_goal')
+      // 本阶段排除项
+      for (const n of [
+        'delegate_task', 'todo', 'find_task', 'get_task_progress', 'wait_for_signal',
+        'list_active_subagents', 'get_subagent_output', 'stop_subagent', 'request_restart',
+      ]) {
+        expect(names, `不该装 ${n}`).not.toContain(n)
+      }
+    })
+
+    it('工具的 cwd 恒等于 ctx.workspace.root（换一个 workspace 就换一个 cwd）', async () => {
+      const { internals } = boot()
+      const wsA = join(tmpRoot, 'ws-a')
+      const wsB = join(tmpRoot, 'ws-b')
+      await fs.mkdir(wsA, { recursive: true })
+      await fs.mkdir(wsB, { recursive: true })
+
+      for (const ws of [wsA, wsB]) {
+        const builtin = internals.buildBuiltinWorkerRuntime({ worker_id: 'w-cwd', workspace: { root: ws } })!
+        const bash = resolveTools(builtin).find((t) => t.name === 'Bash')!
+        const res = await bash.call({ command: 'pwd' }, { signal: new AbortController().signal })
+        expect(String(res.output).trim()).toContain(await fs.realpath(ws))
+      }
+    })
+  })
+
+  // --- 验收 3：运行配置现取 ---
+
+  it('验收 3：改 model slot 后起的新化身用新配置；已经起好的化身用的还是旧的', async () => {
+    const runEngineSpy = vi.spyOn(engineModule, 'runEngine')
+    const { internals } = boot()
+
+    // 第一个 worker：跑一轮 end_turn 就停在 idle（化身还活着）。
+    llm.queue.push({ text: '先歇着', stopReason: 'end_turn' })
+    const objA = dialogObjectIdForPrivate('friend-a')
+    await spawnBuiltin(internals, objA)
+    await waitUntil(async () => {
+      const [w] = await internals.managerStack!.harness.listWorkers(objA)
+      return w.incarnations[0].state === 'idle'
+    })
+    expect(workerBurstModels(runEngineSpy)).toEqual(['model-A'])
+
+    // 经真实 update_config RPC 改 model slot。
+    const updateConfig = internals.methodHandlers.get('update_config')!
+    await updateConfig({ model_config: { powerful: connInfo('model-B') } })
+
+    // 已经起好的那个化身不受影响：它那次 burst 仍记 model-A，没有被追溯改写。
+    expect(workerBurstModels(runEngineSpy)).toEqual(['model-A'])
+
+    // 新起的化身现取到 model-B。
+    llm.queue.push(FINISH)
+    const objB = dialogObjectIdForPrivate('friend-b')
+    await spawnBuiltin(internals, objB)
+    await waitUntil(async () => {
+      const [w] = await internals.managerStack!.harness.listWorkers(objB)
+      return w.task.status === 'completed'
+    })
+    expect(workerBurstModels(runEngineSpy)).toEqual(['model-A', 'model-B'])
+  })
+
+  // --- 验收 2：重启后 revive ---
+
+  it('验收 2：换一个 UnifiedAgent 实例（内存态全丢）后，send_to_worker 仍能透明接续已终态的 worker', async () => {
+    const { internals: first } = boot()
+    llm.queue.push(FINISH)
+    const dialogObjectId = dialogObjectIdForPrivate('friend-revive')
+    const { workerId } = await spawnBuiltin(first, dialogObjectId)
+    await waitUntil(async () => {
+      const [w] = await first.managerStack!.harness.listWorkers(dialogObjectId)
+      return w.task.status === 'completed'
+    })
+
+    // ---- 模拟进程重启：同一个 DATA_DIR 上重新装配一整套栈，内存里的 instances / 配置表全空。
+    const { internals: restarted } = boot()
+    llm.queue.push(FINISH)
+    await restarted.managerStack!.harness.sendToWorker(workerId, '接着干')
+
+    const [revived] = await restarted.managerStack!.harness.listWorkers(dialogObjectId)
+    // 新化身由重启后那套栈的注入工厂现取配置拉起来（seq=2），任务被接续。
+    expect(revived.incarnations).toHaveLength(2)
+    expect(revived.incarnations[1].seq).toBe(2)
+    await waitUntil(async () => {
+      const [w] = await restarted.managerStack!.harness.listWorkers(dialogObjectId)
+      return w.incarnations[1].state === 'exited'
+    })
+  })
+
+  // --- systemPrompt：v3 worker 契约尾巴 ---
+
+  it('systemPrompt = 现网 agent prompt（goal 模式关闭）+ v3 worker 契约尾巴', () => {
+    const { internals } = boot(makeConfig({ systemPrompt: '你是测试人格', skills: [
+      { name: 'demo-skill', description: '演示技能', skill_dir: '/tmp/skills/demo' },
+    ] }))
+    const workspaceRoot = join(tmpRoot, 'ws-prompt')
+    const builtin = internals.buildBuiltinWorkerRuntime({ worker_id: 'w-prompt', workspace: { root: workspaceRoot } })!
+    const prompt = resolvePrompt(builtin)
+
+    // 复用现网装配：admin 人格 + skill 清单都在。
+    expect(prompt).toContain('你是测试人格')
+    expect(prompt).toContain('<available_skills>')
+    expect(prompt).toContain('demo-skill')
+    // 决策 4：goal 模式关闭（GOAL_MODE_DETAILS 段不注入）。
+    expect(prompt).not.toContain('## 目标模式详解')
+    // v3 worker 契约尾巴：workspace 是哪、不直接联系人类、finish_task 是终态信号。
+    expect(prompt).toContain('## 你的角色：worker')
+    expect(prompt).toContain(workspaceRoot)
+    expect(prompt).toContain('没有任何直接联系人类的工具')
+    expect(prompt).toContain('finish_task')
+  })
+
+  // --- 缺配置时 fail-loud ---
+
+  it('model_config 缺 powerful slot → 工厂抛错，spawn 如实落成一次失败尝试（不静默降级）', async () => {
+    const { internals } = boot(makeConfig({ modelConfig: {} }))
+    const dialogObjectId = dialogObjectIdForPrivate('friend-noconf')
+
+    await expect(spawnBuiltin(internals, dialogObjectId)).rejects.toThrow(/powerful/)
+
+    const [w] = await internals.managerStack!.harness.listWorkers(dialogObjectId)
+    expect(w.task.status).toBe('failed')
+    expect(w.incarnations[0].ended_reason).toBe('failed')
+  })
+})

--- a/crabot-agent/tests/workers/harness/harness-continuation.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-continuation.test.ts
@@ -16,6 +16,7 @@ import { dialogObjectIdForPrivate } from '../../../src/workers/harness/ledger-ty
 import type { HarnessEvent } from '../../../src/workers/harness/worker-events'
 import { WorkerExitedError } from '../../../src/workers/errors'
 import { BuiltinWorkerAdapter } from '../../../src/workers/builtin/adapter'
+import type { BuiltinRuntimeContext } from '../../../src/workers/builtin/runtime'
 import type { LLMAdapter } from '../../../src/engine/llm-adapter-types.js'
 import { chunksFromContent } from '../../engine/helpers/mock-stream'
 import type {
@@ -570,6 +571,7 @@ describe('WorkerHarness.handoffIncarnation — handoff 目标是 builtin 时的 
       systemPrompt: '',
       tools: [],
     }
+    const factoryCtxs: BuiltinRuntimeContext[] = []
 
     // 见 harness.ts 文件头"onStateChange 接线契约":先建空壳 Map、建 harness，再建各 adapter
     // （构造时把 harness.handleStateChange 传进去），最后把 adapter 塞进 Map。
@@ -582,7 +584,10 @@ describe('WorkerHarness.handoffIncarnation — handoff 目标是 builtin 时的 
       workersDir,
       now,
       onEvent: (e) => events.push(e),
-      builtinSpawnDefaults: () => builtinDefaults,
+      builtinSpawnDefaults: (ctx) => {
+        factoryCtxs.push(ctx)
+        return builtinDefaults
+      },
     }
     const harness = new WorkerHarness(deps)
     const source = new FakeAdapter({
@@ -602,6 +607,12 @@ describe('WorkerHarness.handoffIncarnation — handoff 目标是 builtin 时的 
 
     expect(builtinTarget.spawnCalls).toHaveLength(1)
     expect(builtinTarget.spawnCalls[0].builtin).toBe(builtinDefaults)
+    // 工厂带 per-worker 上下文（PR F）：交接沿用源化身的 workspace（§5.3 同 workspace 交接），
+    // origin 取台账上这条 worker 自己的——不是随便给一份缺省值。
+    expect(factoryCtxs).toHaveLength(1)
+    expect(factoryCtxs[0].worker_id).toBe(worker.worker_id)
+    expect(factoryCtxs[0].workspace.root).toBe(worker.incarnations[0].workspace)
+    expect(factoryCtxs[0].origin).toEqual(worker.origin)
 
     const [w] = await ledger.listWorkers(dialogObjectIdForPrivate('friend-1'))
     const newEntry = w.incarnations[w.incarnations.length - 1]


### PR DESCRIPTION
## P7 / PR F:builtin worker 注入通道

spec:`crabot-docs/superpowers/specs/2026-08-01-builtin-worker-injection-design.md`

**解决的是:cutover 之后 manager 第一次派活就挂。** `SpawnSpec.builtin` 需要 per-worker 的 tools/prompt/权限,不可能来自 LLM 工具入参,而生产上**没有任何注入点**(`builtinSpawnDefaults` 只被 `handoffIncarnation` 消费,`unified-agent.ts:484-487` 明说刻意不提供)。

### 规模纠正

先前判断"可能超过 P1–P5 任一阶段"**不成立**——那是把 §7.5「收编」的**删除侧**算进了 F,而删除侧天然属于 J(删 dispatcher、摘 worker 侧 messaging 必须同批发布)。实际生产码约 400 行。

### 四个决策

**1. 注入工厂带 per-worker 上下文。** `() => SpawnSpec['builtin']` 的无参签名从根上装不下 workspace/权限/memory 上下文这些 spawn 时才知道的维度,改为 `(ctx: {worker_id, workspace, origin, goal?}) => ...`。`tools` 是 `Resolvable` 且 engine 每轮 turn 都 resolve,一个闭包工厂就够。

**2. 运行配置在起化身时现取,不落盘不快照。** 这条同时解决三件事,也是三种 worker 实现的**统一点**:

| | 配置从哪来 | 改了配置何时生效 |
|---|---|---|
| cc / codex | CLI 自己的(订阅、API key) | 下次起化身 |
| builtin(改前) | crabot model slot | **spawn 时快照,之后永远用那份** |
| builtin(改后) | crabot model slot | 下次起化身 ✅ |

→ 重启后能 revive(`builtinConfigs` 原本只在内存,重启即失)、配置切换语义与 cc/codex 对齐、不落盘 LLM 连接信息。

**契约层表述:harness 不知道也不该知道 worker 的 LLM 是什么;每个 adapter 起化身时自行解析自己的运行配置。**

"起化身"的时机逐个确认过:spawn / handoff 新化身 / revive(含进程重启后)/ fork / idle→running 续 burst **都走现取**;只有"burst 内原地续 burst"不重取——那是同一次 burst 的延续。

**3. workspace 即 cwd,不装 `set_cwd`。** 改前 `spawn` **完全没用 `spec.workspace`**,工作目录靠 `set_cwd` 中途切换——这使 §5.4「workspace 是跨实现交接的唯一介质」对 builtin 不成立:交接时拿到的 workspace 里可能什么都没有,因为 worker 早跑别处去了。

**4. 不装 goal 模式。** 照 cc/codex 的"内置能力 + 需要时指令开启",三种实现概念齐平。

> engine 里 `set_cwd` 与 goal 的代码**不删** —— 现网 worker loop 还在用,删除属退役清理(PR L)。

### 补上了一项不能省的安全配置

runEngine 原本 `permissionConfig` / `hookRegistry` / `contentReviewer` **一项都没传**。其中 **`hookRegistry` 是唯一不能省的**——**工具面过滤挡不住 worker 在 Bash 里直接跑 `crabot` 写命令**。验收 6 是真的让 worker 跑 `crabot <子命令> && touch marker`,断言 `session.jsonl` 出现 `PERMISSION_DENIED` 且 marker 不存在。

权限档位:**不照抄现网 scheduled 路径的 master_private**——那条路的前提是"发起人是系统自身,可信",而 v3 worker 由 manager 代任意会话发起人派活、`creator_friend_id` 又恒空。只开干活必需面(memory/mcp_skill/file_io/shell/browser),需要身份背书的高危面与 CLI 写权限一律关。

### worker 的身份写进了 prompt

不只给个名字,把角色关系立起来:

```
## 你的角色:worker
你是一个 worker:由 manager 派活、向 manager 交付,不直接面对人类。
- 你的工作目录固定为 <workspace.root>,并且没有切换工作目录的工具。所有中间产物和最终产出
  都要落在这个目录里——它是交接的唯一介质:你被换成另一个实现接手时,接手方只能看到这里留下的东西。
- 你没有任何直接联系人类的工具(没有发消息、也没有向人类提问这类原语),不要去找。
- 需要人类拿主意、或者有话想让人类知道时,把它在输出里写清楚然后结束本轮。你会停下来等待;
  读你的输出、判断你是干完了还是在等输入、以及要不要把话转述给人类,都是 manager 的责任。
- 任务完成或确认失败时调用 finish_task。这是你唯一的终态信号。
```

四条分别对应 §5.4 与 §5.1。**没有承诺协议里没有的东西**——特别是没承诺"manager 一定会来问你/一定会转述"(那正是 spec 的未决 #1)。

### 验收(spec 7 条,逐条自证)

1. **端到端不是 stub 到底**:真实 `UnifiedAgent` 构造的栈 → 真实 `spawnWorker`(**不传 builtin**)→ 真实 adapter → 真实 runEngine + 真实 Bash,mock LLM 跑 `pwd > pwd.txt`。断言文件**真的被写出来**且内容 = workspace 真实路径;
2. **重启后 revive**:agent#1 跑到 exited → **换一个 `UnifiedAgent` 实例**(同 DATA_DIR,内存态全空)→ 透明接续,化身链长到 2;
3. **配置现取**:worker A 停 idle(记 `model-A`)→ 经**真实 `update_config` RPC** 改配置 → 断言已起化身那次 burst 仍是 `model-A`(无追溯改写)→ spawn worker B 得 `model-B`;
4. 工具集逐项:正面断言文件/shell/skill/memory/tmp_page 在;反面逐项断言 messaging 三工具 + `send_message` 不在、`mcp__crab-messaging__` 前缀过滤结果为**空数组**、`set_cwd`/goal/`delegate_task`/`todo`/`find_task`/`wait_for_signal`/subagent coordinator 逐个不在;
5. cwd = workspace:两个不同 workspace 各真实跑一次 `pwd`,输出跟着换;
6. hookRegistry 见上;
7. 变异见下。

### 变异验证

| 变异 | 结果 |
|---|---|
| 去掉工厂回退 | **9 挂**(含 manager-integration 两个场景) |
| 去掉 `hookRegistry` | 3 挂 |
| 配置改回 spawn 快照 | 4 挂 |
| **model 快照进闭包(而非现取)** | **只有验收 3 挂**(1 failed / 22 passed)——精准 |
| 把 `set_cwd` 装回去 | 4 挂 |

第 1 步做变异时还揪出自己写的一处**冗余兜底**:adapter 里再兜一次 spawn 会把 harness 的回退整个掩盖(去掉 harness 回退用例照样绿),已删。

### 一处垫片退役

`manager-integration.test.ts` 的 `BuiltinAutoConfigAdapter`(40 行包装类)删掉,同一个队列工厂改挂到 `HarnessDeps.builtinSpawnDefaults`。**4 条用例断言一个字没改就通过**;且变异①现在会让其中两个场景直接挂——垫片在的时候那两条是绿的,**覆盖等于从垫片搬到了生产路径上**。

### 验证

- **2357 passed | 2 skipped**(基线 2348,差值 = 新增 9),零回归;`tsc --noEmit` 干净;`tmux` 无残留

### 发现但未改

1. **不装 bg-shell** → Bash 只能前台跑,**这是相对现网 worker loop 的一处能力收窄**(退出唤醒依赖 `wait_for_signal`、owner 归属未定)。建议与 F2 一并评估;
2. `SEND_MESSAGE_SPEC` 与 worker 契约矛盾:`assembleAgentPrompt` 里那段教 agent 用 `send_message`,而 worker 根本没这工具;现在靠 prompt 尾巴"后说覆盖先说"压制,不干净。根治要动 prompt 装配层、会影响现网 worker loop → 留 J;
3. skill catalog 拼装重复一份(去重必须动 `agent-handler`,与本步"现网零影响"约束冲突,刻意并存并注释:J 删 worker loop 时那份随之消失);
4. `capabilities().goalMode` 仍是 `true` 但已不装 goal(无消费方);
5. **手工联调没做** —— 证据全部来自自动化测试(真实装配 + mock LLM),真机跑一次 manager→builtin worker 建议放 cutover 前的联调窗口。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
