### PR TITLE
fix(workers): cc provision 预写 workspace 信任,消除首次启动弹窗

### DIFF
--- a/crabot-agent/src/workers/claude-code/adapter.ts
+++ b/crabot-agent/src/workers/claude-code/adapter.ts
@@ -9,7 +9,9 @@
  * provision:与 spawn 分离的独立步骤(WorkerAdapter 契约本就是两个方法),由调用方在 spawn 前
  * 调用一次,把 workspace 布好——.claude/settings.json(Stop/Notification hook 接到
  * CliEventChannel.hookCommand,permissions 预配置 acceptEdits 降弹窗)、.claude/skills/(复用
- * Task 3 的 materializeSkills)、.mcp.json(renderMcpJson)、CLAUDE.md(renderContextMd)。
+ * Task 3 的 materializeSkills)、.mcp.json(renderMcpJson)、CLAUDE.md(renderContextMd),
+ * 外加全局 ~/.claude.json 里该 workspace 的信任记录(trustWorkspace,消掉首次进入新目录的
+ * 信任弹窗——它发生在 --permission-mode 之前,命令行拦不住)。
  *
  * spawn 提交纪律:tmux newSession 成功之后才落 meta(running)+注册 runtime——newSession 失败
  * 时不留任何持久痕迹(session_id 可重生成,workspace 内 provision 产物残留可接受),同 worker_id
@@ -127,6 +129,21 @@ function validateSessionRef(sessionRef: string): void {
 /** Re-export for backward compatibility and convenience. */
 export { WorkerExitedError }
 
+/** 全局 ~/.claude.json 的读-改-写互斥锁,按文件路径共享(module 级,跨 adapter 实例生效)。
+ * cc 的信任表是**全局单文件**(与 codex 写 workspace 内 config.toml 的天然隔离相反),多个
+ * worker 并发 provision 时若各读各写,后写的一份会整份覆盖先写的,先写的那条信任记录丢失 →
+ * 那个 worker 照样卡弹窗。跨进程侧 cc 自己也不加锁,同类竞态无法单方面消除,这里只保证
+ * 本进程内(agent 是单实例,worker provision 全在这一个进程里)串行。 */
+const claudeConfigMutexes = new Map<string, AsyncMutex>()
+function claudeConfigMutex(path: string): AsyncMutex {
+  let m = claudeConfigMutexes.get(path)
+  if (!m) {
+    m = new AsyncMutex()
+    claudeConfigMutexes.set(path, m)
+  }
+  return m
+}
+
 /** hook 事件文件路径约定:workspace 内 .claude/events-cli.jsonl。provision 与 spawn 都按此约定定位,保持一致。 */
 export function eventsFilePath(ws: Workspace): string {
   return join(ws.root, '.claude', 'events-cli.jsonl')
@@ -165,6 +182,7 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
   private readonly tmux: TmuxDriver
   private readonly claudeBin: string
   private readonly claudeProjectsDir: string
+  private readonly claudeConfigPath: string
   private readonly runtimes = new Map<string, Runtime>()
   private readonly mutexes = new Map<string, AsyncMutex>()
 
@@ -176,12 +194,16 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
       /** cc trace 文件根目录,默认 ~/.claude/projects;detect() 的 activated 检查也复用它
        *(取 dirname 得到 ~/.claude/)。测试用可注入 fixture 目录,不依赖开发机真实 home。 */
       readonly claudeProjectsDir?: string
+      /** cc 的全局配置文件(信任表所在),默认 ~/.claude.json。测试注入临时路径,
+       * 避免往开发机的真实文件里写 workspace 记录。 */
+      readonly claudeConfigPath?: string
       readonly onStateChange?: (h: IncarnationHandle, state: WorkerContractState) => void
     },
   ) {
     this.tmux = deps.tmux ?? new TmuxDriver()
     this.claudeBin = deps.claudeBin ?? 'claude'
     this.claudeProjectsDir = deps.claudeProjectsDir ?? join(homedir(), '.claude', 'projects')
+    this.claudeConfigPath = deps.claudeConfigPath ?? join(homedir(), '.claude.json')
   }
 
   async detect(): Promise<DetectResult> {
@@ -222,6 +244,8 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
     }
     await fs.writeFile(join(claudeDir, 'settings.json'), JSON.stringify(settings, null, 2) + '\n', 'utf-8')
 
+    await this.trustWorkspace(ws.root)
+
     await materializeSkills(ws.root, caps.skills, '.claude/skills')
 
     const mcpServers = caps.mcp_servers as unknown as ProvisionSources['mcpServers']
@@ -236,6 +260,84 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
       }),
       'utf-8',
     )
