### PR TITLE
fix(agent): 启动时拉取配置改为退避重试,避开与 admin 的启动竞态

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,6 +1,18 @@
 # Crabot 项目进度
 
-> 最后更新：2026-08-01 — Manager/Worker 拆分 P7 / PR F：builtin worker 注入通道（分支 feat/mw-p7f-builtin-injection，未合并 main）
+> 最后更新：2026-08-03 — 冷启动配置竞态修复（分支 fix/agent-config-pull-retry，未合并 main）
+
+## 2026-08-03 — 冷启动配置竞态：agent 拉配置改为退避重试
+
+- 诊断：`.superpowers/sdd/startup-race-diagnosis.md`；实施报告：`.superpowers/sdd/startup-race-fix-report.md`。分级为**小改动**（局部、不碰协议/接口/状态机/权限语义，可用定向回归证明）。
+- 病灶：MM 按 `start_priority` 串行 spawn（admin=10 / agent=20），**间隔仅 1s、无依赖声明**，而 admin 要跑完整个 `onStart()` 才 listen → agent 那一下 pull 必然 ECONNREFUSED → 旧实现**一次性放弃**落 unconfigured；admin 侧 push 兜底的判据又是「agent 已 register」（MM `resolve` 只认 `status==='running'`）→ 此刻还没注册 → `Module not found` → 不再推。**双向死锁**，生产每次冷启动必现，且 `SIGTERM` 按设计不触发重启，只能 `kill -9`。
+- 主修：`ConfigLoader.loadWithRetry()`——pull 失败退避重试（500ms 起、封顶 2s、预算 60s），耗尽预算仍落 unconfigured 兜底。**封顶取 2s 是有理由的**：它等于「admin listen」到「agent register」的额外延迟上限，必须让 register 稳落在 admin 侧 `ensureResumeSweepAfterAgentReady` 那个 60s 就绪窗口内，否则 resume sweep 会被推到窗口外。`CRABOT_ADMIN_ENDPOINT` 缺失属环境问题不是竞态，直接兜底不空转。
+- **修在 pull 侧而不是 push 侧是硬要求**：`pushConfigToAgentModules` 下发的字段里**没有 `system_prompt`、没有 `mcp_servers`**，靠 push 活过来的 agent 是空 prompt + 零 MCP，只是"能跑 LLM"不是"配置完整"。这条是**独立缺陷，本次未修**（任务约束不动 admin），连同 `ensureResumeSweepAfterAgentReady` 首推必失败后 `return` 永不再试那条一起挂账。
+- "等待是安全的"逐条复核过，不是照抄诊断：MM 健康检查只扫 `status==='running'`（:939-944），而 `running` 只在 `handleRegister`（:316）里置，spawn 后是 `starting`；`startModuleProcess` 不 await 注册、全文件无 spawn 超时；`crabot start -d` 的 30s 就绪轮询只探 MM 与 Admin Web 不看 agent；重试窗口内被 stop 走 Node 默认 SIGTERM 直接退出，MM 侧 `wasRunning===false` 不发 crashed、不触发 auto_restart。
+- 附修：启动对账 `startManagerStackReconciliation()` 从 `onStart()` 挪到 `register()` 之后发起——它的 fs 扫描 + tmux 子进程占满 libuv 默认 4 线程池，而 `register()` 的 `getaddrinfo` 排在同一个池上，并发跑会把注册拖慢、放大竞态窗口（诊断 §2.3 推测的机制）。仍不 await，零语义变化；对应集成用例改成按 main.ts 真实顺序调用，钉住的语义一字未减。
+- 顺带修掉日志里那句空 message：admin 未 listen 时 Node 22 happy-eyeballs 抛的 `AggregateError` 的 `.message` 是空字符串（旧日志 `Failed to load config from Admin: ` 冒号后什么都没有就是它），现在退回 `errors[]` 显示真实原因；重试期间首次失败打一行、之后每 10s 才打一行进度，不刷屏。
+- 验证：`crabot-agent` 全量 `2393 passed | 2 skipped`（204 文件），基线（detached 到 base 实跑）`2390 | 2`，差值 = 新增 3，**零回归**；`tsc --noEmit` 干净；变异实测（把退避 break 改成无条件 break = 去掉重试）→ 两条重试用例立刻挂。
+- **不碰的边界**：`startAutoStartModules` / MM 注册契约（用户在 `feat/module-health-lifecycle` 上做那块）、admin 的 push 路径。改动全部落在 `crabot-agent/src/` 三个文件内。
 
 ## 2026-08-01 — Manager/Worker 拆分 P7 / PR F：builtin worker 注入通道（manager 终于能派出一个能干活的 builtin worker）
 

