### PR TITLE
fix(workers): 活性信号只认真实进展，builtin 纳入巡检

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,8 +1,18 @@
 # Crabot 项目进度
 
-> 最后更新：2026-08-05 — worker 活性巡检（分支 feat/worker-liveness-sweep，未合并 main）；上一条「模块健康与 Memory 维护最小修复」已通过 PR #72 合并
+> 最后更新：2026-08-06 — worker 活性信号纠偏与 builtin 覆盖（分支 fix/worker-liveness-signals，待 PR）
 
-## 2026-08-05 — worker 活性巡检：静默停摆终于有人管了
+## 2026-08-06 — worker 活性信号纠偏：动画不再伪装进展，builtin 不再是盲区
+
+- 已确认 Spec 与计划：`crabot-docs/superpowers/specs/2026-08-06-worker-liveness-signal-correction-design.md`、`crabot-docs/superpowers/plans/2026-08-06-worker-liveness-signal-correction-plan.md`；正式协议 `protocol-agent-v3.md` §6.1/§6.3 已先更新并推送文档仓 main（`9fa9280`）。
+- 生产复盘：#75 首版确实两次唤醒 `w-ed8453a7`，但 Claude Code 在空 composer 每约 30 分钟输出一次 `Auto-updating…`，持续刷新 `output-1.log` mtime，恰好永久压住 30 分钟阈值；manager 清掉 MCP 弹窗后也只敲了选项/Enter，没有重发原任务。`w-761654c6` 后来虽正常完成，但 builtin running 约 4 小时期间完全没有连续活性信号。
+- 契约纠偏：`lastActivityAt` 改为“最近一次可观察任务/执行进展”，进程存活、pane 动画和无条件心跳均不算。Claude Code 取 `max(meta mtime, native session JSONL mtime)`；Codex 取 `max(meta mtime, rollout mtime)`；output 只在首报告警时附诊断现场。
+- builtin 覆盖：每化身维护进程内 `activityAt`，只在 spawn/resume/fork/burst 起点、真实 `onLiveProgress`/`onTurn`、成功 `sendInput` 时前进；无常驻实例回退 meta mtime，不加定时心跳。harness 仍不识别实现 ID、不改台账、不自动 kill，30 分钟阈值、5 分钟周期、去重与 `1T→2T→4T` 失败重投不变。
+- 错误降级：单个 activity 文件缺失/不可读时继续其它来源；`ENOENT` 视为正常尚未生成，其它 stat/rollout 定位错误带 worker/seq/path 打 warn；全部来源不可用才返回 `undefined`，本轮跳过、下轮重试。
+- 巡检指引补齐：清掉模态弹窗后若落在空 composer，不能把“弹窗消失”当恢复，必须用非 raw `send_to_worker` 重发完整任务并继续确认 output/事件进展。
+- 验证：TypeScript build 通过；定向 4 文件 **88 tests passed**；`tests/workers + tests/manager` 在 `maxWorkers=1` 下 **845 passed / 5 failed**，5 条全部是既有且未改文件中的 macOS `/var` vs `/private/var` realpath 固定断言（codex PATH 2、workspace manager 3，上一轮 main 基线已记录同样失败）；变异实测——cc/codex 任一重新纳入 output mtime 各 2 条事故用例失败，builtin 常驻信号删除 2 条失败，主线 `onLiveProgress` 更新时间删除 1 条失败。全 Agent 套件未再扩大：m2 正有一条 100% CPU 的四资产 producer pytest 长跑，已知此负载会让 tmux 并发用例成批 flaky。
+
+## 2026-08-05 — worker 活性巡检首版（PR #75，历史设计；信号已由 2026-08-06 纠偏）
 
 - spec：`crabot-docs/superpowers/specs/2026-08-05-worker-liveness-sweep-design.md`；协议改动已直推 crabot-docs main（§6.1 增加可选方法 `lastActivityAt?`）。**这不是新设计，是协议 §6.3 第 3 条「兜底：harness 低频巡扫 tmux pane（纯 harness 行为，零 token），静默异常才唤醒 manager」从未落地**。
 - 病灶：近三天四例 worker 静默停摆（15h / 8.5h / 26min / 至今）**无一被系统自己发现**，共同点是**进程活着、tmux 活着、台账写着 running、但不再产生任何事件**。#70 的就绪握手能在源头拦住其中两例，拦不住另外两例（prompt 确实提交了，失效发生在之后）。根因是**三种 adapter 的 `state()` 返回 running 都是 else 兜底、不是正证**，在语义上分不开"卡住"与"在干活"；`isAlive`、台账 `updated_at` 同样零区分力。

--- a/crabot-agent/src/workers/builtin/adapter.ts
+++ b/crabot-agent/src/workers/builtin/adapter.ts
@@ -56,6 +56,7 @@ import type { Resolvable } from '../../engine/types.js'
 import { SessionTree } from '../session-tree.js'
 import { OutputLog } from '../output-log.js'
 import { AsyncMutex } from '../async-mutex.js'
+import { latestModifiedMs } from '../meta-store.js'
 import { WorkerExitedError } from '../errors.js'
 import {
   BUILTIN_WORKER_PERMISSIONS,
@@ -162,6 +163,8 @@ interface WorkerInstance {
    * 分支下面。每个化身必须维护自己的 tip，只在自己 append 时更新。
    */
   tip: string
+  /** 最近一次真实 engine 进展;不使用定时心跳,避免把挂死调用伪装为健康。 */
+  activityAt: number
   state: WorkerContractState
   ended_reason?: IncarnationEndReason
   outcome?: 'completed' | 'failed'
@@ -319,6 +322,7 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
         sessionTree,
         outputLog,
         tip: rootId,
+        activityAt: Date.now(),
         state: 'running',
         pendingInputs: [],
       }
@@ -385,6 +389,7 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
         sessionTree,
         outputLog,
         tip: wakeId,
+        activityAt: Date.now(),
         state: 'running',
         pendingInputs: [],
       }
@@ -430,6 +435,7 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
         sessionTree,
         outputLog,
         tip: forkId,
+        activityAt: Date.now(),
         state: 'running',
         pendingInputs: [],
       }
@@ -465,6 +471,7 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
 
       if (instance.state === 'running') {
         instance.pendingInputs.push(text)
+        instance.activityAt = Date.now()
         return undefined
       }
 
@@ -474,6 +481,7 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
       const builtin = await this.runtimeFor(h.worker_id, 'sendInput')
       instance.tip = await instance.sessionTree.append(instance.tip, createUserMessage(text))
       await this.transitionState(instance, h, 'running')
+      instance.activityAt = Date.now()
       return builtin
     })
 
@@ -489,6 +497,12 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     const instance = this.instances.get(instanceKey(h.worker_id, h.seq))
     const outputLog = instance ? instance.outputLog : new OutputLog(join(this.deps.dataDir, h.worker_id, `output-${h.seq}.log`))
     return outputLog.read(cursor)