+  }
+
+  /** 把 workspace 预置成"已信任",消灭 cc 首次进入新目录时的信任弹窗。
+   *
+   * m2 实测(cc 2.1.220):交互式启动遇到没见过的目录会先弹
+   * `Do you trust this folder?`,这个检查发生在 `--permission-mode` **之前**,命令行没有
+   * 任何 flag 能跳过——v3 给每个 worker 都建新 workspace,不预置就每次必卡:tmux 会话在、
+   * 台账 running,但 hook 一次都不触发(生产实测 69 分钟零事件,events-cli.jsonl 都不存在)。
+   * 开关是全局 ~/.claude.json 里 `projects["<路径>"].hasTrustDialogAccepted = true`。
+   *
+   * 路径必须用 realpath:cc 自己写入这张表时用的是解析过软链的路径(如 macOS 上 /tmp →
+   * /private/tmp),用逻辑路径预写实测完全无效、弹窗照旧。与 codex 侧写
+   * `[projects."<realpath>"] trust_level = "trusted"` 同一策略(见 codex/adapter.ts 的
+   * provision),差别只在 cc 这张表是**全局共享单文件**,所以要加锁 + 原子替换 + 只补字段。
+   *
+   * 失败一律抛错(fail-loud),不吞:
+   * - 吞掉 → worker 重新静默卡回弹窗,而这个故障态在外部看来是"running 但永远没动静",
+   *   正是本次要根治的、最难诊断的那个现象;
+   * - 文件存在但解析不出来时更不能兜底重写——用户真实项目的条目和登录信息都在同一份文件里,
+   *   宁可 provision 失败(spawn 之前,不留半个 worker),也不能把它覆盖掉。
+   * 文件不存在是正常情形(全新机器),按空配置创建。 */
+  private async trustWorkspace(root: string): Promise<void> {
+    const realRoot = await fs.realpath(root)
+    const configPath = this.claudeConfigPath
+
+    await claudeConfigMutex(configPath).run(async () => {
+      let raw: string | undefined
+      let mode: number | undefined
+      try {
+        raw = await fs.readFile(configPath, 'utf-8')
+        // 只取权限位:原文件是 0644 还是 0600 都原样保留,不因为我们改一次配置就动它的权限。
+        mode = (await fs.stat(configPath)).mode & 0o777
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+          throw new Error(`ClaudeCodeAdapter.provision: cannot read ${configPath} to pre-accept workspace trust: ${(err as Error).message}`)
+        }
+      }
+
+      let config: Record<string, unknown> = {}
+      if (raw !== undefined && raw.trim() !== '') {
+        let parsed: unknown
+        try {
+          parsed = JSON.parse(raw)
+        } catch (err) {
+          throw new Error(
+            `ClaudeCodeAdapter.provision: ${configPath} is not valid JSON (${(err as Error).message}); ` +
+              `refusing to rewrite it — fix or remove the file, then retry`,
+          )
+        }
+        if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+          throw new Error(`ClaudeCodeAdapter.provision: ${configPath} is not a JSON object; refusing to rewrite it`)
+        }
+        config = parsed as Record<string, unknown>
+      }
+
+      const existingProjects = config.projects
+      if (existingProjects !== undefined && (typeof existingProjects !== 'object' || existingProjects === null || Array.isArray(existingProjects))) {
+        throw new Error(`ClaudeCodeAdapter.provision: ${configPath} has a non-object "projects" field; refusing to rewrite it`)
+      }
+      const projects = { ...((existingProjects as Record<string, unknown>) ?? {}) }
+      const entry = projects[realRoot]
+      const merged = typeof entry === 'object' && entry !== null && !Array.isArray(entry) ? { ...(entry as Record<string, unknown>) } : {}
+      // 只补这一个字段:同一个 path 下可能已有 allowedTools / history 等用户数据,不能覆盖。
+      merged.hasTrustDialogAccepted = true
+      projects[realRoot] = merged
+      config.projects = projects
+
+      // 原子替换:先写同目录临时文件再 rename,避免进程/机器在写一半时挂掉留下半截 JSON——
+      // 这份文件是用户全局配置,截断的代价远大于一次 provision 失败。
+      const tmpPath = `${configPath}.crabot-${randomUUID()}.tmp`
+      try {
+        await fs.writeFile(tmpPath, JSON.stringify(config, null, 2) + '\n', { encoding: 'utf-8', mode: mode ?? 0o600 })
+        await fs.rename(tmpPath, configPath)
+      } catch (err) {
+        await fs.rm(tmpPath, { force: true }).catch(() => {})
+        throw new Error(`ClaudeCodeAdapter.provision: cannot write ${configPath} to pre-accept workspace trust: ${(err as Error).message}`)
+      }
+    })
   }
 
   async spawn(spec: SpawnSpec): Promise<IncarnationHandle> {

--- a/crabot-agent/tests/workers/claude-code-adapter.test.ts
+++ b/crabot-agent/tests/workers/claude-code-adapter.test.ts
@@ -37,6 +37,12 @@ async function cleanupTmuxSessions(prefix = 'crabot-w-cctest-'): Promise<void> {
   }
 }
 
+/** 测试用的假 ~/.claude.json —— provision 要往这个全局文件写 workspace 信任记录,
+ * 测试一律注入临时路径,不许碰开发机上的真实文件。 */
+function fakeClaudeConfig(dataDir: string): string {
+  return path.join(dataDir, 'fake-claude.json')
+}
+
 const MOCK_CLI = path.resolve(__dirname, 'fixtures/mock-cli.mjs')
 const FAKE_CLAUDE_VERSION = path.resolve(__dirname, 'fixtures/fake-claude-version.mjs')
 const FAKE_CLAUDE_FORK = path.resolve(__dirname, 'fixtures/fake-claude-fork.mjs')
