### PR TITLE
fix(workers): 打开 builtin worker 压缩并修 write-back 数据损坏

### DIFF
--- a/crabot-agent/src/workers/builtin/adapter.ts
+++ b/crabot-agent/src/workers/builtin/adapter.ts
@@ -86,6 +86,45 @@ const FORK_MAX_TURNS = 8
 /** spawn 时落盘的 per-worker 上下文文件名（见 persistContext）。 */
 const CONTEXT_FILE = 'context.json'
 
+/** 上下文超限收场时写进 output.log 的信号（见 isSilentContextOverflow）。 */
+const CONTEXT_OVERFLOW_NOTICE =
+  '[builtin-worker] 上下文超限：压缩已用尽，模型仍只能返回空回复（stop_reason=max_tokens）。本化身以 failed 收场。\n'
+
+/**
+ * 识别"burst 因上下文超限静默收场"。engine 侧的真实表征（读 query-loop.ts 确认，不是猜的）：
+ * 压缩重试配额（MAX_MAX_TOKENS_COMPACT_RETRIES=2）耗尽后，engine 对静默 max_tokens 直接
+ * `finishTask()` 收场——outcome 变成 `'completed'`（不是 `'failed'`/`'max_turns'`！）、
+ * `finalText=''`，唯一留下的痕迹是 `finalMessages` 末条 assistant 消息的
+ * `stopReason === 'max_tokens'`。这是结构化信号，比在 `EngineResult.error` 里找文案更可靠
+ * （这条路径下 error 根本不会被设置）。
+ *
+ * adapter 若照常落 `idle`，worker 就变成一个"看起来在等输入"的化身：零输出、零错误信号。
+ * manager 看到 idle 会按"停下且没带问题"继续 `send_to_worker` 推它，**每推一次烧一个满窗口
+ * 调用**，且上下文只增不减 —— 死循环。所以必须落成 `exited(failed)`。
+ *
+ * "静默"这个前提本身必须校验，不能只看 stopReason：LLM 输出被 max output tokens 截断
+ * （有实际文字，只是没写完）时 stopReason 同样是 `'max_tokens'`，但 query-loop 的
+ * `isSilentText`（`processed.text.trim().length === 0`）判它为非静默，走正常 end_turn 分支
+ * completed 收场——与上下文超限无关。这里对齐同一判定：只统计末条 assistant 消息里的 text 块
+ * （忽略 tool_use/raw_reasoning，与 partitionResponseContent 一致），trim 后为空才算静默。
+ *
+ * 判定与 `manager/loop.ts` 的 `isContextOverflow` 分支 1 同源（P4 在 manager 上踩的是同一个坑，
+ * 那段注释是这条判定的原始考据）。这里没有直接 import 复用，两个原因：
+ *   1. 那是 manager loop 的模块私有函数，worker 反向依赖 manager 是跨模块方向错误；
+ *   2. 抽到 engine 公共层属于 engine 改动，超出本次"只动 builtin adapter"的修 bug 范围。
+ * manager 那份还有"分支 2：outcome==='failed' 且 error 文案含超限关键字"，这里不需要——
+ * builtin adapter 对 `outcome === 'failed'` 一律落 `exited(crashed)`，本就是 fail-loud 的终态。
+ */
+function isSilentContextOverflow(result: EngineResult): boolean {
+  const last = result.finalMessages[result.finalMessages.length - 1]
+  if (last?.role !== 'assistant' || last.stopReason !== 'max_tokens') return false
+  const text = last.content
+    .filter((b): b is { type: 'text'; text: string } => b.type === 'text')
+    .map((b) => b.text)
+    .join('')
+  return text.trim().length === 0
+}
+
 /** Re-export for backward compatibility and convenience. */
 export { WorkerExitedError }
 
@@ -592,6 +631,14 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     // 和下面的收尾段互斥锁临界区重复处理。
     const pendingWrites: Promise<void>[] = []
     const writeErrors: unknown[] = []
