### PR TITLE
fix(workers): worker 失败不再被记成成功(endReason 落账)

### DIFF
--- a/crabot-agent/src/manager/read-model.ts
+++ b/crabot-agent/src/manager/read-model.ts
@@ -18,11 +18,12 @@
  *   `Math.min(page_size ?? 20, 100)`),admin 侧的处理器没有夹紧,这里以 base-protocol
  *   §5.6 注释("默认 20,最大 100")为准。
  *
- * ## 已知的读模型污染源(不要据此写断言)
+ * ## `task.status` 的可信度分级(不要据此假定"completed = 任务真的成功")
  *
- * harness 的 `processStateChange` 目前硬编码把化身退出记成 `completed`(P7 阻塞项 #1),
- * 也就是说**台账里的 `task.status` 对失败的 worker 是失真的**。本文件只忠实反映台账,
- * 不做任何补偿;修复在 P7 的 harness 侧,不在读模型这一层。
+ * 本文件只忠实反映台账,不做任何补偿。台账的 `task.status` 由 harness 依据 adapter 上报的
+ * `ended_reason` 落定,其可信度因实现而异(协议 §6.3):`builtin` 有 `finish_task` 结构化
+ * 终态上报,`completed`/`failed` 是确证;`claude-code`/`codex` 基于交互式 CLI,没有任何可得
+ * 的任务成败信号,其 `completed` 是**推断**(会话消失且非本进程 kill),不表示任务真的成功。
  *
  * @see crabot-docs/protocols/protocol-agent-v3.md §8.3、§7
  * @see crabot-docs/protocols/base-protocol.md §5.6(分页)、§5.7(TimeRange)

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -2941,9 +2941,9 @@ export class UnifiedAgent extends ModuleBase {
   // ============================================================================
   // Manager/Worker RPC 方法（protocol-agent-v3 §8.2 / §8.3，P5 Task 4）
   //
-  // 已知读模型污染源：harness 的 processStateChange 目前把化身退出一律记成 completed
-  // （P7 阻塞项 #1），因此台账里失败 worker 的 task.status 是失真的。这几个读端点只忠实
-  // 反映台账、不做补偿，修复在 harness 侧。
+  // task.status 的可信度分级（协议 §6.3）：builtin 有 finish_task 结构化终态上报，其
+  // completed/failed 是确证；claude-code/codex 基于交互式 CLI，没有任何可得的任务成败
+  // 信号，其 completed 是推断。这几个读端点只忠实反映台账、不做补偿。
   // ============================================================================
 
   /** manager 栈取件口：未装配即 fail-fast（P5 阶段启动路径尚未接线，见字段注释）。 */

--- a/crabot-agent/src/workers/builtin/adapter.ts
+++ b/crabot-agent/src/workers/builtin/adapter.ts
@@ -235,8 +235,18 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
        * 只有 builtin 传：它的输出天然只有 assistant text（`partitionResponseContent` 只取
        * `type==='text'`，工具调用/结果一个字节都不进），符合"只要 text 不要 tool use"。
        * cc/codex 刻意不传，理由见各自 adapter 的 transitionState 注释。
+       *
+       * `endReason`（可选第四参）：本次转换若是 `exited`，就是 `transitionExited` 拿到的
+       * 那个**必填**的 `ended_reason`。builtin 的它是确证（`finish_task(outcome)` 结构化
+       * 上报 / engine result / kill 标记），harness 直接据此落台账；不传这一参的话，这个
+       * 真值就在回调这一跳被丢掉，harness 只能猜（协议 §6.3）。非 exited 转换不传。
        */
-      readonly onStateChange?: (h: IncarnationHandle, state: WorkerContractState, lastText?: string) => void
+      readonly onStateChange?: (
+        h: IncarnationHandle,
+        state: WorkerContractState,
+        lastText?: string,
+        endReason?: IncarnationEndReason,
+      ) => void
       /**
        * 运行配置工厂：**每次起化身现取一次**（spec 决策 2）。spawn 的那次由调用方
        * （harness.spawnWorker / handoffIncarnation）调同一个工厂后放进 `spec.builtin`；
@@ -453,7 +463,8 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
       }
 
       if (instance.state === 'exited') {
-        throw new WorkerExitedError(h.worker_id, h.seq)
+        // 带上 ended_reason:harness 的透明接续要用它给"台账还没追上"的源化身补终态。
+        throw new WorkerExitedError(h.worker_id, h.seq, instance.ended_reason)
       }
 
       if (instance.state === 'running') {
@@ -1169,8 +1180,11 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     // 观察者（onStateChange）的异常永远不能中断状态机的推进。任何回调错误都被捕获
     // 并仅作 console.error 记录，防止阻塞状态转移或导致后续 burst/sendInput 卡死。
     // session_ref 现读现取 instance.tip，同 transitionState 的注释。
+    // 第四参传的就是上面刚写进 meta 的那个 ended_reason——builtin 这一档是**确证**
+    // （finish_task(outcome) 结构化上报 / engine result / kill 标记），harness 据此落台账。
+    // 不传的话这个真值就在回调这一跳被丢掉，harness 只能猜（协议 §6.3）。
     try {
-      this.deps.onStateChange?.({ ...handle, session_ref: instance.tip }, 'exited', lastText)
+      this.deps.onStateChange?.({ ...handle, session_ref: instance.tip }, 'exited', lastText, ended_reason)
     } catch (err) {
       console.error(`[BuiltinWorkerAdapter] onStateChange callback error for ${handle.worker_id}#${handle.seq}:`, err)
     }

--- a/crabot-agent/src/workers/claude-code/adapter.ts
+++ b/crabot-agent/src/workers/claude-code/adapter.ts
@@ -197,7 +197,22 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
       /** cc 的全局配置文件(信任表所在),默认 ~/.claude.json。测试注入临时路径,
        * 避免往开发机的真实文件里写 workspace 记录。 */
       readonly claudeConfigPath?: string
-      readonly onStateChange?: (h: IncarnationHandle, state: WorkerContractState) => void
+      /**
+       * 第三参 `lastText` 本 adapter 刻意不传(理由见 transitionState 注释),但位置要占住,
+       * 因为第四参 `endReason` 是位置参数:`transitionExited` 拿到的那个**必填**的
+       * `ended_reason`。不传的话这个值会在回调这一跳被丢掉,harness 只能猜。
+       *
+       * 注意可信度(协议 §6.3):cc 的退出判定唯一依据是 `tmux.isAlive`——"会话消失且不是
+       * 我们 kill 的"一律记 `completed`,这是**推断**,不是任务真的成功。把它如实上抛的
+       * 意义在于:猜测点收敛到唯一有资格猜的这一层(只有 adapter 知道是不是自己 kill 的),
+       * 且将来接上真实终态信号时只改这里、harness 不用再动。
+       */
+      readonly onStateChange?: (
+        h: IncarnationHandle,
+        state: WorkerContractState,
+        lastText?: string,
+        endReason?: IncarnationEndReason,
+      ) => void
     },
   ) {
     this.tmux = deps.tmux ?? new TmuxDriver()
@@ -600,7 +615,9 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
     if (!runtime) throw new WorkerExitedError(h.worker_id, h.seq)
 
     const { state: current, stopCount } = await this.syncState(runtime, h)
-    if (current === 'exited') throw new WorkerExitedError(h.worker_id, h.seq)
+    // 带上 ended_reason:harness 的透明接续要用它给"台账还没追上"的源化身补终态。
+    // 上面 `!runtime` 那条分支给不出原因(重启后连落盘 meta 都读不回来),如实缺省。
+    if (current === 'exited') throw new WorkerExitedError(h.worker_id, h.seq, runtime.ended_reason)
 
     // 新一轮开始:把 baseline 推到当前 stop 计数,上一轮遗留的 stop 事件不会被误算进新一轮。
     runtime.stopBaseline = stopCount
@@ -934,7 +951,7 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
     // 的化身继续持有 fs watcher + 轮询定时器,也避免终态之后还往外推状态回调。
     this.stopEventWatch(runtime)
     try {
-      this.deps.onStateChange?.(h, 'exited')
+      this.deps.onStateChange?.(h, 'exited', undefined, ended_reason)
     } catch (err) {
       console.error(`[ClaudeCodeAdapter] onStateChange callback error for ${h.worker_id}#${h.seq}:`, err)
     }

--- a/crabot-agent/src/workers/codex/adapter.ts
+++ b/crabot-agent/src/workers/codex/adapter.ts
@@ -455,7 +455,16 @@ export class CodexWorkerAdapter implements WorkerAdapter {
       readonly codexHomeSource?: string
       /** spawn() 发现真实 session id 的轮询上限(ms),默认 3000;测试用可调小避免拖慢用例。 */
       readonly sessionDiscoveryTimeoutMs?: number
-      readonly onStateChange?: (h: IncarnationHandle, state: WorkerContractState) => void
+      /** 第三参 `lastText` 本 adapter 刻意不传(理由同 cc),但位置要占住,因为第四参
+       * `endReason` 是位置参数:`transitionExited` 拿到的那个**必填**的 `ended_reason`。
+       * 可信度与 cc 完全同构(协议 §6.3):退出判定只认 `tmux.isAlive`,非 kill 一律记
+       * `completed`,是**推断**不是确证。详见 cc adapter 同名 deps 的注释。 */
+      readonly onStateChange?: (
+        h: IncarnationHandle,
+        state: WorkerContractState,
+        lastText?: string,
+        endReason?: IncarnationEndReason,
+      ) => void
     },
   ) {
     this.tmux = deps.tmux ?? new TmuxDriver()
@@ -788,7 +797,9 @@ export class CodexWorkerAdapter implements WorkerAdapter {
     if (!runtime) throw new WorkerExitedError(h.worker_id, h.seq)
 
     const { state: current, stopCount } = await this.syncState(runtime, h)
-    if (current === 'exited') throw new WorkerExitedError(h.worker_id, h.seq)
+    // 带上 ended_reason:harness 的透明接续要用它给"台账还没追上"的源化身补终态。
+    // 上面 `!runtime` 那条分支给不出原因(重启后连落盘 meta 都读不回来),如实缺省。
+    if (current === 'exited') throw new WorkerExitedError(h.worker_id, h.seq, runtime.ended_reason)
 
     // 新一轮开始:把 baseline 推到当前计数,上一轮遗留的 turn-complete 通知不会被误算进新一轮。
     runtime.stopBaseline = stopCount
@@ -1083,7 +1094,7 @@ export class CodexWorkerAdapter implements WorkerAdapter {
     // 终态唯一入口:文件监视在这里摘掉,同 cc adapter。
     this.stopEventWatch(runtime)
     try {
-      this.deps.onStateChange?.(h, 'exited')
+      this.deps.onStateChange?.(h, 'exited', undefined, ended_reason)
     } catch (err) {
       console.error(`[CodexWorkerAdapter] onStateChange callback error for ${h.worker_id}#${h.seq}:`, err)
     }

--- a/crabot-agent/src/workers/errors.ts
+++ b/crabot-agent/src/workers/errors.ts
@@ -4,11 +4,22 @@
  * to ensure consistent error handling and instanceof checks across implementations.
  */
 
+import type { IncarnationEndReason } from './types'
+
 /** Raised when sendInput is called on an incarnation that has already exited. */
 export class WorkerExitedError extends Error {
   constructor(
     readonly worker_id: string,
     readonly seq: number,
+    /**
+     * adapter 侧已知的终止原因。harness 的 §5.3 透明接续在 revive 前要给"台账还没追上、
+     * 仍记着非终态"的源化身补一条终态记录,这个字段就是它唯一能拿到的真值来源(此前
+     * 只能硬编码 'completed',把 adapter 明知的 failed/crashed 丢掉)。
+     *
+     * 允许缺席:重启后 adapter 的常驻 runtime 表为空、连落盘 meta 都读不回来时,抛这个
+     * 错误表达的是"这条化身对我而言与已终态等价",此时确实没有原因可给。
+     */
+    readonly ended_reason?: IncarnationEndReason,
   ) {
     super(`worker ${worker_id}#${seq} has exited`)
     this.name = 'WorkerExitedError'

--- a/crabot-agent/src/workers/harness/harness.ts
+++ b/crabot-agent/src/workers/harness/harness.ts
@@ -242,17 +242,37 @@ export class WorkerHarness {
   /**
    * 见文件头"onStateChange 接线契约"。箭头函数字段:构造时绑定 this,P4 可直接把它作为
    * 三个 adapter 构造 deps 里的 `onStateChange` 传入,不需要 .bind(harness)。
-   * 签名对齐三个 adapter 的 `deps.onStateChange?: (h, state, lastText?) => void`(同步、
-   * 无返回值)——内部把实际的异步台账更新做成 fire-and-forget,任何失败只 console.error,
-   * 不抛给 adapter(adapter 侧本身也已经用 try/catch 包裹了对这个回调的调用,这里双重防御,
-   * 理由一致:观察者的异常不能中断 adapter 自己的状态机推进)。
+   * 签名对齐三个 adapter 的 `deps.onStateChange?: (h, state, lastText?, endReason?) => void`
+   * (同步、无返回值)——内部把实际的异步台账更新做成 fire-and-forget,任何失败只
+   * console.error,不抛给 adapter(adapter 侧本身也已经用 try/catch 包裹了对这个回调的调用,
+   * 这里双重防御,理由一致:观察者的异常不能中断 adapter 自己的状态机推进)。
    *
    * `lastText`:轮次边界上 worker 最后说的那段话,由 adapter 按需提供(只有 builtin 提供,
    * 见其构造 deps 注释)。harness 截断后放进 `state_changed` 事件的 detail,让 manager
    * 醒来就看得到 worker 说了什么,不必先往返一次 `read_worker_output`。
+   *
+   * `endReason`:化身的终止原因,由 adapter 在 `transitionExited` 时提供——那里它本就是
+   * 必填形参,三个实现在调这个回调之前都已经把它写进了自己的 meta。harness 据此落台账,
+   * 不再自己猜(修复前这里硬编码 'completed',把 builtin 经 `finish_task(outcome:'failed')`
+   * 结构化上报的失败真值整个丢掉,台账/task.status/对外事件/HANDOFF.md 四处一起记错)。
+   * 可信度分级见协议 §6.3:builtin 的是确证,cc/codex 的 `completed` 是推断。
    */
-  readonly handleStateChange = (h: IncarnationHandle, state: WorkerContractState, lastText?: string): void => {
-    this.processStateChange(h, state, lastText).catch((err) => {
+  readonly handleStateChange = (
+    h: IncarnationHandle,
+    state: WorkerContractState,
+    lastText?: string,
+    endReason?: IncarnationEndReason,
+  ): void => {
+    // 契约断言(同步抛,不进 fire-and-forget):endReason 只在 exited 时有意义。running/idle
+    // 带着终止原因进来说明调用方的状态机接错了线,静默忽略会让台账落进说不清的中间态——
+    // 抛给 adapter,由它的 try/catch 记 console.error(观察者异常不中断状态机推进)。
+    if (endReason !== undefined && state !== 'exited') {
+      throw new Error(
+        `WorkerHarness.handleStateChange: endReason '${endReason}' is only meaningful for state 'exited', got '${state}' ` +
+          `(${h.worker_id}#${h.seq})`
+      )
+    }
+    this.processStateChange(h, state, lastText, endReason).catch((err) => {
       console.error(`[WorkerHarness] handleStateChange failed for ${h.worker_id}#${h.seq}:`, err)
     })
   }
@@ -422,7 +442,14 @@ export class WorkerHarness {
         // continueTerminalWorker 的 sourceSeq 核对注释)——同样转入透明接续,对
         // sendToWorker 的调用方完全无感(不重新抛出)。
         if (err instanceof WorkerExitedError) {
-          await this.continueTerminalWorker(workerId, item.text, incarnation.impl as WorkerImplId, incarnation.seq, item.raw)
+          await this.continueTerminalWorker(
+            workerId,
+            item.text,
+            incarnation.impl as WorkerImplId,
+            incarnation.seq,
+            item.raw,
+            err.ended_reason
+          )
           return
         }
         throw err
@@ -512,11 +539,20 @@ export class WorkerHarness {
     text: string,
     sourceImpl: WorkerImplId,
     sourceSeq: number,
-    raw: boolean
+    raw: boolean,
+    /**
+     * 调用方是从 adapter 抛出的 WorkerExitedError 走到这里时,该错误携带的 adapter 侧
+     * `ended_reason` 真值;调用方是读台账 state==='exited' 走到这里的则不带(那种情形下
+     * 台账已经有终态记录,reviveIncarnation 的回填段本就不会触发)。
+     */
+    sourceEndReason?: IncarnationEndReason
   ): Promise<void> {
     await this.withLock(workerId, async () => {
       let curImpl = sourceImpl
       let curSeq = sourceSeq
+      // 与 (curImpl, curSeq) 同步前进:每次改换源化身,这个原因也要跟着换成新源的,
+      // 否则会把旧源的终止原因错记到新源头上。
+      let curEndReason = sourceEndReason
 
       for (let iteration = 0; iteration < MAX_CONTINUATION_ITERATIONS; iteration++) {
         const found = await this.deps.ledger.findWorker(workerId)
@@ -550,6 +586,8 @@ export class WorkerHarness {
             // 把它当作新的源头,回到循环顶部,以它走接续。
             curImpl = mainline.impl as WorkerImplId
             curSeq = mainline.seq
+            // 台账已有这条化身的终态记录,回填段不会触发,没有原因要携带。
+            curEndReason = undefined
             continue
           }
           // 按普通投递语义把这条消息补送到当前(存活)主线,不重复接续,并保留原条目的
@@ -573,6 +611,7 @@ export class WorkerHarness {
             if (err instanceof WorkerExitedError) {
               curImpl = mainline.impl as WorkerImplId
               curSeq = mainline.seq
+              curEndReason = err.ended_reason
               continue
             }
             throw err
@@ -588,7 +627,7 @@ export class WorkerHarness {
         }
 
         if (adapter.capabilities().revive) {
-          await this.reviveIncarnation(dialogObjectId, worker, mainline, adapter, text)
+          await this.reviveIncarnation(dialogObjectId, worker, mainline, adapter, text, curEndReason)
         } else {
           // "原 impl 若仍可用则沿用,否则 defaultImpl"(brief)是加 ImplAlreadyUsedError 守卫
           // 之前的选择逻辑,现在必然自绝:mainline.impl 就是正在办理接续的这条化身所在的
@@ -626,6 +665,8 @@ export class WorkerHarness {
     mainline: Incarnation,
     adapter: WorkerAdapter,
     text: string,
+    /** adapter 经 WorkerExitedError 报上来的源化身终止原因(见下面回填段的注释)。 */
+    sourceEndReason?: IncarnationEndReason,
   ): Promise<void> {
     const prevRef: IncarnationRef = { worker_id: worker.worker_id, seq: mainline.seq, session_ref: mainline.session_ref }
     // resume 直接把 text 作为 wakeInput 传入——接续就是这次输入的投递方式,不需要在
@@ -649,15 +690,18 @@ export class WorkerHarness {
       // 注释)——必须在 revive 前把它收尾,否则新化身入链后主线就换成了新 seq,后续迟到的
       // processStateChange 会因 mainline.seq !== h.seq 被直接丢弃,旧化身永久卡在非终态、
       // 无终态记录。对齐 handoffIncarnation 对同一竞态的处理(§5.3):这里同样只在源化身
-      // 台账态非 exited 时才回填,不覆盖已经真实记录过的终态。WorkerExitedError 不携带
-      // end reason,拿不到 adapter 给出的精确失败原因时用 'completed' 记录——语境是"已经
-      // 在准备接续续命",不是被 kill,'completed' 是这里能给出的最贴切近似值。
+      // 台账态非 exited 时才回填,不覆盖已经真实记录过的终态。回填的原因优先取
+      // `sourceEndReason`——adapter 抛 WorkerExitedError 时随错误带上来的自己那份
+      // `ended_reason` 真值(builtin 是 finish_task 的结构化确证);它缺席只有一种情形:
+      // 重启后 adapter 的常驻 runtime 表为空、连落盘 meta 都读不回来,对 adapter 而言
+      // 这条化身只是"与已终态等价",确实无原因可给。那时沿用既有近似值 'completed'
+      // ——语境是"已经在准备接续续命",不是被 kill。
       const incarnations =
         mainline.state !== 'exited'
           ? patchIncarnationBySeq(prev.incarnations, mainline.impl, mainline.seq, {
               state: 'exited',
               ended_at: now,
-              ended_reason: 'completed',
+              ended_reason: sourceEndReason ?? 'completed',
             })
           : prev.incarnations
       const nextTask = reopenTaskForContinuation(prev.task, now)
@@ -1255,8 +1299,10 @@ export class WorkerHarness {
           // adapter.state() 只回答 running/idle/exited 三态,不携带 endReason;fork 是
           // 一次性侧问,正常跑完(cc 场景下是 `claude -p` 子进程退出)就是 completed——
           // 真正的崩溃辨别依赖 adapter 主动上报的回调,但那次回调已经被上面的竞态吞掉、
-          // 不会再发生第二次,这里只能取这个合理缺省(与 processStateChange 对非 kill
-          // 触发的 exited 取 'completed' 同一缺省,见该方法注释)。
+          // 不会再发生第二次,这里只能取这个合理缺省。
+          // 注意与 processStateChange 的区别:那条路径已经改成取 adapter 上报的真值,
+          // 这里取不到——`WorkerContractState` 是三态契约、结构上不携带原因,要拿到真值
+          // 得改契约。如实留作已知限制(不影响主线 task.status,fork 只更新自己的化身条目)。
           ...(exitedOnCommit ? { ended_at: now, ended_reason: 'completed' as IncarnationEndReason } : {}),
         }
         return { ...prevWorker, incarnations: [...prevWorker.incarnations, forkIncarnation], updated_at: now }
@@ -1278,7 +1324,12 @@ export class WorkerHarness {
 
   // ---- 内部 ----
 
-  private async processStateChange(h: IncarnationHandle, state: WorkerContractState, lastText?: string): Promise<void> {
+  private async processStateChange(
+    h: IncarnationHandle,
+    state: WorkerContractState,
+    lastText?: string,
+    reportedEndReason?: IncarnationEndReason,
+  ): Promise<void> {
     // 唤醒事件的正文尾巴:截断在这一处收口,三个 adapter 共用同一上限(见 WAKE_TEXT_MAX_CHARS)。
     const wakeText = truncateWakeText(lastText)
     await this.withLock(h.worker_id, async () => {
@@ -1289,12 +1340,15 @@ export class WorkerHarness {
       const target = findIncarnation(worker, h.impl, h.seq)
       if (!target) return // 未知化身(理论不该发生),防御性丢弃
 
-      // WorkerAdapter.onStateChange 只携带 (handle, state) 三态,没有 endReason——kill 触发的
-      // exited 已经由 killWorker 自己直接落定台账(见下面两处终态短路),能走到这里、还没被
-      // 判定为终态的 exited,只可能是"化身自然结束"(非 kill),endReason 取 completed。
-      // 真正的崩溃(crashed)辨别依赖主动巡检(protocol-agent-v3 §6.3/§12),不在这条被动
-      // 回调路径的能力范围内,由 Task 9 的 reconcileOnStartup 补正。
-      const endReason: IncarnationEndReason | undefined = state === 'exited' ? 'completed' : undefined
+      // endReason 一律取 adapter 上报的真值:三个 adapter 的 transitionExited 形参本就是
+      // 必填的 ended_reason,且都在调回调之前已经把它写进自己的 meta,所以常规路径上
+      // `state==='exited'` 必然带着一个具体值(builtin 是 finish_task 的结构化确证;cc/codex
+      // 是"会话消失且非本进程 kill ⇒ completed"的推断,可信度分级见协议 §6.3)。
+      //
+      // 缺席是**防守分支,不是常规路径**:只有未接线的第四个实现或测试替身才会走到。此时
+      // 不替 adapter 编一个原因——原样把 undefined 交给 taskStatusFromIncarnation,由它既有的
+      // 防守分支(exited + 无原因 ⇒ failed)兜住,宁可记成失败也不谎报成功。
+      const endReason: IncarnationEndReason | undefined = state === 'exited' ? reportedEndReason : undefined
       const now = this.deps.now()
 
       if (target.forked_from !== undefined) {

--- a/crabot-agent/tests/manager/bootstrap.test.ts
+++ b/crabot-agent/tests/manager/bootstrap.test.ts
@@ -22,7 +22,7 @@ import { ClaudeCodeAdapter } from '../../src/workers/claude-code/adapter.js'
 import { CodexWorkerAdapter } from '../../src/workers/codex/adapter.js'
 import { CapabilityNotSupportedError } from '../../src/workers/errors.js'
 import { dialogObjectIdForPrivate, type DialogObjectId, type LedgerWorker } from '../../src/workers/harness/ledger-types.js'
-import type { WorkerAdapter, WorkerImplId, IncarnationHandle, WorkerContractState } from '../../src/workers/types.js'
+import type { WorkerAdapter, WorkerImplId, IncarnationHandle, IncarnationEndReason, WorkerContractState } from '../../src/workers/types.js'
 import type { ManagerKey } from '../../src/manager/types.js'
 import type { LLMAdapter, LLMStreamParams } from '../../src/engine/index.js'
 import type { ChannelMessage } from '../../src/types.js'
@@ -99,15 +99,26 @@ function silentAdapter(): LLMAdapter {
 }
 
 /**
+ * 三个 adapter 的 `onStateChange` 构造 deps 的完整形参表。第四参 `endReason` 是 adapter 在
+ * `transitionExited` 时持有的 `ended_reason` 真值——它必填,所以直接调这个回调模拟 adapter
+ * 上报时,`exited` 必须一并带上它,否则模拟出的是真实 adapter 不会产生的"退出但无原因"。
+ */
+type AdapterStateCallback = (
+  h: IncarnationHandle,
+  s: WorkerContractState,
+  lastText?: string,
+  endReason?: IncarnationEndReason,
+) => void
+
+/**
  * 读出 adapter 构造时收到的 `onStateChange`——三个 adapter 都把构造 deps 存成私有字段
  * `deps`,这里刻意穿透私有性:本用例要验证的正是"构造时传进去的那个引用是不是 harness 的
  * handleStateChange",没有别的观测口。
  */
 function capturedOnStateChange(
   adapter: WorkerAdapter | undefined,
-): ((h: IncarnationHandle, s: WorkerContractState) => void) | undefined {
-  return (adapter as unknown as { deps?: { onStateChange?: (h: IncarnationHandle, s: WorkerContractState) => void } })
-    ?.deps?.onStateChange
+): AdapterStateCallback | undefined {
+  return (adapter as unknown as { deps?: { onStateChange?: AdapterStateCallback } })?.deps?.onStateChange
 }
 
 function makeLedgerWorker(p: {
@@ -242,7 +253,9 @@ describe('manager bootstrap（P5 Task 1）', () => {
 
     const onStateChange = capturedOnStateChange(stack.adapters.get('builtin'))
     expect(onStateChange).toBeDefined()
-    onStateChange!({ worker_id: 'w-builtin-1', seq: 1, impl: 'builtin', session_ref: 'w-builtin-1-ref' }, 'exited')
+    // 第四参 'completed' 复刻真实 adapter:transitionExited 的 ended_reason 是必填形参,
+    // 化身自然结束(非 kill)时三个实现给的都是 'completed'。
+    onStateChange!({ worker_id: 'w-builtin-1', seq: 1, impl: 'builtin', session_ref: 'w-builtin-1-ref' }, 'exited', undefined, 'completed')
 
     await waitUntil(async () => (await stack.ledger.findWorker('w-builtin-1'))?.worker.task.status === 'completed')
     const after = await stack.ledger.findWorker('w-builtin-1')

--- a/crabot-agent/tests/manager/events.test.ts
+++ b/crabot-agent/tests/manager/events.test.ts
@@ -27,7 +27,7 @@ import {
 } from '../../src/workers/harness/ledger-types.js'
 import type { HarnessEvent } from '../../src/workers/harness/harness.js'
 import type { LedgerStore } from '../../src/workers/harness/ledger-store.js'
-import type { WorkerAdapter, WorkerImplId, IncarnationHandle, WorkerContractState } from '../../src/workers/types.js'
+import type { WorkerAdapter, WorkerImplId, IncarnationHandle, IncarnationEndReason, WorkerContractState } from '../../src/workers/types.js'
 import type { ManagerKey } from '../../src/manager/types.js'
 import type { LLMAdapter } from '../../src/engine/index.js'
 import type { Event, ModuleId, RpcClient } from 'crabot-shared'
@@ -138,11 +138,22 @@ function silentAdapter(): LLMAdapter {
   }
 }
 
+/**
+ * 三个 adapter 的 `onStateChange` 构造 deps 的完整形参表。第四参 `endReason` 是 adapter 在
+ * `transitionExited` 时持有的 `ended_reason` 真值——它必填,所以直接调这个回调模拟 adapter
+ * 上报时,`exited` 必须一并带上它,否则模拟出的是真实 adapter 不会产生的"退出但无原因"。
+ */
+type AdapterStateCallback = (
+  h: IncarnationHandle,
+  s: WorkerContractState,
+  lastText?: string,
+  endReason?: IncarnationEndReason,
+) => void
+
 function capturedOnStateChange(
   adapter: WorkerAdapter | undefined,
-): ((h: IncarnationHandle, s: WorkerContractState) => void) | undefined {
-  return (adapter as unknown as { deps?: { onStateChange?: (h: IncarnationHandle, s: WorkerContractState) => void } })
-    ?.deps?.onStateChange
+): AdapterStateCallback | undefined {
+  return (adapter as unknown as { deps?: { onStateChange?: AdapterStateCallback } })?.deps?.onStateChange
 }
 
 // ============================================================================
@@ -487,9 +498,9 @@ describe('agent 对外事件（P5 Task 2）', () => {
 
       const onStateChange = capturedOnStateChange(stack.adapters.get('builtin'))
       expect(onStateChange).toBeDefined()
-      // 注：这里 exited 落成 completed 是 P7 阻塞项 #1（processStateChange 硬编码
-      // endReason='completed'）的直接后果，本用例只验证"事件发得出来"，不验证 completed 的正确性。
-      onStateChange!({ worker_id: 'w-wired', seq: 1, impl: 'builtin', session_ref: 'w-wired-ref' }, 'exited')
+      // 第四参 'completed' 复刻真实 adapter：transitionExited 的 ended_reason 是必填形参，
+      // 化身自然结束（非 kill）时三个实现给的都是 'completed'。本用例只验证"事件发得出来"。
+      onStateChange!({ worker_id: 'w-wired', seq: 1, impl: 'builtin', session_ref: 'w-wired-ref' }, 'exited', undefined, 'completed')
 
       await waitUntil(() => published.length >= 1)
       expect(published[0][0]).toBe('agent.task_status_changed')
@@ -534,7 +545,7 @@ describe('agent 对外事件（P5 Task 2）', () => {
         makeLedgerWorker({ workerId: 'w-nopub', status: 'running' }),
       )
       const onStateChange = capturedOnStateChange(stack.adapters.get('builtin'))
-      onStateChange!({ worker_id: 'w-nopub', seq: 1, impl: 'builtin', session_ref: 'w-nopub-ref' }, 'exited')
+      onStateChange!({ worker_id: 'w-nopub', seq: 1, impl: 'builtin', session_ref: 'w-nopub-ref' }, 'exited', undefined, 'completed')
       await waitUntil(async () => (await stack.ledger.findWorker('w-nopub'))?.worker.task.status === 'completed')
       expect(unhandled).toEqual([])
     })

--- a/crabot-agent/tests/manager/manager-integration.test.ts
+++ b/crabot-agent/tests/manager/manager-integration.test.ts
@@ -520,18 +520,17 @@ describe('manager-integration（P4 Task 10：真实 ManagerRegistry + 真实 Wor
 
       // --- 失败路径：worker B 报告失败，改走 send_master_private ---
       //
-      // 发现的真实缺口(记入 task-10-report.md/PROGRESS.md,不在本任务修复范围):
-      // `WorkerHarness.processStateChange`(harness.ts,P3 既有代码)硬编码
-      // `endReason = state === 'exited' ? 'completed' : undefined`——`WorkerAdapter.onStateChange`
-      // 回调接口本身只带 `(handle, state)` 三态,没有 endReason 通道,harness 因此在"化身自然
-      // 结束"这条被动回调路径上**永远**把 task.status 判成 'completed',不论 worker 自己的
-      // `finish_task(outcome='failed')` 说了什么(worker 自身 meta.json 是对的,真值在
-      // onStateChange 这一跳丢失)。经真实 `harness.spawnWorker` + 真实 `BuiltinWorkerAdapter`
-      // 直接复现确认(非本文件测试装配引入的偏差)。因此这里按**实际观察到的行为**推进:
-      // worker B 的 task.status 最终仍是 'completed';manager 能感知到失败,靠的是读到
-      // worker 在 finish_task 之前吐出的文本结论(assistantText 经 onTurn 写进 outputLog,
-      // 不依赖 task.status/ended_reason)——这条路径本身没有缺陷,只是"结构化终态"这一路
-      // 信号目前失真。
+      // 这条剧本同时是"化身终止原因不再被丢弃"的端到端验收(核心用例):worker B 调
+      // `finish_task(outcome:'failed')`,该真值经 builtin adapter 的 `transitionExited` →
+      // `onStateChange` 第四参 → `harness.processStateChange` 一路送进台账。历史上
+      // harness 在这一跳硬编码 `endReason='completed'`,把它整个丢掉,这里曾按失真行为
+      // 如实钉住 `completed`——现已修复并翻转。
+      //
+      // 全链路真实:真实 `ManagerRegistry` + 真实 `WorkerHarness` + 真实
+      // `BuiltinWorkerAdapter`(只有 LLM 是 mock),所以断言的是生产行为,不是装配偏差。
+      //
+      // manager 侧剧本保持不变(读 worker 输出的文本结论 → `send_master_private`):那条路径
+      // 本来就没有缺陷,不依赖 task.status;本次修复补上的是**结构化终态**这一路信号。
       const workerBLLM = makeWorkerLLM([
         {
           text: '巡检过程中遇到无法恢复的错误，任务未能完成，需要人工介入排查。',
@@ -552,14 +551,19 @@ describe('manager-integration（P4 Task 10：真实 ManagerRegistry + 真实 Wor
 
       await waitUntil(async () => {
         const workers = await assembly.harness.listWorkers(assembly.dialogObjectIdFor(SYSTEM_TASKS_MANAGER_KEY))
-        return workers.filter((w) => w.task.status === 'completed').length >= 2
+        return workers.some((w) => w.worker_id !== workerA.worker_id && w.task.status === 'failed')
       })
       const workersAfterB = await assembly.harness.listWorkers(assembly.dialogObjectIdFor(SYSTEM_TASKS_MANAGER_KEY))
       const workerB = workersAfterB.find((w) => w.worker_id !== workerA.worker_id)!
-      // 如实钉住上面注释描述的现状(已知缺口,不是期望行为)：
-      expect(workerB.task.status).toBe('completed')
-      expect(workerB.incarnations[0].ended_reason).toBe('completed')
+      // 核心验收：worker 自己声明的 outcome:'failed' 一路落到台账，不再被记成成功。
+      expect(workerB.task.status).toBe('failed')
+      expect(workerB.incarnations[0].ended_reason).toBe('failed')
+      // 同一份真值也进了对外事件（appendEvent 带的是提交后的 task.status）——manager 的
+      // 台账块与 admin 侧读端点看到的都是这一份。
       const exitedEventB = findWorkerExitedEvent(assembly.events, workerB.worker_id)!
+      expect(exitedEventB.task_status).toBe('failed')
+      // 对照组：成功的 worker A 仍然是 completed，修复没有把所有退出一刀切判失败。
+      expect(workersAfterB.find((w) => w.worker_id === workerA.worker_id)!.task.status).toBe('completed')
 
       managerScript.queue.push({
         toolCalls: [{ name: 'read_worker_output', id: 'r2', input: { worker_id: workerB.worker_id } }],

--- a/crabot-agent/tests/manager/p5-integration.test.ts
+++ b/crabot-agent/tests/manager/p5-integration.test.ts
@@ -35,7 +35,7 @@ import type {
   LLMConnectionInfo,
   ModuleId,
 } from '../../src/types.js'
-import type { IncarnationHandle, WorkerAdapter, WorkerContractState } from '../../src/workers/types.js'
+import type { IncarnationHandle, IncarnationEndReason, WorkerAdapter, WorkerContractState } from '../../src/workers/types.js'
 import type { Event } from 'crabot-shared'
 import { chunksFromContent } from '../engine/helpers/mock-stream.js'
 
@@ -117,12 +117,23 @@ function overrideManagerLLM(stack: ManagerStack, llm: LLMAdapter): void {
   ;(stack.registry as unknown as { deps: { adapter: () => LLMAdapter } }).deps.adapter = () => llm
 }
 
+/**
+ * 三个 adapter 的 `onStateChange` 构造 deps 的完整形参表。第四参 `endReason` 是 adapter 在
+ * `transitionExited` 时持有的 `ended_reason` 真值——它必填,所以直接调这个回调模拟 adapter
+ * 上报时,`exited` 必须一并带上它,否则模拟出的是真实 adapter 不会产生的"退出但无原因"。
+ */
+type AdapterStateCallback = (
+  h: IncarnationHandle,
+  s: WorkerContractState,
+  lastText?: string,
+  endReason?: IncarnationEndReason,
+) => void
+
 /** 读出 adapter 构造时收到的 `onStateChange`（同 bootstrap.test.ts）。 */
 function capturedOnStateChange(
   adapter: WorkerAdapter | undefined,
-): ((h: IncarnationHandle, s: WorkerContractState) => void) | undefined {
-  return (adapter as unknown as { deps?: { onStateChange?: (h: IncarnationHandle, s: WorkerContractState) => void } })
-    ?.deps?.onStateChange
+): AdapterStateCallback | undefined {
+  return (adapter as unknown as { deps?: { onStateChange?: AdapterStateCallback } })?.deps?.onStateChange
 }
 
 function makeLedgerWorker(p: {
@@ -606,7 +617,7 @@ describe('P5 集成：manager 栈启动接线（Task 6）', () => {
     // upsertWorker（落 completed）→ appendEvent（带 task_status）→ onEvent → 事件出口
     const onStateChange = capturedOnStateChange(stack.adapters.get('builtin'))
     expect(onStateChange).toBeDefined()
-    onStateChange!({ worker_id: 'w-evt', seq: 1, impl: 'builtin', session_ref: 'w-evt-ref' }, 'exited')
+    onStateChange!({ worker_id: 'w-evt', seq: 1, impl: 'builtin', session_ref: 'w-evt-ref' }, 'exited', undefined, 'completed')
 
     await waitUntil(() => publishSpy.mock.calls.length > 0)
 

--- a/crabot-agent/tests/workers/claude-code-adapter.test.ts
+++ b/crabot-agent/tests/workers/claude-code-adapter.test.ts
@@ -1581,6 +1581,66 @@ describe('ClaudeCodeAdapter — CLI hook 事件文件监视(被动 push)', () =>
 
     await adapter.kill(h)
   })
+
+  // ---- onStateChange 的第四参 endReason:cc 上报的是**推断**,不是确证 ----
+
+  it('tmux 会话消失(非本进程 kill)→ 回调第四参上报 completed;这是推断,不表示任务真的成功', async () => {
+    // ⚠️ 这条断言钉住的是 cc adapter 的**能力天花板**,不是"任务成功"这件事的证据。
+    //
+    // cc 的退出判定唯一依据是 `tmux.isAlive`(adapter 的三源合成状态判定不看退出码):
+    // "会话没了且 runtime.killed 没置位" ⇒ 记 'completed'。cc 没有任何可得的任务成败
+    // 信号——退出码没捕获(tmux 未设 remain-on-exit)、hook payload 被 CliEventChannel
+    // 主动丢弃、也没有 builtin 那样的 finish_task 结构化上报。所以一个失败退出的 cc
+    // worker 在这里同样会被记成 'completed'(协议 §6.3 已写明这条可信度分级)。
+    //
+    // 本次修复保证的是"harness 不再丢弃 adapter 已知的真值",不保证"所有实现都知道
+    // 真值"。给 cc/codex 补终态上报是另一个设计任务,不在本次范围。
+    const seen: Array<{ state: WorkerContractState; endReason?: string }> = []
+    class DeadTmux extends NoopTmux {
+      async isAlive(_name: string): Promise<boolean> {
+        return false
+      }
+    }
+    const adapter = new ClaudeCodeAdapter({
+      dataDir,
+      claudeConfigPath: fakeClaudeConfig(dataDir),
+      tmux: new NoopTmux(),
+      claudeBin: 'unused',
+      claudeProjectsDir,
+      onStateChange: (_h, state, _lastText, endReason) => {
+        seen.push({ state, endReason })
+      },
+    })
+    const workerId = `cctest-${randomUUID().slice(0, 8)}`
+    const h = await adapter.spawn({ worker_id: workerId, prompt: '干活', workspace: { root: workspaceRoot } })
+    expect(seen).toEqual([])
+
+    // 会话凭空消失(worker 自己退了 / 崩了 / 被外部杀了——adapter 分辨不出是哪一种)。
+    ;(adapter as unknown as { tmux: TmuxDriver }).tmux = new DeadTmux()
+    await expect(adapter.state(h)).resolves.toBe('exited')
+
+    expect(seen).toEqual([{ state: 'exited', endReason: 'completed' }])
+  })
+
+  it('本进程 kill → 回调第四参上报 killed(这一档是确证:只有 adapter 知道是不是自己动的手)', async () => {
+    const seen: Array<{ state: WorkerContractState; endReason?: string }> = []
+    const adapter = new ClaudeCodeAdapter({
+      dataDir,
+      claudeConfigPath: fakeClaudeConfig(dataDir),
+      tmux: new NoopTmux(),
+      claudeBin: 'unused',
+      claudeProjectsDir,
+      onStateChange: (_h, state, _lastText, endReason) => {
+        seen.push({ state, endReason })
+      },
+    })
+    const workerId = `cctest-${randomUUID().slice(0, 8)}`
+    const h = await adapter.spawn({ worker_id: workerId, prompt: '干活', workspace: { root: workspaceRoot } })
+
+    await adapter.kill(h)
+
+    expect(seen).toEqual([{ state: 'exited', endReason: 'killed' }])
+  })
 })
 
 /**

--- a/crabot-agent/tests/workers/codex-adapter.test.ts
+++ b/crabot-agent/tests/workers/codex-adapter.test.ts
@@ -7,7 +7,7 @@ import * as path from 'node:path'
 import { CodexWorkerAdapter, eventsFilePath, WorkerExitedError, CapabilityNotSupportedError } from '../../src/workers/codex/adapter.js'
 import { TmuxDriver, type TmuxSessionSpec } from '../../src/workers/tmux/driver.js'
 import { CliEventChannel } from '../../src/workers/cli-events.js'
-import type { IncarnationHandle, SpawnSpec, WorkerContractState } from '../../src/workers/types.js'
+import type { IncarnationEndReason, IncarnationHandle, SpawnSpec, WorkerContractState } from '../../src/workers/types.js'
 
 function detectTmux(): boolean {
   try {
@@ -182,7 +182,15 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter (tmux + mock CLI)', () => {
 
   async function provisionedAdapter(
     script: MockStep[],
-    opts?: { withRollout?: boolean },
+    opts?: {
+      withRollout?: boolean
+      onStateChange?: (
+        h: IncarnationHandle,
+        state: WorkerContractState,
+        lastText?: string,
+        endReason?: IncarnationEndReason,
+      ) => void
+    },
   ): Promise<{ adapter: CodexWorkerAdapter; workerId: string; rolloutUuid?: string; rolloutFile?: string }> {
     const channel = new CliEventChannel(eventsFilePath({ root: workspaceRoot }))
     const stopHookCmd = channel.hookCommand('stop')
@@ -200,7 +208,13 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter (tmux + mock CLI)', () => {
 
     const codexBin = codexBinFor(script, stopHookCmd, { rolloutFile })
     // 测试用小轮询上限,避免"故意不配置 rollout 文件"的用例拖慢整个套件。
-    const adapter = new CodexWorkerAdapter({ dataDir, tmux, codexBin, sessionDiscoveryTimeoutMs: 1500 })
+    const adapter = new CodexWorkerAdapter({
+      dataDir,
+      tmux,
+      codexBin,
+      sessionDiscoveryTimeoutMs: 1500,
+      onStateChange: opts?.onStateChange,
+    })
     // provision 建 .codex/ 目录——hook 写入目标目录必须先存在,否则 printf >> 静默失败。
     await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
     return { adapter, workerId: `codextest-${randomUUID().slice(0, 8)}`, rolloutUuid, rolloutFile }
@@ -311,6 +325,54 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter (tmux + mock CLI)', () => {
       await expect(adapter.kill(h)).resolves.toBeUndefined()
       const metaAfterSecondKill = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8'))
       expect(metaAfterSecondKill.ended_reason).toBe('killed')
+    },
+    15000,
+  )
+
+  // ---- onStateChange 的第四参 endReason:codex 上报的是**推断**,不是确证 ----
+
+  it(
+    '会话消失(非本进程 kill)→ 回调第四参上报 completed;这是推断,不表示任务真的成功',
+    async () => {
+      // ⚠️ 这条断言钉住的是 codex adapter 的**能力天花板**,不是"任务成功"这件事的证据。
+      //
+      // codex 的退出判定唯一依据是 `tmux.isAlive`(三源合成状态判定不看退出码):"会话没了
+      // 且 runtime.killed 没置位" ⇒ 记 'completed'。codex 没有任何可得的任务成败信号——
+      // 退出码没捕获(tmux 未设 remain-on-exit)、notify payload 只有 turn-complete、也没有
+      // builtin 那样的 finish_task 结构化上报。所以一个失败退出的 codex worker 在这里同样
+      // 会被记成 'completed'(协议 §6.3 已写明这条可信度分级)。
+      //
+      // 本次修复保证的是"harness 不再丢弃 adapter 已知的真值",不保证"所有实现都知道真值"。
+      // 给 cc/codex 补终态上报是另一个设计任务,不在本次范围。
+      const seen: Array<{ state: WorkerContractState; endReason?: string }> = []
+      const { adapter, workerId } = await provisionedAdapter([{ output: '收尾输出', exit: true }], {
+        onStateChange: (_h, state, _lastText, endReason) => {
+          seen.push({ state, endReason })
+        },
+      })
+      const h = await adapter.spawn(makeSpec(workerId, '你好'))
+
+      await waitForState(adapter, h, 'exited')
+
+      expect(seen).toContainEqual({ state: 'exited', endReason: 'completed' })
+    },
+    15000,
+  )
+
+  it(
+    '本进程 kill → 回调第四参上报 killed(这一档是确证:只有 adapter 知道是不是自己动的手)',
+    async () => {
+      const seen: Array<{ state: WorkerContractState; endReason?: string }> = []
+      const { adapter, workerId } = await provisionedAdapter([{ output: '还在跑' }], {
+        onStateChange: (_h, state, _lastText, endReason) => {
+          seen.push({ state, endReason })
+        },
+      })
+      const h = await adapter.spawn(makeSpec(workerId, '你好'))
+
+      await adapter.kill(h)
+
+      expect(seen).toContainEqual({ state: 'exited', endReason: 'killed' })
     },
     15000,
   )

--- a/crabot-agent/tests/workers/contract-claude-code.test.ts
+++ b/crabot-agent/tests/workers/contract-claude-code.test.ts
@@ -74,7 +74,10 @@ function shQuote(s: string): string {
 /** ScriptStep → mock-cli 的 MockStep:'idle' 触发 stop hook 但不退出;'exit_success'/
  * 'exit_failure' 输出后分别以 0/非 0 退出——cc adapter 的三源合成状态判定只认 tmux
  * isAlive(不看退出码),两者都收敛为 exited(ended_reason 恒 completed,除非被 kill),
- * 契约套件④本身也只断言 state==='exited',不区分退出码,见 contract-suite.ts。 */
+ * 契约套件④本身也只断言 state==='exited',不区分退出码,见 contract-suite.ts。
+ *
+ * 这条"恒 completed"是 **adapter 层的推断**(协议 §6.3 的可信度分级),不是 harness 编的:
+ * harness 现在如实采用 adapter 上报的 ended_reason,而 cc 能上报的就只有这个推断值。 */
 function toMockSteps(script: ScriptStep[]): MockStep[] {
   return script.map((step) =>
     step.then === 'idle'

--- a/crabot-agent/tests/workers/harness/harness-continuation.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-continuation.test.ts
@@ -25,6 +25,7 @@ import type {
   WorkerContractState,
   IncarnationHandle,
   IncarnationRef,
+  IncarnationEndReason,
   SpawnSpec,
   Workspace,
   OutputCursor,
@@ -43,7 +44,12 @@ function handleKey(h: IncarnationHandle): string {
 interface FakeAdapterOpts {
   readonly implId?: WorkerImplId
   readonly caps?: Partial<AdapterCapabilities>
-  readonly onStateChange?: (h: IncarnationHandle, state: WorkerContractState) => void
+  readonly onStateChange?: (
+    h: IncarnationHandle,
+    state: WorkerContractState,
+    lastText?: string,
+    endReason?: IncarnationEndReason,
+  ) => void
   readonly sendInputBehavior?: (h: IncarnationHandle, text: string, opts?: { raw?: boolean }) => Promise<void> | void
   readonly resumeBehavior?: (prev: IncarnationRef, wakeInput: string) => Promise<IncarnationHandle> | IncarnationHandle
   readonly spawnBehavior?: (spec: SpawnSpec) => Promise<IncarnationHandle> | IncarnationHandle
@@ -127,10 +133,17 @@ class FakeAdapter implements WorkerAdapter {
     return { fork: false, revive: false, goalMode: false, subagent: false, structuredTrace: false, ...this.opts.caps }
   }
 
-  /** 测试专用：模拟 adapter 自己触发一次状态回调（镜像真实 adapter 内部调用 deps.onStateChange）。 */
-  emitStateChange(h: IncarnationHandle, state: WorkerContractState): void {
+  /** 测试专用：模拟 adapter 自己触发一次状态回调（镜像真实 adapter 内部调用 deps.onStateChange）。
+   *
+   * `endReason` 对齐真实 adapter 的可选第四参。三个真实 adapter 的 `transitionExited` 形参
+   * 本就是**必填**的 `ended_reason`，不存在"退出了却说不出原因"的情况——所以这个桩在
+   * `state==='exited'` 时也必须给出一个具体值，缺省取 `'completed'`（化身自然结束、非 kill，
+   * 即本文件绝大多数接续用例的剧本：worker 自己干完一轮退出，manager 再投递新消息触发接续）。
+   * 需要复现 failed/crashed/killed 的用例显式传第三参。第三参 `lastText` 这个桩不模拟
+   * （对齐 cc/codex：它们刻意不传），所以透传时占位为 undefined。 */
+  emitStateChange(h: IncarnationHandle, state: WorkerContractState, endReason?: IncarnationEndReason): void {
     this.states.set(handleKey(h), state)
-    this.opts.onStateChange?.(h, state)
+    this.opts.onStateChange?.(h, state, undefined, state === 'exited' ? (endReason ?? 'completed') : undefined)
   }
 }
 

--- a/crabot-agent/tests/workers/harness/harness-continuation.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-continuation.test.ts
@@ -312,6 +312,9 @@ describe('WorkerHarness — 透明接续：revive (capabilities().revive === tru
     const oldEntry = w.incarnations[0]
     expect(oldEntry.state).toBe('exited')
     expect(oldEntry.ended_at).toBeTruthy()
+    // 这里的 'completed' 是**兜底缺省**：本用例的桩抛的 WorkerExitedError 不带 ended_reason，
+    // 对应真实场景是"重启后 adapter 常驻 runtime 表为空、连落盘 meta 都读不回来"，此时
+    // adapter 确实无原因可给。带得出原因的场景见下一条用例。
     expect(oldEntry.ended_reason).toBe('completed')
 
     // 之后即便迟到的状态回调才追上来，也不应该覆盖已经回填的终态记录 —— 此时台账主线
@@ -329,6 +332,61 @@ describe('WorkerHarness — 透明接续：revive (capabilities().revive === tru
     await new Promise((resolve) => setTimeout(resolve, 20))
     const [w2] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
     expect(w2.incarnations[0].ended_reason).toBe('completed')
+  })
+
+  it('WorkerExitedError 带着 adapter 侧的 ended_reason=failed 时，revive 前的回填记 failed，不再记成 completed', async () => {
+    // 上一条用例的兜底缺省（'completed'）曾经是**唯一**行为：WorkerExitedError 不携带原因，
+    // reviveIncarnation 只能硬编码。真实场景里 adapter 是知道的——builtin 的 sendInput 在
+    // `instance.state === 'exited'` 时手上就有 `instance.ended_reason`（finish_task 写进去
+    // 的结构化真值），cc/codex 同理有 `runtime.ended_reason`。现在这个真值随错误上抛。
+    const { harness, adaptersMap } = await makeHarness()
+    const fake = new FakeAdapter({
+      caps: { revive: true },
+      onStateChange: harness.handleStateChange,
+      sendInputBehavior: (h) => {
+        throw new WorkerExitedError(h.worker_id, h.seq, 'failed')
+      },
+    })
+    adaptersMap.set('builtin', fake)
+
+    const worker = await harness.spawnWorker(spawnParams())
+    // 同上一条：台账主线此刻仍是 running（迟到的状态回调没追上），所以 revive 的回填段
+    // 会真正触发——这正是原来把失败记成成功的那一处。
+    const before = (await harness.listWorkers(dialogObjectIdForPrivate('friend-1')))[0]
+    expect(before.incarnations[0].state).toBe('running')
+
+    await expect(harness.sendToWorker(worker.worker_id, '继续')).resolves.toBeUndefined()
+
+    const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    expect(w.incarnations).toHaveLength(2)
+    expect(w.incarnations[0].state).toBe('exited')
+    expect(w.incarnations[0].ended_reason).toBe('failed')
+    // 接续本身照常发生：回填的是"上一棒怎么结束的"，不是"这次接续要不要做"。
+    expect(fake.resumeCalls).toHaveLength(1)
+    expect(w.incarnations[1].state).toBe('running')
+  })
+
+  it('台账已经记着 failed 的化身触发 revive → 回填段不动它，终态记录不被 completed 覆盖', async () => {
+    // 另一条到达 revive 的路径：状态回调已经追上（台账里就是 exited/failed），此时
+    // reviveIncarnation 的回填段按既有规则整段跳过。钉住"接续不会把已确证的失败洗成成功"。
+    const { harness, adaptersMap } = await makeHarness()
+    const fake = new FakeAdapter({ caps: { revive: true }, onStateChange: harness.handleStateChange })
+    adaptersMap.set('builtin', fake)
+
+    const worker = await harness.spawnWorker(spawnParams())
+    const h: IncarnationHandle = { worker_id: worker.worker_id, seq: 1, impl: 'builtin', session_ref: `ref-${worker.worker_id}#1` }
+    fake.emitStateChange(h, 'exited', 'failed')
+    await waitUntil(async () => {
+      const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+      return w.task.status === 'failed'
+    })
+
+    await expect(harness.sendToWorker(worker.worker_id, '再试一次')).resolves.toBeUndefined()
+
+    const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    expect(w.incarnations).toHaveLength(2)
+    expect(w.incarnations[0].ended_reason).toBe('failed') // 没被洗成 completed
+    expect(fake.resumeCalls).toHaveLength(1)
   })
 })
 
@@ -395,6 +453,39 @@ describe('WorkerHarness — 透明接续：handoff (capabilities().revive === fa
     expect(handoffEvents[0].seq).toBe(1)
     const supersededEvents = events.filter((e) => e.kind === 'superseded')
     expect(supersededEvents).toHaveLength(1)
+  })
+
+  it('源化身台账已记 failed 时，HANDOFF.md 的 Previous outcome 写 failed —— 接手化身不会以为上一棒干成了', async () => {
+    // 第四个消费方（台账 / task.status / 对外事件之外）：HANDOFF.md 的 `Previous outcome:` 取
+    // `worker.task.outcome ?? source.ended_reason ?? 'unknown'`，而 task.outcome 在生产链路上
+    // 恒 undefined，所以实际总是取 ended_reason。它被硬编码成 completed 时，跨实现交接的新
+    // 化身会读到"上一化身 outcome: completed"，据此认为任务已经完成。
+    const { harness, adaptersMap } = await makeHarness()
+    const fake = new FakeAdapter({
+      caps: { revive: false },
+      onStateChange: harness.handleStateChange,
+      outputChunk: '跑到一半就失败了',
+    })
+    adaptersMap.set('builtin', fake)
+    const target = new FakeAdapter({ implId: 'claude-code', onStateChange: harness.handleStateChange })
+    adaptersMap.set('claude-code', target)
+
+    const worker = await harness.spawnWorker(spawnParams())
+    const workspaceRoot = worker.incarnations[0].workspace
+
+    // 状态回调已经追上：台账里源化身就是 exited/failed（builtin 的 finish_task(outcome:'failed')）。
+    const h: IncarnationHandle = { worker_id: worker.worker_id, seq: 1, impl: 'builtin', session_ref: `ref-${worker.worker_id}#1` }
+    fake.emitStateChange(h, 'exited', 'failed')
+    await waitUntil(async () => {
+      const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+      return w.task.status === 'failed'
+    })
+
+    await expect(harness.sendToWorker(worker.worker_id, '接着把剩下的做完')).resolves.toBeUndefined()
+
+    const handoffContent = await fs.readFile(join(workspaceRoot, 'HANDOFF.md'), 'utf-8')
+    expect(handoffContent).toContain('Previous outcome: failed')
+    expect(handoffContent).not.toContain('Previous outcome: completed')
   })
 
   it('HANDOFF.md 已存在时追加带时间戳的新段，旧内容仍在（不覆盖）', async () => {
@@ -1299,7 +1390,8 @@ describe('WorkerHarness — 二轮 review PoC 回归：continueTerminalWorker �
     const after = (await harness.listWorkers(dialogObjectIdForPrivate('friend-1')))[0]
     expect(after.incarnations).toHaveLength(3)
     // codex#1 被 revive 之前的补写收尾成终态（reviveIncarnation 既有逻辑：台账态未追上
-    // adapter 真实状态时先回填）。
+    // adapter 真实状态时先回填）。这里的 'completed' 是**兜底缺省**：上面 releaseGate 抛的
+    // WorkerExitedError 不带 ended_reason，回填拿不到真值。带得出真值的场景另有专门用例。
     const codexFirst = after.incarnations.find((i) => i.impl === 'codex' && i.state === 'exited')!
     expect(codexFirst.ended_reason).toBe('completed')
     const finalMainline = after.incarnations[after.incarnations.length - 1]

--- a/crabot-agent/tests/workers/harness/harness-integration.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-integration.test.ts
@@ -164,10 +164,11 @@ describe('WorkerHarness — 真实 builtin adapter 集成冒烟(mock LLM)', () =
 
       const [finalWorker] = await harness.listWorkers(dialogObjectId)
       expect(finalWorker.task.status).toBe('completed')
-      // 注:harness 的被动状态回调路径(processStateChange)目前不回填 task.outcome(P3
-      // 范围内没有把 adapter 的 ended_reason/finish_task outcome 透传进 applyStatusTransition
-      // 的 opts.outcome——终态判定完全靠 task.status + incarnation.ended_reason,outcome 字段
-      // 留空是当前实现的既有行为,不是本次集成测试要覆盖的缺口。
+      // 注:被动状态回调路径现在会把 adapter 的 ended_reason 一路透传进
+      // incarnation.ended_reason 与 task.status,但**不**回填 task.outcome——
+      // applyStatusTransition 的 opts.outcome 至今没有任何生产调用点传值,该字段恒
+      // undefined。终态判定完全靠 task.status + incarnation.ended_reason;激活 task.outcome
+      // 是独立议题(它是宽松的 string,装什么要单独定死),不是本次集成测试要覆盖的缺口。
       expect(finalWorker.incarnations).toHaveLength(1)
       expect(finalWorker.incarnations[0].state).toBe('exited')
       expect(finalWorker.incarnations[0].ended_reason).toBe('completed')

--- a/crabot-agent/tests/workers/harness/harness-lifecycle.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-lifecycle.test.ts
@@ -14,6 +14,7 @@ import type {
   WorkerContractState,
   IncarnationHandle,
   IncarnationRef,
+  IncarnationEndReason,
   SpawnSpec,
   Workspace,
   OutputCursor,
@@ -31,7 +32,12 @@ function handleKey(h: IncarnationHandle): string {
 interface FakeAdapterOpts {
   readonly implId?: WorkerImplId
   readonly caps?: Partial<AdapterCapabilities>
-  readonly onStateChange?: (h: IncarnationHandle, state: WorkerContractState, lastText?: string) => void
+  readonly onStateChange?: (
+    h: IncarnationHandle,
+    state: WorkerContractState,
+    lastText?: string,
+    endReason?: IncarnationEndReason,
+  ) => void
   readonly spawnShouldFail?: Error
   readonly forkShouldFail?: Error
   readonly sendInputBehavior?: (h: IncarnationHandle, text: string, opts?: { raw?: boolean }) => Promise<void> | void
@@ -88,8 +94,10 @@ class FakeAdapter implements WorkerAdapter {
       // 把化身状态转到 exited 并调用 onStateChange——AsyncMutex.run 的入队是同步的
       // (harness.ts withLock 注释)，所以 harness.handleStateChange 派生的 processStateChange
       // 对这个 worker_id 的锁请求，必然排在 queryWorker 落账段(第二次 withLock)前面。
+      // 第四参对齐 cc adapter 的 fork():它的 transitionExited 拿到的是 `execFileAsync`
+      // 成功时的 'completed'(失败走 'crashed'),不是"没有值"。
       this.states.set(handleKey(handle), 'exited')
-      this.opts.onStateChange?.(handle, 'exited')
+      this.opts.onStateChange?.(handle, 'exited', undefined, 'completed')
       return handle
     }
     this.states.set(handleKey(handle), 'running')
@@ -120,10 +128,21 @@ class FakeAdapter implements WorkerAdapter {
   }
 
   /** 测试专用:模拟 adapter 自己触发一次状态回调(镜像真实 adapter 内部调用 deps.onStateChange)。
-   * `lastText` 对齐真实 adapter 的可选第三参(轮次边界上 worker 最后说的那段话)。 */
-  emitStateChange(h: IncarnationHandle, state: WorkerContractState, lastText?: string): void {
+   * `lastText` 对齐真实 adapter 的可选第三参(轮次边界上 worker 最后说的那段话)。
+   *
+   * `endReason` 对齐真实 adapter 的可选第四参。三个真实 adapter 的 `transitionExited` 形参
+   * 本就是**必填**的 `ended_reason`,不存在"退出了却说不出原因"的情况——所以这个桩在
+   * `state==='exited'` 时也必须给出一个具体值,缺省取 `'completed'`(化身自然结束、非 kill,
+   * 即本文件绝大多数用例的剧本)。需要复现 failed/crashed/killed 的用例显式传第四参。
+   * 非 exited 态一律不传:endReason 只在 exited 时有意义(harness 会对此断言)。 */
+  emitStateChange(
+    h: IncarnationHandle,
+    state: WorkerContractState,
+    lastText?: string,
+    endReason?: IncarnationEndReason,
+  ): void {
     this.states.set(handleKey(h), state)
-    this.opts.onStateChange?.(h, state, lastText)
+    this.opts.onStateChange?.(h, state, lastText, state === 'exited' ? (endReason ?? 'completed') : undefined)
   }
 }
 

--- a/crabot-agent/tests/workers/harness/harness-lifecycle.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-lifecycle.test.ts
@@ -291,6 +291,89 @@ describe('WorkerHarness.handleStateChange', () => {
     expect(w2.incarnations[0].ended_reason).toBe('completed')
   })
 
+  // ---- endReason:harness 不再自己猜,一律取 adapter 上报的真值 ----
+
+  it('adapter 上报 endReason=failed → 台账 ended_reason 与 task.status 都落 failed(不再被记成成功)', async () => {
+    // 修复前这里硬编码 `endReason = state === 'exited' ? 'completed' : undefined`,adapter
+    // 明知的失败真值在 onStateChange 这一跳被整个丢掉。真实剧本:builtin worker 自己调
+    // `finish_task(outcome:'failed')`(见 manager-integration.test.ts 的端到端用例)。
+    const { harness, fake } = await makeHarness()
+    const worker = await harness.spawnWorker(spawnParams())
+    events.length = 0
+
+    const h = { worker_id: worker.worker_id, seq: 1, impl: 'builtin' as const, session_ref: `ref-${worker.worker_id}#1` }
+    fake.emitStateChange(h, 'exited', undefined, 'failed')
+
+    await waitUntil(async () => {
+      const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+      return w.task.status === 'failed'
+    })
+    const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    expect(w.task.status).toBe('failed')
+    expect(w.incarnations[0].ended_reason).toBe('failed')
+
+    // 对外事件带的是提交后的 task.status——manager 的台账块、admin 侧读端点看的都是这一份。
+    const stateEvents = events.filter((e) => e.kind === 'state_changed')
+    expect(stateEvents).toHaveLength(1)
+    expect(stateEvents[0].task_status).toBe('failed')
+  })
+
+  it('adapter 上报 endReason=crashed → 台账落 crashed,task.status=failed', async () => {
+    const { harness, fake } = await makeHarness()
+    const worker = await harness.spawnWorker(spawnParams())
+
+    const h = { worker_id: worker.worker_id, seq: 1, impl: 'builtin' as const, session_ref: `ref-${worker.worker_id}#1` }
+    fake.emitStateChange(h, 'exited', undefined, 'crashed')
+
+    await waitUntil(async () => {
+      const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+      return w.task.status === 'failed'
+    })
+    const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    expect(w.incarnations[0].ended_reason).toBe('crashed')
+  })
+
+  it('防守分支:adapter 没给 endReason 却报 exited → 落 failed,不谎报成功', async () => {
+    // ⚠️ 这是**防守分支,不是常规路径**。三个真实 adapter 的 transitionExited 形参都是必填的
+    // ended_reason,常规路径上 exited 必然带着一个具体值;走到这里只可能是未接线的第四个
+    // 实现或测试替身。此时 harness 不替 adapter 编一个原因,原样把 undefined 交给
+    // taskStatusFromIncarnation 的既有防守分支(exited + 无原因 ⇒ failed)——宁可记成失败,
+    // 也不谎报成功。所以这里直接调 harness.handleStateChange(绕过已经把缺省钉死成
+    // 'completed' 的 FakeAdapter),模拟的正是"adapter 什么都不说"。
+    const { harness } = await makeHarness()
+    const worker = await harness.spawnWorker(spawnParams())
+
+    harness.handleStateChange(
+      { worker_id: worker.worker_id, seq: 1, impl: 'builtin', session_ref: `ref-${worker.worker_id}#1` },
+      'exited'
+    )
+
+    await waitUntil(async () => {
+      const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+      return w.incarnations[0].state === 'exited'
+    })
+    const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    expect(w.task.status).toBe('failed')
+    expect(w.incarnations[0].ended_reason).toBeUndefined() // 不编造原因
+  })
+
+  it('契约断言:state 非 exited 却带了 endReason → handleStateChange 同步抛错,不写台账', async () => {
+    // endReason 只在 exited 时有意义。running/idle 带着终止原因进来说明调用方的状态机接错
+    // 了线,静默忽略会让台账落进说不清的中间态。抛给 adapter,由它自己的 try/catch 记
+    // console.error(观察者异常不中断状态机推进,三个 adapter 都是这么包的)。
+    const { harness } = await makeHarness()
+    const worker = await harness.spawnWorker(spawnParams())
+    const h = { worker_id: worker.worker_id, seq: 1, impl: 'builtin' as const, session_ref: `ref-${worker.worker_id}#1` }
+
+    expect(() => harness.handleStateChange(h, 'idle', undefined, 'failed')).toThrow(/only meaningful for state 'exited'/)
+    expect(() => harness.handleStateChange(h, 'running', undefined, 'completed')).toThrow(/only meaningful for state 'exited'/)
+
+    // 台账没有被这次非法回调改动过。
+    const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    expect(w.incarnations[0].state).toBe('running')
+    expect(w.incarnations[0].ended_reason).toBeUndefined()
+  })
+
   it('adapter 带上轮次末尾的 text 时,state_changed 事件的 detail 里带上它(manager 醒来即知 worker 说了什么)', async () => {
     const { harness, fake } = await makeHarness()
     const worker = await harness.spawnWorker(spawnParams())


### PR DESCRIPTION
## worker 失败不再被记成成功

spec:`crabot-docs/superpowers/specs/2026-07-31-worker-end-reason-design.md`
协议(先行,已 push):`protocol-agent-v3.md` §6.3 补记可信度分级(`c73b03a`)

### 问题

worker 结束时 adapter **知道真实原因**——`meta-N.json` 里就写着:

```json
{"seq":1,"state":"exited","ended_reason":"completed","outcome":"completed"}
```

但 adapter 通知 harness 用的 `onStateChange(handle, state)` **只带三态、不带原因**,于是 harness 落账时只能硬编码 `endReason = 'completed'`。

**后果:台账 `status` 那一列在失败路径上完全不可信**,而它有三个要紧的消费方:

- **manager 的 system prompt 台账块** —— manager 靠它做派活决策,把失败读成成功就**不会去补救**;
- **HANDOFF.md 的 `Previous outcome:`** —— 跨实现交接时接手方以为前一棒干成了;
- 对外事件 `agent.task_status_changed`,而且**已落盘不可回溯**。

上线后这条更要紧:manager 的 prompt 现在引导它"优先复用已有 worker、先看台账挑",挑的依据恰恰是这一列。

### 修法

`onStateChange` 加可选第四参,三个 adapter 各传自己的真值(它们的 `transitionExited` 形参本来就是必填的 `ended_reason`),harness 优先取传入值。**协议零改动**——`onStateChange` 只是构造 deps。

修主线与 `reviveIncarnation` 两处;**不修 fork 落账那处**——它是竞态补偿路径,`WorkerContractState` 是三态契约、结构上不携带原因,要修得改契约。

### 边界:cc/codex 的失败仍会被记成 completed

交互式 CLI **根本没有"任务失败"这个概念**,只有"轮次结束":Stop hook 的 `stop_reason` 目前只有 `end_turn` 一个值,`SessionEnd` 的 `session_exit_reason` 说的是"会话怎么退出的",交互式退出码无文档约定。

所以本 PR 只保证**"harness 不再丢弃 adapter 已经知道的真值"**,不保证"所有实现都知道真值"。协议 §6.3 已写明这条可信度差异,要求消费方不得把 CLI 类实现的 `completed` 当作成功的证据。

### 过程中值得记的三件事

**1. 一个"超时而非断言失败"的坑。** 中途状态下 8 个测试超时,根因是**只改了签名没改 builtin 自己的调用点**:builtin 上报 `undefined` → harness 不再编造 `completed` → 命中防守分支落 `failed` → 所有 `waitUntil(status === 'completed')` 的轮询永不成立。**改一半的表现不是断言红,是集体挂起。**

**2. 变异验证抓出测试覆盖的不对称。** spec 验收 5 点名的是「cc/codex 会话消失仍落 completed」,但原有用例**只覆盖了 cc**——变异"codex 去掉传参"时 47 条 codex 用例全绿。补了对称的两条之后该变异挂 2 条。

**3. kill 竞态实测零调整,而且修复前更危险。** spec 未决项裁决为"接受竞态",实际核对下来**没有任何既有用例的时序假设需要改**:`killWorker` 本就把台账直接落 `killed`,adapter 回调现在报的也是 `killed`,两个写入方取值一致,谁先谁后都收敛同一结果。**修复前反而更危险**——回调报 `completed` 会覆盖 `killWorker` 写的 `killed`。

### 那约 20 处 `ended_reason==='completed'` 断言的逐条核对

先分层:**adapter 层直读 `meta-N.json` 的那些历来就对**(真值一直在,只是 harness 没用),不受影响;只有台账层经过 `processStateChange`。

台账层核对结果:**底层其实是 failed 的只有 1 条** —— `manager-integration.test.ts` 的 worker B,也就是 spec 点名必须翻转的那条。其余全部名副其实,或压根不走这条路径(spawn 失败路径由 harness 直接落账、`killed` 走 `killWorker`、`crashed` 走 `reconcileOnStartup`、`superseded` 走 handoff、两条是 spec 排除的 fork 落账、还有几处是 fixture 输入而非断言)。

**翻转的那条**:等待条件从"数出 2 个 completed"改成"存在非 A 的 worker 且 status === failed"(否则同样超时),`task.status` 与 `ended_reason` 都改断 `failed`,补上对外事件 `task_status === 'failed'`,并加**worker A 仍 completed 的对照组**证明不是一刀切。注释从"已知缺口不修"重写为"端到端核心验收"。

### 验收(spec 六条)

| # | 自证 |
|---|---|
| 1 | `finish_task(outcome:'failed')` → 台账 / `task.status` / 对外事件三处由 manager-integration 场景二(真实 builtin 全链路)覆盖;HANDOFF.md 第四处由 harness-continuation 新用例覆盖 |
| 2 | revive 两条:带 reason 回填 / 已记 failed 时整段跳过 |
| 3 | adapter 不传且 `exited` → 落 `failed` 且**不编造原因**(留 undefined),注释写明是防守分支 |
| 4 | 非 exited 却传 endReason → 同步抛错,idle/running 各验一次并断言台账未动 |
| 5 | cc 2 条 + codex 2 条,**标题即写"这是推断"** |
| 6 | 变异 4 组全捕获(builtin 去参 3 挂 / cc 去参 2 挂 / codex 去参 2 挂 / harness 改回硬编码 1 挂) |

### 验证

基线 2396 passed(1 个已知 flaky `bg-entities/trace`,单跑 4/4 绿)→ **2408 passed / 0 failed / 2 skipped**,新增 11 条用例。`tsc --noEmit` 通过。

顺带:`read-model.ts` / `unified-agent.ts` 有两处注释原文写着「已知读模型污染源:harness 硬编码 completed」——描述的正是本次修掉的缺陷,留着就是错的,已改为协议 §6.3 的可信度分级说明,**纯注释零行为变化**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
