### PR TITLE
fix(engine): 上下文压缩失败不再静默降级为假压缩

### DIFF
--- a/crabot-agent/src/agent/agent-handler.ts
+++ b/crabot-agent/src/agent/agent-handler.ts
@@ -1933,10 +1933,13 @@ export class AgentHandler {
           onCompactionEnd: (info) => {
             if (compactionSpanId) {
               const endedAtMs = (compactionStartedAtMs ?? Date.now()) + info.durationMs
+              // 压缩失败时 span 必须写成失败——上下文没压下去却报 "compacted N → N" 是谎报
               traceCallback?.onToolCallEnd(
                 compactionSpanId,
-                `compacted ${info.beforeCount} → ${info.afterCount} msgs in ${info.durationMs}ms`,
-                undefined,
+                info.failedReason === undefined
+                  ? `compacted ${info.beforeCount} → ${info.afterCount} msgs in ${info.durationMs}ms`
+                  : `compaction failed after ${info.durationMs}ms (messages unchanged: ${info.beforeCount})`,
+                info.failedReason,
                 endedAtMs,
               )
               compactionSpanId = undefined

--- a/crabot-agent/src/engine/context-manager.ts
+++ b/crabot-agent/src/engine/context-manager.ts
@@ -41,11 +41,50 @@ interface CumulativeUsage {
   readonly outputTokens: number
 }
 
+/**
+ * 上下文压缩失败（摘要 LLM 调用失败 / 摘要为空 / 找不到合法切点）。
+ *
+ * 压缩失败**不再**静默回退到纯文本折叠——那条回退对 tool_result 正文一字不减，
+ * 等于"假压缩"：上层看到压缩成功、下一轮仍超阈值，于是每轮再烧一次注定失败的摘要调用。
+ * 调用方（query-loop）据此走与"主 LLM 调用失败"同一条 failed 路径。
+ *
+ * 注意：abort 不包在这里——AbortError 原样穿透，让调用方以 aborted 收尾。
+ */
+export class CompactionFailedError extends Error {
+  constructor(message: string, cause?: unknown) {
+    super(message)
+    this.name = 'CompactionFailedError'
+    if (cause !== undefined) {
+      ;(this as Error & { cause?: unknown }).cause = cause
+    }
+  }
+}
+
 export const DEFAULT_COMPACT_THRESHOLD = 0.8
 const DEFAULT_KEEP_RECENT = 6
 const CHARS_PER_TOKEN = 4
 const MESSAGE_OVERHEAD_TOKENS = 4
 const IMAGE_TOKENS = 1000
+
+/**
+ * 摘要输入里单条 tool_result 的字符上限。
+ * 依据：pi 的 `TOOL_RESULT_MAX_CHARS = 2000`（coding-agent/src/core/compaction/utils.ts:89）。
+ * 摘要要的是"这条命令跑成/跑挂了、关键结论是什么"，不是逐字节日志；
+ * 2000 字符（≈500 token）足够覆盖一条命令的头尾结论，又不会让单条 Bash 输出吃掉整个预算。
+ */
+const SUMMARY_TOOL_RESULT_MAX_CHARS = 2000
+
+/**
+ * 摘要输入的总预算比例（相对 maxContextTokens）。
+ * 依据：摘要调用与主循环共用同一个上下文窗口，而它恰恰发生在上下文已过 80% 阈值时——
+ * 逐条截断不设总量上限时，待折叠段的条数仍然无界（几百条 × 2000 字符照样超窗）。
+ * 取窗口的一半：留出 compact system prompt（约 1k token）与摘要输出空间，
+ * 且不引入新的可配置项（保留条数/触发阈值/prompt 内容一律不动）。
+ */
+const SUMMARY_INPUT_BUDGET_RATIO = 0.5
+
+/** findSafeSplitIndex 的哨兵：整段没有任何合法切点（recent 段必然以孤儿 tool_result 打头）。 */
+const NO_SAFE_SPLIT = -1
 
 const DEFAULT_COMPACT_SYSTEM_PROMPT = `你正在为一个长任务压缩上下文。你的目标不是复述聊天记录，而是保留后续继续执行任务所必需的、当前有效的上下文状态。
 
@@ -107,6 +146,12 @@ const DEFAULT_COMPACT_SYSTEM_PROMPT = `你正在为一个长任务压缩上下�
 - 不要省略“已经作废但后续容易误用”的信息。
 - 不要编造原对话中没有的信息；不确定就写成未解决问题或风险。
 - 保持简洁，但不能为了简洁丢掉会改变后续行为的信息。`
+
+/** 超长文本按字符上限截断并标注原长度（摘要输入用）。 */
+function truncate(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text
+  return `${text.slice(0, maxChars)}…[已截断，原长 ${text.length} 字符]`
+}
 
 export class ContextManager {
   private readonly maxContextTokens: number
@@ -190,7 +235,7 @@ export class ContextManager {
     }
 
     const split = this.partitionForCompaction(messages)
-    if (!split) {
+    if (split.kind !== 'ok') {
       return [...messages]
     }
 
@@ -200,45 +245,70 @@ export class ContextManager {
     return [split.firstMessage, summaryMessage, ...split.recentMessages]
   }
 
+  /**
+   * LLM 摘要压缩。失败**不再**静默回退到 compactMessages（那条回退对 tool_result
+   * 正文一字不减，等于假压缩）：
+   * - 摘要调用失败 / 摘要为空 / 无合法切点 → 抛 CompactionFailedError，由调用方决定收尾；
+   * - abort → 原样抛出 AbortError（不包装、不吞掉），调用方以 aborted 收尾。
+   *
+   * @param signal 任务级取消信号，透传给摘要调用——否则中止后摘要仍会跑完重试链。
+   */
   async compactWithLLM(
     messages: ReadonlyArray<EngineMessage>,
     adapter: LLMAdapter,
     model: string,
+    signal?: AbortSignal,
   ): Promise<ReadonlyArray<EngineMessage>> {
     if (messages.length <= this.keepRecentMessages) {
       return [...messages]
     }
 
     const split = this.partitionForCompaction(messages)
-    if (!split) {
+    if (split.kind === 'no-safe-split') {
+      throw new CompactionFailedError(
+        `找不到合法的压缩切点：消息序列中 [1, ${messages.length}) 全是 tool_result，` +
+        '任何切点都会让 recent 段以孤儿 tool_result 打头',
+      )
+    }
+    if (split.kind === 'nothing-to-compact') {
       return [...messages]
     }
 
-    try {
-      const summaryPrompt = this.buildSummaryPrompt(split.oldMessages)
-      const promptMessage = createUserMessage(summaryPrompt)
+    const summaryPrompt = this.buildSummaryPrompt(split.oldMessages)
+    const promptMessage = createUserMessage(summaryPrompt)
 
-      const response = await callNonStreaming(adapter, {
+    let response
+    try {
+      response = await callNonStreaming(adapter, {
         messages: [promptMessage],
         systemPrompt: this.compactSystemPrompt,
         tools: [],
         model,
+        ...(signal !== undefined ? { signal } : {}),
       })
-
-      const summaryText = response.content
-        .filter((b): b is { type: 'text'; text: string } => b.type === 'text')
-        .map((b) => b.text)
-        .join('')
-
-      const summaryMessage = createUserMessage(
-        `[Earlier conversation summary]\n${summaryText}`
-      )
-
-      return [split.firstMessage, summaryMessage, ...split.recentMessages]
-    } catch {
-      // Fall back to text-based compaction
-      return this.compactMessages(messages)
+    } catch (error) {
+      // abort 穿透：任务已在中止路上，不再改写上下文
+      if (signal?.aborted === true || (error instanceof Error && error.name === 'AbortError')) {
+        throw error
+      }
+      throw new CompactionFailedError(`摘要 LLM 调用失败: ${String(error)}`, error)
     }
+
+    const summaryText = response.content
+      .filter((b): b is { type: 'text'; text: string } => b.type === 'text')
+      .map((b) => b.text)
+      .join('')
+
+    if (summaryText.trim().length === 0) {
+      // 空摘要 = 被折叠的一整段凭空消失，同样是"假装压缩成功"
+      throw new CompactionFailedError('摘要 LLM 返回空摘要')
+    }
+
+    const summaryMessage = createUserMessage(
+      `[Earlier conversation summary]\n${summaryText}`
+    )
+
+    return [split.firstMessage, summaryMessage, ...split.recentMessages]
   }
 
   updateFromUsage(usage: { readonly inputTokens: number; readonly outputTokens: number }): void {
@@ -255,18 +325,28 @@ export class ContextManager {
   /**
    * 切出三段：首条 user message（钉住不压，含 task_origin 等任务级 immortal facts，
    * 被摘要 LLM 丢字段会导致回复发错 channel）、待压缩段、recent 段。
-   * 返回 null 表示无可压缩内容（首条之后没有更多 old 消息）。
+   *
+   * - `nothing-to-compact`：首条之后没有更多 old 消息（对话本来就短），正常 no-op；
+   * - `no-safe-split`：存在可折叠内容，但整段找不到合法切点——**故障**，不再静默 no-op。
    */
-  private partitionForCompaction(messages: ReadonlyArray<EngineMessage>): {
-    firstMessage: EngineMessage
-    oldMessages: ReadonlyArray<EngineMessage>
-    recentMessages: ReadonlyArray<EngineMessage>
-  } | null {
+  private partitionForCompaction(messages: ReadonlyArray<EngineMessage>):
+    | {
+        kind: 'ok'
+        firstMessage: EngineMessage
+        oldMessages: ReadonlyArray<EngineMessage>
+        recentMessages: ReadonlyArray<EngineMessage>
+      }
+    | { kind: 'nothing-to-compact' }
+    | { kind: 'no-safe-split' } {
     const splitIndex = this.findSafeSplitIndex(messages)
+    if (splitIndex === NO_SAFE_SPLIT) {
+      return { kind: 'no-safe-split' }
+    }
     if (splitIndex <= 1) {
-      return null
+      return { kind: 'nothing-to-compact' }
     }
     return {
+      kind: 'ok',
       firstMessage: messages[0],
       oldMessages: messages.slice(1, splitIndex),
       recentMessages: messages.slice(splitIndex),
@@ -278,15 +358,36 @@ export class ContextManager {
    * （其匹配的 tool_use 在被压缩段，会触发 LLM API 400）。
    *
    * 默认切点 = messages.length - keepRecentMessages。如果该位置是 tool_result，
-   * 向前回退把对应的 assistant_with_tool_use 一起拉进 recent。assistant 与 tool_result
-   * 严格相邻，所以最多回退一步即可。
+   * 向前回退把对应的 assistant_with_tool_use 一起拉进 recent。engine 自造消息时
+   * assistant 与 tool_result 严格相邻，最多回退一步。
+   *
+   * 但 initialMessages 是外部来源（resume checkpoint / session 树回灌），可能出现
+   * 连续 tool_result——旧实现会一路回退到 <=1，让压缩静默变 no-op。因此回退触底后
+   * 改为**向后**找第一个非 tool_result 位置（recent 段变短，但配对安全）；
+   * 整段都没有合法切点时返回 NO_SAFE_SPLIT，由调用方明确报错，不静默吞掉。
    */
   private findSafeSplitIndex(messages: ReadonlyArray<EngineMessage>): number {
-    let splitIndex = messages.length - this.keepRecentMessages
-    while (splitIndex > 0 && this.isToolResultMessage(messages[splitIndex])) {
+    const defaultIndex = messages.length - this.keepRecentMessages
+    if (defaultIndex <= 1) {
+      // 对话本来就短：无可折叠内容，交由 partitionForCompaction 判 nothing-to-compact
+      return defaultIndex
+    }
+
+    let splitIndex = defaultIndex
+    while (splitIndex > 1 && this.isToolResultMessage(messages[splitIndex])) {
       splitIndex--
     }
-    return splitIndex
+    if (splitIndex > 1 && !this.isToolResultMessage(messages[splitIndex])) {
+      return splitIndex
+    }
+
+    // 回退触底（连续 tool_result）：向后找第一个合法切点
+    for (let forward = defaultIndex + 1; forward < messages.length; forward++) {
+      if (!this.isToolResultMessage(messages[forward])) {
+        return forward
+      }
+    }
+    return NO_SAFE_SPLIT
   }
 
   private isToolResultMessage(msg: EngineMessage): boolean {
@@ -345,7 +446,7 @@ export class ContextManager {
       }
 
       const role = msg.role === 'assistant' ? 'Assistant' : 'User'
-      const text = this.extractText(msg)
+      const text = this.extractText(msg, SUMMARY_TOOL_RESULT_MAX_CHARS)
       if (text) {
         parts.push(`${role}: ${text}`)
       }
@@ -354,7 +455,7 @@ export class ContextManager {
     const lines: string[] = [
       '以下是需要压缩的历史上下文。请生成后续继续执行任务所需的结构化摘要：',
       '',
-      ...parts,
+      ...this.applySummaryInputBudget(parts),
     ]
 
     if (toolNames.size > 0) {
@@ -365,7 +466,44 @@ export class ContextManager {
     return lines.join('\n')
   }
 
-  private extractText(msg: EngineMessage): string {
+  /**
+   * 摘要输入的总量上界：逐条截断之后条数仍然无界，所以再按总字符预算从**最旧**开始丢弃。
+   * 丢最旧是安全的——首条 user message（task_origin / 原始请求）本就被钉住不进摘要输入。
+   */
+  private applySummaryInputBudget(parts: ReadonlyArray<string>): ReadonlyArray<string> {
+    const budgetChars = Math.floor(
+      this.maxContextTokens * SUMMARY_INPUT_BUDGET_RATIO * CHARS_PER_TOKEN,
+    )
+    let used = 0
+    let firstKept = parts.length
+    for (let i = parts.length - 1; i >= 0; i--) {
+      const cost = parts[i].length + 1  // +1: join 的换行
+      if (used + cost > budgetChars) break
+      used += cost
+      firstKept = i
+    }
+    if (firstKept === 0) {
+      return parts
+    }
+    if (firstKept === parts.length) {
+      // 连最后一条都塞不下：保留它的头部，绝不把摘要输入清空
+      firstKept = parts.length - 1
+      return [
+        `[已省略更早的 ${firstKept} 条消息：摘要输入超出 ${budgetChars} 字符预算]`,
+        truncate(parts[firstKept], budgetChars),
+      ]
+    }
+    return [
+      `[已省略更早的 ${firstKept} 条消息：摘要输入超出 ${budgetChars} 字符预算]`,
+      ...parts.slice(firstKept),
+    ]
+  }
+
+  /**
+   * @param maxToolResultChars 单条 tool_result 的字符上限（仅摘要输入路径传，
+   *   纯文本折叠路径不传以保持原行为）
+   */
+  private extractText(msg: EngineMessage, maxToolResultChars?: number): string {
     if (msg.role === 'assistant') {
       const assistantMsg = msg as EngineAssistantMessage
       return assistantMsg.content
@@ -376,7 +514,9 @@ export class ContextManager {
 
     if ('toolResults' in msg) {
       const toolMsg = msg as EngineToolResultMessage
-      return toolMsg.toolResults.map((r) => r.content).join(' ')
+      return toolMsg.toolResults
+        .map((r) => (maxToolResultChars === undefined ? r.content : truncate(r.content, maxToolResultChars)))
+        .join(' ')
     }
 
     const userMsg = msg as EngineUserMessage

--- a/crabot-agent/src/engine/query-loop.ts
+++ b/crabot-agent/src/engine/query-loop.ts
@@ -428,7 +428,15 @@ export async function runEngine(params: RunEngineParams): Promise<EngineResult> 
       systemPrompt: currentSystemPrompt,
       tools: currentTools,
     })) {
-      await compactInPlace(messages, contextManager, adapter, options)
+      const compaction = await compactInPlace(messages, contextManager, adapter, options, abortSignal)
+      if (!compaction.ok) {
+        // 压缩是唯一的下压手段（engine 无 provider 溢出恢复路径）。压不下去还继续跑，
+        // 只会每轮再烧一次注定失败的摘要调用、最终撞窗口——直接以可诊断的原因收尾。
+        if (compaction.aborted) {
+          return buildResult('aborted', finalText, totalTurns, contextManager, messages, exitToolCall, toolCallCount, wroteMemoryOrScene)
+        }
+        return buildResult('failed', finalText, totalTurns, contextManager, messages, exitToolCall, toolCallCount, wroteMemoryOrScene, `上下文压缩失败：${compaction.failedReason}`)
+      }
       // compaction 改写了 messages，上一轮的 usage 观测已失效，回退估算路径
       lastObservedContextTokens = undefined
     }
@@ -624,7 +632,15 @@ export async function runEngine(params: RunEngineParams): Promise<EngineResult> 
           maxTokensCompactRetryCount++
           fireOnTurn(buildSilentTurnEvent(totalTurns, processed.text, stopReason, llmCallMs, llmStartedAtMs, undefined, response.usage))
           messages.pop()
-          await compactInPlace(messages, contextManager, adapter, options)
+          const compaction = await compactInPlace(messages, contextManager, adapter, options, abortSignal)
+          if (!compaction.ok) {
+            // max_tokens 已是 context 打满的硬信号，压缩又没压成 —— 再 continue 只是
+            // 拿同样超大的 input 重跑一次。诚实收尾，不把"没压成"当成配额耗尽。
+            if (compaction.aborted) {
+              return buildResult('aborted', finalText, totalTurns, contextManager, messages, exitToolCall, toolCallCount, wroteMemoryOrScene)
+            }
+            return buildResult('failed', finalText, totalTurns, contextManager, messages, exitToolCall, toolCallCount, wroteMemoryOrScene, `上下文压缩失败：${compaction.failedReason}`)
+          }
           // compaction 改写了 messages，上一轮的 usage 观测已失效，回退估算路径
           lastObservedContextTokens = undefined
           continue
@@ -1103,17 +1119,28 @@ export async function runEngine(params: RunEngineParams): Promise<EngineResult> 
 
 // --- Helpers ---
 
+/**
+ * compaction 结果。失败时 messages 保持原样——**绝不用"假压缩"冒充成功**
+ * （旧实现的文本回退对 tool_result 正文一字不减，等于每轮再烧一次注定失败的摘要调用）。
+ */
+type CompactionOutcome =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly aborted: true }
+  | { readonly ok: false; readonly aborted: false; readonly failedReason: string }
+
 async function compactInPlace(
   messages: EngineMessage[],
   contextManager: ContextManager,
   adapter: LLMAdapter,
   options: EngineOptions,
-): Promise<void> {
+  abortSignal?: AbortSignal,
+): Promise<CompactionOutcome> {
   const startedAtMs = Date.now()
   const beforeCount = messages.length
   options.onCompactionStart?.()
+  let failedReason: string | undefined
   try {
-    const compacted = await contextManager.compactWithLLM(messages, adapter, options.model)
+    const compacted = await contextManager.compactWithLLM(messages, adapter, options.model, abortSignal)
     const finalMessages = options.onAfterCompaction
       ? options.onAfterCompaction(compacted)
       : compacted
@@ -1121,11 +1148,22 @@ async function compactInPlace(
     for (const msg of finalMessages) {
       messages.push(msg)
     }
+    return { ok: true }
+  } catch (error) {
+    if (abortSignal?.aborted === true || (error instanceof Error && error.name === 'AbortError')) {
+      failedReason = 'aborted'
+      return { ok: false, aborted: true }
+    }
+    console.error('[query-loop] context compaction failed:', error)
+    failedReason = formatError(error)
+    return { ok: false, aborted: false, failedReason }
   } finally {
+    // 失败时 afterCount === beforeCount，且带上 failedReason——onCompactionEnd 不得谎报压缩成功
     options.onCompactionEnd?.({
       beforeCount,
       afterCount: messages.length,
       durationMs: Date.now() - startedAtMs,
+      ...(failedReason !== undefined ? { failedReason } : {}),
     })
   }
 }

--- a/crabot-agent/src/engine/types.ts
+++ b/crabot-agent/src/engine/types.ts
@@ -424,9 +424,17 @@ export interface EngineOptions {
    */
   readonly onCompactionStart?: () => void
   /**
-   * 上下文压缩完成时触发。`info` 含压缩前后消息数与耗时。
+   * 上下文压缩结束时触发（成功与失败都触发，失败路径也要关掉 trace span）。
+   * `info` 含压缩前后消息数与耗时；`failedReason` 存在表示这次**没压成**
+   * （messages 保持原样，afterCount === beforeCount）——不得当成压缩成功汇报。
+   * 值为 'aborted' 时表示任务被中止，非压缩本身故障。
    */
-  readonly onCompactionEnd?: (info: { readonly beforeCount: number; readonly afterCount: number; readonly durationMs: number }) => void
+  readonly onCompactionEnd?: (info: {
+    readonly beforeCount: number
+    readonly afterCount: number
+    readonly durationMs: number
+    readonly failedReason?: string
+  }) => void
   /**
    * 禁用所有 compaction 触发路径（既不自动压缩，也不在 max_tokens 静默响应时压缩重试）。
    *

--- a/crabot-agent/tests/engine/compaction-failure.test.ts
+++ b/crabot-agent/tests/engine/compaction-failure.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi } from 'vitest'
+import { runEngine } from '../../src/engine/query-loop.js'
+import { defineTool } from '../../src/engine/tool-framework.js'
+import type { LLMAdapter } from '../../src/engine/llm-adapter.js'
+import { createUserMessage } from '../../src/engine/types.js'
+import type { StreamChunk, EngineOptions, EngineMessage } from '../../src/engine/types.js'
+
+/**
+ * 上下文压缩故障链回归（研究报告 `.superpowers/sdd/pi-compaction-study.md` §五）：
+ * 摘要 LLM 失败时 engine 不得把"假压缩"当成压缩成功，abort 必须穿透。
+ */
+
+const readTool = defineTool({
+  name: 'Read',
+  description: 'Read a file',
+  inputSchema: { type: 'object', properties: { path: { type: 'string' } } },
+  isReadOnly: true,
+  call: async () => ({ output: 'file content', isError: false }),
+})
+
+function baseOptions(overrides: Partial<EngineOptions> = {}): EngineOptions {
+  return {
+    systemPrompt: 'You are a test assistant.',
+    tools: [],
+    model: 'test-model',
+    maxTurns: 10,
+    ...overrides,
+  }
+}
+
+function toolUseResponse(
+  usage: { inputTokens: number; outputTokens: number },
+): ReadonlyArray<StreamChunk> {
+  return [
+    { type: 'message_start', messageId: 'msg-1' },
+    { type: 'tool_use_start', id: 'tu-1', name: 'Read' },
+    { type: 'tool_use_delta', id: 'tu-1', inputJson: JSON.stringify({ path: '/tmp/a' }) },
+    { type: 'tool_use_end', id: 'tu-1' },
+    { type: 'message_end', stopReason: 'tool_use', usage },
+  ]
+}
+
+function textResponse(text: string): ReadonlyArray<StreamChunk> {
+  return [
+    { type: 'message_start', messageId: 'msg-1' },
+    { type: 'text_delta', text },
+    { type: 'message_end', stopReason: 'end_turn', usage: { inputTokens: 10, outputTokens: 5 } },
+  ]
+}
+
+/**
+ * 5 轮 tool_use（messages 达 11 条 > keepRecentMessages=6），第 5 轮 usage 90 >= 阈值 80，
+ * 第 6 轮开始前触发压缩。第 6 次 adapter 调用就是压缩摘要调用。
+ */
+function historyResponses(): ReadonlyArray<ReadonlyArray<StreamChunk>> {
+  const small = { inputTokens: 10, outputTokens: 10 }
+  return [
+    toolUseResponse(small),
+    toolUseResponse(small),
+    toolUseResponse(small),
+    toolUseResponse(small),
+    toolUseResponse({ inputTokens: 90, outputTokens: 10 }),
+  ]
+}
+
+/** 前 5 次正常，第 6 次（摘要调用）按 onSummaryCall 决定行为 */
+function adapterFailingOnSummary(
+  onSummaryCall: () => AsyncGenerator<StreamChunk>,
+): LLMAdapter {
+  const history = historyResponses()
+  let callIndex = 0
+  return {
+    async *stream(params) {
+      const index = callIndex++
+      if (index < history.length) {
+        for (const chunk of history[index]) yield chunk
+        return
+      }
+      // 摘要调用（也可能是压缩之后的主轮调用）
+      for await (const chunk of onSummaryCall()) {
+        if (params.signal?.aborted) {
+          throw new DOMException('Aborted', 'AbortError')
+        }
+        yield chunk
+      }
+    },
+    updateConfig() {},
+  }
+}
+
+function hasSummaryMessage(messages: ReadonlyArray<EngineMessage>): boolean {
+  return messages.some(
+    (m) =>
+      m.role === 'user' &&
+      typeof (m as { content?: unknown }).content === 'string' &&
+      ((m as { content: string }).content.includes('[Earlier conversation summary]') ||
+        (m as { content: string }).content.includes('[Summary of earlier conversation]')),
+  )
+}
+
+describe('runEngine context compaction failure', () => {
+  it('fails the run instead of silently continuing on a fake compaction', async () => {
+    const adapter = adapterFailingOnSummary(async function* () {
+      yield { type: 'error', error: 'summary provider 429 (retries exhausted)' } as StreamChunk
+    })
+    const onCompactionEnd = vi.fn()
+
+    const result = await runEngine({
+      prompt: 'hi',
+      adapter,
+      options: baseOptions({
+        tools: [readTool],
+        contextWindowTokens: 100,
+        onCompactionEnd,
+      }),
+    })
+
+    expect(result.outcome).toBe('failed')
+    expect(result.error).toContain('上下文压缩失败')
+    expect(result.error).toContain('429')
+    // messages 未被"假压缩"改写
+    expect(hasSummaryMessage(result.finalMessages)).toBe(false)
+    // onCompactionEnd 不得谎报成功
+    expect(onCompactionEnd).toHaveBeenCalledTimes(1)
+    const info = onCompactionEnd.mock.calls[0][0] as {
+      beforeCount: number
+      afterCount: number
+      failedReason?: string
+    }
+    expect(info.failedReason).toBeDefined()
+    expect(info.afterCount).toBe(info.beforeCount)
+  })
+
+  it('does not rewrite messages when the run is aborted during compaction', async () => {
+    const controller = new AbortController()
+    const adapter = adapterFailingOnSummary(async function* () {
+      // 摘要调用刚开始就被用户取消
+      controller.abort()
+      yield { type: 'message_start', messageId: 'msg-x' } as StreamChunk
+      yield { type: 'text_delta', text: '摘要（不该被采用）' } as StreamChunk
+      yield { type: 'message_end', stopReason: 'end_turn' } as StreamChunk
+    })
+
+    const result = await runEngine({
+      prompt: 'hi',
+      adapter,
+      options: baseOptions({
+        tools: [readTool],
+        contextWindowTokens: 100,
+        abortSignal: controller.signal,
+      }),
+    })
+
+    expect(result.outcome).toBe('aborted')
+    // abort 途中不许再改一次上下文
+    expect(hasSummaryMessage(result.finalMessages)).toBe(false)
+  })
+
+  it('reports compaction failure in the max_tokens compact-retry path', async () => {
+    // 主轮 max_tokens + 空文本 → 走 compact-retry；此时摘要调用失败
+    const responses: ReadonlyArray<ReadonlyArray<StreamChunk>> = [
+      [
+        { type: 'message_start', messageId: 'msg-1' },
+        { type: 'message_end', stopReason: 'max_tokens', usage: { inputTokens: 10, outputTokens: 0 } },
+      ],
+    ]
+    let callIndex = 0
+    const adapter: LLMAdapter = {
+      async *stream() {
+        const index = callIndex++
+        if (index < responses.length) {
+          for (const chunk of responses[index]) yield chunk
+          return
+        }
+        yield { type: 'error', error: 'summary provider down' } as StreamChunk
+      },
+      updateConfig() {},
+    }
+
+    const initialMessages: EngineMessage[] = ['任务来源', 'a', 'b', 'c', 'd', 'e', 'f', 'g'].map(
+      (text) => createUserMessage(text),
+    )
+
+    const result = await runEngine({
+      prompt: 'unused',
+      initialMessages,
+      adapter,
+      options: baseOptions({ contextWindowTokens: 100000 }),
+    })
+
+    expect(result.outcome).toBe('failed')
+    expect(result.error).toContain('上下文压缩失败')
+    expect(hasSummaryMessage(result.finalMessages)).toBe(false)
+  })
+
+  it('still completes normally when compaction succeeds', async () => {
+    // 反向不变量：成功路径行为不变（压缩成功 → 摘要进上下文 → 继续跑到 completed）
+    let phase = 0
+    const history = historyResponses()
+    const adapter: LLMAdapter = {
+      async *stream() {
+        const index = phase++
+        const chunks =
+          index < history.length
+            ? history[index]
+            : index === history.length
+              ? textResponse('对话摘要')
+              : textResponse('done')
+        for (const chunk of chunks) yield chunk
+      },
+      updateConfig() {},
+    }
+    const onCompactionEnd = vi.fn()
+
+    const result = await runEngine({
+      prompt: 'hi',
+      adapter,
+      options: baseOptions({ tools: [readTool], contextWindowTokens: 100, onCompactionEnd }),
+    })
+
+    expect(result.outcome).toBe('completed')
+    expect(result.finalText).toBe('done')
+    expect(hasSummaryMessage(result.finalMessages)).toBe(true)
+    const info = onCompactionEnd.mock.calls[0][0] as { failedReason?: string; afterCount: number; beforeCount: number }
+    expect(info.failedReason).toBeUndefined()
+    expect(info.afterCount).toBeLessThan(info.beforeCount)
+  })
+})

--- a/crabot-agent/tests/engine/context-manager.test.ts
+++ b/crabot-agent/tests/engine/context-manager.test.ts
@@ -7,7 +7,7 @@ import {
   type ContentBlock,
   type StreamChunk,
 } from '../../src/engine/types'
-import { ContextManager } from '../../src/engine/context-manager'
+import { ContextManager, CompactionFailedError } from '../../src/engine/context-manager'
 import type { LLMAdapter } from '../../src/engine/llm-adapter'
 
 function mockAdapter(responseText: string): LLMAdapter {
@@ -30,9 +30,21 @@ function mockFailingAdapter(errorMessage: string): LLMAdapter {
   }
 }
 
+/** 摘要调用中途被取消：adapter 直接抛 AbortError（callNonStreaming 不重试、原样上抛）。 */
+function mockAbortingAdapter(): LLMAdapter {
+  return {
+    // eslint-disable-next-line require-yield
+    async *stream() {
+      throw new DOMException('Aborted', 'AbortError')
+    },
+    updateConfig() {},
+  }
+}
+
 interface CapturedCall {
   messages: EngineMessage[]
   systemPrompt: string
+  signal?: AbortSignal
 }
 
 function capturingAdapter(responseText: string): { adapter: LLMAdapter; captured: CapturedCall } {
@@ -41,6 +53,7 @@ function capturingAdapter(responseText: string): { adapter: LLMAdapter; captured
     async *stream(params) {
       captured.messages = [...params.messages]
       captured.systemPrompt = params.systemPrompt
+      captured.signal = params.signal
       yield { type: 'message_start', messageId: 'msg_1' } as StreamChunk
       yield { type: 'text_delta', text: responseText } as StreamChunk
       yield { type: 'message_end', stopReason: 'end_turn' } as StreamChunk
@@ -472,7 +485,9 @@ describe('ContextManager', () => {
       expect(compacted[4]).toBe(messages[4])
     })
 
-    it('should fall back to text-based compact on LLM error', async () => {
+    // 坑 1：摘要失败静默降级成"假压缩"。旧实现 catch 后回退 compactMessages，
+    // 而后者对 tool_result 返回全量正文——上层看到"压缩成功"，token 却几乎没降。
+    it('rejects with CompactionFailedError instead of a fake compaction when the summary LLM fails', async () => {
       const cm = new ContextManager({
         maxContextTokens: 10000,
         keepRecentMessages: 2,
@@ -486,16 +501,215 @@ describe('ContextManager', () => {
       ]
 
       const adapter = mockFailingAdapter('LLM service unavailable')
+
+      await expect(cm.compactWithLLM(messages, adapter, 'test-model')).rejects.toBeInstanceOf(
+        CompactionFailedError,
+      )
+      // 原始 messages 不被改写
+      expect(messages).toHaveLength(4)
+    })
+
+    it('never returns a "compacted" result whose tokens did not actually drop (summary LLM failure)', async () => {
+      // 复现坑 1 的可观测后果：worker 场景的 token 由 tool_result 正文主导，
+      // 文本回退只丢掉 tool_use 入参/图片/消息开销，正文一字不减。
+      const cm = new ContextManager({
+        maxContextTokens: 100000,
+        keepRecentMessages: 2,
+      })
+
+      const bashOutput = 'x'.repeat(40000)
+      const messages: EngineMessage[] = [
+        createUserMessage('任务来源：跑一遍测试'),
+        createAssistantMessage(
+          [{ type: 'tool_use', id: 'tu_1', name: 'Bash', input: { command: 'pnpm test' } }],
+          'tool_use',
+        ),
+        createToolResultMessage('tu_1', bashOutput, false),
+        createAssistantMessage(
+          [{ type: 'tool_use', id: 'tu_2', name: 'Bash', input: { command: 'pnpm test again' } }],
+          'tool_use',
+        ),
+        createToolResultMessage('tu_2', bashOutput, false),
+        createUserMessage('继续'),
+        createAssistantMessage([{ type: 'text', text: '好的' }], 'end_turn'),
+      ]
+      const beforeTokens = cm.estimateTotalTokens(messages)
+
+      const adapter = mockFailingAdapter('429 rate limited (retries exhausted)')
+      const outcome = await cm
+        .compactWithLLM(messages, adapter, 'test-model')
+        .then((compacted) => ({ resolved: true as const, compacted }))
+        .catch((error: unknown) => ({ resolved: false as const, error }))
+
+      if (outcome.resolved) {
+        // 若实现选择返回而不是抛错，那也必须是"真的压下来了"，不许假装成功
+        expect(cm.estimateTotalTokens(outcome.compacted)).toBeLessThan(beforeTokens / 2)
+      } else {
+        expect(outcome.error).toBeInstanceOf(CompactionFailedError)
+      }
+    })
+
+    it('rejects when the summary LLM returns empty text', async () => {
+      // 空摘要 = 整段被折叠内容凭空消失，同样属于"假装压缩成功"
+      const cm = new ContextManager({ maxContextTokens: 10000, keepRecentMessages: 2 })
+      const messages: EngineMessage[] = [
+        createUserMessage('First question'),
+        createAssistantMessage([{ type: 'text', text: 'First answer' }], 'end_turn'),
+        createUserMessage('Second question'),
+        createAssistantMessage([{ type: 'text', text: 'Second answer' }], 'end_turn'),
+      ]
+
+      const adapter = mockAdapter('   ')
+      await expect(cm.compactWithLLM(messages, adapter, 'test-model')).rejects.toBeInstanceOf(
+        CompactionFailedError,
+      )
+    })
+
+    // 坑 2：同一个 catch 吞掉 abort——中止途中还多改一次 messages
+    it('propagates abort errors instead of swallowing them into a text fallback', async () => {
+      const cm = new ContextManager({
+        maxContextTokens: 10000,
+        keepRecentMessages: 2,
+      })
+
+      const messages: EngineMessage[] = [
+        createUserMessage('First question'),
+        createAssistantMessage([{ type: 'text', text: 'First answer' }], 'end_turn'),
+        createUserMessage('Second question'),
+        createAssistantMessage([{ type: 'text', text: 'Second answer' }], 'end_turn'),
+      ]
+
+      const adapter = mockAbortingAdapter()
+      const error = await cm
+        .compactWithLLM(messages, adapter, 'test-model')
+        .then(() => undefined, (e: unknown) => e)
+
+      expect(error).toBeInstanceOf(Error)
+      expect((error as Error).name).toBe('AbortError')
+      // 不许被包装成压缩失败——调用方要能区分"中止"与"压缩挂了"
+      expect(error).not.toBeInstanceOf(CompactionFailedError)
+    })
+
+    it('forwards the abort signal to the summarization call', async () => {
+      const cm = new ContextManager({
+        maxContextTokens: 10000,
+        keepRecentMessages: 2,
+      })
+      const messages: EngineMessage[] = [
+        createUserMessage('First question'),
+        createAssistantMessage([{ type: 'text', text: 'First answer' }], 'end_turn'),
+        createUserMessage('Second question'),
+        createAssistantMessage([{ type: 'text', text: 'Second answer' }], 'end_turn'),
+      ]
+
+      const controller = new AbortController()
+      const { adapter, captured } = capturingAdapter('摘要')
+      await cm.compactWithLLM(messages, adapter, 'test-model', controller.signal)
+
+      expect(captured.signal).toBe(controller.signal)
+    })
+
+    // 坑 3：摘要输入自己会超窗——待折叠段全量（含全量 tool_result）拼一条消息喂给摘要模型
+    it('truncates each tool_result in the summary prompt', async () => {
+      const cm = new ContextManager({
+        maxContextTokens: 100000,
+        keepRecentMessages: 2,
+      })
+
+      const huge = 'y'.repeat(50000)
+      const messages: EngineMessage[] = [
+        createUserMessage('任务'),
+        createAssistantMessage(
+          [{ type: 'tool_use', id: 'tu_1', name: 'Bash', input: { command: 'cat big.log' } }],
+          'tool_use',
+        ),
+        createToolResultMessage('tu_1', huge, false),
+        createUserMessage('继续'),
+        createAssistantMessage([{ type: 'text', text: '好的' }], 'end_turn'),
+      ]
+
+      const { adapter, captured } = capturingAdapter('摘要')
+      await cm.compactWithLLM(messages, adapter, 'test-model')
+
+      const prompt = (captured.messages[0] as { content: string }).content
+      expect(prompt).toContain('已截断')
+      expect(prompt.length).toBeLessThan(10000)
+    })
+
+    it('caps the total summary prompt by a budget derived from the context window', async () => {
+      // maxContextTokens=1000 → 预算 1000 * 4 * 0.5 = 2000 字符。
+      // 30 条 2000 字符的 tool_result（逐条截断后仍有 6 万字符）必须被整体裁到预算内。
+      const cm = new ContextManager({
+        maxContextTokens: 1000,
+        keepRecentMessages: 2,
+      })
+
+      const messages: EngineMessage[] = [createUserMessage('任务')]
+      for (let i = 0; i < 30; i++) {
+        messages.push(
+          createAssistantMessage(
+            [{ type: 'tool_use', id: `tu_${i}`, name: 'Bash', input: { command: `run ${i}` } }],
+            'tool_use',
+          ),
+        )
+        messages.push(createToolResultMessage(`tu_${i}`, `result ${i} ${'z'.repeat(2000)}`, false))
+      }
+      messages.push(createUserMessage('继续'))
+      messages.push(createAssistantMessage([{ type: 'text', text: '好的' }], 'end_turn'))
+
+      const { adapter, captured } = capturingAdapter('摘要')
+      await cm.compactWithLLM(messages, adapter, 'test-model')
+
+      const prompt = (captured.messages[0] as { content: string }).content
+      expect(prompt.length).toBeLessThan(3000)
+      expect(prompt).toContain('已省略更早')
+      // 保留的是最近的那一段（最旧的被丢）
+      expect(prompt).toContain('result 29')
+      expect(prompt).not.toContain('result 0 ')
+    })
+
+    // 坑 4：findSafeSplitIndex 的回退无界——外部来源（resume checkpoint / session 树回灌）
+    // 出现连续 tool_result 时会一路退到 <=1，压缩静默变 no-op
+    it('still compacts when the folded range is a run of consecutive tool_results', async () => {
+      const cm = new ContextManager({
+        maxContextTokens: 10000,
+        keepRecentMessages: 3,
+      })
+
+      // index 1..8 全是 tool_result（外部回灌的病态形态），index 9 是普通 user message
+      const messages: EngineMessage[] = [createUserMessage('任务来源')]
+      for (let i = 1; i <= 8; i++) {
+        messages.push(createToolResultMessage(`tu_${i}`, `result ${i}`, false))
+      }
+      messages.push(createUserMessage('最新一条'))
+
+      const { adapter } = capturingAdapter('摘要')
       const compacted = await cm.compactWithLLM(messages, adapter, 'test-model')
 
-      // Should still produce a valid result via text-based fallback
-      expect(compacted).toHaveLength(4) // 1 first + 1 summary + 2 recent
-      expect(compacted[0]).toBe(messages[0]) // 首条钉住
-      expect(compacted[1].role).toBe('user')
-      const summaryContent = (compacted[1] as { content: string | ContentBlock[] }).content
-      expect(typeof summaryContent).toBe('string')
-      // Text-based fallback uses [Summary of earlier conversation]
-      expect(summaryContent).toContain('[Summary')
+      // 不许静默 no-op：首条钉住 + 摘要 + recent 段
+      expect(compacted.length).toBeLessThan(messages.length)
+      expect(compacted[0]).toBe(messages[0])
+      // recent 段第一条不能是孤儿 tool_result（其 tool_use 已被折叠进摘要）
+      const firstRecent = compacted[2]
+      expect('toolResults' in firstRecent).toBe(false)
+      expect(firstRecent).toBe(messages[9])
+    })
+
+    it('rejects when no safe split point exists at all', async () => {
+      const cm = new ContextManager({
+        maxContextTokens: 10000,
+        keepRecentMessages: 3,
+      })
+
+      const messages: EngineMessage[] = [createUserMessage('任务来源')]
+      for (let i = 1; i <= 9; i++) {
+        messages.push(createToolResultMessage(`tu_${i}`, `result ${i}`, false))
+      }
+
+      const { adapter } = capturingAdapter('摘要')
+      await expect(cm.compactWithLLM(messages, adapter, 'test-model')).rejects.toBeInstanceOf(
+        CompactionFailedError,
+      )
     })
 
     it('should not compact if messages count is at or below keepRecentMessages', async () => {


### PR DESCRIPTION
## 修 engine 上下文压缩的故障链

**只修 bug,不改压缩策略**(保留条数、触发阈值、摘要 prompt 一律未动)。

起因:研究 pi 的压缩实现时,顺带把 crabot 自己这条故障链翻了出来(`.superpowers/sdd/pi-compaction-study.md`)。

### 故障链(四个坑,同一个模式)

**坑 1 — 摘要失败静默降级成"假压缩"。** `context-manager.ts:238-241` 是个**空 catch**:摘要 LLM 失败 → 静默回退到 `compactMessages()`,而后者的 `extractText` 对 tool_result 返回**全量 content**——只丢掉 tool_use 入参、图片和消息开销,**正文一字不减**。

实测:构造 worker 形态的上下文(两条 40000 字符的 Bash tool_result 主导 token),压缩前后 **20049 → 20033 tokens,只省了 16 个**。而 `onCompactionEnd` 照常汇报 before/after 条数,看起来一切正常。

完整故障链:摘要调用失败(最可能是 429 风暴,`callNonStreaming` 已重试耗尽)→ 静默"压缩成功" → 下轮仍超阈值 → **每轮再烧一次注定失败的调用** → 撞窗口 → engine 没有 provider 溢出恢复路径 → task failed。**全程无一条日志。**

**坑 2 — 同一个 catch 吞掉 abort**,而且 `signal` 压根没透传给摘要调用,中止途中还会多改一次 messages。

**坑 3 — 摘要输入自己会超窗。** `buildSummaryPrompt` 把待折叠段**全量**(含全量 tool_result)拼成一条消息喂给摘要模型——**上下文快爆时这次调用恰恰最可能超窗**,一失败就落进坑 1。

**坑 4 — `findSafeSplitIndex` 回退无界。** 注释假定"最多退一步",那只在 engine 自造消息时成立;`initialMessages`(resume checkpoint / session 树回灌)若有连续 tool_result 会一路退到 ≤1 → `partitionForCompaction` 返 null → **压缩静默变 no-op**。

### 修法

失败即抛 `CompactionFailedError`(原错误挂 `cause`),**messages 保持原样**;abort **原样抛 AbortError 不包装**,并把 `signal` 真的透传下去。

**为什么选 fail 而不是继续跑**:engine 没有 provider 溢出恢复路径,压缩是唯一的下压手段;压不下去继续跑,只会每轮再烧一次注定失败的摘要调用,最终仍然 failed——只是错误变成随机的 provider 报错,更难定位。而 `callNonStreaming` 是重试耗尽才抛,不是抖动。query-loop 对"LLM 调用失败"的既有语义就是 `buildResult('failed', formatError(err))`,摘要本身就是一次 LLM 调用,复用同一条路径,不新造语义。

`onCompactionEnd` 失败时**仍然触发**(否则 agent-handler 的 `__compaction__` span 会泄漏),但带上 `failedReason` 且 `afterCount === beforeCount`——只报 before/after 会让 trace 显示 `compacted 20 → 20 msgs`,那就是谎报。`EngineOptions` 的公开形状零改动,新字段是可选的。

**坑 3 的截断策略**(两层,都是常量/派生值,不引入新配置项):

1. 单条 tool_result ≤ **2000 字符**,对齐 pi 的 `TOOL_RESULT_MAX_CHARS`——摘要要的是"跑成/跑挂 + 关键结论";
2. 总预算 = `maxContextTokens × 0.5 × 4` 字符,从**最旧**开始丢并标注。pi 只做逐条截断够用,是因为它只喂"上次压缩之后的新增段";crabot 每次重喂 `[1, split)` 整段、**条数无界**,逐条截断挡不住。

### 复现测试(先 RED)

12 条,RED 阶段全 FAIL。构造方式刻意贴近真实失效形态:

- 坑 1 的关键那条断言"要么抛错,要么压缩后 token < 压缩前一半",修复前实测就是上面那个 20049 → 20033;
- query-loop 层:5 轮真实 usage 触发压缩 → 摘要返回 429 → 断言 `outcome==='failed'`、error 含原始 429 文案、`finalMessages` 无摘要消息、`onCompactionEnd` 带 `failedReason`;
- 坑 2:摘要调用开始时 abort → 断言 `outcome==='aborted'` **且上下文没被改写**;
- 坑 4:index 1..8 全是 tool_result(外部回灌的病态形态)→ 断言压缩真的发生,修复前是静默 no-op;
- 另加一条**反向不变量**:压缩成功路径行为不变(RED 阶段就 PASS)。

### 变异验证

| 变异 | 结果 |
|---|---|
| 把 `throw CompactionFailedError` 换回 `return this.compactMessages(...)` | **4 挂** |
| 删掉 abort 穿透分支 | 1 挂 |
| 不透传 `signal` | 2 挂 |

### 验证

- 基线 `2355 passed`(2 个已知 flaky)→ 修复后 `2367 passed`(+12 = 新增数),`tsc --noEmit` 干净
- **既有测试只改了一条**:`should fall back to text-based compact on LLM error` —— 它断言的正是被修正的错误行为(摘要失败后返回"压缩成功"的数组)。保留同样的输入构造,把预期从"静默回退"改成"明确失败"

### 提醒(未处理)

`ContextManager.compactMessages()` 现在没有生产调用方了(此前只被那条静默回退触发),仍是 public 且有单测覆盖,按项目规范保留,只提醒。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
