### PR TITLE
fix(workers): cc 启动弹窗吞 prompt 的投递验证闭环

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,9 +1,19 @@
 # Crabot 项目进度
 
-> 最后更新：2026-08-06 — worker 活性信号纠偏与 builtin 覆盖（分支 fix/worker-liveness-signals，待 PR）
+> 最后更新：2026-08-06 — cc 首条 prompt 投递验证（分支 fix/cc-prompt-delivery-verify，待 PR）
+
+## 2026-08-06 — cc 启动弹窗吞 prompt 的投递验证闭环（MCP 弹窗事故第三次实例）
+
+- 现场：部署活性信号后，admin-chat 触发的 cc 验证任务（w-d2304bb6）启动时弹 arXivPaper MCP 信任窗，首条 prompt 被弹窗吞掉，worker 停在空 composer 直到 30 分钟巡检兜底。铁证：output 日志里 `\e[?2004h` 在 byte 507、弹窗在 byte 890——**就绪信号之后 cc 才异步弹窗**，推翻 paste-ready.ts「弹窗会挡住就绪信号」的设计假设。同类事故第三次：8/4 卡 8.5h（paste-ready 修复前）、w-ed8453a7 8/5 卡 6h33m、w-d2304bb6 8/6。
+- 修复（小改动，局限 cc adapter spawn 阶段）：sendText(prompt) 后**用结果验证投递**——轮询 cc 会话记录（`~/.claude/projects/<slug>/<sessionId>.jsonl`）直到出现 user 消息；失败 → Esc 清理残留弹窗 + 重投一次完整 prompt + 再验证；仍失败 → 走既有 `reportStartupStall` 暂扣（带现场给 manager），绝不静默留下 running。不再依赖 TUI 文案，复用 lastActivityAt 已有的 session 定位逻辑。
+- 不变量：就绪握手（60s 等 `\e[?2004h`）不动；stall 暂扣语义不变；manager 恢复路径不变（弹窗已被消费时非 raw `send_to_worker` 重发完整任务即恢复——本次就是这么恢复的）。
+- 测试：mock-cli 支持复刻 cc 写会话记录（`MOCK_CLI_SESSION_DIR/SLUG`）与「模态框吞前 N 条输入」（`DROP_SUBMIT_COUNT`）；新增 3 用例（正常落账 / 首条被吞自动重投 / 持续被吞落 stall）。现有 spawn 测试通过 `promptDeliveryTimeoutMs: 0`（跳过投递验证）保持旧行为，改动面只在构造参数。
+- 验证：`claude-code-adapter.test.ts` 65/65、相关 4 文件 88/88、合计 153/153；变异（禁用验证逻辑）→ 新用例 2 挂。
+- 已知边界：codex 的启动弹窗未做对称处理（其 spawn 靠等 rollout 文件，机制不同），记入 follow-up；全局 MCP 禁用清单同步进 workspace 暂不做（保留弹窗现场便于验证）。
 
 ## 2026-08-06 — worker 活性信号纠偏：动画不再伪装进展，builtin 不再是盲区
 
+- 已合并：PR #76（squash `96b72f6`，@claude APPROVED 自动合并），已部署 m2（`crabot stop → upgrade → start`，health 全绿、fatal.log 无新条目、dist 含新信号）。部署后首轮巡检即命中 w-ed8453a7（被 `Auto-updating…` 掩盖 17.3h 的停摆）：新信号正确告警（1039 分钟无活动），manager 29s 内 kill 闭环。w-e865d356（停摆 builtin）重启后由 recovery 正确标记 failed。
 - 已确认 Spec 与计划：`crabot-docs/superpowers/specs/2026-08-06-worker-liveness-signal-correction-design.md`、`crabot-docs/superpowers/plans/2026-08-06-worker-liveness-signal-correction-plan.md`；正式协议 `protocol-agent-v3.md` §6.1/§6.3 已先更新并推送文档仓 main（`9fa9280`）。
 - 生产复盘：#75 首版确实两次唤醒 `w-ed8453a7`，但 Claude Code 在空 composer 每约 30 分钟输出一次 `Auto-updating…`，持续刷新 `output-1.log` mtime，恰好永久压住 30 分钟阈值；manager 清掉 MCP 弹窗后也只敲了选项/Enter，没有重发原任务。`w-761654c6` 后来虽正常完成，但 builtin running 约 4 小时期间完全没有连续活性信号。
 - 契约纠偏：`lastActivityAt` 改为“最近一次可观察任务/执行进展”，进程存活、pane 动画和无条件心跳均不算。Claude Code 取 `max(meta mtime, native session JSONL mtime)`；Codex 取 `max(meta mtime, rollout mtime)`；output 只在首报告警时附诊断现场。