@@ -81,9 +87,13 @@ async function waitForState(
 
 describe('ClaudeCodeAdapter.provision', () => {
   let ws: string
+  /** 假的 ~/.claude.json —— provision 会写全局信任表,测试必须注入临时路径,绝不能碰开发机真实文件。 */
+  let claudeConfigPath: string
 
   beforeEach(async () => {
     ws = await fs.mkdtemp(path.join(os.tmpdir(), 'cc-adapter-provision-'))
+    claudeConfigPath = path.join(ws, 'fake-home', '.claude.json')
+    await fs.mkdir(path.dirname(claudeConfigPath), { recursive: true })
   })
 
   afterEach(async () => {
@@ -91,7 +101,7 @@ describe('ClaudeCodeAdapter.provision', () => {
   })
 
   it('写出 .claude/settings.json(含 Stop/Notification hook 与 permissions)、.mcp.json、CLAUDE.md', async () => {
-    const adapter = new ClaudeCodeAdapter({ dataDir: ws })
+    const adapter = new ClaudeCodeAdapter({ dataDir: ws, claudeConfigPath })
     await adapter.provision({ root: ws }, { skills: [], mcp_servers: [{ name: 'x', transport: 'stdio', command: 'node' }] })
 
     const settings = JSON.parse(await fs.readFile(path.join(ws, '.claude/settings.json'), 'utf-8'))
@@ -104,6 +114,96 @@ describe('ClaudeCodeAdapter.provision', () => {
 
     const claudeMd = await fs.readFile(path.join(ws, 'CLAUDE.md'), 'utf-8')
     expect(claudeMd).toContain('你是 crabot 的 worker')
+  })
+
+  // ~/.claude.json 的 projects[<realpath>].hasTrustDialogAccepted —— cc 交互式启动的
+  // "Do you trust this folder?" 弹窗开关。不预写 → 新 workspace 每次必卡在弹窗上,
+  // hook 一次都不触发(生产实测:69 分钟零事件)。
+  describe('workspace 信任预写(~/.claude.json)', () => {
+    async function readConfig(): Promise<Record<string, any>> {
+      return JSON.parse(await fs.readFile(claudeConfigPath, 'utf-8'))
+    }
+
+    it('文件不存在时创建,并按 workspace 的 realpath 落 hasTrustDialogAccepted', async () => {
+      // 经软链到达 workspace:cc 自己写入时用的是解析过软链的路径,预写必须用 realpath,
+      // 否则(实测)弹窗照旧。
+      const realRoot = await fs.mkdtemp(path.join(await fs.realpath(os.tmpdir()), 'cc-trust-real-'))
+      const linkRoot = path.join(ws, 'link-to-ws')
+      await fs.symlink(realRoot, linkRoot)
+
+      const adapter = new ClaudeCodeAdapter({ dataDir: ws, claudeConfigPath })
+      try {
+        await adapter.provision({ root: linkRoot }, { skills: [], mcp_servers: [] })
+
+        const config = await readConfig()
+        expect(config.projects[realRoot]).toEqual({ hasTrustDialogAccepted: true })
+        expect(config.projects[linkRoot]).toBeUndefined()
+      } finally {
+        await fs.rm(realRoot, { recursive: true, force: true }).catch(() => {})
+      }
+    })
+
+    it('不覆盖同一 path 已有的其它字段,也不动其它项目条目与顶层字段', async () => {
+      const realWs = await fs.realpath(ws)
+      await fs.writeFile(
+        claudeConfigPath,
+        JSON.stringify(
+          {
+            numStartups: 42,
+            oauthAccount: { accountUuid: 'u-1' },
+            projects: {
+              [realWs]: { allowedTools: ['Bash(ls:*)'], history: [{ display: '之前的对话' }] },
+              '/home/someone/real-project': { hasTrustDialogAccepted: true, allowedTools: ['Read'] },
+            },
+          },
+          null,
+          2,
+        ),
+        'utf-8',
+      )
+
+      const adapter = new ClaudeCodeAdapter({ dataDir: ws, claudeConfigPath })
+      await adapter.provision({ root: ws }, { skills: [], mcp_servers: [] })
+
+      const config = await readConfig()
+      expect(config.projects[realWs]).toEqual({
+        allowedTools: ['Bash(ls:*)'],
+        history: [{ display: '之前的对话' }],
+        hasTrustDialogAccepted: true,
+      })
+      expect(config.projects['/home/someone/real-project']).toEqual({ hasTrustDialogAccepted: true, allowedTools: ['Read'] })
+      expect(config.numStartups).toBe(42)
+      expect(config.oauthAccount).toEqual({ accountUuid: 'u-1' })
+    })
+
+    it('并发 provision 多个 worker:每条记录都在,互不覆盖', async () => {
+      const roots: string[] = []
+      for (let i = 0; i < 6; i++) {
+        const root = path.join(ws, `worker-ws-${i}`)
+        await fs.mkdir(root, { recursive: true })
+        roots.push(await fs.realpath(root))
+      }
+      // 每个 worker 一个独立 adapter 实例(生产上 harness 可并发 provision),
+      // 共享同一份全局 ~/.claude.json —— 读-改-写必须串行化,否则后写的整份覆盖先写的。
+      await Promise.all(
+        roots.map((root) =>
+          new ClaudeCodeAdapter({ dataDir: ws, claudeConfigPath }).provision({ root }, { skills: [], mcp_servers: [] }),
+        ),
+      )
+
+      const config = await readConfig()
+      for (const root of roots) {
+        expect(config.projects[root], `缺少 ${root} 的信任记录`).toEqual({ hasTrustDialogAccepted: true })
+      }
+    })
+
+    it('已有文件是坏 JSON 时报错退出,不覆盖用户真实配置', async () => {
+      await fs.writeFile(claudeConfigPath, '{ 这不是 JSON', 'utf-8')
+      const adapter = new ClaudeCodeAdapter({ dataDir: ws, claudeConfigPath })
+
+      await expect(adapter.provision({ root: ws }, { skills: [], mcp_servers: [] })).rejects.toThrow(/\.claude\.json/)
+      expect(await fs.readFile(claudeConfigPath, 'utf-8')).toBe('{ 这不是 JSON')
+    })
   })
 })
 
@@ -127,7 +227,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter (tmux + mock CLI)', () => {
   async function provisionedAdapter(script: MockStep[]): Promise<{ adapter: ClaudeCodeAdapter; workerId: string }> {
     const channel = new CliEventChannel(eventsFilePath({ root: workspaceRoot }))
     const stopHookCmd = channel.hookCommand('stop')
-    const adapter = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin: claudeBinFor(script, stopHookCmd) })
+    const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin: claudeBinFor(script, stopHookCmd) })
     // provision 建 .claude/ 目录 —— hook 写入目标目录必须先存在,否则 printf >> 静默失败。
     await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
     return { adapter, workerId: `cctest-${randomUUID().slice(0, 8)}` }
@@ -291,7 +391,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — 四轮 review PoC 回归:
       // 因此持续存活,直到显式 kill,给"重连一个仍存活的会话"提供稳定的时间窗口。
       const claudeBin = claudeBinFor([{ output: '第一段输出' }, { output: '第二段输出' }], stopHookCmd)
 
-      const adapterA = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin })
+      const adapterA = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin })
       await adapterA.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
       const workerId = `cctest-${randomUUID().slice(0, 8)}`
       const h = await adapterA.spawn({ worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } })
@@ -299,7 +399,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — 四轮 review PoC 回归:
       await waitForOutputContains(adapterA, h, '第一段输出')
 
       // "重启":全新 adapter 实例,同一 dataDir,内存 runtimes 为空,从未见过这个化身。
-      const adapterB = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin: 'unused-not-invoked-by-sendInput' })
+      const adapterB = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin: 'unused-not-invoked-by-sendInput' })
 
       // 修复前这里直接抛通用 Error;修复后 ensureRuntime 从落盘 meta(含本轮新增的
       // workspace_root)+ 真实 tmux isAlive 探测重建出可操作的 runtime。
@@ -326,7 +426,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — 四轮 review PoC 回归:
       const stopHookCmd = channel.hookCommand('stop')
       const claudeBin = claudeBinFor([{ output: '第一段输出' }], stopHookCmd)
 
