### PR TITLE
feat(workers): cc 工具权限全自动（codex 保持零审批沙箱）

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,8 +1,16 @@
 # Crabot 项目进度
 
-> 最后更新：2026-08-06 — cc 首条 prompt 投递验证（分支 fix/cc-prompt-delivery-verify，待 PR）
+> 最后更新：2026-08-06 — worker 权限自动批准（cc bypassPermissions / codex yolo，分支 fix/worker-permission-auto-approve，待 PR）
 
-## 2026-08-06 — cc 启动弹窗吞 prompt 的投递验证闭环（MCP 弹窗事故第三次实例）
+## 2026-08-06 — worker 权限自动批准：工具调用零审批弹窗
+
+- 背景：投递验证（#77）治了启动期弹窗，但运行期 cc 在 `acceptEdits` 下每调一次 Bash/网络工具仍弹权限确认窗，等 manager 处理一次，成本高。codex 已是 `--ask-for-approval never` + 网络已放开，主要改动在 cc。
+- Spec：`crabot-docs/superpowers/specs/2026-08-06-worker-permission-auto-approve-design.md`（用户确认）。
+- 决策：cc spawn/resume `--permission-mode acceptEdits` → `bypassPermissions`（settings.json `defaultMode` 同步）；codex `--ask-for-approval never` → `--yolo`（语义等价显式化），`--sandbox workspace-write` 保留（写限 workspace）+ `network_access=true` 维持（网络已放开）。
+- 取舍：审批维度全放开（治卡死）、沙箱维度能留就留（codex 写限 workspace 零便利损失）；cc 无沙箱维度，任意 Bash 破坏面接受，容器化记 follow-up。
+- 验证：cc/codex adapter 测试 132 passed / 2 failed（既有 macOS `/var` vs `/private/var` realpath 基线，stash 对比确认与本次无关）；测试断言直接钉住新值（改回即挂）。
+
+## 2026-08-06 — cc 启动弹窗吞 prompt 的投递验证闭环（已合并 PR #77，已部署）
 
 - 现场：部署活性信号后，admin-chat 触发的 cc 验证任务（w-d2304bb6）启动时弹 arXivPaper MCP 信任窗，首条 prompt 被弹窗吞掉，worker 停在空 composer 直到 30 分钟巡检兜底。铁证：output 日志里 `\e[?2004h` 在 byte 507、弹窗在 byte 890——**就绪信号之后 cc 才异步弹窗**，推翻 paste-ready.ts「弹窗会挡住就绪信号」的设计假设。同类事故第三次：8/4 卡 8.5h（paste-ready 修复前）、w-ed8453a7 8/5 卡 6h33m、w-d2304bb6 8/6。
 - 修复（小改动，局限 cc adapter spawn 阶段）：sendText(prompt) 后**用结果验证投递**——轮询 cc 会话记录（`~/.claude/projects/<slug>/<sessionId>.jsonl`）直到出现 user 消息；失败 → Esc 清理残留弹窗 + 重投一次完整 prompt + 再验证；仍失败 → 走既有 `reportStartupStall` 暂扣（带现场给 manager），绝不静默留下 running。不再依赖 TUI 文案，复用 lastActivityAt 已有的 session 定位逻辑。

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,14 +1,14 @@
 # Crabot 项目进度
 
-> 最后更新：2026-08-06 — worker 权限自动批准（cc bypassPermissions / codex yolo，分支 fix/worker-permission-auto-approve，待 PR）
+> 最后更新：2026-08-06 — worker 权限自动批准（cc bypassPermissions / codex 保持 never，分支 fix/worker-permission-auto-approve，待 PR）
 
 ## 2026-08-06 — worker 权限自动批准：工具调用零审批弹窗
 
 - 背景：投递验证（#77）治了启动期弹窗，但运行期 cc 在 `acceptEdits` 下每调一次 Bash/网络工具仍弹权限确认窗，等 manager 处理一次，成本高。codex 已是 `--ask-for-approval never` + 网络已放开，主要改动在 cc。
 - Spec：`crabot-docs/superpowers/specs/2026-08-06-worker-permission-auto-approve-design.md`（用户确认）。
-- 决策：cc spawn/resume `--permission-mode acceptEdits` → `bypassPermissions`（settings.json `defaultMode` 同步）；codex `--ask-for-approval never` → `--yolo`（语义等价显式化），`--sandbox workspace-write` 保留（写限 workspace）+ `network_access=true` 维持（网络已放开）。
+- 决策：cc spawn `--permission-mode acceptEdits` → `bypassPermissions`，settings.json `defaultMode` 同步，并预写 `~/.claude.json` 顶层 `bypassPermissionsModeAccepted=true` 消掉首次 bypass 的一次性确认弹窗；cc resume 继续依赖 settings。codex 保持 `--ask-for-approval never --sandbox workspace-write` + `network_access=true`（已经零审批、写限 workspace、网络放开）。review 核实 `--yolo` 会同时 bypass sandbox 后否决该方案，用户再次确认。
 - 取舍：审批维度全放开（治卡死）、沙箱维度能留就留（codex 写限 workspace 零便利损失）；cc 无沙箱维度，任意 Bash 破坏面接受，容器化记 follow-up。
-- 验证：cc/codex adapter 测试 132 passed / 2 failed（既有 macOS `/var` vs `/private/var` realpath 基线，stash 对比确认与本次无关）；测试断言直接钉住新值（改回即挂）。
+- 验证：cc **66 passed**；cc/codex 合计 **133 passed / 2 failed**（两条为既有 macOS `/var` vs `/private/var` realpath 基线，stash 对比确认与本次无关）；测试断言钉住 cc settings、全局 bypass 预授权、spawn argv，以及 codex 既有安全边界。
 
 ## 2026-08-06 — cc 启动弹窗吞 prompt 的投递验证闭环（已合并 PR #77，已部署）
 

