### PR TITLE
fix(agent): 日志不再写死进程,后台任务失败不再静默

### DIFF
--- a/crabot-agent/src/core/stdio-guard.ts
+++ b/crabot-agent/src/core/stdio-guard.ts
@@ -1,0 +1,47 @@
+/**
+ * stdout / stderr 写失败的收口 —— 一处装上，覆盖全仓所有 `console.*` 调用点。
+ *
+ * ## 事故（2026-08-05 06:38:05Z）
+ *
+ * LLM 端点抖动 → `withStreamConsumptionRetry` 疯狂打重试日志 → MM 被 SIGTERM 后 stderr 管道
+ * 读端关闭 → `console.error` 的写以 EPIPE 失败 → `main.ts` 的 `uncaughtException` 处理器把它
+ * 转成 `process.exit(1)`。**一个记录故障的动作把进程杀了**：agent 死了 47 秒，重启时 reconcile
+ * 判死两个在跑的化身，其中一条 cc 任务落终态 `failed`。
+ *
+ * ## 为什么这一处能收口（Node 22 实测，见 tests/core/stdio-guard.test.ts）
+ *
+ * 1. 管道的写失败**不是同步抛**的：`process.stdout/stderr` 在管道上是 `net.Socket`，errno 在
+ *    `afterWriteDispatched` 里就地构造成 Error（所以它的栈末端仍是那句 `console.error`），
+ *    再经 `destroy(err)` 在下一个 tick 以 **'error' 事件**派发。`console.error` 与
+ *    `process.stderr.write()` 都不会 throw —— 在调用点包 try/catch 一次也抓不到。
+ * 2. Node 的 `Console` 自带的防护**只挡得住第一条**：`kWriteToConsole` 的写回调里有
+ *    `if (err !== null && !stream._writableState.errorEmitted) stream.once('error', noop)`。
+ *    `errorEmitted` 是黏性的——第一次 EPIPE 被那个 noop 吃掉后它就永久为 true，**第二条及以后
+ *    的日志**再失败时 Node 不再补挂 noop，'error' 事件落到零监听器上 → EventEmitter 直接
+ *    throw → uncaughtException。这正是"平时崩不了、日志一刷屏就崩"的原因，也是事故当天
+ *    重试风暴触发它的原因。
+ * 3. 装一个**常驻**监听器同时堵死两头：'error' 永远有人接，不再 throw；且
+ *    `listenerCount('error') > 0` 让 Console 那套"临时挂了又摘"的动作彻底不再参与。
+ *
+ * ## 为什么不筛错误码（只吞 EPIPE）
+ *
+ * 这个监听器上能收到的一切，按定义都是"日志出口本身写不出去"：既无处上报（要报也只能往
+ * 同一个坏掉的出口写），也与进程正在做的事（RPC、落盘、台账）无关。只吞 EPIPE、其余 rethrow
+ * 的写法不是更安全，而是把同一场崩溃原样搬到 EIO（控制终端消失，daemon 化后的典型形态）和
+ * ERR_STREAM_DESTROYED 上——在 'error' 处理器里 rethrow 同样是 uncaughtException。
+ * Node 自己的 `Console` 是同一取舍：同步写错误一律吞，只放行 stack overflow
+ * （lib/internal/console/constructor.js 的 `kWriteToConsole`，注释写着 "Sorry, there's no
+ * proper way to pass along the error here"）。
+ *
+ * 代价（如实记）：stdio 写失败从此完全不可见。可接受——它本来也只能通过写 stdio 来"可见"。
+ * 进程真正的健康信号走 MM 的 health check 与 `data/agent/fatal.log`，不依赖这条通道。
+ *
+ * **不动 `main.ts` 的 `uncaughtException` → `exit(1)`**：那是最后防线，不该为这一种错误削弱它。
+ */
+export function installStdioErrorGuard(): void {
+  for (const stream of [process.stdout, process.stderr]) {
+    stream.on('error', () => {
+      // 静默：往已经坏掉的出口写"出口坏了"只会再触发一次同样的失败。
+    })
+  }
+}

--- a/crabot-agent/src/main.ts
+++ b/crabot-agent/src/main.ts
@@ -11,6 +11,11 @@ import { startHeapSampler } from './diagnostics/heap-sampler.js'
 import { checkFdaIfEnabled } from './engine/tools/fda-check.js'
 import type { UnifiedAgentConfig } from './types.js'
 import { getAgentDataDir } from './core/data-paths.js'
+import { installStdioErrorGuard } from './core/stdio-guard.js'
+
+// 必须是进程里的第一件事：它之后的任何一行日志（含下面的 heap sampler / FDA 提示）在
+// stdout/stderr 管道断开时都会以 'error' 事件打到零监听器上 → uncaughtException（见该文件头）。
+installStdioErrorGuard()
 
 startHeapSampler({ intervalMs: 30_000 })
 

--- a/crabot-agent/src/manager/bootstrap.ts
+++ b/crabot-agent/src/manager/bootstrap.ts
@@ -56,7 +56,7 @@ import {
   type ResolvedPrincipal,
 } from './principal.js'
 import type { CompactionPolicy } from './compaction.js'
-import type { ManagerKey } from './types.js'
+import type { ManagerEpisodeFailure, ManagerKey } from './types.js'
 
 // 与 `unified-agent.ts` 同款引用路径:这两个常量没有从 `engine/index.ts` 转出,直接引子模块
 // (engine 本阶段零改动,不为此新增 barrel 导出)。
@@ -157,7 +157,34 @@ export interface BootstrapDeps {
    * 只维护台账、不对外发事件。
    */
   readonly publishEvent?: AgentEventPublisher
+  /**
+   * fail-loud 兜底出口:worker 事件唤醒的 manager episode 失败时,直接告诉人类一声。
+   * 接线范式与上面的 `publishEvent` 完全一致(可选;不注入则这条路保持"只记日志"的既有行为)。
+   *
+   * 为什么要有:`onEvent` 是 fire-and-forget,原本只 `.catch(console.error)`,且**从不看
+   * outcome**——最常见的失败(F1:LLM 挂 / key 过期 / 限流耗尽,不抛错、只把 `outcome` 写成
+   * `failed`)因此完全静默。人类那一侧的表现是"worker 干完了/挂了,但再也没人来汇报"。
+   *
+   * 实现落在 `unified-agent.ts`(`sendBackgroundFailLoud`):出站要 `rpcClient` + channel 端口,
+   * 而那是 agent 的东西,不是 manager 栈的。这里只交出口子。
+   */
+  readonly reportEpisodeFailure?: EpisodeFailureReporter
 }