-      const adapterA = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin })
+      const adapterA = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin })
       await adapterA.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
       const workerId = `cctest-${randomUUID().slice(0, 8)}`
       const h = await adapterA.spawn({ worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } })
@@ -338,7 +438,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — 四轮 review PoC 回归:
       execFileSync('tmux', ['kill-session', '-t', `crabot-w-${workerId}-1`], { stdio: 'ignore' })
 
       // "重启":全新 adapter 实例,同一 dataDir,内存 runtimes 为空。
-      const adapterB = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin: 'unused-not-invoked-by-sendInput' })
+      const adapterB = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin: 'unused-not-invoked-by-sendInput' })
 
       // 修复前:sendInput 直接抛通用 Error("no such incarnation...resident in this
       // process")——harness 只对 WorkerExitedError 转透明接续,通用 Error 会原样穿透砸给
@@ -360,7 +460,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — 四轮 review PoC 回归:
       const argvFile = path.join(dataDir, 'poc3-fork-argv.jsonl')
       const claudeBin = `env FAKE_ARGV_FILE=${shQuote(argvFile)} FAKE_FORK_STDOUT=${shQuote('侧问回复内容')} node ${shQuote(FAKE_CLAUDE_FORK)}`
 
-      const adapterA = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin })
+      const adapterA = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin })
       await adapterA.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
       const workerId = `cctest-${randomUUID().slice(0, 8)}`
 
@@ -383,7 +483,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — 四轮 review PoC 回归:
       // 两份历史。resume(#1) 会先经 ensureRuntime 只重建出 #1 这一条 runtime(#2 从未被
       // 提及,不会被重建),旧版 nextSeq 只扫内存 runtimes(此时仅 #1)算出 2,与磁盘上的
       // #2 撞号。
-      const adapterB = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin })
+      const adapterB = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin })
       const h3 = await adapterB.resume({ worker_id: workerId, seq: 1, session_ref: meta1.session_id }, '继续')
 
       // 磁盘感知修复后:新化身分配到 3(不是 2),不撞上 #2 的号位。
@@ -478,7 +578,7 @@ describe('ClaudeCodeAdapter — syncState 锁纪律(P2 Task 4 评审 Important #
     '并发 state() 与事件到达交错后,终读 idle 不回退成 running',
     async () => {
       const tmux = new RaceTmux()
-      const adapter = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin: 'unused-in-this-test' })
+      const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin: 'unused-in-this-test' })
       const workerId = `cctest-${randomUUID().slice(0, 8)}`
       const h = await adapter.spawn({ worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } })
 
@@ -536,7 +636,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — spawn 提交纪律(P2 Tas
       const stopHookCmd = channel.hookCommand('stop')
       // claudeBin 用一个存在的 sleep 命令(附加参数被 bash -c 脚本忽略),不依赖真实 claude 二进制,
       // 只用来验证 tmux 会话能正常起来、sendText 能正常注入。
-      const adapter = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin: `bash -c 'sleep 5'` })
+      const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin: `bash -c 'sleep 5'` })
       await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
       const workerId = `cctest-${randomUUID().slice(0, 8)}`
       const spec: SpawnSpec = { worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } }
@@ -577,7 +677,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — spawn 提交纪律(P2 Tas
         }
       }
       const tmux = new NewSessionOkSendTextFailsTmux()
-      const adapter = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin: `bash -c 'sleep 5'` })
+      const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin: `bash -c 'sleep 5'` })
       await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
       const workerId = `cctest-${randomUUID().slice(0, 8)}`
       const spec: SpawnSpec = { worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } }
