### PR TITLE
fix(workers): suppress current Claude Code bypass warning

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,14 +1,22 @@
 # Crabot 项目进度
 
-> 最后更新：2026-08-06 — worker 权限自动批准（cc bypassPermissions / codex 保持 never，分支 fix/worker-permission-auto-approve，待 PR）
+> 最后更新：2026-08-07 — #78 已部署；真实 Admin Chat 发现 cc 2.1.223 bypass 危险确认字段版本失配，修复中
 
-## 2026-08-06 — worker 权限自动批准：工具调用零审批弹窗
+## 2026-08-07 — cc bypass 首次危险确认窗版本修复（进行中）
+
+- #78 已 squash 合并为 `9236e333` 并部署；MM/Admin/Agent/Memory/三渠道最终全绿，`fatal.log` 无新增。Codex 继续保持 `--ask-for-approval never --sandbox workspace-write` + `network_access=true`。
+- 真实浏览器 Admin Chat 端到端验收：cc worker `w-ca15efb2-a389-482c-a6a8-2f965961e33c` 明确出现 `WARNING: Claude Code running in Bypass Permissions mode / No, exit / Yes, I accept`，随后 pane 退出、任务 `spawn_failed`，证明 `~/.claude.json.bypassPermissionsModeAccepted=true` 对 Claude Code 2.1.223 无效；Bash 尚未执行。
+- 对照基线：Codex worker `w-292a9f0d-46fd-4880-b19c-9379b62d4cde` 无审批完成代理网络请求、workspace 写入与读取核验，输出 `CODEX_ADMIN_CHAT_VALIDATION_OK` 后已清理。
+- 真实 CLI 探针：workspace `.claude/settings.json` 写 `skipDangerousModePermissionPrompt=true` 仍无效；启动命令追加 `--settings '{"skipDangerousModePermissionPrompt":true}'` 后无弹窗完成 Bash、网络与 workspace 写入并回到 idle。修订 Spec `crabot-docs/.../2026-08-06-worker-permission-auto-approve-design.md`（`80fb6f0`）及实施计划（`d114b90`）已确认。
+- 当前实现：cc spawn/resume 对称注入启动级 `--settings`，不永久修改用户级 `~/.claude/settings.json`；停止继续写无效旧字段，但不删除用户已有值。TDD 起点 5 条失败，实施后 cc **66/66 passed**；cc+codex **133 passed / 2 个既有 `/var`→`/private/var` PATH 基线失败**；build 通过。真实当前构建的 spawn 已无弹窗完成 Bash、网络和写入；resume 同样不再出现危险确认窗，但 wakeInput 留在 composer 未提交，复现既有且明确排除的“resume prompt 投递验证”follow-up，不混入本次修复。独立本地 reviewer 结论 **APPROVED，无 blocker**；待部署后 Admin Chat spawn 复验。
+
+## 2026-08-06 — worker 权限自动批准：工具调用零审批弹窗（已合并 PR #78，已部署；cc 首次警告见上方修复）
 
 - 背景：投递验证（#77）治了启动期弹窗，但运行期 cc 在 `acceptEdits` 下每调一次 Bash/网络工具仍弹权限确认窗，等 manager 处理一次，成本高。codex 已是 `--ask-for-approval never` + 网络已放开，主要改动在 cc。
-- Spec：`crabot-docs/superpowers/specs/2026-08-06-worker-permission-auto-approve-design.md`（用户确认）。
-- 决策：cc spawn `--permission-mode acceptEdits` → `bypassPermissions`，settings.json `defaultMode` 同步，并预写 `~/.claude.json` 顶层 `bypassPermissionsModeAccepted=true` 消掉首次 bypass 的一次性确认弹窗；cc resume 继续依赖 settings。codex 保持 `--ask-for-approval never --sandbox workspace-write` + `network_access=true`（已经零审批、写限 workspace、网络放开）。review 核实 `--yolo` 会同时 bypass sandbox 后否决该方案，用户再次确认。
+- Spec：`crabot-docs/superpowers/specs/2026-08-06-worker-permission-auto-approve-design.md`。
+- #78 决策：cc spawn `--permission-mode acceptEdits` → `bypassPermissions`，workspace settings `defaultMode` 同步；codex 保持 `--ask-for-approval never --sandbox workspace-write` + `network_access=true`，明确拒绝会同时 bypass sandbox 的 `--yolo`。首次 bypass 警告的原实现基于旧字段，已由 2026-08-07 真实验收推翻并在上方修正。
 - 取舍：审批维度全放开（治卡死）、沙箱维度能留就留（codex 写限 workspace 零便利损失）；cc 无沙箱维度，任意 Bash 破坏面接受，容器化记 follow-up。