+    // 本次 burst 内是否真的发生过一次成功的压缩。压缩是对 messages 的**整体重写**
+    // （query-loop.ts compactInPlace：messages.length = 0 后重填），一旦发生，
+    // finalMessages 就不再是 initialMessages 的后缀，下面的 write-back 必须换一条路径。
+    // 判据只看 failedReason 缺席：压缩失败 / abort 都会带上它且 messages 保持原样
+    // （engine 压缩故障链修复后的语义，见 EngineOptions.onCompactionEnd 注释），
+    // 所以"没带 failedReason" ⇒ messages 已被重写。宁可多判（压缩恰好是空操作时也走整条
+    // 重写路径，代价只是多复制一份节点），也绝不能漏判——漏判就是静默数据损坏。
+    let compactedThisBurst = false
     const result: EngineResult = await runEngine({
       prompt: '',
       adapter: builtin.adapter,
@@ -602,8 +649,14 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
         model: builtin.model,
         ...(builtin.maxTurnsPerBurst !== undefined ? { maxTurns: builtin.maxTurnsPerBurst } : {}),
         ...this.safetyOptions(builtin),
-        // session 树以原始消息为真相源，burst 内禁用压缩。压缩与树的协同（折叠节点）是 P7 集成议题。
-        disableCompaction: true,
+        // 长活 worker 的窗口是在**一次 burst 内部**被跑满的（maxTurns 默认 200），
+        // burst 边界折叠够不着，只有 engine 的 per-turn 阈值压缩 + max_tokens 强压重试
+        // 才治得了。session 树仍以原始消息为真相源：老节点一个不删，压缩后的序列另起
+        // 一条新根链（见下面的 write-back）。
+        disableCompaction: false,
+        onCompactionEnd: (info) => {
+          if (info.failedReason === undefined) compactedThisBurst = true
+        },
         abortSignal: abortController.signal,
         onTurn: (event) => {
           if (event.assistantText) {
@@ -629,24 +682,7 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     // 期间新 sendInput 插队"的窗口——判定与状态落定必须是同一个不可分割的临界区。
     // 续 burst 的递归调用放在锁外触发（见下），不然会把 runEngine 的执行时长堵在锁里。
     const continueBurst = await mutex.run(async () => {
-      // burst 结束：把新增消息（finalMessages 相对 initialMessages 的后缀）逐条 append 进 session 树。
-      // 防御断言：若压缩被意外启用，finalMessages.length 会小于 initialMessages.length，
-      // 此时不回写新消息，标化身为 exited(crashed) 并记日志。
-      if (result.finalMessages.length < initialMessages.length) {
-        console.error(
-          `[builtin-adapter] runBurst compaction guard triggered for worker ${instance.worker_id}: ` +
-          `finalMessages.length (${result.finalMessages.length}) < initialMessages.length (${initialMessages.length}). ` +
-          `Compaction was unexpectedly enabled; marking incarnation as crashed.`,
-        )
-        await this.transitionExited(instance, handle, 'crashed')
-        return false
-      }
-      const newMessages = result.finalMessages.slice(initialMessages.length)
-      let parent = tip
-      for (const msg of newMessages as EngineMessage[]) {
-        parent = await instance.sessionTree.append(parent, msg)
-      }
-      instance.tip = parent
+      await this.writeBack(instance, tip, result, initialMessages.length, compactedThisBurst)
 
       if (result.outcome === 'failed' || result.outcome === 'aborted') {
         await this.transitionExited(instance, handle, result.outcome === 'aborted' ? 'killed' : 'crashed')
@@ -666,6 +702,15 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
       // 收尾段检查点）。无论如何都不能继续/续 burst，直接落 exited(killed)。
       if (instance.killRequested) {
         await this.transitionExited(instance, handle, 'killed')
+        return false
+      }
+
+      // 上下文超限静默收场：必须落成真实终态，绝不能落 idle（见 isSilentContextOverflow）。
+      // 位置在 pendingInputs 续 burst 之前——上下文已经压不下去了，再喂新输入续 burst 只是
+      // 每轮再烧一个满窗口调用；排队的消息按既有语义进 dead-letter（transitionExited 负责）。
+      if (isSilentContextOverflow(result)) {
+        await instance.outputLog.append(CONTEXT_OVERFLOW_NOTICE)
+        await this.transitionExited(instance, handle, 'failed', 'failed')
         return false
       }
 
@@ -726,6 +771,8 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     // （crashed 收尾），与 runBurst 保持一致的错误语义。
     const pendingWrites: Promise<void>[] = []
     const writeErrors: unknown[] = []
+    // 见 runBurst 同名变量的注释。
+    let compactedThisBurst = false
     const result: EngineResult = await runEngine({
       prompt: '',
       adapter: builtin.adapter,
@@ -738,7 +785,13 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
         model: builtin.model,
         maxTurns: FORK_MAX_TURNS,
         ...this.safetyOptions(builtin),
-        disableCompaction: true,
+        // fork 也必须开：从压缩点**之前**的老节点 fork 时，pathTo 回溯拿到的是完整未压缩
+        // 历史，本身就可能超窗口。不开压缩，老链 fork 必撞窗口。代价是轻量侧问也可能付一次
+        // 摘要成本——可接受（只在真的超阈值时才付）。
+        disableCompaction: false,
+        onCompactionEnd: (info) => {
+          if (info.failedReason === undefined) compactedThisBurst = true
+        },
         abortSignal: abortController.signal,
         onTurn: (event) => {
           if (event.assistantText) {
@@ -760,21 +813,7 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     }
 
     await mutex.run(async () => {
-      if (result.finalMessages.length < initialMessages.length) {
-        console.error(
-          `[builtin-adapter] runForkBurst compaction guard triggered for worker ${instance.worker_id}: ` +
-          `finalMessages.length (${result.finalMessages.length}) < initialMessages.length (${initialMessages.length}). ` +
-          `Compaction was unexpectedly enabled; marking incarnation as crashed.`,
-        )
-        await this.transitionExited(instance, handle, 'crashed')
-        return
-      }
-      const newMessages = result.finalMessages.slice(initialMessages.length)
-      let parent = tip
-      for (const msg of newMessages as EngineMessage[]) {
-        parent = await instance.sessionTree.append(parent, msg)
-      }
-      instance.tip = parent
+      await this.writeBack(instance, tip, result, initialMessages.length, compactedThisBurst)
 
       if (result.outcome === 'failed' || result.outcome === 'aborted') {
         await this.transitionExited(instance, handle, result.outcome === 'aborted' ? 'killed' : 'crashed')
@@ -788,9 +827,59 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
         return
       }
 
+      // 侧问同样不能因为"上下文满了"就静默报 completed（见 isSilentContextOverflow）。
+      if (isSilentContextOverflow(result)) {
+        await instance.outputLog.append(CONTEXT_OVERFLOW_NOTICE)
+        await this.transitionExited(instance, handle, 'failed', 'failed')
+        return
+      }
+
       // 'completed'（end_turn）与 'max_turns' 都视为一次性侧问正常收尾。
       await this.transitionExited(instance, handle, 'completed', 'completed')
     })
+  }
+
+  /**
+   * burst 收尾把消息写回 session 树。两条互斥路径：
+   *
+   * - **未压缩**：`finalMessages` 是 `initialMessages` + 一段后缀，只回写后缀、挂在 `tip`
+   *   下（P1 起的原行为，一字不变）。
+   * - **压缩过**：`compactInPlace` 是对 messages 的整体重写（`[首条, 摘要, 最近若干条]` 再
+   *   续跑），与老链不再有"公共前缀"关系。此时按后缀 `slice(initialMessages.length)` 取到的
+   *   是**压缩后数组的错位区间**：摘要节点被掐掉、压缩后新生成的前半段消息被掐掉，而切口那
+   *   一条大概率正是一条 `tool_result`——它配对的 `assistant(tool_use)` 恰在被掐掉的那段里。
+   *   这条孤儿 `tool_result` 一旦嫁接到老 tip 下就**落盘了**，之后任何 resume/fork 把
+   *   `pathTo` 的结果发给 LLM 都是 API 400，且 400 文案不匹配任何自愈判定 = 永久卡死。
+   *   （旧的 `finalMessages.length < initialMessages.length` 防御断言挡不住这一幕：长 burst
+   *   压缩后继续跑，长度往往反而更大，断言静默放行；而它触发时又会把整个 burst 几十轮的
+   *   工作全丢掉判 crashed——既漏判又误杀，故删除，由 `compacted` 信号取代。）
+   *
+   *   修法是把整条 `finalMessages` 作为一条**新根链**写入（`append(null, …)`，SessionTree
+   *   本就允许多根，零改动）。老链一个节点不删，因此"从任意历史节点分支"仍然成立——从压缩点
+   *   之前的节点 fork 拿到的是未压缩全量（贵，但可行，且 fork burst 也开着压缩）。
+   */
+  private async writeBack(
+    instance: WorkerInstance,
+    tip: string,
+    result: EngineResult,
+    initialCount: number,
+    compacted: boolean,
+  ): Promise<void> {
+    if (compacted) {
+      let parent: string | null = null
+      for (const msg of result.finalMessages as EngineMessage[]) {
+        parent = await instance.sessionTree.append(parent, msg)
+      }
+      // finalMessages 理论上不会为空（至少含被钉住的首条），空则保持 tip 不动。
+      if (parent !== null) instance.tip = parent
+      return
+    }
+    const newMessages = result.finalMessages.slice(initialCount)
+    let parent = tip
+    for (const msg of newMessages as EngineMessage[]) {
+      parent = await instance.sessionTree.append(parent, msg)
+    }
+    instance.tip = parent
   }
 
   /** worker_id 对应的互斥锁，惰性创建（见 workerMutexes 字段注释）。 */

--- a/crabot-agent/tests/workers/builtin-adapter.test.ts
+++ b/crabot-agent/tests/workers/builtin-adapter.test.ts
@@ -7,6 +7,8 @@ import { BuiltinWorkerAdapter, WorkerExitedError } from '../../src/workers/built
 import { SessionTree } from '../../src/workers/session-tree.js'
 import type { SpawnSpec, IncarnationHandle, IncarnationRef, WorkerContractState } from '../../src/workers/types.js'
 import type { LLMAdapter } from '../../src/engine/llm-adapter-types.js'
+import { defineTool } from '../../src/engine/index.js'
+import type { EngineMessage, ToolDefinition } from '../../src/engine/index.js'
 import * as engineModule from '../../src/engine/query-loop.js'
 import { chunksFromContent } from '../engine/helpers/mock-stream.js'
 
@@ -136,7 +138,131 @@ function makeAdapterGatedFromSecondCall(
   } as unknown as LLMAdapter
 }
 
-function spec(opts: { adapter: LLMAdapter; worker_id?: string }): SpawnSpec {
+/** 一个无副作用的工具，用来在测试里造出 assistant(tool_use) + toolResults 的成对消息。 */
+const ECHO_TOOL: ToolDefinition = defineTool({
+  name: 'echo',
+  description: '回显',
+  isReadOnly: true,
+  inputSchema: { type: 'object', properties: { s: { type: 'string' } } },
+  call: async () => ({ output: 'ok', isError: false }),
+})
+
+interface TurnScript {
+  text?: string
+  toolCalls?: Array<{ name: string; id: string; input: Record<string, unknown> }>
+  stopReason: 'end_turn' | 'tool_use' | 'max_tokens'
+  usage?: { inputTokens: number; outputTokens: number }
+}
+
+/**
+ * 会区分"worker 的 turn 调用"与"压缩摘要调用"的 mock。
+ *
+ * 判据是 `systemPrompt`：ContextManager.compactWithLLM 用自己的 DEFAULT_COMPACT_SYSTEM_PROMPT
+ * 调 callNonStreaming，而测试里 worker 的 systemPrompt 恒为 ''。（不能用 `tools` 判——
+ * runForkBurst 的工具集不含 finish_task，工具为空时与摘要调用无从区分。）
+ * 摘要调用不消费 turn 脚本。
+ */
+function isCompactionCall(params: { systemPrompt?: string }): boolean {
+  return (params.systemPrompt ?? '').length > 0
+}
+
+function makeCompactionAwareAdapter(turns: TurnScript[]): LLMAdapter & { compactionCalls: number } {
+  let i = 0
+  const self = {
+    compactionCalls: 0,
+    stream: vi.fn(async function* (params: { systemPrompt?: string }) {
+      if (isCompactionCall(params)) {
+        self.compactionCalls++
+        yield* chunksFromContent([{ type: 'text', text: '这是被折叠段的摘要。' }], 'end_turn', {
+          inputTokens: 50,
+          outputTokens: 20,
+        })
+        return
+      }
+      const r = turns[i++] ?? turns[turns.length - 1]
+      const content: unknown[] = []
+      if (r.text) content.push({ type: 'text', text: r.text })
+      for (const tc of r.toolCalls ?? []) {
+        content.push({ type: 'tool_use', id: tc.id, name: tc.name, input: tc.input })
+      }
+      yield* chunksFromContent(content, r.stopReason, r.usage ?? { inputTokens: 100, outputTokens: 50 })
+    }),
+    updateConfig: () => {},
+  }
+  return self as unknown as LLMAdapter & { compactionCalls: number }
+}
+
+/**
+ * "起跑 N 条 → burst 内压缩 → 继续跑到 L>N" 的复现脚本（配 contextWindowTokens: 2000，
+ * 阈值 = 2000×0.8 = 1600）：
+ *
+ * - burst 1（spawn）：5 轮 echo + 1 轮收口 → 树里 12 条消息；
+ * - sendInput 追加 1 条 → burst 2 起跑 N = 13；
+ * - burst 2 turn 1（b1）汇报 inputTokens=1900 > 1600 → turn 2 开头 shouldCompact 命中，
+ *   15 条被整体重写成 8 条 [首条, 摘要, 最近 6 条]；
+ * - 其后 b2/b3/b4 + 收口共 7 条 → L = 15。L(15) >= N(13)，旧 length 断言不触发；
+ *   `slice(13)` 取到的是压缩后数组的 index 13（toolResults b4，**孤儿**）与 14。
+ */
+function compactionScript(): TurnScript[] {
+  const echo = (id: string, usage?: { inputTokens: number; outputTokens: number }): TurnScript => ({
+    toolCalls: [{ name: 'echo', id, input: { s: id } }],
+    stopReason: 'tool_use',
+    ...(usage ? { usage } : {}),
+  })
+  return [
+    echo('a1'), echo('a2'), echo('a3'), echo('a4'), echo('a5'),
+    { text: '第一段结束', stopReason: 'end_turn' },
+    // burst 2：第一轮汇报满窗口 usage，逼出下一轮开头的压缩。
+    echo('b1', { inputTokens: 1900, outputTokens: 50 }),
+    echo('b2'), echo('b3'), echo('b4'),
+    { text: '第二段结束', stopReason: 'end_turn' },
+  ]
+}
+
+/** 每轮都返回 text='' + stop_reason='max_tokens'（engine 眼里的"静默 max_tokens"）。 */
+function makeSilentMaxTokensAdapter(gate?: Promise<void>): LLMAdapter {
+  return {
+    stream: vi.fn(async function* (params: { systemPrompt?: string }) {
+      if (gate) await gate
+      if (isCompactionCall(params)) {
+        // 压缩摘要调用（消息太少时 ContextManager 直接返回原样，这里也照常给一段文本）
+        yield* chunksFromContent([{ type: 'text', text: '摘要' }], 'end_turn')
+        return
+      }
+      yield* chunksFromContent([], 'max_tokens', { inputTokens: 199_000, outputTokens: 0 })
+    }),
+    updateConfig: () => {},
+  } as unknown as LLMAdapter
+}
+
+/**
+ * 返回路径里所有"孤儿 tool_result"的 tool_use_id：一条 toolResults 消息，其紧邻的前一条
+ * 不是携带同名 tool_use 的 assistant 消息。孤儿 tool_result 会让 LLM API 直接 400，
+ * 且 400 文案不匹配任何自愈判定——落在 session 树里就是永久卡死。
+ */
+function orphanToolResultIds(path: ReadonlyArray<EngineMessage>): string[] {
+  const orphans: string[] = []
+  path.forEach((msg, idx) => {
+    if (!('toolResults' in msg)) return
+    const prev = idx > 0 ? path[idx - 1] : undefined
+    const available = new Set<string>(
+      prev?.role === 'assistant'
+        ? prev.content.filter((b) => b.type === 'tool_use').map((b) => (b as { id: string }).id)
+        : [],
+    )
+    for (const r of msg.toolResults) {
+      if (!available.has(r.tool_use_id)) orphans.push(r.tool_use_id)
+    }
+  })
+  return orphans
+}
+
+function spec(opts: {
+  adapter: LLMAdapter
+  worker_id?: string
+  tools?: ReadonlyArray<ToolDefinition>
+  contextWindowTokens?: number
+}): SpawnSpec {
   return {
     worker_id: opts.worker_id ?? randomUUID(),
     prompt: '测试任务',
@@ -145,7 +271,8 @@ function spec(opts: { adapter: LLMAdapter; worker_id?: string }): SpawnSpec {
       adapter: opts.adapter,
       model: 'test',
       systemPrompt: '',
-      tools: [],
+      tools: opts.tools ?? [],
+      ...(opts.contextWindowTokens !== undefined ? { contextWindowTokens: opts.contextWindowTokens } : {}),
     },
   }
 }
@@ -233,7 +360,7 @@ describe('BuiltinWorkerAdapter', () => {
     expect(meta.ended_reason).toBe('crashed')
   })
 
-  it('runBurst 传递 disableCompaction: true 到 runEngine', async () => {
+  it('runBurst 传递 disableCompaction: false 到 runEngine', async () => {
     const runEngineSpy = vi.spyOn(engineModule, 'runEngine')
     const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
     const s = spec({
@@ -245,7 +372,7 @@ describe('BuiltinWorkerAdapter', () => {
 
     expect(runEngineSpy).toHaveBeenCalled()
     const callArgs = runEngineSpy.mock.calls[0]?.[0]
-    expect(callArgs?.options?.disableCompaction).toBe(true)
+    expect(callArgs?.options?.disableCompaction).toBe(false)
   })
 
   it('sendInput(idle) → 追加新一轮用户消息并起新 burst，新 burst 可见旧上下文', async () => {
@@ -1425,5 +1552,217 @@ describe('BuiltinWorkerAdapter', () => {
     const retryHandle = await adapter.fork(prevRef, '侧问-重试')
     expect(retryHandle.seq).toBe(2)
     await waitState(adapter, retryHandle, 'exited')
+  })
+
+  // --- 上下文压缩（F2） ---
+
+  it('burst 内发生压缩 → 不得把错位后缀嫁接到老链（数据损坏复现）', async () => {
+    const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+    const llm = makeCompactionAwareAdapter(compactionScript())
+    const s = spec({ adapter: llm, tools: [ECHO_TOOL], contextWindowTokens: 2000 })
+
+    const h = await adapter.spawn(s)
+    await waitState(adapter, h, 'idle')
+
+    // 第一段 burst 建出 13 条消息的老链（1 prompt + 5×(assistant tool_use + toolResults) + 1 收口
+    // assistant = 12，再加下面 sendInput 的 1 条 user）。
+    const treeAfterBurst1 = await SessionTree.load(join(tmp, s.worker_id, 'session.jsonl'))
+    const tipAfterBurst1 = treeAfterBurst1.latestTip()!
+    const oldChainLen = treeAfterBurst1.pathTo(tipAfterBurst1).length
+    expect(oldChainLen).toBe(12)
+
+    await adapter.sendInput(h, '继续干活')
+    await waitState(adapter, h, 'idle')
+
+    // 第二段 burst：turn 1 汇报 1900 tokens（阈值 2000×0.8=1600）→ turn 2 开头触发压缩，
+    // 压缩把 15 条重写成 8 条，随后又跑到 15 条收口。L(15) >= N(13) —— 旧的 length 防御断言
+    // 不会触发，静默放行。
+    expect(llm.compactionCalls).toBeGreaterThan(0)
+
+    const tree = await SessionTree.load(join(tmp, s.worker_id, 'session.jsonl'))
+    const meta = JSON.parse(await fs.readFile(join(tmp, s.worker_id, 'meta-1.json'), 'utf-8')) as { tip_node_id: string }
+    const path = tree.pathTo(meta.tip_node_id)
+    const serialized = JSON.stringify(path)
+
+    // ① 摘要节点必须在路径里（后缀 slice 会把它掐掉）。
+    expect(serialized).toContain('[Earlier conversation summary]')
+    // ② 压缩后新生成的消息一条都不能丢（后缀 slice 会掐掉 b1/b2/b3）。
+    for (const id of ['b1', 'b2', 'b3', 'b4']) {
+      expect(serialized).toContain(id)
+    }
+    // ③ 路径里不得出现孤儿 tool_result —— 它会让后续任何 resume/fork 永久 API 400。
+    expect(orphanToolResultIds(path)).toEqual([])
+  })
+
+  it('压缩后老链一个节点不删：从压缩点之前的节点仍能 fork，拿到的是未压缩全量', async () => {
+    const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+    const llm = makeCompactionAwareAdapter([
+      ...compactionScript(),
+      // fork 侧问：第一轮汇报满窗口 usage，逼出第二轮开头的压缩——从压缩点之前的老节点
+      // fork 拿到的是未压缩全量，本来就可能超窗口，fork burst 必须自己也能压。
+      { toolCalls: [{ name: 'echo', id: 'f1', input: {} }], stopReason: 'tool_use', usage: { inputTokens: 1900, outputTokens: 50 } },
+      { text: 'fork 侧问回复', stopReason: 'end_turn', usage: { inputTokens: 100, outputTokens: 10 } },
+    ])
+    const s = spec({ adapter: llm, tools: [ECHO_TOOL], contextWindowTokens: 2000 })
+
+    const h = await adapter.spawn(s)
+    await waitState(adapter, h, 'idle')
+    const treeAfterBurst1 = await SessionTree.load(join(tmp, s.worker_id, 'session.jsonl'))
+    const oldTip = treeAfterBurst1.latestTip()!
+
+    await adapter.sendInput(h, '继续干活')
+    await waitState(adapter, h, 'idle')
+
+    // 老链仍然完整可回溯（压缩点之前的节点）。
+    const tree = await SessionTree.load(join(tmp, s.worker_id, 'session.jsonl'))
+    const oldPath = tree.pathTo(oldTip)
+    expect(oldPath.length).toBe(12)
+    expect(JSON.stringify(oldPath)).not.toContain('[Earlier conversation summary]')
+    expect(orphanToolResultIds(oldPath)).toEqual([])
+
+    // 从这个未压缩的老节点 fork：能跑通，且 fork burst 自己也开着压缩（否则老链 fork 必撞窗口）。
+    const compactionCallsBeforeFork = llm.compactionCalls
+    const forkH = await adapter.fork({ worker_id: s.worker_id, seq: 1, session_ref: oldTip }, '侧问一句')
+    await waitState(adapter, forkH, 'exited')
+    const forkMeta = JSON.parse(await fs.readFile(join(tmp, s.worker_id, 'meta-2.json'), 'utf-8')) as {
+      ended_reason: string
+      tip_node_id: string
+    }
+    expect(forkMeta.ended_reason).toBe('completed')
+    // fork burst 内部确实压过一次（disableCompaction 若为 true，这里恒为 0）。
+    expect(llm.compactionCalls).toBeGreaterThan(compactionCallsBeforeFork)
+
+    const treeAfterFork = await SessionTree.load(join(tmp, s.worker_id, 'session.jsonl'))
+    const forkPath = treeAfterFork.pathTo(forkMeta.tip_node_id)
+    expect(orphanToolResultIds(forkPath)).toEqual([])
+    expect(JSON.stringify(forkPath)).toContain('[Earlier conversation summary]')
+    expect(JSON.stringify(forkPath)).toContain('fork 侧问回复')
+
+    // 主线 tip 不受 fork 影响。
+    const mainMeta = JSON.parse(await fs.readFile(join(tmp, s.worker_id, 'meta-1.json'), 'utf-8')) as { tip_node_id: string }
+    expect(mainMeta.tip_node_id).not.toBe(forkMeta.tip_node_id)
+    expect(orphanToolResultIds(treeAfterFork.pathTo(mainMeta.tip_node_id))).toEqual([])
+  })
+
+  it('压缩后 resume：新化身从压缩链续跑，路径无孤儿 tool_result', async () => {
+    const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+    const llm = makeCompactionAwareAdapter([
+      ...compactionScript(),
+      { text: 'resume 后第一轮', stopReason: 'end_turn', usage: { inputTokens: 100, outputTokens: 10 } },
+    ])
+    const s = spec({ adapter: llm, tools: [ECHO_TOOL], contextWindowTokens: 2000 })
+
+    const h = await adapter.spawn(s)
+    await waitState(adapter, h, 'idle')
+    await adapter.sendInput(h, '继续干活')
+    await waitState(adapter, h, 'idle')
+
+    await adapter.kill(h)
+    const meta1 = JSON.parse(await fs.readFile(join(tmp, s.worker_id, 'meta-1.json'), 'utf-8')) as { tip_node_id: string }
+    const h2 = await adapter.resume({ worker_id: s.worker_id, seq: 1, session_ref: meta1.tip_node_id }, '醒醒')
+    await waitState(adapter, h2, 'idle')
+
+    const tree = await SessionTree.load(join(tmp, s.worker_id, 'session.jsonl'))
+    const meta2 = JSON.parse(await fs.readFile(join(tmp, s.worker_id, 'meta-2.json'), 'utf-8')) as { tip_node_id: string }
+    const path = tree.pathTo(meta2.tip_node_id)
+    expect(orphanToolResultIds(path)).toEqual([])
+    const serialized = JSON.stringify(path)
+    expect(serialized).toContain('[Earlier conversation summary]')
+    expect(serialized).toContain('醒醒')
+    expect(serialized).toContain('resume 后第一轮')
+  })
+
+  it('未发生压缩时 write-back 仍是"后缀挂在 tip 下"：不另起新链', async () => {
+    const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+    const s = spec({ adapter: makeAdapter([{ text: '一轮就收工', stopReason: 'end_turn' }]) })
+
+    const h = await adapter.spawn(s)
+    await waitState(adapter, h, 'idle')
+
+    // 单根：prompt 根节点 + 一条 assistant，没有第二条根。
+    const raw = await fs.readFile(join(tmp, s.worker_id, 'session.jsonl'), 'utf-8')
+    const nodes = raw.split('\n').filter((l) => l.trim()).map((l) => JSON.parse(l) as { parent_id: string | null })
+    expect(nodes.length).toBe(2)
+    expect(nodes.filter((n) => n.parent_id === null).length).toBe(1)
+  })
+
+  it('runBurst / runForkBurst 都开压缩（disableCompaction: false）', async () => {
+    const runEngineSpy = vi.spyOn(engineModule, 'runEngine')
+    const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+    const s = spec({
+      adapter: makeAdapter([
+        { text: '主线首轮', stopReason: 'end_turn' },
+        { text: 'fork 回复', stopReason: 'end_turn' },
+      ]),
+    })
+
+    const h = await adapter.spawn(s)
+    await waitState(adapter, h, 'idle')
+    const meta = JSON.parse(await fs.readFile(join(tmp, s.worker_id, 'meta-1.json'), 'utf-8')) as { tip_node_id: string }
+    const forkH = await adapter.fork({ worker_id: s.worker_id, seq: 1, session_ref: meta.tip_node_id }, '侧问')
+    await waitState(adapter, forkH, 'exited')
+
+    expect(runEngineSpy.mock.calls[0]?.[0]?.options?.disableCompaction).toBe(false)
+    expect(runEngineSpy.mock.calls[1]?.[0]?.options?.disableCompaction).toBe(false)
+  })
+
+  it('静默 max_tokens（engine 压缩配额耗尽）→ exited(failed)，不是 idle', async () => {
+    const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+    // 每轮都返回 text='' + stop_reason='max_tokens'：engine 压两次仍不行 → finishTask()
+    // 收场（outcome='completed'、finalText=''），adapter 必须把它落成真实终态。
+    const s = spec({ adapter: makeSilentMaxTokensAdapter() })
+
+    const h = await adapter.spawn(s)
+    await waitState(adapter, h, 'exited')
+
+    const meta = JSON.parse(await fs.readFile(join(tmp, s.worker_id, 'meta-1.json'), 'utf-8')) as {
+      state: string
+      ended_reason: string
+      outcome: string
+    }
+    expect(meta.state).toBe('exited')
+    expect(meta.ended_reason).toBe('failed')
+    expect(meta.outcome).toBe('failed')
+
+    // manager 侧看得见原因：output 里有一条明确的错误信号，不再是"零输出零错误信号"。
+    const { chunk } = await adapter.readOutput(h, { offset: 0 })
+    expect(chunk).toContain('上下文超限')
+  })
+
+  it('静默 max_tokens 命中时不再续 burst：pendingInputs 直接进 dead-letter', async () => {
+    const gate = deferred<void>()
+    const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+    const s = spec({ adapter: makeSilentMaxTokensAdapter(gate.promise) })
+
+    const h = await adapter.spawn(s)
+    expect(await adapter.state(h)).toBe('running')
+    await adapter.sendInput(h, '再推一把')
+    gate.resolve()
+    await waitState(adapter, h, 'exited')
+
+    const meta = JSON.parse(await fs.readFile(join(tmp, s.worker_id, 'meta-1.json'), 'utf-8')) as { ended_reason: string }
+    expect(meta.ended_reason).toBe('failed')
+    const { chunk } = await adapter.readOutput(h, { offset: 0 })
+    expect(chunk).toContain('[dead-letter]')
+    expect(chunk).toContain('再推一把')
+  })
+
+  it('fork burst 静默 max_tokens → exited(failed)，不是 completed', async () => {
+    const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+    const s = spec({ adapter: makeSilentMaxTokensAdapter() })
+    // 主线用普通 adapter 先跑出一个 tip，fork 再用静默 adapter —— 这里图省事：主线也会
+    // 落 exited(failed)，但 tip 已经落定，fork 仍可从它分叉。
+    const h = await adapter.spawn(s)
+    await waitState(adapter, h, 'exited')
+    const meta = JSON.parse(await fs.readFile(join(tmp, s.worker_id, 'meta-1.json'), 'utf-8')) as { tip_node_id: string }
+
+    const forkH = await adapter.fork({ worker_id: s.worker_id, seq: 1, session_ref: meta.tip_node_id }, '侧问')
+    await waitState(adapter, forkH, 'exited')
+    const forkMeta = JSON.parse(await fs.readFile(join(tmp, s.worker_id, 'meta-2.json'), 'utf-8')) as {
+      ended_reason: string
+      outcome: string
+    }
+    expect(forkMeta.ended_reason).toBe('failed')
+    expect(forkMeta.outcome).toBe('failed')
   })
 })


### PR DESCRIPTION
## 打开 builtin worker 的上下文压缩,并修它暴露的 write-back 数据损坏

压缩三步里的第 2 步(第 1 步是 #57)。**只改 `workers/builtin/adapter.ts`**,engine / session-tree / 协议零改动。

builtin adapter 当初把 `disableCompaction` 写死为 `true`,注释自陈是"P7 集成议题"。现在把它打开——但直接打开会立刻造成静默数据损坏,所以本 PR 的主体是修那个。

### 静默数据损坏(实测坐实)

write-back 用 `finalMessages.slice(initialMessages.length)`,**假设 finalMessages 是 initialMessages + 后缀**;而 `compactInPlace` 是**整体重写**。

复现构造:窗口 2000 token(阈值 1600),burst 2 起跑 N=13 条,第二轮开头触发压缩把 15 条整体重写成 8 条,其后再跑 4 轮到 L=15。

只翻 `disableCompaction: false`、write-back 不动,**落盘路径实测**:

```
assistant "第一段结束" → user "继续干活" → user{toolResults:[b4]} → assistant "第二段结束"
```

三处损坏同时坐实:

1. **摘要节点丢了**(断言首先挂在这里);
2. `b1/b2/b3` 六条 + 那条 `assistant(tool_use b4)` **全丢**;
3. **嫁接点正是孤儿 `tool_result(b4)`** —— 前一条是普通 user 消息。

第 3 条就是"之后任何 resume/fork 永久 API 400、落盘且无自愈路径"的成因。变异验证复跑时,resume 用例把它打成 `expected [ 'b4' ] to deeply equal []`——**可机检,不靠肉眼看 JSON**。

而现有那条防御断言在这个场景下**完全不触发**(`L=15 >= N=13`,静默放行);反过来 `L < N` 时它又会误杀整个 burst 几十轮的工作。

### 修法

用 `onCompactionEnd` 的信号判断本 burst 有没有压缩过:

- **压缩过** → 不再往老链嫁接后缀,把压缩后的完整序列作为**一条新根链**写入。`session-tree.ts` 的 `append(null, …)` 本就合法,**多根天然成立,零改动**;
- **没压缩过** → 保持现有的后缀 slice 路径,**行为逐字不变**;
- 删掉那条既漏判又误杀的 length 断言,由上面的信号取代。

老节点全部保留,**任意历史节点仍可分支**(压缩点之前的节点 fork 出来是未压缩全量)。

### 压缩失败路径:三种情形自洽,不需要额外分支

#57 之后压缩失败会抛错终止 burst,所以这里要想清楚:

| 情形 | `compacted` | write-back 走哪条 | 终态 |
|---|---|---|---|
| 只压过一次且失败 | false | 后缀路径(messages 未被改写,后缀假设仍成立) | `exited(crashed)` |
| 先成功后失败 | true | 整条新链(**压缩后的工作不丢**) | `exited(crashed)` |
| abort | `failedReason='aborted'` | 后缀路径 | `exited(killed)` |

关键是 write-back 在 outcome 判定**之前**(既有次序未动),**失败的 burst 也先把工作落盘再判终态**。

### 静默 max_tokens 落 `exited(failed)`,不再是 idle

这是"死循环烧钱"的根:engine 遇静默 max_tokens 直接 `finishTask()` 返回 `completed` + 空 finalText,adapter 落 **idle** → worker 变成"看起来在等输入"的化身,**零输出零错误信号** → manager 见 idle 继续 `send_to_worker` 推它,**每推一次烧一个满窗口调用**。

压缩开启后这条路径本应极少发生,但兜底必须 fail-loud。

**一处取舍**:`manager/loop.ts:534-548` 有识别同一情况的既有逻辑(P4 踩过同一个坑),我**对齐了它的语义**(尤其"静默必须校验、不能只看 stopReason"那条)但**没有 import**。原因:① 那是 manager loop 的模块私有函数,`workers/` 反向依赖 `manager/` 是**跨模块方向错误**,还会把整个 manager loop 拖进 adapter 的 import 图;② 干净做法是抽到 engine 公共层,但那是 engine 改动、超出本次范围。**代码注释已写明后续应提到 `engine/` 消重复。** 如果倾向现在就抽,可以改。

### fork burst 也开压缩

不开则老链 fork 必撞窗口。代价是轻量侧问也可能付一次摘要成本,可接受。

### 变异验证

| 变异 | 结果 |
|---|---|
| 去掉"压缩过整条写" | 3 挂(**含孤儿 b4 现形**) |
| 静默 max_tokens 改回 idle | 3 挂 |
| fork burst 关掉压缩 | 2 挂 |

### 验证

**2377 passed | 2 skipped,零失败**(基线 `1 failed | 2368 passed`,那 1 个是已知 flaky `bg-shell`;2368+8+1=2377,零回归)。`tsc --noEmit` 干净,`tmux` 无残留。

### 发现但未改

1. **压缩空操作仍报成功** —— engine 侧无法区分"压了"和"没压成也没报错"。本次用偏保守判定绕过:**宁可多判多复制一份节点,绝不漏判**;
2. 单条超大 `tool_result` 仍是死局(tail relief 未实现,那份 `2026-07-18` spec 三项决策至今全未实施);
3. 压缩参数不可调,且摘要 prompt 是为对话型 agent 写的(worker 没有"用户")—— 属压缩三步的第 3 步;
4. **新链与老链无血缘记录** —— P6 的 readTrace 要观测时需补 `derived_from`;
5. 摘要 LLM 调用不进 trace;`maxTurnsPerBurst` 现网未设。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