--- a/crabot-agent/src/workers/claude-code/adapter.ts
+++ b/crabot-agent/src/workers/claude-code/adapter.ts
@@ -12,10 +12,10 @@
  * 调用一次,把 workspace 布好——.claude/settings.json(Stop/Notification hook 接到
  * CliEventChannel.hookCommand,permissions 预配置 bypassPermissions 降弹窗)、.claude/skills/(复用
  * Task 3 的 materializeSkills)、.mcp.json(renderMcpJson)、CLAUDE.md(renderContextMd),
- * 外加全局 ~/.claude.json 里该 workspace 的两条预授权记录(preAcceptStartupDialogs:
- * hasTrustDialogAccepted 消掉"首次进入新目录"的信任弹窗——它发生在 --permission-mode 之前,
- * 命令行拦不住;enabledMcpjsonServers 消掉紧随其后的 "New MCP server found" 弹窗——那个弹窗
- * 的触发源正是我们自己写下的 .mcp.json)。
+ * 外加全局 ~/.claude.json 里的三类预授权(preAcceptStartupDialogs):workspace project entry 的
+ * hasTrustDialogAccepted 消掉"首次进入新目录"信任弹窗(它发生在 --permission-mode 之前,
+ * 命令行拦不住);enabledMcpjsonServers 消掉紧随其后的 "New MCP server found" 弹窗;顶层
+ * bypassPermissionsModeAccepted 消掉首次进入 bypass 模式的一次性危险确认弹窗。
  *
  * spawn 提交纪律:tmux newSession 成功之后才落 meta(running)+注册 runtime——newSession 失败
  * 时不留任何持久痕迹(session_id 可重生成,workspace 内 provision 产物残留可接受),同 worker_id
@@ -321,8 +321,12 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
     )
   }
 