@@ -615,6 +715,7 @@ describe('ClaudeCodeAdapter.detect', () => {
   it('claude 二进制不存在/不可执行 → installed:false, activated:false', async () => {
     const adapter = new ClaudeCodeAdapter({
       dataDir,
+      claudeConfigPath: fakeClaudeConfig(dataDir),
       claudeBin: '/nonexistent/claude-bin-does-not-exist-crabot-test',
     })
     const result = await adapter.detect()
@@ -629,6 +730,7 @@ describe('ClaudeCodeAdapter.detect', () => {
 
     const adapter = new ClaudeCodeAdapter({
       dataDir,
+      claudeConfigPath: fakeClaudeConfig(dataDir),
       claudeBin: versionBin('9.9.9 (Claude Code)'),
       claudeProjectsDir: path.join(claudeDir, 'projects'),
     })
@@ -644,6 +746,7 @@ describe('ClaudeCodeAdapter.detect', () => {
 
     const adapter = new ClaudeCodeAdapter({
       dataDir,
+      claudeConfigPath: fakeClaudeConfig(dataDir),
       claudeBin: versionBin('9.9.9 (Claude Code)'),
       claudeProjectsDir: path.join(claudeDir, 'projects'),
     })
@@ -655,6 +758,7 @@ describe('ClaudeCodeAdapter.detect', () => {
   it('claude 已安装但 ~/.claude/ 目录本身不存在 → activated:false(不抛错)', async () => {
     const adapter = new ClaudeCodeAdapter({
       dataDir,
+      claudeConfigPath: fakeClaudeConfig(dataDir),
       claudeBin: versionBin('9.9.9 (Claude Code)'),
       claudeProjectsDir: path.join(home, '.claude-does-not-exist', 'projects'),
     })
@@ -679,7 +783,7 @@ describe('ClaudeCodeAdapter — session_ref UUID 边界校验', () => {
   })
 
   it('resume() 拒绝非 UUID 格式的 session_ref(含 shell 注入特征),不执行任何命令', async () => {
-    const adapter = new ClaudeCodeAdapter({ dataDir, claudeBin: 'unused' })
+    const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), claudeBin: 'unused' })
     const workerId = `cctest-${randomUUID().slice(0, 8)}`
 
     // 先 spawn 一个真实化身以供 resume 前置条件
@@ -698,7 +802,7 @@ describe('ClaudeCodeAdapter — session_ref UUID 边界校验', () => {
   })
 
   it('fork() 拒绝非 UUID 格式的 session_ref(含 shell 注入特征),不执行子进程', async () => {
-    const adapter = new ClaudeCodeAdapter({ dataDir, claudeBin: 'unused' })
+    const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), claudeBin: 'unused' })
     const workerId = `cctest-${randomUUID().slice(0, 8)}`
 
     const maliciousSessionRef = 'x; touch /tmp/pwned'
@@ -712,7 +816,7 @@ describe('ClaudeCodeAdapter — session_ref UUID 边界校验', () => {
   })
 
   it('resume() 拒绝空白或特殊字符 session_ref', async () => {
-    const adapter = new ClaudeCodeAdapter({ dataDir, claudeBin: 'unused' })
+    const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), claudeBin: 'unused' })
     const workerId = `cctest-${randomUUID().slice(0, 8)}`
 
     const invalidRefs = ['', ' ', '$(whoami)', '`id`', '{test}', '../../../etc/passwd']
@@ -725,7 +829,7 @@ describe('ClaudeCodeAdapter — session_ref UUID 边界校验', () => {
   })
 
   it('fork() 拒绝空白或特殊字符 session_ref', async () => {
-    const adapter = new ClaudeCodeAdapter({ dataDir, claudeBin: 'unused' })
+    const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), claudeBin: 'unused' })
     const workerId = `cctest-${randomUUID().slice(0, 8)}`
 
     const invalidRefs = ['', ' ', '$(whoami)', '`id`', '{test}', '../../../etc/passwd']
@@ -738,7 +842,7 @@ describe('ClaudeCodeAdapter — session_ref UUID 边界校验', () => {
   })
 
   it('resume() 接受有效 UUID 格式的 session_ref(至少通过前置校验)', async () => {
-    const adapter = new ClaudeCodeAdapter({ dataDir, claudeBin: 'unused' })
+    const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), claudeBin: 'unused' })
     const workerId = `cctest-${randomUUID().slice(0, 8)}`
     const validUuid = randomUUID()
 
@@ -749,7 +853,7 @@ describe('ClaudeCodeAdapter — session_ref UUID 边界校验', () => {
   })
 
   it('fork() 接受有效 UUID 格式的 session_ref(至少通过前置校验)', async () => {
-    const adapter = new ClaudeCodeAdapter({ dataDir, claudeBin: 'unused' })
+    const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), claudeBin: 'unused' })
     const workerId = `cctest-${randomUUID().slice(0, 8)}`
     const validUuid = randomUUID()
 
@@ -784,7 +888,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter.resume', () => {
       const stopHookCmd = channel.hookCommand('stop')
       const argvFile = path.join(dataDir, 'argv.jsonl')
       const claudeBin = claudeBinFor([{ output: '第一轮输出', exit: true }], stopHookCmd, argvFile)
-      const adapter = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin })
+      const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin })
       await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
       const workerId = `cctest-${randomUUID().slice(0, 8)}`
 
@@ -830,7 +934,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter.resume', () => {
       const channel = new CliEventChannel(eventsFilePath({ root: workspaceRoot }))
       const stopHookCmd = channel.hookCommand('stop')
       const claudeBin = claudeBinFor([{ output: '还在跑,不退出也不 emitStop' }], stopHookCmd)
-      const adapter = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin })
+      const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin })
       await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
       const workerId = `cctest-${randomUUID().slice(0, 8)}`
 
@@ -852,7 +956,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter.resume', () => {
       const channel = new CliEventChannel(eventsFilePath({ root: workspaceRoot }))
       const stopHookCmd = channel.hookCommand('stop')
       const claudeBin = claudeBinFor([{ output: '第一轮输出', exit: true }], stopHookCmd)
-      const adapter = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin })
+      const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin })
       await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
       const workerId = `cctest-${randomUUID().slice(0, 8)}`
 
@@ -928,7 +1032,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter.fork', () => {
       const tmux = new CountingTmux()
       const argvFile = path.join(dataDir, 'fork-argv.jsonl')
       const claudeBin = forkClaudeBin(argvFile, '侧问回复内容')
-      const adapter = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin })
+      const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin })
       await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
       const workerId = `cctest-${randomUUID().slice(0, 8)}`
 
@@ -987,7 +1091,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter.fork', () => {
       const tmux = new CountingTmux()
       const argvFile = path.join(dataDir, 'fork-argv-crash.jsonl')
       const claudeBin = forkClaudeBin(argvFile, '', 1)
-      const adapter = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin })
+      const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin })
       await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
       const workerId = `cctest-${randomUUID().slice(0, 8)}`
 
@@ -1013,7 +1117,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter.fork', () => {
       const tmux = new CountingTmux()
       const argvFile = path.join(dataDir, 'fork-argv-seq.jsonl')
       const claudeBin = forkClaudeBin(argvFile, '侧问回复')
-      const adapter = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin })
+      const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin })
       await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
       const workerId = `cctest-${randomUUID().slice(0, 8)}`
 
@@ -1043,7 +1147,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter.fork', () => {
       const tmux = new CountingTmux()
       const argvFile = path.join(dataDir, 'fork-then-resume-argv.jsonl')
       const claudeBin = forkClaudeBin(argvFile, '侧问回复')
-      const adapter = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin })
+      const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin })
       await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
       const workerId = `cctest-${randomUUID().slice(0, 8)}`
 
@@ -1174,7 +1278,7 @@ describe('ClaudeCodeAdapter.readTrace', () => {
 
   it('按 ~/.claude/projects/<slug>/<session_id>.jsonl 解析并归一化', async () => {
     const tmux = new NoopTmux()
-    const adapter = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin: 'unused', claudeProjectsDir })
+    const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin: 'unused', claudeProjectsDir })
     const workerId = `cctest-${randomUUID().slice(0, 8)}`
     const { h, sessionId } = await spawnedHandle(adapter, workerId)
 
@@ -1208,7 +1312,7 @@ describe('ClaudeCodeAdapter.readTrace', () => {
 
   it('cursor.offset 按行号跳过已读部分', async () => {
     const tmux = new NoopTmux()
-    const adapter = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin: 'unused', claudeProjectsDir })
+    const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin: 'unused', claudeProjectsDir })
     const workerId = `cctest-${randomUUID().slice(0, 8)}`
     const { h, sessionId } = await spawnedHandle(adapter, workerId)
 