+  }
+
+  async lastActivityAt(h: IncarnationHandle): Promise<number | undefined> {
+    const instance = this.instances.get(instanceKey(h.worker_id, h.seq))
+    if (instance) return instance.activityAt
+    return latestModifiedMs([join(this.deps.dataDir, h.worker_id, `meta-${h.seq}.json`)], `${h.worker_id}#${h.seq}`)
   }
 
   async state(h: IncarnationHandle): Promise<WorkerContractState> {
@@ -639,6 +653,7 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
       return ac
     })
     if (!abortController) return
+    instance.activityAt = Date.now()
 
     // pendingWrites 里的 promise 必须在 push 的同一刻就挂上 catch：burst 可能跑几分钟，
     // onTurn 到下面 await Promise.all(pendingWrites) 之间跨度很长，若 append 提前 reject
@@ -693,7 +708,11 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
           if (info.failedReason === undefined) compactedThisBurst = true
         },
         abortSignal: abortController.signal,
+        onLiveProgress: () => {
+          instance.activityAt = Date.now()
+        },
         onTurn: (event) => {
+          instance.activityAt = Date.now()
           if (event.assistantText) {
             lastAssistantText = event.assistantText
             pendingWrites.push(
@@ -805,6 +824,7 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
       return ac
     })
     if (!abortController) return
+    instance.activityAt = Date.now()
 
     // 同 runBurst：push 时立即挂 catch，避免 append 在长时间跑的 burst 期间 reject 却
     // 没有 handler，触发 unhandledRejection 打崩进程。错误收集到 writeErrors，
@@ -838,7 +858,11 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
           if (info.failedReason === undefined) compactedThisBurst = true
         },
         abortSignal: abortController.signal,