+
+/**
+ * `BootstrapDeps.reportEpisodeFailure` 的形状。
+ *
+ * - `target`:告诉谁。由本模块从台账解出(见 `onEvent` 处的注释),已是 `{channel_id, session_id}`;
+ * - `subject`:哪件事没跑成,直接做兜底文案的主语;
+ * - `failure`:失败形态(判据双管,见 `ManagerEpisodeFailure`)。
+ *
+ * **返回 void 且实现方绝不能抛**:调用点在游离 promise 的收尾里,抛出去就是 unhandledRejection。
+ */
+export type EpisodeFailureReporter = (report: {
+  readonly target: { readonly channel_id: string; readonly session_id: string }
+  readonly subject: string
+  readonly failure: ManagerEpisodeFailure
+}) => void
 
 /** `ManagerKey` → `{channel_id, session_id}`。按**第一个** `::` 切,session_id 里再含 `::` 也不会被截断。 */
 function channelSessionFromManagerKey(key: ManagerKey): { channel_id: string; session_id: string } {
@@ -224,6 +251,35 @@ export function buildManagerStack(deps: BootstrapDeps): ManagerStack {
     ? makeTaskStatusEventBridge({ ledger, publish: deps.publishEvent })
     : undefined
 
+  /**
+   * worker 事件唤醒的 episode 失败 → `deps.reportEpisodeFailure`(fail-loud)。
+   *
+   * 目标会话取**该 worker 的监护 manager**(`origin.spawned_by_session`),台账查不到则落系统
+   * 线程——与 `routeWorkerEvent` 自己的路由判据逐字相同,所以"哪个 manager 挂了"和"告诉谁"
+   * 永远是同一个会话。不用 `report_to`:那是 worker **结果**的回报目标,可以与监护 session 不同
+   * (同一 friend 跨 channel 共享台账),拿它当告警目标会把话说到另一个对话里去。
+   *
+   * **绝不抛**:调用点在游离 promise 的 `.then`/`.catch` 收尾里,从这里抛出去就是
+   * unhandledRejection → 打死 agent 进程。台账读失败(findWorker)也只记日志。
+   */
+  const reportWorkerEventFailure = async (workerId: string, failure: ManagerEpisodeFailure): Promise<void> => {
+    if (!deps.reportEpisodeFailure) return
+    try {
+      const found = await ledger.findWorker(workerId)
+      const target = channelSessionFromManagerKey(
+        found?.worker.origin.spawned_by_session ?? SYSTEM_TASKS_MANAGER_KEY,
+      )
+      const title = found?.worker.task.title
+      deps.reportEpisodeFailure({
+        target,
+        subject: `worker「${title ?? workerId}」的状态更新`,
+        failure,
+      })
+    } catch (err) {
+      console.error(`[manager-bootstrap] fail-loud 上报失败 (worker=${workerId}):`, err)
+    }
+  }
+
   // --- 四步接线契约 step 1:先建空壳 Map ---
   const adapters = new Map<WorkerImplId, WorkerAdapter>()
 
@@ -246,9 +302,21 @@ export function buildManagerStack(deps: BootstrapDeps): ManagerStack {
       publishTaskStatusChanged?.(event)
 
       if (!registry || !shouldWakeOnHarnessEvent(event)) return
-      void registry.routeWorkerEvent(event).catch((err) => {
-        console.error(`[manager-bootstrap] routeWorkerEvent 失败 (worker=${event.worker_id}, kind=${event.kind}):`, err)
-      })
+      // fail-loud 的判据必须双管:`.catch` 只抓得到 F2(中途抛错),而最常见的 F1(LLM 挂 /
+      // key 过期 / 限流耗尽)是**正常 resolve 且 outcome='failed'**——只 catch 等于对它全瞎。
+      void registry
+        .routeWorkerEvent(event)
+        .then(async (result) => {
+          if (result?.outcome !== 'failed' && result?.outcome !== 'aborted') return
+          console.error(
+            `[manager-bootstrap] routeWorkerEvent episode outcome=${result.outcome} (worker=${event.worker_id}, kind=${event.kind})`,
+          )
+          await reportWorkerEventFailure(event.worker_id, { kind: 'outcome', outcome: result.outcome })
+        })
+        .catch(async (err) => {
+          console.error(`[manager-bootstrap] routeWorkerEvent 失败 (worker=${event.worker_id}, kind=${event.kind}):`, err)
+          await reportWorkerEventFailure(event.worker_id, { kind: 'threw', error: err })
+        })
     },
     builtinSpawnDefaults: deps.builtinSpawnDefaults,
   }

--- a/crabot-agent/src/manager/types.ts
+++ b/crabot-agent/src/manager/types.ts
@@ -24,3 +24,19 @@ export interface ManagerSessionState {
   /** 已折叠进摘要的消息条数(诊断用) */
   readonly foldedCount: number
 }
+
+/**
+ * fail-loud 兜底:manager episode 失败的两种形态。
+ *
+ * `ManagerLoop` 只有 F2 会抛错;最常见的 F1(LLM 挂 / key 过期 / 限流耗尽重试)记
+ * `outcome:'failed'`、把整批输入推回 mailbox,然后**正常 resolve**。所以判据必须双管:
+ * `catch` 抓 F2,`outcome ∈ {failed, aborted}` 抓 F1。只写 try/catch 抓不住最常见的那种。
+ *
+ * 住在这里而不是 `unified-agent.ts`:除了三条人类消息入口,`bootstrap.ts` 的 worker 事件
+ * 出口也要按同一套判据上报(`BootstrapDeps.reportEpisodeFailure`),两边必须是同一个类型。
+ *
+ * @see crabot-docs/superpowers/plans/2026-08-01-mw-p7-j-cutover.md §三
+ */
+export type ManagerEpisodeFailure =
+  | { readonly kind: 'threw'; readonly error: unknown }
+  | { readonly kind: 'outcome'; readonly outcome: 'failed' | 'aborted' }

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -69,6 +69,9 @@ import { DEFAULT_MAX_CONTEXT_TOKENS } from './engine/query-loop.js'
 import { buildManagerStack, reconcileManagerStack, type ManagerStack } from './manager/bootstrap.js'
 import { makeAgentEventPublisher } from './manager/events.js'
 import { resolveManagerModelConfig } from './manager/model-slot.js'
+import { splitManagerKey } from './manager/principal.js'
+import { SYSTEM_TASKS_MANAGER_KEY } from './manager/registry.js'
+import type { ManagerEpisodeFailure } from './manager/types.js'
 import { createCrabMemoryServer, filterMemoryToolsByProfile } from './mcp/crab-memory.js'
 import {
   BUILTIN_WORKER_PERMISSIONS,
@@ -264,19 +267,6 @@ const WORKER_TRACE_LAYER2_UNAVAILABLE =
   '当前仅返回 harness 亲历的生命周期事件（第一层）'
 
 /**
- * fail-loud 兜底：入站 lane handler 上 manager episode 失败时的失败形态。
- *
- * `ManagerLoop` 只有 F2 会抛错；最常见的 F1（LLM 挂 / key 过期 / 限流耗尽重试）记
- * `outcome:'failed'`、把整批输入推回 mailbox，然后**正常 resolve**。所以判据必须双管：
- * `catch` 抓 F2，`outcome ∈ {failed, aborted}` 抓 F1。只写 try/catch 抓不住最常见的那种。
- *
- * @see crabot-docs/superpowers/plans/2026-08-01-mw-p7-j-cutover.md §三
- */
-type ManagerEpisodeFailure =
-  | { readonly kind: 'threw'; readonly error: unknown }
-  | { readonly kind: 'outcome'; readonly outcome: 'failed' | 'aborted' }
-
-/**
  * fail-loud 兜底回复的按 key 冷却窗口。
  *
  * F1 形态下整批输入被推回 mailbox 等下次唤醒重投，同一批消息因此会**反复**触发失败；
@@ -316,6 +306,40 @@ function buildFailLoudText(failure: ManagerEpisodeFailure): string {
   return (
     `我这条消息没处理完就出错了，暂时回不了你。错误：${detail}。` +
     '可以稍后再发一次；一直这样的话请管理员看一下 agent 日志。'
+  )
+}
+
+/**
+ * **非人类触发**（定时任务 / worker 事件）的兜底正文。
+ *
+ * 不能复用 `buildFailLoudText`：那份全篇第二人称（"我这条消息没处理完…暂时回不了你"），
+ * 而这两条路上**没人刚说话**——照搬过去读起来是错的，人类会以为自己刚发的消息丢了。
+ * 这里必须点名是**哪件事**没跑成（`subject`），否则一句无主语的"出错了"既说不清要重跑什么，
+ * 也说不清该不该管。下一步动作也不同：人类消息可以"再发一次"，这两条只能手动重跑。
+ *
+ * `subject` 直接做句子主语，例：`定时任务「每日早报」` / `worker「w-3f2a」的状态更新`。
+ * model slot 缺失的特判与人类那份同源（同一条错误、同一个解法）。
+ */
+function buildBackgroundFailLoudText(subject: string, failure: ManagerEpisodeFailure): string {
+  if (failure.kind === 'outcome') {
+    return (
+      `${subject}没跑成（模型这一轮 ${failure.outcome} 了）。` +
+      '常见原因是 LLM 服务不可用、API key 过期或额度用尽——' +
+      '请管理员到 Admin 的全局设置里检查模型配置，之后手动重跑一次。'
+    )
+  }
+
+  const raw = failure.error instanceof Error ? failure.error.message : String(failure.error)
+  if (raw.includes("model_config 缺少")) {
+    return (
+      `Crabot 还没配好 manager 用的模型，${subject}没跑成。` +
+      '请管理员打开 Admin → 全局设置，给 manager（没有就给 powerful）槽位选好 provider 和模型，然后手动重跑一次。'
+    )
+  }
+  const detail = raw.length > FAIL_LOUD_ERROR_MAX_CHARS ? `${raw.slice(0, FAIL_LOUD_ERROR_MAX_CHARS)}…` : raw
+  return (
+    `${subject}没跑成，出错了。错误：${detail}。` +
+    '可以稍后手动重跑；一直这样的话请管理员看一下 agent 日志。'
   )
 }
 
@@ -668,6 +692,12 @@ export class UnifiedAgent extends ModuleBase {
         moduleId: this.config.moduleId,
         now: () => new Date().toISOString(),
       }),
+      // fail-loud 出口（worker 事件唤醒的 episode 失败）：装配层只负责解出"告诉谁 / 哪件事"，
+      // 出站那一跳（rpcClient + channel 端口 + 冷却）是 agent 的东西，落在这里。
+      // 游离 promise 的收尾在调用侧，`sendBackgroundFailLoud` 自己保证不抛。
+      reportEpisodeFailure: (report) => {
+        void this.sendBackgroundFailLoud(report.target, report.subject, report.failure)
+      },
     })
   }
 