@@ -1228,7 +1332,7 @@ describe('ClaudeCodeAdapter.readTrace', () => {
 
   it('nextCursor 计入跳过的坏行/未知类型行,两次 readTrace 按 nextCursor 续读不重不漏', async () => {
     const tmux = new NoopTmux()
-    const adapter = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin: 'unused', claudeProjectsDir })
+    const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin: 'unused', claudeProjectsDir })
     const workerId = `cctest-${randomUUID().slice(0, 8)}`
     const { h, sessionId } = await spawnedHandle(adapter, workerId)
 
@@ -1267,7 +1371,7 @@ describe('ClaudeCodeAdapter.readTrace', () => {
 
   it('半行(CLI 写入未完成,无结尾换行符)不消费,补全后续读不丢事件', async () => {
     const tmux = new NoopTmux()
-    const adapter = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin: 'unused', claudeProjectsDir })
+    const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin: 'unused', claudeProjectsDir })
     const workerId = `cctest-${randomUUID().slice(0, 8)}`
     const { h, sessionId } = await spawnedHandle(adapter, workerId)
 
@@ -1331,7 +1435,7 @@ describe('ClaudeCodeAdapter.readTrace', () => {
 
   it('trace 文件不存在 → 返回空事件数组,不抛错,cursor 原样透传', async () => {
     const tmux = new NoopTmux()
-    const adapter = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin: 'unused', claudeProjectsDir })
+    const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin: 'unused', claudeProjectsDir })
     const workerId = `cctest-${randomUUID().slice(0, 8)}`
     const { h } = await spawnedHandle(adapter, workerId)
     // 不写任何 fixture 文件。
@@ -1349,7 +1453,7 @@ describe('ClaudeCodeAdapter.readTrace', () => {
 
   it('对本进程内不常驻的 incarnation 调用 readTrace 应拒绝', async () => {
     const tmux = new NoopTmux()
-    const adapter = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin: 'unused', claudeProjectsDir })
+    const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin: 'unused', claudeProjectsDir })
     await expect(adapter.readTrace({ worker_id: 'nope', seq: 1, impl: 'claude-code' })).rejects.toThrow()
   })
 })