--- a/crabot-agent/src/workers/claude-code/adapter.ts
+++ b/crabot-agent/src/workers/claude-code/adapter.ts
@@ -120,6 +120,17 @@ import type {
 
 const execFileAsync = promisify(execFile)
 
+/**
+ * 首条 prompt 投递验证的超时(毫秒)。
+ *
+ * 2026-08-06 生产实证(w-d2304bb6):`\e[?2004h` 只证明"paste 会被包裹",不证明"没有启动期
+ * 模态框"——cc 在就绪信号之后异步弹出 MCP 信任窗(arXivPaper),首条 paste 被弹窗消费,worker
+ * 静默停在空 composer。投递后轮询 cc 的会话记录(session jsonl)直到出现这条 user 消息,用结果
+ * 说话。cc 收到输入到落 session 是毫秒级,15s 给弹窗确认/重绘留足余量且远小于 60s 握手超时。
+ */
+const PROMPT_DELIVERY_TIMEOUT_MS = 15_000
+const PROMPT_DELIVERY_POLL_INTERVAL_MS = 250
+
 /** POSIX shell 单引号转义,与 tmux/driver.ts 的私有 shQuote 同款用法(独立复制一份)。 */
 function shQuote(s: string): string {
   return `'${s.replace(/'/g, `'\\''`)}'`
@@ -207,6 +218,7 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
   private readonly claudeProjectsDir: string
   private readonly claudeConfigPath: string
   private readonly pasteReadyTimeoutMs: number
+  private readonly promptDeliveryTimeoutMs: number
   private readonly runtimes = new Map<string, Runtime>()
   private readonly mutexes = new Map<string, AsyncMutex>()
 
@@ -225,6 +237,12 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
        * 实测取值依据)。测试注入小值,避免为了走超时分支真的等一分钟。 */
       readonly pasteReadyTimeoutMs?: number
       /**
+       * 首条 prompt 投递验证的等待上限,默认 PROMPT_DELIVERY_TIMEOUT_MS(见该常量注释,2026-08-06
+       * 生产实证:就绪信号之后 cc 仍可能异步弹 MCP 信任窗把 prompt 整个吞掉)。传 0 或负数跳过
+       * 验证——测试里没有真实 cc 进程写 session jsonl 的夹具(纯 fake tmux)注入 0 保持旧行为。
+       */
+      readonly promptDeliveryTimeoutMs?: number
+      /**
        * `report.lastText` 本 adapter 刻意不报(理由见 transitionState 注释),只报
        * `report.endReason`:`transitionExited` 拿到的那个**必填**的 `ended_reason`。不报的
        * 话这个值会在回调这一跳被丢掉,harness 只能猜。
@@ -242,6 +260,7 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
     this.claudeProjectsDir = deps.claudeProjectsDir ?? join(homedir(), '.claude', 'projects')
     this.claudeConfigPath = deps.claudeConfigPath ?? join(homedir(), '.claude.json')
     this.pasteReadyTimeoutMs = deps.pasteReadyTimeoutMs ?? DEFAULT_PASTE_READY_TIMEOUT_MS
+    this.promptDeliveryTimeoutMs = deps.promptDeliveryTimeoutMs ?? PROMPT_DELIVERY_TIMEOUT_MS
   }
 
   async detect(): Promise<DetectResult> {
@@ -453,18 +472,44 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
     // 首条任务输入经 sendText 注入,cc 把它当第一条用户消息。注入失败:session 可能已经起来
     // 但没喂到任务,不能放任 running——按 kill 路径清理 tmux 会话后落 exited(crashed)(不是
     // killed,这不是用户发起的 kill),spawn 仍然 reject 把失败如实报给调用方。
-    try {
-      await this.tmux.sendText(sessionName, spec.prompt)
-    } catch (err) {
-      await this.getMutex(handle.worker_id).run(async () => {
-        if (runtime.state === 'exited') return
-        await this.tmux.killSession(sessionName)
-        await this.transitionExited(runtime, handle, 'crashed')
-      })
-      throw err
+    await this.sendTextOrKill(runtime, handle, spec.prompt)
+
+    // 投递验证:就绪握手只证明"paste 会被包裹",不证明"没有启动期模态框"——2026-08-06 生产
+    // 实证 cc 在 \e[?2004h 之后异步弹出 MCP 信任窗,首条 paste 被弹窗消费,worker 静默停在空
+    // composer 直到 30 分钟巡检兜底。这里用结果说话:轮询 cc 的会话记录(session jsonl)直到
+    // 出现这条 user 消息。验证失败 → 判定被模态框吞掉:Esc 取消残留弹窗、重投一次完整任务、
+    // 再验证;仍失败 → 走与 pasteReady 超时同一收场(reportStartupStall 暂扣),绝不静默留下
+    // running。
+    if (this.promptDeliveryTimeoutMs > 0) {
+      const sessionFile = join(this.claudeProjectsDir, projectSlug(spec.workspace.root), `${sessionId}.jsonl`)
+      if (!(await verifyPromptDelivered(sessionFile, this.promptDeliveryTimeoutMs))) {
+        await this.sendTextOrKill(runtime, handle, '\u001b')
+        await this.sendTextOrKill(runtime, handle, spec.prompt)
+        if (!(await verifyPromptDelivered(sessionFile, this.promptDeliveryTimeoutMs))) {
+          await this.reportStartupStall(runtime, handle, outputFile)
+          return handle
+        }
+      }
     }
 
     return handle
+  }
+
+  /**
+   * sendText 失败统一收场:会话可能已死,不能放任 running——按 kill 路径清理 tmux 会话后落
+   * exited(crashed)(不是 killed,这不是用户发起的 kill),异常继续上抛如实报给调用方。
+   */
+  private async sendTextOrKill(runtime: Runtime, h: IncarnationHandle, text: string): Promise<void> {
+    try {
+      await this.tmux.sendText(runtime.sessionName, text)
+    } catch (err) {
+      await this.getMutex(h.worker_id).run(async () => {
+        if (runtime.state === 'exited') return
+        await this.tmux.killSession(runtime.sessionName)
+        await this.transitionExited(runtime, h, 'crashed')
+      })
+      throw err
+    }
   }
 
   async resume(prev: IncarnationRef, wakeInput: string): Promise<IncarnationHandle> {
@@ -1190,6 +1235,44 @@ function workerIdLabelFromWorkspace(ws: Workspace): string {
 /** cc 的 project 目录 slug 规则:cwd 路径里的 `/` 与 `.` 都替换成 `-`(已用真实 ~/.claude/projects/ 核实)。 */
 function projectSlug(cwd: string): string {
   return cwd.replace(/[/.]/g, '-')
+}
+
+/**
+ * 投递验证的探针:session jsonl 里是否已出现一条 user 消息(cc 收到输入即落盘,见
+ * `verifyPromptDelivered` 的注释)。文件还不存在/半行/JSON 未完成都算"还没到",继续下一轮。
+ * 非 ENOENT 的读取错误告警后同样按"还没到"处理(保守:宁可多等一轮,不因诊断噪音误判)。
+ */
+async function sessionHasUserMessage(filePath: string): Promise<boolean> {
+  let raw: string
+  try {
+    raw = await fs.readFile(filePath, 'utf-8')
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return false
+    console.warn(`[claude-code-adapter] prompt delivery check: cannot read ${filePath}:`, err)
+    return false
+  }
+  for (const line of raw.split('\n')) {
+    if (line.trim() === '') continue
+    let obj: unknown
+    try {
+      obj = JSON.parse(line)
+    } catch {
+      continue // 写入中途的半行:跳过,下一轮再看
+    }
+    const m = obj as { type?: string; message?: { role?: string } }
+    if (m.type === 'user' && m.message?.role === 'user') return true
+  }
+  return false
+}
+
+/** 轮询 session jsonl 直到出现 user 消息;超时返回 false。见 PROMPT_DELIVERY_TIMEOUT_MS 注释。 */
+async function verifyPromptDelivered(filePath: string, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs
+  for (;;) {
+    if (await sessionHasUserMessage(filePath)) return true
+    if (Date.now() >= deadline) return false
+    await new Promise((r) => setTimeout(r, PROMPT_DELIVERY_POLL_INTERVAL_MS))
+  }
 }
 
 function truncate(text: string, max: number): string {

--- a/crabot-agent/src/workers/claude-code/adapter.ts
+++ b/crabot-agent/src/workers/claude-code/adapter.ts
@@ -93,7 +93,7 @@ import { homedir } from 'os'
 import { execFile } from 'child_process'
 import { promisify } from 'util'
 import { TmuxDriver } from '../tmux/driver.js'
-import { DEFAULT_PASTE_READY_TIMEOUT_MS, describeStartupStall, readOutputTail, waitForPasteReady } from '../tmux/paste-ready.js'
+import { DEFAULT_PASTE_READY_TIMEOUT_MS, describeDeliveryStall, describeStartupStall, readOutputTail, waitForPasteReady } from '../tmux/paste-ready.js'
 import { CliEventChannel, EVENTS_FILE_ENV } from '../cli-events.js'
 import { OutputLog } from '../output-log.js'
 import { decodeTerminalOutput } from '../terminal-output.js'
@@ -481,7 +481,11 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
     // 再验证;仍失败 → 走与 pasteReady 超时同一收场(reportStartupStall 暂扣),绝不静默留下
     // running。
     if (this.promptDeliveryTimeoutMs > 0) {
-      const sessionFile = join(this.claudeProjectsDir, projectSlug(spec.workspace.root), `${sessionId}.jsonl`)
+      // cc 落盘的 session 记录用 workspace 的 **realpath** slug(provision 段实证:逻辑路径
+      // "实测完全无效",~/.claude.json 的 project key 全是 realpath)——软链分量(/tmp、被软链的
+      // DATA_DIR)会导致验证读错路径、对健康会话假阴性。spawn 时 workspace 已存在,realpath 必成功。
+      const realRoot = await fs.realpath(spec.workspace.root)
+      const sessionFile = join(this.claudeProjectsDir, projectSlug(realRoot), `${sessionId}.jsonl`)
       if (!(await verifyPromptDelivered(sessionFile, this.promptDeliveryTimeoutMs))) {
         // 取消残留弹窗必须发真正的 Escape 键(sendKeys),不能 sendText——sendText 走
         // paste-buffer 粘贴,ESC 只会作为文本字符进 composer,真正作用于弹窗的是粘贴结尾的
@@ -490,7 +494,13 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
         await this.sendKeysOrKill(runtime, handle, ['Escape'])
         await this.sendTextOrKill(runtime, handle, spec.prompt)
         if (!(await verifyPromptDelivered(sessionFile, this.promptDeliveryTimeoutMs))) {
-          await this.reportStartupStall(runtime, handle, outputFile)
+          await this.reportStartupStall(runtime, handle, outputFile, {
+            note: describeDeliveryStall({
+              impl: 'claude-code',
+              timeoutMs: this.promptDeliveryTimeoutMs,
+              tail: decodeTerminalOutput(await readOutputTail(outputFile)),
+            }),
+          })
           return handle
         }
       }
@@ -1153,16 +1163,21 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
    * 在 `read_worker_output` 里拿到可读文本、在唤醒事件里拿到同一份日志的转义序列乱码。解码
    * 位置也与 `readOutput` 一致地留在 adapter 这一层(builtin 的输出是纯文本,不该被解码)。
    */
-  private async reportStartupStall(runtime: Runtime, h: IncarnationHandle, outputFile: string): Promise<void> {
+  private async reportStartupStall(
+    runtime: Runtime,
+    h: IncarnationHandle,
+    outputFile: string,
+    opts?: { note?: string },
+  ): Promise<void> {
     const tail = decodeTerminalOutput(await readOutputTail(outputFile))
     // 等待期间进程可能是**自己死了**(启动即失败:二进制缺失、PATH 不对、pane 里的命令立刻
     // 退出),那不是"停在一个界面上等人",谎报 idle 会让 manager 对着一具尸体发指令。先让既有
     // 的三源判定跑一遍,它会如实落 exited;只有确实还活着才走下面的暂扣汇报。
     //
-    // 落 `'crashed'` 而不是 syncState 缺省的 `'completed'`:本函数被调用的前提就是"就绪信号
-    // 没等到 ⇒ 开工输入一个字符都没投递",此刻会话没了只可能是启动即失败(二进制缺失、PATH
-    // 不对、pane 命令立刻退出),completed 在这条路径上明确不可能成立。吃缺省推断会让一个
-    // 从没干过活的 worker 在台账上落成"成功完成"终态(同 #66 修的那类"失败记成成功")。
+    // 落 `'crashed'` 而不是 syncState 缺省的 `'completed'`:本函数被调用的前提就是"开工输入
+    // 没落地"——就绪握手超时(一个字符都没投递,completed 不可能)或投递验证失败(prompt 被
+    // 启动期模态框吞掉,任务实际没开始),completed 在这两条路径上都不成立。吃缺省推断会让
+    // 一个从没干过活的 worker 在台账上落成"成功完成"终态(同 #66 修的那类"失败记成成功")。
     if ((await this.syncState(runtime, h, 'crashed')).state === 'exited') return
     await this.getMutex(h.worker_id).run(async () => {
       if (runtime.state === 'exited') return // 判定与提交之间又被并发抢先:终态不可覆盖
@@ -1171,7 +1186,8 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
       // 只是"落了一下",下一次 state() 就把它连同台账一起翻回 running。
       runtime.startupStalled = true
       await this.transitionState(runtime, h, 'idle', {
-        outputTail: describeStartupStall({ impl: 'claude-code', timeoutMs: this.pasteReadyTimeoutMs, tail }),
+        outputTail:
+          opts?.note ?? describeStartupStall({ impl: 'claude-code', timeoutMs: this.pasteReadyTimeoutMs, tail }),
       })
     })
   }

--- a/crabot-agent/src/workers/claude-code/adapter.ts
+++ b/crabot-agent/src/workers/claude-code/adapter.ts
@@ -483,7 +483,11 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
     if (this.promptDeliveryTimeoutMs > 0) {
       const sessionFile = join(this.claudeProjectsDir, projectSlug(spec.workspace.root), `${sessionId}.jsonl`)
       if (!(await verifyPromptDelivered(sessionFile, this.promptDeliveryTimeoutMs))) {
-        await this.sendTextOrKill(runtime, handle, '\u001b')
+        // 取消残留弹窗必须发真正的 Escape 键(sendKeys),不能 sendText——sendText 走
+        // paste-buffer 粘贴,ESC 只会作为文本字符进 composer,真正作用于弹窗的是粘贴结尾的
+        // Enter,可能激活弹窗默认选项(对 MCP 信任窗等于静默授权信任,与 provision 的
+        // enabledMcpjsonServers 授权边界相抵)。
+        await this.sendKeysOrKill(runtime, handle, ['Escape'])
         await this.sendTextOrKill(runtime, handle, spec.prompt)
         if (!(await verifyPromptDelivered(sessionFile, this.promptDeliveryTimeoutMs))) {
           await this.reportStartupStall(runtime, handle, outputFile)
@@ -502,6 +506,20 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
   private async sendTextOrKill(runtime: Runtime, h: IncarnationHandle, text: string): Promise<void> {
     try {
       await this.tmux.sendText(runtime.sessionName, text)
+    } catch (err) {
+      await this.getMutex(h.worker_id).run(async () => {
+        if (runtime.state === 'exited') return
+        await this.tmux.killSession(runtime.sessionName)
+        await this.transitionExited(runtime, h, 'crashed')
+      })
+      throw err
+    }
+  }
+
+  /** sendTextOrKill 的 sendKeys 版本(Esc 清弹窗用,见 spawn 投递验证注释)。 */
+  private async sendKeysOrKill(runtime: Runtime, h: IncarnationHandle, keys: string[]): Promise<void> {
+    try {
+      await this.tmux.sendKeys(runtime.sessionName, keys)
     } catch (err) {
       await this.getMutex(h.worker_id).run(async () => {
         if (runtime.state === 'exited') return

--- a/crabot-agent/src/workers/tmux/paste-ready.ts
+++ b/crabot-agent/src/workers/tmux/paste-ready.ts
@@ -141,6 +141,22 @@ export function describeStartupStall(opts: { impl: string; timeoutMs: number; ta
 }
 
 /**
+ * 投递验证失败的暂扣正文(与 describeStartupStall 平行):就绪握手已通过、prompt 已投递过
+ * (可能两次)并已发过 Esc,但会话记录里始终没出现这条 user 消息——判定被启动期模态框(如
+ * MCP 信任窗)吞掉。正文必须如实反映这一现场,不能复用"未就绪/一个字符都没投递"的失实描述
+ * (2026-08-06 review 指正,否则 manager 会按错的现场做决策)。
+ */
+export function describeDeliveryStall(opts: { impl: string; timeoutMs: number; tail: string }): string {
+  const seconds = Math.round(opts.timeoutMs / 1000)
+  const note =
+    `[crabot] ${opts.impl} 启动成功(就绪握手已通过),但首条任务输入投递后 ${seconds}s 内没有出现在会话记录里——` +
+    `判定被启动期模态框(如 MCP 信任窗)吞掉,已自动按 Esc 并重投一次仍无效。进程/会话仍活着、台账仍记着 running。` +
+    `上面是该化身终端输出的尾部(已解码成可读文本,与 read_worker_output 同一形态),据此判断卡在哪:` +
+    `可用 send_to_worker 的 raw 模式敲键清掉界面,再以非 raw 重发完整任务。`
+  return `${opts.tail || '(终端至今没有任何输出)'}\n---\n${note}`
+}
+
+/**
  * 读 output 日志的**尾部**(最多 maxBytes 字节),原样返回。
  *
  * 用途只有一个:就绪握手超时时把"屏幕这一刻在说什么"随唤醒事件交给 manager 判断

--- a/crabot-agent/tests/workers/claude-code-adapter.test.ts
+++ b/crabot-agent/tests/workers/claude-code-adapter.test.ts
@@ -795,14 +795,14 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — prompt 投递验证(2026-
   /** 投递验证的专用夹具:mock-cli 会往 claudeProjectsDir 写 cc 会话记录。 */
   async function deliveryAdapter(
     script: MockStep[],
-    opts?: { dropSubmitCount?: number; deliveryTimeoutMs?: number },
+    opts?: { dropSubmitCount?: number; deliveryTimeoutMs?: number; tmux?: TmuxDriver },
   ): Promise<{ adapter: ClaudeCodeAdapter; workerId: string }> {
     const channel = new CliEventChannel(eventsFilePath({ root: workspaceRoot }))
     const stopHookCmd = channel.hookCommand('stop')
     const adapter = new ClaudeCodeAdapter({
       dataDir,
       claudeConfigPath: fakeClaudeConfig(dataDir),
-      tmux: new TmuxDriver(),
+      tmux: opts?.tmux ?? new TmuxDriver(),
       claudeBin: claudeBinFor(script, stopHookCmd, undefined, {
         dir: claudeProjectsDir,
         slug: slug(workspaceRoot),
@@ -833,12 +833,21 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — prompt 投递验证(2026-
   })
 
   it('弹窗吞掉首条 prompt 时自动 Esc 清理并重投,第二次真正落地(不落 stall)', async () => {
-    const { adapter, workerId } = await deliveryAdapter([{ output: '任务输出', emitStop: true }], { dropSubmitCount: 1 })
+    const tmux = new CountingTmux()
+    const { adapter, workerId } = await deliveryAdapter([{ output: '任务输出', emitStop: true }], {
+      dropSubmitCount: 1,
+      tmux,
+    })
     const h = await adapter.spawn({ worker_id: workerId, prompt: '完整任务', workspace: { root: workspaceRoot } })
 
     // 关键断言:验证通过,没有走 startup stall 路径;state 迁移是事件驱动的,不在此断言。
     const meta = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8'))
     expect(meta.startup_stalled).toBeUndefined()
+    // Esc 清弹窗必须走 sendKeys(真正发 Escape 键),不能 sendText——sendText 是 paste-buffer
+    // 粘贴文本,粘贴结尾的 Enter 会激活弹窗默认选项(对 MCP 信任窗等于静默授权,与 provision
+    // 的 enabledMcpjsonServers 授权边界相抵)。这条断言钉住实现,改回 sendText 立即挂。
+    expect(tmux.calls.sendKeys).toBe(1)
+    expect(tmux.calls.sendText).toBe(2) // 首投 + 重投
     // 会话记录里只有重投后的那一条 user 消息(被吞的首条没有落账)
     const sessionFile = path.join(claudeProjectsDir, slug(workspaceRoot), `${h.session_ref}.jsonl`)
     const raw = await fs.readFile(sessionFile, 'utf-8')

--- a/crabot-agent/tests/workers/claude-code-adapter.test.ts
+++ b/crabot-agent/tests/workers/claude-code-adapter.test.ts
@@ -65,9 +65,19 @@ function shQuote(s: string): string {
  * 命令行,充当测试用的 claudeBin——mock CLI 不解析 settings.json,直接从 env 拿脚本和 stop
  * hook 命令。argvFile 可选:传了就让 mock-cli 把收到的 argv(如 resume 的 `--resume <id>`)
  * 记一行 JSON 进这个文件,供测试断言。 */
-function claudeBinFor(script: MockStep[], stopHookCmd: string, argvFile?: string): string {
+function claudeBinFor(
+  script: MockStep[],
+  stopHookCmd: string,
+  argvFile?: string,
+  session?: { dir: string; slug: string; dropSubmitCount?: number },
+): string {
   const argvEnv = argvFile ? `MOCK_CLI_ARGV_FILE=${shQuote(argvFile)} ` : ''
-  return `env MOCK_CLI_SCRIPT=${shQuote(JSON.stringify(script))} MOCK_CLI_STOP_HOOK_CMD=${shQuote(stopHookCmd)} ${argvEnv}node ${shQuote(MOCK_CLI)}`
+  // session 注入:真实 cc 收到用户消息会追加进 `<claudeProjectsDir>/<slug>/<session_id>.jsonl`,
+  // prompt 投递验证的用例需要 mock 复刻这个行为(mock-cli 的 MOCK_CLI_SESSION_DIR/SLUG)。
+  const sessionEnv = session
+    ? `MOCK_CLI_SESSION_DIR=${shQuote(session.dir)} MOCK_CLI_SESSION_SLUG=${shQuote(session.slug)}${session.dropSubmitCount ? ` MOCK_CLI_DROP_SUBMIT_COUNT=${session.dropSubmitCount}` : ''} `
+    : ''
+  return `env MOCK_CLI_SCRIPT=${shQuote(JSON.stringify(script))} MOCK_CLI_STOP_HOOK_CMD=${shQuote(stopHookCmd)} ${argvEnv}${sessionEnv}node ${shQuote(MOCK_CLI)}`
 }
 
 /** 假 TmuxDriver 的 newSession 替身:落一份 output 日志并写入 \e[?2004h。
@@ -278,7 +288,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter (tmux + mock CLI)', () => {
   async function provisionedAdapter(script: MockStep[]): Promise<{ adapter: ClaudeCodeAdapter; workerId: string }> {
     const channel = new CliEventChannel(eventsFilePath({ root: workspaceRoot }))
     const stopHookCmd = channel.hookCommand('stop')
-    const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin: claudeBinFor(script, stopHookCmd) })
+    const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin: claudeBinFor(script, stopHookCmd), promptDeliveryTimeoutMs: 0 })
     // provision 建 .claude/ 目录 —— hook 写入目标目录必须先存在,否则 printf >> 静默失败。
     await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
     return { adapter, workerId: `cctest-${randomUUID().slice(0, 8)}` }
@@ -442,7 +452,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — 四轮 review PoC 回归:
       // 因此持续存活,直到显式 kill,给"重连一个仍存活的会话"提供稳定的时间窗口。
       const claudeBin = claudeBinFor([{ output: '第一段输出' }, { output: '第二段输出' }], stopHookCmd)
 
-      const adapterA = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin })
+      const adapterA = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin, promptDeliveryTimeoutMs: 0 })
       await adapterA.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
       const workerId = `cctest-${randomUUID().slice(0, 8)}`
       const h = await adapterA.spawn({ worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } })
@@ -477,7 +487,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — 四轮 review PoC 回归:
       const stopHookCmd = channel.hookCommand('stop')
       const claudeBin = claudeBinFor([{ output: '第一段输出' }], stopHookCmd)
 
-      const adapterA = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin })
+      const adapterA = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin, promptDeliveryTimeoutMs: 0 })
       await adapterA.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
       const workerId = `cctest-${randomUUID().slice(0, 8)}`
       const h = await adapterA.spawn({ worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } })
@@ -511,7 +521,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — 四轮 review PoC 回归:
       const argvFile = path.join(dataDir, 'poc3-fork-argv.jsonl')
       const claudeBin = `env FAKE_ARGV_FILE=${shQuote(argvFile)} FAKE_FORK_STDOUT=${shQuote('侧问回复内容')} node ${shQuote(FAKE_CLAUDE_FORK)}`
 
-      const adapterA = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin })
+      const adapterA = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin, promptDeliveryTimeoutMs: 0 })
       await adapterA.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
       const workerId = `cctest-${randomUUID().slice(0, 8)}`
 
@@ -534,7 +544,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — 四轮 review PoC 回归:
       // 两份历史。resume(#1) 会先经 ensureRuntime 只重建出 #1 这一条 runtime(#2 从未被
       // 提及,不会被重建),旧版 nextSeq 只扫内存 runtimes(此时仅 #1)算出 2,与磁盘上的
       // #2 撞号。
-      const adapterB = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin })
+      const adapterB = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin, promptDeliveryTimeoutMs: 0 })
       const h3 = await adapterB.resume({ worker_id: workerId, seq: 1, session_ref: meta1.session_id }, '继续')
 
       // 磁盘感知修复后:新化身分配到 3(不是 2),不撞上 #2 的号位。
@@ -631,7 +641,7 @@ describe('ClaudeCodeAdapter — syncState 锁纪律(P2 Task 4 评审 Important #
     '并发 state() 与事件到达交错后,终读 idle 不回退成 running',
     async () => {
       const tmux = new RaceTmux()
-      const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin: 'unused-in-this-test' })
+      const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin: 'unused-in-this-test', promptDeliveryTimeoutMs: 0 })
       const workerId = `cctest-${randomUUID().slice(0, 8)}`
       const h = await adapter.spawn({ worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } })
 
@@ -689,7 +699,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — spawn 提交纪律(P2 Tas
       const stopHookCmd = channel.hookCommand('stop')
       // claudeBin 用一个存在的 sleep 命令(附加参数被 bash -c 脚本忽略),不依赖真实 claude 二进制,
       // 只用来验证 tmux 会话能正常起来、sendText 能正常注入。
-      const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin: READY_IDLE_BIN })
+      const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin: READY_IDLE_BIN, promptDeliveryTimeoutMs: 0 })
       await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
       const workerId = `cctest-${randomUUID().slice(0, 8)}`
       const spec: SpawnSpec = { worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } }
@@ -730,7 +740,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — spawn 提交纪律(P2 Tas
         }
       }
       const tmux = new NewSessionOkSendTextFailsTmux()
-      const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin: READY_IDLE_BIN })
+      const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin: READY_IDLE_BIN, promptDeliveryTimeoutMs: 0 })
       await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
       const workerId = `cctest-${randomUUID().slice(0, 8)}`
       const spec: SpawnSpec = { worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } }
@@ -745,6 +755,108 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — spawn 提交纪律(P2 Tas
     },
     15000,
   )
+})
+
+describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — prompt 投递验证(2026-08-06 MCP 弹窗事故修复)', () => {
+  let dataDir: string
+  let workspaceRoot: string
+  let claudeProjectsDir: string
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'cc-adapter-delivery-data-'))
+    workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'cc-adapter-delivery-ws-'))
+    claudeProjectsDir = await fs.mkdtemp(path.join(os.tmpdir(), 'cc-adapter-delivery-projects-'))
+  })
+
+  afterEach(async () => {
+    await cleanupTmuxSessions()
+    await fs.rm(dataDir, { recursive: true, force: true }).catch(() => {})
+    await fs.rm(workspaceRoot, { recursive: true, force: true }).catch(() => {})
+    await fs.rm(claudeProjectsDir, { recursive: true, force: true }).catch(() => {})
+  })
+
+  const slug = (root: string) => root.replace(/[/.]/g, '-')
+
+  async function waitForIdle(
+    adapter: ClaudeCodeAdapter,
+    h: IncarnationHandle,
+    timeoutMs = 8000,
+  ): Promise<void> {
+    const deadline = Date.now() + timeoutMs
+    let last: WorkerContractState | undefined
+    while (Date.now() < deadline) {
+      last = await adapter.state(h)
+      if (last === 'idle') return
+      await new Promise((r) => setTimeout(r, 100))
+    }
+    throw new Error(`waitForIdle timeout: last '${last}'`)
+  }
+
+  /** 投递验证的专用夹具:mock-cli 会往 claudeProjectsDir 写 cc 会话记录。 */
+  async function deliveryAdapter(
+    script: MockStep[],
+    opts?: { dropSubmitCount?: number; deliveryTimeoutMs?: number },
+  ): Promise<{ adapter: ClaudeCodeAdapter; workerId: string }> {
+    const channel = new CliEventChannel(eventsFilePath({ root: workspaceRoot }))
+    const stopHookCmd = channel.hookCommand('stop')
+    const adapter = new ClaudeCodeAdapter({
+      dataDir,
+      claudeConfigPath: fakeClaudeConfig(dataDir),
+      tmux: new TmuxDriver(),
+      claudeBin: claudeBinFor(script, stopHookCmd, undefined, {
+        dir: claudeProjectsDir,
+        slug: slug(workspaceRoot),
+        dropSubmitCount: opts?.dropSubmitCount,
+      }),
+      claudeProjectsDir,
+      promptDeliveryTimeoutMs: opts?.deliveryTimeoutMs ?? 2000,
+    })
+    await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
+    return { adapter, workerId: `cctest-${randomUUID().slice(0, 8)}` }
+  }
+
+  it('正常路径:prompt 投递后 session 记录出现 user 消息,spawn 正常返回且不落 stall', async () => {
+    const { adapter, workerId } = await deliveryAdapter([{ output: '任务输出', emitStop: true }])
+    const h = await adapter.spawn({ worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } })
+
+    expect(h.worker_id).toBe(workerId)
+    // 关键断言:没走 startup stall 路径(startup_stalled 未被置位);state 迁移是事件驱动的,
+    // 此刻读 meta 可能是 running 或已收敛 idle,不在此断言。
+    const meta = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8'))
+    expect(meta.startup_stalled).toBeUndefined()
+
+    const sessionFile = path.join(claudeProjectsDir, slug(workspaceRoot), `${h.session_ref}.jsonl`)
+    const raw = await fs.readFile(sessionFile, 'utf-8')
+    expect(raw).toContain('"type":"user"')
+
+    await adapter.kill(h)
+  })
+
+  it('弹窗吞掉首条 prompt 时自动 Esc 清理并重投,第二次真正落地(不落 stall)', async () => {
+    const { adapter, workerId } = await deliveryAdapter([{ output: '任务输出', emitStop: true }], { dropSubmitCount: 1 })
+    const h = await adapter.spawn({ worker_id: workerId, prompt: '完整任务', workspace: { root: workspaceRoot } })
+
+    // 关键断言:验证通过,没有走 startup stall 路径;state 迁移是事件驱动的,不在此断言。
+    const meta = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8'))
+    expect(meta.startup_stalled).toBeUndefined()
+    // 会话记录里只有重投后的那一条 user 消息(被吞的首条没有落账)
+    const sessionFile = path.join(claudeProjectsDir, slug(workspaceRoot), `${h.session_ref}.jsonl`)
+    const raw = await fs.readFile(sessionFile, 'utf-8')
+    const userLines = raw.split('\n').filter((l) => l.includes('"type":"user"'))
+    expect(userLines).toHaveLength(1)
+
+    await adapter.kill(h)
+  })
+
+  it('弹窗持续存在(两次投递都被吞)→ 走 startup stall 暂扣,不静默留下 running', async () => {
+    const { adapter, workerId } = await deliveryAdapter([{ output: '永远不会输出' }], { dropSubmitCount: 10 })
+    const h = await adapter.spawn({ worker_id: workerId, prompt: '完整任务', workspace: { root: workspaceRoot } })
+
+    await waitForIdle(adapter, h)
+    const meta = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8'))
+    expect(meta.state).toBe('idle')
+    expect(meta.startup_stalled).toBe(true)
+  })
 })
 
 describe('ClaudeCodeAdapter.detect', () => {
@@ -836,7 +948,7 @@ describe('ClaudeCodeAdapter — session_ref UUID 边界校验', () => {
   })
 
   it('resume() 拒绝非 UUID 格式的 session_ref(含 shell 注入特征),不执行任何命令', async () => {
-    const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), claudeBin: 'unused' })
+    const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), claudeBin: 'unused', promptDeliveryTimeoutMs: 0 })
     const workerId = `cctest-${randomUUID().slice(0, 8)}`
 
     // 先 spawn 一个真实化身以供 resume 前置条件
@@ -855,7 +967,7 @@ describe('ClaudeCodeAdapter — session_ref UUID 边界校验', () => {
   })
 
   it('fork() 拒绝非 UUID 格式的 session_ref(含 shell 注入特征),不执行子进程', async () => {
-    const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), claudeBin: 'unused' })
+    const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), claudeBin: 'unused', promptDeliveryTimeoutMs: 0 })
     const workerId = `cctest-${randomUUID().slice(0, 8)}`
 
     const maliciousSessionRef = 'x; touch /tmp/pwned'
@@ -869,7 +981,7 @@ describe('ClaudeCodeAdapter — session_ref UUID 边界校验', () => {
   })
 
   it('resume() 拒绝空白或特殊字符 session_ref', async () => {
-    const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), claudeBin: 'unused' })
+    const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), claudeBin: 'unused', promptDeliveryTimeoutMs: 0 })
     const workerId = `cctest-${randomUUID().slice(0, 8)}`
 
     const invalidRefs = ['', ' ', '$(whoami)', '`id`', '{test}', '../../../etc/passwd']
@@ -882,7 +994,7 @@ describe('ClaudeCodeAdapter — session_ref UUID 边界校验', () => {
   })
 
   it('fork() 拒绝空白或特殊字符 session_ref', async () => {
-    const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), claudeBin: 'unused' })
+    const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), claudeBin: 'unused', promptDeliveryTimeoutMs: 0 })
     const workerId = `cctest-${randomUUID().slice(0, 8)}`
 
     const invalidRefs = ['', ' ', '$(whoami)', '`id`', '{test}', '../../../etc/passwd']
@@ -895,7 +1007,7 @@ describe('ClaudeCodeAdapter — session_ref UUID 边界校验', () => {
   })
 
   it('resume() 接受有效 UUID 格式的 session_ref(至少通过前置校验)', async () => {
-    const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), claudeBin: 'unused' })
+    const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), claudeBin: 'unused', promptDeliveryTimeoutMs: 0 })
     const workerId = `cctest-${randomUUID().slice(0, 8)}`
     const validUuid = randomUUID()
 
@@ -906,7 +1018,7 @@ describe('ClaudeCodeAdapter — session_ref UUID 边界校验', () => {
   })
 
   it('fork() 接受有效 UUID 格式的 session_ref(至少通过前置校验)', async () => {
-    const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), claudeBin: 'unused' })
+    const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), claudeBin: 'unused', promptDeliveryTimeoutMs: 0 })
     const workerId = `cctest-${randomUUID().slice(0, 8)}`
     const validUuid = randomUUID()
 
@@ -941,7 +1053,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter.resume', () => {
       const stopHookCmd = channel.hookCommand('stop')
       const argvFile = path.join(dataDir, 'argv.jsonl')
       const claudeBin = claudeBinFor([{ output: '第一轮输出', exit: true }], stopHookCmd, argvFile)
-      const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin })
+      const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin, promptDeliveryTimeoutMs: 0 })
       await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
       const workerId = `cctest-${randomUUID().slice(0, 8)}`
 
@@ -987,7 +1099,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter.resume', () => {
       const channel = new CliEventChannel(eventsFilePath({ root: workspaceRoot }))
       const stopHookCmd = channel.hookCommand('stop')
       const claudeBin = claudeBinFor([{ output: '还在跑,不退出也不 emitStop' }], stopHookCmd)
-      const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin })
+      const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin, promptDeliveryTimeoutMs: 0 })
       await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
       const workerId = `cctest-${randomUUID().slice(0, 8)}`
 
@@ -1009,7 +1121,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter.resume', () => {
       const channel = new CliEventChannel(eventsFilePath({ root: workspaceRoot }))
       const stopHookCmd = channel.hookCommand('stop')
       const claudeBin = claudeBinFor([{ output: '第一轮输出', exit: true }], stopHookCmd)
-      const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin })
+      const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin, promptDeliveryTimeoutMs: 0 })
       await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
       const workerId = `cctest-${randomUUID().slice(0, 8)}`
 
@@ -1085,7 +1197,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter.fork', () => {
       const tmux = new CountingTmux()
       const argvFile = path.join(dataDir, 'fork-argv.jsonl')
       const claudeBin = forkClaudeBin(argvFile, '侧问回复内容')
-      const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin })
+      const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin, promptDeliveryTimeoutMs: 0 })
       await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
       const workerId = `cctest-${randomUUID().slice(0, 8)}`
 
@@ -1144,7 +1256,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter.fork', () => {
       const tmux = new CountingTmux()
       const argvFile = path.join(dataDir, 'fork-argv-crash.jsonl')
       const claudeBin = forkClaudeBin(argvFile, '', 1)
-      const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin })
+      const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin, promptDeliveryTimeoutMs: 0 })
       await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
       const workerId = `cctest-${randomUUID().slice(0, 8)}`
 
@@ -1170,7 +1282,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter.fork', () => {
       const tmux = new CountingTmux()
       const argvFile = path.join(dataDir, 'fork-argv-seq.jsonl')
       const claudeBin = forkClaudeBin(argvFile, '侧问回复')
-      const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin })
+      const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin, promptDeliveryTimeoutMs: 0 })
       await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
       const workerId = `cctest-${randomUUID().slice(0, 8)}`
 
@@ -1200,7 +1312,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter.fork', () => {
       const tmux = new CountingTmux()
       const argvFile = path.join(dataDir, 'fork-then-resume-argv.jsonl')
       const claudeBin = forkClaudeBin(argvFile, '侧问回复')
-      const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin })
+      const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin, promptDeliveryTimeoutMs: 0 })
       await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
       const workerId = `cctest-${randomUUID().slice(0, 8)}`
 
@@ -1333,7 +1445,7 @@ describe('ClaudeCodeAdapter.readTrace', () => {
 
   it('按 ~/.claude/projects/<slug>/<session_id>.jsonl 解析并归一化', async () => {
     const tmux = new NoopTmux()
-    const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin: 'unused', claudeProjectsDir })
+    const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin: 'unused', promptDeliveryTimeoutMs: 0, claudeProjectsDir })
     const workerId = `cctest-${randomUUID().slice(0, 8)}`
     const { h, sessionId } = await spawnedHandle(adapter, workerId)
 
@@ -1367,7 +1479,7 @@ describe('ClaudeCodeAdapter.readTrace', () => {
 
   it('cursor.offset 按行号跳过已读部分', async () => {
     const tmux = new NoopTmux()
-    const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin: 'unused', claudeProjectsDir })
+    const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin: 'unused', promptDeliveryTimeoutMs: 0, claudeProjectsDir })
     const workerId = `cctest-${randomUUID().slice(0, 8)}`
     const { h, sessionId } = await spawnedHandle(adapter, workerId)
 
@@ -1387,7 +1499,7 @@ describe('ClaudeCodeAdapter.readTrace', () => {
 
   it('nextCursor 计入跳过的坏行/未知类型行,两次 readTrace 按 nextCursor 续读不重不漏', async () => {
     const tmux = new NoopTmux()
-    const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin: 'unused', claudeProjectsDir })
+    const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin: 'unused', promptDeliveryTimeoutMs: 0, claudeProjectsDir })
     const workerId = `cctest-${randomUUID().slice(0, 8)}`
     const { h, sessionId } = await spawnedHandle(adapter, workerId)
 
@@ -1426,7 +1538,7 @@ describe('ClaudeCodeAdapter.readTrace', () => {
 
   it('半行(CLI 写入未完成,无结尾换行符)不消费,补全后续读不丢事件', async () => {
     const tmux = new NoopTmux()
-    const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin: 'unused', claudeProjectsDir })
+    const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin: 'unused', promptDeliveryTimeoutMs: 0, claudeProjectsDir })
     const workerId = `cctest-${randomUUID().slice(0, 8)}`
     const { h, sessionId } = await spawnedHandle(adapter, workerId)
 
@@ -1490,7 +1602,7 @@ describe('ClaudeCodeAdapter.readTrace', () => {
 
   it('trace 文件不存在 → 返回空事件数组,不抛错,cursor 原样透传', async () => {
     const tmux = new NoopTmux()
-    const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin: 'unused', claudeProjectsDir })
+    const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin: 'unused', promptDeliveryTimeoutMs: 0, claudeProjectsDir })
     const workerId = `cctest-${randomUUID().slice(0, 8)}`
     const { h } = await spawnedHandle(adapter, workerId)
     // 不写任何 fixture 文件。
@@ -1508,7 +1620,7 @@ describe('ClaudeCodeAdapter.readTrace', () => {
 
   it('对本进程内不常驻的 incarnation 调用 readTrace 应拒绝', async () => {
     const tmux = new NoopTmux()
-    const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin: 'unused', claudeProjectsDir })
+    const adapter = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin: 'unused', promptDeliveryTimeoutMs: 0, claudeProjectsDir })
     await expect(adapter.readTrace({ worker_id: 'nope', seq: 1, impl: 'claude-code' })).rejects.toThrow()
   })
 })
@@ -1563,7 +1675,7 @@ describe('ClaudeCodeAdapter — CLI hook 事件文件监视(被动 push)', () =>
       dataDir,
       claudeConfigPath: fakeClaudeConfig(dataDir),
       tmux,
-      claudeBin: 'unused',
+      claudeBin: 'unused', promptDeliveryTimeoutMs: 0,
       claudeProjectsDir,
       onStateChange: (h, state) => {
         seen.push({ seq: h.seq, state })
@@ -1588,7 +1700,7 @@ describe('ClaudeCodeAdapter — CLI hook 事件文件监视(被动 push)', () =>
       dataDir,
       claudeConfigPath: fakeClaudeConfig(dataDir),
       tmux,
-      claudeBin: 'unused',
+      claudeBin: 'unused', promptDeliveryTimeoutMs: 0,
       claudeProjectsDir,
       onStateChange: (_h, state) => {
         seen.push(state)
@@ -1617,7 +1729,7 @@ describe('ClaudeCodeAdapter — CLI hook 事件文件监视(被动 push)', () =>
       dataDir,
       claudeConfigPath: fakeClaudeConfig(dataDir),
       tmux,
-      claudeBin: 'unused',
+      claudeBin: 'unused', promptDeliveryTimeoutMs: 0,
       claudeProjectsDir,
       onStateChange: (_h, state) => {
         seen.push(state)
@@ -1660,7 +1772,7 @@ describe('ClaudeCodeAdapter — CLI hook 事件文件监视(被动 push)', () =>
       dataDir,
       claudeConfigPath: fakeClaudeConfig(dataDir),
       tmux: new NoopTmux(),
-      claudeBin: 'unused',
+      claudeBin: 'unused', promptDeliveryTimeoutMs: 0,
       claudeProjectsDir,
       onStateChange: (_h, state, report) => {
         seen.push({ state, endReason: report?.endReason })
@@ -1683,7 +1795,7 @@ describe('ClaudeCodeAdapter — CLI hook 事件文件监视(被动 push)', () =>
       dataDir,
       claudeConfigPath: fakeClaudeConfig(dataDir),
       tmux: new NoopTmux(),
-      claudeBin: 'unused',
+      claudeBin: 'unused', promptDeliveryTimeoutMs: 0,
       claudeProjectsDir,
       onStateChange: (_h, state, report) => {
         seen.push({ state, endReason: report?.endReason })
@@ -1761,7 +1873,7 @@ describe('ClaudeCodeAdapter.fork — 侧问收尾不污染主线 stop 计数', (
       dataDir,
       claudeConfigPath: fakeClaudeConfig(dataDir),
       tmux: new NoopTmux(),
-      claudeBin: forkClaudeBinRunningStopHook(),
+      claudeBin: forkClaudeBinRunningStopHook(), promptDeliveryTimeoutMs: 0,
       claudeProjectsDir,
     })
     await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
@@ -1784,7 +1896,7 @@ describe('ClaudeCodeAdapter.fork — 侧问收尾不污染主线 stop 计数', (
       dataDir,
       claudeConfigPath: fakeClaudeConfig(dataDir),
       tmux: new NoopTmux(),
-      claudeBin: forkClaudeBinRunningStopHook(),
+      claudeBin: forkClaudeBinRunningStopHook(), promptDeliveryTimeoutMs: 0,
       claudeProjectsDir,
       onStateChange: (h, state) => {
         seen.push({ seq: h.seq, state })
@@ -1858,7 +1970,7 @@ describe('ClaudeCodeAdapter.ensureRuntime — 并发重建不泄漏 watcher', ()
       dataDir,
       claudeConfigPath: fakeClaudeConfig(dataDir),
       tmux,
-      claudeBin: 'unused',
+      claudeBin: 'unused', promptDeliveryTimeoutMs: 0,
       claudeProjectsDir,
       onStateChange: (_h, state) => {
         seen.push(state)
@@ -1966,6 +2078,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — 启动期就绪握手(\\e
       tmux,
       claudeBin: `env ${envParts.join(' ')} node ${shQuote(MOCK_CLI)}`,
       pasteReadyTimeoutMs: opts.pasteReadyTimeoutMs,
+      promptDeliveryTimeoutMs: 0, // 这些用例验证的是握手/粘贴语义,不注入 session 记录,跳过投递验证
       onStateChange: (_h, state, report) => seen.push({ state, report }),
     })
     await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })

--- a/crabot-agent/tests/workers/claude-code-adapter.test.ts
+++ b/crabot-agent/tests/workers/claude-code-adapter.test.ts
@@ -777,6 +777,11 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — prompt 投递验证(2026-
 
   const slug = (root: string) => root.replace(/[/.]/g, '-')
 
+  /** cc 落盘用 workspace 的 realpath slug(macOS /var → /private/var 软链,见 adapter spawn 注释)。 */
+  async function wsSlug(): Promise<string> {
+    return slug(await fs.realpath(workspaceRoot))
+  }
+
   async function waitForIdle(
     adapter: ClaudeCodeAdapter,
     h: IncarnationHandle,
@@ -795,7 +800,12 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — prompt 投递验证(2026-
   /** 投递验证的专用夹具:mock-cli 会往 claudeProjectsDir 写 cc 会话记录。 */
   async function deliveryAdapter(
     script: MockStep[],
-    opts?: { dropSubmitCount?: number; deliveryTimeoutMs?: number; tmux?: TmuxDriver },
+    opts?: {
+      dropSubmitCount?: number
+      deliveryTimeoutMs?: number
+      tmux?: TmuxDriver
+      onStateChange?: (h: IncarnationHandle, state: WorkerContractState, report?: StateChangeReport) => void
+    },
   ): Promise<{ adapter: ClaudeCodeAdapter; workerId: string }> {
     const channel = new CliEventChannel(eventsFilePath({ root: workspaceRoot }))
     const stopHookCmd = channel.hookCommand('stop')
@@ -803,9 +813,10 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — prompt 投递验证(2026-
       dataDir,
       claudeConfigPath: fakeClaudeConfig(dataDir),
       tmux: opts?.tmux ?? new TmuxDriver(),
+      onStateChange: opts?.onStateChange,
       claudeBin: claudeBinFor(script, stopHookCmd, undefined, {
         dir: claudeProjectsDir,
-        slug: slug(workspaceRoot),
+        slug: await wsSlug(),
         dropSubmitCount: opts?.dropSubmitCount,
       }),
       claudeProjectsDir,
@@ -825,7 +836,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — prompt 投递验证(2026-
     const meta = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8'))
     expect(meta.startup_stalled).toBeUndefined()
 
-    const sessionFile = path.join(claudeProjectsDir, slug(workspaceRoot), `${h.session_ref}.jsonl`)
+    const sessionFile = path.join(claudeProjectsDir, await wsSlug(), `${h.session_ref}.jsonl`)
     const raw = await fs.readFile(sessionFile, 'utf-8')
     expect(raw).toContain('"type":"user"')
 
@@ -849,7 +860,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — prompt 投递验证(2026-
     expect(tmux.calls.sendKeys).toBe(1)
     expect(tmux.calls.sendText).toBe(2) // 首投 + 重投
     // 会话记录里只有重投后的那一条 user 消息(被吞的首条没有落账)
-    const sessionFile = path.join(claudeProjectsDir, slug(workspaceRoot), `${h.session_ref}.jsonl`)
+    const sessionFile = path.join(claudeProjectsDir, await wsSlug(), `${h.session_ref}.jsonl`)
     const raw = await fs.readFile(sessionFile, 'utf-8')
     const userLines = raw.split('\n').filter((l) => l.includes('"type":"user"'))
     expect(userLines).toHaveLength(1)
@@ -858,13 +869,22 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — prompt 投递验证(2026-
   })
 
   it('弹窗持续存在(两次投递都被吞)→ 走 startup stall 暂扣,不静默留下 running', async () => {
-    const { adapter, workerId } = await deliveryAdapter([{ output: '永远不会输出' }], { dropSubmitCount: 10 })
+    const reports: Array<{ state: string; outputTail?: string }> = []
+    const { adapter, workerId } = await deliveryAdapter([{ output: '永远不会输出' }], {
+      dropSubmitCount: 10,
+      onStateChange: (_h, state, report) => void reports.push({ state, outputTail: report?.outputTail }),
+    })
     const h = await adapter.spawn({ worker_id: workerId, prompt: '完整任务', workspace: { root: workspaceRoot } })
 
     await waitForIdle(adapter, h)
     const meta = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8'))
     expect(meta.state).toBe('idle')
     expect(meta.startup_stalled).toBe(true)
+    // 暂扣正文必须如实描述投递验证失败(握手已通过、prompt 被吞),不能复用"未就绪/一个字符
+    // 都没投递"的失实描述——否则 manager 按错的现场做决策。
+    const idleReport = reports.find((r) => r.state === 'idle')
+    expect(idleReport?.outputTail).toContain('没有出现在会话记录')
+    expect(idleReport?.outputTail).toContain('自动按 Esc 并重投一次')
   })
 })
 

--- a/crabot-agent/tests/workers/fixtures/mock-cli.mjs
+++ b/crabot-agent/tests/workers/fixtures/mock-cli.mjs
@@ -42,10 +42,19 @@
 // sendText 机制的问题——真实 cc/codex 进程启动更慢,同样需要先起来才能谈 bracketed paste)。
 // MOCK_CLI_PASTE_READY_DELAY_MS / MOCK_CLI_BANNER(可选)——见下方声明处的注释:分别用于
 // 复刻"TUI 迟迟不请求 bracketed paste"的真实时序,和扮演挡在启动期的模态框文字。
+// MOCK_CLI_SESSION_DIR + MOCK_CLI_SESSION_SLUG(可选)——真实 cc 收到一条用户消息后会把它
+// 追加进 `<claudeProjectsDir>/<slug>/<session_id>.jsonl`(会话记录)。mock 复刻同款行为:设置
+// 后,每次 submit 都往 `<MOCK_CLI_SESSION_DIR>/<MOCK_CLI_SESSION_SLUG>/<--session-id 的
+// 值>.jsonl` 追加一行 cc 格式的 user 消息(paste 投递验证的用例靠它断言"prompt 真的进了会话",
+// 而不是只看到 paste 被包裹)。MOCK_CLI_DROP_FIRST_SUBMIT(可选,=1)——把第一次 submit 当
+// 启动期模态框吞掉(不写 session、不推进脚本),复刻 2026-08-06 生产实证:cc 在发出就绪信号
+// \e[?2004h 之后异步弹出 MCP 信任窗,首条 paste 被弹窗消费、会话记录里没有这条用户消息。
+// MOCK_CLI_DROP_SUBMIT_COUNT(可选,数字)——丢弃前 N 次 submit(不写 session、不推进脚本),
+// 模拟模态框持续吞输入;DROP_FIRST_SUBMIT 是它的 1 次特例(两者共存时取 COUNT)。
 import { exec } from 'node:child_process'
 import { promisify } from 'node:util'
 import { appendFileSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
-import { dirname } from 'node:path'
+import { dirname, join } from 'node:path'
 
 const execAsync = promisify(exec)
 
@@ -123,8 +132,10 @@ function announcePasteReady() {
   if (readyFile) writeFileSync(readyFile, '')
 }
 
+// 就绪信号:必须在 stdin 监听挂好之后再宣布——否则 adapter 等到 \e[?2004h 立即 sendText,
+// paste 可能在 `process.stdin.on('data')`(见文件末尾)挂上之前到达,内容静默丢失。真实 cc
+// 启动更慢(TUI 就绪时 stdin 早已就绪),这里把立即分支推迟到监听注册之后即可消除测试竞态。
 if (pasteReadyDelayMs > 0) setTimeout(announcePasteReady, pasteReadyDelayMs)
-else announcePasteReady()
 
 let insidePaste = false
 let pending = '' // 尚未解析完的原始字节(可能横跨多个 data 事件,含被截断的半个标记)
@@ -139,8 +150,36 @@ function trailingMarkerPrefixLen(str, marker) {
   return 0
 }
 
+const sessionDir = process.env.MOCK_CLI_SESSION_DIR
+const sessionSlug = process.env.MOCK_CLI_SESSION_SLUG
+const dropSubmitCount = Number(
+  process.env.MOCK_CLI_DROP_SUBMIT_COUNT || (process.env.MOCK_CLI_DROP_FIRST_SUBMIT === '1' ? 1 : 0),
+)
+let submitCount = 0
+
+/** 真实 cc 收到用户消息后会追加进会话记录,见文件头 MOCK_CLI_SESSION_DIR 注释。 */
+function writeSessionEntry(content) {
+  // 真实 cc 只把可打印的用户消息写进会话记录;纯控制序列(Esc 清弹窗等)不产生 user 消息。
+  // 注意判定是"仅含控制字符"才跳过——中文等非 ASCII 可打印内容必须保留。
+  if (/^[\x00-\x1f\x7f]*$/.test(content)) return
+  if (!sessionDir || !sessionSlug) return
+  const sessionIdIndex = process.argv.indexOf('--session-id')
+  if (sessionIdIndex === -1) return
+  const sessionId = process.argv[sessionIdIndex + 1]
+  if (!sessionId) return
+  const file = join(sessionDir, sessionSlug, `${sessionId}.jsonl`)
+  mkdirSync(dirname(file), { recursive: true })
+  appendFileSync(
+    file,
+    JSON.stringify({ type: 'user', message: { role: 'user', content: [{ type: 'text', text: content }] } }) + '\n',
+  )
+}
+
 function submit(content) {
+  submitCount += 1
+  if (submitCount <= dropSubmitCount) return // 启动期模态框吞掉前 N 条输入:不写 session、不推进脚本
   if (stdinLogFile) appendFileSync(stdinLogFile, JSON.stringify(content) + '\n')
+  writeSessionEntry(content)
   void runStep()
 }
 
@@ -184,3 +223,6 @@ process.stdin.on('data', (chunk) => {
     break
   }
 })
+
+// stdin 监听已挂好,现在宣布就绪不丢输入(见上方就绪信号的注释)。
+if (pasteReadyDelayMs <= 0) announcePasteReady()


### PR DESCRIPTION
## 背景

部署活性信号（PR #76）后，admin-chat 触发的 cc 验证任务（w-d2304bb6）再次卡死：cc 启动时弹出 arXivPaper MCP 信任窗，首条 prompt 被弹窗吞掉，worker 停在空 composer 直到巡检兜底。**同类事故第三次**：8/4 卡 8.5h（paste-ready 修复前）、w-ed8453a7 8/5 卡 6h33m、w-d2304bb6 今天。

**铁证**（output 日志字节偏移）：`\e[?2004h` 在 byte 507、arXivPaper 弹窗在 byte 890——**cc 在发出就绪信号之后才异步弹 MCP 信任窗**。这推翻了 `paste-ready.ts` 的设计假设（"启动期模态框会挡住就绪信号"），测试也只覆盖了"弹窗在就绪前→stall"路径，没覆盖"弹窗在就绪后"。

## 修复：把"就绪"从信号预判升级为结果验证

cc adapter 的 spawn 在 `sendText(prompt)` 后增加**投递验证闭环**：

1. 轮询 cc 会话记录（`~/.claude/projects/<slug>/<sessionId>.jsonl`）直到出现这条 user 消息；
2. 验证失败 → 判定被启动期模态框吞掉：Esc 清理残留弹窗 + 重投一次完整 prompt + 再验证；
3. 仍失败 → 走既有 `reportStartupStall` 暂扣（带现场给 manager），**绝不静默留下 running**。

- 不依赖 TUI 文案（cc 升级就失效），session JSONL 是 cc 的持久会话记录、语义稳定；
- 复用 lastActivityAt 已有的 session 定位逻辑（`claudeProjectsDir + projectSlug + sessionId.jsonl`）；
- 把"静默卡死"从等 30 分钟巡检收敛到 spawn 阶段秒级闭环；
- 协议、状态机、巡检阈值/退避、manager 恢复路径全部不变。

## 测试

- mock-cli 支持复刻 cc 写会话记录（`MOCK_CLI_SESSION_DIR/SLUG`）与"模态框吞前 N 条输入"（`DROP_SUBMIT_COUNT`）；
- 新增 3 用例：正常落账 / 首条被吞自动重投成功 / 持续被吞落 startup stall；
- 现有 spawn 测试通过新构造参数 `promptDeliveryTimeoutMs: 0`（跳过投递验证）保持旧行为——改动面只在构造参数，不加 session 夹具的 fake tmux 用例不受影响；
- 验证：`claude-code-adapter.test.ts` 65/65，相关 4 文件 88/88，合计 153/153；**变异**（禁用验证逻辑）→ 新用例 2 挂。

## 已知边界（不在本 PR）

- codex 启动弹窗未做对称处理（其 spawn 靠等 rollout 文件，机制不同），记入 follow-up；
- 全局 MCP 禁用清单同步进 crabot workspace 暂不做（刻意保留 arXivPaper 弹窗现场，用于验证本修复在生产是否生效）。