-- 验证：cc **66 passed**；cc/codex 合计 **133 passed / 2 failed**（两条为既有 macOS `/var` vs `/private/var` realpath 基线，stash 对比确认与本次无关）；测试断言钉住 cc settings、全局 bypass 预授权、spawn argv，以及 codex 既有安全边界。
+- #78 合并前验证：cc **66 passed**；cc/codex 合计 **133 passed / 2 failed**（两条为既有 macOS `/var` vs `/private/var` realpath 基线）；测试断言钉住 cc settings、spawn argv及 codex 安全边界。
 
 ## 2026-08-06 — cc 启动弹窗吞 prompt 的投递验证闭环（已合并 PR #77，已部署）
 

--- a/crabot-agent/src/workers/claude-code/adapter.ts
+++ b/crabot-agent/src/workers/claude-code/adapter.ts
@@ -2,20 +2,22 @@
  * ClaudeCodeAdapter — WorkerAdapter 契约的 claude-code 实现。
  *
  * spawn:session_id = randomUUID() 出生即定(即 session_ref);建 <dataDir>/<worker_id>/ 目录;
- * tmux newSession 拉起 `<claudeBin> --session-id <uuid> --permission-mode bypassPermissions`,交互态
- * 跑在 tmux pane 里,cwd=workspace,pane 输出经 tmux pipe-pane 落 output-<seq>.log;meta 落盘为
- * running;**等 pane 输出里出现 \e[?2004h(TUI 已开启 bracketed paste)之后**,首条任务输入
- * (spec.prompt)才经 tmux sendText 注入(cc 把它当第一条用户消息)。等不到就绪 → 不投递、
- * 落 idle 并把 output 尾部随唤醒事件交给 manager(见 spawn 内的握手段与 reportStartupStall)。
+ * tmux newSession 拉起 `<claudeBin> --settings <bypass-warning-json> --session-id <uuid>
+ * --permission-mode bypassPermissions`,交互态跑在 tmux pane 里,cwd=workspace,pane 输出经 tmux
+ * pipe-pane 落 output-<seq>.log;meta 落盘为 running;**等 pane 输出里出现
+ * \e[?2004h(TUI 已开启 bracketed paste)之后**,首条任务输入(spec.prompt)才经 tmux sendText
+ * 注入(cc 把它当第一条用户消息)。等不到就绪 → 不投递、落 idle 并把 output 尾部随唤醒事件
+ * 交给 manager(见 spawn 内的握手段与 reportStartupStall)。
  *
  * provision:与 spawn 分离的独立步骤(WorkerAdapter 契约本就是两个方法),由调用方在 spawn 前
  * 调用一次,把 workspace 布好——.claude/settings.json(Stop/Notification hook 接到
  * CliEventChannel.hookCommand,permissions 预配置 bypassPermissions 降弹窗)、.claude/skills/(复用
  * Task 3 的 materializeSkills)、.mcp.json(renderMcpJson)、CLAUDE.md(renderContextMd),
- * 外加全局 ~/.claude.json 里的三类预授权(preAcceptStartupDialogs):workspace project entry 的
+ * 外加全局 ~/.claude.json 里 workspace project entry 的两类预授权(preAcceptStartupDialogs):
  * hasTrustDialogAccepted 消掉"首次进入新目录"信任弹窗(它发生在 --permission-mode 之前,
- * 命令行拦不住);enabledMcpjsonServers 消掉紧随其后的 "New MCP server found" 弹窗;顶层
- * bypassPermissionsModeAccepted 消掉首次进入 bypass 模式的一次性危险确认弹窗。
+ * 命令行拦不住);enabledMcpjsonServers 消掉紧随其后的 "New MCP server found" 弹窗。首次进入
+ * bypass 模式的危险确认不接受 project settings,由 spawn/resume 每次通过 --settings 注入当前
+ * cc 字段 skipDangerousModePermissionPrompt,不永久修改用户级 ~/.claude/settings.json。
  *
  * spawn 提交纪律:tmux newSession 成功之后才落 meta(running)+注册 runtime——newSession 失败
  * 时不留任何持久痕迹(session_id 可重生成,workspace 内 provision 产物残留可接受),同 worker_id
@@ -135,6 +137,15 @@ const PROMPT_DELIVERY_POLL_INTERVAL_MS = 250
 function shQuote(s: string): string {
   return `'${s.replace(/'/g, `'\\''`)}'`
 }
+
+/**
+ * Claude Code 2.1.223 的 bypass 一次性危险确认开关。
+ *
+ * 真实 Admin Chat 验收证明旧的 ~/.claude.json.bypassPermissionsModeAccepted 已无效,project
+ * settings 里的新字段也不生效;只有启动级 --settings 能在不永久修改用户级
+ * ~/.claude/settings.json 的前提下消掉弹窗。值是 adapter 内部常量,仍经 shQuote 进入 shell。
+ */
+const BYPASS_WARNING_SETTINGS_ARG = `--settings ${shQuote(JSON.stringify({ skipDangerousModePermissionPrompt: true }))}`
 
 /** UUID 格式校验:标准 UUID 格式(8-4-4-4-12 十六进制段,由连字符分隔)。*/
 function validateSessionRef(sessionRef: string): void {
@@ -295,9 +306,9 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
         Stop: [{ hooks: [{ type: 'command', command: channel.hookCommand('stop') }] }],
         Notification: [{ hooks: [{ type: 'command', command: channel.hookCommand('notification') }] }],
       },
-      // --permission-mode bypassPermissions 已在命令行传了,这里在 settings.json 里重复声明一份,
-      // 覆盖命令行参数之外(如未来 --resume)也走同一降弹窗策略的场景。bypassPermissions =
-      // 等价 auto-mode/--dangerously-skip-permissions:工具调用零审批弹窗(否则每调一次 Bash/网络
+      // --permission-mode bypassPermissions 已在 spawn 命令行传了,这里在 settings.json 里重复
+      // 声明一份,让 resume 也选择同一模式。bypassPermissions = 等价
+      // auto-mode/--dangerously-skip-permissions:工具调用零审批弹窗(否则每调一次 Bash/网络
       // 就要 manager 处理一次)。取舍见 specs/2026-08-06-worker-permission-auto-approve-design.md。
       permissions: { defaultMode: 'bypassPermissions' },
     }
@@ -321,12 +332,11 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
     )
   }
 
-  /** 在全局 ~/.claude.json 预置三类启动授权:
+  /** 在全局 ~/.claude.json 预置两类 project 级启动授权:
    * 1. workspace project entry 已信任;
-   * 2. 已授权本项目的 MCP server;
-   * 3. 顶层 bypassPermissionsModeAccepted 已接受。
+   * 2. 已授权本项目的 MCP server。
    *
-   * 目的都是消灭 cc 启动前/启动中会阻塞输入的模态弹窗。
+   * bypassPermissions 的危险确认由 spawn/resume 启动参数处理,不属于本文件的全局预写。
    *
    * ## 弹窗②:`New MCP server found in this project: <name>`
    *
@@ -352,13 +362,8 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
    * `[projects."<realpath>"] trust_level = "trusted"` 同一策略(见 codex/adapter.ts 的
    * provision),差别只在 cc 这张表是**全局共享单文件**,所以要加锁 + 原子替换 + 只补字段。
    *
-   * ## 弹窗③:`bypass permissions mode` 一次性危险确认
-   *
-   * cc 首次进入 bypassPermissions 会再弹一次确认,结果记在 ~/.claude.json 顶层
-   * `bypassPermissionsModeAccepted`；默认项是 "No, exit"。不预置就会让全新机器上的首个
-   * bypass worker 卡在启动弹窗,#77 的 Esc 兜底还可能直接退出 cc。由于本 adapter 已明确
-   * 选择 bypassPermissions,这里统一置 true 是该运行模式的必要前置,不是暗中扩大不同模式的
-   * 权限。
+   * 当前方法只消除两类 project 级启动弹窗。bypassPermissions 的危险确认不接受这里的
+   * ~/.claude.json 或 workspace settings,由 spawn/resume 的 --settings 启动参数处理。
    *
    * 失败一律抛错(fail-loud),不吞:
    * - 吞掉 → worker 重新静默卡回弹窗,而这个故障态在外部看来是"running 但永远没动静",
@@ -416,12 +421,6 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
       projects[realRoot] = merged
       config.projects = projects
 
-      // bypass 模式的一次性确认弹窗(cc 首次进 bypassPermissions 时弹,确认结果记顶层
-      // bypassPermissionsModeAccepted,默认项是 "No, exit")——不预写则全新机器上首个 worker
-      // 必卡启动弹窗,且 #77 的 Esc 兜底可能直接退出 cc。由于本 adapter 已明确选择
-      // bypassPermissions,统一置 true 是运行模式前置;其它顶层字段与 project 数据仍原样保留。
-      config.bypassPermissionsModeAccepted = true
-
       // 原子替换:先写同目录临时文件再 rename,避免进程/机器在写一半时挂掉留下半截 JSON——
       // 这份文件是用户全局配置,截断的代价远大于一次 provision 失败。
       const tmpPath = `${configPath}.crabot-${randomUUID()}.tmp`
@@ -448,7 +447,7 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
 
     const sessionName = `crabot-w-${spec.worker_id}-${seq}`
     const outputFile = join(dir, `output-${seq}.log`)
-    const command = `${this.claudeBin} --session-id ${sessionId} --permission-mode bypassPermissions`
+    const command = `${this.claudeBin} ${BYPASS_WARNING_SETTINGS_ARG} --session-id ${sessionId} --permission-mode bypassPermissions`
 
     // newSession 成功之后才落 meta(running)+注册 runtime:tmux 失败时不留任何持久痕迹
     // (session_id 可重生成,workspace 内 provision 产物残留可接受),同 worker_id 可安全重试。
@@ -612,10 +611,11 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
       const sessionName = `crabot-w-${prev.worker_id}-${seq}`
       const outputFile = join(dir, `output-${seq}.log`)
       // 不重复传 --permission-mode:provision 阶段已把 bypassPermissions 写进 settings.json,覆盖
-      // 命令行没有重复声明的场景(resume 正是这样的场景)。session_ref 是 cc 侧的会话 uuid,
+      // 命令行没有重复声明的场景(resume 正是这样的场景)。危险确认开关则不接受 project
+      // settings,必须与 spawn 对称地每次通过 --settings 注入。session_ref 是 cc 侧的会话 uuid,
       // 沿用不变。拼接时用 shQuote 转义 session_ref,防止 shell 注入(双层防御:
       // 入口已校验 UUID 格式,拼接时再加引号转义,提高防御深度)。
-      const command = `${this.claudeBin} --resume ${shQuote(prev.session_ref)}`
+      const command = `${this.claudeBin} ${BYPASS_WARNING_SETTINGS_ARG} --resume ${shQuote(prev.session_ref)}`
 
       // 锁纪律与 spawn 一致:tmux newSession 成功之后才落 meta(running)+注册 runtime。
       await this.tmux.newSession({ name: sessionName, cwd: prevRuntime.workspaceRoot, command, outputFile })

--- a/crabot-agent/tests/workers/claude-code-adapter.test.ts
+++ b/crabot-agent/tests/workers/claude-code-adapter.test.ts
@@ -159,7 +159,7 @@ describe('ClaudeCodeAdapter.provision', () => {
         const config = await readConfig()
         expect(config.projects[realRoot]).toEqual({ hasTrustDialogAccepted: true, enabledMcpjsonServers: [] })
         expect(config.projects[linkRoot]).toBeUndefined()
-        expect(config.bypassPermissionsModeAccepted).toBe(true)
+        expect(config.bypassPermissionsModeAccepted).toBeUndefined()
       } finally {
         await fs.rm(realRoot, { recursive: true, force: true }).catch(() => {})
       }
@@ -173,6 +173,8 @@ describe('ClaudeCodeAdapter.provision', () => {
           {
             numStartups: 42,
             oauthAccount: { accountUuid: 'u-1' },
+            // 老版本残留由用户所有:本次只停止继续写,不越权删除或改值。
+            bypassPermissionsModeAccepted: false,
             projects: {
               [realWs]: { allowedTools: ['Bash(ls:*)'], history: [{ display: '之前的对话' }] },
               '/home/someone/real-project': { hasTrustDialogAccepted: true, allowedTools: ['Read'] },
@@ -197,7 +199,7 @@ describe('ClaudeCodeAdapter.provision', () => {
       expect(config.projects['/home/someone/real-project']).toEqual({ hasTrustDialogAccepted: true, allowedTools: ['Read'] })
       expect(config.numStartups).toBe(42)
       expect(config.oauthAccount).toEqual({ accountUuid: 'u-1' })
-      expect(config.bypassPermissionsModeAccepted).toBe(true)
+      expect(config.bypassPermissionsModeAccepted).toBe(false)
     })
 
     it('并发 provision 多个 worker:每条记录都在,互不覆盖', async () => {
@@ -216,7 +218,7 @@ describe('ClaudeCodeAdapter.provision', () => {
       )
 
       const config = await readConfig()
-      expect(config.bypassPermissionsModeAccepted).toBe(true)
+      expect(config.bypassPermissionsModeAccepted).toBeUndefined()
       for (const root of roots) {
         expect(config.projects[root], `缺少 ${root} 的预授权记录`).toEqual({ hasTrustDialogAccepted: true, enabledMcpjsonServers: [] })
       }
@@ -302,7 +304,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter (tmux + mock CLI)', () => {
   }
 
   it(
-    'spawn 命令行显式使用 --permission-mode bypassPermissions,工具调用零审批弹窗',
+    'spawn 命令行显式使用 bypassPermissions 并按当前 cc 字段跳过首次危险确认窗',
     async () => {
       const channel = new CliEventChannel(eventsFilePath({ root: workspaceRoot }))
       const argvFile = path.join(dataDir, 'spawn-permission-argv.jsonl')
@@ -321,6 +323,9 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter (tmux + mock CLI)', () => {
       const modeIdx = argv.indexOf('--permission-mode')
       expect(modeIdx).toBeGreaterThan(-1)
       expect(argv[modeIdx + 1]).toBe('bypassPermissions')
+      const settingsIdx = argv.indexOf('--settings')
+      expect(settingsIdx).toBeGreaterThan(-1)
+      expect(JSON.parse(argv[settingsIdx + 1])).toEqual({ skipDangerousModePermissionPrompt: true })
 
       await adapter.kill(h)
     },
@@ -1105,7 +1110,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter.resume', () => {
   })
 
   it(
-    'resume 后新会话收到 --resume <session_ref> 参数;session_ref 不变,新化身 seq+1',
+    'resume 后新会话收到 --resume <session_ref> 与跳过 bypass 危险确认的附加 settings;session_ref 不变,新化身 seq+1',
     async () => {
       const channel = new CliEventChannel(eventsFilePath({ root: workspaceRoot }))
       const stopHookCmd = channel.hookCommand('stop')
@@ -1145,6 +1150,9 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter.resume', () => {
       const resumeArgv = argvLines[argvLines.length - 1]
       expect(resumeArgv).toContain('--resume')
       expect(resumeArgv[resumeArgv.indexOf('--resume') + 1]).toBe(meta1.session_id)
+      const settingsIdx = resumeArgv.indexOf('--settings')
+      expect(settingsIdx).toBeGreaterThan(-1)
+      expect(JSON.parse(resumeArgv[settingsIdx + 1])).toEqual({ skipDangerousModePermissionPrompt: true })
 
       await adapter.kill(h2)
     },


### PR DESCRIPTION
## 问题

PR #78 部署后，真实 Admin Chat 的 Claude Code 2.1.223 仍显示 Bypass Permissions 危险确认窗。`~/.claude.json.bypassPermissionsModeAccepted=true` 已无效，默认 `No, exit` 导致 worker spawn_failed。

## 修复

- cc spawn/resume 每次通过 `--settings` 注入 `skipDangerousModePermissionPrompt=true`
- 保持 `--permission-mode bypassPermissions` 与 workspace `defaultMode`
- 停止继续写无效旧字段；已有用户字段保持不动
- 不修改用户级 `~/.claude/settings.json`
- Codex 零改动

## 验证

- TDD 起点：5 条新断言失败
- cc adapter：66/66 passed
- cc+codex：133 passed / 2 个既有 macOS `/var`→`/private/var` PATH 基线失败
- TypeScript build、`git diff --check` 通过
- 真实当前构建 spawn：无弹窗完成 Bash、代理网络与 workspace 写入
- 真实 resume：危险确认窗消失；既有 wakeInput 投递问题仍按 Spec 排除为 follow-up
- 用户级 `~/.claude/settings.json` 未写入新字段
- 独立本地 reviewer：APPROVED，无 blocker

Spec：`crabot-docs/superpowers/specs/2026-08-06-worker-permission-auto-approve-design.md`（docs `80fb6f0`）
Plan：docs `d114b90`