### PR TITLE
fix(workers): codex provision 继承宿主 config.toml,修端点丢失导致的 401

### DIFF
--- a/crabot-agent/package.json
+++ b/crabot-agent/package.json
@@ -27,6 +27,7 @@
     "crabot-shared": "file:../crabot-shared",
     "js-yaml": "^4.1.1",
     "jsonrepair": "^3.13.3",
+    "smol-toml": "^1.7.1",
     "vscode-jsonrpc": "^8.2.1",
     "vscode-languageserver-protocol": "^3.17.5",
     "zod": "^3.25.28"

--- a/crabot-agent/pnpm-lock.yaml
+++ b/crabot-agent/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       jsonrepair:
         specifier: ^3.13.3
         version: 3.14.0
+      smol-toml:
+        specifier: ^1.7.1
+        version: 1.7.1
       vscode-jsonrpc:
         specifier: ^8.2.1
         version: 8.2.1
@@ -1302,6 +1305,10 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  smol-toml@1.7.1:
+    resolution: {integrity: sha512-PPlsspAZ4jbMBu5DMFhfUGDQLu/vrL4SyBROVS37x8ynnVmFIs1VPBz1Co8Xks3TvpIaZXmU85y4DrQ+UyVFoQ==}
+    engines: {node: '>= 18'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -2712,6 +2719,8 @@ snapshots:
   siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
+
+  smol-toml@1.7.1: {}
 
   source-map-js@1.2.1: {}
 

--- a/crabot-agent/src/workers/codex/adapter.ts
+++ b/crabot-agent/src/workers/codex/adapter.ts
@@ -63,11 +63,21 @@
  * 效果上只是"turn 结束就打一个标记",与 cc 的 Stop hook 语义等价) + `[projects."<realpath>"]`
  * 段(`trust_level = "trusted"`,把 workspace 声明成受信任目录——codex 源码里交互式 TUI 判断
  * "是否受信目录"的真实机制,取代不存在的 `--skip-git-repo-check` flag,见"spawn/resume 启动
- * 参数"节;path 用 `fs.realpath(ws.root)` 解析符号链接后按本文件的 `tomlString` 转义) +
- * mcp_servers 段(复用 Task 3 的 `renderCodexMcpToml`)。TOML 要求根级 key 必须出现在第一个
- * table 之前(codex-docs: config.md 曾用这条规则解释"notify 放最后不生效"的排查案例),所以
- * notify 行必须排在 `[projects...]`/`[mcp_servers."x"]` 表头之前(这两个表之间的先后顺序不
- * 影响解析,各自表头下只跟自己的键)。
+ * 参数"节;path 用 `fs.realpath(ws.root)` 解析符号链接) + mcp_servers 段(复用 Task 3 的
+ * `renderCodexMcpToml`)。
+ *
+ * 这三块是**叠加在宿主 `<codexHomeSource>/config.toml` 之上**的,不是从零写出一份新配置:
+ * `.codex/` 在这里被当成独立 `CODEX_HOME`,codex 就完全不会去读用户真正的 `~/.codex/
+ * config.toml`,于是 `model_provider` / `[model_providers.*].base_url` 这些"请求发去哪"的
+ * 配置会全部丢失,退回 codex 的内置默认端点。生产实证:auth.json 搬过来了、端点没搬,worker
+ * 拿着自建镜像的 key 打 api.openai.com,报 401 invalid_api_key。隔离 home 就得整份继承宿主
+ * 登录态,不能只搬凭据。宿主配置不存在 → 干净降级;损坏 → 显式抛错(见 `readHostConfig`)。
+ * 其中 `[mcp_servers]` 由 crabot 的 caps **整体覆盖**宿主的,不做合并:caps 是这个任务的授权
+ * 边界,宿主配置不该有能力把它扩大。
+ *
+ * TOML 要求根级 key 必须出现在第一个 table 之前(codex-docs: config.md 曾用这条规则解释
+ * "notify 放最后不生效"的排查案例)。叠加宿主配置之后,宿主自带 table,靠字符串拼接已经保证
+ * 不了这条,所以整份文档交给 `smol-toml` 的 `stringify` 统一排布(它先出根级标量、再出 table)。
  *
  * `<ws.root>/.codex/auth.json`:既然 `.codex/` 在这里被当成独立 `CODEX_HOME`,真实登录态
  * (`codexHomeSource`,默认 `~/.codex`)里的 `auth.json`(codex-docs:
@@ -137,6 +147,7 @@ import { OutputLog } from '../output-log.js'
 import { AsyncMutex } from '../async-mutex.js'
 import { writeMetaAtomic, maxSeqOnDisk } from '../meta-store.js'
 import { WorkerExitedError, CapabilityNotSupportedError } from '../errors.js'
+import { parse as parseToml, stringify as stringifyToml } from 'smol-toml'
 import { materializeSkills, renderCodexMcpToml, renderContextMd, type ProvisionSources } from '../provision/materialize.js'
 import type {
   AdapterCapabilities,
@@ -162,20 +173,11 @@ function shQuote(s: string): string {
   return `'${s.replace(/'/g, `'\\''`)}'`
 }
 
-/** TOML 双引号字符串转义 + 包裹,与 provision/materialize.ts 的私有 tomlString 同款用法
- * (独立复制一份,materialize.ts 未导出它——同 cc adapter 复制 shQuote 的先例)。 */
-function tomlString(value: string): string {
-  let out = ''
-  for (const ch of value) {
-    if (ch === '\\') out += '\\\\'
-    else if (ch === '"') out += '\\"'
-    else {
-      const code = ch.charCodeAt(0)
-      if (code < 0x20 || code === 0x7f) out += '\\u' + code.toString(16).padStart(4, '0')
-      else out += ch
-    }
-  }
-  return `"${out}"`
+/** 取一个 TOML table 值当普通对象用;不是 table(缺失/标量/数组)就当空表。 */
+function asTable(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {}
 }
 
 /** 从 codexBin 配置里摘出"实际会被 exec 的可执行文件"这一个 token。生产配置通常就是单个
@@ -526,6 +528,42 @@ export class CodexWorkerAdapter implements WorkerAdapter {
     return { installed: true, activated, detail: versionOutput }
   }
 
+  /**
+   * 读宿主 CODEX_HOME 的 config.toml 作为 workspace 配置的基底。
+   *
+   * - 文件不存在(全新机器 / 没配过 codex)→ 返回空表,干净降级成"只有 crabot 三块"。
+   * - 其它读失败(权限等)与解析失败 → 显式抛错,**不静默降级**:降级出来的配置会精确
+   *   重现本 adapter 修掉的那个生产事故——auth.json 搬了、端点回落到官方默认,worker 拿着
+   *   自建镜像的 key 打 api.openai.com 报 401,而且无声无息。宁可 provision 失败。
+   *   (同 cc adapter 写全局 ~/.claude.json 时"宁可 provision 失败也不能覆盖掉它"的纪律。)
+   * - 错误消息只带路径与解析位置:smol-toml 的 err.message 里嵌了出错处的代码片段,宿主
+   *   配置可能含凭据,那段内容绝不能进错误消息 / 日志。
+   */
+  private async readHostConfig(): Promise<Record<string, unknown>> {
+    const hostConfigPath = join(this.codexHomeSource, 'config.toml')
+    let raw: string
+    try {
+      raw = await fs.readFile(hostConfigPath, 'utf-8')
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return {}
+      throw new Error(
+        `CodexWorkerAdapter.provision: cannot read host codex config at ${hostConfigPath} ` +
+          `(${(err as NodeJS.ErrnoException).code ?? 'unknown error'})`,
+      )
+    }
+    try {
+      return asTable(parseToml(raw))
+    } catch (err) {
+      const at = err as { line?: number; column?: number }
+      const where = at.line !== undefined ? ` at line ${at.line}, column ${at.column}` : ''
+      throw new Error(
+        `CodexWorkerAdapter.provision: host codex config at ${hostConfigPath} is not valid TOML${where}. ` +
+          `Fix it (or remove it) before running codex workers — provisioning without it would silently ` +
+          `fall back to codex's built-in defaults, sending requests to the wrong endpoint.`,
+      )
+    }
+  }
+
   async provision(ws: Workspace, caps: CapabilityBundle): Promise<void> {
     const codexDir = join(ws.root, '.codex')
     await fs.mkdir(codexDir, { recursive: true })
@@ -541,20 +579,38 @@ export class CodexWorkerAdapter implements WorkerAdapter {
     // 额外参数会落在 shell 的 $0 上,脚本本身不引用位置参数,效果上只是"turn 结束就打一个
     // 标记"——与 cc 的 Stop hook(丢弃 stdin payload,同一设计取舍,见 CliEventChannel 头
     // 注释)语义一致。
-    const notifyLine = `notify = [${tomlString('/bin/sh')}, ${tomlString('-c')}, ${tomlString(channel.hookCommand('stop'))}]\n`
+    const notify = ['/bin/sh', '-c', channel.hookCommand('stop')]
 
     // codex 源码里交互式 TUI 判断"是否受信目录"的真实机制是 config.toml 的
     // [projects."<绝对路径>"] 表 + trust_level = "trusted"(取代不存在的 --skip-git-repo-check
     // flag,见文件头"spawn/resume 启动参数"节)。path 用 ws.root 的 realpath(worker workspace
     // 可能经符号链接到达,codex 内部按规范化后的路径比较)。
     const realRoot = await fs.realpath(ws.root)
-    const trustLine = `[projects.${tomlString(realRoot)}]\ntrust_level = "trusted"\n`
 
+    // 隔离 CODEX_HOME 必须整份继承宿主登录态,不能只搬 auth.json:宿主 config.toml 里的
+    // model_provider / [model_providers.*].base_url 才是"请求发去哪"。只搬 key 不搬端点会
+    // 让 worker 拿着自建镜像的 key 打官方 api.openai.com,报 401 invalid_api_key(生产实证)。
+    const config = await this.readHostConfig()
+
+    config.notify = notify
+
+    // 宿主已有的 [projects."别的目录"] 一并留着(codex 只按路径匹配,带过来无害),但本
+    // workspace 这条必须由 crabot 说了算,不能被宿主的同名表挤掉。
+    const hostProjects = asTable(config.projects)
+    config.projects = { ...hostProjects, [realRoot]: { trust_level: 'trusted' } }
+
+    // mcp_servers 由 crabot 的能力集**整体覆盖**,不与宿主合并:caps 是这个任务的授权边界,
+    // 宿主配置不该有能力把它扩大。复用 renderCodexMcpToml 保持 mcp 段形状的单一真相来源,
+    // 解析回对象只是为了并进同一份文档统一序列化。
     const mcpServers = caps.mcp_servers as unknown as ProvisionSources['mcpServers']
-    const mcpToml = renderCodexMcpToml(mcpServers)
-    // TOML 要求根级 key 必须出现在第一个 table 之前,否则会被解析成前一个 table 的子字段——
-    // notify 必须排在 [projects...]/[mcp_servers."x"] 表头之前。
-    await fs.writeFile(join(codexDir, 'config.toml'), notifyLine + '\n' + trustLine + '\n' + mcpToml, 'utf-8')
+    const renderedMcp = asTable(parseToml(renderCodexMcpToml(mcpServers)).mcp_servers)
+    if (Object.keys(renderedMcp).length > 0) config.mcp_servers = renderedMcp
+    else delete config.mcp_servers
+
+    // TOML 要求根级 key 必须出现在第一个 table 之前,否则会被解析成前一个 table 的子字段。
+    // 叠加了宿主配置之后靠字符串拼接已经保证不了这条(宿主自带 table),改由序列化器统一
+    // 排布:smol-toml 的 stringify 先出根级标量、再出 table。
+    await fs.writeFile(join(codexDir, 'config.toml'), stringifyToml(config), 'utf-8')
 
     // codex-docs: 既然 .codex/ 在这里被当成独立 CODEX_HOME,真实登录态里的 auth.json 要搬
     // 一份过来,否则隔离出来的 CODEX_HOME 过不了鉴权。找不到就跳过(本机/CI 未 `codex

--- a/crabot-agent/tests/workers/codex-adapter.test.ts
+++ b/crabot-agent/tests/workers/codex-adapter.test.ts
@@ -4,6 +4,7 @@ import { randomUUID } from 'node:crypto'
 import * as fs from 'node:fs/promises'
 import * as os from 'node:os'
 import * as path from 'node:path'
+import { parse as parseToml } from 'smol-toml'
 import { CodexWorkerAdapter, eventsFilePath, WorkerExitedError, CapabilityNotSupportedError } from '../../src/workers/codex/adapter.js'
 import { TmuxDriver, type TmuxSessionSpec } from '../../src/workers/tmux/driver.js'
 import { CliEventChannel } from '../../src/workers/cli-events.js'
@@ -107,8 +108,9 @@ describe('CodexWorkerAdapter.provision', () => {
     const configToml = await fs.readFile(path.join(ws, '.codex/config.toml'), 'utf-8')
     expect(configToml).toContain('notify = ')
     expect(configToml).toContain('events-cli.jsonl')
-    expect(configToml).toContain('[mcp_servers."x"]')
-    expect(configToml).toContain('command = "node"')
+    // 序列化交给 smol-toml 之后表头是否给 key 加引号属于格式细节(`[mcp_servers.x]` 与
+    // `[mcp_servers."x"]` 语义等价),这里钉语义不钉引号风格。
+    expect((parseToml(configToml) as any).mcp_servers).toEqual({ x: { command: 'node' } })
     // TOML 根级 key(notify)必须出现在第一个 table([mcp_servers...])之前。
     expect(configToml.indexOf('notify =')).toBeLessThan(configToml.indexOf('[mcp_servers'))
 
@@ -160,6 +162,143 @@ describe('CodexWorkerAdapter.provision', () => {
     expect(configToml).toContain('trust_level = "trusted"')
     // TOML 根级 key(notify)必须出现在 [projects...] 表头之前。
     expect(configToml.indexOf('notify =')).toBeLessThan(configToml.indexOf('[projects.'))
+  })
+
+  // ── provision 继承宿主 ~/.codex/config.toml ──────────────────────────────
+  // 生产事故:.codex 被重定向成隔离 CODEX_HOME 后,auth.json 搬了、config.toml 没搬,
+  // 于是 key 是给 mirror 的、endpoint 却回落到官方 api.openai.com,报 401。
+  // 隔离 home 就必须整份继承宿主登录态,不只是凭据。
+  describe('继承宿主 config.toml', () => {
+    /** 不含任何凭据的宿主配置样例——固件里绝不放真实/仿真 key。 */
+    const HOST_CONFIG = [
+      'model = "gpt-5-codex"',
+      'model_provider = "custom"',
+      'disable_response_storage = true',
+      '',
+      '[model_providers.custom]',
+      'name = "mirror"',
+      'base_url = "https://mirror.xinshu.ai"',
+      'wire_api = "responses"',
+      '',
+    ].join('\n')
+
+    async function provisionWithHost(
+      hostToml: string | null,
+      mcp: { name: string; transport: 'stdio'; command: string }[] = [],
+    ): Promise<Record<string, any>> {
+      if (hostToml !== null) {
+        await fs.writeFile(path.join(codexHomeSource, 'config.toml'), hostToml, 'utf-8')
+      }
+      const adapter = new CodexWorkerAdapter({ dataDir: ws, codexHomeSource })
+      await adapter.provision({ root: ws }, { skills: [], mcp_servers: mcp })
+      const raw = await fs.readFile(path.join(ws, '.codex/config.toml'), 'utf-8')
+      return parseToml(raw) as Record<string, any>
+    }
+
+    it('宿主的 model_provider / base_url 等被带进 workspace 配置(否则 key 搬了端点没搬)', async () => {
+      const parsed = await provisionWithHost(HOST_CONFIG)
+
+      expect(parsed.model).toBe('gpt-5-codex')
+      expect(parsed.model_provider).toBe('custom')
+      expect(parsed.disable_response_storage).toBe(true)
+      expect(parsed.model_providers.custom.base_url).toBe('https://mirror.xinshu.ai')
+      expect(parsed.model_providers.custom.wire_api).toBe('responses')
+    })
+
+    it('叠加后 crabot 自己的三块仍然正确(notify 可用 / trust_level 指向本 workspace / mcp_servers 是 crabot 的能力集)', async () => {
+      const parsed = await provisionWithHost(HOST_CONFIG, [{ name: 'crabot', transport: 'stdio', command: 'node' }])
+      const realRoot = await fs.realpath(ws)
+
+      // notify:数组形式的程序契约,且指向本 workspace 的事件文件
+      expect(Array.isArray(parsed.notify)).toBe(true)
+      expect(parsed.notify[0]).toBe('/bin/sh')
+      expect(parsed.notify.join(' ')).toContain('events-cli.jsonl')
+
+      // trust_level 必须存在且指向本 workspace 的 realpath
+      expect(parsed.projects[realRoot]).toEqual({ trust_level: 'trusted' })
+
+      // mcp_servers 是 crabot 的能力集
+      expect(parsed.mcp_servers).toEqual({ crabot: { command: 'node' } })
+    })
+
+    it('宿主的 [mcp_servers] 不与 crabot 的合并——caps 是任务授权边界,crabot 胜', async () => {
+      const hostWithMcp = HOST_CONFIG + [
+        '[mcp_servers.hostonly]',
+        'command = "host-mcp"',
+        '',
+        '[mcp_servers.crabot]',
+        'command = "host-version-of-crabot"',
+        '',
+      ].join('\n')
+
+      const parsed = await provisionWithHost(hostWithMcp, [{ name: 'crabot', transport: 'stdio', command: 'node' }])
+
+      // 宿主独有的 server 不得被带进来(否则宿主配置能扩大 worker 的授权边界)
+      expect(parsed.mcp_servers.hostonly).toBeUndefined()
+      // 同名冲突时 crabot 的定义胜出
+      expect(parsed.mcp_servers).toEqual({ crabot: { command: 'node' } })
+    })
+
+    it('宿主已有的 [projects."别的目录"] 一并带过来,但不挤掉 crabot 为本 workspace 写的那条', async () => {
+      const hostWithProjects = HOST_CONFIG + [
+        '[projects."/some/other/host/dir"]',
+        'trust_level = "trusted"',
+        '',
+      ].join('\n')
+
+      const parsed = await provisionWithHost(hostWithProjects)
+      const realRoot = await fs.realpath(ws)
+
+      expect(parsed.projects['/some/other/host/dir']).toEqual({ trust_level: 'trusted' })
+      expect(parsed.projects[realRoot]).toEqual({ trust_level: 'trusted' })
+    })
+
+    it('TOML 根级 key 排在所有 table 之前——用解析结果验证,不是字符串包含', async () => {
+      const parsed = await provisionWithHost(HOST_CONFIG, [{ name: 'crabot', transport: 'stdio', command: 'node' }])
+
+      // 根级 key 若排到 [model_providers.custom] 之后,TOML 语义上会变成那个表的子字段:
+      // 顶层读不到 notify,反而在表里冒出来。两侧都钉住才能真正抓到排序退化。
+      expect(parsed.notify).toBeDefined()
+      expect(parsed.model_provider).toBe('custom')
+      expect(parsed.model_providers.custom.notify).toBeUndefined()
+      expect(parsed.model_providers.custom.model_provider).toBeUndefined()
+      expect(parsed.projects[await fs.realpath(ws)].notify).toBeUndefined()
+      expect(parsed.mcp_servers.crabot.notify).toBeUndefined()
+    })
+
+    it('宿主没有 config.toml(全新机器)→ 干净降级成只有 crabot 三块', async () => {
+      const parsed = await provisionWithHost(null, [{ name: 'crabot', transport: 'stdio', command: 'node' }])
+      const realRoot = await fs.realpath(ws)
+
+      expect(parsed.notify).toBeDefined()
+      expect(parsed.projects[realRoot]).toEqual({ trust_level: 'trusted' })
+      expect(parsed.mcp_servers).toEqual({ crabot: { command: 'node' } })
+      expect(parsed.model_provider).toBeUndefined()
+    })
+
+    it('宿主 config.toml 损坏 → provision 显式失败,且错误消息不带文件内容', async () => {
+      // 静默降级会精确重现本次生产事故:key 在、端点错,而且无声无息。
+      await fs.writeFile(
+        path.join(codexHomeSource, 'config.toml'),
+        'model_provider = "custom"\nbroken = [[[\n',
+        'utf-8',
+      )
+      const adapter = new CodexWorkerAdapter({ dataDir: ws, codexHomeSource })
+
+      await expect(adapter.provision({ root: ws }, { skills: [], mcp_servers: [] })).rejects.toThrow(
+        /config\.toml/,
+      )
+
+      // 错误消息只能带路径 + 解析位置,不能把文件内容(可能含凭据)回显出来
+      const err = await adapter
+        .provision({ root: ws }, { skills: [], mcp_servers: [] })
+        .then(() => null, (e: Error) => e)
+      expect(err).not.toBeNull()
+      expect(err!.message).toContain(path.join(codexHomeSource, 'config.toml'))
+      expect(err!.message).not.toContain('model_provider')
+      expect(err!.message).not.toContain('broken')
+      expect(err!.message).not.toContain('[[[')
+    })
   })
 })
 


### PR DESCRIPTION
## codex worker 的端点配置在 provision 时被丢掉

### 生产实证(今天,m2)

用户的任务被 manager 换成 codex 重跑,worker 起来后报:

```
unexpected status 401 Unauthorized: Incorrect API key provided: sk-8b9ef***9f04
url: https://api.openai.com/v1/responses, auth error code: invalid_api_key
```

用户一眼看出不对:「我 codex 配置的端点不是 `https://mirror.xinshu.ai` 吗?」

**不是 key 无效,是 key 被送错了地方。**

### 根因:key 搬了,端点没搬

- `codex/adapter.ts:601,616` 把 `CODEX_HOME` 重定向到 `<workspace>/.codex`;
- `provision()` 在那个位置**整份 `writeFile`** 出一个只含 `notify` + `[projects."…"] trust_level` + `[mcp_servers]` 的 `config.toml`;
- 宿主 `~/.codex/config.toml` 里的 `model_provider = "custom"`、`[model_providers.custom] base_url`、`model`、`wire_api`、`disable_response_storage` **一个都没被带过去**;
- 而 `auth.json` 是被**原样拷贝**的。

codex 于是把 workspace 的 `.codex` 当成一个全新的顶层 home(实证:里面有它自己生成的 `installation_id`、独立 `history.jsonl`、`state_5.sqlite`),`~/.codex/config.toml` 一个字节都没读 → 回落到内置默认 provider `openai` → 拿着**只对 mirror 有效的 key** 打官方端点 → 401。

**对照 cc**:cc adapter **完全不隔离 home**(建 session 时不传 `env`、不设 `CLAUDE_CONFIG_DIR`),用户配置原样生效;它往全局 `~/.claude.json` 写时**只补 projects 字段**,加锁 + 原子替换,注释明写「宁可 provision 失败也不能把它覆盖掉」(`claude-code/adapter.ts:287-349`)。**codex adapter 对它自己造出来的那份顶层配置没有对应纪律。**

这不是「配置传递缺失」——CLI worker 架构上就是依赖宿主 CLI 登录态(`grep endpoint|apikey|buildConnectionInfo crabot-agent/src/workers/` 零命中,有意为之)。是 **`CODEX_HOME` 隔离破坏了这个依赖**:只继承了 auth.json,丢了 config.toml。

### 改动

provision 时先读宿主 `~/.codex/config.toml` 作基底,再叠加 crabot 的三块 —— 与 `auth.json` 的搬运策略一致,本来就是同一个道理:**隔离 home 就得继承宿主登录态**。

`[mcp_servers]` 由 **crabot 的能力集覆盖**而非合并:caps 是任务授权边界,不该被宿主配置扩大。

### 为什么加 `smol-toml` 依赖

先找过不解析的路,没有安全的:

1. **叠加需要删除,不只是追加。** 宿主若已定义 `notify` / `[projects.*]` / `[mcp_servers.*]`,直接拼接产生重复键/重复表 → **codex 直接起不来**,比原 bug 更糟。而一台配了镜像端点的机器,很可能也配了 `[mcp_servers]`。
2. **按 `^\s*\[` 逐行判表头会误判** —— 多行基本/字面字符串(`"""…"""`)和跨行数组里都能合法出现行首 `[`。判错就是静默删错段落,**正是本次在修的那类错误**。
3. TOML 根级 key 必须排在所有 table 之前的约束,现在由 `stringify` 保证,不再依赖拼接顺序。

选 `smol-toml@1.7.1`:零传递依赖、BSD-3、TOML 1.0.0、周下载 2700 万。排除 `toml`(只能 parse)、`@iarna/toml`(停更、停在 0.5 规范)、`@ltd/j-toml`(LGPL,不宜进 Apache-2.0 仓库)。`install.sh` 的 `pnpm install` 不用动。

### 损坏的宿主配置:显式失败,不降级

静默降级会**精确重现本次事故** —— key 在、端点错 —— 而且无声无息,这个 bug 正是因此活到生产的。真实 codex 遇到损坏配置本身也起不来,失败没挡住任何本来能工作的场景。**非 ENOENT 的读失败(权限等)同样抛错**,不当「没配过」;只有 ENOENT 干净降级成今天的行为(全新机器必须能用)。

### ⚠️ 实测发现的凭证泄露面

**`smol-toml` 的 `err.message` 里嵌了出错位置的源码片段** —— 探针里它把 `api_key = "sk-SUPERSECRET"` 整行原样回显了出来。

所以错误消息**只取 `err.line`/`err.column` + 文件路径,绝不透传 `err.message`**,并有断言钉死「错误消息不含文件内容」。

### 用例与变异

新增 7 条,RED 已确认(修复前 4 挂)。

| 变异 | 结果 |
|---|---|
| 不读宿主基底 | 4 条挂(含端点继承那条) |
| `[mcp_servers]` 改成合并 | **恰好 1 条**挂,正是 mcp 边界那条 |
| 根级 key 排到 table 之后 | 5 条挂(含排序那条) |

排序用例是**真解析验证**:断言 `parsed.notify` 在顶层,且 `model_providers.custom` / `projects[realRoot]` / `mcp_servers.crabot` 里都没冒出 `notify` —— 排序退化时根级 key 会被吸进最后一个 table,两侧都钉才抓得住。

另钉住:宿主里**别的目录**的 `[projects."…"]` 信任记录共存时,crabot 为本 workspace 写的那条 `trust_level` 必须在且指向本 workspace。

改动了 1 条既有断言:`[mcp_servers."x"]` → 解析后比对 `{ x: { command: 'node' } }`。真序列化器不给合法裸键加引号,格式细节、语义等价。`renderCodexMcpToml` 及其 `provision.test.ts` 的逐字符串断言一字未动 —— provision 改为 `parseToml(renderCodexMcpToml(...))`,mcp 段形状仍是单一真相来源。

### 验证

`tsc --noEmit` 干净(agent 与仓库根)。全量 **2422 passed**(基线 2414,+7 吻合);唯一 failed 是 `bg-tools.test.ts`,与基线那两条一起单跑 **64/64 全绿**,并发 flaky。

### Follow-up(按边界未做)

- `auth.json` 的拷贝仍是**静默 catch**,拷坏了没人知道;本次新代码没重蹈(只对 ENOENT 降级);
- `materialize.ts` 里手写的 `tomlString`/`escapeTomlBasicString` 现在可由 `smol-toml` 退役,属独立清理(`codex/adapter.ts` 里那份**复制品**因本次改动变成孤儿,已随手删 —— 是本次改动自己造出来的死代码);
- 已知并发 flaky 名单新增 `bg-tools.test.ts`(此前已知 `bg-shell.test.ts`、`harness-continuation.test.ts`)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