@@ -1296,6 +1326,10 @@ export class UnifiedAgent extends ModuleBase {
    * 前端那个转圈的占位气泡靠 `request_id` 匹配 `chat_reply` 才会被替换掉 —— 只有
    * `chat_callback` 能收口它。兜底文案是纯文本，`chat_reply` 的 string content 装得下，无损。
    *
+   * **`subject` 切换成"非人类触发"文案**（定时任务 / worker 事件，见
+   * `sendBackgroundFailLoud`）：判据、冷却、出站那一跳全部照旧，只有正文换成第三人称的
+   * `buildBackgroundFailLoudText`。
+   *
    * 返回**这一次有没有真的把话送出去**：`false` = 冷却命中或出站 RPC 自身失败。
    * channel 两条路忽略它（送不出去就只能落日志）；admin chat 靠它决定要不要把异常抛回
    * RPC 调用方，让 admin 侧既有的 `chat_error` 兜住占位气泡（见 `processAdminChatMessage`）。
@@ -1307,6 +1341,7 @@ export class UnifiedAgent extends ModuleBase {
     sessionId: string,
     failure: ManagerEpisodeFailure,
     adminChatRequestId?: string,
+    subject?: string,
   ): Promise<boolean> {
     const key = `${channelId}::${sessionId}`
     const now = Date.now()
@@ -1319,7 +1354,7 @@ export class UnifiedAgent extends ModuleBase {
     this.failLoudSentAt.set(key, now)
 
     try {
-      const text = buildFailLoudText(failure)
+      const text = subject === undefined ? buildFailLoudText(failure) : buildBackgroundFailLoudText(subject, failure)
       if (adminChatRequestId !== undefined) {
         await this.rpcClient.call(
           await this.getAdminPort(),
@@ -1346,6 +1381,41 @@ export class UnifiedAgent extends ModuleBase {
         error instanceof Error ? error.message : String(error),
       )
       return false
+    }
+  }
+
+  /**
+   * fail-loud 的**非人类触发**入口：定时任务（`handleTriggerSchedule`）与 worker 事件
+   * （`BootstrapDeps.reportEpisodeFailure`）两条路共用。
+   *
+   * 与三条人类消息入口的差别只有两处，其余（判据、冷却表、出站 RPC、送不出去只落日志）全共用：
+   *
+   * 1. **文案换第三人称并点名 `subject`**：这两条路上没人刚说话，"暂时回不了你"是错的；
+   * 2. **admin-web 一律投 `system-tasks` 线程**：admin 的 `storeAssistantMessage` 只在
+   *    `session_id === 'admin-chat'` 时 `claimPendingRequestId()`——把当时在飞的那条人类
+   *    提问的占位气泡**机会主义地**认领掉（chat-manager.ts:454）。故障期人类消息与定时任务
+   *    常常一起失败，正是最容易撞上的时刻：撞上就等于"人类的问题被一句『定时任务没跑成』
+   *    顶替，自己的气泡永远转圈"。改投 `system-tasks` 后不认领任何 request_id，而两个
+   *    session 的消息落的是同一个 store、同一条 `chat_push`（admin 侧不按 session 分流），
+   *    人类照样在 Master Chat 里看得到——只是不再顶替别人的气泡。
+   *
+   * **绝不抛**：两个调用方都是游离 promise 的收尾（`.then`/`.catch` 内），从这里抛出去就是
+   * unhandledRejection → 打死 agent 进程，正是本轮要消灭的那类事故。
+   */
+  private async sendBackgroundFailLoud(
+    target: { channel_id: string; session_id: string },
+    subject: string,
+    failure: ManagerEpisodeFailure,
+  ): Promise<void> {
+    try {
+      const sessionId =
+        target.channel_id === 'admin-web' ? splitManagerKey(SYSTEM_TASKS_MANAGER_KEY).sessionId : target.session_id
+      await this.sendFailLoudReply(target.channel_id, sessionId, failure, undefined, subject)
+    } catch (error) {
+      console.error(
+        `[${this.config.moduleId}] fail-loud（${subject}）自身出错:`,
+        error instanceof Error ? error.message : String(error),
+      )
     }
   }
 
@@ -2964,9 +3034,24 @@ export class UnifiedAgent extends ModuleBase {
    * 权限身份（`creator_friend_id` / `is_builtin`）随唤醒事件下传，最终落到本次 episode 派出
    * 的 worker 的 `origin.creator_friend_id`（§4.4）。这是过渡形态：admin 调用点仍走
    * `create_task_from_schedule` 并自行下发 `resolved_permissions`，P7 cutover 时收敛。
+   *
+   * **fail-loud（判据双管）**：fire-and-forget 只 `.catch()` 等于漏掉最常见的那种失败——
+   * F1（LLM 挂 / key 过期 / 限流耗尽）不抛错，只在 `EpisodeResult.outcome` 上写 `failed`。
+   * 定时任务本来就没人盯着，静默失败的表现是"早报没发、反思没生成"，而人类收不到任何提示。
+   * 因此这里既看 `outcome` 也 `catch`，两条都接到 `sendBackgroundFailLoud`（文案第三人称、
+   * 点名是哪个定时任务）。目标会话 = `target_session`，没有则落系统任务线程（与
+   * `routeSchedule` 的路由归属同一判据，见 `SYSTEM_TASKS_MANAGER_KEY`）。
+   *
+   * 受理仍然是同步 `{accepted:true}`：新增的只是游离 promise 的收尾，一步都没 await。
    */
   private handleTriggerSchedule(params: TriggerScheduleParams): TriggerScheduleResult {
     const { registry } = this.requireManagerStack()
+    const systemThread = splitManagerKey(SYSTEM_TASKS_MANAGER_KEY)
+    const target = params.target_session ?? {
+      channel_id: systemThread.channelId,
+      session_id: systemThread.sessionId,
+    }
+    const subject = `定时任务「${params.title || params.schedule_id}」`
     void registry
       .routeSchedule({
         scheduleId: params.schedule_id,
@@ -2976,12 +3061,20 @@ export class UnifiedAgent extends ModuleBase {
         creatorFriendId: params.creator_friend_id,
         isBuiltin: params.is_builtin,
       })
-      .catch((error) => {
+      .then(async (result) => {
+        if (result.outcome !== 'failed' && result.outcome !== 'aborted') return
+        console.error(
+          `[${this.config.moduleId}] trigger_schedule episode outcome=${result.outcome} (schedule=${params.schedule_id})`,
+        )
+        await this.sendBackgroundFailLoud(target, subject, { kind: 'outcome', outcome: result.outcome })
+      })
+      .catch(async (error) => {
         const message = error instanceof Error ? error.message : String(error)
         console.error(
           `[${this.config.moduleId}] trigger_schedule 路由失败 (schedule=${params.schedule_id}):`,
           message
         )
+        await this.sendBackgroundFailLoud(target, subject, { kind: 'threw', error })
       })
     return { accepted: true }
   }

--- a/crabot-agent/tests/core/fixtures/stdio-epipe-child.ts
+++ b/crabot-agent/tests/core/fixtures/stdio-epipe-child.ts
@@ -1,0 +1,32 @@
+/**
+ * `stdio-guard.test.ts` 的被测子进程 —— 真复现：父进程关掉管道读端后继续 `console.error`。
+ *
+ * 跑法是 `node --experimental-strip-types`（Node 22.6+），因此这里**直接 import 生产代码**
+ * （带 `.ts` 后缀，type stripping 的解析规则）。用 inline 一份等价实现就测不到生产代码，
+ * 变异（删掉 `installStdioErrorGuard` 的监听器）也不会挂。
+ *
+ * 约定：
+ * - `GUARD=1` 装生产守卫，`GUARD=0` 不装（不装 = 事故当天的现场）；
+ * - 崩溃时以 42 退出（`uncaughtException` 处理器，复刻 `main.ts` 的 `exit(1)` 语义，
+ *   换个码是为了与"写到一半被信号打死"区分开）；活到最后正常 0 退出。
+ */
+import { installStdioErrorGuard } from '../../../src/core/stdio-guard.ts'
+
+if (process.env.GUARD === '1') installStdioErrorGuard()
+
+process.on('uncaughtException', () => {
+  process.exit(42)
+})
+
+let n = 0
+const timer = setInterval(() => {
+  n++
+  // 一条日志不够：Node 的 Console 自带的防护只挡得住第一条（`errorEmitted` 黏性），
+  // 事故里也是重试风暴刷屏才炸的。
+  console.error(`noisy retry log line ${'x'.repeat(2000)} ${n}`)
+  console.log(`noisy stdout line ${'x'.repeat(2000)} ${n}`)
+  if (n > 40) {
+    clearInterval(timer)
+    process.exit(0)
+  }
+}, 5)

--- a/crabot-agent/tests/core/stdio-guard.test.ts
+++ b/crabot-agent/tests/core/stdio-guard.test.ts
@@ -1,0 +1,97 @@
+/**
+ * `src/core/stdio-guard.ts` —— 2026-08-05 事故的回归测试。
+ *
+ * 事故：LLM 端点抖动 → 重试逻辑刷屏打日志 → MM 被 SIGTERM 后 stderr 管道读端关闭 →
+ * `console.error` 的 EPIPE 变成 uncaughtException → agent 被自己的兜底处理器 exit(1)。
+ *
+ * 两层验证，缺一不可：
+ *
+ * | 层 | 手法 | 证明什么 |
+ * |---|---|---|
+ * | ① 真复现 | spawn 子进程 → 关掉管道读端 → 子进程继续 `console.error` | EPIPE 真的会打死进程，且守卫真的拦得住 |
+ * | ② 事件语义 | 本进程装守卫后手动 emit EPIPE | 生产函数装的是常驻 'error' 监听器（变异检测口） |
+ *
+ * ① 之所以要子进程：EPIPE 只有在"真有一根读端已关闭的管道"时才产生，vitest 自己的进程里
+ * 造不出来（它的 stdout/stderr 归 vitest 管，弄坏了整个 runner 就没输出了）。子进程跑
+ * `node --experimental-strip-types`（Node 22.6+）直接 import 生产 .ts —— Node < 22.6 上该
+ * 用例会 skip，此时只剩 ② 兜着（②对"删掉监听器"这一变异同样敏感）。
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { spawn } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+import { installStdioErrorGuard } from '../../src/core/stdio-guard.js'
+
+const CHILD = fileURLToPath(new URL('./fixtures/stdio-epipe-child.ts', import.meta.url))
+
+/** Node 22.6+ 才有 type stripping；老版本上没法在子进程里直接跑生产 .ts。 */
+const CAN_STRIP_TYPES = process.allowedNodeEnvironmentFlags.has('--experimental-strip-types')
+
+/**
+ * 起一个子进程，40ms 后掐掉它 stdout/stderr 的读端，返回它的退出码。
+ * 退出码 42 = 子进程内的 uncaughtException 处理器开火（即事故形态）；0 = 活到自己跑完。
+ */
+function runChildWithBrokenPipe(guard: boolean): Promise<number | null> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, ['--experimental-strip-types', '--no-warnings', CHILD], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, GUARD: guard ? '1' : '0' },
+    })
+    child.stdout.on('data', () => {})
+    child.stderr.on('data', () => {})
+    // 读端一关，子进程后续的写就是 EPIPE
+    setTimeout(() => {
+      child.stdout.destroy()
+      child.stderr.destroy()
+    }, 40)
+    child.on('error', reject)
+    child.on('exit', (code) => resolve(code))
+  })
+}
+
+describe('installStdioErrorGuard —— 日志写失败不得打死进程', () => {
+  afterEach(() => {
+    process.stdout.removeAllListeners('error')
+    process.stderr.removeAllListeners('error')
+  })
+
+  it.skipIf(!CAN_STRIP_TYPES)(
+    '真复现：管道读端关闭后继续 console.error —— 不装守卫必崩，装了守卫活到跑完',
+    async () => {
+      // 不装守卫 = 事故当天的现场。这一条同时也是"复现有效"的自证：它若不再是 42，
+      // 说明这个复现装置已经测不到东西了，下面那条"装了守卫是 0"也就不再有意义。
+      expect(await runChildWithBrokenPipe(false)).toBe(42)
+
+      expect(await runChildWithBrokenPipe(true)).toBe(0)
+    },
+    20_000,
+  )
+
+  it('装上守卫后，stdout/stderr 的 EPIPE 事件不再变成 uncaughtException', () => {
+    installStdioErrorGuard()
+
+    // 不装守卫时零监听器的 'error' 会被 EventEmitter 直接抛出（= 生产里的 uncaughtException）。
+    for (const stream of [process.stdout, process.stderr]) {
+      const epipe = Object.assign(new Error('write EPIPE'), { code: 'EPIPE', syscall: 'write' })
+      expect(() => stream.emit('error', epipe)).not.toThrow()
+    }
+  })
+
+  it('监听器是常驻的，不是 once —— 事故正是从第二条日志开始崩的', () => {
+    installStdioErrorGuard()
+
+    const err = (): Error => Object.assign(new Error('write EPIPE'), { code: 'EPIPE' })
+    expect(() => process.stderr.emit('error', err())).not.toThrow()
+    expect(() => process.stderr.emit('error', err())).not.toThrow()
+    expect(() => process.stderr.emit('error', err())).not.toThrow()
+  })
+
+  it('EIO / ERR_STREAM_DESTROYED 一并吞掉（只筛 EPIPE 等于把同一场崩溃搬到别的码上）', () => {
+    installStdioErrorGuard()
+
+    for (const code of ['EIO', 'ERR_STREAM_DESTROYED']) {
+      const err = Object.assign(new Error(`write ${code}`), { code })
+      expect(() => process.stderr.emit('error', err)).not.toThrow()
+    }
+  })
+})

--- a/crabot-agent/tests/manager/fail-loud-worker-event.test.ts
+++ b/crabot-agent/tests/manager/fail-loud-worker-event.test.ts
@@ -1,0 +1,263 @@
+/**
+ * worker 事件路径的 fail-loud 兜底 —— `bootstrap.ts` 的 `onEvent` + `BootstrapDeps.reportEpisodeFailure`。
+ *
+ * ## 事前形态
+ *
+ * `onEvent` 是 fire-and-forget,原本只 `.catch(console.error)`,且**从不看 outcome**。而
+ * `ManagerLoop` 最常见的失败(F1:LLM 挂 / key 过期 / 限流耗尽重试)不抛错,只把
+ * `EpisodeResult.outcome` 写成 `failed`。于是"worker 干完了/挂了,但再也没人来汇报"这件事
+ * 对人类**完全静默**——agent 还活着、health 还是绿的。
+ *
+ * ## 手法
+ *
+ * 真装配(`buildManagerStack`)+ 真 harness 事件(走 adapter 上报口 `harness.handleStateChange`)
+ * + 真 `ManagerLoop`;**唯一被替身的是 LLM 和出站 rpcClient**。`reportEpisodeFailure` 接的是
+ * 生产同款实现(`UnifiedAgent.prototype.sendBackgroundFailLoud`),所以文案、目标改写、冷却
+ * 全都是生产代码在跑,不是测试里另写一份。
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { promises as fs } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+import { UnifiedAgent } from '../../src/unified-agent.js'
+import { buildManagerStack, type BootstrapDeps, type ManagerStack } from '../../src/manager/bootstrap.js'
+import type { PrincipalResolverDeps } from '../../src/manager/principal.js'
+import type { ManagerKey } from '../../src/manager/types.js'
+import { dialogObjectIdForPrivate, type LedgerWorker } from '../../src/workers/harness/ledger-types.js'
+import type { LLMAdapter } from '../../src/engine/index.js'
+import { createCrabMemoryServer } from '../../src/mcp/crab-memory.js'
+
+const ADMIN_PORT = 18000
+const WECHAT_PORT = 18001
+
+interface RpcCall {
+  port: number
+  method: string
+  params: Record<string, unknown>
+}
+
+/** 最小 crab-memory server(照抄 tests/manager/bootstrap.test.ts)。 */
+function makeMemoryServer() {
+  return createCrabMemoryServer(
+    { rpcClient: { call: vi.fn() } as never, moduleId: 'fail-loud-test', getMemoryPort: async () => 19100 },
+    { visibility: 'internal', scopes: [], isMasterPrivate: false },
+  )
+}
+
+/** 身份解析原料的最小桩:一律"解析不出来"。 */
+function makePrincipalResolver(): PrincipalResolverDeps {
+  return {
+    resolvePermissions: async () => null,
+    sessionMemoryScopes: async (sessionId) => [sessionId],
+    sceneProfile: async () => null,
+    crabSelfHandle: () => undefined,
+    masterFriendId: async () => undefined,
+  }
+}
+
+function makeMessagingDeps() {
+  return {
+    rpcClient: { call: vi.fn() } as never,
+    moduleId: 'fail-loud-test',
+    getAdminPort: async () => ADMIN_PORT,
+    resolveChannelPort: async () => WECHAT_PORT,
+  }
+}
+
+/** 一调就挂的 manager LLM —— F1 的真实来路(端点抖动 / key 过期 / 限流耗尽)。 */
+function brokenLLM(): LLMAdapter {
+  return {
+    // eslint-disable-next-line require-yield
+    async *stream() {
+      throw new Error('LLM boom')
+    },
+    updateConfig: () => {},
+  }
+}
+
+function makeLedgerWorker(p: { workerId: string; title: string; spawnedBySession: ManagerKey }): LedgerWorker {
+  return {
+    worker_id: p.workerId,
+    task: { id: p.workerId, title: p.title, status: 'running', created_at: '2026-01-01T00:00:00.000Z' },
+    origin: { spawned_by_session: p.spawnedBySession, trigger_type: 'message' },
+    report_to: { channel_id: 'wechat', session_id: 'sess-1' },
+    incarnations: [
+      {
+        seq: 1,
+        impl: 'builtin',
+        state: 'running',
+        workspace: '/tmp/ws-not-used',
+        session_ref: `${p.workerId}-ref`,
+        started_at: '2026-01-01T00:00:00.000Z',
+      },
+    ],
+    updated_at: '2026-01-01T00:00:00.000Z',
+  }
+}
+
+async function waitUntil(cond: () => boolean, timeoutMs = 6000, intervalMs = 20): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (cond()) return
+    await new Promise((resolve) => setTimeout(resolve, intervalMs))
+  }
+  throw new Error('waitUntil timed out')
+}
+
+describe('worker 事件路径的 fail-loud（bootstrap.onEvent → reportEpisodeFailure）', () => {
+  let tmpRoot: string
+  let rpcCalls: RpcCall[]
+  let sendFails: boolean
+  let errorSpy: ReturnType<typeof vi.spyOn>
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(async () => {
+    tmpRoot = await fs.mkdtemp(join(tmpdir(), 'fail-loud-worker-'))
+    rpcCalls = []
+    sendFails = false
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(async () => {
+    vi.restoreAllMocks()
+    await fs.rm(tmpRoot, { recursive: true, force: true })
+  })
+
+  /**
+   * 生产同款的兜底出口:`UnifiedAgent.prototype.sendBackgroundFailLoud` 挂在一个只塞了出站
+   * 三件套的实例上(`Object.create` 绕过构造函数,与 tests/manager/rpc-handlers.test.ts 同法)。
+   * 文案 / 目标改写 / 冷却因此全是生产代码在跑。
+   */
+  function makeReporter(): NonNullable<BootstrapDeps['reportEpisodeFailure']> {
+    const agent = Object.create(UnifiedAgent.prototype) as Record<string, unknown>
+    agent.config = { moduleId: 'fail-loud-test' }
+    agent.failLoudSentAt = new Map<string, number>()
+    agent.channelPorts = new Map([['wechat', WECHAT_PORT]])
+    agent.adminPort = ADMIN_PORT
+    agent.rpcClient = {
+      call: async (port: number, method: string, params: Record<string, unknown>) => {
+        rpcCalls.push({ port, method, params })
+        if (sendFails) throw new Error('channel 也挂了')
+        return {}
+      },
+      resolve: async () => [],
+    }
+    const typed = agent as unknown as {
+      sendBackgroundFailLoud(
+        target: { channel_id: string; session_id: string },
+        subject: string,
+        failure: unknown,
+      ): Promise<void>
+    }
+    return (report) => {
+      void typed.sendBackgroundFailLoud(report.target, report.subject, report.failure)
+    }
+  }
+
+  function makeStack(overrides: Partial<BootstrapDeps> = {}): ManagerStack {
+    const deps: BootstrapDeps = {
+      dataRoot: join(tmpRoot, 'data'),
+      now: () => new Date().toISOString(),
+      managerAdapter: () => brokenLLM(),
+      managerModel: () => 'test-manager-model',
+      messagingDeps: makeMessagingDeps(),
+      memoryServerFor: () => makeMemoryServer(),
+      callAdmin: async () => ({}) as never,
+      principalResolver: makePrincipalResolver(),
+      reportEpisodeFailure: makeReporter(),
+      ...overrides,
+    }
+    return buildManagerStack(deps)
+  }
+
+  /** 台账里种一条 worker,再从 adapter 上报口推一个 exited —— 走的是生产的 onEvent 接线。 */
+  async function seedAndFireEvent(stack: ManagerStack, p: { workerId: string; title: string }): Promise<void> {
+    await stack.ledger.upsertWorker(dialogObjectIdForPrivate('friend-1'), p.workerId, () =>
+      makeLedgerWorker({ workerId: p.workerId, title: p.title, spawnedBySession: 'wechat::sess-1' as ManagerKey }),
+    )
+    stack.harness.handleStateChange(
+      { worker_id: p.workerId, seq: 1, impl: 'builtin', session_ref: `${p.workerId}-ref` },
+      'exited',
+      { endReason: 'completed' },
+    )
+  }
+
+  function sentText(): string | undefined {
+    const sent = rpcCalls.find((c) => c.method === 'send_message')
+    return (sent?.params.content as { text: string } | undefined)?.text
+  }
+
+  it('LLM 挂掉（F1：episode 正常 resolve、outcome=failed）→ 监护会话收到兜底消息，文案是非人类触发变体', async () => {
+    const stack = makeStack()
+    await seedAndFireEvent(stack, { workerId: 'w-1', title: '整理会议纪要' })
+
+    await waitUntil(() => rpcCalls.some((c) => c.method === 'send_message'))
+
+    const sent = rpcCalls.find((c) => c.method === 'send_message')!
+    // 目标 = 该 worker 的监护 manager（origin.spawned_by_session），不是 report_to、不是系统线程
+    expect(sent.port).toBe(WECHAT_PORT)
+    expect(sent.params.session_id).toBe('sess-1')
+
+    const text = sentText()
+    expect(text).toContain('worker「整理会议纪要」的状态更新')
+    expect(text).toContain('没跑成')
+    // worker 事件不是人在说话：人类那份第二人称文案照搬过来是错的
+    expect(text).not.toContain('回不了你')
+    expect(text).not.toContain('再发一次')
+  })
+
+  it('按 key 冷却仍然生效：同一会话连着两个失败 episode 只发一条', async () => {
+    const stack = makeStack()
+    await seedAndFireEvent(stack, { workerId: 'w-1', title: '任务甲' })
+    await waitUntil(() => rpcCalls.some((c) => c.method === 'send_message'))
+    await seedAndFireEvent(stack, { workerId: 'w-2', title: '任务乙' })
+
+    // 第二条事件的 episode 也要跑完，再看有没有多发
+    await new Promise((resolve) => setTimeout(resolve, 200))
+    expect(rpcCalls.filter((c) => c.method === 'send_message')).toHaveLength(1)
+    expect(warnSpy).toHaveBeenCalled()
+  })
+
+  it('送不出去（目标会话所在 channel 也挂了）只落日志，不抛、不产生 unhandledRejection', async () => {
+    const unhandled: unknown[] = []
+    const onUnhandled = (reason: unknown): void => {
+      unhandled.push(reason)
+    }
+    process.on('unhandledRejection', onUnhandled)
+    try {
+      sendFails = true
+      const stack = makeStack()
+      await seedAndFireEvent(stack, { workerId: 'w-1', title: '任务' })
+
+      await waitUntil(() => rpcCalls.some((c) => c.method === 'send_message'))
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      expect(unhandled).toEqual([])
+      expect(errorSpy).toHaveBeenCalled()
+    } finally {
+      process.off('unhandledRejection', onUnhandled)
+    }
+  })
+
+  it('不注入 reportEpisodeFailure 时保持既有行为：只记日志、不炸（可选钩子）', async () => {
+    const unhandled: unknown[] = []
+    const onUnhandled = (reason: unknown): void => {
+      unhandled.push(reason)
+    }
+    process.on('unhandledRejection', onUnhandled)
+    try {
+      const stack = makeStack({ reportEpisodeFailure: undefined })
+      await seedAndFireEvent(stack, { workerId: 'w-1', title: '任务' })
+
+      await waitUntil(() => errorSpy.mock.calls.length > 0)
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      expect(rpcCalls.filter((c) => c.method === 'send_message')).toEqual([])
+      expect(unhandled).toEqual([])
+    } finally {
+      process.off('unhandledRejection', onUnhandled)
+    }
+  })
+})

--- a/crabot-agent/tests/manager/rpc-handlers.test.ts
+++ b/crabot-agent/tests/manager/rpc-handlers.test.ts
@@ -54,6 +54,17 @@ function buildAgent(managerStack?: unknown): AgentUnderTest {
   return agent as unknown as AgentUnderTest
 }
 
+/** `routeSchedule` 的成功返回形状(handler 的 fail-loud 收尾要读 `outcome`)。 */
+function completedEpisode(outcome: 'completed' | 'failed' | 'aborted' = 'completed'): {
+  episodeId: string
+  outcome: string
+  turns: number
+  consumedEvents: boolean
+  repliedToHuman: boolean
+} {
+  return { episodeId: 'ep-1', outcome, turns: 1, consumedEvents: true, repliedToHuman: false }
+}
+
 function makeLedgerWorker(p: {
   workerId: string
   status?: LedgerWorker['task']['status']
@@ -198,7 +209,11 @@ describe('trigger_schedule(§8.2)', () => {
 
   it('参数按 §8.2 原样透传给 registry.routeSchedule(含 target_session / 权限身份)', () => {
     const calls: unknown[] = []
-    const agent = buildAgent({ registry: { routeSchedule: (p: unknown) => { calls.push(p); return Promise.resolve() } } })
+    // resolve 一个**成功**的 episode:handler 的收尾要读 `outcome`(fail-loud 判据双管),
+    // 裸 `Promise.resolve()` 已经不是 `routeSchedule` 的真实契约形状。
+    const agent = buildAgent({
+      registry: { routeSchedule: (p: unknown) => { calls.push(p); return Promise.resolve(completedEpisode()) } },
+    })
 
     agent.handleTriggerSchedule({
       schedule_id: 'sc-9',
@@ -224,6 +239,224 @@ describe('trigger_schedule(§8.2)', () => {
     expect(() => agent.handleTriggerSchedule({ schedule_id: 'sc', title: 't', description: 'd' })).toThrow(
       /Manager stack not initialized/,
     )
+  })
+})
+
+// ============================================================================
+// §8.2 fail-loud:定时任务失败不再静默
+//
+// 事前形态:游离 promise 只 `.catch(console.error)`,**从不看 outcome**——最常见的失败
+// (F1:LLM 挂 / key 过期 / 限流耗尽,不抛错、只把 outcome 写成 failed)因此完全静默,
+// 人类那边的表现就是"早报没发、反思没生成",而且没有任何提示。
+//
+// 这里只替身 `registry.routeSchedule` 与出站 `rpcClient`:判据、文案、冷却、目标解析
+// 全部走生产代码。
+// ============================================================================
+
+describe('trigger_schedule 的 fail-loud 兜底', () => {
+  const ADMIN_PORT = 18000
+  const WECHAT_PORT = 18001
+
+  interface RpcCall {
+    port: number
+    method: string
+    params: Record<string, unknown>
+  }
+
+  interface FailLoudAgent extends AgentUnderTest {
+    failLoudSentAt: Map<string, number>
+  }
+
+  function buildOutboundAgent(routeSchedule: () => Promise<unknown>): {
+    agent: FailLoudAgent
+    rpcCalls: RpcCall[]
+    failSend: { value: boolean }
+  } {
+    const rpcCalls: RpcCall[] = []
+    const failSend = { value: false }
+    const agent = buildAgent({ registry: { routeSchedule } }) as unknown as Record<string, unknown>
+    agent.failLoudSentAt = new Map<string, number>()
+    agent.silentEpisodeStreak = new Map<string, number>()
+    // 端口预置:出站不走 rpcClient.resolve(那是另一条链路的事)
+    agent.channelPorts = new Map([['wechat', WECHAT_PORT]])
+    agent.adminPort = ADMIN_PORT
+    agent.rpcClient = {
+      call: async (port: number, method: string, params: Record<string, unknown>) => {
+        rpcCalls.push({ port, method, params })
+        if (failSend.value) throw new Error('channel 也挂了')
+        return {}
+      },
+      resolve: async () => [],
+    }
+    return { agent: agent as unknown as FailLoudAgent, rpcCalls, failSend }
+  }
+
+  function sentText(rpcCalls: RpcCall[]): string | undefined {
+    const sent = rpcCalls.find((c) => c.method === 'send_message')
+    return (sent?.params.content as { text: string } | undefined)?.text
+  }
+
+  /** 游离 promise 的收尾跑在微任务里,handler 同步返回后要给它几个回合。 */
+  async function settle(): Promise<void> {
+    for (let i = 0; i < 10; i++) await Promise.resolve()
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+
+  let errorSpy: ReturnType<typeof vi.spyOn>
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('F1(outcome=failed,不抛错)→ 目标会话收到兜底消息', async () => {
+    const { agent, rpcCalls } = buildOutboundAgent(async () => completedEpisode('failed'))
+
+    agent.handleTriggerSchedule({
+      schedule_id: 'sc-morning',
+      title: '每日早报',
+      description: '每天 8 点发早报',
+      target_session: { channel_id: 'wechat', session_id: 'sess-1' },
+    })
+    await settle()
+
+    const sent = rpcCalls.find((c) => c.method === 'send_message')
+    expect(sent, '只 catch 不看 outcome 时这里必然是 undefined —— 正是事前的静默形态').toBeDefined()
+    expect(sent!.port).toBe(WECHAT_PORT)
+    expect(sent!.params.session_id).toBe('sess-1')
+  })
+
+  it('文案是"非人类触发"变体:点名哪个定时任务,且不出现第二人称的"回不了你"', async () => {
+    const { agent, rpcCalls } = buildOutboundAgent(async () => completedEpisode('failed'))
+
+    agent.handleTriggerSchedule({
+      schedule_id: 'sc-morning',
+      title: '每日早报',
+      description: 'd',
+      target_session: { channel_id: 'wechat', session_id: 'sess-1' },
+    })
+    await settle()
+
+    const text = sentText(rpcCalls)
+    expect(text).toContain('定时任务「每日早报」')
+    expect(text).toContain('没跑成')
+    expect(text).toContain('failed')
+    expect(text).toContain('管理员')
+    // 人类消息那份文案照搬过来是错的:定时任务触发时没人刚说话
+    expect(text).not.toContain('回不了你')
+    expect(text).not.toContain('再发一次')
+  })
+
+  it('F2(episode 抛错)→ 兜底文案带上原始错误信息', async () => {
+    const { agent, rpcCalls } = buildOutboundAgent(async () => {
+      throw new Error('adapter thunk 炸了')
+    })
+
+    agent.handleTriggerSchedule({
+      schedule_id: 'sc-x',
+      title: '晚间反思',
+      description: 'd',
+      target_session: { channel_id: 'wechat', session_id: 'sess-1' },
+    })
+    await settle()
+
+    const text = sentText(rpcCalls)
+    expect(text).toContain('定时任务「晚间反思」')
+    expect(text).toContain('adapter thunk 炸了')
+  })
+
+  it('outcome=completed → 不发兜底(误报比漏报更伤)', async () => {
+    const { agent, rpcCalls } = buildOutboundAgent(async () => completedEpisode('completed'))
+
+    agent.handleTriggerSchedule({
+      schedule_id: 'sc-ok',
+      title: '正常任务',
+      description: 'd',
+      target_session: { channel_id: 'wechat', session_id: 'sess-1' },
+    })
+    await settle()
+
+    expect(rpcCalls).toEqual([])
+  })
+
+  it('无 target_session → 投系统任务线程(与 routeSchedule 的路由归属同一判据)', async () => {
+    const { agent, rpcCalls } = buildOutboundAgent(async () => completedEpisode('failed'))
+
+    agent.handleTriggerSchedule({ schedule_id: 'sc-sys', title: '系统巡检', description: 'd' })
+    await settle()
+
+    const sent = rpcCalls.find((c) => c.method === 'send_message')
+    expect(sent!.port).toBe(ADMIN_PORT)
+    expect(sent!.params.session_id).toBe('system-tasks')
+  })
+
+  it('target_session 指向 Master Chat 时改投 system-tasks —— 不认领人类那条在飞的占位气泡', async () => {
+    const { agent, rpcCalls } = buildOutboundAgent(async () => completedEpisode('failed'))
+
+    agent.handleTriggerSchedule({
+      schedule_id: 'sc-master',
+      title: '主人专属早报',
+      description: 'd',
+      target_session: { channel_id: 'admin-web', session_id: 'admin-chat' },
+    })
+    await settle()
+
+    const sent = rpcCalls.find((c) => c.method === 'send_message')
+    expect(sent!.port).toBe(ADMIN_PORT)
+    // admin 的 storeAssistantMessage 只在 session_id==='admin-chat' 时 claimPendingRequestId():
+    // 投 admin-chat 会把当时在飞的那条人类提问的气泡顶掉(它自己的答案就永远转圈了)。
+    // 两个 session 落的是同一个 store / 同一条 chat_push,人类照样看得到。
+    expect(sent!.params.session_id).toBe('system-tasks')
+  })
+
+  it('按 key 冷却仍然生效:连续失败只发一条', async () => {
+    const { agent, rpcCalls } = buildOutboundAgent(async () => completedEpisode('failed'))
+
+    for (let i = 0; i < 3; i++) {
+      agent.handleTriggerSchedule({
+        schedule_id: 'sc-loop',
+        title: '高频任务',
+        description: 'd',
+        target_session: { channel_id: 'wechat', session_id: 'sess-1' },
+      })
+      await settle()
+    }
+
+    expect(rpcCalls.filter((c) => c.method === 'send_message')).toHaveLength(1)
+    expect(warnSpy).toHaveBeenCalled()
+  })
+
+  it('送不出去(channel 也挂了)只落日志,不抛、不产生 unhandledRejection', async () => {
+    const unhandled: unknown[] = []
+    const onUnhandled = (reason: unknown): void => {
+      unhandled.push(reason)
+    }
+    process.on('unhandledRejection', onUnhandled)
+    try {
+      const { agent, failSend } = buildOutboundAgent(async () => completedEpisode('failed'))
+      failSend.value = true
+
+      expect(
+        agent.handleTriggerSchedule({
+          schedule_id: 'sc-dead',
+          title: '任务',
+          description: 'd',
+          target_session: { channel_id: 'wechat', session_id: 'sess-1' },
+        }),
+      ).toEqual({ accepted: true })
+      await settle()
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      expect(unhandled).toEqual([])
+      expect(errorSpy).toHaveBeenCalled()
+    } finally {
+      process.off('unhandledRejection', onUnhandled)
+    }
   })
 })
 


### PR DESCRIPTION
## 故障可见性:日志不再写死进程 + 后台失败不再静默

两条配套小改动,都来自 2026-08-05 的真实事故。

---

## B. 打印错误日志的动作把 agent 写死了

### 事故

06:38:05Z agent 崩溃:

```
fatal.log: uncaughtException — Error: write EPIPE
栈末端:    withStreamConsumptionRetry (llm-adapter-types.js:86) 的 console.error
```

LLM 端点抖动 → 重试逻辑疯狂打日志 → MM 被 SIGTERM 后 stderr 管道关闭 → `console.error` 写失败抛 EPIPE → 未捕获 → `process.exit(1)`。agent 死 47 秒,重启时 reconcile 判死两个化身,**一个 cc 任务落终态 `failed`,用户的任务白跑**。

一个记录故障的动作把进程杀了。

### 真正的机制:`errorEmitted` 是黏性的

Node 的 `kWriteToConsole` 里有个自愈:

```js
if (err !== null && !stream._writableState.errorEmitted) stream.once('error', noop)
```

写失败时补挂一个 `once('error', noop)` 吃掉错误。**但 `errorEmitted` 一旦置 true 就不再补挂** —— 实测:第 1 条 EPIPE 被 noop 吃掉、标志置 true;**第 2 条开始直接崩**。

**这正好解释了为什么事故是「重试刷屏」时才炸** —— 偶发一行日志根本崩不了,必须连续写才会。栈也对得上:Error 在 `afterWriteDispatched` 同步构造,所以末端还留着 `console.error → llm-adapter-types.js:86`,随后才异步 emit。

### 三步实证

1. **真复现**:spawn 子进程 → 关掉管道读端 → 继续 `console.error`。不装守卫退出码 **42**(它自己的 uncaughtException 处理器开火),装守卫 **0**;
2. **投递路径**:给 `console.error` 和 `process.stderr.write()` 各包 try/catch 写 40 次 —— **同步 catch 一次都没抓到**,`stderr.on('error')` 收到 36 次。
   ⇒ **在调用点包 try/catch 是无效修法**,`writeFatal` 里那个 try/catch 同样挡不住;
3. **变异 `on` → `once`** → 真复现用例挂,证明「常驻监听」而非一次性是必要的。

### 修法:一处收口

在 `main.ts` 的 `uncaughtException` 处理器**之前**给 `process.stdout` / `process.stderr` 装常驻 `on('error')`。全仓 187 处 `console.*` 同风险且没有 logger 抽象,收口在出口是唯一不用逐点改的办法。

**一律吞,不筛错误码。** 依据:①这个监听器上收到的一切按定义都是「日志出口自己写不出去」,无处上报;②在 error 处理器里 rethrow 同样是 uncaughtException —— 「只吞 EPIPE」等于把同一场崩溃搬到 EIO(控制终端消失,daemon 化典型)和 ERR_STREAM_DESTROYED 上,用例把这两个码显式钉住了;③Node 自己的 Console 就是一律吞、只放行 stack overflow,注释原文 *"Sorry, there's no proper way to pass along the error here."*。代价(stdio 写失败从此不可见)写进了文件头注释。

### 两处**没有**动

- **`retry-utils.ts:7` 把 EPIPE 列为可重试 —— 合理,保留。** 那里的 EPIPE 是「往 LLM 端点的 socket 写失败」,标准瞬时网络错误;日志 EPIPE 走 stream 的 error 事件,**从不进 `isRetryableError`**。两者在代码上零交汇,原以为的「恶性循环」在实现上不成立;
- **`uncaughtException` → `exit(1)` 保留。** 在最后防线上为一种错误开口子,会让所有未来的同类错误静默。修在源头是对的。

---

## C. 定时任务和 worker 事件失败时,你收不到任何提示

### 现状

LLM 调用彻底失败时系统会直接回一句「暂时回不了你」(`buildFailLoudText` / `sendFailLoudReply`,每 key 5 分钟冷却)。**但它只装在「用户主动说话」的三条路上**(私聊 / 群 / admin chat)。

- **schedule** `unified-agent.ts:2968-2987`:fire-and-forget,只 `.catch(console.error)`,**从不看 outcome**;
- **worker-event** `bootstrap.ts:237-252`:同理。

⇒ 早报没发出来、反思没生成 —— **完全静默**。这不是新机制,是已有逻辑没接全。

### 接法

- **schedule**:既有 `.catch` 旁加 `.then` 判 outcome,两条都进 `sendBackgroundFailLoud`;`{accepted:true}` 仍同步返回;目标 = `target_session ?? SYSTEM_TASKS_MANAGER_KEY`;无 request_id 走 `send_message`;
- **worker-event**:加可选 `BootstrapDeps.reportEpisodeFailure`(照抄 `publishEvent?` 的接线范式,不注入 = 保持既有只记日志,有用例钉住)。目标取台账 `origin.spawned_by_session`,查不到落系统线程 —— **与 `routeWorkerEvent` 自己的路由判据逐字相同**。

  **刻意没用 `report_to`**:那是 worker 结果的回报目标,可能与监护 session 不同,拿它当告警目标会把话说到另一个对话里去。

### admin-chat 的气泡占用

`storeAssistantMessage` 只在 `session_id === 'admin-chat'` 时认领 in-flight request_id,直接投递会**顶替掉当时在飞的另一个气泡**。

处理:对 `channel_id === 'admin-web'` 的目标**一律改投 `system-tasks`**。读 admin 代码确认三点:白名单已放开 `system-tasks`;该 session 不认领任何 request_id(admin 自己的注释就写着"不能吃掉 Master Chat 的 in-flight request");`ChatMessage` 上根本没有 session 字段、admin 不按 session 分流,两者落**同一个 store、同一条 chat_push** —— **人类照样在 Master Chat 里看得到**,只是不再顶替别人的气泡。**admin 侧零改动。**

### 文案变体(人类三条路的文案一字未改)

第二人称的「暂时回不了你」对「没人刚说话」的触发读起来是错的,所以另起 `buildBackgroundFailLoudText`:

> `${subject}没跑成(模型这一轮 ${outcome} 了)。常见原因是 LLM 服务不可用、API key 过期或额度用尽——请管理员到 Admin 的全局设置里检查模型配置,之后手动重跑一次。`

> `${subject}没跑成,出错了。错误:${detail}。可以稍后手动重跑;一直这样的话请管理员看一下 agent 日志。`

> model slot 缺失:`Crabot 还没配好 manager 用的模型,${subject}没跑成。请管理员打开 Admin → 全局设置,给 manager(没有就给 powerful)槽位选好 provider 和模型,然后手动重跑一次。`

`subject` = `定时任务「<title 或 schedule_id>」` / `worker「<台账 task.title 或 worker_id>」的状态更新`。用例显式断言**不含**「回不了你」「再发一次」。

---

## 测试与变异

新增 15 条(stdio-guard 4 / schedule 7 / worker-event 4)。worker-event 那条是**真装配** `buildManagerStack` + 真 harness 事件 + 真 ManagerLoop,只替身 LLM 与出站 rpcClient,reporter 接的是生产同款 `sendBackgroundFailLoud`。

| 变异 | 结果 |
|---|---|
| 去掉 stdio 守卫监听器 | stdio-guard **4/4 挂** |
| `on` → `once`(额外做的) | **3/4 挂**(含真复现) |
| schedule 不判 outcome | schedule 组 **6/7 挂** |
| worker-event 不判 outcome | worker-event **3/4 挂** |

**限制(不假装测到了)**:真复现那条用 `node --experimental-strip-types` 直接跑生产 `.ts`,Node < 22.6 上自动 skip;此时只剩另外三条,它们对「删掉监听器」同样敏感。

## 验证

`tsc --noEmit` 通过。

全量 **2488 passed / 12 failed**。12 条失败全是 tmux 支撑的 adapter 用例(codex-adapter 8 / claude-code-adapter 3 / harness-integration 1),**与本改动无关,两条证据**:①`git stash -u` 撤掉全部改动后 `codex-adapter.test.ts` 在同一时间窗**照样挂 8 条**(恢复后挂 9 条,条数每跑一变);②机器 4 核 3GB、`load average 3.84`,这批用例真起 tmux + mock CLI 子进程等状态收敛。同机空闲时(改动前基线)这批全绿,基线是 2483 passed / 1 failed(已知 flaky `bg-entities/trace.test.ts`)。

## Follow-up(按边界未做)

- **MM / admin / memory 的入口没有 stdio 守卫**,同一风险面,本轮只修事故落点 agent;
- 全仓 187 处 `console.*` 无 logger 抽象;**重试日志本身没有节流** —— 事故当天的日志风暴是根因之一;
- 「跑完但一句话没说」在这两条新路径上同样不告警,与人类三条路的既有取舍一致;
- admin-web 的背景 fail-loud 冷却键合并成了一个。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