--- a/crabot-agent/src/core/config-loader.ts
+++ b/crabot-agent/src/core/config-loader.ts
@@ -59,6 +59,103 @@ export class ConfigLoader {
   }
 
   /**
+   * 启动期加载配置：失败退避重试，耗尽预算才落 unconfigured 兜底。
+   *
+   * **为什么要重试**：MM 按 start_priority 串行 spawn（admin=10 / agent=20），间隔只有 1s
+   * 且没有依赖声明，而 admin 要跑完整个 onStart()（loadData / 迁移 / 各 manager / web server）
+   * 才 listen —— agent 启动时那一下 pull 必然 ECONNREFUSED。旧实现 pull 一次就放弃落
+   * unconfigured；而 admin 侧的 push 兜底判据是「agent 已 register」，此刻还没注册 → 推不动，
+   * 双向死锁，只能 kill -9 agent。重试把 pull 这条主路径等到 admin 就绪为止。
+   *
+   * **为什么可以等**：MM 的健康检查只覆盖 status==='running' 的模块
+   * （crabot-core/src/index.ts:939-944），status 是 register 时才置的；spawn 后到 register
+   * 之间是 'starting'，MM 既不探活也没有 spawn 超时。所以推迟 register 几十秒是安全的。
+   *
+   * **为什么必须走 pull 而不是靠 push**：admin 的 pushConfigToAgentModules 不下发
+   * system_prompt / mcp_servers，靠 push 活过来的 agent 是空 prompt + 零 MCP。
+   *
+   * 默认预算 60s 与 admin 侧 ensureResumeSweepAfterAgentReady 的 60s 等待窗口对齐；
+   * 单次退避封顶 2s，保证「admin listen」到「agent register」的额外延迟不超过一个退避间隔。
+   * 参数仅为可测注入，生产用默认值。
+   */
+  static async loadWithRetry(
+    rpcClient: RpcClient,
+    adminEndpoint: string | undefined,
+    options: { budgetMs?: number; initialDelayMs?: number; maxDelayMs?: number } = {}
+  ): Promise<UnifiedAgentConfig> {
+    const budgetMs = options.budgetMs ?? 60_000
+    const initialDelayMs = options.initialDelayMs ?? 500
+    const maxDelayMs = options.maxDelayMs ?? 2_000
+
+    // endpoint 没配是环境问题，不是启动竞态，重试只会白等一个预算
+    if (adminEndpoint) {
+      const startedAt = Date.now()
+      const deadline = startedAt + budgetMs
+      let delay = initialDelayMs
+      let attempts = 0
+      let lastLoggedAt = 0
+      let lastError = ''
+
+      for (;;) {
+        attempts += 1
+        try {
+          const config = await this.load('', rpcClient, adminEndpoint)
+          if (attempts > 1) {
+            console.log(
+              `[ConfigLoader] Admin 就绪，第 ${attempts} 次拉取成功（等待 ${Math.round((Date.now() - startedAt) / 1000)}s）`
+            )
+          }
+          return config
+        } catch (error) {
+          lastError = this.describeError(error)
+          const now = Date.now()
+          if (attempts === 1) {
+            // 首次失败只打一行，说清楚在等谁、等多久，避免每次退避都刷屏
+            console.warn(
+              `[ConfigLoader] Admin 暂不可达（${lastError}），等待 Admin 就绪后重试（最长 ${Math.round(budgetMs / 1000)}s）`
+            )
+            lastLoggedAt = now
+          } else if (now - lastLoggedAt >= 10_000) {
+            console.warn(
+              `[ConfigLoader] 仍在等待 Admin 就绪（已等 ${Math.round((now - startedAt) / 1000)}s，第 ${attempts} 次尝试）`
+            )
+            lastLoggedAt = now
+          }
+          if (now + delay >= deadline) break
+          await new Promise((resolve) => setTimeout(resolve, delay))
+          delay = Math.min(delay * 2, maxDelayMs)
+        }
+      }
+
+      console.warn(
+        `[ConfigLoader] Failed to load config from Admin: ${lastError}（${attempts} 次尝试，耗时 ${Math.round((Date.now() - startedAt) / 1000)}s）`
+      )
+    } else {
+      console.warn('[ConfigLoader] Failed to load config from Admin: Admin endpoint not configured')
+    }
+
+    console.warn('Starting in unconfigured mode, waiting for config push from Admin...')
+    return this.createUnconfiguredConfig()
+  }
+
+  /**
+   * admin 未 listen 时 Node 22 的 happy-eyeballs 抛的是 AggregateError，其 message 为空字符串
+   * ——旧日志里那句 `Failed to load config from Admin: ` 冒号后什么都没有就是它。
+   * 这里退回 name/errors 让日志有信息量。
+   */
+  private static describeError(error: unknown): string {
+    if (error instanceof Error) {
+      if (error.message) return error.message
+      const inner = (error as { errors?: unknown[] }).errors
+      if (Array.isArray(inner) && inner.length > 0) {
+        return inner.map((e) => (e instanceof Error ? e.message : String(e))).join('; ')
+      }
+      return error.name
+    }
+    return String(error)
+  }
+
+  /**
    * 从 Admin 获取配置
    */
   private static async loadFromAdmin(

--- a/crabot-agent/src/main.ts
+++ b/crabot-agent/src/main.ts
@@ -54,15 +54,9 @@ async function main(): Promise<void> {
   // 从 Admin 加载配置（唯一来源）
   const adminEndpoint = process.env.CRABOT_ADMIN_ENDPOINT
 
-  let config: UnifiedAgentConfig
-  try {
-    config = await ConfigLoader.load('', rpcClient, adminEndpoint)
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error)
-    console.warn(`Failed to load config from Admin: ${message}`)
-    console.warn('Starting in unconfigured mode, waiting for config push from Admin...')
-    config = ConfigLoader.createUnconfiguredConfig()
-  }
+  // admin 比 agent 只早 spawn 约 1s，但要跑完整个 onStart() 才 listen —— 首次 pull 必然扑空。
+  // 退避重试等 admin 就绪；耗尽预算仍落 unconfigured 兜底（见 ConfigLoader.loadWithRetry）。
+  const config: UnifiedAgentConfig = await ConfigLoader.loadWithRetry(rpcClient, adminEndpoint)
 
   // Module Manager 会通过环境变量分配端口，覆盖配置文件中的端口
   if (process.env.Crabot_PORT) {
@@ -98,6 +92,9 @@ async function main(): Promise<void> {
   try {
     await agent.start()
     await agent.register()
+    // 启动对账放在 register 之后发：它的 fs 扫描 + tmux 子进程会占满 libuv 默认 4 线程池，
+    // 而 register 的 getaddrinfo 排在同一个池上——并发跑会把注册拖慢。仍然不 await。
+    agent.startManagerStackReconciliation()
     console.log('Unified Agent module started successfully')
     console.log(`- Module ID: ${config.module_id}`)
     console.log(`- Port: ${config.port}`)

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -3181,7 +3181,6 @@ export class UnifiedAgent extends ModuleBase {
     // 探測是否有飛書 channel，決定是否注入 read_feishu_document 工具
     this.detectFeishuChannel().catch(() => {/* 探测失败不影响启动 */})
     this.sessionManager.startCleanup()
-    this.startManagerStackReconciliation()
 
     // Connect to external MCP servers (Admin-configured)
     if (this.agentConfig?.mcp_servers && this.agentConfig.mcp_servers.length > 0) {
@@ -3216,7 +3215,12 @@ export class UnifiedAgent extends ModuleBase {
   }
 
   /**
-   * manager 栈的启动对账（§12），`onStart()` 里发一次，**不 await**。
+   * manager 栈的启动对账（§12），启动时发一次，**不 await**。
+   *
+   * **为什么在 register 之后发**（`main.ts`）：对账的 fs 扫描（`scanOrphans` 逐个 worker
+   * 目录 readdir + readFile）和 adapter 的 tmux 子进程都占 libuv 默认 4 线程池，而
+   * `register()` 的 `getaddrinfo` 排在同一个池上——与注册并发跑会把注册拖慢，放大
+   * 「agent 尚未注册 → admin 推不动配置」的冷启动窗口。对账本身什么时候跑都行。
    *
    * **为什么不 await**：对账要向三个 adapter 逐个问在途化身的死活（CLI 实现会起子进程），
    * 台账非空时耗时不可控；agent 的启动不能挂在它上面——`start()` 返回晚了，MM 的健康探测
@@ -3227,7 +3231,7 @@ export class UnifiedAgent extends ModuleBase {
    * `reconcileOnStartup` 走 `LedgerStore.init()` → 一次 `mkdir -p <dataRoot>/agent/ledgers`
    * 加一次空目录 readdir，随后零 worker 可对账。唯一的可观测副作用就是那个空目录被建出来。
    */
-  private startManagerStackReconciliation(): void {
+  startManagerStackReconciliation(): void {
     const stack = this.managerStack
     if (!stack) return
     void reconcileManagerStack(stack)

--- a/crabot-agent/tests/core/config-loader.test.ts
+++ b/crabot-agent/tests/core/config-loader.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
+import type { RpcClient } from 'crabot-shared'
 import { ConfigLoader } from '../../src/core/config-loader.js'
 
 /**
@@ -30,5 +31,85 @@ describe('ConfigLoader.convertAdminConfigToLocal — tmp_page_base_url 透传', 
       convertAdminConfigToLocal: (c: unknown, id: string) => { agent_config: { tmp_page_base_url?: string } }
     }).convertAdminConfigToLocal(baseAdminConfig, 'crabot-agent')
     expect(local.agent_config.tmp_page_base_url).toBeUndefined()
+  })
+})
+
+/**
+ * 回归：冷启动竞态。MM 按 start_priority 串行 spawn（admin=10 / agent=20），间隔仅 1s 且无依赖
+ * 声明，而 admin 要跑完整个 onStart() 才 listen —— agent 启动时那一下 pull 必然 ECONNREFUSED。
+ * 旧实现只 pull 一次就落 unconfigured，而 admin 侧的 push 兜底又要求 agent 已 register，
+ * 双向死锁，生产上每次冷启动必现，只能 kill -9 agent 才能救活。
+ *
+ * 这里锁住：pull 失败要退避重试到 admin 就绪（拿到的是**完整**配置，含 system_prompt /
+ * mcp_servers，push 路径给不了这两个字段）；重试耗尽仍要落 unconfigured 兜底，不能让 agent 起不来。
+ */
+describe('ConfigLoader.loadWithRetry — 启动期拉配置退避重试', () => {
+  const realAdminConfig = {
+    instance_id: 'crabot-agent',
+    role: 'worker' as const,
+    system_prompt: '你是 crabot',
+    model_config: { default: { endpoint: 'https://api.anthropic.com', apikey: 'sk-x', model_id: 'claude', format: 'anthropic' } },
+    mcp_servers: [{ name: 'fs', command: 'node', args: [] }],
+  }
+
+  /** admin 未 listen 时 Node 22 happy-eyeballs 抛的就是这个：message 为空字符串 */
+  function connRefused(): Error {
+    return new AggregateError(
+      [new Error('connect ECONNREFUSED ::1:19002'), new Error('connect ECONNREFUSED 127.0.0.1:19002')],
+      ''
+    )
+  }
+
+  function fakeRpcClient(failTimes: number, result: unknown = { config: realAdminConfig }) {
+    let calls = 0
+    const call = vi.fn(async () => {
+      calls += 1
+      if (calls <= failTimes) throw connRefused()
+      return result
+    })
+    return { client: { call } as unknown as RpcClient, calls: () => calls }
+  }
+
+  it('admin 前 N 次不可达、之后可达 → 最终拿到真配置（而不是 unconfigured）', async () => {
+    const { client, calls } = fakeRpcClient(3)
+
+    const config = await ConfigLoader.loadWithRetry(client, 'http://localhost:19002', {
+      budgetMs: 5_000,
+      initialDelayMs: 1,
+      maxDelayMs: 2,
+    })
+
+    expect(calls()).toBe(4)
+    expect(config.agent_config?.system_prompt).toBe('你是 crabot')
+    expect(config.agent_config?.model_config).toHaveProperty('default')
+    expect(config.agent_config?.mcp_servers).toHaveLength(1)
+  })
+
+  it('admin 始终不可达 → 重试耗尽后落 unconfigured 兜底（agent 仍能起来）', async () => {
+    const { client, calls } = fakeRpcClient(Number.POSITIVE_INFINITY)
+
+    const config = await ConfigLoader.loadWithRetry(client, 'http://localhost:19002', {
+      budgetMs: 40,
+      initialDelayMs: 5,
+      maxDelayMs: 5,
+    })
+
+    expect(calls()).toBeGreaterThan(1)
+    expect(config.module_type).toBe('agent')
+    expect(config.agent_config?.system_prompt).toBe('')
+    expect(config.agent_config?.model_config).toEqual({})
+  })
+
+  it('adminEndpoint 未配置属环境问题、不是竞态 → 立即落 unconfigured，不空转重试', async () => {
+    const { client, calls } = fakeRpcClient(0)
+
+    const config = await ConfigLoader.loadWithRetry(client, undefined, {
+      budgetMs: 60_000,
+      initialDelayMs: 1,
+      maxDelayMs: 2,
+    })
+
+    expect(calls()).toBe(0)
+    expect(config.agent_config?.system_prompt).toBe('')
   })
 })

--- a/crabot-agent/tests/manager/p5-integration.test.ts
+++ b/crabot-agent/tests/manager/p5-integration.test.ts
@@ -11,7 +11,7 @@
  * ③ 三个读端点对**真实台账 / 真实输出日志**返回正确数据；
  * ④ 真实状态迁移会发出 `agent.task_status_changed`，载荷逐字对齐 §9.2；
  * ⑤ §11 的 manager slot 解析与"没配 manager slot 也必须能启动"的降级路径；
- * ⑥ `onStart()` 里的启动对账真的跑了。
+ * ⑥ 启动对账真的跑了（发起点在 register 之后，见对应用例）。
  *
  * **唯一被替换的生产件是 manager 的 LLM**：`BootstrapDeps.managerAdapter` 那个 thunk 会经
  * `adapterFromSdkEnv` 建出真会发 HTTP 的 adapter，测试里换成脚本化的 mock（换法见
@@ -631,7 +631,13 @@ describe('P5 集成：manager 栈启动接线（Task 6）', () => {
 
   // --- ⑥ onStart 的启动对账 ---
 
-  it('onStart() 异步跑一次启动对账：台账里残留的 running 化身被对账掉，且不阻塞 onStart 返回', async () => {
+  /**
+   * 对账的**发起点在 register 之后**（`main.ts`：start → register → startManagerStackReconciliation），
+   * 不再挂在 `onStart()` 里：它的 fs 扫描 + tmux 子进程会和 `register()` 的 getaddrinfo 抢同一个
+   * libuv 线程池，并发跑会把注册拖慢、放大冷启动竞态窗口。这里按 main.ts 的真实顺序调用，
+   * 钉住的语义不变：启动时异步跑一次、且不阻塞启动返回。
+   */
+  it('启动时异步跑一次启动对账（register 之后发起）：台账里残留的 running 化身被对账掉，且不阻塞启动', async () => {
     boot()
     const stack = internals.managerStack!
     // 对账把化身判死会落 `exited` 事件，onEvent 的另一条支路会去唤醒监护 manager（要跑 LLM）。
@@ -646,6 +652,8 @@ describe('P5 集成：manager 栈启动接线（Task 6）', () => {
     )
 
     await internals.onStart()
+    // main.ts 里这一句跑在 `await agent.register()` 之后
+    agent.startManagerStackReconciliation()
     try {
       // 进程里没有这个化身的任何痕迹（builtin adapter 的 dataDir 下无 meta）→ 对账判定它已死
       await waitUntil(async () => {


### PR DESCRIPTION
## 修启动竞态:agent 拉配置改为退避重试

**生产上每次冷启动必现**,每次部署都要手动 `kill -9` agent 才能救活。

### 死锁的形状

```
MM 按 start_priority 串行 spawn,间隔仅 1 秒、无依赖声明:admin(10) → memory(15) → agent(20)

agent  拉配置 → admin 那时还没 listen(它要跑完整个 onStart,含加载 2696 个 task)
       → 失败 → createUnconfiguredConfig(),一次性,无重试
       → 约 15ms 后才 register

admin  起来后推配置 → 判据是 MM 的 resolve(只认 status==='running',即 agent 调过 register)
       → 那时 agent 还没注册 → Module not found → 不再推
```

双向都失败,之后谁也不重试。`SIGTERM` 还救不了(按设计只有 `crashed` 才触发重启),**必须 `kill -9`**。

### 诊断中被证伪的两条(记下来免得再猜)

- **不是 `initializeManagerStack()` 撑大了窗口** —— 它确实纯构造无 I/O,实测 agent 从 pull 失败到 register **只隔约 15ms**;P1–P7 也没改动 agent 启动路径上任何一句 `await`;
- **"上次成功启动 = P1–P3 之后"记错了** —— 那天的 HEAD 是 #42,**早于整个拆分**。

而 15ms 的窗口不可能每次被精准命中 → m2 上必有东西把它拖长了。最可能是 **P5 加的启动对账**:它虽不 await,但**与 register 并发**,`scanOrphans` + `reconcileOnStartup` 的大量 `fs/promises` 与 tmux 子进程会**占满 libuv 默认 4 线程池**,而 `register()` 的 `getaddrinfo` **排在同一个池上**。

### 修法(两处,都避开了 MM 编排)

**1. 主修:`ConfigLoader.loadWithRetry`**

预算 **60s**、起始退避 500ms 倍增、**封顶 2s**、约 31 次尝试。

参数不是拍的:60s 对齐 admin 侧 `ensureResumeSweepAfterAgentReady` 那个 60s 就绪窗口(项目里已有的、对 admin 冷启动耗时的唯一显式估计);**封顶 2s 才是真正有约束的那个**——它等于"admin listen"到"agent register"的额外延迟上限,取 10s/30s 会把 register 推出 admin 那个 60s 窗口、让 resume sweep 落空。

`CRABOT_ADMIN_ENDPOINT` 缺失属环境问题不是竞态,**不重试**立即兜底(否则 dev 单跑 agent 每次白等 60s)。耗尽预算仍走 `createUnconfiguredConfig()`,**兜底不破**。

顺带修掉一个查日志时的坑:Node 22 happy-eyeballs 对 `::1`+`127.0.0.1` 全拒时抛的 `AggregateError` **`.message` 是空串**——生产日志里那句 `Failed to load config from Admin:` 后面什么都没有就是这么来的。现在退回 `errors[]` 显示 `connect ECONNREFUSED …`。

**2. 附修:启动对账挪到 `register()` 之后**

从 `onStart()` 挪到 `main.ts` 的 `await agent.register()` 之后。仍 `void` 不 await、失败只 warn,**零语义变化**,但让出了 register 那段时间的线程池。

### 安全性:未注册的模块不会被 MM 判死(逐条复核,非照单全收)

1. spawn 后状态是 `starting`;全文件置 `'running'` 只有两处——`handleRegister` 内和 `skip_health_check` 专用,而 `crabot-agent` **没有** `skip_health_check` ⇒ 它变 running **只可能**靠自己 register;
2. `runHealthChecks()` 的 filter 是 `status === 'running' && !skip_health_check`,**`starting` 根本不进探活集合**,不可能累计失败触发 SIGKILL;
3. **无 spawn 超时**:`startModuleProcess` spawn 完即返回不 await 注册;`startAutoStartModules` 只是固定 `sleep(1000)`;全文件 `setInterval` 只有磁盘水位线和健康检查两处;
4. 额外查了诊断没提的一条:`scripts/start.mjs` 的 30s 就绪轮询**只探 MM 与 Admin Web,不看 agent**,晚注册不会让 `crabot start -d` 报超时;
5. 重试窗口内被 stop 也安全:MM 的 `stop()` 把 `starting` 模块一并 SIGTERM,此时 agent 尚未装 SIGTERM handler(handler 在配置加载之后注册),走 Node 默认行为直接退出;MM 的 exit 分支 `wasRunning === false` ⇒ 不发 crashed、不触发 auto_restart。

### 用例(先写先红)

1. 假 RpcClient **前 3 次抛 message 为空串的 `AggregateError`**(真机 ECONNREFUSED 的形状),第 4 次返回真配置 → 断言调用 4 次且拿到的是**真配置**(`system_prompt` 有值、mcp 长度 1),不是 unconfigured;
2. 始终不可达 + 预算 40ms → 断言尝试 > 1 次且返回兜底配置(**agent 仍能起来**);
3. `adminEndpoint` 缺失 → 零次 RPC、立即兜底。

变异:把预算判断改成无条件 `break`(等价去掉重试)→ 用例 1、2 均挂。

改了一条既有用例(`p5-integration`):原先直接调 `internals.onStart()` 等对账结果,对账挪走后会超时;改成按 `main.ts` 的真实顺序发起,**断言一字未减**(异步跑一次、不阻塞、残留 running 化身被判死、路由被调用)。

### 验证

基线(detached 到 `d2e3b3b0` 实跑)**2390 passed / 0 failed** → 改动后 **2393 passed / 0 failed**(+3 = 新增用例),`tsc --noEmit` 干净。

### 顺带发现的两个独立缺陷(**本次未修**)

1. **`pushConfigToAgentModules` 下发字段里没有 `system_prompt`、没有 `mcp_servers`** —— 靠 admin 补推活过来的 agent 会是**空 prompt + 零 MCP**。这也是修复必须落在 pull 侧、不能靠 push 兜的硬理由;
2. **`ensureResumeSweepAfterAgentReady` 首推必抛** `Config not found for instance` 然后 `return` **永不再试** —— 它跑在 `agentManager.initialize()` 之前。那张网现在等于是空的。

> 本 PR **刻意不碰** MM 的 `startAutoStartModules` 与任何注册契约 —— 那块正在 `feat/module-health-lifecycle` 分支上被改(`enforce registration readiness contract` 等),碰了必然撞车。那条线落地后,本次的重试会自然退化成用不上的兜底,无需回退。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
