### PR TITLE
fix(agent): manager 与 builtin worker 关闭 v2 的强制汇报 gate

### DIFF
--- a/crabot-agent/src/manager/loop.ts
+++ b/crabot-agent/src/manager/loop.ts
@@ -512,6 +512,15 @@ export class ManagerLoop {
       disableCompaction: true,
       humanMessageQueue: this.mailbox,
       onTurn: () => refreshLedgerRender(),
+      // engine 的 forced_summary 兜底(silent end_turn → 注入"你还没向人类发过内容"追问,
+      // 最多 3 次)是 v2 worker loop 的机制:那条路径下 caller 用一整套 outbound buffer
+      // 跟踪"这轮有没有发过",engine 只是照着它的判定兜底。manager 没有那套跟踪,不传等于
+      // 恒等于"没发过"——现网实证:manager 明明已经 send_message 回过话了,收尾时仍被连追
+      // 三次,逼出三条重复发言。
+      // 更根本的是语义:manager 本来就是"跟人类说话的那位",这一轮该不该说话由它自己判断
+      // (纪律写在 manager system prompt 的收尾责任段里),不需要 engine 在运行时替它决定。
+      // 静默 end_turn 对 manager 是完全正常的完成态(比如这次唤醒只是派活或只读检查)。
+      suppressForcedSummary: () => true,
     }
 
     const result = await runEngine({

--- a/crabot-agent/src/workers/builtin/adapter.ts
+++ b/crabot-agent/src/workers/builtin/adapter.ts
@@ -673,6 +673,15 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
         // 才治得了。session 树仍以原始消息为真相源：老节点一个不删，压缩后的序列另起
         // 一条新根链（见下面的 write-back）。
         disableCompaction: false,
+        // engine 的 forced_summary 兜底（silent end_turn → 注入"你还没向人类发过内容，
+        // 请调 send_message"追问，最多 3 次）是 v2 worker loop 的机制，对 v3 的 builtin
+        // worker 完全不适用：worker 不跟人类说话，工具面里根本没有 send_message，被催
+        // 也无从执行——每次 end_turn 白烧最多 3 轮 LLM。而且那段文案与 worker 的 system
+        // prompt 直接冲突（prompt 刻意不提"联系人类"，就是不想把这个念头塞进上下文），
+        // 还会污染带给 manager 的收尾 assistantText（催出来的废话）。
+        // worker 的收尾信号是 finish_task；silent end_turn 只意味着"这一 burst 说完了"，
+        // 由上面的收尾段落成 idle 等下一次唤醒，本就是正常态。
+        suppressForcedSummary: () => true,
         onCompactionEnd: (info) => {
           if (info.failedReason === undefined) compactedThisBurst = true
         },
@@ -809,6 +818,10 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
         // 历史，本身就可能超窗口。不开压缩，老链 fork 必撞窗口。代价是轻量侧问也可能付一次
         // 摘要成本——可接受（只在真的超阈值时才付）。
         disableCompaction: false,
+        // 同 runBurst：v2 的 forced_summary 兜底对 v3 worker 不适用。fork 更甚——它连
+        // finish_task 都没有，end_turn 就是侧问的正常收尾信号，静默收尾（比如答案已经
+        // 通过工具写出去了）不该被追着要"发给人类"。
+        suppressForcedSummary: () => true,
         onCompactionEnd: (info) => {
           if (info.failedReason === undefined) compactedThisBurst = true
         },

--- a/crabot-agent/tests/manager/loop.test.ts
+++ b/crabot-agent/tests/manager/loop.test.ts
@@ -760,6 +760,24 @@ describe('ManagerLoop', () => {
     expect(state.recent.length).toBeGreaterThan(0)
   })
 
+  it('manager 静默 end_turn(本轮没调任何发送工具)不触发 engine 的 forced_summary 追问,也不多烧 LLM 轮次', async () => {
+    const { adapter, calls, queue } = makeAdapter()
+    // 只脚本化一轮:静默 end_turn(无 text、无工具调用)。若 forced_summary gate 生效,
+    // engine 会注入追问并续 loop —— 队列已空,mock 会用默认回复应答,calls 变成 2 次以上。
+    queue.push({ stopReason: 'end_turn' })
+
+    const loop = new ManagerLoop(baseDeps({ store, adapter }))
+    const result = await loop.wakeUp({ kind: 'human_messages', messages: [makeChannelMessage('你好')] })
+
+    expect(result.outcome).toBe('completed')
+    // 语义不变量①:没有任何一轮的上下文里出现过 forced_summary 的文案。
+    const allMessages = JSON.stringify(calls.map((c) => c.messages))
+    expect(allMessages).not.toContain('你刚才以 end_turn 结束但还没有向人类发送任何内容')
+    // 语义不变量②:静默 end_turn 直接被接受为正常完成态,只跑了一轮 LLM。
+    expect(calls).toHaveLength(1)
+    expect(result.turns).toBe(1)
+  })
+
   // --- EpisodeResult.repliedToHuman(P7 J Task 3.1:群聊注意力退避的 `replied` 信号) ---
 
   describe('EpisodeResult.repliedToHuman', () => {

--- a/crabot-agent/tests/workers/builtin-adapter.test.ts
+++ b/crabot-agent/tests/workers/builtin-adapter.test.ts
@@ -12,6 +12,10 @@ import type { EngineMessage, ToolDefinition } from '../../src/engine/index.js'
 import * as engineModule from '../../src/engine/query-loop.js'
 import { chunksFromContent } from '../engine/helpers/mock-stream.js'
 
+/** engine 的 FORCED_SUMMARY_PROMPT 首句(query-loop.ts)。worker 不跟人类说话、也没有
+ *  send_message 工具，这段文案一旦出现在它的上下文里就是 bug。 */
+const FORCED_SUMMARY_MARKER = '你刚才以 end_turn 结束但还没有向人类发送任何内容'
+
 function makeAdapter(
   responses: Array<{
     text?: string
@@ -375,6 +379,21 @@ describe('BuiltinWorkerAdapter', () => {
     expect(callArgs?.options?.disableCompaction).toBe(false)
   })
 
+  it('runBurst 静默 end_turn 不触发 engine 的 forced_summary 追问,也不多烧 LLM 轮次', async () => {
+    const llm = makeAdapter([{ stopReason: 'end_turn' }]) // 无 text、无工具调用 = 静默 end_turn
+    const workerAdapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+    const h = await workerAdapter.spawn(spec({ adapter: llm }))
+    await waitState(workerAdapter, h, 'idle')
+
+    const streamMock = llm.stream as unknown as { mock: { calls: Array<[{ messages: unknown }]> } }
+    // 语义不变量①:worker 的上下文里从未出现过 forced_summary 的文案(它连 send_message
+    // 工具都没有,被催也无从执行)。messages 数组是 engine 跨轮原地 push 的同一个引用,
+    // 事后 stringify 即可看到本次 burst 注入过的全部内容。
+    expect(JSON.stringify(streamMock.mock.calls)).not.toContain(FORCED_SUMMARY_MARKER)
+    // 语义不变量②:静默 end_turn 直接被接受,只跑了一轮 LLM(gate 生效时会变成 1+3 轮)。
+    expect(streamMock.mock.calls).toHaveLength(1)
+  })
+
   it('sendInput(idle) → 追加新一轮用户消息并起新 burst，新 burst 可见旧上下文', async () => {
     const runEngineSpy = vi.spyOn(engineModule, 'runEngine')
     const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
@@ -589,6 +608,30 @@ describe('BuiltinWorkerAdapter', () => {
       .map((l) => JSON.parse(l) as { node_id: string; parent_id: string | null })
     const childrenOfMainTip = rawNodes.filter((n) => n.parent_id === mainTip)
     expect(childrenOfMainTip.length).toBe(1)
+  })
+
+  it('runForkBurst 静默 end_turn 同样不触发 forced_summary 追问,也不多烧 LLM 轮次', async () => {
+    const llm = makeAdapter([
+      { text: '首轮回复', stopReason: 'end_turn' }, // 主线 burst
+      { stopReason: 'end_turn' }, // fork 的 burst:静默 end_turn(此后重复该条)
+    ])
+    const workerAdapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+    const s = spec({ adapter: llm })
+    const h = await workerAdapter.spawn(s)
+    await waitState(workerAdapter, h, 'idle')
+
+    const tree = await SessionTree.load(join(tmp, s.worker_id, 'session.jsonl'))
+    const prevRef: IncarnationRef = { worker_id: s.worker_id, seq: 1, session_ref: tree.latestTip()! }
+    const forkHandle = await workerAdapter.fork(prevRef, '侧问问题')
+    await waitState(workerAdapter, forkHandle, 'exited')
+
+    const streamMock = llm.stream as unknown as { mock: { calls: Array<[{ messages: unknown }]> } }
+    expect(JSON.stringify(streamMock.mock.calls)).not.toContain(FORCED_SUMMARY_MARKER)
+    // 主线 1 轮 + fork 1 轮 = 2 轮;gate 生效时 fork 会多烧 3 轮。
+    expect(streamMock.mock.calls).toHaveLength(2)
+
+    const forkMeta = JSON.parse(await fs.readFile(join(tmp, s.worker_id, 'meta-2.json'), 'utf-8'))
+    expect(forkMeta.ended_reason).toBe('completed')
   })
 
   it('fork 不要求 prev 处于任何特定状态：主线仍 running 时也能 fork', async () => {


### PR DESCRIPTION
## 关掉 v2 的强制汇报 gate(manager / builtin worker)

**上线当天真机发现的问题**,每次对话都在白烧 LLM 调用。

### 现象

admin-chat 上一次简单提问,manager 回了**四条**消息:

```
 5 assistant  send_message("检查完成:核心系统当前运行正常…")   ← 已经答了
 8 user       你刚才以 end_turn 结束但还没有向人类发送任何内容…  ← engine 注入
10 user       (同一句又来一次)
11 assistant  send_message("补充说明:本次仅做了只读健康检查…")
14 user       (第三次)
15 assistant  send_message("健康检查结果已经汇报完毕…")
```

### 根因

engine 内置 `FORCED_SUMMARY_PROMPT`(`query-loop.ts:53`):agent 以 end_turn 收尾但"没向人类发过内容"时注入追问逼它重说,最多 3 次。

它由 `options.suppressForcedSummary?.()` 关闭,而全仓**只有一个传入点**——`agent-handler.ts:1760`,即 v2 的 worker loop。**manager 没传,builtin worker 也没传。**

关键在于:**"有没有发过"是 caller 告诉 engine 的,不是 engine 自己看的**。v2 用一整套 outbound buffer 跟踪算这个值;manager 没有那套,于是**永远等于"没发过"**,gate 每轮必触发。

### 两处后果

| | |
|---|---|
| **manager** | 每次 end_turn 被催 → 一条回答后跟两条废话,每条多烧一轮 LLM(上方即实测) |
| **builtin worker** | **更糟** —— v3 的 worker **根本没有 `send_message` 工具**(它不跟人类说话,收尾用 `finish_task`)。gate 一遍遍让它去调一个不存在的工具,**每次 end_turn 白烧最多 3 轮** |

第二条还跟另外两处设计打架:worker 的 prompt 刻意**不提**"联系人类"(避免把念头塞进上下文),而 engine 在运行时反复提;#61 刚做的"end_turn 带 text 给 manager",带过去的可能正是被催出来的废话。

### 改法

纯 additive,只补开关 + 注释,**engine 里 gate 本身一行未动**(v2 的 `agent-handler` 还在用它;删除属退役清理 PR L 的范围):

- `manager/loop.ts` 的 `runAttempt()`;
- `workers/builtin/adapter.ts` 的 `runBurst`(主 burst)与 `runForkBurst`(fork)。

注释按各自场景写明理由:manager 自己就是跟人类说话的那位、说不说由它判断(纪律在 system prompt);worker 在 v3 下不跟人类说话、收尾信号是 `finish_task`;fork 连 `finish_task` 都没有,`end_turn` 就是侧问的正常收尾。

### 用例:断行为不断参数

三条用例都**跑真实 engine** + mock LLM,观察实际发生的事:

1. **没有注入** —— 把 adapter 每次 `stream` 收到的全部 `messages` stringify,断言不含 `FORCED_SUMMARY_PROMPT` 首句。engine 跨轮在同一数组上原地 push,所以事后一次 stringify 就能看到本次 run 注入过的全部内容,**触发过哪怕一次都会被抓到**;
2. **没有额外 LLM 轮次** —— 断言 stream 调用次数恰为 1(fork 用例是主线 1 + fork 1 = 2)。mock 队列耗尽后重复最后一条脚本,gate 一旦生效必然多出 3 轮;
3. 附带断正常态没被改坏(`turns===1` / `outcome==='completed'` / fork 的 `ended_reason==='completed'`)。

RED 阶段三条全红,失败输出里能直接看到上下文里被连注的 3 条 `FORCED_SUMMARY_PROMPT`。

### 变异验证

| 变异 | 结果 |
|---|---|
| 删 manager 那处 | `loop.test.ts` 1 failed(正是新用例) |
| 删 `runBurst` 那处 | 只挂 runBurst 用例 |
| 删 `runForkBurst` 那处 | 只挂 runForkBurst 用例 |

一一对应,无交叉遮蔽。

### 验证

基线 **2387 passed / 0 failed** → 改后 **2389 passed | 1 failed**,唯一失败是已知 flaky `bg-entities/trace`(单跑 4/4 通过,且它测的是 bg shell 退出码 → trace 事件,**根本不经过 `runEngine`**)。`tsc --noEmit` exit 0。

### 另外两处漏传的 `runEngine`,**刻意没动**

`engine/sub-agent.ts:78`(forkEngine)与 `engine/bg-entities/bg-agent.ts:167`(spawnPersistentAgent)同样没传,但它们**不在 v3 的 manager/worker 路径上**,而且语义不同:**subagent / bg-agent 的交付物就是 finalText**(返回给父 agent),silent end_turn 在那里确实是异常,gate 的"逼它重说"有价值。

那里真正错的只是**文案提到了 `send_message`**(subagent 通常没这个工具)——改它等于改 gate 实现本身,落在退役清理 PR L 的范围。已记录。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