+        onLiveProgress: () => {
+          instance.activityAt = Date.now()
+        },
         onTurn: (event) => {
+          instance.activityAt = Date.now()
           if (event.assistantText) {
             pendingWrites.push(
               instance.outputLog.append(event.assistantText + '\n').catch((err) => {

--- a/crabot-agent/src/workers/claude-code/adapter.ts
+++ b/crabot-agent/src/workers/claude-code/adapter.ts
@@ -98,7 +98,7 @@ import { CliEventChannel, EVENTS_FILE_ENV } from '../cli-events.js'
 import { OutputLog } from '../output-log.js'
 import { decodeTerminalOutput } from '../terminal-output.js'
 import { AsyncMutex } from '../async-mutex.js'
-import { writeMetaAtomic, maxSeqOnDisk } from '../meta-store.js'
+import { writeMetaAtomic, maxSeqOnDisk, latestModifiedMs } from '../meta-store.js'
 import { WorkerExitedError } from '../errors.js'
 import { materializeSkills, renderMcpJson, renderContextMd, type ProvisionSources } from '../provision/materialize.js'
 import type {
@@ -707,17 +707,23 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
   }
 
   /**
-   * 活性信号(protocol-agent-v3 §6.1 `lastActivityAt`):pane 输出日志的 mtime。
+   * 活性信号(protocol-agent-v3 §6.1):任务/执行进展的最近时刻。
    *
-   * tmux `pipe-pane` 抓的是 pane 的**整条输出流**,TUI 在模型思考期间持续重绘自旋动画 ——
-   * 所以"这份文件多久没长了"能把"想得久"和"卡死了"分开,而 `state()` 的 running 是 else
-   * 兜底、在语义上分不开(见 syncState)。路径解析与 `readOutput` 同一条(有常驻 runtime 用
-   * 它的 OutputLog,没有就按约定路径重建),保证进程重启后仍然可判。
+   * pane output 可能只是 TUI spinner 或 Auto-updating 重绘,不能拿它当任务活动。
+   * 原生 session JSONL 记录实际会话进展;meta 则提供 spawn/resume/input/state 转换的
+   * 控制进展基线。两者任一暂时不可读时用另一来源,都不可读才交给 harness 本轮跳过。
    */
   async lastActivityAt(h: IncarnationHandle): Promise<number | undefined> {
+    const dir = join(this.deps.dataDir, h.worker_id)
+    const metaPath = join(dir, `meta-${h.seq}.json`)
     const runtime = this.runtimes.get(instanceKey(h))
-    const outputLog = runtime ? runtime.outputLog : new OutputLog(join(this.deps.dataDir, h.worker_id, `output-${h.seq}.log`))
-    return outputLog.lastModifiedMs()
+    const meta = runtime ? undefined : await this.readMetaFile(dir, h.seq)
+    const workspaceRoot = runtime?.workspaceRoot ?? meta?.workspace_root
+    const sessionId = runtime?.sessionId ?? meta?.session_id ?? h.session_ref
+    const tracePath = workspaceRoot && sessionId
+      ? join(this.claudeProjectsDir, projectSlug(workspaceRoot), `${sessionId}.jsonl`)
+      : undefined
+    return latestModifiedMs([metaPath, tracePath], `${h.worker_id}#${h.seq}`)
   }
 
   /**

--- a/crabot-agent/src/workers/codex/adapter.ts
+++ b/crabot-agent/src/workers/codex/adapter.ts
@@ -166,7 +166,7 @@ import { CliEventChannel } from '../cli-events.js'
 import { OutputLog } from '../output-log.js'
 import { decodeTerminalOutput } from '../terminal-output.js'
 import { AsyncMutex } from '../async-mutex.js'
-import { writeMetaAtomic, maxSeqOnDisk } from '../meta-store.js'
+import { writeMetaAtomic, maxSeqOnDisk, latestModifiedMs } from '../meta-store.js'
 import { WorkerExitedError, CapabilityNotSupportedError } from '../errors.js'
 import { parse as parseToml, stringify as stringifyToml } from 'smol-toml'
 import { materializeSkills, renderCodexMcpToml, renderContextMd, type ProvisionSources } from '../provision/materialize.js'
@@ -386,16 +386,21 @@ async function pollForNewRollout(sessionsDir: string, cutoffMs: number, timeoutM
 
 /** 读 rollout 文件首行的 session_meta.payload.session_id(m2 真机实测的权威字段)。首行还
  * 不是完整/合法的 session_meta(文件刚创建、还没来得及写完)一律返回 undefined,调用方退回
- * 文件名解析,不抛错、不重试——真机实测文件名与内容里的 id 完全一致,这里只是"能拿到内容
- * 就优先信内容"的加固,拿不到不算失败。五轮 review 修复:读出的 id 额外按 UUID_RE 校验格式,
- * 不合法(畸形值)一律当成"拿不到",打 warn 并退回文件名解析——避免畸形 id 未经校验就被
- * 写进 meta.session_id 与 handle.session_ref(会让 spawn 静默成功、resume/readTrace 必然
- * 失效)。 */
-async function readSessionIdFromRolloutContent(path: string): Promise<string | undefined> {
+ * 文件名解析,不重试——真机实测文件名与内容里的 id 完全一致,这里只是"能拿到内容就优先信
+ * 内容"的加固。`throwOnAccessError` 只供活性巡检定位路径时使用:ENOENT 仍是正常降级,
+ * 其它读错误上抛给调用方记录 worker/seq/path;既有 spawn/readTrace 调用保持静默降级。
+ * 五轮 review 修复:读出的 id 额外按 UUID_RE 校验格式,不合法(畸形值)一律当成"拿不到",
+ * 打 warn 并退回文件名解析——避免畸形 id 未经校验就被写进 meta.session_id 与
+ * handle.session_ref(会让 spawn 静默成功、resume/readTrace 必然失效)。 */
+async function readSessionIdFromRolloutContent(
+  path: string,
+  throwOnAccessError: boolean = false,
+): Promise<string | undefined> {
   let raw: string
   try {
     raw = await fs.readFile(path, 'utf-8')
-  } catch {
+  } catch (err) {
+    if (throwOnAccessError && (err as NodeJS.ErrnoException).code !== 'ENOENT') throw err
     return undefined
   }
   const firstLine = raw.split('\n', 1)[0]
@@ -418,7 +423,7 @@ async function readSessionIdFromRolloutContent(path: string): Promise<string | u
 }
 
 /**
- * 四轮 review 修复(ensureRuntime 专用):按已知 session_id 精确查找对应的 rollout 文件——
+ * 四轮 review 修复:按已知 session_id 精确查找对应的 rollout 文件——
  * 不看 mtime,只看文件名里嵌的 uuid 是否匹配 exactly。meta 只落 session_id +
  * session_discovery 状态,不落 rolloutPath 这个绝对路径(升级前的 meta 结构就没有它,补
  * 一个字段不如直接按已知的确定性文件名规则重新找一遍,与 sessionName/outputFile 等其它
@@ -433,7 +438,11 @@ async function readSessionIdFromRolloutContent(path: string): Promise<string | u
  * warn(便于诊断"为什么按文件名找不到,但按内容能找到"),仍然找不到才返回 undefined(与
  * 原语义一致,readTrace 优雅降级)。
  */
-async function findRolloutFileBySessionId(sessionsDir: string, sessionId: string): Promise<string | undefined> {
+async function findRolloutFileBySessionId(
+  sessionsDir: string,
+  sessionId: string,
+  throwOnAccessError: boolean = false,
+): Promise<string | undefined> {
   const candidates: string[] = []
 
   async function walk(dir: string, depth: number): Promise<string | undefined> {
@@ -441,7 +450,8 @@ async function findRolloutFileBySessionId(sessionsDir: string, sessionId: string
     let entries: Dirent[]
     try {
       entries = await fs.readdir(dir, { withFileTypes: true })
-    } catch {
+    } catch (err) {
+      if (throwOnAccessError && (err as NodeJS.ErrnoException).code !== 'ENOENT') throw err
       return undefined
     }
     for (const entry of entries) {
@@ -463,7 +473,7 @@ async function findRolloutFileBySessionId(sessionsDir: string, sessionId: string
   if (exact) return exact
 
   for (const candidate of candidates) {
-    const contentSessionId = await readSessionIdFromRolloutContent(candidate)
+    const contentSessionId = await readSessionIdFromRolloutContent(candidate, throwOnAccessError)
     if (contentSessionId === sessionId) {
       console.warn(`[codex-adapter] rollout file located via content session_id fallback (filename uuid did not match): ${candidate}`)
       return candidate
@@ -960,17 +970,26 @@ export class CodexWorkerAdapter implements WorkerAdapter {
   }
 
   /**
-   * 活性信号(protocol-agent-v3 §6.1 `lastActivityAt`):pane 输出日志的 mtime。
+   * 活性信号(protocol-agent-v3 §6.1):任务/执行进展的最近时刻。
    *
-   * tmux `pipe-pane` 抓的是 pane 的**整条输出流**,TUI 在模型思考期间持续重绘自旋动画 ——
-   * 所以"这份文件多久没长了"能把"想得久"和"卡死了"分开,而 `state()` 的 running 是 else
-   * 兜底、在语义上分不开(见 syncState)。路径解析与 `readOutput` 同一条(有常驻 runtime 用
-   * 它的 OutputLog,没有就按约定路径重建),保证进程重启后仍然可判。
+   * pane output 的 TUI 重绘不参与判定。rollout 是 Codex 的原生会话记录;meta 为
+   * spawn/resume/input/state 转换提供控制进展基线。任一来源失败时继续使用另一来源。
    */
   async lastActivityAt(h: IncarnationHandle): Promise<number | undefined> {
+    const dir = join(this.deps.dataDir, h.worker_id)
+    const metaPath = join(dir, `meta-${h.seq}.json`)
     const runtime = this.runtimes.get(instanceKey(h))
-    const outputLog = runtime ? runtime.outputLog : new OutputLog(join(this.deps.dataDir, h.worker_id, `output-${h.seq}.log`))
-    return outputLog.lastModifiedMs()
+    const meta = runtime ? undefined : await this.readMetaFile(dir, h.seq)
+    let rolloutPath = runtime?.rolloutPath
+    if (!rolloutPath && meta?.session_discovery === 'discovered' && meta.workspace_root && meta.session_id) {
+      const sessionsDir = join(meta.workspace_root, '.codex', 'sessions')
+      try {
+        rolloutPath = await findRolloutFileBySessionId(sessionsDir, meta.session_id, true)
+      } catch (err) {
+        console.warn(`[worker liveness] rollout discovery failed for ${h.worker_id}#${h.seq} at ${sessionsDir}:`, err)
+      }
+    }
+    return latestModifiedMs([metaPath, rolloutPath], `${h.worker_id}#${h.seq}`)
   }
 
   /**

--- a/crabot-agent/src/workers/harness/harness.ts
+++ b/crabot-agent/src/workers/harness/harness.ts
@@ -171,11 +171,9 @@ const MAX_CONTINUATION_ITERATIONS = 3
  * 取 30 分钟,依据是 m2 现网日志的实测(见
  * `crabot-docs/superpowers/specs/2026-08-05-worker-liveness-sweep-design.md` 决策 5):
  * - **健康侧的噪声地板**:38 份健康的 cc/codex 原生会话记录里,相邻两条事件的最大间隔是
- *   codex 384s / cc 301s(p99 普遍在 10–110s)。而事件间隔已经是**保守上界** ——
- *   那段时间里 TUI 的自旋动画一直在往 pane 写字节,pane 级的静默远短于此。30 分钟对
- *   最坏的健康样本仍有 4.7 倍余量;
- * - **故障侧的量级**:四例真实停摆的零增长时长是 26min / 4h51m / 8h30m / 15h,与噪声
- *   地板之间隔着一个数量级。
+ *   codex 384s / cc 301s(p99 普遍在 10–110s)。30 分钟对最坏健康样本仍有 4.7 倍余量;
+ * - **故障侧的量级**:四例真实停摆的任务进展零前进时长是 26min / 4h51m / 8h30m / 15h,
+ *   与噪声地板之间隔着一个数量级。终端动画不参与此判据。
  *
  * 方向按 spec:宁可偏宽——漏报一次的代价(晚半小时发现)远小于误报打断一个真在干活的
  * worker(白烧一次 manager episode,还可能把它 kill 掉)。
@@ -202,11 +200,11 @@ export const LIVENESS_SWEEP_INTERVAL_MS = 5 * 60_000
 function describeLivenessStall(opts: { impl: WorkerImplId; staleMs: number; tail: string }): string {
   const minutes = Math.round(opts.staleMs / 60_000)
   const note =
-    `[crabot] 活性巡检:该 ${opts.impl} 化身的终端输出已经 ${minutes} 分钟没有任何新增,` +
+    `[crabot] 活性巡检:该 ${opts.impl} 化身已经 ${minutes} 分钟没有新的可观察任务活动,` +
     `但进程/会话仍然活着、台账仍记着 running。上面是它终端输出的尾部(已解码成可读文本,` +
     `与 read_worker_output 同一形态)。**巡检不替你判断**它是干完了、在等输入,还是卡死了——` +
-    `请据现场决定下一步:用 read_worker_output 看更早的内容、用 send_to_worker(必要时 raw 模式敲键)` +
-    `问一句或催一下、或者 kill_worker 重来。`
+    `请据现场决定下一步:仍是模态弹窗时可用 raw 模式敲键;清障后若落在空 composer,不能把弹窗消失当作恢复,` +
+    `应以非 raw 的 send_to_worker 重发完整任务,再用 output/事件确认确实前进;必要时 read_worker_output 诊断或 kill_worker 重来。`
   return `${opts.tail || '(终端至今没有任何输出)'}\n---\n${note}`
 }
 
@@ -224,7 +222,7 @@ function describeLivenessStall(opts: { impl: WorkerImplId; staleMs: number; tail
  */
 function describeLivenessRetry(opts: { impl: WorkerImplId; staleMs: number }): string {
   return (
-    `[crabot] 活性巡检:该 ${opts.impl} 化身仍然没有任何输出(已静默 ${Math.round(opts.staleMs / 60_000)} 分钟)。` +
+    `[crabot] 活性巡检:该 ${opts.impl} 化身仍然没有新的可观察任务活动(已静默 ${Math.round(opts.staleMs / 60_000)} 分钟)。` +
     `现场在前一条唤醒里,这条只是重试投递,不再重复正文。`
   )
 }
@@ -1161,7 +1159,8 @@ export class WorkerHarness {
    *
    * 之所以需要这一层:三种 adapter 的 `state()` 返回 `running` 都是 else 兜底,不是正证 ——
    * 它在语义上区分不了"在干活"与"卡住了";`isAlive`、台账 `updated_at` 同样零区分力。
-   * 唯一有区分力的信号是**输出增长**,由可选契约方法 `lastActivityAt` 提供。
+   * 唯一有区分力的信号是**任务/执行进展**,由可选契约方法 `lastActivityAt` 提供;
+   * pane output 只用于首次告警时给 manager 看现场。
    *
    * 四条纪律:
    *
@@ -1169,9 +1168,8 @@ export class WorkerHarness {
    *    `syncState` 会把它翻回 running(adapter 才是化身状态的权威)——那是 #70 review 抓到的
    *    "idle 不粘"。而且判断语义(干完了 / 等输入 / 卡住)与决策的责任完全在 manager 侧(§4.3),
    *    巡检只负责让 manager 知道;
-   * 2. **不做实现特判**。不实现 `lastActivityAt` 的 adapter(builtin)天然被跳过——它的
-   *    output 只在有 assistantText 时才写,没有连续活性信号;将来要覆盖它,实现该方法即可,
-   *    本方法一个字都不用改;
+   * 2. **不做实现特判**。不实现 `lastActivityAt` 的 adapter 天然被跳过;三种内置实现
+   *    都已提供信号,未来实现若无法建立可靠进展基线才可选择不实现。
    * 3. **只看主线化身**(`forked_from` 为空,与 §5.3 判定主线化身的规则同源)。cc 的 fork
    *    是无头 `claude -p` 侧问,整个执行期可能零输出,拿它当停摆就是纯误报;
    * 4. **同一次停摆只发一份现场**,之后的重试是**带退避的、不带正文的再投递**。展开说:

--- a/crabot-agent/src/workers/meta-store.ts
+++ b/crabot-agent/src/workers/meta-store.ts
@@ -15,6 +15,29 @@ export async function writeMetaAtomic(dir: string, seq: number, meta: unknown): 
 }
 
 /**
+ * 多来源活性时间取最新值。ENOENT 是尚未生成/已清理的正常降级,不记录;其它错误必须带
+ * 化身和路径留痕,再继续尝试其它独立来源。
+ */
+export async function latestModifiedMs(
+  paths: ReadonlyArray<string | undefined>,
+  context: string,
+): Promise<number | undefined> {
+  let latest: number | undefined
+  for (const path of paths) {
+    if (!path) continue
+    try {
+      const mtimeMs = (await fs.stat(path)).mtimeMs
+      if (latest === undefined || mtimeMs > latest) latest = mtimeMs
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+        console.warn(`[worker liveness] stat failed for ${context} at ${path}:`, err)
+      }
+    }
+  }
+  return latest
+}
+
+/**
  * 扫 dir 下 meta-<seq>.json 文件名,返回其中最大的 seq(没有任何 meta 文件、或 dir 本身不
  * 存在,都返回 0)。供 nextSeq() 做磁盘感知——五轮 review 修复:重启后新 adapter 实例的
  * 内存态(runtimes/instances)只含按需重建过的化身,不是该 worker 的全部历史,nextSeq 只看

--- a/crabot-agent/src/workers/types.ts
+++ b/crabot-agent/src/workers/types.ts
@@ -145,16 +145,10 @@ export interface WorkerAdapter {
   readOutput(h: IncarnationHandle, cursor: OutputCursor): Promise<{ chunk: string; nextCursor: OutputCursor }>
   state(h: IncarnationHandle): Promise<WorkerContractState>
   /**
-   * 该化身**最近一次可观测活动**的时刻(epoch ms);无法判定时返回 undefined
-   * (protocol-agent-v3 §6.1)。供 §6.3 第 3 条的活性巡检使用——
-   * **不实现此方法的实现不参与活性巡检**(harness 侧不做实现特判,见
-   * `WorkerHarness.sweepLiveness`)。
-   *
-   * 语义是"这个化身最近一次被观察到还在动",不承诺精确到某一次模型输出:cc/codex 取
-   * 自己 pane 输出日志的 mtime(tmux pipe-pane 抓的是整条输出流,TUI 的自旋动画在模型
-   * 思考期间持续写字节,所以"长时间思考"与"卡死"在这个信号上可分)。builtin 不实现:
-   * 它的 output 只在有 assistantText 时才写,一个全程只调工具的化身根本不产生输出文件,
-   * 没有连续的活性信号。
+   * 该化身**最近一次可观察到的任务/执行进展**时刻(epoch ms);全部来源不可用时返回
+   * undefined(protocol-agent-v3 §6.1)。进程存活、终端动画和无条件定时心跳不算进展。
+   * 不实现者不参与活性巡检(harness 不做实现特判)。CLI 取 meta 与原生会话记录,
+   * builtin 以真实 engine 进展更新、无常驻实例时以 meta 兜底。
    */
   lastActivityAt?(h: IncarnationHandle): Promise<number | undefined>
   readTrace?(h: IncarnationHandle, cursor?: TraceCursor): Promise<{ events: NormalizedTraceEvent[]; nextCursor: TraceCursor }>

--- a/crabot-agent/tests/manager/fail-loud-worker-event.test.ts
+++ b/crabot-agent/tests/manager/fail-loud-worker-event.test.ts
@@ -248,7 +248,7 @@ describe('worker 事件路径的 fail-loud（bootstrap.onEvent → reportEpisode
    * - 活性巡检要的是**返回值**：把"这次唤醒没被消费"交回 harness，好让它**按退避重试投递**。
    *
    * 失败时两件事必须同时发生。这里用真装配 + 真 `ClaudeCodeAdapter.lastActivityAt`
-   * （对约定路径的 output 日志做一次 mtime 探测，不需要 tmux）把整条链跑通：
+   * （对 meta 与原生 session 记录做 mtime 探测，pane output 只作告警现场）把整条链跑通：
    * 巡检发事件 → 真 `ManagerLoop` 撞上挂掉的 LLM → 落 `outcome='failed'`。
    *
    * 重试的形态是 PR #75 review 的修正：**带退避、且不带正文** —— 现场在 episode 失败时被
@@ -261,19 +261,27 @@ describe('worker 事件路径的 fail-loud（bootstrap.onEvent → reportEpisode
     const workerId = 'w-stalled'
     const dataRoot = join(tmpRoot, 'data')
 
-    // 台账：主线化身 running、impl=claude-code（builtin 不实现 lastActivityAt，不参与巡检）
+    // 台账：主线化身 running、impl=claude-code。
+    // builtin 也有自己的 progress 信号；这里选择 CLI 是为了覆盖原生 meta 基线。
     await stack.ledger.upsertWorker(dialogObjectIdForPrivate('friend-1'), workerId, () => {
       const worker = makeLedgerWorker({ workerId, title: '卡住的活', spawnedBySession: 'wechat::sess-1' as ManagerKey })
       return { ...worker, incarnations: [{ ...worker.incarnations[0], impl: 'claude-code' }] }
     })
 
-    // pane 日志：按 cc adapter 的约定路径落盘，mtime 摆到 2 小时前 —— 这就是"很久没动"的现场
+    // pane 日志仍用于首报告警现场;停摆基线取同化身的 meta mtime,不能让 TUI output 重绘决定活性。
     const logDir = join(dataRoot, 'agent', 'worker-adapters', 'claude-code', workerId)
     await fs.mkdir(logDir, { recursive: true })
+    const stalledAt = new Date(clockMs - 2 * 60 * 60 * 1000)
+    const metaPath = join(logDir, 'meta-1.json')
+    await fs.writeFile(metaPath, JSON.stringify({
+      seq: 1,
+      state: 'running',
+      session_id: 'stalled-session',
+      workspace_root: join(tmpRoot, 'workspace'),
+    }), 'utf-8')
+    await fs.utimes(metaPath, stalledAt, stalledAt)
     const logPath = join(logDir, 'output-1.log')
     await fs.writeFile(logPath, '⏺ 正在读取文件…', 'utf-8')
-    const stalledAt = new Date(clockMs - 2 * 60 * 60 * 1000)
-    await fs.utimes(logPath, stalledAt, stalledAt)
 
     const wakeTexts = async (): Promise<string[]> =>
       (await stack.harness.readWorkerEvents(workerId))

--- a/crabot-agent/tests/workers/builtin-adapter.test.ts
+++ b/crabot-agent/tests/workers/builtin-adapter.test.ts
@@ -330,6 +330,51 @@ describe('BuiltinWorkerAdapter', () => {
     expect(chunk).toContain('A 还是 B')
   })
 
+  it('常驻化身只以真实 engine/input 进展更新时间，主线与 fork 回调均接线', async () => {
+    let now = 1_000
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now)
+    const runEngineSpy = vi.spyOn(engineModule, 'runEngine').mockImplementation(
+      () => new Promise(() => {}),
+    )
+    try {
+      const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+      const h = await adapter.spawn(spec({ adapter: makeAdapter([{ stopReason: 'end_turn' }]) }))
+      await vi.waitFor(() => expect(runEngineSpy).toHaveBeenCalledTimes(1))
+      expect(await adapter.lastActivityAt(h)).toBe(1_000)
+
+      // 没有任何 engine/input 回调时,时间流逝本身不能续命。
+      now = 1_500
+      expect(await adapter.lastActivityAt(h)).toBe(1_000)
+
+      now = 2_000
+      const mainOptions = runEngineSpy.mock.calls[0][0].options
+      mainOptions.onLiveProgress!({ type: 'tools_start', tools: [] })
+      expect(await adapter.lastActivityAt(h)).toBe(2_000)
+
+      now = 3_000
+      mainOptions.onTurn!({ turnNumber: 1, assistantText: '', toolCalls: [], stopReason: 'end_turn' })
+      expect(await adapter.lastActivityAt(h)).toBe(3_000)
+
+      now = 4_000
+      await adapter.sendInput(h, '运行中追加的输入')
+      expect(await adapter.lastActivityAt(h)).toBe(4_000)
+
+      const fork = await adapter.fork(h, '侧问')
+      await vi.waitFor(() => expect(runEngineSpy).toHaveBeenCalledTimes(2))
+      now = 5_000
+      const forkOptions = runEngineSpy.mock.calls[1][0].options
+      forkOptions.onLiveProgress!({ type: 'tools_end', results: [] })
+      expect(await adapter.lastActivityAt(fork)).toBe(5_000)
+
+      now = 6_000
+      await expect(adapter.sendInput({ ...h, seq: 99 }, '不存在的化身')).rejects.toThrow(/no such incarnation/)
+      expect(await adapter.lastActivityAt(h)).toBe(4_000)
+    } finally {
+      runEngineSpy.mockRestore()
+      nowSpy.mockRestore()
+    }
+  })
+
   it('finish_task → exited(completed)', async () => {
     const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
     const s = spec({
@@ -455,7 +500,37 @@ describe('BuiltinWorkerAdapter', () => {
     expect(streamMock.mock.calls).toHaveLength(1)
   })
 
-  it('sendInput(idle) → 追加新一轮用户消息并起新 burst，新 burst 可见旧上下文', async () => {
+  it('sendInput(idle) 成功转 running 才更新 activityAt，失败投递不更新', async () => {
+    let now = 1_000
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now)
+    const gate = deferred<void>()
+    try {
+      const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+      const h = await adapter.spawn(spec({
+        adapter: makeAdapterGatedFromSecondCall(gate.promise, [
+          { text: '首轮', stopReason: 'end_turn' },
+          { text: '续轮', stopReason: 'end_turn' },
+        ]),
+      }))
+      await waitState(adapter, h, 'idle')
+
+      now = 2_000
+      await adapter.sendInput(h, 'idle 输入')
+      await vi.waitFor(async () => expect(await adapter.lastActivityAt(h)).toBe(2_000))
+
+      now = 3_000
+      const activityBeforeFailedInput = await adapter.lastActivityAt(h)
+      await expect(adapter.sendInput({ ...h, seq: 99 }, '失败输入')).rejects.toThrow(/no such incarnation/)
+      expect(await adapter.lastActivityAt(h)).toBe(activityBeforeFailedInput)
+
+      gate.resolve()
+      await waitState(adapter, h, 'idle')
+    } finally {
+      nowSpy.mockRestore()
+    }
+  })
+
+  it('sendInput(idle) → 追加新一轮用户消息并起新 burst，新 burst可见旧上下文', async () => {
     const runEngineSpy = vi.spyOn(engineModule, 'runEngine')
     const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
     const s = spec({

--- a/crabot-agent/tests/workers/harness/harness-liveness.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-liveness.test.ts
@@ -40,9 +40,8 @@ function handleKey(h: { worker_id: string; seq: number }): string {
 }
 
 /**
- * CLI 形态的 adapter 桩:实现可选契约方法 `lastActivityAt`(cc/codex 的真实实现是对自己
- * output 日志的一次 fs.stat,这里直接由用例摆布返回值),`readOutput` 返回一段可断言的
- * pane 尾部。
+ * CLI 形态的 adapter 桩:实现可选契约方法 `lastActivityAt`(真实实现从 meta 与原生会话
+ * 记录建立任务进展基线,这里直接由用例摆布返回值),`readOutput` 返回一段可断言的 pane 尾部。
  */
 class CliLikeAdapter implements WorkerAdapter {
   readonly implId: WorkerImplId
@@ -93,7 +92,7 @@ class CliLikeAdapter implements WorkerAdapter {
   }
 }
 
-/** builtin 形态:**不实现** `lastActivityAt`,按协议 §6.1 应被巡检天然跳过(不靠实现特判)。 */
+/** 任意未实现可选方法的第三方/未来 adapter 都应被巡检天然跳过,不靠实现 ID 特判。 */
 class NoSignalAdapter extends CliLikeAdapter {
   // @ts-expect-error 故意把可选契约方法抹成 undefined,复刻"adapter 没实现这个方法"的形态
   lastActivityAt = undefined
@@ -194,16 +193,19 @@ describe.each<WorkerImplId>(['claude-code', 'codex'])('WorkerHarness.sweepLivene
     const text = woke[0].detail?.text as string
     expect(text).toContain('⏺ 正在读取文件…')
     expect(text).toContain('活性巡检')
+    expect(text).toContain('没有新的可观察任务活动')
+    expect(text).toContain('非 raw 的 send_to_worker')
+    expect(text).toContain('空 composer')
     // 合成指引排在 output 尾部**之后**——否则会被 truncateWakeText 的保尾截断吃掉(#70 教训)
     expect(text.indexOf('⏺ 正在读取文件…')).toBeLessThan(text.indexOf('活性巡检'))
     // 零新事件 kind、零新状态
     expect(woke[0].kind).toBe('state_changed')
   })
 
-  it('② lastActivityAt 持续前进(思考中的 TUI)→ 零事件', async () => {
+  it('② lastActivityAt 持续前进(真实任务进展)→ 零事件', async () => {
     const { harness, adapter, workerId } = await spawnRunning()
 
-    // 每次巡检前 worker 都动过一点(自旋动画持续写字节),累计远超阈值
+    // 每次巡检前 worker 都有真实进展;累计远超阈值也不该告警。
     for (let i = 0; i < 10; i++) {
       clockMs += 10 * MINUTE
       adapter.activity.set(`${workerId}#1`, clockMs - MINUTE)
@@ -215,7 +217,7 @@ describe.each<WorkerImplId>(['claude-code', 'codex'])('WorkerHarness.sweepLivene
     expect(adapter.lastActivityAtCalls.length).toBe(10)
   })
 
-  it('③ 不实现 lastActivityAt 的 adapter(builtin 形态)被跳过:零事件、无异常', async () => {
+  it('③ 不实现 lastActivityAt 的 adapter 被跳过:零事件、无异常', async () => {
     const adapter = new NoSignalAdapter()
     const { harness } = await makeHarness(adapter)
     const worker = await harness.spawnWorker(spawnParams())

--- a/crabot-agent/tests/workers/liveness-signal.test.ts
+++ b/crabot-agent/tests/workers/liveness-signal.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import * as fs from 'fs/promises'
 import * as path from 'path'
 import * as os from 'os'
@@ -8,65 +8,213 @@ import { BuiltinWorkerAdapter } from '../../src/workers/builtin/adapter'
 import type { IncarnationHandle, WorkerAdapter } from '../../src/workers/types'
 
 /**
- * 可选契约方法 `lastActivityAt`(protocol-agent-v3 §6.1)在 adapter 层的落点:
- * **cc/codex 各自实现为对自己 output 日志的一次 mtime 探测,builtin 不实现**。
- *
- * 两个 CLI adapter 在内存里没有常驻 runtime 时都按约定路径
- * `<dataDir>/<worker_id>/output-<seq>.log` 重建 OutputLog(与 readOutput 同一条路径解析),
- * 所以这些用例只需把固件写到那个路径,不用真的起 tmux;这同时也锁住了"agent 重启后仍然
- * 判得了活性"这条性质。
- *
- * 两侧对称覆盖:参数化跑两遍,避免只给 cc 写用例、删掉 codex 一侧实现还能全绿。
+ * `lastActivityAt` 是任务/执行进展信号,不是 pane 的任意字节活动。
+ * CLI 的 output 可能只因 TUI 的 Auto-updating/spinner 重绘而增长;那不能掩盖停摆。
  */
 describe('lastActivityAt(活性信号,adapter 层边界)', () => {
   let dataDir: string
+  let workspaceRoot: string
 
   beforeEach(async () => {
     dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'liveness-signal-'))
+    workspaceRoot = path.join(dataDir, 'workspace')
+    await fs.mkdir(workspaceRoot, { recursive: true })
   })
 
   afterEach(async () => {
     await fs.rm(dataDir, { recursive: true, force: true }).catch(() => {})
   })
 
-  function handle(workerId: string, impl: IncarnationHandle['impl']): IncarnationHandle {
-    return { worker_id: workerId, seq: 1, impl, session_ref: 'unused' }
+  function handle(workerId: string, impl: IncarnationHandle['impl'], sessionRef: string): IncarnationHandle {
+    return { worker_id: workerId, seq: 1, impl, session_ref: sessionRef }
   }
 
-  const cases: Array<[IncarnationHandle['impl'], () => WorkerAdapter]> = [
-    ['claude-code', () => new ClaudeCodeAdapter({ dataDir })],
-    ['codex', () => new CodexWorkerAdapter({ dataDir })],
+  async function writeMeta(workerId: string, meta: Record<string, unknown>, mtime: number): Promise<string> {
+    const dir = path.join(dataDir, workerId)
+    const metaPath = path.join(dir, 'meta-1.json')
+    await fs.mkdir(dir, { recursive: true })
+    await fs.writeFile(metaPath, JSON.stringify(meta), 'utf-8')
+    await fs.utimes(metaPath, new Date(mtime), new Date(mtime))
+    return metaPath
+  }
+
+  async function replaceWithBrokenSymlink(filePath: string): Promise<void> {
+    await fs.rm(filePath)
+    await fs.symlink(filePath, filePath)
+  }
+
+  async function seedCliSignal(
+    impl: IncarnationHandle['impl'],
+    make: (workerId: string, sessionId: string) => Promise<{ adapter: WorkerAdapter; handle: IncarnationHandle; nativePath: string }>,
+    suffix: string,
+  ): Promise<{ adapter: WorkerAdapter; h: IncarnationHandle; metaPath: string; nativePath: string; metaAt: number }> {
+    const workerId = `w-${impl}-${suffix}`
+    const sessionId = '33333333-3333-4333-8333-333333333333'
+    const metaAt = Date.parse('2026-08-05T00:00:00.000Z')
+    const { adapter, handle: h, nativePath } = await make(workerId, sessionId)
+    const metaPath = await writeMeta(workerId, {
+      seq: 1,
+      state: 'running',
+      session_id: sessionId,
+      workspace_root: workspaceRoot,
+      ...(impl === 'codex' ? { session_discovery: 'discovered' } : {}),
+    }, metaAt)
+    return { adapter, h, metaPath, nativePath, metaAt }
+  }
+
+  const cases: Array<[
+    IncarnationHandle['impl'],
+    (workerId: string, sessionId: string) => Promise<{ adapter: WorkerAdapter; handle: IncarnationHandle; nativePath: string }>,
+  ]> = [
+    [
+      'claude-code',
+      async (workerId, sessionId) => {
+        const projectsDir = path.join(dataDir, 'claude-projects')
+        const slug = workspaceRoot.replace(/[/.]/g, '-')
+        const nativePath = path.join(projectsDir, slug, `${sessionId}.jsonl`)
+        await fs.mkdir(path.dirname(nativePath), { recursive: true })
+        await fs.writeFile(nativePath, '{}\n', 'utf-8')
+        return {
+          adapter: new ClaudeCodeAdapter({ dataDir, claudeProjectsDir: projectsDir }),
+          handle: handle(workerId, 'claude-code', sessionId),
+          nativePath,
+        }
+      },
+    ],
+    [
+      'codex',
+      async (workerId, sessionId) => {
+        const nativePath = path.join(workspaceRoot, '.codex', 'sessions', '2026', '08', '06', `rollout-2026-08-06T00-00-00-${sessionId}.jsonl`)
+        await fs.mkdir(path.dirname(nativePath), { recursive: true })
+        await fs.writeFile(nativePath, JSON.stringify({ type: 'session_meta', payload: { session_id: sessionId } }) + '\n', 'utf-8')
+        return {
+          adapter: new CodexWorkerAdapter({ dataDir }),
+          handle: handle(workerId, 'codex', sessionId),
+          nativePath,
+        }
+      },
+    ],
   ]
 
-  it.each(cases)('%s:返回 output 日志的 mtime,写入后随之前进', async (impl, make) => {
+  it.each(cases)('%s:取 meta 与原生记录的最新 mtime,忽略持续刷新的 pane output', async (impl, make) => {
     const workerId = `w-${impl}-activity`
-    const adapter = make()
-    const h = handle(workerId, impl)
-    const logPath = path.join(dataDir, workerId, 'output-1.log')
+    const sessionId = '11111111-1111-4111-8111-111111111111'
+    const metaAt = Date.parse('2026-08-05T00:00:00.000Z')
+    const nativeAt = metaAt + 60_000
+    const outputAt = nativeAt + 24 * 60 * 60_000
+    const { adapter, handle: h, nativePath } = await make(workerId, sessionId)
 
-    await fs.mkdir(path.join(dataDir, workerId), { recursive: true })
-    await fs.writeFile(logPath, 'first frame', 'utf-8')
-    // mtime 摆到一个确定的过去时刻:这正是"化身很久没动"的现场形态
-    const stalledAt = Date.parse('2026-08-05T00:00:00.000Z')
-    await fs.utimes(logPath, new Date(stalledAt), new Date(stalledAt))
+    await writeMeta(workerId, {
+      seq: 1,
+      state: 'running',
+      session_id: sessionId,
+      workspace_root: workspaceRoot,
+      ...(impl === 'codex' ? { session_discovery: 'discovered' } : {}),
+    }, metaAt)
+    await fs.utimes(nativePath, new Date(nativeAt), new Date(nativeAt))
 
-    expect(await adapter.lastActivityAt!(h)).toBe(stalledAt)
+    const outputPath = path.join(dataDir, workerId, 'output-1.log')
+    await fs.writeFile(outputPath, 'Auto-updating…', 'utf-8')
+    await fs.utimes(outputPath, new Date(outputAt), new Date(outputAt))
 
-    // 又吐了一帧(TUI 自旋动画持续写字节)→ 信号前进
-    const movedAt = stalledAt + 60_000
-    await fs.appendFile(logPath, ' next frame', 'utf-8')
-    await fs.utimes(logPath, new Date(movedAt), new Date(movedAt))
-    expect(await adapter.lastActivityAt!(h)).toBe(movedAt)
+    expect(await adapter.lastActivityAt!(h)).toBe(nativeAt)
   })
 
-  it.each(cases)('%s:日志文件还不存在 → undefined(判不了,不是"很久没动")', async (impl, make) => {
-    const adapter = make()
-    expect(await adapter.lastActivityAt!(handle(`w-${impl}-nolog`, impl))).toBeUndefined()
+  it.each(cases)('%s:原生记录缺失时回退 meta mtime,而非 output mtime', async (impl, make) => {
+    const workerId = `w-${impl}-fallback`
+    const sessionId = '22222222-2222-4222-8222-222222222222'
+    const metaAt = Date.parse('2026-08-05T00:00:00.000Z')
+    const outputAt = metaAt + 24 * 60 * 60_000
+    const { adapter, handle: h, nativePath } = await make(workerId, sessionId)
+
+    await writeMeta(workerId, {
+      seq: 1,
+      state: 'running',
+      session_id: sessionId,
+      workspace_root: workspaceRoot,
+      ...(impl === 'codex' ? { session_discovery: 'discovered' } : {}),
+    }, metaAt)
+    await fs.rm(nativePath)
+    const outputPath = path.join(dataDir, workerId, 'output-1.log')
+    await fs.writeFile(outputPath, 'Auto-updating…', 'utf-8')
+    await fs.utimes(outputPath, new Date(outputAt), new Date(outputAt))
+
+    expect(await adapter.lastActivityAt!(h)).toBe(metaAt)
   })
 
-  it('builtin 不实现该方法:它的 output 只在有 assistantText 时才写,没有连续活性信号', () => {
+  it.each(cases)('%s:原生记录 stat 非 ENOENT 失败时告警并回退 meta', async (impl, make) => {
+    const { adapter, h, nativePath, metaAt } = await seedCliSignal(impl, make, 'native-error')
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    await replaceWithBrokenSymlink(nativePath)
+
+    expect(await adapter.lastActivityAt!(h)).toBe(metaAt)
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining(`worker liveness] stat failed for ${h.worker_id}#${h.seq} at ${nativePath}`),
+      expect.anything(),
+    )
+  })
+
+  it.each(cases)('%s:meta 不可读且无法定位原生记录时告警并返回 undefined', async (impl, make) => {
+    const { adapter, h, metaPath } = await seedCliSignal(impl, make, 'all-errors')
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    await replaceWithBrokenSymlink(metaPath)
+
+    expect(await adapter.lastActivityAt!(h)).toBeUndefined()
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining(`worker liveness] stat failed for ${h.worker_id}#${h.seq} at ${metaPath}`),
+      expect.anything(),
+    )
+  })
+
+  it('codex:rollout 目录非正常不可读时告警并保留 meta 基线', async () => {
+    const impl = 'codex' as const
+    const make = cases.find(([id]) => id === impl)![1]
+    const { adapter, h, metaAt } = await seedCliSignal(impl, make, 'discovery-error')
+    const sessionsDir = path.join(workspaceRoot, '.codex', 'sessions')
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    await fs.rm(sessionsDir, { recursive: true })
+    await fs.symlink(sessionsDir, sessionsDir)
+
+    expect(await adapter.lastActivityAt!(h)).toBe(metaAt)
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining(`worker liveness] rollout discovery failed for ${h.worker_id}#${h.seq} at ${sessionsDir}`),
+      expect.anything(),
+    )
+  })
+
+  it('codex:候选 rollout 内容非正常不可读时告警并保留 meta 基线', async () => {
+    const impl = 'codex' as const
+    const make = cases.find(([id]) => id === impl)![1]
+    const { adapter, h, nativePath, metaAt } = await seedCliSignal(impl, make, 'candidate-read-error')
+    const sessionsDir = path.join(workspaceRoot, '.codex', 'sessions')
+    const candidateId = '44444444-4444-4444-8444-444444444444'
+    const candidatePath = path.join(path.dirname(nativePath), `rollout-2026-08-06T00-00-01-${candidateId}.jsonl`)
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    await fs.rm(nativePath)
+    await fs.symlink(candidatePath, candidatePath)
+
+    expect(await adapter.lastActivityAt!(h)).toBe(metaAt)
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining(`worker liveness] rollout discovery failed for ${h.worker_id}#${h.seq} at ${sessionsDir}`),
+      expect.anything(),
+    )
+  })
+
+  it('builtin 实现该方法:无常驻化身时回退 meta mtime,不借 output 当活性', async () => {
+    const workerId = 'w-builtin-fallback'
+    const metaAt = Date.parse('2026-08-05T00:00:00.000Z')
+    const outputAt = metaAt + 24 * 60 * 60_000
+    await writeMeta(workerId, { seq: 1, state: 'running', tip_node_id: 'tip-1' }, metaAt)
+    const outputPath = path.join(dataDir, workerId, 'output-1.log')
+    await fs.writeFile(outputPath, 'assistant text', 'utf-8')
+    await fs.utimes(outputPath, new Date(outputAt), new Date(outputAt))
+
     const adapter: WorkerAdapter = new BuiltinWorkerAdapter({ dataDir })
-    // 巡检据此天然跳过它(harness 侧没有、也不该有 `if (impl === 'builtin')` 这类特判)
-    expect(adapter.lastActivityAt).toBeUndefined()
+    expect(await adapter.lastActivityAt!(handle(workerId, 'builtin', 'tip-1'))).toBe(metaAt)
+  })
+
+  it('没有 meta 或原生进展记录时返回 undefined', async () => {
+    const adapter = new ClaudeCodeAdapter({ dataDir, claudeProjectsDir: path.join(dataDir, 'claude-projects') })
+    expect(await adapter.lastActivityAt!(handle('w-nolog', 'claude-code', 'unused'))).toBeUndefined()
   })
 })


### PR DESCRIPTION
## 背景

#75 的首版活性巡检把 CLI pane output mtime 当作活性。真机继续观察发现，Claude Code 停在空 composer 时仍每约 30 分钟输出一次 `Auto-updating…`，恰好永久重置 30 分钟阈值；builtin 则完全没有连续活性信号。

Spec / 协议已先在文档仓确认并更新：

- [Worker 活性信号纠偏与 builtin 覆盖设计](https://github.com/smilefufu/crabot-docs/blob/main/superpowers/specs/2026-08-06-worker-liveness-signal-correction-design.md)
- [实施计划](https://github.com/smilefufu/crabot-docs/blob/main/superpowers/plans/2026-08-06-worker-liveness-signal-correction-plan.md)
- `protocol-agent-v3.md` §6.1 / §6.3（docs commit `9fa9280`）

## 改动

- `lastActivityAt` 收紧为“最近一次可观察任务/执行进展”，不再把进程存活、终端动画或人工定时心跳算作进展；
- Claude Code：`max(meta mtime, native session JSONL mtime)`；
- Codex：`max(meta mtime, rollout mtime)`；
- builtin：按 spawn/resume/fork/burst、真实 `onLiveProgress` / `onTurn`、成功 `sendInput` 维护进程内 `activityAt`，无常驻实例时回退 meta；
- 单个 activity 来源失败时继续其它来源；`ENOENT` 正常降级，其它 stat / rollout 定位错误带 worker/seq/path 告警；
- output 仍只在首报告警时附诊断现场；harness 的 30m/5m、主线筛选、事件 kind、台账不变、去重与失败退避全部保持；
- 巡检指引补充：清弹窗后若是空 composer，必须非 raw 重发完整任务并继续确认进展。

## 验证

- `cd crabot-agent && npm run build` ✅
- 定向：4 files / **88 tests passed** ✅
  - `tests/workers/liveness-signal.test.ts`
  - `tests/workers/builtin-adapter.test.ts`
  - `tests/workers/harness/harness-liveness.test.ts`
  - `tests/manager/fail-loud-worker-event.test.ts`
- 扩大覆盖（串行，避免与现有 100% CPU producer pytest 争抢）：`tests/workers + tests/manager` → **845 passed / 5 failed**
  - 5 条均为 main 已记录的 macOS `/var` → `/private/var` realpath 固定断言：codex PATH 2、workspace manager 3；涉及测试与对应生产路径本 PR 未改。
- `git diff --check` ✅
- 变异验证：
  - cc/codex 任一重新纳入 output mtime → 各 2 条事故回归失败；
  - builtin 常驻信号删除 → 2 条失败；
  - 主线 `onLiveProgress` 更新时间删除 → 1 条失败；
  - Codex candidate rollout 内容错误重新静默吞掉 → 新 ELOOP 用例失败。

## 不变量 / 非目标

- 不自动 kill、不改 task/化身状态、不新增事件 kind；
- 不改 mailbox 重投（C5）、透明接续（A9）或 recovery 误杀（A11）；
- 单次合法操作超过 30 分钟可能触发一次 manager 复核，但巡检本身不会中断它。
