### PR TITLE
fix(workers): codex worker 放行 workspace-write 沙箱的网络

### DIFF
--- a/crabot-agent/src/workers/codex/adapter.ts
+++ b/crabot-agent/src/workers/codex/adapter.ts
@@ -122,6 +122,15 @@
  *    下的真机结论错误套用到了交互式路径(exec 路径实测,交互态未单独验证)。已改为 provision
  *    时把 workspace 写成 config.toml 里的受信任目录,见"provision"节。
  *
+ * **网络放行**:`--sandbox workspace-write` 下 `sandbox_workspace_write.network_access`
+ * 默认 false,且沙箱(macOS seatbelt)的拒绝把 loopback 一起挡掉——worker 外网和本机端口
+ * 同时不可达(m2 实测 codex-cli 0.146.0:只给 `--sandbox workspace-write` 时
+ * `curl example.com` HTTP=000,补上 network_access=true 后 HTTP=200)。所以 spawn/resume
+ * 都固定追加 `-c sandbox_workspace_write.network_access=true`(`-c/--config key=value` 是
+ * 主命令级全局选项,值按 TOML 解析,同一文档页确认;与 `--sandbox` 同类,resume 时同样必须
+ * 排在 `resume` 子命令之前)。**保留写限制**:worker 仍不能往 workspace 之外乱写,只放开网络。
+ * 注:builtin worker 的 shell 本来就没有沙箱,单卡 codex 的网络只是把不对称当安全。
+ *
  * 另外 PATH 显式经 `buildEnv()`/`resolveBinDir()` 前置了 codexBin 解析出的真实目录(nvm
  * 部署陷阱,见该函数注释):tmux server 是常驻进程,其环境不一定等于当前 agent 进程的环境
  * (m2 上 codex 是 nvm 装的 node 脚本,tmux server 环境不含对应 node 的 bin 目录时,子进程
@@ -179,6 +188,11 @@ import type {
 } from '../types.js'
 
 const execFileAsync = promisify(execFile)
+
+/** spawn/resume 都要带的主命令级选项:放行 workspace-write 沙箱的出网。见文件头
+ * "spawn/resume 启动参数"节。取值只含 `[A-Za-z_.=]`,不含 shell 元字符,拼进经 `sh -c`
+ * 跑的 tmux 命令行时无需额外引号(与相邻的 `--sandbox workspace-write` 写法一致)。 */
+const CODEX_NETWORK_ACCESS_OPT = '-c sandbox_workspace_write.network_access=true'
 
 /** POSIX shell 单引号转义,与 cc adapter 的私有 shQuote 同款用法(独立复制一份)。 */
 function shQuote(s: string): string {
@@ -695,7 +709,8 @@ export class CodexWorkerAdapter implements WorkerAdapter {
     // 不传 --skip-git-repo-check(m2 实测顶层交互式 codex 不支持这个 flag,只有 codex exec
     // 才有——见文件头"spawn/resume 启动参数"节);受信目录改由 provision 写进 config.toml 的
     // [projects."<realpath>"] trust_level = "trusted" 解决。
-    const command = `${this.codexBin} --ask-for-approval never --sandbox workspace-write`
+    // 网络放行见文件头"spawn/resume 启动参数"节。
+    const command = `${this.codexBin} --ask-for-approval never --sandbox workspace-write ${CODEX_NETWORK_ACCESS_OPT}`
     const spawnStartedAt = Date.now()
 
     // newSession 成功之后才落 meta(running)+注册 runtime,同 cc 纪律:tmux 失败时不留任何
@@ -834,8 +849,9 @@ export class CodexWorkerAdapter implements WorkerAdapter {
       // m2 实测:--ask-for-approval/--sandbox 这类主命令级选项必须排在 `resume` 子命令**之前**
       // ——放在 `resume <id>` 后面 codex 会报 usage 错、exit=2(原实现把它们放在 `resume <id>`
       // 之后,是未经真机验证的错误猜测,这里按实测结果改正)。不传 --skip-git-repo-check,
-      // 理由同 spawn(见文件头"spawn/resume 启动参数"节)。
-      const command = `${this.codexBin} --ask-for-approval never --sandbox workspace-write resume ${shQuote(prev.session_ref)}`
+      // 理由同 spawn(见文件头"spawn/resume 启动参数"节)。-c 同属主命令级选项,同样放在
+      // `resume` 之前。
+      const command = `${this.codexBin} --ask-for-approval never --sandbox workspace-write ${CODEX_NETWORK_ACCESS_OPT} resume ${shQuote(prev.session_ref)}`
 
       // 锁纪律与 spawn 一致:tmux newSession 成功之后才落 meta(running)+注册 runtime;
       // PATH 前置同 spawn(nvm 部署陷阱)。

--- a/crabot-agent/tests/workers/codex-adapter.test.ts
+++ b/crabot-agent/tests/workers/codex-adapter.test.ts
@@ -686,7 +686,7 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter (tmux + mock CLI)', () => {
   )
 
   it(
-    'spawn 命令行不携带 --skip-git-repo-check(该 flag 只注册在 codex exec 子解析器上,m2 实测顶层交互式 codex 没有这个 Option,传了会被 clap usage 错误拒绝),--ask-for-approval/--sandbox 取值合法',
+    'spawn 命令行不携带 --skip-git-repo-check(该 flag 只注册在 codex exec 子解析器上,m2 实测顶层交互式 codex 没有这个 Option,传了会被 clap usage 错误拒绝),--ask-for-approval/--sandbox 取值合法,且带 -c sandbox_workspace_write.network_access=true(否则 worker 外网+本机端口全不可达)',
     async () => {
       const channel = new CliEventChannel(eventsFilePath({ root: workspaceRoot }))
       const stopHookCmd = channel.hookCommand('stop')
@@ -706,6 +706,9 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter (tmux + mock CLI)', () => {
       const sandboxIdx = argv.indexOf('--sandbox')
       expect(sandboxIdx).toBeGreaterThan(-1)
       expect(['read-only', 'workspace-write', 'danger-full-access']).toContain(argv[sandboxIdx + 1])
+      const configIdx = argv.indexOf('-c')
+      expect(configIdx).toBeGreaterThan(-1)
+      expect(argv[configIdx + 1]).toBe('sandbox_workspace_write.network_access=true')
 
       await adapter.kill(h)
     },
@@ -713,7 +716,7 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter (tmux + mock CLI)', () => {
   )
 
   it(
-    'resume 命令行不携带 --skip-git-repo-check,--ask-for-approval/--sandbox 放在 resume 子命令之前(放后面 codex 报 usage 错、exit=2,m2 实测)',
+    'resume 命令行不携带 --skip-git-repo-check,--ask-for-approval/--sandbox/-c 放在 resume 子命令之前(放后面 codex 报 usage 错、exit=2,m2 实测),且 -c 放行了 workspace-write 沙箱的网络',
     async () => {
       const channel = new CliEventChannel(eventsFilePath({ root: workspaceRoot }))
       const stopHookCmd = channel.hookCommand('stop')
@@ -735,11 +738,13 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter (tmux + mock CLI)', () => {
       expect(argv).not.toContain('--skip-git-repo-check')
       const resumeIdx = argv.indexOf('resume')
       expect(resumeIdx).toBeGreaterThan(-1)
-      for (const flag of ['--ask-for-approval', '--sandbox']) {
+      for (const flag of ['--ask-for-approval', '--sandbox', '-c']) {
         const idx = argv.indexOf(flag)
         expect(idx).toBeGreaterThan(-1)
         expect(idx).toBeLessThan(resumeIdx)
       }
+      const configIdx = argv.indexOf('-c')
+      expect(argv[configIdx + 1]).toBe('sandbox_workspace_write.network_access=true')
     },
     15000,
   )


### PR DESCRIPTION
## codex worker 放行 workspace-write 沙箱的网络

### 问题

crabot 起 codex worker 用的是 `codex --ask-for-approval never --sandbox workspace-write`,**没有任何 `-c` 覆盖**。而 `workspace-write` 模式下 `sandbox_workspace_write.network_access` 默认 **false**,且 seatbelt 的拒绝**连 loopback 一起挡**。

生产上有真实任务因此失败 —— worker 报告「执行环境无法访问外网和本机行情端口,没有拿到可核验的收盘价及连续 K 线」。**外网和本机端口同时不通**,正是这个默认值的表现。

m2 实测(codex-cli 0.146.0):

```
-c 'sandbox_mode="workspace-write"'                      → curl example.com  HTTP=000
同上 + -c 'sandbox_workspace_write.network_access=true'  → curl example.com  HTTP=200
```

宿主 `~/.codex/config.toml` 里没有任何 sandbox / network 配置,所以这不是 #68 的配置继承问题,纯粹是起进程时没给这个选项。

### 决定与理由

用户明确要求放开,论据是:

> 「你光限 codex 有啥用呢?builtin agent 连沙箱都没有。我自己用一般是用 `codex --yolo`。」

即 builtin worker 的 shell 本来就无沙箱,单卡 codex 是把不对称当安全。

**保留 `--sandbox workspace-write` 的写限制**,不改用 `--yolo` / `danger-full-access`:目标是网络可达,而写限制不妨碍这个目标,却能挡住 worker 往 workspace 外乱写。

### 改动

两个起 codex 交互进程的地方(spawn / resume)各加 `-c 'sandbox_workspace_write.network_access=true'`,抽成模块级常量避免两处漂移。

**找全的方式**:全仓 grep `--sandbox` / `workspace-write` / `codexBin` / `ask-for-approval` 四组关键词交叉核对。`codexBin` 在 src 里只有 4 处运行时使用 —— `resolveBinDir` 缓存、`detect()` 的 `--version` 探测(不起 TUI),以及这 2 个 `tmux.newSession`。没有第三处。

### 参数格式:m2 实机坐实,不是照文档猜

**① `-c` 是顶层交互式 `codex` 的合法 global arg**

```
$ codex --ask-for-approval never --sandbox workspace-write \
    -c 'sandbox_workspace_write.network_access=true' 'hello ...' --version
codex-cli 0.146.0
EXIT=0
```

对照组证明 clap 确实在校验(`--version` 不会掩盖 usage error):

```
$ codex --bogus-flag-xyz --version
error: unexpected argument '--bogus-flag-xyz' found
EXIT=2
```

**② key 名与取值格式正确,值确实按 TOML 解析成布尔** —— 用 `codex debug models`(只读、不起会话、会真正反序列化 config)做类型探针:

```
$ codex debug models -c 'sandbox_workspace_write.network_access=true'
EXIT=0                      # 无任何错误输出

$ codex debug models -c 'sandbox_workspace_write.network_access="notabool"'
Error: invalid type: string "notabool", expected a boolean
       in `sandbox_workspace_write.network_access`
EXIT=1
```

这条报错一次坐实三件事:key 路径被 config schema 认识(不是被当无用字段吞掉)、字段类型是 `bool`、`=true` 走 TOML 解析成布尔而非字符串。

**③ 位置无约束**,顶层 `-c` 会传播进子命令(用坏值当探针,两个位置都触发同一条类型错误)。`codex resume --help` 自己的 Options 里也独立列了 `-c`。

> 注:`-c` 在 `resume` 前属顶层 global arg 传播,在 `resume` 后命中 `resume` 自己的 `-c` —— 两条都生效,但**同时在两侧传**的语义未验证,所以代码只在一个位置传。

**引号与注入面**:`spec.command` 作为单个 argv 传给 `tmux new-session`,由 tmux 交给 `sh -c`。取值只含 `[A-Za-z_.=]`,无 shell 元字符、无 glob,因此沿用现有 `--sandbox workspace-write` 的裸 token 写法,不引入新的注入面。

### 测试

扩展已有的两个 argv 断言用例(沿用其 mock-cli `MOCK_CLI_ARGV_FILE` 捕获 argv 的风格),不新增用例:

- spawn:断言 `-c` 存在且下一 token 为该取值;
- resume:把 `-c` 并入「必须早于 `resume`」的循环,另断言取值。

RED 确认:改代码前两条都 FAIL(`expected -1 to be greater than -1`)。

**变异分别验证**(不是一起去掉):只从 spawn 去掉 → 仅 spawn 用例挂;只从 resume 去掉 → 仅 resume 用例挂。

### 验证

`tsc --noEmit` 通过。全量 **2484 passed | 2 skipped**,与分支起点基线**完全一致**(本次只给已有用例加断言,不新增用例,故数字不变),未触发已知 flaky。

### 若之后要与 `--yolo` 完全对齐

把两处的 `--sandbox workspace-write ${CODEX_NETWORK_ACCESS_OPT}` 换成 `--sandbox danger-full-access`,常量与其两处引用一并删除(`sandbox_workspace_write.*` 只对 workspace-write 生效)。

**不建议改用 `--yolo` / `--dangerously-bypass-approvals-and-sandbox`**:它同时覆盖 approval 策略,与现有 `--ask-for-approval never` 语义重叠,且顶层交互式路径下的行为没在 m2 验过;`danger-full-access` 是同一张已验证 Global Options 表里的合法取值,改动面更小。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