-  /** 把 workspace 在全局 ~/.claude.json 里预置成"已信任 + 已授权本项目的 MCP server",
-   * 消灭 cc 首次进入新目录时那两个**阻塞式**启动弹窗。
+  /** 在全局 ~/.claude.json 预置三类启动授权:
+   * 1. workspace project entry 已信任;
+   * 2. 已授权本项目的 MCP server;
+   * 3. 顶层 bypassPermissionsModeAccepted 已接受。
+   *
+   * 目的都是消灭 cc 启动前/启动中会阻塞输入的模态弹窗。
    *
    * ## 弹窗②:`New MCP server found in this project: <name>`
    *
@@ -347,6 +351,14 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
    * /private/tmp),用逻辑路径预写实测完全无效、弹窗照旧。与 codex 侧写
    * `[projects."<realpath>"] trust_level = "trusted"` 同一策略(见 codex/adapter.ts 的
    * provision),差别只在 cc 这张表是**全局共享单文件**,所以要加锁 + 原子替换 + 只补字段。
+   *
+   * ## 弹窗③:`bypass permissions mode` 一次性危险确认
+   *
+   * cc 首次进入 bypassPermissions 会再弹一次确认,结果记在 ~/.claude.json 顶层
+   * `bypassPermissionsModeAccepted`；默认项是 "No, exit"。不预置就会让全新机器上的首个
+   * bypass worker 卡在启动弹窗,#77 的 Esc 兜底还可能直接退出 cc。由于本 adapter 已明确
+   * 选择 bypassPermissions,这里统一置 true 是该运行模式的必要前置,不是暗中扩大不同模式的
+   * 权限。
    *
    * 失败一律抛错(fail-loud),不吞:
    * - 吞掉 → worker 重新静默卡回弹窗,而这个故障态在外部看来是"running 但永远没动静",
@@ -403,6 +415,12 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
       merged.enabledMcpjsonServers = [...mcpServerNames]
       projects[realRoot] = merged
       config.projects = projects
+
+      // bypass 模式的一次性确认弹窗(cc 首次进 bypassPermissions 时弹,确认结果记顶层
+      // bypassPermissionsModeAccepted,默认项是 "No, exit")——不预写则全新机器上首个 worker
+      // 必卡启动弹窗,且 #77 的 Esc 兜底可能直接退出 cc。由于本 adapter 已明确选择
+      // bypassPermissions,统一置 true 是运行模式前置;其它顶层字段与 project 数据仍原样保留。
+      config.bypassPermissionsModeAccepted = true
 
       // 原子替换:先写同目录临时文件再 rename,避免进程/机器在写一半时挂掉留下半截 JSON——
       // 这份文件是用户全局配置,截断的代价远大于一次 provision 失败。

--- a/crabot-agent/src/workers/claude-code/adapter.ts
+++ b/crabot-agent/src/workers/claude-code/adapter.ts
@@ -2,7 +2,7 @@
  * ClaudeCodeAdapter — WorkerAdapter 契约的 claude-code 实现。
  *
  * spawn:session_id = randomUUID() 出生即定(即 session_ref);建 <dataDir>/<worker_id>/ 目录;
- * tmux newSession 拉起 `<claudeBin> --session-id <uuid> --permission-mode acceptEdits`,交互态
+ * tmux newSession 拉起 `<claudeBin> --session-id <uuid> --permission-mode bypassPermissions`,交互态
  * 跑在 tmux pane 里,cwd=workspace,pane 输出经 tmux pipe-pane 落 output-<seq>.log;meta 落盘为
  * running;**等 pane 输出里出现 \e[?2004h(TUI 已开启 bracketed paste)之后**,首条任务输入
  * (spec.prompt)才经 tmux sendText 注入(cc 把它当第一条用户消息)。等不到就绪 → 不投递、
@@ -10,7 +10,7 @@
  *
  * provision:与 spawn 分离的独立步骤(WorkerAdapter 契约本就是两个方法),由调用方在 spawn 前
  * 调用一次,把 workspace 布好——.claude/settings.json(Stop/Notification hook 接到
- * CliEventChannel.hookCommand,permissions 预配置 acceptEdits 降弹窗)、.claude/skills/(复用
+ * CliEventChannel.hookCommand,permissions 预配置 bypassPermissions 降弹窗)、.claude/skills/(复用
  * Task 3 的 materializeSkills)、.mcp.json(renderMcpJson)、CLAUDE.md(renderContextMd),
  * 外加全局 ~/.claude.json 里该 workspace 的两条预授权记录(preAcceptStartupDialogs:
  * hasTrustDialogAccepted 消掉"首次进入新目录"的信任弹窗——它发生在 --permission-mode 之前,
@@ -59,7 +59,7 @@
  * 四轮 review 修复;meta 也没有才报错——不再要求"只能 resume 本进程 spawn 过的化身"),校验
  * 其已 exited(未 exited 直接拒绝)→ 新 tmux 会话跑
  * `<claudeBin> --resume <prev.session_ref>`(不重复传 --permission-mode,provision 阶段已把
- * acceptEdits 写进 settings.json 兜底命令行之外的场景)→ seq+1 化身、独立 meta/output、
+ * bypassPermissions 写进 settings.json 兜底命令行之外的场景)→ seq+1 化身、独立 meta/output、
  * session_ref 原样透传(cc 侧同一个会话 id)。锁纪律与 spawn 一致:tmux newSession 成功后才
  * 提交 meta+runtime,首条 wakeInput(sendText)失败按 kill 路径清理并落 exited(crashed)。
  *
@@ -295,9 +295,11 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
         Stop: [{ hooks: [{ type: 'command', command: channel.hookCommand('stop') }] }],
         Notification: [{ hooks: [{ type: 'command', command: channel.hookCommand('notification') }] }],
       },
-      // --permission-mode acceptEdits 已在命令行传了,这里在 settings.json 里重复声明一份,
-      // 覆盖命令行参数之外(如未来 --resume)也走同一降弹窗策略的场景。
-      permissions: { defaultMode: 'acceptEdits' },
+      // --permission-mode bypassPermissions 已在命令行传了,这里在 settings.json 里重复声明一份,
+      // 覆盖命令行参数之外(如未来 --resume)也走同一降弹窗策略的场景。bypassPermissions =
+      // 等价 auto-mode/--dangerously-skip-permissions:工具调用零审批弹窗(否则每调一次 Bash/网络
+      // 就要 manager 处理一次)。取舍见 specs/2026-08-06-worker-permission-auto-approve-design.md。
+      permissions: { defaultMode: 'bypassPermissions' },
     }
     await fs.writeFile(join(claudeDir, 'settings.json'), JSON.stringify(settings, null, 2) + '\n', 'utf-8')
 
@@ -428,7 +430,7 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
 
     const sessionName = `crabot-w-${spec.worker_id}-${seq}`
     const outputFile = join(dir, `output-${seq}.log`)
-    const command = `${this.claudeBin} --session-id ${sessionId} --permission-mode acceptEdits`
+    const command = `${this.claudeBin} --session-id ${sessionId} --permission-mode bypassPermissions`
 
     // newSession 成功之后才落 meta(running)+注册 runtime:tmux 失败时不留任何持久痕迹
     // (session_id 可重生成,workspace 内 provision 产物残留可接受),同 worker_id 可安全重试。
@@ -591,7 +593,7 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
       handle = { worker_id: prev.worker_id, seq, impl: 'claude-code', session_ref: prev.session_ref }
       const sessionName = `crabot-w-${prev.worker_id}-${seq}`
       const outputFile = join(dir, `output-${seq}.log`)
-      // 不重复传 --permission-mode:provision 阶段已把 acceptEdits 写进 settings.json,覆盖
+      // 不重复传 --permission-mode:provision 阶段已把 bypassPermissions 写进 settings.json,覆盖
       // 命令行没有重复声明的场景(resume 正是这样的场景)。session_ref 是 cc 侧的会话 uuid,
       // 沿用不变。拼接时用 shQuote 转义 session_ref,防止 shell 注入(双层防御:
       // 入口已校验 UUID 格式,拼接时再加引号转义,提高防御深度)。

--- a/crabot-agent/src/workers/codex/adapter.ts
+++ b/crabot-agent/src/workers/codex/adapter.ts
@@ -103,17 +103,17 @@
  * ## spawn/resume 启动参数
  *
  * codex-docs(learn.chatgpt.com/docs/developer-commands):交互态 `codex` 主命令顶层支持
- * `--ask-for-approval`(`untrusted|on-request|never`)与 `--sandbox`
- * (`read-only|workspace-write|danger-full-access`)。本 adapter 固定传
- * `--ask-for-approval never --sandbox workspace-write`,与 cc 用
- * `--permission-mode acceptEdits` 同样的自动化意图——不能让审批弹窗卡住 tmux pane。
+ * `--ask-for-approval`(`untrusted|on-request|never`)、`--yolo`(等价 never,显式声明零审批)与
+ * `--sandbox`(`read-only|workspace-write|danger-full-access`)。本 adapter 固定传
+ * `--yolo --sandbox workspace-write`,与 cc 用
+ * `--permission-mode bypassPermissions` 同样的自动化意图——不能让审批弹窗卡住 tmux pane。
  * `codex resume <SESSION_ID>` 是独立子命令(不是 `--resume` flag),同一文档页确认。
  *
  * m2 真机实测校准了两点原先靠猜测沿用、未经验证的行为:
- * 1. **主命令级选项必须排在 `resume` 子命令之前**:`codex resume <id> --ask-for-approval
- *    never --sandbox workspace-write`(选项跟在 `resume <id>` 后面)会被 codex 当成 usage
+ * 1. **主命令级选项必须排在 `resume` 子命令之前**:`codex resume <id> --yolo
+ *    --sandbox workspace-write`(选项跟在 `resume <id>` 后面)会被 codex 当成 usage
  *    错误、exit=2 拒绝——本 adapter 曾经就是这么拼的(未验证的猜测),已按实测改成
- *    `codex --ask-for-approval never --sandbox workspace-write resume <id>`(选项在前)。
+ *    `codex --yolo --sandbox workspace-write resume <id>`(选项在前)。
  * 2. **不传 `--skip-git-repo-check`,改用 config.toml 的 `[projects."<path>"] trust_level`**:
  *    上一轮曾给 spawn/resume 加过 `--skip-git-repo-check`,诊断("worker workspace 不是受信
  *    目录,不处理会卡住")是对的,但这个 flag **只注册在 `codex exec` 子解析器上**——m2 实测
@@ -714,13 +714,13 @@ export class CodexWorkerAdapter implements WorkerAdapter {
     const codexHome = join(spec.workspace.root, '.codex')
     const sessionName = `crabot-w-${spec.worker_id}-${seq}`
     const outputFile = join(dir, `output-${seq}.log`)
-    // codex-docs + m2 实测:交互态无 --session-id 等价参数;--ask-for-approval never
-    // --sandbox workspace-write 与 cc 用 --permission-mode acceptEdits 同样的自动化意图。
+    // codex-docs + m2 实测:交互态无 --session-id 等价参数;--yolo
+    // --sandbox workspace-write 与 cc 用 --permission-mode bypassPermissions 同样的自动化意图。
     // 不传 --skip-git-repo-check(m2 实测顶层交互式 codex 不支持这个 flag,只有 codex exec
     // 才有——见文件头"spawn/resume 启动参数"节);受信目录改由 provision 写进 config.toml 的
     // [projects."<realpath>"] trust_level = "trusted" 解决。
     // 网络放行见文件头"spawn/resume 启动参数"节。
-    const command = `${this.codexBin} --ask-for-approval never --sandbox workspace-write ${CODEX_NETWORK_ACCESS_OPT}`
+    const command = `${this.codexBin} --yolo --sandbox workspace-write ${CODEX_NETWORK_ACCESS_OPT}`
     const spawnStartedAt = Date.now()
 
     // newSession 成功之后才落 meta(running)+注册 runtime,同 cc 纪律:tmux 失败时不留任何
@@ -856,12 +856,12 @@ export class CodexWorkerAdapter implements WorkerAdapter {
       const sessionName = `crabot-w-${prev.worker_id}-${seq}`
       const outputFile = join(dir, `output-${seq}.log`)
       // codex-docs: `codex resume <SESSION_ID>` 是独立子命令(不是 --resume flag)。
-      // m2 实测:--ask-for-approval/--sandbox 这类主命令级选项必须排在 `resume` 子命令**之前**
+      // m2 实测:--yolo/--sandbox 这类主命令级选项必须排在 `resume` 子命令**之前**
       // ——放在 `resume <id>` 后面 codex 会报 usage 错、exit=2(原实现把它们放在 `resume <id>`
       // 之后,是未经真机验证的错误猜测,这里按实测结果改正)。不传 --skip-git-repo-check,
       // 理由同 spawn(见文件头"spawn/resume 启动参数"节)。-c 同属主命令级选项,同样放在
       // `resume` 之前。
-      const command = `${this.codexBin} --ask-for-approval never --sandbox workspace-write ${CODEX_NETWORK_ACCESS_OPT} resume ${shQuote(prev.session_ref)}`
+      const command = `${this.codexBin} --yolo --sandbox workspace-write ${CODEX_NETWORK_ACCESS_OPT} resume ${shQuote(prev.session_ref)}`
 
       // 锁纪律与 spawn 一致:tmux newSession 成功之后才落 meta(running)+注册 runtime;
       // PATH 前置同 spawn(nvm 部署陷阱)。

--- a/crabot-agent/src/workers/codex/adapter.ts
+++ b/crabot-agent/src/workers/codex/adapter.ts
@@ -103,17 +103,17 @@
  * ## spawn/resume 启动参数
  *
  * codex-docs(learn.chatgpt.com/docs/developer-commands):交互态 `codex` 主命令顶层支持
- * `--ask-for-approval`(`untrusted|on-request|never`)、`--yolo`(等价 never,显式声明零审批)与
- * `--sandbox`(`read-only|workspace-write|danger-full-access`)。本 adapter 固定传
- * `--yolo --sandbox workspace-write`,与 cc 用
+ * `--ask-for-approval`(`untrusted|on-request|never`)与 `--sandbox`
+ * (`read-only|workspace-write|danger-full-access`)。本 adapter 固定传
+ * `--ask-for-approval never --sandbox workspace-write`,与 cc 用
  * `--permission-mode bypassPermissions` 同样的自动化意图——不能让审批弹窗卡住 tmux pane。
  * `codex resume <SESSION_ID>` 是独立子命令(不是 `--resume` flag),同一文档页确认。
  *
  * m2 真机实测校准了两点原先靠猜测沿用、未经验证的行为:
- * 1. **主命令级选项必须排在 `resume` 子命令之前**:`codex resume <id> --yolo
- *    --sandbox workspace-write`(选项跟在 `resume <id>` 后面)会被 codex 当成 usage
+ * 1. **主命令级选项必须排在 `resume` 子命令之前**:`codex resume <id> --ask-for-approval
+ *    never --sandbox workspace-write`(选项跟在 `resume <id>` 后面)会被 codex 当成 usage
  *    错误、exit=2 拒绝——本 adapter 曾经就是这么拼的(未验证的猜测),已按实测改成
- *    `codex --yolo --sandbox workspace-write resume <id>`(选项在前)。
+ *    `codex --ask-for-approval never --sandbox workspace-write resume <id>`(选项在前)。
  * 2. **不传 `--skip-git-repo-check`,改用 config.toml 的 `[projects."<path>"] trust_level`**:
  *    上一轮曾给 spawn/resume 加过 `--skip-git-repo-check`,诊断("worker workspace 不是受信
  *    目录,不处理会卡住")是对的,但这个 flag **只注册在 `codex exec` 子解析器上**——m2 实测
@@ -714,13 +714,13 @@ export class CodexWorkerAdapter implements WorkerAdapter {
     const codexHome = join(spec.workspace.root, '.codex')
     const sessionName = `crabot-w-${spec.worker_id}-${seq}`
     const outputFile = join(dir, `output-${seq}.log`)
-    // codex-docs + m2 实测:交互态无 --session-id 等价参数;--yolo
+    // codex-docs + m2 实测:交互态无 --session-id 等价参数;--ask-for-approval never
     // --sandbox workspace-write 与 cc 用 --permission-mode bypassPermissions 同样的自动化意图。
     // 不传 --skip-git-repo-check(m2 实测顶层交互式 codex 不支持这个 flag,只有 codex exec
     // 才有——见文件头"spawn/resume 启动参数"节);受信目录改由 provision 写进 config.toml 的
     // [projects."<realpath>"] trust_level = "trusted" 解决。
     // 网络放行见文件头"spawn/resume 启动参数"节。
-    const command = `${this.codexBin} --yolo --sandbox workspace-write ${CODEX_NETWORK_ACCESS_OPT}`
+    const command = `${this.codexBin} --ask-for-approval never --sandbox workspace-write ${CODEX_NETWORK_ACCESS_OPT}`
     const spawnStartedAt = Date.now()
 
     // newSession 成功之后才落 meta(running)+注册 runtime,同 cc 纪律:tmux 失败时不留任何
@@ -856,12 +856,12 @@ export class CodexWorkerAdapter implements WorkerAdapter {
       const sessionName = `crabot-w-${prev.worker_id}-${seq}`
       const outputFile = join(dir, `output-${seq}.log`)
       // codex-docs: `codex resume <SESSION_ID>` 是独立子命令(不是 --resume flag)。
-      // m2 实测:--yolo/--sandbox 这类主命令级选项必须排在 `resume` 子命令**之前**
+      // m2 实测:--ask-for-approval/--sandbox 这类主命令级选项必须排在 `resume` 子命令**之前**
       // ——放在 `resume <id>` 后面 codex 会报 usage 错、exit=2(原实现把它们放在 `resume <id>`
       // 之后,是未经真机验证的错误猜测,这里按实测结果改正)。不传 --skip-git-repo-check,
       // 理由同 spawn(见文件头"spawn/resume 启动参数"节)。-c 同属主命令级选项,同样放在
       // `resume` 之前。
-      const command = `${this.codexBin} --yolo --sandbox workspace-write ${CODEX_NETWORK_ACCESS_OPT} resume ${shQuote(prev.session_ref)}`
+      const command = `${this.codexBin} --ask-for-approval never --sandbox workspace-write ${CODEX_NETWORK_ACCESS_OPT} resume ${shQuote(prev.session_ref)}`
 
       // 锁纪律与 spawn 一致:tmux newSession 成功之后才落 meta(running)+注册 runtime;
       // PATH 前置同 spawn(nvm 部署陷阱)。

--- a/crabot-agent/tests/workers/claude-code-adapter.test.ts
+++ b/crabot-agent/tests/workers/claude-code-adapter.test.ts
@@ -159,12 +159,13 @@ describe('ClaudeCodeAdapter.provision', () => {
         const config = await readConfig()
         expect(config.projects[realRoot]).toEqual({ hasTrustDialogAccepted: true, enabledMcpjsonServers: [] })
         expect(config.projects[linkRoot]).toBeUndefined()
+        expect(config.bypassPermissionsModeAccepted).toBe(true)
       } finally {
         await fs.rm(realRoot, { recursive: true, force: true }).catch(() => {})
       }
     })
 
-    it('不覆盖同一 path 已有的其它字段,也不动其它项目条目与顶层字段', async () => {
+    it('不覆盖同一 path 已有字段与无关顶层字段,仅补启动预授权', async () => {
       const realWs = await fs.realpath(ws)
       await fs.writeFile(
         claudeConfigPath,
@@ -196,6 +197,7 @@ describe('ClaudeCodeAdapter.provision', () => {
       expect(config.projects['/home/someone/real-project']).toEqual({ hasTrustDialogAccepted: true, allowedTools: ['Read'] })
       expect(config.numStartups).toBe(42)
       expect(config.oauthAccount).toEqual({ accountUuid: 'u-1' })
+      expect(config.bypassPermissionsModeAccepted).toBe(true)
     })
 
     it('并发 provision 多个 worker:每条记录都在,互不覆盖', async () => {
@@ -214,6 +216,7 @@ describe('ClaudeCodeAdapter.provision', () => {
       )
 
       const config = await readConfig()
+      expect(config.bypassPermissionsModeAccepted).toBe(true)
       for (const root of roots) {
         expect(config.projects[root], `缺少 ${root} 的预授权记录`).toEqual({ hasTrustDialogAccepted: true, enabledMcpjsonServers: [] })
       }
@@ -297,6 +300,32 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter (tmux + mock CLI)', () => {
   function makeSpec(workerId: string, prompt: string): SpawnSpec {
     return { worker_id: workerId, prompt, workspace: { root: workspaceRoot } }
   }
+
+  it(
+    'spawn 命令行显式使用 --permission-mode bypassPermissions,工具调用零审批弹窗',
+    async () => {
+      const channel = new CliEventChannel(eventsFilePath({ root: workspaceRoot }))
+      const argvFile = path.join(dataDir, 'spawn-permission-argv.jsonl')
+      const adapter = new ClaudeCodeAdapter({
+        dataDir,
+        claudeConfigPath: fakeClaudeConfig(dataDir),
+        tmux,
+        claudeBin: claudeBinFor([], channel.hookCommand('stop'), argvFile),
+        promptDeliveryTimeoutMs: 0,
+      })
+      await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
+      const workerId = `cctest-${randomUUID().slice(0, 8)}`
+      const h = await adapter.spawn(makeSpec(workerId, '你好'))
+
+      const argv: string[] = JSON.parse((await fs.readFile(argvFile, 'utf-8')).trim().split('\n')[0])
+      const modeIdx = argv.indexOf('--permission-mode')
+      expect(modeIdx).toBeGreaterThan(-1)
+      expect(argv[modeIdx + 1]).toBe('bypassPermissions')
+
+      await adapter.kill(h)
+    },
+    15000,
+  )
 
   it(
     '① spawn → mock 输出 → Stop hook → state 收敛 idle,readOutput 可读到该输出',

--- a/crabot-agent/tests/workers/claude-code-adapter.test.ts
+++ b/crabot-agent/tests/workers/claude-code-adapter.test.ts
@@ -140,7 +140,7 @@ describe('ClaudeCodeAdapter.provision', () => {
   // ~/.claude.json 的 projects[<realpath>].hasTrustDialogAccepted —— cc 交互式启动的
   // "Do you trust this folder?" 弹窗开关。不预写 → 新 workspace 每次必卡在弹窗上,
   // hook 一次都不触发(生产实测:69 分钟零事件)。
-  describe('workspace 启动弹窗预授权(~/.claude.json)', () => {
+  describe('cc 启动弹窗预授权(~/.claude.json)', () => {
     async function readConfig(): Promise<Record<string, any>> {
       return JSON.parse(await fs.readFile(claudeConfigPath, 'utf-8'))
     }

--- a/crabot-agent/tests/workers/claude-code-adapter.test.ts
+++ b/crabot-agent/tests/workers/claude-code-adapter.test.ts
@@ -128,7 +128,7 @@ describe('ClaudeCodeAdapter.provision', () => {
     const settings = JSON.parse(await fs.readFile(path.join(ws, '.claude/settings.json'), 'utf-8'))
     expect(settings.hooks.Stop[0].hooks[0].command).toContain('events-cli.jsonl')
     expect(settings.hooks.Notification[0].hooks[0].command).toContain('events-cli.jsonl')
-    expect(settings.permissions.defaultMode).toBe('acceptEdits')
+    expect(settings.permissions.defaultMode).toBe('bypassPermissions')
 
     const mcpJson = JSON.parse(await fs.readFile(path.join(ws, '.mcp.json'), 'utf-8'))
     expect(mcpJson.mcpServers.x.command).toBe('node')

--- a/crabot-agent/tests/workers/codex-adapter.test.ts
+++ b/crabot-agent/tests/workers/codex-adapter.test.ts
@@ -686,7 +686,7 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter (tmux + mock CLI)', () => {
   )
 
   it(
-    'spawn 命令行不携带 --skip-git-repo-check(该 flag 只注册在 codex exec 子解析器上,m2 实测顶层交互式 codex 没有这个 Option,传了会被 clap usage 错误拒绝),--yolo/--sandbox 取值合法,且带 -c sandbox_workspace_write.network_access=true(否则 worker 外网+本机端口全不可达)',
+    'spawn 命令行不携带 --skip-git-repo-check(该 flag 只注册在 codex exec 子解析器上,m2 实测顶层交互式 codex 没有这个 Option,传了会被 clap usage 错误拒绝),--ask-for-approval/--sandbox 取值合法,且带 -c sandbox_workspace_write.network_access=true(否则 worker 外网+本机端口全不可达)',
     async () => {
       const channel = new CliEventChannel(eventsFilePath({ root: workspaceRoot }))
       const stopHookCmd = channel.hookCommand('stop')
@@ -700,7 +700,9 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter (tmux + mock CLI)', () => {
 
       const argv: string[] = JSON.parse((await fs.readFile(argvFile, 'utf-8')).trim().split('\n')[0])
       expect(argv).not.toContain('--skip-git-repo-check')
-      expect(argv).toContain('--yolo')
+      const approvalIdx = argv.indexOf('--ask-for-approval')
+      expect(approvalIdx).toBeGreaterThan(-1)
+      expect(argv[approvalIdx + 1]).toBe('never')
       const sandboxIdx = argv.indexOf('--sandbox')
       expect(sandboxIdx).toBeGreaterThan(-1)
       expect(['read-only', 'workspace-write', 'danger-full-access']).toContain(argv[sandboxIdx + 1])
@@ -714,7 +716,7 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter (tmux + mock CLI)', () => {
   )
 
   it(
-    'resume 命令行不携带 --skip-git-repo-check,--yolo/--sandbox/-c 放在 resume 子命令之前(放后面 codex 报 usage 错、exit=2,m2 实测),且 -c 放行了 workspace-write 沙箱的网络',
+    'resume 命令行不携带 --skip-git-repo-check,--ask-for-approval/--sandbox/-c 放在 resume 子命令之前(放后面 codex 报 usage 错、exit=2,m2 实测),且 -c 放行了 workspace-write 沙箱的网络',
     async () => {
       const channel = new CliEventChannel(eventsFilePath({ root: workspaceRoot }))
       const stopHookCmd = channel.hookCommand('stop')
@@ -736,7 +738,7 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter (tmux + mock CLI)', () => {
       expect(argv).not.toContain('--skip-git-repo-check')
       const resumeIdx = argv.indexOf('resume')
       expect(resumeIdx).toBeGreaterThan(-1)
-      for (const flag of ['--yolo', '--sandbox', '-c']) {
+      for (const flag of ['--ask-for-approval', '--sandbox', '-c']) {
         const idx = argv.indexOf(flag)
         expect(idx).toBeGreaterThan(-1)
         expect(idx).toBeLessThan(resumeIdx)

--- a/crabot-agent/tests/workers/codex-adapter.test.ts
+++ b/crabot-agent/tests/workers/codex-adapter.test.ts
@@ -686,7 +686,7 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter (tmux + mock CLI)', () => {
   )
 
   it(
-    'spawn 命令行不携带 --skip-git-repo-check(该 flag 只注册在 codex exec 子解析器上,m2 实测顶层交互式 codex 没有这个 Option,传了会被 clap usage 错误拒绝),--ask-for-approval/--sandbox 取值合法,且带 -c sandbox_workspace_write.network_access=true(否则 worker 外网+本机端口全不可达)',
+    'spawn 命令行不携带 --skip-git-repo-check/--yolo,固定 --ask-for-approval never + --sandbox workspace-write,且带 -c sandbox_workspace_write.network_access=true(否则 worker 外网+本机端口全不可达)',
     async () => {
       const channel = new CliEventChannel(eventsFilePath({ root: workspaceRoot }))
       const stopHookCmd = channel.hookCommand('stop')
@@ -700,12 +700,13 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter (tmux + mock CLI)', () => {
 
       const argv: string[] = JSON.parse((await fs.readFile(argvFile, 'utf-8')).trim().split('\n')[0])
       expect(argv).not.toContain('--skip-git-repo-check')
+      expect(argv).not.toContain('--yolo')
       const approvalIdx = argv.indexOf('--ask-for-approval')
       expect(approvalIdx).toBeGreaterThan(-1)
       expect(argv[approvalIdx + 1]).toBe('never')
       const sandboxIdx = argv.indexOf('--sandbox')
       expect(sandboxIdx).toBeGreaterThan(-1)
-      expect(['read-only', 'workspace-write', 'danger-full-access']).toContain(argv[sandboxIdx + 1])
+      expect(argv[sandboxIdx + 1]).toBe('workspace-write')
       const configIdx = argv.indexOf('-c')
       expect(configIdx).toBeGreaterThan(-1)
       expect(argv[configIdx + 1]).toBe('sandbox_workspace_write.network_access=true')
@@ -716,7 +717,7 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter (tmux + mock CLI)', () => {
   )
 
   it(
-    'resume 命令行不携带 --skip-git-repo-check,--ask-for-approval/--sandbox/-c 放在 resume 子命令之前(放后面 codex 报 usage 错、exit=2,m2 实测),且 -c 放行了 workspace-write 沙箱的网络',
+    'resume 命令行不携带 --skip-git-repo-check/--yolo,固定 never + workspace-write,且审批/沙箱/网络选项放在 resume 子命令之前',
     async () => {
       const channel = new CliEventChannel(eventsFilePath({ root: workspaceRoot }))
       const stopHookCmd = channel.hookCommand('stop')
@@ -736,6 +737,7 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter (tmux + mock CLI)', () => {
       // 第一行是 spawn 主线的 argv,第二行才是 resume 触发的调用。
       const argv: string[] = JSON.parse(lines[1])
       expect(argv).not.toContain('--skip-git-repo-check')
+      expect(argv).not.toContain('--yolo')
       const resumeIdx = argv.indexOf('resume')
       expect(resumeIdx).toBeGreaterThan(-1)
       for (const flag of ['--ask-for-approval', '--sandbox', '-c']) {
@@ -743,6 +745,10 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter (tmux + mock CLI)', () => {
         expect(idx).toBeGreaterThan(-1)
         expect(idx).toBeLessThan(resumeIdx)
       }
+      const approvalIdx = argv.indexOf('--ask-for-approval')
+      expect(argv[approvalIdx + 1]).toBe('never')
+      const sandboxIdx = argv.indexOf('--sandbox')
+      expect(argv[sandboxIdx + 1]).toBe('workspace-write')
       const configIdx = argv.indexOf('-c')
       expect(argv[configIdx + 1]).toBe('sandbox_workspace_write.network_access=true')
     },

--- a/crabot-agent/tests/workers/codex-adapter.test.ts
+++ b/crabot-agent/tests/workers/codex-adapter.test.ts
@@ -686,7 +686,7 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter (tmux + mock CLI)', () => {
   )
 
   it(
-    'spawn 命令行不携带 --skip-git-repo-check(该 flag 只注册在 codex exec 子解析器上,m2 实测顶层交互式 codex 没有这个 Option,传了会被 clap usage 错误拒绝),--ask-for-approval/--sandbox 取值合法,且带 -c sandbox_workspace_write.network_access=true(否则 worker 外网+本机端口全不可达)',
+    'spawn 命令行不携带 --skip-git-repo-check(该 flag 只注册在 codex exec 子解析器上,m2 实测顶层交互式 codex 没有这个 Option,传了会被 clap usage 错误拒绝),--yolo/--sandbox 取值合法,且带 -c sandbox_workspace_write.network_access=true(否则 worker 外网+本机端口全不可达)',
     async () => {
       const channel = new CliEventChannel(eventsFilePath({ root: workspaceRoot }))
       const stopHookCmd = channel.hookCommand('stop')
@@ -700,9 +700,7 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter (tmux + mock CLI)', () => {
 
       const argv: string[] = JSON.parse((await fs.readFile(argvFile, 'utf-8')).trim().split('\n')[0])
       expect(argv).not.toContain('--skip-git-repo-check')
-      const approvalIdx = argv.indexOf('--ask-for-approval')
-      expect(approvalIdx).toBeGreaterThan(-1)
-      expect(argv[approvalIdx + 1]).toBe('never')
+      expect(argv).toContain('--yolo')
       const sandboxIdx = argv.indexOf('--sandbox')
       expect(sandboxIdx).toBeGreaterThan(-1)
       expect(['read-only', 'workspace-write', 'danger-full-access']).toContain(argv[sandboxIdx + 1])
@@ -716,7 +714,7 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter (tmux + mock CLI)', () => {
   )
 
   it(
-    'resume 命令行不携带 --skip-git-repo-check,--ask-for-approval/--sandbox/-c 放在 resume 子命令之前(放后面 codex 报 usage 错、exit=2,m2 实测),且 -c 放行了 workspace-write 沙箱的网络',
+    'resume 命令行不携带 --skip-git-repo-check,--yolo/--sandbox/-c 放在 resume 子命令之前(放后面 codex 报 usage 错、exit=2,m2 实测),且 -c 放行了 workspace-write 沙箱的网络',
     async () => {
       const channel = new CliEventChannel(eventsFilePath({ root: workspaceRoot }))
       const stopHookCmd = channel.hookCommand('stop')
@@ -738,7 +736,7 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter (tmux + mock CLI)', () => {
       expect(argv).not.toContain('--skip-git-repo-check')
       const resumeIdx = argv.indexOf('resume')
       expect(resumeIdx).toBeGreaterThan(-1)
-      for (const flag of ['--ask-for-approval', '--sandbox', '-c']) {
+      for (const flag of ['--yolo', '--sandbox', '-c']) {
         const idx = argv.indexOf(flag)
         expect(idx).toBeGreaterThan(-1)
         expect(idx).toBeLessThan(resumeIdx)


### PR DESCRIPTION
## 背景

投递验证（#77）治了启动期弹窗，但 cc 在 `acceptEdits` 下运行期每次 Bash/网络等工具调用仍弹权限确认——worker 每调一次工具就等 manager 处理一次。

Spec（用户确认，review 纠正 codex `--yolo` 语义后再次确认）：`crabot-docs/superpowers/specs/2026-08-06-worker-permission-auto-approve-design.md`（文档仓 `510a0f1`）。

## 最终决策

| 实现 | 决策 |
|---|---|
| cc spawn | `--permission-mode bypassPermissions`（等价 `--dangerously-skip-permissions` / auto-mode） |
| cc resume | 继续依赖 provision 写入的 `settings.permissions.defaultMode=bypassPermissions` |
| cc 首次 bypass 弹窗 | provision 在 `~/.claude.json` 顶层预写 `bypassPermissionsModeAccepted=true`，消掉默认 "No, exit" 的一次性确认 |
| codex | **保持不变**：`--ask-for-approval never --sandbox workspace-write -c sandbox_workspace_write.network_access=true`（已经零审批、写限 workspace、网络放开） |

**明确拒绝 `--yolo`**：官方定义是 `--dangerously-bypass-approvals-and-sandbox` 的别名，会同时废掉 sandbox，且部分版本与显式 `--sandbox` 冲突。它不是 `never` 的等价显式写法，无功能收益、纯增风险。

## 安全取舍

- cc 无独立沙箱维度：接受任意 Bash 破坏面；任务源自管理员派活 + 台账留痕，容器化记 follow-up。
- codex 保留 workspace-write 沙箱：审批已全开且网络已放，保留写边界没有便利损失。

## 验证

- cc adapter：**66 passed**；
- cc + codex adapter：**133 passed / 2 failed**；两条为既有 macOS `/var` vs `/private/var` PATH realpath 基线，stash 对比确认 main 同样失败；
- 新断言钉住：
  - settings `defaultMode === bypassPermissions`；
  - `~/.claude.json` 顶层 `bypassPermissionsModeAccepted === true`（含全新文件、并发 provision、保留无关字段）；
  - spawn argv `--permission-mode bypassPermissions`；
  - codex 既有安全边界不变；
- TypeScript build、`git diff --check` 通过。