@@ -1402,6 +1506,7 @@ describe('ClaudeCodeAdapter — CLI hook 事件文件监视(被动 push)', () =>
     const tmux = new NoopTmux()
     const adapter = new ClaudeCodeAdapter({
       dataDir,
+      claudeConfigPath: fakeClaudeConfig(dataDir),
       tmux,
       claudeBin: 'unused',
       claudeProjectsDir,
@@ -1426,6 +1531,7 @@ describe('ClaudeCodeAdapter — CLI hook 事件文件监视(被动 push)', () =>
     const tmux = new NoopTmux()
     const adapter = new ClaudeCodeAdapter({
       dataDir,
+      claudeConfigPath: fakeClaudeConfig(dataDir),
       tmux,
       claudeBin: 'unused',
       claudeProjectsDir,
@@ -1454,6 +1560,7 @@ describe('ClaudeCodeAdapter — CLI hook 事件文件监视(被动 push)', () =>
     const tmux = new NoopTmux()
     const adapter = new ClaudeCodeAdapter({
       dataDir,
+      claudeConfigPath: fakeClaudeConfig(dataDir),
       tmux,
       claudeBin: 'unused',
       claudeProjectsDir,
@@ -1537,6 +1644,7 @@ describe('ClaudeCodeAdapter.fork — 侧问收尾不污染主线 stop 计数', (
   it('侧问收尾的 stop 事件落进 fork 化身自己的事件文件,不进 workspace 共享事件文件', async () => {
     const adapter = new ClaudeCodeAdapter({
       dataDir,
+      claudeConfigPath: fakeClaudeConfig(dataDir),
       tmux: new NoopTmux(),
       claudeBin: forkClaudeBinRunningStopHook(),
       claudeProjectsDir,
@@ -1559,6 +1667,7 @@ describe('ClaudeCodeAdapter.fork — 侧问收尾不污染主线 stop 计数', (
     const seen: Array<{ seq: number; state: WorkerContractState }> = []
     const adapter = new ClaudeCodeAdapter({
       dataDir,
+      claudeConfigPath: fakeClaudeConfig(dataDir),
       tmux: new NoopTmux(),
       claudeBin: forkClaudeBinRunningStopHook(),
       claudeProjectsDir,
@@ -1632,6 +1741,7 @@ describe('ClaudeCodeAdapter.ensureRuntime — 并发重建不泄漏 watcher', ()
     const seen: WorkerContractState[] = []
     const adapter = new ClaudeCodeAdapter({
       dataDir,
+      claudeConfigPath: fakeClaudeConfig(dataDir),
       tmux,
       claudeBin: 'unused',
       claudeProjectsDir,

--- a/crabot-agent/tests/workers/contract-claude-code.test.ts
+++ b/crabot-agent/tests/workers/contract-claude-code.test.ts
@@ -99,7 +99,15 @@ async function makeClaudeCodeFixture(): Promise<ContractFixture> {
   const claudeBin = `env MOCK_CLI_SCRIPT_FILE=${shQuote(scriptFile)} MOCK_CLI_STOP_HOOK_CMD=${shQuote(stopHookCmd)} node ${shQuote(MOCK_CLI)}`
 
   const tmux = new TmuxDriver()
-  const adapter = new ClaudeCodeAdapter({ dataDir, tmux, claudeBin, claudeProjectsDir })
+  // claudeConfigPath:provision 会往这个"全局 ~/.claude.json"写 workspace 信任记录,
+  // 契约测试一律注入临时路径,不许碰开发机上的真实文件。
+  const adapter = new ClaudeCodeAdapter({
+    dataDir,
+    tmux,
+    claudeBin,
+    claudeProjectsDir,
+    claudeConfigPath: path.join(dataDir, 'fake-claude.json'),
+  })
   // provision 建 .claude/ 目录——hook 写入目标目录必须先存在,否则 printf >> 静默失败
   // (mock-cli 直接执行 hookCmd 本身,不解析 settings.json,但事件文件所在目录仍要求先存在)。
   await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })

--- a/crabot-agent/tests/workers/harness/harness-integration.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-integration.test.ts
@@ -302,7 +302,7 @@ describe.skipIf(!tmuxAvailable)('WorkerHarness — 真实 claude-code adapter �
         onEvent: (e) => events.push(e),
       }
       const harness = new WorkerHarness(deps)
-      const ccAdapter = new ClaudeCodeAdapter({ dataDir: ccDataDir, claudeBin, onStateChange: harness.handleStateChange })
+      const ccAdapter = new ClaudeCodeAdapter({ dataDir: ccDataDir, claudeConfigPath: join(dataDir, 'fake-claude.json'), claudeBin, onStateChange: harness.handleStateChange })
       adaptersMap.set('claude-code', ccAdapter)
 
       const dialogObjectId = dialogObjectIdForPrivate('friend-cc-integ')
@@ -422,7 +422,7 @@ describe.skipIf(!tmuxAvailable)(
           workersDir,
           now,
         })
-        const adapterA = new ClaudeCodeAdapter({ dataDir: ccDataDir, claudeBin, onStateChange: harness1.handleStateChange })
+        const adapterA = new ClaudeCodeAdapter({ dataDir: ccDataDir, claudeConfigPath: join(dataDir, 'fake-claude.json'), claudeBin, onStateChange: harness1.handleStateChange })
         adaptersMap1.set('claude-code', adapterA)
 
         const aliveWorker = await harness1.spawnWorker({
@@ -465,7 +465,7 @@ describe.skipIf(!tmuxAvailable)(
           workersDir,
           now,
         })
-        const adapterB = new ClaudeCodeAdapter({ dataDir: ccDataDir, claudeBin, onStateChange: harness2.handleStateChange })
+        const adapterB = new ClaudeCodeAdapter({ dataDir: ccDataDir, claudeConfigPath: join(dataDir, 'fake-claude.json'), claudeBin, onStateChange: harness2.handleStateChange })
         adaptersMap2.set('claude-code', adapterB)
 
         // 修复前:adapterB.state() 无 runtime 时直接读 meta,两个 worker 的 meta 都还停留
@@ -495,7 +495,13 @@ describe.skipIf(!tmuxAvailable)(
         workspaceRoot = await fs.mkdtemp(join(tmpdir(), 'harness-integ-cc-restart-ws-'))
 
         const claudeBin = claudeBinFor([{ output: '先答一句' }], ':')
-        const adapterA = new ClaudeCodeAdapter({ dataDir: ccDataDir, claudeBin })
+        // claudeConfigPath:provision 会往这个"全局 ~/.claude.json"写 workspace 信任记录,
+        // 测试注入临时路径,不许碰开发机上的真实文件。
+        const adapterA = new ClaudeCodeAdapter({
+          dataDir: ccDataDir,
+          claudeBin,
+          claudeConfigPath: join(dataDir, 'fake-claude.json'),
+        })
         await adapterA.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
 
         const workerId = `cctest-restart-${randomUUID().slice(0, 8)}`
@@ -509,7 +515,7 @@ describe.skipIf(!tmuxAvailable)(
         })
 
         // 模拟"重启":全新 adapter 实例,同一 dataDir,内存 runtimes 为空,从未见过这个化身。
-        const adapterB = new ClaudeCodeAdapter({ dataDir: ccDataDir, claudeBin: 'unused-not-invoked-by-state' })
+        const adapterB = new ClaudeCodeAdapter({ dataDir: ccDataDir, claudeConfigPath: join(dataDir, 'fake-claude.json'), claudeBin: 'unused-not-invoked-by-state' })
 
         // tmux 会话仍存活 → 回落读 meta(running,spawn 时写的值)——精度有限但至少不是
         // 编造的 exited。
@@ -547,7 +553,7 @@ describe.skipIf(!tmuxAvailable)(
 
         const adaptersMap1 = new Map<WorkerImplId, WorkerAdapter>()
         const harness1 = new WorkerHarness({ adapters: adaptersMap1, defaultImpl: 'claude-code', ledger, workspaces, workersDir, now })
-        const adapterA = new ClaudeCodeAdapter({ dataDir: ccDataDir, claudeBin, onStateChange: harness1.handleStateChange })
+        const adapterA = new ClaudeCodeAdapter({ dataDir: ccDataDir, claudeConfigPath: join(dataDir, 'fake-claude.json'), claudeBin, onStateChange: harness1.handleStateChange })
         adaptersMap1.set('claude-code', adapterA)
 
         const worker = await harness1.spawnWorker({
@@ -568,7 +574,7 @@ describe.skipIf(!tmuxAvailable)(
         // "重启":全新 harness + adapter 实例,指向同一份台账/dataDir,内存 runtimes 为空。
         const adaptersMap2 = new Map<WorkerImplId, WorkerAdapter>()
         const harness2 = new WorkerHarness({ adapters: adaptersMap2, defaultImpl: 'claude-code', ledger, workspaces, workersDir, now })
-        const adapterB = new ClaudeCodeAdapter({ dataDir: ccDataDir, claudeBin, onStateChange: harness2.handleStateChange })
+        const adapterB = new ClaudeCodeAdapter({ dataDir: ccDataDir, claudeConfigPath: join(dataDir, 'fake-claude.json'), claudeBin, onStateChange: harness2.handleStateChange })
         adaptersMap2.set('claude-code', adapterB)
 
         const report = await harness2.reconcileOnStartup()
@@ -614,7 +620,7 @@ describe.skipIf(!tmuxAvailable)(
 
         const adaptersMap1 = new Map<WorkerImplId, WorkerAdapter>()
         const harness1 = new WorkerHarness({ adapters: adaptersMap1, defaultImpl: 'claude-code', ledger, workspaces, workersDir, now })
-        const adapterA = new ClaudeCodeAdapter({ dataDir: ccDataDir, claudeBin, onStateChange: harness1.handleStateChange })
+        const adapterA = new ClaudeCodeAdapter({ dataDir: ccDataDir, claudeConfigPath: join(dataDir, 'fake-claude.json'), claudeBin, onStateChange: harness1.handleStateChange })
         adaptersMap1.set('claude-code', adapterA)
 
         const worker = await harness1.spawnWorker({
@@ -644,7 +650,7 @@ describe.skipIf(!tmuxAvailable)(
         // continueTerminalWorker → reviveIncarnation)能不能独立兜住这种场景。
         const adaptersMap2 = new Map<WorkerImplId, WorkerAdapter>()
         const harness2 = new WorkerHarness({ adapters: adaptersMap2, defaultImpl: 'claude-code', ledger, workspaces, workersDir, now })
-        const adapterB = new ClaudeCodeAdapter({ dataDir: ccDataDir, claudeBin, onStateChange: harness2.handleStateChange })
+        const adapterB = new ClaudeCodeAdapter({ dataDir: ccDataDir, claudeConfigPath: join(dataDir, 'fake-claude.json'), claudeBin, onStateChange: harness2.handleStateChange })
         adaptersMap2.set('claude-code', adapterB)
 
         await expect(harness2.sendToWorker(worker.worker_id, '接着办')).resolves.toBeUndefined()


### PR DESCRIPTION
## cc provision 预写 workspace 信任,消除首次启动弹窗

**上线后真机发现:claude-code worker 至今一次都没真正跑起来过。**

### 现象

worker 拉起后 tmux 会话在、台账 `running`,但**69 分钟零事件**,`events-cli.jsonl` 根本不存在(hook 从未触发)。`capture-pane` 显示它卡在:

```
❯ 1. Yes, I trust this folder
  2. No, exit
Enter to confirm · Esc to cancel
```

v3 **给每个 worker 都建新 workspace**,所以这个弹窗每次必现。而 `--permission-mode acceptEdits` 管不到它——**信任检查发生在权限模式之前**。

### 这不是缺设计,是 cc 侧漏了 codex 已有的对称实现

```
codex/adapter.ts:542   config.toml 的 [projects."<realpath>"] trust_level = "trusted"
claude-code/adapter.ts   ——(缺)
```

spec §权限预配置的既定策略就是「提前写好 CLI 的权限设置,**把交互式弹窗消灭在源头**」。codex 照做了,cc 没有。

而且 **codex 那段注释已经踩过 realpath 这个坑**:「path 用 ws.root 的 realpath(worker workspace 可能经符号链接到达,codex 内部按规范化后的路径比较)」——跟我这次在 cc 上实测出来的完全一致。

### 方案(m2 真机实测确定,cc 2.1.220)

| 项 | 值 |
|---|---|
| 文件 | `~/.claude.json`(**全局**) |
| 位置 | `projects[<workspace 的 realpath>]` |
| 字段 | `hasTrustDialogAccepted: true` |

**realpath 是决定性的**:实测用逻辑路径 `/tmp/xxx` 预写**完全无效**、弹窗照旧,而 cc 自己写入时用的是 `/private/tmp/xxx`(macOS 软链)。换 realpath 后弹窗消失、cc 直接进工作界面。

排除的方案:`-p` 非交互模式我们用不了(worker 需要交互式会话持续 sendInput);`--permission-mode` 各取值都不影响该弹窗。

### 与 codex 的唯一结构差异:全局文件

codex 写的是 workspace 内的 `config.toml`(天然隔离),cc 这边是**全局** `~/.claude.json`,和用户真实项目条目、登录信息在同一份文件里。因此:

**并发**:module 级、按 configPath 分 key 的 `AsyncMutex` 串行化整个读-改-写。锁挂实例上锁不住跨 adapter 实例的并发(harness 确实会持有多个实例);按路径分 key 让注入不同路径的测试互不阻塞。

**光有原子写不够** —— 它防的是"写一半",防不了"两边基于同一份过期基线各写完整份",后写的整份覆盖先写的、先写那条信任记录消失,那个 worker 照样卡弹窗。落盘仍走同目录临时文件 + `rename`,权限位从原文件继承。

**不上 flock**:crabot 强制单实例,所有 provision 都在同一个 agent 进程内;跨进程真正的对手是 cc 自己,而**它写这份文件时不取任何锁**,我们单方面加锁只增复杂度。这条毫秒级残留竞态已在注释里写明是 cc 侧不配合的固有限制。

### fail-loud 而不是 fail-soft

- 文件不存在 → 正常情形(全新机器),按空配置创建;
- 存在但不是合法 JSON / `projects` 不是对象 → **抛错,provision 失败,原文件一字节不改**;
- IO 错误 → 抛错。

理由:① 吞掉异常 = worker 静默卡回弹窗,**而这正是本次要根治的、最难诊断的那个现象**,fail-soft 会把它伪装成"运行中";② 解析不出来时更不能兜底重写——用户真实项目条目和登录信息在同一份文件里。provision 失败发生在 spawn **之前**,不留半个 worker。

(对比:codex 那边 `auth.json` 拷贝是 fail-soft,因为缺登录态会在 spawn 时变成**可见报错**,不是静默挂起。)

### 用例

1. **realpath**:真目录建在 `realpath(tmpdir())` 下,另造软链指向它,用**软链路径**调 provision,断言记录落在 realRoot 而非 linkRoot。**特意造软链**是因为 Linux 上 `/tmp` 通常不是软链,不造的话这条用例对 realpath 变异是瞎的;
2. **不覆盖已有字段**:预置配置——目标 path 下已有 `allowedTools`/`history`,另有一条真实项目条目,顶层有 `numStartups`/`oauthAccount`。provision 后用 `toEqual` **精确匹配**(多写一个字段也会挂),另一条目与顶层字段原样不动;
3. **并发**:6 个 workspace × 6 个**独立 adapter 实例**共享同一 configPath,`Promise.all` 并发,断言 6 条全在;
4. 坏 JSON → reject 且文件逐字节不变。

**变异**:① realpath→逻辑路径 → 1 挂;② 锁失效 → 并发用例挂;③ 整体覆盖 entry → 1 挂;④ 删掉调用 → 4 全挂。

### 一个过程中的教训

改动让 provision **开始写全局文件**,于是所有触发 provision 的测试都必须注入临时路径。第一轮只注入了单行构造,**多行构造的 fork describe 漏网**——跑完全量后本机真实 `~/.claude.json` 真的多出 4 条 `/tmp/cc-adapter-forkstop-ws-*`。已补齐到 39 处注入,泄漏条目已从本机清掉(只删那 4 个 key),最后一轮全量前后按 `projects` key 比对**零新增**。

### 验证

基线 2393 passed / 0 failed → 改动后 **2396 passed**,唯一失败是已知 flaky `bg-entities/trace`(单跑 4/4 绿)。三个 worker 测试文件单独跑 62/62(含真实 tmux)。`tsc --noEmit` 干净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
