### PR TITLE
feat(workers): commit interactive CLI input safely

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,15 +1,15 @@
 # Crabot 项目进度
 
-> 最后更新：2026-08-08 — PR #80 最终收口已实现、推送并进入自动 review
+> 最后更新：2026-08-09 — PR #80/#81 最终实现与 stacked 回归完成，等待 required review
 
-## 2026-08-08 — PR #80：legacy loop 最终退役与 builtin bg-shell durable delivery（已推送，待自动 review）
+## 2026-08-09 — PR #80：legacy loop 最终退役与 builtin bg-shell durable delivery（等待 review）
 
 - 已按 `protocol-agent-v3.md` v3.0.5 和 `2026-08-08-pr80-finalization-{design,plan}.md` 收口：`wait_for_signal` 零生产残留；`start_task` / `start_recovery_task` / `create_task_from_schedule` / `resume_task*` / `cancel_task` / `abort_worker` 不再注册生产 RPC，Admin restart resume/self-healing 与 recent-terminal revival 链路已删除。
 - builtin worker 的后台 shell owner 记录 `worker_id`；shell 终态与 `exit_notification=pending` 原子落 registry。正常 exit、startup reap、readopt reaper 均走同一 receipt，重启扫描 terminal+pending；实际 WorkerInbox 投递后落 `delivered`，取消/无 worker/无化身落 `dead_letter`，意外失败保持 pending 并做有界退避重试。
 - durable receipt 采用 at-least-once：adapter 已收输入但 settlement 未落盘的崩溃窄窗允许重放；同进程 retry 用稳定 `entity_id` 在 WorkerInbox 去重，不因暂扣提前 settlement。pending receipt 不被 task cleanup 或 7 日 GC 删除；每 worker 保持 FIFO、不同 worker 独立，startup reconciliation 先落实例级 settled gate，迟到创建的 AgentHandler 也会立即开门。
 - agent-native system task 没有 incarnation；启动对账若其仍非终态，明确标 `failed`（`execution context lost on agent restart`）并发状态事件。`sendToWorker` / `queryWorker` / `killWorker` / `switchWorkerImpl` 等 worker-only API 统一抛 domain error，不伪造 incarnation。
 - Admin 历史 task 只作归档：启动读取时把遗留非终态记录本地修复为 failed，不再尝试恢复或控制 Agent worker；memory graph rebuild 仍是 `trigger_schedule → system-thread manager → crab-memory` 的 manager-native 特例。
-- 当前验证：Shared/Agent/Admin TypeScript build 与 Admin Web production build 通过；durable registry/inbox/harness/reconciliation focused Agent 测试最终 **164 passed**，Admin focused 测试 **123 passed**。Agent 全量最终为 **2509 passed / 20 failed / 2 skipped**：20 条均为本机既有环境问题（9 条 claude-code contract + 5 条 harness integration tmux timeout、1 条 tmux pane 前台命令、2 条 `/var`→`/private/var` Codex PATH、3 条 workspace realpath），本次相关测试均通过。Admin 全量 **1069 passed / 1 failed**，唯一失败是既有 `v1-cleanup` 跨仓扫描命中 Agent 的 `store_memory` 测试字面。多轮 fresh/Claude review 发现 retry liveness、settlement-only repair、per-worker/startup FIFO、迟到 handler gate、startup pending-busy 口径与 explicit-seq domain error，均已修复并补回归；最终独立 durable 与 contract 复审均为 **no material findings**。实现已推送 PR #80，等待 latest-head 自动 review；不自行 merge。
+- 当前 stacked head 验证：Shared/Agent/Admin TypeScript build 通过；PR #80 durable/recovery + PR #81 CLI/harness 组合 focused **15 files / 369 passed**，Admin focused **70 passed**。Agent 串行全量 **2575 passed / 4 failed / 2 skipped**，4 条仅为既有 macOS tmux foreground-command 与 `/var`→`/private/var` workspace realpath；Admin 全量 **1069 passed / 1 failed**，唯一失败为既有 `v1-cleanup` 跨仓扫描命中 Agent 测试字面。多轮 review 发现 retry liveness、settlement-only repair、per-worker/startup FIFO、迟到 handler gate、startup pending-busy 口径、explicit-seq domain error 及 CLI durable hold 生命周期，均已修复并补回归；独立终审均无 blocker/major。PR #80 head `82d83f1`，等待 latest-head 自动 review，不自行 merge。
 
 ## 2026-08-07 — cc bypass 首次危险确认窗版本修复（进行中）
 
@@ -1222,6 +1222,6 @@ Module Manager (port 19000)
 - Claude Code / Codex 已迁移到单层 `running / waiting_text / waiting_action / exited` 控制状态；首投所有权由 `initial_input` 明确结算。
 - 输入提交实现同一 pane 内单次 paste、证据化 Enter（最多补一次）；modal/pending 由 raw 受控清障，普通 WorkerInbox FIFO 与 bg-shell 通知语义保持不变。
 - Codex 0.146 的 rollout 改为首条普通输入接受后发现；startup stall 经 raw 恢复时不再提前固化占位 session。
-- 已补齐 PR review 发现的长 prompt/paste chip、Codex notify stdin、Stop 并发落账、交互区误判、延后 session_ref watcher 与 exited hold 生命周期问题；独立终审 `APPROVED`。
-- TypeScript build 与 10 文件 292 个定向测试通过；Claude Code 2.1.226 / Codex 0.146.0 真实 tmux 黑盒已验证 spawn、resume、Claude steering 和 Codex pending→raw Tab queue。
-- PR #81 以 PR #80 为 base；等待两条 PR 的自动 review / merge gate 收敛后再部署与 Admin Chat 回归。
+- 已补齐两轮 PR review：长 prompt/paste chip、Codex notify stdin、Stop 并发落账、两端交互区误判、延后 session_ref watcher、exited hold 生命周期、post-paste empty 所有权和 pane capture 额外进程均已修复；stacked review 另发现 durable bg receipt 在 CLI `hold_consumed` 后缺失结算，现已覆盖 raw 提交/放弃、自然退出、kill/drain、显式 handoff 和 in-flight switch 竞态；独立终审 `APPROVED`。
+- 最新 stacked head TypeScript build 与 PR #80/#81 组合定向集 **15 files / 369 tests** 通过；Claude Code 2.1.226 / Codex 0.146.0 真实 tmux 黑盒已验证 spawn、resume、Claude steering 和 Codex pending→raw Tab queue。
+- PR #81 已 rebase 到 PR #80 `addc422`，当前等待自动 review / merge gate；两条 PR 合并前不部署。

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1217,10 +1217,11 @@ Module Manager (port 19000)
 - memory graph rebuild 改为 manager-native `trigger_schedule`，不再创建无法观察的 legacy pending task。
 - 当前定向构建与测试通过；全量回归及 PR review 尚待完成。
 
-## 2026-08-08 — CLI 交互输入提交（实施完成，待 PR）
+## 2026-08-08 — CLI 交互输入提交（stacked PR #81）
 
 - Claude Code / Codex 已迁移到单层 `running / waiting_text / waiting_action / exited` 控制状态；首投所有权由 `initial_input` 明确结算。
 - 输入提交实现同一 pane 内单次 paste、证据化 Enter（最多补一次）；modal/pending 由 raw 受控清障，普通 WorkerInbox FIFO 与 bg-shell 通知语义保持不变。
 - Codex 0.146 的 rollout 改为首条普通输入接受后发现；startup stall 经 raw 恢复时不再提前固化占位 session。
-- 定向回归 286 tests 通过，TypeScript build 通过；Claude Code 2.1.226 / Codex 0.146.0 真实 tmux 黑盒验证 spawn、resume、Claude steering 和 Codex pending→raw Tab queue。
-- 全量 2555 tests 中 2535 通过；剩余 18 个失败均位于未修改的 audit / inbound / workspace path 基线范围。下一步：最终 review、提交分支并创建 PR。
+- 已补齐 PR review 发现的长 prompt/paste chip、Codex notify stdin、Stop 并发落账、交互区误判、延后 session_ref watcher 与 exited hold 生命周期问题；独立终审 `APPROVED`。
+- TypeScript build 与 10 文件 292 个定向测试通过；Claude Code 2.1.226 / Codex 0.146.0 真实 tmux 黑盒已验证 spawn、resume、Claude steering 和 Codex pending→raw Tab queue。
+- PR #81 以 PR #80 为 base；等待两条 PR 的自动 review / merge gate 收敛后再部署与 Admin Chat 回归。

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1216,3 +1216,11 @@ Module Manager (port 19000)
 - 已删除 legacy schedule RPC/recovery RPC 与等待工具；`process_message` 仅保留 admin_chat，媒体下载改为独立 manager 通知。
 - memory graph rebuild 改为 manager-native `trigger_schedule`，不再创建无法观察的 legacy pending task。
 - 当前定向构建与测试通过；全量回归及 PR review 尚待完成。
+
+## 2026-08-08 — CLI 交互输入提交（实施完成，待 PR）
+
+- Claude Code / Codex 已迁移到单层 `running / waiting_text / waiting_action / exited` 控制状态；首投所有权由 `initial_input` 明确结算。
+- 输入提交实现同一 pane 内单次 paste、证据化 Enter（最多补一次）；modal/pending 由 raw 受控清障，普通 WorkerInbox FIFO 与 bg-shell 通知语义保持不变。
+- Codex 0.146 的 rollout 改为首条普通输入接受后发现；startup stall 经 raw 恢复时不再提前固化占位 session。
+- 定向回归 286 tests 通过，TypeScript build 通过；Claude Code 2.1.226 / Codex 0.146.0 真实 tmux 黑盒验证 spawn、resume、Claude steering 和 Codex pending→raw Tab queue。
+- 全量 2555 tests 中 2535 通过；剩余 18 个失败均位于未修改的 audit / inbound / workspace path 基线范围。下一步：最终 review、提交分支并创建 PR。

--- a/crabot-agent/src/workers/claude-code/adapter.ts
+++ b/crabot-agent/src/workers/claude-code/adapter.ts
@@ -427,9 +427,13 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
       mode === 'steering' && runtime.controlState.kind === 'running'
         ? { kind: 'running' }
         : { kind: 'waiting_action', reason: result.disposition === 'not_pasted' ? 'input_surface_unavailable' : 'input_pending' }
+    let waitReason: string
+    if (next.kind === 'waiting_action') waitReason = next.reason
+    else if (result.disposition === 'pending_in_ui') waitReason = 'input_pending'
+    else waitReason = 'input_surface_unavailable'
     const report: StateChangeReport = {
       outputTail: result.snapshot.text || baseline,
-      waitReason: next.kind === 'waiting_action' ? next.reason : result.disposition,
+      waitReason,
     }
     await this.transitionControlState(runtime, h, next, report, notify)
     return { control_state: next.kind, disposition: result.disposition, report }

--- a/crabot-agent/src/workers/claude-code/adapter.ts
+++ b/crabot-agent/src/workers/claude-code/adapter.ts
@@ -1,92 +1,28 @@
 /**
- * ClaudeCodeAdapter — WorkerAdapter 契约的 claude-code 实现。
+ * Claude Code WorkerAdapter.
  *
- * spawn:session_id = randomUUID() 出生即定(即 session_ref);建 <dataDir>/<worker_id>/ 目录;
- * tmux newSession 拉起 `<claudeBin> --settings <bypass-warning-json> --session-id <uuid>
- * --permission-mode bypassPermissions`,交互态跑在 tmux pane 里,cwd=workspace,pane 输出经 tmux
- * pipe-pane 落 output-<seq>.log;meta 落盘为 running;**等 pane 输出里出现
- * \e[?2004h(TUI 已开启 bracketed paste)之后**,首条任务输入(spec.prompt)才经 tmux sendText
- * 注入(cc 把它当第一条用户消息)。等不到就绪 → 不投递、落 idle 并把 output 尾部随唤醒事件
- * 交给 manager(见 spawn 内的握手段与 reportStartupStall)。
+ * Interactive incarnations run in tmux. spawn/resume wait for bracketed-paste readiness,
+ * then submit their opening input through the guarded transaction
+ * `empty composer -> one paste -> same composer pending -> Enter` (one Enter retry, never a
+ * second paste). The returned handle carries `initial_input`, so the harness settles both
+ * control state and text ownership only after the incarnation is addressable in the ledger.
  *
- * provision:与 spawn 分离的独立步骤(WorkerAdapter 契约本就是两个方法),由调用方在 spawn 前
- * 调用一次,把 workspace 布好——.claude/settings.json(Stop/Notification hook 接到
- * CliEventChannel.hookCommand,permissions 预配置 bypassPermissions 降弹窗)、.claude/skills/(复用
- * Task 3 的 materializeSkills)、.mcp.json(renderMcpJson)、CLAUDE.md(renderContextMd),
- * 外加全局 ~/.claude.json 里 workspace project entry 的两类预授权(preAcceptStartupDialogs):
- * hasTrustDialogAccepted 消掉"首次进入新目录"信任弹窗(它发生在 --permission-mode 之前,
- * 命令行拦不住);enabledMcpjsonServers 消掉紧随其后的 "New MCP server found" 弹窗。首次进入
- * bypass 模式的危险确认不接受 project settings,由 spawn/resume 每次通过 --settings 注入当前
- * cc 字段 skipDangerousModePermissionPrompt,不永久修改用户级 ~/.claude/settings.json。
+ * Runtime truth is one `CliControlState`: running, waiting_text, waiting_action, or exited.
+ * Stop hooks move running to waiting_text. Supported Notification payloads move to
+ * waiting_action only when the current pane still shows the matching interaction. Composer
+ * presence is used only to guard one input transaction, never as turn-complete/liveness proof.
+ * Normal input uses steering while running and primary input while waiting_text. waiting_action
+ * rejects normal text without writing to the pane. raw sends only the requested keys, then
+ * re-probes the pane before changing state.
  *
- * spawn 提交纪律:tmux newSession 成功之后才落 meta(running)+注册 runtime——newSession 失败
- * 时不留任何持久痕迹(session_id 可重生成,workspace 内 provision 产物残留可接受),同 worker_id
- * 可安全重试 spawn。首条输入(sendText)失败:此时已注册的化身按 kill 路径清理 tmux 会话后落
- * exited(crashed)(不是 killed——这不是用户发起的 kill),不放任 running;spawn 仍然 reject。
+ * provision writes workspace hooks, skills, MCP/context files, and pre-accepts workspace trust.
+ * spawn/resume retain bypassPermissions and inject the process-local dangerous-mode warning
+ * setting; they do not modify ~/.claude/settings.json. Native session JSONL is used for trace and
+ * diagnostics only: missing records never trigger an automatic re-paste.
  *
- * state 三源合成,按优先级依次判定(前一源给出确定结果就不再看后一源):
- *   1. tmux isAlive() 为 false → exited(终态优先,是否 killed 由本地 killed 标记区分
- *      killed/completed)——进程可能在发过 stop 事件之后自退(崩溃/OOM/自敲 exit),必须先判
- *      isAlive,否则 stop 计数恒大于 baseline 会一直判成 idle,永远走不到这条分支;
- *   2. 会话还活着时,事件文件:自上一次 sendInput(或 spawn)以来出现过新的 'stop' 事件 → idle;
- *   3. 启动期就绪握手超时的暂扣标志(Runtime.startupStalled,落盘 meta.startup_stalled)置位
- *      → idle。这一源专治"开工输入根本没投递过、stop 计数永远不会涨"的化身,没有它,
- *      reportStartupStall 刚落的 idle 会被下一次 syncState 翻回 running;
- *   4. 默认 running。
- * 用"自上次输入以来的 stop 计数"(stopBaseline)而非"是否曾经见过 stop"来判定,是因为
- * cc 每答完一轮都会再触发一次 Stop——sendInput 时必须把 baseline 推到当前计数,否则上一轮
- * 遗留的 stop 事件会让新一轮还没答完就被误判成 idle。
- *
- * 状态判定(读事件基线/isAlive)与提交(改内存 + 写 meta)整体在该 worker 的互斥锁内原子完成
- * (锁按 worker 粒度,不阻塞其他 worker;isAlive 是 tmux 子进程调用,锁内执行可接受)——避免
- * "判定用的是过期快照,提交时才发现已被另一次并发调用改写"的窗口:两次并发 state() 若只在
- * 提交这一步加锁,后完成判定的那次会拿着过期快照无条件覆盖先完成的那次刚落的新鲜结果。
- * 判定与提交现在是同一个不可分割的临界区,保证 exited 终态不可覆盖、也不丢并发更新。
- *
- * sendInput:活会话直接 tmux sendText(cc 自带 steering 队列,不需要我们排队);raw 选项走
- * tmux sendKeys(text 按空白切分成按键名数组,如 "y Enter" → ['y','Enter']);exited 态抛
- * WorkerExitedError(与 builtin 同名同语义的独立类,不 import builtin)。
- *
- * kill:tmux killSession → exited(killed),幂等(已 exited 直接返回,不覆盖原 ended_reason)。
- *
- * meta-<seq>.json 布局沿用 P1:{ seq, state, session_id, ended_reason? },写法抽到
- * src/workers/meta-store.ts 共享(不改 builtin 自己的 writeMeta)。
- *
- * detect:`<claudeBin> --version`(经 `sh -c` 跑,claudeBin 本就是一段 shell 命令片段——
- * 与 spawn 把它塞进 tmux pane 命令是同一语义)成功 → installed;activated 看
- * `dirname(claudeProjectsDir)`(即约定的 `~/.claude/`)下是否有 settings.json 或
- * .credentials.json,不做任何网络调用。
- *
- * resume:先经 ensureRuntime 取 prev 化身的 runtime(常驻内存直接用,否则从落盘 meta 重建,
- * 四轮 review 修复;meta 也没有才报错——不再要求"只能 resume 本进程 spawn 过的化身"),校验
- * 其已 exited(未 exited 直接拒绝)→ 新 tmux 会话跑
- * `<claudeBin> --resume <prev.session_ref>`(不重复传 --permission-mode,provision 阶段已把
- * bypassPermissions 写进 settings.json 兜底命令行之外的场景)→ seq+1 化身、独立 meta/output、
- * session_ref 原样透传(cc 侧同一个会话 id)。锁纪律与 spawn 一致:tmux newSession 成功后才
- * 提交 meta+runtime,首条 wakeInput(sendText)失败按 kill 路径清理并落 exited(crashed)。
- *
- * fork(侧问,query_worker 的底座):无头一击,不进 tmux——
- * `<claudeBin> -p <forkInput> --resume <prev.session_ref> --fork-session --output-format text`
- * (经 `sh -c` 跑,forkInput/参数逐个 shQuote 转义)子进程 stdout 落到 fork 化身自己的
- * output-<seq>.log;退出码 0 → exited(completed),非 0 → exited(crashed)。为可观测起见,
- * 先在 per-worker 互斥锁内提交一段 meta(running)+注册 runtime,子进程本身(可能耗时较长)在
- * 锁外跑不阻塞同 worker_id 上的其它操作(主线不受影响),跑完后再在锁内提交终态。cc 的
- * --fork-session 在其内部生成一个新会话 id,但 `--output-format text` 的 stdout 不携带它,
- * 拿不到就拿不到——fork 化身的 session_id 落一个本地生成的占位 UUID,不对应真实 cc 会话
- * 文件,该化身自己的 readTrace 会优雅退化为空数组(已知限制,见 Task 5 报告)。
- * 无头进程的 hook 事件经 env(CliEventChannel.EVENTS_FILE_ENV)重定向到 fork 化身私有的
- * `fork-events-<seq>.jsonl`,不写 workspace 共享的那份——否则侧问收尾会污染主线的 stop
- * 计数(详见 fork() 内 execOpts 注释)。
- *
- * readTrace:workspace root 经 cc 的 slug 规则(`/`与`.`都替换成`-`)映射到
- * `<claudeProjectsDir>/<slug>/<session_id>.jsonl`,按行增量解析并归一化——
- * type=user/assistant → kind message(role 对应,summary 取消息文本截 200);assistant 内的
- * tool_use content block → kind tool_call;user 记录带 toolUseResult 字段 → kind
- * tool_result;type=system → kind lifecycle;其余 type(mode/summary/queue-operation 等)跳过。
- * cursor.offset 是行号(非字节偏移);文件不存在时返回空数组(见下方"与 brief 的偏差")。
- * trace 文件路径依赖 workspace root——经 ensureRuntime 从 meta 的 workspace_root 字段
- * (四轮 review 新增持久化)重建,不再要求"只能对本进程内常驻 runtime 的化身调用";老化身
- * (升级前写的 meta 缺这个字段)时拒绝并给出可诊断错误,不是本次修复能补的历史缺口。
+ * Meta persists the external running/idle/exited state plus wait_mode/wait_reason for idle CLI
+ * states. ensureRuntime reconstructs a runtime from meta and deterministic tmux names after an
+ * agent restart. Headless fork remains isolated from the main interaction event file.
  */
 import { promises as fs } from 'fs'
 import { join, dirname } from 'path'
@@ -94,20 +30,24 @@ import { randomUUID } from 'crypto'
 import { homedir } from 'os'
 import { execFile } from 'child_process'
 import { promisify } from 'util'
-import { TmuxDriver } from '../tmux/driver.js'
+import { TmuxDriver, type PaneSnapshot } from '../tmux/driver.js'
+import { commitInput, waitForPaneChange, type InputMode } from '../tmux/input-commit.js'
 import { DEFAULT_PASTE_READY_TIMEOUT_MS, describeStartupStall, readOutputTail, waitForPasteReady } from '../tmux/paste-ready.js'
 import { CliEventChannel, EVENTS_FILE_ENV } from '../cli-events.js'
 import { OutputLog } from '../output-log.js'
 import { decodeTerminalOutput } from '../terminal-output.js'
 import { AsyncMutex } from '../async-mutex.js'
 import { writeMetaAtomic, maxSeqOnDisk, latestModifiedMs } from '../meta-store.js'
-import { WorkerExitedError } from '../errors.js'
+import { WorkerExitedError, CliInputStallError } from '../errors.js'
+import { probeClaudeInput, acceptedClaudeInput, hasClaudeInteraction } from './input-surface.js'
 import { materializeSkills, renderMcpJson, renderContextMd, type ProvisionSources } from '../provision/materialize.js'
 import type {
   AdapterCapabilities,
   CapabilityBundle,
+  CliControlState,
   DetectResult,
   IncarnationEndReason,
+  InitialInputResult,
   StateChangeReport,
   IncarnationHandle,
   IncarnationRef,
@@ -121,17 +61,6 @@ import type {
 } from '../types.js'
 
 const execFileAsync = promisify(execFile)
-
-/**
- * 首条 prompt 投递验证的超时(毫秒)。
- *
- * 2026-08-06 生产实证(w-d2304bb6):`\e[?2004h` 只证明"paste 会被包裹",不证明"没有启动期
- * 模态框"——cc 在就绪信号之后异步弹出 MCP 信任窗(arXivPaper),首条 paste 被弹窗消费,worker
- * 静默停在空 composer。投递后轮询 cc 的会话记录(session jsonl)直到出现这条 user 消息,用结果
- * 说话。cc 收到输入到落 session 是毫秒级,15s 给弹窗确认/重绘留足余量且远小于 60s 握手超时。
- */
-const PROMPT_DELIVERY_TIMEOUT_MS = 15_000
-const PROMPT_DELIVERY_POLL_INTERVAL_MS = 250
 
 /** POSIX shell 单引号转义,与 tmux/driver.ts 的私有 shQuote 同款用法(独立复制一份)。 */
 function shQuote(s: string): string {
@@ -191,24 +120,13 @@ interface Runtime {
   readonly sessionId: string
   readonly outputLog: OutputLog
   readonly eventChannel: CliEventChannel
-  state: WorkerContractState
+  controlState: CliControlState
   ended_reason?: IncarnationEndReason
   /** 自上一次 sendInput(或 spawn)以来"已计入"的 stop 事件数;新 stop 数超过它才判定本轮 idle。 */
   stopBaseline: number
   killed: boolean
-  /**
-   * 启动期就绪握手超时后的**暂扣态**(见 reportStartupStall)。
-   *
-   * 三源判定认不出这种 idle:pane 活着、stop 计数一个没涨(开工输入根本没投递过),
-   * `computed` 恒为 `running` —— 于是 reportStartupStall 刚落的 idle 会被下一次 syncState
-   * 原样翻回 running,连带把台账从 waiting_input 拉回"正在干活"。而 `state()` 是每次 agent
-   * 重启对账必调的,这条翻转不是偶发而是必然。所以这里给三源判定补第四个信息源:标志置位
-   * 且没有新 stop 时维持 idle,由 sendInput(manager 真的出手了)清除。
-   *
-   * 跟着 meta 落盘(`startup_stalled`),否则重启后重建的 runtime 丢掉标志,同一条翻转在
-   * 新进程里照样发生——而"重启后台账变幽灵 running"正是本次要根治的形态。
-   */
-  startupStalled?: boolean
+  /** Set only for the narrow "accepted input then pane exited before return" settlement. */
+  acceptedExitReport?: StateChangeReport
   /** CliEventChannel.watch() 的停止函数(协议 §6.2.3 的文件监视)。tmux 化身在建立
    * runtime 时装上、落终态时摘掉;无头 fork 化身不装(见 startEventWatch)。 */
   stopEventWatch?: () => void
@@ -221,6 +139,21 @@ function instanceKey(h: { worker_id: string; seq: number }): string {
   return `${h.worker_id}#${h.seq}`
 }
 
+function contractState(state: CliControlState): WorkerContractState {
+  switch (state.kind) {
+    case 'running': return 'running'
+    case 'exited': return 'exited'
+    default: return 'idle'
+  }
+}
+
+function controlFromMeta(meta: { state?: WorkerContractState; wait_mode?: 'text' | 'action'; wait_reason?: string; startup_stalled?: boolean }, alive: boolean): CliControlState {
+  if (!alive || meta.state === 'exited') return { kind: 'exited' }
+  if (meta.startup_stalled || meta.wait_mode === 'action') return { kind: 'waiting_action', reason: meta.wait_reason ?? 'startup_stall' }
+  if (meta.state === 'idle') return { kind: 'waiting_text' }
+  return { kind: 'running' }
+}
+
 export class ClaudeCodeAdapter implements WorkerAdapter {
   readonly implId = 'claude-code' as const
 
@@ -229,7 +162,6 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
   private readonly claudeProjectsDir: string
   private readonly claudeConfigPath: string
   private readonly pasteReadyTimeoutMs: number
-  private readonly promptDeliveryTimeoutMs: number
   private readonly runtimes = new Map<string, Runtime>()
   private readonly mutexes = new Map<string, AsyncMutex>()
 
@@ -247,11 +179,7 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
       /** 启动期就绪握手的等待上限,默认 DEFAULT_PASTE_READY_TIMEOUT_MS(见该常量注释里的
        * 实测取值依据)。测试注入小值,避免为了走超时分支真的等一分钟。 */
       readonly pasteReadyTimeoutMs?: number
-      /**
-       * 首条 prompt 投递验证的等待上限,默认 PROMPT_DELIVERY_TIMEOUT_MS(见该常量注释,2026-08-06
-       * 生产实证:就绪信号之后 cc 仍可能异步弹 MCP 信任窗把 prompt 整个吞掉)。传 0 或负数跳过
-       * 验证——测试里没有真实 cc 进程写 session jsonl 的夹具(纯 fake tmux)注入 0 保持旧行为。
-       */
+      /** @deprecated 原生 session 记录只作诊断；缺回执不得触发自动重贴。 */
       readonly promptDeliveryTimeoutMs?: number
       /**
        * `report.lastText` 本 adapter 刻意不报(理由见 transitionState 注释),只报
@@ -271,7 +199,6 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
     this.claudeProjectsDir = deps.claudeProjectsDir ?? join(homedir(), '.claude', 'projects')
     this.claudeConfigPath = deps.claudeConfigPath ?? join(homedir(), '.claude.json')
     this.pasteReadyTimeoutMs = deps.pasteReadyTimeoutMs ?? DEFAULT_PASTE_READY_TIMEOUT_MS
-    this.promptDeliveryTimeoutMs = deps.promptDeliveryTimeoutMs ?? PROMPT_DELIVERY_TIMEOUT_MS
   }
 
   async detect(): Promise<DetectResult> {
@@ -434,6 +361,80 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
     })
   }
 
+  private async capture(runtime: Runtime): Promise<PaneSnapshot> {
+    const snapshot = await this.tmux.capturePane(runtime.sessionName)
+    return { ...snapshot, text: decodeTerminalOutput(snapshot.text) }
+  }
+
+  private async commitGuardedInput(
+    runtime: Runtime,
+    h: IncarnationHandle,
+    text: string,
+    mode: InputMode,
+    notify: boolean,
+    foldStop: boolean,
+  ): Promise<InitialInputResult> {
+    let baseline = ''
+    let pasted = false
+    let result
+    try {
+      baseline = (await this.capture(runtime)).text
+      result = await commitInput(
+        {
+          pasteText: async (value) => {
+            await this.tmux.pasteText(runtime.sessionName, value)
+            pasted = true
+          },
+          sendEnter: () => this.tmux.sendKeys(runtime.sessionName, ['Enter']),
+          capture: () => this.capture(runtime),
+        },
+        (snapshot, phase) => probeClaudeInput(snapshot, mode, phase === 'after_paste' ? text : undefined, phase === 'before_paste'),
+        (snapshot) => acceptedClaudeInput(snapshot, mode, text),
+        text,
+      )
+    } catch (err) {
+      if (!(await this.tmux.isAlive(runtime.sessionName))) {
+        const reason: IncarnationEndReason = pasted ? 'completed' : 'crashed'
+        await this.transitionExited(runtime, h, reason, notify)
+        return {
+          control_state: 'exited',
+          disposition: pasted ? 'accepted' : 'not_pasted',
+          report: { endReason: reason },
+        }
+      }
+      throw err
+    }
+
+    if (result.disposition === 'accepted') {
+      if (!(await this.tmux.isAlive(runtime.sessionName))) {
+        await this.transitionExited(runtime, h, 'completed', notify)
+        return { control_state: 'exited', disposition: 'accepted', report: { endReason: 'completed' } }
+      }
+      if (foldStop) {
+        const events = await runtime.eventChannel.readAll()
+        const stopCount = events.filter((event) => event.kind === 'stop').length
+        if (stopCount > runtime.stopBaseline) {
+          runtime.stopBaseline = stopCount
+          await this.transitionControlState(runtime, h, { kind: 'waiting_text' }, undefined, notify)
+          return { control_state: 'waiting_text', disposition: 'accepted' }
+        }
+      }
+      await this.transitionControlState(runtime, h, { kind: 'running' }, undefined, notify)
+      return { control_state: 'running', disposition: 'accepted' }
+    }
+
+    const next: CliControlState =
+      mode === 'steering' && runtime.controlState.kind === 'running'
+        ? { kind: 'running' }
+        : { kind: 'waiting_action', reason: result.disposition === 'not_pasted' ? 'input_surface_unavailable' : 'input_pending' }
+    const report: StateChangeReport = {
+      outputTail: result.snapshot.text || baseline,
+      waitReason: next.kind === 'waiting_action' ? next.reason : result.disposition,
+    }
+    await this.transitionControlState(runtime, h, next, report, notify)
+    return { control_state: next.kind, disposition: result.disposition, report }
+  }
+
   async spawn(spec: SpawnSpec): Promise<IncarnationHandle> {
     const seq = 1
     const sessionId = randomUUID()
@@ -463,14 +464,13 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
       sessionId,
       outputLog: new OutputLog(outputFile),
       eventChannel,
-      state: 'running',
+      controlState: { kind: 'running' },
       stopBaseline: await this.initialStopBaseline(eventChannel),
       killed: false,
     }
 
     await writeMetaAtomic(dir, seq, { seq, state: 'running', session_id: sessionId, workspace_root: spec.workspace.root })
     this.runtimes.set(instanceKey(handle), runtime)
-    this.startEventWatch(runtime, handle)
 
     // 启动期就绪握手(见 tmux/paste-ready.ts):等 cc 在 pane 里发出 \e[?2004h 之后再投递,
     // 否则 paste-buffer -p 会静默降级成裸文本注入,prompt 里每个换行都变成一次 Enter——
@@ -484,51 +484,24 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
       isAlive: () => this.tmux.isAlive(sessionName),
     })
     if (!pasteReady) {
-      await this.reportStartupStall(runtime, handle, outputFile)
-      return handle
+      const initial_input = await this.initialStartupStall(runtime, handle, outputFile)
+      this.startEventWatch(runtime, handle)
+      return { ...handle, initial_input }
     }
 
-    // 首条任务输入经 sendText 注入,cc 把它当第一条用户消息。注入失败:session 可能已经起来
-    // 但没喂到任务,不能放任 running——按 kill 路径清理 tmux 会话后落 exited(crashed)(不是
-    // killed,这不是用户发起的 kill),spawn 仍然 reject 把失败如实报给调用方。
-    await this.sendTextOrKill(runtime, handle, spec.prompt)
-
-    // 就绪握手只保证 bracketed paste；当前版本不再以 Escape+重贴猜测 modal 是否
-    // 吞了文本。重复 paste 会把仍在 composer 的任务文本直接追加，违反 at-most-once。
-    // 后续受控输入事务会以 pane probe/receipt 结算，native JSONL 仅作诊断。
-
-    return handle
-  }
-
-  /**
-   * sendText 失败统一收场:会话可能已死,不能放任 running——按 kill 路径清理 tmux 会话后落
-   * exited(crashed)(不是 killed,这不是用户发起的 kill),异常继续上抛如实报给调用方。
-   */
-  private async sendTextOrKill(runtime: Runtime, h: IncarnationHandle, text: string): Promise<void> {
+    let initial_input: InitialInputResult
     try {
-      await this.tmux.sendText(runtime.sessionName, text)
+      initial_input = await this.commitGuardedInput(runtime, handle, spec.prompt, 'primary', false, true)
     } catch (err) {
-      await this.getMutex(h.worker_id).run(async () => {
-        if (runtime.state === 'exited') return
+      await this.getMutex(handle.worker_id).run(async () => {
+        if (runtime.controlState.kind === 'exited') return
         await this.tmux.killSession(runtime.sessionName)
-        await this.transitionExited(runtime, h, 'crashed')
+        await this.transitionExited(runtime, handle, 'crashed')
       })
       throw err
     }
-  }
-
-  /** sendTextOrKill 的 sendKeys 版本(Esc 清弹窗用,见 spawn 投递验证注释)。 */
-  private async sendKeysOrKill(runtime: Runtime, h: IncarnationHandle, keys: string[]): Promise<void> {
-    try {
-      await this.tmux.sendKeys(runtime.sessionName, keys)
-    } catch (err) {
-      await this.getMutex(h.worker_id).run(async () => {
-        if (runtime.state === 'exited') return
-        await this.tmux.killSession(runtime.sessionName)
-        await this.transitionExited(runtime, h, 'crashed')
-      })
-      throw err
-    }
+    this.startEventWatch(runtime, handle)
+    return { ...handle, initial_input }
   }
 
   async resume(prev: IncarnationRef, wakeInput: string): Promise<IncarnationHandle> {
@@ -574,6 +547,7 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
     //   此之前失败,resumed 仍未被设置,后续重试不会被"已 resume"拒绝(P2 review #2)。
     let handle!: IncarnationHandle
     let runtime!: Runtime
+    let outputFile!: string
     await this.getMutex(prev.worker_id).run(async () => {
       if (prevRuntime.resumed) {
         throw new Error(`ClaudeCodeAdapter.resume: incarnation ${prev.worker_id}#${prev.seq} already resumed (concurrent resume of the same prev incarnation?)`)
@@ -581,7 +555,7 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
       const seq = await this.nextSeq(prev.worker_id)
       handle = { worker_id: prev.worker_id, seq, impl: 'claude-code', session_ref: prev.session_ref }
       const sessionName = `crabot-w-${prev.worker_id}-${seq}`
-      const outputFile = join(dir, `output-${seq}.log`)
+      outputFile = join(dir, `output-${seq}.log`)
       // 不重复传 --permission-mode:provision 阶段已把 bypassPermissions 写进 settings.json,覆盖
       // 命令行没有重复声明的场景(resume 正是这样的场景)。危险确认开关则不接受 project
       // settings,必须与 spawn 对称地每次通过 --settings 注入。session_ref 是 cc 侧的会话 uuid,
@@ -602,7 +576,7 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
         sessionId: prev.session_ref,
         outputLog: new OutputLog(outputFile),
         eventChannel,
-        state: 'running',
+        controlState: { kind: 'running' },
         // 复用上一化身的 workspace ⇒ 事件文件里已有它留下的 stop 事件,基线必须现读现算。
         stopBaseline: await this.initialStopBaseline(eventChannel),
         killed: false,
@@ -610,24 +584,32 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
 
       await writeMetaAtomic(dir, seq, { seq, state: 'running', session_id: prev.session_ref, workspace_root: prevRuntime.workspaceRoot })
       this.runtimes.set(instanceKey(handle), runtime)
-      this.startEventWatch(runtime, handle)
       prevRuntime.resumed = true
     })
 
-    // 首条 wakeInput 注入失败:按 spawn 同款纪律处理——已注册的化身清理 tmux 会话后落
-    // exited(crashed)(不是 killed,不是用户发起的 kill),resume 仍然 reject。
+    const pasteReady = await waitForPasteReady(outputFile, {
+      timeoutMs: this.pasteReadyTimeoutMs,
+      isAlive: () => this.tmux.isAlive(runtime.sessionName),
+    })
+    if (!pasteReady) {
+      const initial_input = await this.initialStartupStall(runtime, handle, outputFile)
+      this.startEventWatch(runtime, handle)
+      return { ...handle, initial_input }
+    }
+
+    let initial_input: InitialInputResult
     try {
-      await this.tmux.sendText(runtime.sessionName, wakeInput)
+      initial_input = await this.commitGuardedInput(runtime, handle, wakeInput, 'primary', false, true)
     } catch (err) {
       await this.getMutex(handle.worker_id).run(async () => {
-        if (runtime.state === 'exited') return
+        if (runtime.controlState.kind === 'exited') return
         await this.tmux.killSession(runtime.sessionName)
         await this.transitionExited(runtime, handle, 'crashed')
       })
       throw err
     }
-
-    return handle
+    this.startEventWatch(runtime, handle)
+    return { ...handle, initial_input }
   }
 
   async fork(prev: IncarnationRef, forkInput: string): Promise<IncarnationHandle> {
@@ -680,7 +662,7 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
         sessionId,
         outputLog: new OutputLog(outputFile),
         eventChannel: new CliEventChannel(forkEventsFile),
-        state: 'running',
+        controlState: { kind: 'running' },
         stopBaseline: 0,
         killed: false,
       }
@@ -719,7 +701,7 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
     if (stdout) await runtime.outputLog.append(stdout)
 
     await this.getMutex(prev.worker_id).run(async () => {
-      if (runtime.state === 'exited') return // 幂等兜底
+      if (runtime.controlState.kind === 'exited') return // 幂等兜底
       await this.transitionExited(runtime, handle, endedReason)
     })
 
@@ -727,38 +709,72 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
   }
 
   async sendInput(h: IncarnationHandle, text: string, opts?: { raw?: boolean }): Promise<void> {
-    // 四轮 review 修复:重启后新建的 adapter 实例 runtimes 必为空,旧实现在这里直接抛通用
-    // Error("no such incarnation...resident in this process")——harness 只对 WorkerExitedError
-    // 转透明接续,通用 Error 会原样穿透砸给调用方,消息永久卡在队首(protocol-agent-v3 §13
-    // "tmux worker 独立存活 → 重启后 harness 重连接管"在操作层的失效)。改用 ensureRuntime
-    // 从落盘 meta 重建;它拿不到任何记录(真·未知化身)时,对 sendInput 的调用方而言效果
-    // 与"已终态"等价(harness 的透明接续兜底不区分这两种情况),同样抛 WorkerExitedError。
     const runtime = await this.ensureRuntime(h)
     if (!runtime) throw new WorkerExitedError(h.worker_id, h.seq)
 
-    const { state: current, stopCount } = await this.syncState(runtime, h)
-    // 带上 ended_reason:harness 的透明接续要用它给"台账还没追上"的源化身补终态。
-    // 上面 `!runtime` 那条分支给不出原因(重启后连落盘 meta 都读不回来),如实缺省。
+    const { state: current } = await this.syncState(runtime, h)
     if (current === 'exited') throw new WorkerExitedError(h.worker_id, h.seq, runtime.ended_reason)
 
-    // 新一轮开始:把 baseline 推到当前 stop 计数,上一轮遗留的 stop 事件不会被误算进新一轮。
-    runtime.stopBaseline = stopCount
+    return this.getMutex(h.worker_id).run(async () => {
+      if (runtime.controlState.kind === 'exited') throw new WorkerExitedError(h.worker_id, h.seq, runtime.ended_reason)
 
-    if (opts?.raw) {
-      const keys = text.split(/\s+/).filter((k) => k.length > 0)
-      await this.tmux.sendKeys(runtime.sessionName, keys)
-    } else {
-      await this.tmux.sendText(runtime.sessionName, text)
-    }
+      if (opts?.raw) {
+        const before = await this.capture(runtime)
+        const keys = text.split(/\s+/).filter((key) => key.length > 0)
+        await this.tmux.sendKeys(runtime.sessionName, keys)
+        const snapshot = await waitForPaneChange(() => this.capture(runtime), before.text)
+        if (hasClaudeInteraction(snapshot.text)) {
+          const report: StateChangeReport = { outputTail: snapshot.text, waitReason: 'interaction_required' }
+          await this.transitionControlState(runtime, h, { kind: 'waiting_action', reason: 'interaction_required' }, report, false)
+          throw new CliInputStallError('not_pasted', 'waiting_action', report)
+        }
+        const primaryProbe = probeClaudeInput(snapshot, 'primary', undefined, false)
+        if (primaryProbe === 'pending') {
+          const next: CliControlState = runtime.controlState.kind === 'running'
+            ? { kind: 'running' }
+            : { kind: 'waiting_action', reason: 'input_pending' }
+          const report: StateChangeReport = { outputTail: snapshot.text, waitReason: 'input_pending' }
+          await this.transitionControlState(runtime, h, next, report, false)
+          throw new CliInputStallError('pending_in_ui', next.kind, report)
+        }
+        if (primaryProbe === 'empty' && (runtime.controlState.kind === 'running' || /esc to interrupt/i.test(snapshot.text))) {
+          await this.transitionControlState(runtime, h, { kind: 'running' })
+          return
+        }
+        if (primaryProbe === 'empty') {
+          await this.transitionControlState(runtime, h, { kind: 'waiting_text' })
+          return
+        }
+        const reason = runtime.controlState.kind === 'waiting_action'
+          ? runtime.controlState.reason
+          : 'input_surface_unavailable'
+        const report: StateChangeReport = { outputTail: snapshot.text, waitReason: reason }
+        await this.transitionControlState(runtime, h, { kind: 'waiting_action', reason }, report, false)
+        throw new CliInputStallError('not_pasted', 'waiting_action', report)
+      }
 
-    await this.getMutex(h.worker_id).run(async () => {
-      if (runtime.state === 'exited') return
-      // 暂扣解除:manager 已经出手(raw 敲键清界面,或重投 prompt),从这一刻起 idle/running
-      // 重新由三源判定说了算。清除与 transitionState 的 meta 写入在同一个临界区里完成,
-      // 落盘的 startup_stalled 随之消失,重启后不会再被当作暂扣态复原。
-      runtime.startupStalled = false
-      await this.transitionState(runtime, h, 'running')
+      if (runtime.controlState.kind === 'waiting_action') {
+        const snapshot = await this.capture(runtime)
+        const report: StateChangeReport = { outputTail: snapshot.text, waitReason: runtime.controlState.reason }
+        throw new CliInputStallError('not_pasted', 'waiting_action', report)
+      }
+
+      const mode: InputMode = runtime.controlState.kind === 'running' ? 'steering' : 'primary'
+      const result = await this.commitGuardedInput(runtime, h, text, mode, false, false)
+      if (result.disposition !== 'accepted') {
+        throw new CliInputStallError(result.disposition, result.control_state, result.report)
+      }
+      if (result.control_state === 'exited') {
+        runtime.acceptedExitReport = result.report ?? { endReason: runtime.ended_reason ?? 'completed' }
+      }
     })
+  }
+
+  takeAcceptedInputExit(h: IncarnationHandle): StateChangeReport | undefined {
+    const runtime = this.runtimes.get(instanceKey(h))
+    const report = runtime?.acceptedExitReport
+    if (runtime) runtime.acceptedExitReport = undefined
+    return report
   }
 
   /**
@@ -858,15 +874,12 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
   }
 
   async kill(h: IncarnationHandle): Promise<void> {
-    // 四轮 review 修复:重启后新建的 adapter 实例对已经确已终态(或压根没有落盘记录)的
-    // 化身调 kill,以前直接抛通用 Error,harness.killWorker/handoffIncarnation 对此没有
-    // try/catch,错误会穿透打断整个操作(半成品:HANDOFF.md 已写、旧化身未标 superseded 却
-    // 卡死)。ensureRuntime 拿不到任何落盘记录时直接幂等返回(无事可做);拿到时 runtime.state
-    // 已经是探活得到的真实值,下面既有的 exited 幂等分支自然覆盖"会话已经不在了"的情形。
+    // Meta reconstruction makes kill work after an agent restart; missing meta and already-exited
+    // incarnations are both idempotent no-ops.
     const runtime = await this.ensureRuntime(h)
     if (!runtime) return
     await this.getMutex(h.worker_id).run(async () => {
-      if (runtime.state === 'exited') return // 幂等:不覆盖原 ended_reason
+      if (runtime.controlState.kind === 'exited') return // 幂等:不覆盖原 ended_reason
       runtime.killed = true
       await this.tmux.killSession(runtime.sessionName)
       await this.transitionExited(runtime, h, 'killed')
@@ -880,73 +893,31 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
   // --- Internal ---
 
   /**
-   * 三源合成状态判定:tmux isAlive(false → exited,终态优先) > 事件文件(会话还活着时,新
-   * stop → idle) > 默认 running。与内存态不同则在互斥锁内原子迁移(改内存 + 写 meta)。
-   * 返回判定结果与本次读到的 stop 计数(供 sendInput 复用,避免重复读一遍事件文件)。
-   *
-   * `deadReason`:本次判定发现会话已经不在了、且不是本进程发起的 kill 时,落哪个
-   * ended_reason。缺省 `'completed'` 是协议 §6.3 给"干过活之后自然退出"校准的推断,它成立
-   * 的前提是这个化身确实开过工。启动期就绪握手那条路径上前提不成立——开工输入一个字符都
-   * 没投递过,completed 不可能为真,再吃这个缺省推断就会把"启动即死"记成"成功完成"
-   * (harness 的 taskStatusFromIncarnation 据此把 task 记成 completed,manager 与 recovery
-   * 从此不再过问),所以那条路径显式传 `'crashed'`。
-   *
-   * 七轮 review:`deadReason` 只管得住 `reportStartupStall` 里的**那一次**调用,即"握手等待
-   * 期间就死了"这一个时点。而暂扣是个**持续状态**:标志置位、idle 落盘之后进程才死(pane
-   * 被外部收走、TUI 自退、机器重启后残留会话消失),后续任何一次 syncState——事件监视回调、
-   * sendInput 的前置判定、agent 重启后 reconcileOnStartup 调的 state()——判到 exited 仍会吃
-   * 缺省推断,同一个"没干过活却记成成功完成"从另一个时点回来。所以 exited 分支直接看
-   * `runtime.startupStalled`:置位就落 `'crashed'`,覆盖暂扣之后的所有时点;标志跟着
-   * meta.startup_stalled 落盘,重启后由 ensureRuntime 复原,这条判定在新进程里同样成立。
-   *
-   * 三者优先级 `killed > startupStalled > deadReason`:本进程发起的 kill 是确证,永远优先;
-   * `sendInput` 成功投递后会清掉 `startupStalled`(连同落盘的 startup_stalled),所以"投递过
-   * 之后才死"的化身不受这条影响,照旧走缺省推断——这正是"没干过活"与"干过活"的分界。
+   * Reconcile tmux existence and Stop events with the resident control state. A startup/action
+   * wait that dies before proven progress is classified crashed; other external exits retain the
+   * protocol's completed inference. The whole read/transition is serialized per worker.
    */
   private async syncState(
     runtime: Runtime,
     h: IncarnationHandle,
     deadReason: IncarnationEndReason = 'completed',
   ): Promise<{ state: WorkerContractState; stopCount: number }> {
-    if (runtime.state === 'exited') return { state: 'exited', stopCount: runtime.stopBaseline }
+    if (runtime.controlState.kind === 'exited') return { state: 'exited', stopCount: runtime.stopBaseline }
 
     return this.getMutex(h.worker_id).run(async () => {
-      // 锁内重读:进锁前 runtime.state 可能已被并发操作(如 kill,或排在前面的另一次
-      // syncState)抢先落定为 exited——终态不可覆盖。
-      if (runtime.state === 'exited') return { state: 'exited', stopCount: runtime.stopBaseline }
-
+      if (runtime.controlState.kind === 'exited') return { state: 'exited', stopCount: runtime.stopBaseline }
       const events = await runtime.eventChannel.readAll()
-      const stopCount = events.filter((e) => e.kind === 'stop').length
-
-      // isAlive 检查提到最前(终态优先):进程可能在发过 stop 事件之后自退(崩溃/OOM/自敲
-      // exit)——stopCount 恒 > baseline 会一直判成 idle,永远走不到下面的 isAlive 分支,
-      // 化身不落 exited,resume 被永久拒绝(P2 review #2)。会话已经不在了就直接 exited,
-      // 不管有没有新 stop 事件;只有会话还活着,才轮到 stop 事件区分 idle/running。
-      let computed: WorkerContractState
+      const stopCount = events.filter((event) => event.kind === 'stop').length
       if (!(await this.tmux.isAlive(runtime.sessionName))) {
-        computed = 'exited'
-      } else if (stopCount > runtime.stopBaseline) {
-        computed = 'idle'
-      } else if (runtime.startupStalled) {
-        // 启动期就绪握手超时的暂扣(见 Runtime.startupStalled):开工输入一个字符都没投递过,
-        // stop 计数永远不会涨,落回 running 就是谎报"正在干活"。维持 idle 直到 sendInput 清标志。
-        computed = 'idle'
-      } else {
-        computed = 'running'
+        let reason = deadReason
+        if (runtime.killed) reason = 'killed'
+        else if (runtime.controlState.kind === 'waiting_action') reason = 'crashed'
+        await this.transitionExited(runtime, h, reason)
+      } else if (stopCount > runtime.stopBaseline && runtime.controlState.kind !== 'waiting_text') {
+        runtime.stopBaseline = stopCount
+        await this.transitionControlState(runtime, h, { kind: 'waiting_text' })
       }
-
-      if (computed !== runtime.state) {
-        if (computed === 'exited') {
-          // 暂扣态置位 ⇒ 开工输入一个字符都没投递过(sendInput 成功才清标志),缺省的
-          // "非 kill ⇒ completed"推断在这里明确不可能成立。见本方法注释里的优先级说明。
-          const reason: IncarnationEndReason = runtime.killed ? 'killed' : runtime.startupStalled ? 'crashed' : deadReason
-          await this.transitionExited(runtime, h, reason)
-        } else {
-          await this.transitionState(runtime, h, computed)
-        }
-      }
-
-      return { state: runtime.state, stopCount }
+      return { state: contractState(runtime.controlState), stopCount }
     })
   }
 
@@ -959,54 +930,8 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
     return mutex
   }
 
-  /**
-   * 四轮 review 修复:重启后新建的 adapter 实例 `runtimes` 必为空,以前 sendInput/kill/
-   * resume/fork/readTrace 在这种情况下清一色直接抛通用 Error("no such incarnation ...
-   * resident in this process")——这个错误不是 WorkerExitedError,harness 只对
-   * WorkerExitedError 转透明接续,通用 Error 会原样穿透砸给调用方,消息永久卡在队首、
-   * kill 抛错用户无法终止、switchWorkerImpl 半成品重复追加 HANDOFF.md(§13"tmux worker
-   * 独立存活 → 重启后 harness 重连接管"在操作层的失效;Task 10 只修了 state() 自己的探活
-   * 分支,这次把同一探活逻辑收拢成所有操作共用的单一重建入口)。
-   *
-   * runtimes 命中直接返回。未命中时读 meta-<seq>.json——**meta 完全不存在**(从未 spawn
-   * 过,或目录已被清理)是唯一返回 undefined 的情形,调用方据此判断"真·未知化身"。
-   *
-   * 关键设计取舍:tmux 会话是否还活着**不**作为"能不能重建"的门槛,只影响重建出的
-   * `runtime.state` 取值('exited'/'running')。原因:resume()/fork() 的合法调用目标本来
-   * 就是一个已终态的化身——它自己的 tmux 会话必然已经不在了;若"会话不存在"直接返回
-   * undefined,重启后 resume 永远无法工作,正好背离本轮修复的目的。改为让重建出的
-   * runtime.state 如实反映一次真实 tmux isAlive 探测的结果(不采信 meta 里可能陈旧的
-   * state 字段),后续操作各自基于这个准确的 state 得到正确行为:
-   *   - sendInput:见该方法注释,`runtime.state==='exited'` 时既有的 syncState 快路径
-   *     自然产出 WorkerExitedError,等价于"ensureRuntime 直接返回 undefined ⇒ 抛
-   *     WorkerExitedError"这一表面语义(仅当 meta 也不存在时才真的走这条兜底分支)。
-   *   - kill:既有的 exited 幂等分支(不重复 kill、不覆盖 ended_reason)天然覆盖"会话
-   *     已经不在了"的情形,不需要在 kill() 里另外判断。
-   *   - resume/fork:重建成功即可拿到 dir/workspaceRoot 继续走下去,不受 tmux 死活影响。
-   *
-   * workspace_root 是本轮修复新增进 meta 的持久化项(spawn/resume/fork/transitionState/
-   * transitionExited 统一写入)。老化身(升级前写的 meta)缺这个字段时按已知限制降级——
-   * workspaceRoot 退化为空串,eventChannel 指向一个不存在的占位路径(CliEventChannel.readAll
-   * 对不存在的文件返回空数组,不抛错,只是探测不到新 stop 事件,不影响 exited 判定,因为
-   * 那条判定只依赖 tmux isAlive,不依赖事件文件)。resume()/fork()/readTrace() 在真正需要
-   * workspaceRoot 时(tmux newSession 的 cwd、execFile 的 cwd、trace 文件路径)显式拒绝并
-   * 给出可诊断错误,不把空串悄悄传下去。
-   *
-   * stopBaseline 重建时刻起算新基线(当前已存在的 stop 事件数):不知道历史 baseline,把
-   * "此刻已经存在的 stop 事件"当作已核销,避免重启前遗留的 stop 事件被误判成本轮新完成
-   * (与 spawn()/sendInput() 推进 baseline 的动机一致)——代价是重建后首次 syncState 之前
-   * 无法准确复原"当时到底是 running 还是 idle"这个精细区分(只影响 idle 报告精度,不影响
-   * exited 判定的正确性,是可接受的已知限制)。
-   *
-   * **重建整体在 per-worker 互斥锁内完成**(锁内再查一次 map):重启后同一化身被并发首次
-   * 触达(如启动对账的 state() 与 recovery 触发的 sendInput() 同时到达)是常态,而
-   * "runtimes.get 未命中"到"runtimes.set"之间隔着 readMetaFile / isAlive / readAll 三个
-   * await。不加锁时两次调用各自重建一个 Runtime、各装一个 watcher,后 set 的胜出;败者却被
-   * 自己 watcher 的闭包持有——transitionExited 只摘胜者的,败者的 fs.watch + 2s 轮询到进程
-   * 退出为止一直活着,每个 stop 事件两边各迁移一次,harness 收到两次 onStateChange、manager
-   * 被重复唤醒,持续整个进程生命周期。锁内重查让后来者直接复用前一次的成果,不产出第二个
-   * runtime,也就没有第二个 watcher 可泄漏。
-   */
+  /** Rebuild a CLI runtime from meta plus the deterministic tmux name. The per-worker lock and
+   * lock-local map recheck prevent duplicate runtimes/watchers during concurrent first access. */
   private async ensureRuntime(ref: { worker_id: string; seq: number; session_ref?: string }): Promise<Runtime | undefined> {
     const key = instanceKey(ref)
     const existing = this.runtimes.get(key)
@@ -1023,11 +948,6 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
 
       const sessionName = `crabot-w-${ref.worker_id}-${ref.seq}`
       const alive = await this.tmux.isAlive(sessionName)
-      // 启动期就绪握手超时的暂扣态是上面那条"重建后无法复原 running/idle 精细区分"的**唯一
-      // 例外**:它有独立落盘的确证(startup_stalled),且判错的代价不是精度损失而是语义错误
-      // ——一个开工输入一个字符都没投递过的 worker 在台账上显示"正在干活",manager 从此不
-      // 再过问。见 Runtime.startupStalled。
-      const stalled = alive && meta.startup_stalled === true
       const workspaceRoot = meta.workspace_root ?? ''
       const sessionId = meta.session_id ?? ref.session_ref ?? ''
       const outputFile = join(dir, `output-${ref.seq}.log`)
@@ -1049,11 +969,10 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
         sessionId,
         outputLog: new OutputLog(outputFile),
         eventChannel,
-        state: alive ? (stalled ? 'idle' : 'running') : 'exited',
+        controlState: controlFromMeta(meta, alive),
         ended_reason: alive ? undefined : meta.ended_reason,
         stopBaseline,
         killed: false,
-        startupStalled: stalled,
       }
       this.runtimes.set(key, runtime)
       // 重启后重连接管(§13):会话还活着的化身在这里重新装上文件监视,它之后每一轮 hook
@@ -1069,7 +988,7 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
     dir: string,
     seq: number,
   ): Promise<
-    { session_id?: string; workspace_root?: string; ended_reason?: IncarnationEndReason; startup_stalled?: boolean } | undefined
+    { session_id?: string; workspace_root?: string; ended_reason?: IncarnationEndReason; state?: WorkerContractState; wait_mode?: 'text' | 'action'; wait_reason?: string; startup_stalled?: boolean } | undefined
   > {
     try {
       const raw = await fs.readFile(join(dir, `meta-${seq}.json`), 'utf-8')
@@ -1115,76 +1034,57 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
    * 发言"——仍然无解,而那正是 `lastText` 的语义。所以 cc/codex 的唤醒事件只带状态,manager
    * 需要正文时走 `read_worker_output`——那条路本来就通,行为与本次改动之前逐字一致。
    *
-   * 唯一的例外是 `report.outputTail`(见 reportStartupStall):启动期就绪握手超时时,manager
+   * 唯一的例外是 `report.outputTail`(见 initialStartupStall):启动期就绪握手超时时,manager
    * 手上没有任何别的线索能判断"卡在哪",而这是**每个化身至多付一次**的一次性成本,与上面
    * "每轮都付一遍"的量纲完全不同。
    */
-  private async transitionState(
+  private async transitionControlState(
     runtime: Runtime,
     h: IncarnationHandle,
-    state: WorkerContractState,
+    state: CliControlState,
     report?: StateChangeReport,
+    notify = true,
   ): Promise<void> {
+    const external = contractState(state)
+    const changed = runtime.controlState.kind !== state.kind ||
+      (runtime.controlState.kind === 'waiting_action' && state.kind === 'waiting_action' && runtime.controlState.reason !== state.reason)
     await writeMetaAtomic(runtime.dir, runtime.seq, {
       seq: runtime.seq,
-      state,
+      state: external,
       session_id: runtime.sessionId,
       workspace_root: runtime.workspaceRoot,
-      // 暂扣态跟着落盘:重启后 ensureRuntime 靠它把 idle 复原回来(见 Runtime.startupStalled)。
-      // 只在置位时写,不置位就不出现在 meta 里——老 meta 缺这个字段等价于"没暂扣"。
-      ...(runtime.startupStalled ? { startup_stalled: true } : {}),
+      ...(state.kind === 'waiting_text' ? { wait_mode: 'text' as const } : {}),
+      ...(state.kind === 'waiting_action' ? { wait_mode: 'action' as const, wait_reason: state.reason } : {}),
     })
-    runtime.state = state
+    runtime.controlState = state
+    if (!notify || !changed) return
     try {
-      this.deps.onStateChange?.(h, state, report)
+      this.deps.onStateChange?.(h, external, report)
     } catch (err) {
       console.error(`[ClaudeCodeAdapter] onStateChange callback error for ${h.worker_id}#${h.seq}:`, err)
     }
   }
 
-  /**
-   * 就绪握手超时的收场:落 `idle` + 把 output 尾部随唤醒事件交给 manager。**零协议改动**
-   * (protocol-agent-v3 §4.3:"worker 停下且输出尾巴带着问题"本来就是 idle 的一种情况,
-   * 判断语义与决策的责任在 manager 侧;§5.5 又明确授予它 `raw` 敲键的能力)。
-   *
-   * 不走"kill + exited(crashed)":那条路现成(见 kill()),但它把一个还能救的现场直接销毁。
-   * 保留进程交给 manager 决策严格更优,且不额外增加静默风险——化身已经落 idle,manager
-   * 必被唤醒。
-   *
-   * 尾部与 `readOutput` 走同一个解码器:manager 手上只有一个 worker 的一份日志,它没有理由
-   * 在 `read_worker_output` 里拿到可读文本、在唤醒事件里拿到同一份日志的转义序列乱码。解码
-   * 位置也与 `readOutput` 一致地留在 adapter 这一层(builtin 的输出是纯文本,不该被解码)。
-   */
-  private async reportStartupStall(
+  private async initialStartupStall(
     runtime: Runtime,
     h: IncarnationHandle,
     outputFile: string,
-    opts?: { note?: string },
-  ): Promise<void> {
+  ): Promise<InitialInputResult> {
     const tail = decodeTerminalOutput(await readOutputTail(outputFile))
-    // 等待期间进程可能是**自己死了**(启动即失败:二进制缺失、PATH 不对、pane 里的命令立刻
-    // 退出),那不是"停在一个界面上等人",谎报 idle 会让 manager 对着一具尸体发指令。先让既有
-    // 的三源判定跑一遍,它会如实落 exited;只有确实还活着才走下面的暂扣汇报。
-    //
-    // 落 `'crashed'` 而不是 syncState 缺省的 `'completed'`:本函数被调用的前提就是"开工输入
-    // 没落地"——就绪握手超时(一个字符都没投递,completed 不可能)或投递验证失败(prompt 被
-    // 启动期模态框吞掉,任务实际没开始),completed 在这两条路径上都不成立。吃缺省推断会让
-    // 一个从没干过活的 worker 在台账上落成"成功完成"终态(同 #66 修的那类"失败记成成功")。
-    if ((await this.syncState(runtime, h, 'crashed')).state === 'exited') return
-    await this.getMutex(h.worker_id).run(async () => {
-      if (runtime.state === 'exited') return // 判定与提交之间又被并发抢先:终态不可覆盖
-      // 先置标志再迁移:这一次 transitionState 的 meta 写入要带上 startup_stalled,且此后
-      // 任何一次 syncState 都必须维持 idle(见 Runtime.startupStalled)——否则这条 idle
-      // 只是"落了一下",下一次 state() 就把它连同台账一起翻回 running。
-      runtime.startupStalled = true
-      await this.transitionState(runtime, h, 'idle', {
-        outputTail:
-          opts?.note ?? describeStartupStall({ impl: 'claude-code', timeoutMs: this.pasteReadyTimeoutMs, tail }),
-      })
-    })
+    if (!(await this.tmux.isAlive(runtime.sessionName))) {
+      await this.transitionExited(runtime, h, 'crashed', false)
+      return { control_state: 'exited', disposition: 'not_pasted', report: { endReason: 'crashed', outputTail: tail } }
+    }
+    const state: CliControlState = { kind: 'waiting_action', reason: 'startup_stall' }
+    const report: StateChangeReport = {
+      outputTail: describeStartupStall({ impl: 'claude-code', timeoutMs: this.pasteReadyTimeoutMs, tail }),
+      waitReason: 'startup_stall',
+    }
+    await this.transitionControlState(runtime, h, state, report, false)
+    return { control_state: 'waiting_action', disposition: 'not_pasted', report }
   }
 
-  private async transitionExited(runtime: Runtime, h: IncarnationHandle, ended_reason: IncarnationEndReason): Promise<void> {
+  private async transitionExited(runtime: Runtime, h: IncarnationHandle, ended_reason: IncarnationEndReason, notify = true): Promise<void> {
     await writeMetaAtomic(runtime.dir, runtime.seq, {
       seq: runtime.seq,
       state: 'exited',
@@ -1192,11 +1092,12 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
       ended_reason,
       workspace_root: runtime.workspaceRoot,
     })
-    runtime.state = 'exited'
+    runtime.controlState = { kind: 'exited', reason: ended_reason }
     runtime.ended_reason = ended_reason
     // 终态唯一入口:文件监视在这里摘掉(kill / 自然结束 / 崩溃都汇到这里),避免已经死掉
     // 的化身继续持有 fs watcher + 轮询定时器,也避免终态之后还往外推状态回调。
     this.stopEventWatch(runtime)
+    if (!notify) return
     try {
       this.deps.onStateChange?.(h, 'exited', { endReason: ended_reason })
     } catch (err) {
@@ -1222,9 +1123,31 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
    */
   private startEventWatch(runtime: Runtime, h: IncarnationHandle): void {
     if (!runtime.sessionName) return // fork 化身,无 tmux 也无 hook
-    if (runtime.state === 'exited') return
-    if (runtime.stopEventWatch) return // 幂等:同一 runtime 只装一个
-    runtime.stopEventWatch = runtime.eventChannel.watch(() => {
+    if (runtime.controlState.kind === 'exited') return
+    if (runtime.stopEventWatch) return
+    runtime.stopEventWatch = runtime.eventChannel.watch((event) => {
+      if (event.kind === 'notification') {
+        const raw = event.raw as { notification_type?: unknown; message?: unknown; title?: unknown } | null
+        const type = typeof raw?.notification_type === 'string' ? raw.notification_type : undefined
+        if (!type || !['permission_prompt', 'elicitation_dialog', 'agent_needs_input'].includes(type)) return
+        void this.getMutex(h.worker_id).run(async () => {
+          if (runtime.controlState.kind === 'exited') return
+          const snapshot = await this.capture(runtime)
+          if (!hasClaudeInteraction(snapshot.text)) return
+          const message = typeof raw?.message === 'string' ? raw.message : undefined
+          const title = typeof raw?.title === 'string' ? raw.title : undefined
+          const report: StateChangeReport = {
+            outputTail: snapshot.text,
+            waitReason: 'interaction_required',
+            notification: { type, ...(message ? { message } : {}), ...(title ? { title } : {}) },
+          }
+          await this.transitionControlState(runtime, h, { kind: 'waiting_action', reason: 'interaction_required' }, report)
+        }).catch((err) => {
+          console.error(`[ClaudeCodeAdapter] notification pane check failed for ${h.worker_id}#${h.seq}:`, err)
+        })
+        return
+      }
+      if (event.kind !== 'stop') return
       this.syncState(runtime, h).catch((err) => {
         console.error(`[ClaudeCodeAdapter] cli event driven syncState failed for ${h.worker_id}#${h.seq}:`, err)
       })
@@ -1261,44 +1184,6 @@ function workerIdLabelFromWorkspace(ws: Workspace): string {
 /** cc 的 project 目录 slug 规则:cwd 路径里的 `/` 与 `.` 都替换成 `-`(已用真实 ~/.claude/projects/ 核实)。 */
 function projectSlug(cwd: string): string {
   return cwd.replace(/[/.]/g, '-')
-}
-
-/**
- * 投递验证的探针:session jsonl 里是否已出现一条 user 消息(cc 收到输入即落盘,见
- * `verifyPromptDelivered` 的注释)。文件还不存在/半行/JSON 未完成都算"还没到",继续下一轮。
- * 非 ENOENT 的读取错误告警后同样按"还没到"处理(保守:宁可多等一轮,不因诊断噪音误判)。
- */
-async function sessionHasUserMessage(filePath: string): Promise<boolean> {
-  let raw: string
-  try {
-    raw = await fs.readFile(filePath, 'utf-8')
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return false
-    console.warn(`[claude-code-adapter] prompt delivery check: cannot read ${filePath}:`, err)
-    return false
-  }
-  for (const line of raw.split('\n')) {
-    if (line.trim() === '') continue
-    let obj: unknown
-    try {
-      obj = JSON.parse(line)
-    } catch {
-      continue // 写入中途的半行:跳过,下一轮再看
-    }
-    const m = obj as { type?: string; message?: { role?: string } }
-    if (m.type === 'user' && m.message?.role === 'user') return true
-  }
-  return false
-}
-
-/** 轮询 session jsonl 直到出现 user 消息;超时返回 false。见 PROMPT_DELIVERY_TIMEOUT_MS 注释。 */
-async function verifyPromptDelivered(filePath: string, timeoutMs: number): Promise<boolean> {
-  const deadline = Date.now() + timeoutMs
-  for (;;) {
-    if (await sessionHasUserMessage(filePath)) return true
-    if (Date.now() >= deadline) return false
-    await new Promise((r) => setTimeout(r, PROMPT_DELIVERY_POLL_INTERVAL_MS))
-  }
 }
 
 function truncate(text: string, max: number): string {

--- a/crabot-agent/src/workers/claude-code/adapter.ts
+++ b/crabot-agent/src/workers/claude-code/adapter.ts
@@ -95,7 +95,7 @@ import { homedir } from 'os'
 import { execFile } from 'child_process'
 import { promisify } from 'util'
 import { TmuxDriver } from '../tmux/driver.js'
-import { DEFAULT_PASTE_READY_TIMEOUT_MS, describeDeliveryStall, describeStartupStall, readOutputTail, waitForPasteReady } from '../tmux/paste-ready.js'
+import { DEFAULT_PASTE_READY_TIMEOUT_MS, describeStartupStall, readOutputTail, waitForPasteReady } from '../tmux/paste-ready.js'
 import { CliEventChannel, EVENTS_FILE_ENV } from '../cli-events.js'
 import { OutputLog } from '../output-log.js'
 import { decodeTerminalOutput } from '../terminal-output.js'
@@ -493,37 +493,9 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
     // killed,这不是用户发起的 kill),spawn 仍然 reject 把失败如实报给调用方。
     await this.sendTextOrKill(runtime, handle, spec.prompt)
 
-    // 投递验证:就绪握手只证明"paste 会被包裹",不证明"没有启动期模态框"——2026-08-06 生产
-    // 实证 cc 在 \e[?2004h 之后异步弹出 MCP 信任窗,首条 paste 被弹窗消费,worker 静默停在空
-    // composer 直到 30 分钟巡检兜底。这里用结果说话:轮询 cc 的会话记录(session jsonl)直到
-    // 出现这条 user 消息。验证失败 → 判定被模态框吞掉:Esc 取消残留弹窗、重投一次完整任务、
-    // 再验证;仍失败 → 走与 pasteReady 超时同一收场(reportStartupStall 暂扣),绝不静默留下
-    // running。
-    if (this.promptDeliveryTimeoutMs > 0) {
-      // cc 落盘的 session 记录用 workspace 的 **realpath** slug(provision 段实证:逻辑路径
-      // "实测完全无效",~/.claude.json 的 project key 全是 realpath)——软链分量(/tmp、被软链的
-      // DATA_DIR)会导致验证读错路径、对健康会话假阴性。spawn 时 workspace 已存在,realpath 必成功。
-      const realRoot = await fs.realpath(spec.workspace.root)
-      const sessionFile = join(this.claudeProjectsDir, projectSlug(realRoot), `${sessionId}.jsonl`)
-      if (!(await verifyPromptDelivered(sessionFile, this.promptDeliveryTimeoutMs))) {
-        // 取消残留弹窗必须发真正的 Escape 键(sendKeys),不能 sendText——sendText 走
-        // paste-buffer 粘贴,ESC 只会作为文本字符进 composer,真正作用于弹窗的是粘贴结尾的
-        // Enter,可能激活弹窗默认选项(对 MCP 信任窗等于静默授权信任,与 provision 的
-        // enabledMcpjsonServers 授权边界相抵)。
-        await this.sendKeysOrKill(runtime, handle, ['Escape'])
-        await this.sendTextOrKill(runtime, handle, spec.prompt)
-        if (!(await verifyPromptDelivered(sessionFile, this.promptDeliveryTimeoutMs))) {
-          await this.reportStartupStall(runtime, handle, outputFile, {
-            note: describeDeliveryStall({
-              impl: 'claude-code',
-              timeoutMs: this.promptDeliveryTimeoutMs,
-              tail: decodeTerminalOutput(await readOutputTail(outputFile)),
-            }),
-          })
-          return handle
-        }
-      }
-    }
+    // 就绪握手只保证 bracketed paste；当前版本不再以 Escape+重贴猜测 modal 是否
+    // 吞了文本。重复 paste 会把仍在 composer 的任务文本直接追加，违反 at-most-once。
+    // 后续受控输入事务会以 pane probe/receipt 结算，native JSONL 仅作诊断。
 
     return handle
   }

--- a/crabot-agent/src/workers/claude-code/input-surface.ts
+++ b/crabot-agent/src/workers/claude-code/input-surface.ts
@@ -17,7 +17,7 @@ export function probeClaudeInput(snapshot: PaneSnapshot, mode: InputMode, text?:
   const active = /esc to interrupt/i.test(pane)
   if (enforceMode && (mode === 'steering') !== active) return 'unavailable'
   if (text !== undefined) {
-    if (composerContains(composer, text)) return 'pending'
+    if (composerMatchesExpected(composer, text)) return 'pending'
     return composer.length === 0 ? 'empty' : 'unavailable'
   }
   return composer.length === 0 ? 'empty' : 'pending'
@@ -26,7 +26,7 @@ export function probeClaudeInput(snapshot: PaneSnapshot, mode: InputMode, text?:
 /** A submit is visually accepted only after the pasted text is no longer in the composer. */
 export function acceptedClaudeInput(snapshot: PaneSnapshot, mode: InputMode, text: string): boolean {
   const composer = claudeComposerText(snapshot)
-  if (hasClaudeInteraction(snapshot.text) || (composer !== undefined && composerContains(composer, text))) return false
+  if (hasClaudeInteraction(snapshot.text) || (composer !== undefined && composerMatchesExpected(composer, text))) return false
   // Steering keeps the active marker and normally renders a queued message.
   return mode === 'primary' ? composer === '' || /esc to interrupt/i.test(snapshot.text) : /queued|queue/i.test(snapshot.text)
 }
@@ -54,8 +54,13 @@ function claudeComposerText(snapshot: PaneSnapshot): string | undefined {
   return undefined
 }
 
-function composerContains(composer: string, text: string): boolean {
+function composerMatchesExpected(composer: string, text: string): boolean {
   const normalize = (value: string) => value.replace(/\s+/g, ' ').trim()
+  const current = normalize(composer)
   const expected = normalize(text)
-  return expected.length > 0 && normalize(composer).includes(expected)
+  if (expected.length === 0) return false
+  if (current.includes(expected)) return true
+  if (/\[Pasted text #\d+(?:[^\]]*)\]/i.test(current)) return true
+  if (expected.length < 24) return false
+  return current.includes(expected.slice(0, 24)) || current.includes(expected.slice(-24))
 }

--- a/crabot-agent/src/workers/claude-code/input-surface.ts
+++ b/crabot-agent/src/workers/claude-code/input-surface.ts
@@ -1,0 +1,32 @@
+import type { PaneSnapshot } from '../tmux/driver.js'
+import type { InputMode, InputProbe } from '../tmux/input-commit.js'
+
+/**
+ * Claude Code viewport recognizer for one guarded input transaction.
+ * It deliberately answers only whether the expected input surface is safe; it
+ * does not infer turn completion from a composer being visible.
+ */
+export function probeClaudeInput(snapshot: PaneSnapshot, mode: InputMode, text?: string): InputProbe {
+  const pane = snapshot.text
+  if (hasClaudeInteraction(pane) || !hasClaudeComposer(pane)) return 'unavailable'
+  const active = /esc to interrupt/i.test(pane)
+  if ((mode === 'steering') !== active) return 'unavailable'
+  if (text !== undefined && pane.includes(text)) return 'pending'
+  return 'empty'
+}
+
+/** A submit is visually accepted only after the pasted text is no longer in the composer. */
+export function acceptedClaudeInput(snapshot: PaneSnapshot, mode: InputMode, text: string): boolean {
+  if (hasClaudeInteraction(snapshot.text) || snapshot.text.includes(text)) return false
+  // Steering keeps the active marker and normally renders a queued message.
+  return mode === 'primary' ? hasClaudeComposer(snapshot.text) || /esc to interrupt/i.test(snapshot.text) : /queued|queue/i.test(snapshot.text)
+}
+
+/** Notification must be corroborated by a current interaction surface. */
+export function hasClaudeInteraction(pane: string): boolean {
+  return /(?:AskUserQuestion|Claude needs your permission|permission required|\b(?:yes|no),?\s*(?:I accept|exit)\b|select an option|use arrow keys)/i.test(pane)
+}
+
+function hasClaudeComposer(pane: string): boolean {
+  return /(?:^|\n)\s*❯(?:\s|$)/m.test(pane)
+}

--- a/crabot-agent/src/workers/claude-code/input-surface.ts
+++ b/crabot-agent/src/workers/claude-code/input-surface.ts
@@ -33,7 +33,17 @@ export function acceptedClaudeInput(snapshot: PaneSnapshot, mode: InputMode, tex
 
 /** Notification must be corroborated by a current interaction surface. */
 export function hasClaudeInteraction(pane: string): boolean {
-  return /(?:AskUserQuestion|Claude needs your permission|permission required|\b(?:yes|no),?\s*(?:I accept|exit)\b|select an option|use arrow keys)/i.test(pane)
+  // A footer-anchored ordinary composer means a previously rendered selector in
+  // the transcript is no longer the active surface.
+  if (claudeComposerText({ text: pane }) !== undefined) return false
+  const tailLines = pane.split('\n').slice(-16)
+  const tail = tailLines.join('\n')
+  const hasOption = tailLines.some((line) => /^\s*(?:❯|[○◉☐☑]|\d+[.)])\s+\S/.test(line))
+  const hasYes = /(?:^|\n)\s*(?:❯\s*)?(?:\d+[.)]\s*)?Yes\b/i.test(tail)
+  const hasNo = /(?:^|\n)\s*(?:❯\s*)?(?:\d+[.)]\s*)?No\b/i.test(tail)
+  const permissionPrompt = /(?:Claude needs your permission|permission required|Do you want to proceed)/i.test(tail)
+  const selectionFooter = /(?:Enter to (?:select|confirm)|(?:↑|↓|up|down).*to navigate|use arrow keys to navigate)/i.test(tail)
+  return (permissionPrompt && hasYes && hasNo) || (selectionFooter && hasOption)
 }
 
 function claudeComposerText(snapshot: PaneSnapshot): string | undefined {

--- a/crabot-agent/src/workers/claude-code/input-surface.ts
+++ b/crabot-agent/src/workers/claude-code/input-surface.ts
@@ -1,25 +1,34 @@
 import type { PaneSnapshot } from '../tmux/driver.js'
 import type { InputMode, InputProbe } from '../tmux/input-commit.js'
 
+const CLAUDE_FOOTER = /^\s*(?:esc to interrupt|⏵⏵|(?:\?\s*)?for shortcuts|context left|bypass permissions|.*shift\+tab)/i
+const CLAUDE_COMPOSER_BOUNDARY = /^\s*(?:[─━-]{3,}|esc to interrupt|⏵⏵|(?:\?\s*)?for shortcuts|context left|bypass permissions)/i
+
 /**
  * Claude Code viewport recognizer for one guarded input transaction.
  * It deliberately answers only whether the expected input surface is safe; it
  * does not infer turn completion from a composer being visible.
  */
-export function probeClaudeInput(snapshot: PaneSnapshot, mode: InputMode, text?: string): InputProbe {
+export function probeClaudeInput(snapshot: PaneSnapshot, mode: InputMode, text?: string, enforceMode = true): InputProbe {
   const pane = snapshot.text
-  if (hasClaudeInteraction(pane) || !hasClaudeComposer(pane)) return 'unavailable'
+  if (hasClaudeInteraction(pane)) return 'unavailable'
+  const composer = claudeComposerText(snapshot)
+  if (composer === undefined) return 'unavailable'
   const active = /esc to interrupt/i.test(pane)
-  if ((mode === 'steering') !== active) return 'unavailable'
-  if (text !== undefined && pane.includes(text)) return 'pending'
-  return 'empty'
+  if (enforceMode && (mode === 'steering') !== active) return 'unavailable'
+  if (text !== undefined) {
+    if (composerContains(composer, text)) return 'pending'
+    return composer.length === 0 ? 'empty' : 'unavailable'
+  }
+  return composer.length === 0 ? 'empty' : 'pending'
 }
 
 /** A submit is visually accepted only after the pasted text is no longer in the composer. */
 export function acceptedClaudeInput(snapshot: PaneSnapshot, mode: InputMode, text: string): boolean {
-  if (hasClaudeInteraction(snapshot.text) || snapshot.text.includes(text)) return false
+  const composer = claudeComposerText(snapshot)
+  if (hasClaudeInteraction(snapshot.text) || (composer !== undefined && composerContains(composer, text))) return false
   // Steering keeps the active marker and normally renders a queued message.
-  return mode === 'primary' ? hasClaudeComposer(snapshot.text) || /esc to interrupt/i.test(snapshot.text) : /queued|queue/i.test(snapshot.text)
+  return mode === 'primary' ? composer === '' || /esc to interrupt/i.test(snapshot.text) : /queued|queue/i.test(snapshot.text)
 }
 
 /** Notification must be corroborated by a current interaction surface. */
@@ -27,6 +36,26 @@ export function hasClaudeInteraction(pane: string): boolean {
   return /(?:AskUserQuestion|Claude needs your permission|permission required|\b(?:yes|no),?\s*(?:I accept|exit)\b|select an option|use arrow keys)/i.test(pane)
 }
 
-function hasClaudeComposer(pane: string): boolean {
-  return /(?:^|\n)\s*❯(?:\s|$)/m.test(pane)
+function claudeComposerText(snapshot: PaneSnapshot): string | undefined {
+  const lines = snapshot.text.split('\n')
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const match = lines[i].match(/^\s*❯(?:\s?(.*))?$/)
+    if (!match) continue
+    const anchored = lines.slice(i + 1).some((line) => CLAUDE_FOOTER.test(line))
+    if (!anchored) return undefined
+    const content = [match[1] ?? '']
+    for (let j = i + 1; j < lines.length; j++) {
+      if (CLAUDE_COMPOSER_BOUNDARY.test(lines[j])) break
+      content.push(lines[j])
+    }
+    const value = content.join('\n').trim()
+    return /^Try\s+["“].+["”]$/i.test(value) ? '' : value
+  }
+  return undefined
+}
+
+function composerContains(composer: string, text: string): boolean {
+  const normalize = (value: string) => value.replace(/\s+/g, ' ').trim()
+  const expected = normalize(text)
+  return expected.length > 0 && normalize(composer).includes(expected)
 }

--- a/crabot-agent/src/workers/cli-events.ts
+++ b/crabot-agent/src/workers/cli-events.ts
@@ -64,7 +64,7 @@ export class CliEventChannel {
     const kindJsonEscaped = JSON.stringify(kind).slice(1, -1)
     const format = '{"ts":"%s","kind":"%s","raw":%s}\\n'
     const target = `"\${${EVENTS_FILE_ENV}:-${dqEscape(this.filePath)}}"`
-    const raw = kind === 'notification' ? "raw=$(tr -d '\\r\\n'); if [ -z \"$raw\" ]; then raw=null; fi" : 'raw=null'
+    const raw = "raw=$(tr -d '\\r\\n'); if [ -z \"$raw\" ]; then raw=null; fi"
     return [
       'ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)',
       raw,

--- a/crabot-agent/src/workers/cli-events.ts
+++ b/crabot-agent/src/workers/cli-events.ts
@@ -50,10 +50,9 @@ export class CliEventChannel {
    * 生成供 CLI hook 使用的 shell 片段(POSIX sh,不依赖 node/jq 等非必装工具)。
    * 只用 printf + date -u 拼一行 JSON 并追加到事件文件。
    *
-   * 设计取舍:hook 的 stdin(如 claude code 会喂 JSON payload)在这一版**直接丢弃**,
-   * raw 固定为 null——把 stdin 内容原样塞进 JSON 字符串涉及运行时转义(引号、换行、
-   * 反斜杠等),在纯 POSIX shell 里做这件事风险远大于收益。后续如果需要 payload,
-   * 再升级为读 stdin 并转义写入 raw 字段。
+   * hook 的 stdin 是 CLI 提供的 JSON payload。它只作为 JSON 值写进 raw，绝不执行、
+   * 解释或重编码；去掉 CR/LF 仅用于把格式化 JSON 收束为单行（JSON 字符串里的换行必为
+   * `\\n` 转义，因而不会被改变）。空 stdin 保持 legacy raw:null。
    *
    * 追加目标是 `"${CRABOT_CLI_EVENTS_FILE:-<本 channel 的路径>}"`——运行时可被调用方经
    * env 重定向到私有文件,见 EVENTS_FILE_ENV 注释。
@@ -63,11 +62,13 @@ export class CliEventChannel {
     // 再整体当作单个 shell 单引号字面量传给 printf 的 %s——避免 kind 内容
     // 里出现 % 之类字符被 printf 误当格式指令解析。
     const kindJsonEscaped = JSON.stringify(kind).slice(1, -1)
-    const format = '{"ts":"%s","kind":"%s","raw":null}\\n'
+    const format = '{"ts":"%s","kind":"%s","raw":%s}\\n'
     const target = `"\${${EVENTS_FILE_ENV}:-${dqEscape(this.filePath)}}"`
+    const raw = kind === 'notification' ? "raw=$(tr -d '\\r\\n'); if [ -z \"$raw\" ]; then raw=null; fi" : 'raw=null'
     return [
       'ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)',
-      `printf '${format}' "$ts" ${shQuote(kindJsonEscaped)} >> ${target}`,
+      raw,
+      `printf '${format}' "$ts" ${shQuote(kindJsonEscaped)} "$raw" >> ${target}`,
     ].join('; ')
   }
 

--- a/crabot-agent/src/workers/codex/adapter.ts
+++ b/crabot-agent/src/workers/codex/adapter.ts
@@ -1,158 +1,22 @@
 /**
- * CodexWorkerAdapter — WorkerAdapter 契约的 OpenAI codex CLI 实现。
+ * Codex WorkerAdapter.
  *
- * 2026-07-30 在部署机 m2(codex-cli 0.144.1)上做了一轮真机校准,修正了四处此前只能靠文档/
- * 源码推断的行为:session 发现(优先信 rollout 内容里的权威 session_id,见下方"session 发现"
- * 节)、nvm 部署形态下 tmux 拉起子进程解析不到 codex 自身 node 的陷阱(见 resolveBinDir/
- * buildEnv)、spawn/resume 命令行参数顺序(见"spawn/resume 启动参数"节)、readTrace 的
- * rollout 行结构(见 normalizeRolloutLine)。同日的后续一轮校准修正了上一轮引入的一个回归:
- * 曾误把 `codex exec` 专属的 `--skip-git-repo-check` 当成交互式顶层命令也支持的参数加了
- * 上去,m2 实测顶层 `codex`/`codex resume` 的 Options 全清单里都没有这个 flag,传了会被 clap
- * 拒绝——已改为 provision 时把 workspace 写成 config.toml 里的受信任目录(见"provision"节的
- * trust_level 段)。未被这两轮校准覆盖的细节仍按公开文档/codex 源码(github.com/openai/codex,
- * developers.openai.com/codex 系列页面,已跳转到 learn.chatgpt.com/docs/*)推断实现,标注为
- * `codex-docs:` 的引用点维持原样,后续如有出入以真机行为为准。
+ * Interactive incarnations run in tmux with approval_policy=never, workspace-write sandbox, and
+ * workspace network access. spawn/resume wait for bracketed-paste readiness and submit opening
+ * input through the guarded `empty -> one paste -> pending -> Enter` transaction (one Enter retry,
+ * never a second paste). `initial_input` on the returned handle gives the harness explicit state
+ * and text ownership for accepted, not_pasted, and pending_in_ui outcomes.
  *
- * ## 与 cc adapter 的关键差异(决定了本文件的整体形状)
+ * Runtime truth is one `CliControlState`: running, waiting_text, waiting_action, or exited.
+ * agent-turn-complete notify events move running to waiting_text. Composer/footer rendering is
+ * used only for primary/steering input safety and queued-message acceptance, not for liveness or
+ * turn completion. raw sends only requested keys and re-probes before changing state.
  *
- * 1. **没有 `--session-id` 等价参数**:交互态 `codex` 不接受预先指定 session id
- *    (codex-docs: openai/codex#3817"No way to resume in non-interactive mode when session
- *    id is not outputted"、openai/codex Discussion #3827"session_id 是会话开始时自动生成,
- *    无法手动指定/覆盖")。session id 由 codex 自己生成,只能靠事后发现——本 adapter 轮询
- *    `<CODEX_HOME>/sessions/**\/rollout-*.jsonl` 文件名里内嵌的 uuid(见下方"session 发现"节)。
- * 2. **notify 不能走"项目级配置自动发现"**:codex 会从 cwd 向上找 `.codex/config.toml`
- *    作为项目级覆盖层叠加到 `~/.codex/config.toml` 之上,但项目级覆盖明确排除了一批"跑在
- *    本机、涉及凭据/遥测"的 key,其中就包括 `notify`(codex-docs:
- *    learn.chatgpt.com/docs/config-file/config-basic 的限制清单原文:"Codex ignores the
- *    following keys in project-local .codex/config.toml and prints a startup warning...
- *    notify")。因此本 adapter **不依赖项目级自动发现**,而是把 `<workspace>/.codex/`
- *    整个目录当成这个 worker 专属的 `CODEX_HOME`(spawn/resume 时经 tmux env 传
- *    `CODEX_HOME=<workspace>/.codex`),让 notify 在"顶层用户配置"这一层生效。
- * 3. **没有无头 fork 等价物**:cc 的 fork 靠 `-p ... --resume ... --fork-session
- *    --output-format text` 一条命令跑完侧问退出;codex 的 `exec` 子命令没有这个能力
- *    (codex-docs: openai/codex#11750、#17568 两个 open 的 feature request,标题分别是
- *    "Add `codex exec fork` subcommand for headless/non-interactive fork"、"exec: add fork
- *    subcommand for non-interactive session forking";#11750 描述目前唯一的变通方案是拉起
- *    交互式 TUI 塞进伪终端、轮询文件系统等新 rollout 文件出现、杀掉 TUI、再用
- *    `codex exec resume` 接力——这已经不是"无头一击",是要在 fork() 内部重新实现一遍
- *    tmux 交互流程)。因此 `capabilities().fork` 如实定为 `false`,`fork()` 直接抛
- *    `CapabilityNotSupportedError`。
- *
- * ## 启动期就绪握手(spawn 专用,排在 session 发现之前)
- *
- * tmux newSession 之后**先等 pane 输出里出现 `\e[?2004h`**(TUI 已开启 bracketed paste),
- * 才谈 session 发现与投递开工输入;等不到就**不投递**,落 idle 并把 output 尾部随唤醒事件
- * 交给 manager 决策(见 spawn 内的握手段、reportStartupStall,机制细节见 tmux/paste-ready.ts)。
- * 这一段与 cc adapter 完全对称——两边发 prompt 走的是同一个 `TmuxDriver.sendText`,
- * `paste-buffer -p` 的前提(目标程序已请求 bracketed paste)此前两边都没有任何代码保障。
- *
- * ## session 发现(spawn 专用)
- *
- * codex 走的是交互式 TUI(本 adapter 用 tmux 拉起 `codex ...`,不是 `codex exec`),拿不到
- * `codex exec --json` 的 `thread.started` 事件流,只能靠事后发现——codex-docs: rollout 文件
- * 路径 `<CODEX_HOME>/sessions/YYYY/MM/DD/rollout-YYYY-MM-DDThh-mm-ss-<uuid>.jsonl`(来自
- * codex-rs/rollout/src/list.rs 注释)。spawn() 在 tmux newSession 成功后、注入首条 prompt
- * 之前,有限时间(`sessionDiscoveryTimeoutMs`,默认 3000ms)轮询这个目录树找新出现的
- * rollout 文件;m2 真机实测:文件一旦被发现,优先读它首行 `session_meta.payload.session_id`
- * 作为权威 session_id(比文件名解析更可靠,是 codex 自己声明的值),内容还没写完整(文件刚
- * 创建的竞态、或老版本 codex 不写这个字段)才退回文件名里嵌的 uuid(实测两者完全一致,退回
- * 不算精度损失)。轮询超时(codex 还没来得及落盘,或本次跑的是不写 rollout 文件的 mock)
- * 就退化为本地生成的占位 uuid——这个占位 uuid 不对应任何真实 codex 会话文件,该化身自己的
- * resume()/readTrace() 会因此失效(resume 传给 codex 的 session id 是假的;readTrace 因为
- * `rolloutPath` 是 undefined 直接退化为空数组),是已知限制,真机环境下正常运行基本不会
- * 触发(轮询窗口内文件必现)。
- *
- * ## provision:workspace 级配置
- *
- * `<ws.root>/.codex/config.toml`:notify 段(指向 `CliEventChannel.hookCommand('notification'
- * 概念上等价的 'stop')`,用 `/bin/sh -c` 包一层,因为 codex-docs 确认 notify 是"程序+固定参数
- * 数组,codex 会在末尾追加一个 JSON payload 作为额外参数"——见
- * learn.chatgpt.com/docs/config-file/config-advanced;固定参数脚本本身不读那个额外参数,
- * 效果上只是"turn 结束就打一个标记",与 cc 的 Stop hook 语义等价) + `[projects."<realpath>"]`
- * 段(`trust_level = "trusted"`,把 workspace 声明成受信任目录——codex 源码里交互式 TUI 判断
- * "是否受信目录"的真实机制,取代不存在的 `--skip-git-repo-check` flag,见"spawn/resume 启动
- * 参数"节;path 用 `fs.realpath(ws.root)` 解析符号链接) + mcp_servers 段(复用 Task 3 的
- * `renderCodexMcpToml`)。
- *
- * 这三块是**叠加在宿主 `<codexHomeSource>/config.toml` 之上**的,不是从零写出一份新配置:
- * `.codex/` 在这里被当成独立 `CODEX_HOME`,codex 就完全不会去读用户真正的 `~/.codex/
- * config.toml`,于是 `model_provider` / `[model_providers.*].base_url` 这些"请求发去哪"的
- * 配置会全部丢失,退回 codex 的内置默认端点。生产实证:auth.json 搬过来了、端点没搬,worker
- * 拿着自建镜像的 key 打 api.openai.com,报 401 invalid_api_key。隔离 home 就得整份继承宿主
- * 登录态,不能只搬凭据。宿主配置不存在 → 干净降级;损坏 → 显式抛错(见 `readHostConfig`)。
- * 其中 `[mcp_servers]` 由 crabot 的 caps **整体覆盖**宿主的,不做合并:caps 是这个任务的授权
- * 边界,宿主配置不该有能力把它扩大。
- *
- * TOML 要求根级 key 必须出现在第一个 table 之前(codex-docs: config.md 曾用这条规则解释
- * "notify 放最后不生效"的排查案例)。叠加宿主配置之后,宿主自带 table,靠字符串拼接已经保证
- * 不了这条,所以整份文档交给 `smol-toml` 的 `stringify` 统一排布(它先出根级标量、再出 table)。
- *
- * `<ws.root>/.codex/auth.json`:既然 `.codex/` 在这里被当成独立 `CODEX_HOME`,真实登录态
- * (`codexHomeSource`,默认 `~/.codex`)里的 `auth.json`(codex-docs:
- * learn.chatgpt.com/docs/auth"Codex caches login details locally... at ~/.codex/auth.json"
- * )要搬一份过来,否则这个隔离出来的 CODEX_HOME 过不了鉴权;找不到就跳过(本机/CI 未登录),
- * 不阻塞 provision。
- *
- * `<ws.root>/.codex/skills/<name>/`:codex-docs 确认 skills 支持 `.codex/skills/`(项目级)
- * 或 `~/.codex/skills/`(个人级)两种位置;本方案下 `.codex/` 本身就是 CODEX_HOME,两个
- * 语义重合到同一目录,直接复用 Task 3 的 `materializeSkills`。
- *
- * `<ws.root>/AGENTS.md`:codex-docs 确认 codex 从项目根往下逐级查找 AGENTS.md,与 cc 的
- * CLAUDE.md 一样落在 workspace 根,复用 `renderContextMd`。
- *
- * ## spawn/resume 启动参数
- *
- * codex-docs(learn.chatgpt.com/docs/developer-commands):交互态 `codex` 主命令顶层支持
- * `--ask-for-approval`(`untrusted|on-request|never`)与 `--sandbox`
- * (`read-only|workspace-write|danger-full-access`)。本 adapter 固定传
- * `--ask-for-approval never --sandbox workspace-write`,与 cc 用
- * `--permission-mode bypassPermissions` 同样的自动化意图——不能让审批弹窗卡住 tmux pane。
- * `codex resume <SESSION_ID>` 是独立子命令(不是 `--resume` flag),同一文档页确认。
- *
- * m2 真机实测校准了两点原先靠猜测沿用、未经验证的行为:
- * 1. **主命令级选项必须排在 `resume` 子命令之前**:`codex resume <id> --ask-for-approval
- *    never --sandbox workspace-write`(选项跟在 `resume <id>` 后面)会被 codex 当成 usage
- *    错误、exit=2 拒绝——本 adapter 曾经就是这么拼的(未验证的猜测),已按实测改成
- *    `codex --ask-for-approval never --sandbox workspace-write resume <id>`(选项在前)。
- * 2. **不传 `--skip-git-repo-check`,改用 config.toml 的 `[projects."<path>"] trust_level`**:
- *    上一轮曾给 spawn/resume 加过 `--skip-git-repo-check`,诊断("worker workspace 不是受信
- *    目录,不处理会卡住")是对的,但这个 flag **只注册在 `codex exec` 子解析器上**——m2 实测
- *    `codex --help`/`codex resume --help` 的顶层交互式 Options 全清单里都没有它,传给交互式
- *    `codex`/`codex resume` 会被 clap 当 usage 错误直接拒绝(exit=2),是把 `codex exec` 路径
- *    下的真机结论错误套用到了交互式路径(exec 路径实测,交互态未单独验证)。已改为 provision
- *    时把 workspace 写成 config.toml 里的受信任目录,见"provision"节。
- *
- * **网络放行**:`--sandbox workspace-write` 下 `sandbox_workspace_write.network_access`
- * 默认 false,且沙箱(macOS seatbelt)的拒绝把 loopback 一起挡掉——worker 外网和本机端口
- * 同时不可达(m2 实测 codex-cli 0.146.0:只给 `--sandbox workspace-write` 时
- * `curl example.com` HTTP=000,补上 network_access=true 后 HTTP=200)。所以 spawn/resume
- * 都固定追加 `-c sandbox_workspace_write.network_access=true`(`-c/--config key=value` 是
- * 主命令级全局选项,值按 TOML 解析,同一文档页确认;与 `--sandbox` 同类,resume 时同样必须
- * 排在 `resume` 子命令之前)。**保留写限制**:worker 仍不能往 workspace 之外乱写,只放开网络。
- * 注:builtin worker 的 shell 本来就没有沙箱,单卡 codex 的网络只是把不对称当安全。
- *
- * 另外 PATH 显式经 `buildEnv()`/`resolveBinDir()` 前置了 codexBin 解析出的真实目录(nvm
- * 部署陷阱,见该函数注释):tmux server 是常驻进程,其环境不一定等于当前 agent 进程的环境
- * (m2 上 codex 是 nvm 装的 node 脚本,tmux server 环境不含对应 node 的 bin 目录时,子进程
- * 直接报 `env: node: No such file or directory`)。
- *
- * ## 提交纪律与状态判定
- *
- * 与 cc 完全一致(锁纪律、三源合成状态判定、spawn/resume 首条输入失败按 kill 路径清理落
- * exited(crashed)、session_ref UUID 边界校验 + shQuote):tmux newSession 成功之后才落
- * meta(running)+ 注册 runtime;判定与提交在该 worker 的互斥锁内原子完成。三源合成里的
- * "事件文件新增" 现在对应的是 codex 的 agent-turn-complete 通知(只有这一种事件类型,
- * codex-docs 确认目前 notify 仅支持 agent-turn-complete),复用同一个 'stop' kind 字符串
- * 与 stopBaseline 机制,语义与 cc 的"自上次输入以来新的 Stop 事件"完全对应。启动期就绪握手
- * 超时的暂扣标志(Runtime.startupStalled,落盘 meta.startup_stalled)同样是三源之外的一源,
- * 语义与 cc 逐字一致。
- *
- * ## readTrace
- *
- * 解析 `<CODEX_HOME>/sessions/.../rollout-*.jsonl`,信封结构与五种顶层 type 的字段形状已按
- * m2 真机实测校准(见 normalizeRolloutLine 注释),测试 fixture 按实测字段手写。rolloutPath
- * 经 ensureRuntime 从 meta 的 workspace_root + session_discovery 字段(四轮 review 新增持久化)
- * 重新按 session_id 精确查找重建,不再要求"只能对本进程内常驻 runtime 的化身调用"(同 cc)。
+ * provision writes workspace-local Codex config, skills, MCP, and context files. Session discovery
+ * reads native rollout metadata; a placeholder session can continue visually but cannot be
+ * resumed. Native rollout data is trace/diagnostic evidence and never causes automatic re-paste.
+ * Meta persists external state plus wait_mode/wait_reason and supports runtime reconstruction from
+ * deterministic tmux names after an agent restart. Codex fork remains unsupported.
  */
 import { promises as fs, type Dirent } from 'fs'
 import { join, dirname } from 'path'
@@ -160,21 +24,25 @@ import { randomUUID } from 'crypto'
 import { homedir } from 'os'
 import { execFile } from 'child_process'
 import { promisify } from 'util'
-import { TmuxDriver } from '../tmux/driver.js'
+import { TmuxDriver, type PaneSnapshot } from '../tmux/driver.js'
+import { commitInput, waitForPaneChange, type InputMode } from '../tmux/input-commit.js'
 import { DEFAULT_PASTE_READY_TIMEOUT_MS, describeStartupStall, readOutputTail, waitForPasteReady } from '../tmux/paste-ready.js'
 import { CliEventChannel } from '../cli-events.js'
 import { OutputLog } from '../output-log.js'
 import { decodeTerminalOutput } from '../terminal-output.js'
 import { AsyncMutex } from '../async-mutex.js'
 import { writeMetaAtomic, maxSeqOnDisk, latestModifiedMs } from '../meta-store.js'
-import { WorkerExitedError, CapabilityNotSupportedError } from '../errors.js'
+import { WorkerExitedError, CapabilityNotSupportedError, CliInputStallError } from '../errors.js'
+import { probeCodexInput, acceptedCodexInput } from './input-surface.js'
 import { parse as parseToml, stringify as stringifyToml } from 'smol-toml'
 import { materializeSkills, renderCodexMcpToml, renderContextMd, type ProvisionSources } from '../provision/materialize.js'
 import type {
   AdapterCapabilities,
   CapabilityBundle,
+  CliControlState,
   DetectResult,
   IncarnationEndReason,
+  InitialInputResult,
   StateChangeReport,
   IncarnationHandle,
   IncarnationRef,
@@ -286,30 +154,28 @@ interface Runtime {
   /** 本 worker 专属的隔离 CODEX_HOME(= `<workspaceRoot>/.codex`),spawn/resume 全程不变。 */
   readonly codexHome: string
   readonly sessionName: string
-  readonly sessionId: string
-  /** spawn 时发现的 rollout 文件绝对路径;发现失败(占位 session_id)则为 undefined。 */
-  readonly rolloutPath?: string
+  sessionId: string
+  /** 首投接受后发现的 rollout 文件绝对路径；发现失败时为 undefined。 */
+  rolloutPath?: string
   readonly outputLog: OutputLog
   readonly eventChannel: CliEventChannel
   /** spawn 时 session 发现的结果:'discovered' 表示发现了真实 rollout 文件,'placeholder' 表示超时降级。
    * 内部状态机用,会透传到 meta 文件。 */
-  readonly sessionDiscoveryStatus: 'discovered' | 'placeholder'
-  state: WorkerContractState
+  sessionDiscoveryStatus: 'discovered' | 'placeholder'
+  /** 首个 TUI 进程启动时刻，用于首投接受后的 rollout 发现。 */
+  readonly discoveryStartedAt: number
+  /** Session discovered by a synchronous sendInput; consumed by the harness settlement. */
+  pendingSessionRef?: string
+  controlState: CliControlState
   ended_reason?: IncarnationEndReason
   /** 自上一次 sendInput(或 spawn)以来"已计入"的 turn-complete 通知数;新计数超过它才判定
    * 本轮 idle。语义与 cc 的 stopBaseline 完全对应。 */
   stopBaseline: number
   killed: boolean
-  /**
-   * 启动期就绪握手超时后的**暂扣态**(见 reportStartupStall)。语义、落盘方式与清除时机
-   * 与 cc adapter 的同名字段逐字一致,见那里的注释:三源判定认不出这种 idle(pane 活着、
-   * turn-complete 计数一个没涨,因为开工输入根本没投递过),不补这一源的话
-   * reportStartupStall 刚落的 idle 会被下一次 syncState 翻回 running,台账上一个从没干过
-   * 活的 worker 显示"正在干活"。跟着 meta 落盘(`startup_stalled`)以熬过 agent 重启。
-   */
-  startupStalled?: boolean
   /** CliEventChannel.watch() 的停止函数(协议 §6.2.3 的文件监视)。建立 runtime 时装上、
    * 落终态时摘掉,语义与 cc adapter 的同名字段完全一致。 */
+  /** Set only for the narrow "accepted input then pane exited before return" settlement. */
+  acceptedExitReport?: StateChangeReport
   stopEventWatch?: () => void
   /** 是否已经被 resume 过一次。resume() 锁内检测"对同一 prev 的重复 resume"(先到先得,
    * 后来者报错),对齐 builtin/cc 同款语义(P2 review #2)。 */
@@ -318,6 +184,21 @@ interface Runtime {
 
 function instanceKey(h: { worker_id: string; seq: number }): string {
   return `${h.worker_id}#${h.seq}`
+}
+
+function contractState(state: CliControlState): WorkerContractState {
+  switch (state.kind) {
+    case 'running': return 'running'
+    case 'exited': return 'exited'
+    default: return 'idle'
+  }
+}
+
+function controlFromMeta(meta: { state?: WorkerContractState; wait_mode?: 'text' | 'action'; wait_reason?: string; startup_stalled?: boolean }, alive: boolean): CliControlState {
+  if (!alive || meta.state === 'exited') return { kind: 'exited' }
+  if (meta.startup_stalled || meta.wait_mode === 'action') return { kind: 'waiting_action', reason: meta.wait_reason ?? 'startup_stall' }
+  if (meta.state === 'idle') return { kind: 'waiting_text' }
+  return { kind: 'running' }
 }
 
 const ROLLOUT_FILENAME_RE =
@@ -702,6 +583,102 @@ export class CodexWorkerAdapter implements WorkerAdapter {
     )
   }
 
+  private async capture(runtime: Runtime): Promise<PaneSnapshot> {
+    const snapshot = await this.tmux.capturePane(runtime.sessionName)
+    return { ...snapshot, text: decodeTerminalOutput(snapshot.text) }
+  }
+
+  private async discoverSpawnedSession(
+    runtime: Runtime,
+    h: IncarnationHandle,
+  ): Promise<IncarnationHandle> {
+    const discovered = await pollForNewRollout(join(runtime.codexHome, 'sessions'), runtime.discoveryStartedAt, this.sessionDiscoveryTimeoutMs)
+    runtime.sessionId = discovered?.sessionId ?? randomUUID()
+    runtime.rolloutPath = discovered?.path
+    runtime.sessionDiscoveryStatus = discovered ? 'discovered' : 'placeholder'
+    const discoveredHandle = { ...h, session_ref: runtime.sessionId }
+    if (!discovered) {
+      console.warn(
+        `[codex-adapter] session discovery timed out for ${h.worker_id}, using placeholder uuid; resume/readTrace will degrade`,
+      )
+    }
+    if (runtime.controlState.kind === 'exited') {
+      await this.transitionExited(runtime, discoveredHandle, runtime.controlState.reason ?? runtime.ended_reason ?? 'crashed', false)
+    } else {
+      await this.transitionControlState(runtime, discoveredHandle, runtime.controlState, undefined, false)
+    }
+    return discoveredHandle
+  }
+
+  private async commitGuardedInput(
+    runtime: Runtime,
+    h: IncarnationHandle,
+    text: string,
+    mode: InputMode,
+    notify: boolean,
+    foldStop: boolean,
+  ): Promise<InitialInputResult> {
+    let baseline = ''
+    let pasted = false
+    let result
+    try {
+      baseline = (await this.capture(runtime)).text
+      result = await commitInput(
+        {
+          pasteText: async (value) => {
+            await this.tmux.pasteText(runtime.sessionName, value)
+            pasted = true
+          },
+          sendEnter: () => this.tmux.sendKeys(runtime.sessionName, ['Enter']),
+          capture: () => this.capture(runtime),
+        },
+        (snapshot, phase) => probeCodexInput(snapshot, mode, phase === 'after_paste' ? text : undefined, phase === 'before_paste'),
+        (snapshot) => acceptedCodexInput(snapshot, mode, text, baseline),
+        text,
+      )
+    } catch (err) {
+      if (!(await this.tmux.isAlive(runtime.sessionName))) {
+        const reason: IncarnationEndReason = pasted ? 'completed' : 'crashed'
+        await this.transitionExited(runtime, h, reason, notify)
+        return {
+          control_state: 'exited',
+          disposition: pasted ? 'accepted' : 'not_pasted',
+          report: { endReason: reason },
+        }
+      }
+      throw err
+    }
+
+    if (result.disposition === 'accepted') {
+      if (!(await this.tmux.isAlive(runtime.sessionName))) {
+        await this.transitionExited(runtime, h, 'completed', notify)
+        return { control_state: 'exited', disposition: 'accepted', report: { endReason: 'completed' } }
+      }
+      if (foldStop) {
+        const events = await runtime.eventChannel.readAll()
+        const stopCount = events.filter((event) => event.kind === 'stop').length
+        if (stopCount > runtime.stopBaseline) {
+          runtime.stopBaseline = stopCount
+          await this.transitionControlState(runtime, h, { kind: 'waiting_text' }, undefined, notify)
+          return { control_state: 'waiting_text', disposition: 'accepted' }
+        }
+      }
+      await this.transitionControlState(runtime, h, { kind: 'running' }, undefined, notify)
+      return { control_state: 'running', disposition: 'accepted' }
+    }
+
+    const next: CliControlState =
+      mode === 'steering' && runtime.controlState.kind === 'running'
+        ? { kind: 'running' }
+        : { kind: 'waiting_action', reason: result.disposition === 'not_pasted' ? 'input_surface_unavailable' : 'input_pending' }
+    const report: StateChangeReport = {
+      outputTail: result.snapshot.text || baseline,
+      waitReason: next.kind === 'waiting_action' ? next.reason : result.disposition,
+    }
+    await this.transitionControlState(runtime, h, next, report, notify)
+    return { control_state: next.kind, disposition: result.disposition, report }
+  }
+
   async spawn(spec: SpawnSpec): Promise<IncarnationHandle> {
     const seq = 1
     if (this.runtimes.has(instanceKey({ worker_id: spec.worker_id, seq }))) {
@@ -740,26 +717,17 @@ export class CodexWorkerAdapter implements WorkerAdapter {
       isAlive: () => this.tmux.isAlive(sessionName),
     })
 
-    // session 发现:见文件头注释"session 发现"节。
-    // 未就绪时**不做发现、也不编占位 uuid**:此刻 codex 会话确实没建立,给一个长得像真值的
-    // uuid 只会让 resume/readTrace 拿着假 id 静默失效。session_ref 留空,如实表示"没有会话"
-    // (harness 在 adapter.spawn 返回前本来就用空串占位,空串是这一层既有的"未知"表示)。
-    const discovered = pasteReady
-      ? await pollForNewRollout(join(codexHome, 'sessions'), spawnStartedAt, this.sessionDiscoveryTimeoutMs)
-      : null
-    const sessionId = discovered ? discovered.sessionId : pasteReady ? randomUUID() : ''
-    const sessionDiscoveryStatus = discovered ? 'discovered' : 'placeholder'
+    // Codex 0.146 在首条 prompt 提交前不会创建 rollout。这里先建立空 session_ref 的
+    // runtime，待 guarded initial input 被接受后再发现真实 session；启动期未投递则保持空值。
+    const sessionId = ''
+    const sessionDiscoveryStatus: 'discovered' | 'placeholder' = 'placeholder'
     if (!pasteReady) {
       console.warn(
         `[codex-adapter] startup readiness handshake timed out for ${spec.worker_id}; opening input NOT delivered, session_ref left empty`,
       )
-    } else if (sessionDiscoveryStatus === 'placeholder') {
-      console.warn(
-        `[codex-adapter] session discovery timed out for ${spec.worker_id}, using placeholder uuid; resume/readTrace will degrade`,
-      )
     }
 
-    const handle: IncarnationHandle = { worker_id: spec.worker_id, seq, impl: 'codex', session_ref: sessionId }
+    let handle: IncarnationHandle = { worker_id: spec.worker_id, seq, impl: 'codex', session_ref: sessionId }
 
     const eventChannel = new CliEventChannel(eventsFilePath(spec.workspace))
     const runtime: Runtime = {
@@ -770,11 +738,12 @@ export class CodexWorkerAdapter implements WorkerAdapter {
       codexHome,
       sessionName,
       sessionId,
-      rolloutPath: discovered?.path,
+      rolloutPath: undefined,
       outputLog: new OutputLog(outputFile),
       eventChannel,
       sessionDiscoveryStatus,
-      state: 'running',
+      discoveryStartedAt: spawnStartedAt,
+      controlState: { kind: 'running' },
       stopBaseline: await this.initialStopBaseline(eventChannel),
       killed: false,
     }
@@ -787,30 +756,40 @@ export class CodexWorkerAdapter implements WorkerAdapter {
       workspace_root: spec.workspace.root,
     })
     this.runtimes.set(instanceKey(handle), runtime)
-    this.startEventWatch(runtime, handle)
 
     // 等不到就绪就**不投递**(协议 §5.5 的"不安全态暂扣"):prompt 原封不动留在 spec 里没被
     // 消耗,manager 处理掉障碍后经 send_to_worker 重新投递即可。这里绝不能退化成"超时了也
     // 照发"——那正是 pollForNewRollout 现在的写法,也正是本次要根治的行为。
     if (!pasteReady) {
-      await this.reportStartupStall(runtime, handle, outputFile)
-      return handle
+      const initial_input = await this.initialStartupStall(runtime, handle, outputFile)
+      this.startEventWatch(runtime, handle)
+      return { ...handle, initial_input }
     }
 
-    // 首条任务输入注入失败:不能放任 running——按 kill 路径清理 tmux 会话后落
-    // exited(crashed)(不是 killed,不是用户发起的 kill),spawn 仍然 reject。
+    let initial_input: InitialInputResult
     try {
-      await this.tmux.sendText(sessionName, spec.prompt)
+      initial_input = await this.commitGuardedInput(runtime, handle, spec.prompt, 'primary', false, true)
     } catch (err) {
       await this.getMutex(handle.worker_id).run(async () => {
-        if (runtime.state === 'exited') return
+        if (runtime.controlState.kind === 'exited') return
         await this.tmux.killSession(sessionName)
         await this.transitionExited(runtime, handle, 'crashed')
       })
       throw err
     }
-
-    return handle
+    if (initial_input.disposition === 'accepted') {
+      handle = await this.discoverSpawnedSession(runtime, handle)
+      await this.syncState(runtime, handle, 'completed', false)
+      initial_input = {
+        ...initial_input,
+        control_state: runtime.controlState.kind,
+        ...(runtime.controlState.kind === 'exited'
+          ? { report: { ...initial_input.report, endReason: runtime.controlState.reason } }
+          : {}),
+      }
+    }
+    this.startEventWatch(runtime, handle)
+    return { ...handle, initial_input }
   }
 
   async resume(prev: IncarnationRef, wakeInput: string): Promise<IncarnationHandle> {
@@ -837,6 +816,10 @@ export class CodexWorkerAdapter implements WorkerAdapter {
       )
     }
 
+    if (prevRuntime.sessionDiscoveryStatus !== 'discovered' || !prevRuntime.rolloutPath) {
+      throw new Error(`CodexWorkerAdapter.resume: incarnation ${prev.worker_id}#${prev.seq} has no discovered rollout and cannot be resumed`)
+    }
+
     const dir = prevRuntime.dir
 
     // 重复 resume 检测(先到先得)+ seq 分配(nextSeq(),该 worker 现存所有化身 max seq + 1)+
@@ -847,6 +830,7 @@ export class CodexWorkerAdapter implements WorkerAdapter {
     // 在 writeMeta 成功之后才提交,保证失败路径(newSession 抛错)幂等可重试。
     let handle!: IncarnationHandle
     let runtime!: Runtime
+    let outputFile!: string
     await this.getMutex(prev.worker_id).run(async () => {
       if (prevRuntime.resumed) {
         throw new Error(`CodexWorkerAdapter.resume: incarnation ${prev.worker_id}#${prev.seq} already resumed (concurrent resume of the same prev incarnation?)`)
@@ -854,7 +838,7 @@ export class CodexWorkerAdapter implements WorkerAdapter {
       const seq = await this.nextSeq(prev.worker_id)
       handle = { worker_id: prev.worker_id, seq, impl: 'codex', session_ref: prev.session_ref }
       const sessionName = `crabot-w-${prev.worker_id}-${seq}`
-      const outputFile = join(dir, `output-${seq}.log`)
+      outputFile = join(dir, `output-${seq}.log`)
       // codex-docs: `codex resume <SESSION_ID>` 是独立子命令(不是 --resume flag)。
       // m2 实测:--ask-for-approval/--sandbox 这类主命令级选项必须排在 `resume` 子命令**之前**
       // ——放在 `resume <id>` 后面 codex 会报 usage 错、exit=2(原实现把它们放在 `resume <id>`
@@ -882,7 +866,8 @@ export class CodexWorkerAdapter implements WorkerAdapter {
         outputLog: new OutputLog(outputFile),
         eventChannel,
         sessionDiscoveryStatus: prevRuntime.sessionDiscoveryStatus,
-        state: 'running',
+        discoveryStartedAt: Date.now(),
+        controlState: { kind: 'running' },
         // 复用上一化身的 workspace ⇒ 事件文件里已有它留下的通知,基线必须现读现算(见
         // initialStopBaseline 注释)。
         stopBaseline: await this.initialStopBaseline(eventChannel),
@@ -897,24 +882,32 @@ export class CodexWorkerAdapter implements WorkerAdapter {
         workspace_root: prevRuntime.workspaceRoot,
       })
       this.runtimes.set(instanceKey(handle), runtime)
-      this.startEventWatch(runtime, handle)
       prevRuntime.resumed = true
     })
 
-    // 首条 wakeInput 注入失败:按 spawn 同款纪律处理——已注册的化身清理 tmux 会话后落
-    // exited(crashed),resume 仍然 reject。
+    const pasteReady = await waitForPasteReady(outputFile, {
+      timeoutMs: this.pasteReadyTimeoutMs,
+      isAlive: () => this.tmux.isAlive(runtime.sessionName),
+    })
+    if (!pasteReady) {
+      const initial_input = await this.initialStartupStall(runtime, handle, outputFile)
+      this.startEventWatch(runtime, handle)
+      return { ...handle, initial_input }
+    }
+
+    let initial_input: InitialInputResult
     try {
-      await this.tmux.sendText(runtime.sessionName, wakeInput)
+      initial_input = await this.commitGuardedInput(runtime, handle, wakeInput, 'primary', false, true)
     } catch (err) {
       await this.getMutex(handle.worker_id).run(async () => {
-        if (runtime.state === 'exited') return
+        if (runtime.controlState.kind === 'exited') return
         await this.tmux.killSession(runtime.sessionName)
         await this.transitionExited(runtime, handle, 'crashed')
       })
       throw err
     }
-
-    return handle
+    this.startEventWatch(runtime, handle)
+    return { ...handle, initial_input }
   }
 
   async fork(_prev: IncarnationRef, _forkInput: string): Promise<IncarnationHandle> {
@@ -928,35 +921,74 @@ export class CodexWorkerAdapter implements WorkerAdapter {
   }
 
   async sendInput(h: IncarnationHandle, text: string, opts?: { raw?: boolean }): Promise<void> {
-    // 四轮 review 修复(同 cc adapter):重启后新建的 adapter 实例 runtimes 必为空,旧实现
-    // 在这里直接抛通用 Error,harness 只对 WorkerExitedError 转透明接续,通用 Error 会原样
-    // 穿透砸给调用方,消息永久卡在队首。ensureRuntime 拿不到任何落盘记录(真·未知化身)
-    // 时,对调用方而言效果与"已终态"等价,同样抛 WorkerExitedError。
     const runtime = await this.ensureRuntime(h)
     if (!runtime) throw new WorkerExitedError(h.worker_id, h.seq)
-
-    const { state: current, stopCount } = await this.syncState(runtime, h)
-    // 带上 ended_reason:harness 的透明接续要用它给"台账还没追上"的源化身补终态。
-    // 上面 `!runtime` 那条分支给不出原因(重启后连落盘 meta 都读不回来),如实缺省。
+    const { state: current } = await this.syncState(runtime, h)
     if (current === 'exited') throw new WorkerExitedError(h.worker_id, h.seq, runtime.ended_reason)
 
-    // 新一轮开始:把 baseline 推到当前计数,上一轮遗留的 turn-complete 通知不会被误算进新一轮。
-    runtime.stopBaseline = stopCount
+    return this.getMutex(h.worker_id).run(async () => {
+      if (runtime.controlState.kind === 'exited') throw new WorkerExitedError(h.worker_id, h.seq, runtime.ended_reason)
 
-    if (opts?.raw) {
-      const keys = text.split(/\s+/).filter((k) => k.length > 0)
-      await this.tmux.sendKeys(runtime.sessionName, keys)
-    } else {
-      await this.tmux.sendText(runtime.sessionName, text)
-    }
+      if (opts?.raw) {
+        const before = await this.capture(runtime)
+        const keys = text.split(/\s+/).filter((key) => key.length > 0)
+        await this.tmux.sendKeys(runtime.sessionName, keys)
+        const snapshot = await waitForPaneChange(() => this.capture(runtime), before.text)
+        const primaryProbe = probeCodexInput(snapshot, 'primary', undefined, false)
+        if (primaryProbe === 'pending') {
+          const next: CliControlState = runtime.controlState.kind === 'running'
+            ? { kind: 'running' }
+            : { kind: 'waiting_action', reason: 'input_pending' }
+          const report: StateChangeReport = { outputTail: snapshot.text, waitReason: 'input_pending' }
+          await this.transitionControlState(runtime, h, next, report, false)
+          throw new CliInputStallError('pending_in_ui', next.kind, report)
+        }
+        if (primaryProbe === 'empty' && (runtime.controlState.kind === 'running' || /Working\b/i.test(snapshot.text))) {
+          await this.transitionControlState(runtime, h, { kind: 'running' })
+          return
+        }
+        if (primaryProbe === 'empty') {
+          await this.transitionControlState(runtime, h, { kind: 'waiting_text' })
+          return
+        }
+        const reason = runtime.controlState.kind === 'waiting_action'
+          ? runtime.controlState.reason
+          : 'input_surface_unavailable'
+        const report: StateChangeReport = { outputTail: snapshot.text, waitReason: reason }
+        await this.transitionControlState(runtime, h, { kind: 'waiting_action', reason }, report, false)
+        throw new CliInputStallError('not_pasted', 'waiting_action', report)
+      }
 
-    await this.getMutex(h.worker_id).run(async () => {
-      if (runtime.state === 'exited') return
-      // 暂扣解除:manager 已经出手(raw 敲键清界面,或重投 prompt)。与 transitionState 的
-      // meta 写入同一临界区,落盘的 startup_stalled 随之消失(同 cc adapter)。
-      runtime.startupStalled = false
-      await this.transitionState(runtime, h, 'running')
+      if (runtime.controlState.kind === 'waiting_action') {
+        const snapshot = await this.capture(runtime)
+        const report: StateChangeReport = { outputTail: snapshot.text, waitReason: runtime.controlState.reason }
+        throw new CliInputStallError('not_pasted', 'waiting_action', report)
+      }
+      const mode: InputMode = runtime.controlState.kind === 'running' ? 'steering' : 'primary'
+      const result = await this.commitGuardedInput(runtime, h, text, mode, false, false)
+      if (result.disposition !== 'accepted') throw new CliInputStallError(result.disposition, result.control_state, result.report)
+      if (!runtime.sessionId) {
+        const discoveredHandle = await this.discoverSpawnedSession(runtime, h)
+        runtime.pendingSessionRef = discoveredHandle.session_ref
+      }
+      if (result.control_state === 'exited') {
+        runtime.acceptedExitReport = result.report ?? { endReason: runtime.ended_reason ?? 'completed' }
+      }
     })
+  }
+
+  takeUpdatedSessionRef(h: IncarnationHandle): string | undefined {
+    const runtime = this.runtimes.get(instanceKey(h))
+    const value = runtime?.pendingSessionRef
+    if (runtime) runtime.pendingSessionRef = undefined
+    return value
+  }
+
+  takeAcceptedInputExit(h: IncarnationHandle): StateChangeReport | undefined {
+    const runtime = this.runtimes.get(instanceKey(h))
+    const report = runtime?.acceptedExitReport
+    if (runtime) runtime.acceptedExitReport = undefined
+    return report
   }
 
   /**
@@ -1051,15 +1083,12 @@ export class CodexWorkerAdapter implements WorkerAdapter {
   }
 
   async kill(h: IncarnationHandle): Promise<void> {
-    // 四轮 review 修复(同 cc adapter):重启后新建的 adapter 实例对确已终态(或压根没有
-    // 落盘记录)的化身调 kill,以前直接抛通用 Error,harness.killWorker/handoffIncarnation
-    // 没有 try/catch,错误会穿透打断整个操作。ensureRuntime 拿不到任何落盘记录时直接幂等
-    // 返回;拿到时 runtime.state 已经是探活得到的真实值,下面既有的 exited 幂等分支自然
-    // 覆盖"会话已经不在了"的情形。
+    // Meta reconstruction makes kill work after an agent restart; missing meta and already-exited
+    // incarnations are both idempotent no-ops.
     const runtime = await this.ensureRuntime(h)
     if (!runtime) return
     await this.getMutex(h.worker_id).run(async () => {
-      if (runtime.state === 'exited') return // 幂等:不覆盖原 ended_reason
+      if (runtime.controlState.kind === 'exited') return // 幂等:不覆盖原 ended_reason
       runtime.killed = true
       await this.tmux.killSession(runtime.sessionName)
       await this.transitionExited(runtime, h, 'killed')
@@ -1073,64 +1102,31 @@ export class CodexWorkerAdapter implements WorkerAdapter {
   // --- Internal ---
 
   /**
-   * 三源合成状态判定:tmux isAlive(false → exited,终态优先) > 事件文件(会话还活着时,新
-   * turn-complete 通知 → idle) > 默认 running。与内存态不同则在互斥锁内原子迁移(改内存 +
-   * 写 meta)。判定与提交整体在锁内完成,理由与 cc 完全一致(见 cc adapter.ts 文件头注释,
-   * 避免过期快照覆盖并发落定的新结果)。
-   *
-   * `deadReason`:发现会话已经不在了、且不是本进程发起的 kill 时落哪个 ended_reason。缺省
-   * `'completed'` 是协议 §6.3 给"干过活之后自然退出"校准的推断;启动期就绪握手那条路径上
-   * 这个前提不成立(开工输入一个字符都没投递过),由调用方显式传 `'crashed'`,免得"启动即
-   * 死"在台账上落成"成功完成"终态。逐字同 cc adapter,见那里的注释。
-   *
-   * 七轮 review:`deadReason` 只管住"握手等待期间就死了"这一个时点,而暂扣是持续状态——
-   * 标志置位、idle 落盘之后才死的化身,后续任何一次 syncState 仍会吃缺省推断。所以 exited
-   * 分支直接看 `runtime.startupStalled`,置位就落 `'crashed'`;标志落盘,重启后由
-   * ensureRuntime 复原,判定在新进程里同样成立。优先级 `killed > startupStalled > deadReason`,
-   * `sendInput` 成功投递会清标志,"投递过之后才死"不受影响。逐字同 cc adapter。
+   * Reconcile tmux existence and turn-complete events with the resident control state. A
+   * startup/action wait that dies before proven progress is classified crashed; other external
+   * exits retain the protocol's completed inference. Serialized per worker.
    */
   private async syncState(
     runtime: Runtime,
     h: IncarnationHandle,
     deadReason: IncarnationEndReason = 'completed',
+    notify = true,
   ): Promise<{ state: WorkerContractState; stopCount: number }> {
-    if (runtime.state === 'exited') return { state: 'exited', stopCount: runtime.stopBaseline }
-
+    if (runtime.controlState.kind === 'exited') return { state: 'exited', stopCount: runtime.stopBaseline }
     return this.getMutex(h.worker_id).run(async () => {
-      if (runtime.state === 'exited') return { state: 'exited', stopCount: runtime.stopBaseline }
-
+      if (runtime.controlState.kind === 'exited') return { state: 'exited', stopCount: runtime.stopBaseline }
       const events = await runtime.eventChannel.readAll()
-      const stopCount = events.filter((e) => e.kind === 'stop').length
-
-      // isAlive 检查提到最前(终态优先):进程可能在发过 turn-complete 通知之后自退(崩溃/
-      // OOM/自敲 exit)——stopCount 恒 > baseline 会一直判成 idle,永远走不到下面的 isAlive
-      // 分支,化身不落 exited,resume 被永久拒绝(P2 review #2,同 cc adapter 修复)。会话
-      // 已经不在了就直接 exited,不管有没有新通知;只有会话还活着,才轮到通知区分 idle/running。
-      let computed: WorkerContractState
+      const stopCount = events.filter((event) => event.kind === 'stop').length
       if (!(await this.tmux.isAlive(runtime.sessionName))) {
-        computed = 'exited'
-      } else if (stopCount > runtime.stopBaseline) {
-        computed = 'idle'
-      } else if (runtime.startupStalled) {
-        // 启动期就绪握手超时的暂扣(见 Runtime.startupStalled):开工输入一个字符都没投递过,
-        // turn-complete 计数永远不会涨,落回 running 就是谎报"正在干活"。维持 idle 到 sendInput。
-        computed = 'idle'
-      } else {
-        computed = 'running'
+        let reason = deadReason
+        if (runtime.killed) reason = 'killed'
+        else if (runtime.controlState.kind === 'waiting_action') reason = 'crashed'
+        await this.transitionExited(runtime, h, reason, notify)
+      } else if (stopCount > runtime.stopBaseline && runtime.controlState.kind !== 'waiting_text') {
+        runtime.stopBaseline = stopCount
+        await this.transitionControlState(runtime, h, { kind: 'waiting_text' }, undefined, notify)
       }
-
-      if (computed !== runtime.state) {
-        if (computed === 'exited') {
-          // 暂扣态置位 ⇒ 开工输入一个字符都没投递过(sendInput 成功才清标志),缺省的
-          // "非 kill ⇒ completed"推断在这里明确不可能成立。见本方法注释里的优先级说明。
-          const reason: IncarnationEndReason = runtime.killed ? 'killed' : runtime.startupStalled ? 'crashed' : deadReason
-          await this.transitionExited(runtime, h, reason)
-        } else {
-          await this.transitionState(runtime, h, computed)
-        }
-      }
-
-      return { state: runtime.state, stopCount }
+      return { state: contractState(runtime.controlState), stopCount }
     })
   }
 
@@ -1143,23 +1139,8 @@ export class CodexWorkerAdapter implements WorkerAdapter {
     return mutex
   }
 
-  /**
-   * 四轮 review 修复(与 cc adapter 同款设计,见其 ensureRuntime 注释——这里只记 codex
-   * 特有的差异):runtimes 命中直接返回;未命中时读 meta-<seq>.json,meta 完全不存在才
-   * 返回 undefined(真·未知化身)。tmux 会话是否还活着不作为"能不能重建"的门槛,只影响
-   * 重建出的 runtime.state。
-   *
-   * codex 专属字段:codexHome 从 workspace_root 派生(`<workspaceRoot>/.codex`,与
-   * provision/spawn 的约定一致);rolloutPath 不落盘(meta 只落 session_id +
-   * session_discovery),session_discovery==='discovered' 时用
-   * findRolloutFileBySessionId 按已知 session_id 重新在 codexHome/sessions 下精确查找,
-   * 找不到(文件被移走/清理)则退化为 undefined,readTrace 优雅降级为空数组(与 spawn 时
-   * 发现失败的已知限制同一降级路径)。
-   *
-   * 重建整体在 per-worker 互斥锁内完成(锁内再查一次 map),理由与 cc adapter 完全一致:
-   * 不加锁时并发首次触达会各自重建一个 Runtime、各装一个 watcher,败者的 watcher 永不被
-   * 摘除,每个轮次边界重复唤醒 manager 一次。详见 cc adapter 的 ensureRuntime 注释。
-   */
+  /** Rebuild a CLI runtime from meta plus the deterministic tmux name and rollout metadata. The
+   * per-worker lock and lock-local map recheck prevent duplicate runtimes/watchers. */
   private async ensureRuntime(ref: { worker_id: string; seq: number; session_ref?: string }): Promise<Runtime | undefined> {
     const key = instanceKey(ref)
     const existing = this.runtimes.get(key)
@@ -1176,9 +1157,6 @@ export class CodexWorkerAdapter implements WorkerAdapter {
 
       const sessionName = `crabot-w-${ref.worker_id}-${ref.seq}`
       const alive = await this.tmux.isAlive(sessionName)
-      // 启动期就绪握手超时的暂扣态是"重建无法复原 running/idle 精细区分"的唯一例外:它有
-      // 独立落盘的确证,且判错的代价是语义错误而非精度损失(同 cc adapter,见那里的注释)。
-      const stalled = alive && meta.startup_stalled === true
       const workspaceRoot = meta.workspace_root ?? ''
       const sessionId = meta.session_id ?? ref.session_ref ?? ''
       const codexHome = workspaceRoot ? join(workspaceRoot, '.codex') : ''
@@ -1207,11 +1185,11 @@ export class CodexWorkerAdapter implements WorkerAdapter {
         outputLog: new OutputLog(outputFile),
         eventChannel,
         sessionDiscoveryStatus,
-        state: alive ? (stalled ? 'idle' : 'running') : 'exited',
+        discoveryStartedAt: Date.now(),
+        controlState: controlFromMeta(meta, alive),
         ended_reason: alive ? undefined : meta.ended_reason,
         stopBaseline,
         killed: false,
-        startupStalled: stalled,
       }
       this.runtimes.set(key, runtime)
       // 重启后重连接管(§13):会话还活着的化身在这里重新装上文件监视。已终态的化身
@@ -1232,6 +1210,9 @@ export class CodexWorkerAdapter implements WorkerAdapter {
         workspace_root?: string
         ended_reason?: IncarnationEndReason
         session_discovery?: 'discovered' | 'placeholder'
+        state?: WorkerContractState
+        wait_mode?: 'text' | 'action'
+        wait_reason?: string
         startup_stalled?: boolean
       }
     | undefined
@@ -1266,55 +1247,50 @@ export class CodexWorkerAdapter implements WorkerAdapter {
   /** `onStateChange` 的 `report.lastText` 在 codex 这边同样刻意不传,理由与 cc 完全一致
    * (输出是 tmux 落的 TUI 字节流,解码后也切不出"哪一段才算 assistant 发言")——见
    * `workers/claude-code/adapter.ts` 的 transitionState 注释;唯一的例外同样是
-   * `report.outputTail`(启动期就绪握手超时,每个化身至多付一次,见 reportStartupStall)。 */
-  private async transitionState(
+   * `report.outputTail`(启动期就绪握手超时,每个化身至多付一次,见 initialStartupStall)。 */
+  private async transitionControlState(
     runtime: Runtime,
     h: IncarnationHandle,
-    state: WorkerContractState,
+    state: CliControlState,
     report?: StateChangeReport,
+    notify = true,
   ): Promise<void> {
+    const external = contractState(state)
+    const changed = runtime.controlState.kind !== state.kind ||
+      (runtime.controlState.kind === 'waiting_action' && state.kind === 'waiting_action' && runtime.controlState.reason !== state.reason)
     await writeMetaAtomic(runtime.dir, runtime.seq, {
       seq: runtime.seq,
-      state,
+      state: external,
       session_id: runtime.sessionId,
       session_discovery: runtime.sessionDiscoveryStatus,
       workspace_root: runtime.workspaceRoot,
-      // 暂扣态跟着落盘,重启后 ensureRuntime 靠它复原 idle(见 Runtime.startupStalled)。
-      // 只在置位时写;老 meta 缺这个字段等价于"没暂扣"。
-      ...(runtime.startupStalled ? { startup_stalled: true } : {}),
+      ...(state.kind === 'waiting_text' ? { wait_mode: 'text' as const } : {}),
+      ...(state.kind === 'waiting_action' ? { wait_mode: 'action' as const, wait_reason: state.reason } : {}),
     })
-    runtime.state = state
+    runtime.controlState = state
+    if (!notify || !changed) return
     try {
-      this.deps.onStateChange?.(h, state, report)
+      this.deps.onStateChange?.(h, external, report)
     } catch (err) {
       console.error(`[CodexWorkerAdapter] onStateChange callback error for ${h.worker_id}#${h.seq}:`, err)
     }
   }
 
-  /** 就绪握手超时的收场:落 `idle` + 把 output 尾部随唤醒事件交给 manager。语义、取舍与
-   * cc adapter 的同名方法逐字一致(零协议改动、不 kill 现场、尾部与 readOutput 共用同一个
-   * 解码器),见那里的注释。 */
-  private async reportStartupStall(runtime: Runtime, h: IncarnationHandle, outputFile: string): Promise<void> {
+  private async initialStartupStall(runtime: Runtime, h: IncarnationHandle, outputFile: string): Promise<InitialInputResult> {
     const tail = decodeTerminalOutput(await readOutputTail(outputFile))
-    // 等待期间进程可能是**自己死了**(启动即失败:二进制缺失、PATH 不对、pane 里的命令立刻
-    // 退出),那不是"停在一个界面上等人",谎报 idle 会让 manager 对着一具尸体发指令。先让既有
-    // 的三源判定跑一遍,它会如实落 exited;只有确实还活着才走下面的暂扣汇报。
-    //
-    // 落 `'crashed'` 而不是 syncState 缺省的 `'completed'`:此刻会话没了只可能是启动即失败,
-    // 而开工输入一个字符都没投递过,completed 明确不可能成立(同 cc adapter)。
-    if ((await this.syncState(runtime, h, 'crashed')).state === 'exited') return
-    await this.getMutex(h.worker_id).run(async () => {
-      if (runtime.state === 'exited') return // 判定与提交之间又被并发抢先:终态不可覆盖
-      // 先置标志再迁移:这次 meta 写入要带上 startup_stalled,且此后每次 syncState 都必须
-      // 维持 idle,否则这条 idle 只是"落了一下"(同 cc adapter,见 Runtime.startupStalled)。
-      runtime.startupStalled = true
-      await this.transitionState(runtime, h, 'idle', {
-        outputTail: describeStartupStall({ impl: 'codex', timeoutMs: this.pasteReadyTimeoutMs, tail }),
-      })
-    })
+    if (!(await this.tmux.isAlive(runtime.sessionName))) {
+      await this.transitionExited(runtime, h, 'crashed', false)
+      return { control_state: 'exited', disposition: 'not_pasted', report: { endReason: 'crashed', outputTail: tail } }
+    }
+    const report: StateChangeReport = {
+      outputTail: describeStartupStall({ impl: 'codex', timeoutMs: this.pasteReadyTimeoutMs, tail }),
+      waitReason: 'startup_stall',
+    }
+    await this.transitionControlState(runtime, h, { kind: 'waiting_action', reason: 'startup_stall' }, report, false)
+    return { control_state: 'waiting_action', disposition: 'not_pasted', report }
   }
 
-  private async transitionExited(runtime: Runtime, h: IncarnationHandle, ended_reason: IncarnationEndReason): Promise<void> {
+  private async transitionExited(runtime: Runtime, h: IncarnationHandle, ended_reason: IncarnationEndReason, notify = true): Promise<void> {
     await writeMetaAtomic(runtime.dir, runtime.seq, {
       seq: runtime.seq,
       state: 'exited',
@@ -1323,10 +1299,11 @@ export class CodexWorkerAdapter implements WorkerAdapter {
       session_discovery: runtime.sessionDiscoveryStatus,
       workspace_root: runtime.workspaceRoot,
     })
-    runtime.state = 'exited'
+    runtime.controlState = { kind: 'exited', reason: ended_reason }
     runtime.ended_reason = ended_reason
     // 终态唯一入口:文件监视在这里摘掉,同 cc adapter。
     this.stopEventWatch(runtime)
+    if (!notify) return
     try {
       this.deps.onStateChange?.(h, 'exited', { endReason: ended_reason })
     } catch (err) {
@@ -1343,7 +1320,7 @@ export class CodexWorkerAdapter implements WorkerAdapter {
    */
   private startEventWatch(runtime: Runtime, h: IncarnationHandle): void {
     if (!runtime.sessionName) return
-    if (runtime.state === 'exited') return
+    if (runtime.controlState.kind === 'exited') return
     if (runtime.stopEventWatch) return // 幂等:同一 runtime 只装一个
     runtime.stopEventWatch = runtime.eventChannel.watch(() => {
       this.syncState(runtime, h).catch((err) => {

--- a/crabot-agent/src/workers/codex/adapter.ts
+++ b/crabot-agent/src/workers/codex/adapter.ts
@@ -513,11 +513,11 @@ export class CodexWorkerAdapter implements WorkerAdapter {
     // CODEX_HOME(spawn/resume 经 tmux env 传递),绕开这条项目级限制。
     //
     // notify 的程序契约是"数组:可执行文件 + 固定参数",codex 运行时会在末尾追加一个 JSON
-    // payload 作为额外参数(config-advanced 原文确认)。这里用 `/bin/sh -c <script>` 包一层,
-    // 额外参数会落在 shell 的 $0 上,脚本本身不引用位置参数,效果上只是"turn 结束就打一个
-    // 标记"——与 cc 的 Stop hook(丢弃 stdin payload,同一设计取舍,见 CliEventChannel 头
-    // 注释)语义一致。
-    const notify = ['/bin/sh', '-c', channel.hookCommand('stop')]
+    // payload 作为额外参数(config-advanced 原文确认)。这里用 `/bin/sh -c <script>` 包一层;
+    // payload 落在 shell 的 $0 上。Stop 事件只需要 turn 边界标记,不解析这个 argv payload;
+    // Claude Code hook 则由 stdin 接收并记录原始 JSON。Codex notify 的 stdin 必须显式关闭,
+    // 否则 hook 会从 pane pty 读取并与 TUI 争抢输入。
+    const notify = ['/bin/sh', '-c', `(${channel.hookCommand('stop')}) </dev/null`]
 
     // codex 源码里交互式 TUI 判断"是否受信目录"的真实机制是 config.toml 的
     // [projects."<绝对路径>"] 表 + trust_level = "trusted"(取代不存在的 --skip-git-repo-check
@@ -671,9 +671,13 @@ export class CodexWorkerAdapter implements WorkerAdapter {
       mode === 'steering' && runtime.controlState.kind === 'running'
         ? { kind: 'running' }
         : { kind: 'waiting_action', reason: result.disposition === 'not_pasted' ? 'input_surface_unavailable' : 'input_pending' }
+    let waitReason: string
+    if (next.kind === 'waiting_action') waitReason = next.reason
+    else if (result.disposition === 'pending_in_ui') waitReason = 'input_pending'
+    else waitReason = 'input_surface_unavailable'
     const report: StateChangeReport = {
       outputTail: result.snapshot.text || baseline,
-      waitReason: next.kind === 'waiting_action' ? next.reason : result.disposition,
+      waitReason,
     }
     await this.transitionControlState(runtime, h, next, report, notify)
     return { control_state: next.kind, disposition: result.disposition, report }
@@ -1323,7 +1327,8 @@ export class CodexWorkerAdapter implements WorkerAdapter {
     if (runtime.controlState.kind === 'exited') return
     if (runtime.stopEventWatch) return // 幂等:同一 runtime 只装一个
     runtime.stopEventWatch = runtime.eventChannel.watch(() => {
-      this.syncState(runtime, h).catch((err) => {
+      const currentHandle = { ...h, session_ref: runtime.sessionId }
+      this.syncState(runtime, currentHandle).catch((err) => {
         console.error(`[CodexWorkerAdapter] cli event driven syncState failed for ${h.worker_id}#${h.seq}:`, err)
       })
     })

--- a/crabot-agent/src/workers/codex/input-surface.ts
+++ b/crabot-agent/src/workers/codex/input-surface.ts
@@ -23,10 +23,10 @@ export function probeCodexInput(snapshot: PaneSnapshot, mode: InputMode, text?: 
   if (hasCodexInteraction(pane)) return 'unavailable'
   const composer = codexComposerText(snapshot)
   if (composer === undefined) return 'unavailable'
-  const working = /Working\b.*(?:esc to interrupt)?/i.test(pane)
+  const working = codexIsWorking(snapshot)
   if (enforceMode && (mode === 'steering') !== working) return 'unavailable'
   if (text !== undefined) {
-    if (composerContains(composer, text)) return 'pending'
+    if (composerMatchesExpected(composer, text)) return 'pending'
     return composer.length === 0 ? 'empty' : 'unavailable'
   }
   return composer.length === 0 ? 'empty' : 'pending'
@@ -35,18 +35,27 @@ export function probeCodexInput(snapshot: PaneSnapshot, mode: InputMode, text?: 
 /** Codex steering receipt is visual only: a newly rendered queue region. */
 export function acceptedCodexInput(snapshot: PaneSnapshot, mode: InputMode, text: string, baseline: string): boolean {
   const composer = codexComposerText(snapshot)
-  if (hasCodexInteraction(snapshot.text) || (composer !== undefined && composerContains(composer, text))) return false
-  if (mode === 'primary') return composer === '' || /Working\b/i.test(snapshot.text)
+  if (hasCodexInteraction(snapshot.text) || (composer !== undefined && composerMatchesExpected(composer, text))) return false
+  if (mode === 'primary') return composer === '' || codexIsWorking(snapshot)
   return snapshot.text !== baseline && /Messages to be submitted after next tool call|queued message|queued/i.test(snapshot.text)
 }
 
 function hasCodexInteraction(pane: string): boolean {
-  return /(?:approve|deny|permission|required selection|select an option|use arrow keys)/i.test(pane)
+  const tail = pane.split('\n').slice(-14).join('\n')
+  return /(?:Would you like to|Do you want to|Allow Codex to|approval required)[\s\S]{0,600}(?:\bYes\b[\s\S]{0,120}\bNo\b|\bapprove\b[\s/|]+\bdeny\b)/i.test(tail)
+}
+
+function codexIsWorking(snapshot: PaneSnapshot): boolean {
+  const lines = snapshot.text.split('\n')
+  const composerIndex = findLastComposerIndex(lines)
+  if (composerIndex < 0) return false
+  const nearby = lines.slice(Math.max(0, composerIndex - 6), composerIndex + 7)
+  return nearby.some((line) => /^\s*(?:[•·✦]\s*)?Working\b.*esc to interrupt/i.test(line))
 }
 
 function codexComposerText(snapshot: PaneSnapshot): string | undefined {
   const lines = snapshot.text.split('\n')
-  for (let i = lines.length - 1; i >= 0; i--) {
+  for (let i = findLastComposerIndex(lines); i >= 0; i--) {
     const match = lines[i].match(/^\s*›(?:\s?(.*))?$/)
     if (!match) continue
     const anchored = lines.slice(i + 1).some((line) => CODEX_FOOTER.test(line))
@@ -62,12 +71,24 @@ function codexComposerText(snapshot: PaneSnapshot): string | undefined {
   return undefined
 }
 
+function findLastComposerIndex(lines: string[]): number {
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (/^\s*›(?:\s|$)/.test(lines[i])) return i
+  }
+  return -1
+}
+
 function isCodexPlaceholder(value: string): boolean {
   return CODEX_PLACEHOLDERS.some((placeholder) => value.startsWith(placeholder))
 }
 
-function composerContains(composer: string, text: string): boolean {
+function composerMatchesExpected(composer: string, text: string): boolean {
   const normalize = (value: string) => value.replace(/\s+/g, ' ').trim()
+  const current = normalize(composer)
   const expected = normalize(text)
-  return expected.length > 0 && normalize(composer).includes(expected)
+  if (expected.length === 0) return false
+  if (current.includes(expected)) return true
+  if (/\[(?:Pasted text #\d+|Pasted Content)[^\]]*\]/i.test(current)) return true
+  if (expected.length < 24) return false
+  return current.includes(expected.slice(0, 24)) || current.includes(expected.slice(-24))
 }

--- a/crabot-agent/src/workers/codex/input-surface.ts
+++ b/crabot-agent/src/workers/codex/input-surface.ts
@@ -1,20 +1,42 @@
 import type { PaneSnapshot } from '../tmux/driver.js'
 import type { InputMode, InputProbe } from '../tmux/input-commit.js'
 
+const CODEX_FOOTER = /^\s*(?:Working\b|esc to interrupt|(?:\?\s*)?for shortcuts|\d+% context|context left|.*\s·\s\/)/i
+const CODEX_COMPOSER_BOUNDARY = /^\s*(?:[─━-]{3,}|Working\b|esc to interrupt|(?:\?\s*)?for shortcuts|\d+% context|context left|.*\s·\s\/)/i
+const CODEX_PLACEHOLDERS = [
+  'Explain this codebase',
+  'Summarize recent commits',
+  'Implement {feature}',
+  'Find and fix a bug in @filename',
+  'Write tests for @filename',
+  'Improve documentation in @filename',
+  'Run /review on my current changes',
+  'Use /skills to list available skills',
+  'Check recently modified functions for compatibility',
+  'How many files have been modified?',
+  'Will this algorithm scale well?',
+]
+
 /** Codex-specific viewport recognizer. It has no interaction-notify equivalent. */
-export function probeCodexInput(snapshot: PaneSnapshot, mode: InputMode, text?: string): InputProbe {
+export function probeCodexInput(snapshot: PaneSnapshot, mode: InputMode, text?: string, enforceMode = true): InputProbe {
   const pane = snapshot.text
-  if (hasCodexInteraction(pane) || !hasCodexComposer(pane)) return 'unavailable'
+  if (hasCodexInteraction(pane)) return 'unavailable'
+  const composer = codexComposerText(snapshot)
+  if (composer === undefined) return 'unavailable'
   const working = /Working\b.*(?:esc to interrupt)?/i.test(pane)
-  if ((mode === 'steering') !== working) return 'unavailable'
-  if (text !== undefined && pane.includes(text)) return 'pending'
-  return 'empty'
+  if (enforceMode && (mode === 'steering') !== working) return 'unavailable'
+  if (text !== undefined) {
+    if (composerContains(composer, text)) return 'pending'
+    return composer.length === 0 ? 'empty' : 'unavailable'
+  }
+  return composer.length === 0 ? 'empty' : 'pending'
 }
 
 /** Codex steering receipt is visual only: a newly rendered queue region. */
 export function acceptedCodexInput(snapshot: PaneSnapshot, mode: InputMode, text: string, baseline: string): boolean {
-  if (hasCodexInteraction(snapshot.text) || snapshot.text.includes(text)) return false
-  if (mode === 'primary') return hasCodexComposer(snapshot.text) || /Working\b/i.test(snapshot.text)
+  const composer = codexComposerText(snapshot)
+  if (hasCodexInteraction(snapshot.text) || (composer !== undefined && composerContains(composer, text))) return false
+  if (mode === 'primary') return composer === '' || /Working\b/i.test(snapshot.text)
   return snapshot.text !== baseline && /Messages to be submitted after next tool call|queued message|queued/i.test(snapshot.text)
 }
 
@@ -22,6 +44,30 @@ function hasCodexInteraction(pane: string): boolean {
   return /(?:approve|deny|permission|required selection|select an option|use arrow keys)/i.test(pane)
 }
 
-function hasCodexComposer(pane: string): boolean {
-  return /(?:^|\n)\s*›(?:\s|$)/m.test(pane)
+function codexComposerText(snapshot: PaneSnapshot): string | undefined {
+  const lines = snapshot.text.split('\n')
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const match = lines[i].match(/^\s*›(?:\s?(.*))?$/)
+    if (!match) continue
+    const anchored = lines.slice(i + 1).some((line) => CODEX_FOOTER.test(line))
+    if (!anchored) return undefined
+    const content = [match[1] ?? '']
+    for (let j = i + 1; j < lines.length; j++) {
+      if (CODEX_COMPOSER_BOUNDARY.test(lines[j])) break
+      content.push(lines[j])
+    }
+    const value = content.join('\n').trim()
+    return isCodexPlaceholder(value) ? '' : value
+  }
+  return undefined
+}
+
+function isCodexPlaceholder(value: string): boolean {
+  return CODEX_PLACEHOLDERS.some((placeholder) => value.startsWith(placeholder))
+}
+
+function composerContains(composer: string, text: string): boolean {
+  const normalize = (value: string) => value.replace(/\s+/g, ' ').trim()
+  const expected = normalize(text)
+  return expected.length > 0 && normalize(composer).includes(expected)
 }

--- a/crabot-agent/src/workers/codex/input-surface.ts
+++ b/crabot-agent/src/workers/codex/input-surface.ts
@@ -1,0 +1,27 @@
+import type { PaneSnapshot } from '../tmux/driver.js'
+import type { InputMode, InputProbe } from '../tmux/input-commit.js'
+
+/** Codex-specific viewport recognizer. It has no interaction-notify equivalent. */
+export function probeCodexInput(snapshot: PaneSnapshot, mode: InputMode, text?: string): InputProbe {
+  const pane = snapshot.text
+  if (hasCodexInteraction(pane) || !hasCodexComposer(pane)) return 'unavailable'
+  const working = /Working\b.*(?:esc to interrupt)?/i.test(pane)
+  if ((mode === 'steering') !== working) return 'unavailable'
+  if (text !== undefined && pane.includes(text)) return 'pending'
+  return 'empty'
+}
+
+/** Codex steering receipt is visual only: a newly rendered queue region. */
+export function acceptedCodexInput(snapshot: PaneSnapshot, mode: InputMode, text: string, baseline: string): boolean {
+  if (hasCodexInteraction(snapshot.text) || snapshot.text.includes(text)) return false
+  if (mode === 'primary') return hasCodexComposer(snapshot.text) || /Working\b/i.test(snapshot.text)
+  return snapshot.text !== baseline && /Messages to be submitted after next tool call|queued message|queued/i.test(snapshot.text)
+}
+
+function hasCodexInteraction(pane: string): boolean {
+  return /(?:approve|deny|permission|required selection|select an option|use arrow keys)/i.test(pane)
+}
+
+function hasCodexComposer(pane: string): boolean {
+  return /(?:^|\n)\s*›(?:\s|$)/m.test(pane)
+}

--- a/crabot-agent/src/workers/errors.ts
+++ b/crabot-agent/src/workers/errors.ts
@@ -4,7 +4,7 @@
  * to ensure consistent error handling and instanceof checks across implementations.
  */
 
-import type { IncarnationEndReason } from './types'
+import type { IncarnationEndReason, InitialInputDisposition, CliControlState, StateChangeReport } from './types'
 
 /** Raised when sendInput is called on an incarnation that has already exited. */
 export class WorkerExitedError extends Error {
@@ -23,6 +23,19 @@ export class WorkerExitedError extends Error {
   ) {
     super(`worker ${worker_id}#${seq} has exited`)
     this.name = 'WorkerExitedError'
+  }
+}
+
+
+/** A CLI input surface prevented a safe automatic commit. The harness owns queue settlement. */
+export class CliInputStallError extends Error {
+  constructor(
+    readonly disposition: Exclude<InitialInputDisposition, 'accepted'>,
+    readonly control_state: CliControlState['kind'],
+    readonly report?: StateChangeReport,
+  ) {
+    super(`CLI input stalled (${disposition}, ${control_state})`)
+    this.name = 'CliInputStallError'
   }
 }
 

--- a/crabot-agent/src/workers/harness/harness.ts
+++ b/crabot-agent/src/workers/harness/harness.ts
@@ -80,12 +80,17 @@ import type {
 } from '../types'
 import type { BuiltinRuntimeFactory } from '../builtin/runtime'
 import type { ResolvedPermissions } from '../../types'
-import { CapabilityNotSupportedError, WorkerExitedError } from '../errors'
+import { CapabilityNotSupportedError, WorkerExitedError, CliInputStallError } from '../errors'
 import { AsyncMutex } from '../async-mutex'
 import type { DialogObjectId, Incarnation, LedgerWorker, TaskStatus } from './ledger-types'
 import type { LedgerStore } from './ledger-store'
 import type { WorkspaceManager } from './workspace-manager'
-import { WorkerInbox, type InboxItem, type InboxSettlement } from './inbox'
+import {
+  WorkerInbox,
+  type InboxItem,
+  type InboxDeliveryResult,
+  type InboxSettlement,
+} from './inbox'
 import { WorkerEventLog, type HarnessEvent, type HarnessEventDelivery, type HarnessEventKind } from './worker-events'
 import { applyStatusTransition, canTransition, isTerminalStatus, reviveTask, taskStatusFromIncarnation } from './task-status'
 import { join } from 'path'
@@ -154,6 +159,56 @@ function truncateWakeText(
   if (trimmed.length <= maxChars) return trimmed
   const mark = `[已截断,共 ${trimmed.length} 字符${overflowHint}]`
   return keep === 'head' ? `${trimmed.slice(0, maxChars)}…${mark}` : `${mark}…${trimmed.slice(-maxChars)}`
+}
+
+function cliContractState(kind: NonNullable<IncarnationHandle['initial_input']>['control_state']): WorkerContractState {
+  switch (kind) {
+    case 'running': return 'running'
+    case 'exited': return 'exited'
+    default: return 'idle'
+  }
+}
+
+function settleCliTask(
+  task: LedgerWorker['task'],
+  state: WorkerContractState,
+  report: StateChangeReport | undefined,
+  now: string,
+): LedgerWorker['task'] {
+  if (state === 'running') return task
+  if (state === 'idle') return applyStatusTransition(task, 'waiting_input', { now })
+  const target = taskStatusFromIncarnation('exited', report?.endReason)
+  if (target === 'running') return task
+  return applyStatusTransition(task, target, {
+    now,
+    ...(target === 'failed' ? { error: report?.endReason ?? 'initial CLI process exited' } : {}),
+  })
+}
+
+function cliReportDetail(state: WorkerContractState, report: StateChangeReport | undefined): Record<string, unknown> {
+  if (state === 'exited') {
+    return { to: 'exited', kind: 'initial_input_settled', ...(report?.endReason ? { reason: report.endReason } : {}) }
+  }
+  const text = report?.outputTail?.trim()
+  if (report?.notification) {
+    return {
+      to: state,
+      kind: 'interaction_required',
+      wait_mode: 'action',
+      wait_reason: report.waitReason ?? 'interaction_required',
+      notification_type: report.notification.type,
+      ...(report.notification.message ? { message: report.notification.message } : {}),
+      ...(report.notification.title ? { title: report.notification.title } : {}),
+      text: text ?? '',
+    }
+  }
+  return {
+    to: state,
+    kind: report?.waitReason === 'input_pending' ? 'input_pending' : 'input_delivery_stalled',
+    ...(state === 'idle' ? { wait_mode: 'action' } : {}),
+    ...(report?.waitReason ? { wait_reason: report.waitReason } : {}),
+    ...(text ? { text } : {}),
+  }
 }
 
 /**
@@ -552,16 +607,34 @@ export class WorkerHarness {
       }
 
       const now = this.deps.now()
-      // adapter.spawn 返回的 handle 自描述真实 session_ref(protocol-agent-v3 §6.1)——初始
-      // 化身注册时(见上面 initial.incarnations[0])这个值还不存在,只能占位;spawn 成功后
-      // 在这里补写真值,和 task 状态一起原子落盘。
+      const initialInput = spawnedHandle.initial_input
+      const initialState = cliContractState(initialInput?.control_state ?? 'running')
       const spawned = await this.deps.ledger.upsertWorker(p.dialogObjectId, workerId, (prev) => {
         if (!prev) return undefined
-        const nextTask = applyStatusTransition(prev.task, 'running', { now })
-        const incarnations = patchIncarnationBySeq(prev.incarnations, impl, 1, { session_ref: spawnedHandle.session_ref })
+        let nextTask = applyStatusTransition(prev.task, 'running', { now })
+        nextTask = settleCliTask(nextTask, initialState, initialInput?.report, now)
+        const incarnations = patchIncarnationBySeq(prev.incarnations, impl, 1, {
+          session_ref: spawnedHandle.session_ref,
+          state: initialState,
+          ...(initialState === 'exited'
+            ? { ended_at: now, ended_reason: initialInput?.report?.endReason ?? 'crashed' }
+            : {}),
+        })
         return { ...prev, task: nextTask, incarnations, updated_at: now }
       })
+
+      const inbox = this.getInbox(workerId)
+      if (initialState !== 'exited' && initialInput?.disposition === 'not_pasted') {
+        inbox.enqueueFront({ text: p.prompt, raw: false, enqueued_at: now })
+        inbox.hold('waiting_action')
+      } else if (initialState !== 'exited' && initialInput?.disposition === 'pending_in_ui') {
+        inbox.hold('input_pending')
+      }
+
       await this.appendEvent(workerId, 1, 'spawned', { impl }, spawned?.task.status)
+      if (initialInput && (initialInput.disposition !== 'accepted' || initialState === 'exited')) {
+        await this.appendEvent(workerId, 1, 'state_changed', cliReportDetail(initialState, initialInput.report), spawned?.task.status)
+      }
       return spawned as LedgerWorker
     })
   }
@@ -666,7 +739,29 @@ export class WorkerHarness {
             err.ended_reason
           )
         }
+        if (err instanceof CliInputStallError) {
+          await this.recordCliInputResult(handle, err.control_state, err.report)
+          return {
+            action: item.raw || err.disposition === 'pending_in_ui' ? 'hold_consumed' : 'hold_requeue',
+            reason: err.disposition === 'pending_in_ui' ? 'input_pending' : 'waiting_action',
+          } satisfies InboxDeliveryResult
+        }
         throw err
+      }
+      if (handle.impl !== 'builtin' && !item.raw) {
+        const cliAdapter = adapter as WorkerAdapter & {
+          takeAcceptedInputExit?: (h: IncarnationHandle) => StateChangeReport | undefined
+          takeUpdatedSessionRef?: (h: IncarnationHandle) => string | undefined
+        }
+        const sessionRef = cliAdapter.takeUpdatedSessionRef?.(handle)
+        const settledHandle = sessionRef ? { ...handle, session_ref: sessionRef } : handle
+        const acceptedExit = cliAdapter.takeAcceptedInputExit?.(settledHandle)
+        if (acceptedExit) await this.recordCliInputResult(settledHandle, 'exited', acceptedExit)
+        else await this.recordCliInputResult(settledHandle, 'running')
+      }
+      if (item.raw) {
+        inbox.release('waiting_action')
+        inbox.release('input_pending')
       }
       await this.appendEvent(workerId, handle.seq, 'input_sent', { text_len: item.text.length })
       return 'delivered'
@@ -888,16 +983,21 @@ export class WorkerHarness {
     // resume 成功之后再补一次 adapter.sendInput。
     const newHandle = await adapter.resume(prevRef, text)
 
+    const initialInput = newHandle.initial_input
+    const initialState = cliContractState(initialInput?.control_state ?? 'running')
     const now = this.deps.now()
     const revived = await this.deps.ledger.upsertWorker(dialogObjectId, worker.worker_id, (prev) => {
       if (!prev) return undefined
       const newIncarnation: Incarnation = {
         seq: newHandle.seq,
         impl: newHandle.impl,
-        state: 'running',
+        state: initialState,
         workspace: mainline.workspace,
         session_ref: newHandle.session_ref,
         started_at: now,
+        ...(initialState === 'exited'
+          ? { ended_at: now, ended_reason: initialInput?.report?.endReason ?? 'crashed' }
+          : {}),
         // forked_from 不填——resume 产出的新化身入主线链(protocol-agent-v3 §5.3)。
       }
       // 源化身(mainline)台账态若仍非 exited——sendToWorker 经 WorkerExitedError 走到这里时,
@@ -919,10 +1019,22 @@ export class WorkerHarness {
               ended_reason: sourceEndReason ?? 'completed',
             })
           : prev.incarnations
-      const nextTask = reopenTaskForContinuation(prev.task, now)
+      let nextTask = reopenTaskForContinuation(prev.task, now)
+      nextTask = settleCliTask(nextTask, initialState, initialInput?.report, now)
       return { ...prev, task: nextTask, incarnations: [...incarnations, newIncarnation], updated_at: now }
     })
+
+    const inbox = this.getInbox(worker.worker_id)
+    if (initialState !== 'exited' && initialInput?.disposition === 'not_pasted') {
+      inbox.enqueueFront({ text, raw: false, enqueued_at: now })
+      inbox.hold('waiting_action')
+    } else if (initialState !== 'exited' && initialInput?.disposition === 'pending_in_ui') {
+      inbox.hold('input_pending')
+    }
     await this.appendEvent(worker.worker_id, newHandle.seq, 'resumed', { from_seq: mainline.seq }, revived?.task.status)
+    if (initialInput && (initialInput.disposition !== 'accepted' || initialState === 'exited')) {
+      await this.appendEvent(worker.worker_id, newHandle.seq, 'state_changed', cliReportDetail(initialState, initialInput.report), revived?.task.status)
+    }
   }
 
   /**
@@ -1055,20 +1167,34 @@ export class WorkerHarness {
     })
 
     // 4. 化身链 +1,task 重新回到 running(见 reopenTaskForContinuation 注释)。
+    const initialInput = newHandle.initial_input
+    const initialState = cliContractState(initialInput?.control_state ?? 'running')
     const now = this.deps.now()
     const handedOff = await this.deps.ledger.upsertWorker(dialogObjectId, worker.worker_id, (prev) => {
       if (!prev) return undefined
       const newIncarnation: Incarnation = {
         seq: newHandle.seq,
         impl: targetImpl,
-        state: 'running',
+        state: initialState,
         workspace: source.workspace,
         session_ref: newHandle.session_ref,
         started_at: now,
+        ...(initialState === 'exited'
+          ? { ended_at: now, ended_reason: initialInput?.report?.endReason ?? 'crashed' }
+          : {}),
       }
-      const nextTask = reopenTaskForContinuation(prev.task, now)
+      let nextTask = reopenTaskForContinuation(prev.task, now)
+      nextTask = settleCliTask(nextTask, initialState, initialInput?.report, now)
       return { ...prev, task: nextTask, incarnations: [...prev.incarnations, newIncarnation], updated_at: now }
     })
+
+    const inbox = this.getInbox(worker.worker_id)
+    if (initialState !== 'exited' && initialInput?.disposition === 'not_pasted') {
+      inbox.enqueueFront({ text: prompt, raw: false, enqueued_at: now })
+      inbox.hold('waiting_action')
+    } else if (initialState !== 'exited' && initialInput?.disposition === 'pending_in_ui') {
+      inbox.hold('input_pending')
+    }
     // 与 reviveIncarnation 收尾时发 'resumed' 事件对称——交接产出的新化身同样是一次"开工",
     // 缺了这个事件会让事件流看不到 handoff 之后新主线是何时、以何种 impl 建起来的。
     await this.appendEvent(
@@ -1078,6 +1204,9 @@ export class WorkerHarness {
       { impl: targetImpl, from_seq: source.seq },
       handedOff?.task.status
     )
+    if (initialInput && (initialInput.disposition !== 'accepted' || initialState === 'exited')) {
+      await this.appendEvent(worker.worker_id, newHandle.seq, 'state_changed', cliReportDetail(initialState, initialInput.report), handedOff?.task.status)
+    }
   }
 
   /**
@@ -1778,6 +1907,51 @@ export class WorkerHarness {
 
   // ---- 内部 ----
 
+  private async recordCliInputResult(
+    h: IncarnationHandle,
+    controlState: NonNullable<IncarnationHandle['initial_input']>['control_state'],
+    report?: StateChangeReport,
+  ): Promise<void> {
+    const external = cliContractState(controlState)
+    let committedStatus: TaskStatus | undefined
+    await this.withLock(h.worker_id, async () => {
+      const found = await this.deps.ledger.findWorker(h.worker_id)
+      if (!found) return
+      const { worker, dialogObjectId } = found
+      const target = findIncarnation(worker, h.impl, h.seq)
+      if (!target || target.state === 'exited' || isTerminalStatus(worker.task.status)) return
+
+      let desired: TaskStatus
+      if (external === 'running') desired = 'running'
+      else if (external === 'idle') {
+        const bgRunning = (await this.deps.hasRunningBg?.(h.worker_id)) ?? false
+        desired = bgRunning || this.hasPendingBgNotification(h.worker_id) ? 'running' : 'waiting_input'
+      } else {
+        desired = taskStatusFromIncarnation('exited', report?.endReason)
+      }
+      const now = this.deps.now()
+      const committed = await this.deps.ledger.upsertWorker(dialogObjectId, h.worker_id, (prev) => {
+        if (!prev) return undefined
+        const task = prev.task.status === desired ? prev.task : applyStatusTransition(prev.task, desired, {
+          now,
+          ...(desired === 'failed' ? { error: report?.endReason ?? 'CLI incarnation exited' } : {}),
+        })
+        const incarnations = patchIncarnationBySeq(prev.incarnations, h.impl, h.seq, {
+          state: external,
+          session_ref: h.session_ref,
+          ...(external === 'exited' ? { ended_at: now, ended_reason: report?.endReason ?? 'crashed' } : {}),
+        })
+        return { ...prev, task, incarnations, updated_at: now }
+      })
+      committedStatus = committed?.task.status
+    })
+    if (report) {
+      await this.appendEvent(h.worker_id, h.seq, 'state_changed', cliReportDetail(external, report), committedStatus)
+    } else if (external !== 'running') {
+      await this.appendEvent(h.worker_id, h.seq, 'state_changed', { to: external }, committedStatus)
+    }
+  }
+
   private async processStateChange(
     h: IncarnationHandle,
     state: WorkerContractState,
@@ -1901,10 +2075,16 @@ export class WorkerHarness {
         h.worker_id,
         h.seq,
         'state_changed',
-        { to: state, ...wakeDetail },
+        report?.notification ? cliReportDetail(state, report) : { to: state, ...wakeDetail },
         committed?.task.status
       )
     })
+
+    if (!report?.notification && (state === 'idle' || state === 'running')) {
+      const inbox = this.getInbox(h.worker_id)
+      inbox.release('waiting_action')
+      await this.flushInbox(h.worker_id)
+    }
   }
 
   private withLock<T>(workerId: string, fn: () => Promise<T>): Promise<T> {

--- a/crabot-agent/src/workers/harness/harness.ts
+++ b/crabot-agent/src/workers/harness/harness.ts
@@ -462,6 +462,8 @@ export class WorkerHarness {
   private readonly eventLogs = new Map<string, WorkerEventLog>()
   /** 活性巡检的已报标记,键是 `<worker_id>#<impl>#<seq>`(见 `sweepLiveness`)。 */
   private readonly stallReports = new Map<string, StallReportMark>()
+  /** Adapter state callbacks observed per incarnation; used to order harness-owned CLI input settlement. */
+  private readonly stateChangeRevisions = new Map<string, number>()
   private sweepInFlight = false
   private sweepTimer?: ReturnType<typeof setInterval>
   /** `stopLivenessSweep` 置位后不再接受 `startLivenessSweep`(见该方法注释的停机竞态)。 */
@@ -496,6 +498,8 @@ export class WorkerHarness {
           `(${h.worker_id}#${h.seq})`
       )
     }
+    const revisionKey = `${h.worker_id}#${h.impl}#${h.seq}`
+    this.stateChangeRevisions.set(revisionKey, (this.stateChangeRevisions.get(revisionKey) ?? 0) + 1)
     this.processStateChange(h, state, report).catch((err) => {
       console.error(`[WorkerHarness] handleStateChange failed for ${h.worker_id}#${h.seq}:`, err)
     })
@@ -624,6 +628,7 @@ export class WorkerHarness {
       })
 
       const inbox = this.getInbox(workerId)
+      inbox.release()
       if (initialState !== 'exited' && initialInput?.disposition === 'not_pasted') {
         inbox.enqueueFront({ text: p.prompt, raw: false, enqueued_at: now })
         inbox.hold('waiting_action')
@@ -722,6 +727,7 @@ export class WorkerHarness {
         impl: incarnation.impl as WorkerImplId,
         session_ref: incarnation.session_ref,
       }
+      const stateChangeRevision = this.stateChangeRevisions.get(`${handle.worker_id}#${handle.impl}#${handle.seq}`) ?? 0
       try {
         await adapter.sendInput(handle, item.text, { raw: item.raw })
       } catch (err) {
@@ -757,7 +763,7 @@ export class WorkerHarness {
         const settledHandle = sessionRef ? { ...handle, session_ref: sessionRef } : handle
         const acceptedExit = cliAdapter.takeAcceptedInputExit?.(settledHandle)
         if (acceptedExit) await this.recordCliInputResult(settledHandle, 'exited', acceptedExit)
-        else await this.recordCliInputResult(settledHandle, 'running')
+        else await this.recordCliInputResult(settledHandle, 'running', undefined, stateChangeRevision)
       }
       if (item.raw) {
         inbox.release('waiting_action')
@@ -1025,6 +1031,7 @@ export class WorkerHarness {
     })
 
     const inbox = this.getInbox(worker.worker_id)
+    inbox.release()
     if (initialState !== 'exited' && initialInput?.disposition === 'not_pasted') {
       inbox.enqueueFront({ text, raw: false, enqueued_at: now })
       inbox.hold('waiting_action')
@@ -1189,6 +1196,7 @@ export class WorkerHarness {
     })
 
     const inbox = this.getInbox(worker.worker_id)
+    inbox.release()
     if (initialState !== 'exited' && initialInput?.disposition === 'not_pasted') {
       inbox.enqueueFront({ text: prompt, raw: false, enqueued_at: now })
       inbox.hold('waiting_action')
@@ -1911,7 +1919,12 @@ export class WorkerHarness {
     h: IncarnationHandle,
     controlState: NonNullable<IncarnationHandle['initial_input']>['control_state'],
     report?: StateChangeReport,
+    expectedStateChangeRevision?: number,
   ): Promise<void> {
+    if (expectedStateChangeRevision !== undefined) {
+      const revisionKey = `${h.worker_id}#${h.impl}#${h.seq}`
+      if ((this.stateChangeRevisions.get(revisionKey) ?? 0) !== expectedStateChangeRevision) return
+    }
     const external = cliContractState(controlState)
     let committedStatus: TaskStatus | undefined
     await this.withLock(h.worker_id, async () => {
@@ -1945,6 +1958,7 @@ export class WorkerHarness {
       })
       committedStatus = committed?.task.status
     })
+    if (external === 'exited') this.getInbox(h.worker_id).release()
     if (report) {
       await this.appendEvent(h.worker_id, h.seq, 'state_changed', cliReportDetail(external, report), committedStatus)
     } else if (external !== 'running') {
@@ -1957,6 +1971,7 @@ export class WorkerHarness {
     state: WorkerContractState,
     report?: StateChangeReport,
   ): Promise<void> {
+    let settledCurrentExit = false
     // 唤醒事件的两段正文:截断在这一处收口,三个 adapter 共用同一上限。text 截断后还能按
     // offset 去 read_worker_output 读全文,summary 不进 output、没有这条后路,所以提示语
     // 不同、上限也不同(见两个常量各自的注释)。
@@ -2068,6 +2083,7 @@ export class WorkerHarness {
         )
         return { ...prev, task: nextTask, incarnations, updated_at: now }
       })
+      settledCurrentExit = state === 'exited' && committed !== undefined
       // 主线分支是 task 状态机的主要推进点——事件必须自带落账后的状态,否则订阅方现读台账
       // 时若已经有下一次落账(如 §5.3 透明接续把终态拉回 running),这次迁移(含 completed
       // 这类终态)会被整条吞掉。见 worker-events.ts `HarnessEvent.task_status`。
@@ -2080,7 +2096,11 @@ export class WorkerHarness {
       )
     })
 
-    if (!report?.notification && (state === 'idle' || state === 'running')) {
+    if (!report?.notification && settledCurrentExit) {
+      const inbox = this.getInbox(h.worker_id)
+      inbox.release()
+      await this.flushInbox(h.worker_id)
+    } else if (!report?.notification && (state === 'idle' || state === 'running')) {
       const inbox = this.getInbox(h.worker_id)
       inbox.release('waiting_action')
       await this.flushInbox(h.worker_id)

--- a/crabot-agent/src/workers/harness/harness.ts
+++ b/crabot-agent/src/workers/harness/harness.ts
@@ -211,6 +211,12 @@ function cliReportDetail(state: WorkerContractState, report: StateChangeReport |
   }
 }
 
+/** Raw keys that explicitly discard the current composer instead of submitting it. */
+function rawAbandonsComposer(text: string): boolean {
+  const keys = text.toLowerCase().split(/\s+/).filter(Boolean)
+  return keys.some((key) => key === 'escape' || key === 'esc' || key === 'c-c' || key === 'c-u')
+}
+
 /**
  * continueTerminalWorker 锁内可重入求值循环的上限次数。每一轮代表"主线又换了一次"的
  * 重新判定,防止病态并发抖动(主线连续多次接续/切换)让这次投递在临界区内无限打转。3
@@ -464,12 +470,22 @@ export class WorkerHarness {
   private readonly stallReports = new Map<string, StallReportMark>()
   /** Adapter state callbacks observed per incarnation; used to order harness-owned CLI input settlement. */
   private readonly stateChangeRevisions = new Map<string, number>()
+  /** Synchronous generation of the pane that currently owns input for each logical worker. */
+  private readonly inputOwnershipRevisions = new Map<string, number>()
   private sweepInFlight = false
   private sweepTimer?: ReturnType<typeof setInterval>
   /** `stopLivenessSweep` 置位后不再接受 `startLivenessSweep`(见该方法注释的停机竞态)。 */
   private sweepStopped = false
 
   constructor(private readonly deps: HarnessDeps) {}
+
+  private inputOwnershipRevision(workerId: string): number {
+    return this.inputOwnershipRevisions.get(workerId) ?? 0
+  }
+
+  private bumpInputOwnershipRevision(workerId: string): void {
+    this.inputOwnershipRevisions.set(workerId, this.inputOwnershipRevision(workerId) + 1)
+  }
 
   /**
    * 见文件头"onStateChange 接线契约"。箭头函数字段:构造时绑定 this,P4 可直接把它作为
@@ -728,6 +744,7 @@ export class WorkerHarness {
         session_ref: incarnation.session_ref,
       }
       const stateChangeRevision = this.stateChangeRevisions.get(`${handle.worker_id}#${handle.impl}#${handle.seq}`) ?? 0
+      const inputOwnershipRevision = this.inputOwnershipRevision(workerId)
       try {
         await adapter.sendInput(handle, item.text, { raw: item.raw })
       } catch (err) {
@@ -746,10 +763,12 @@ export class WorkerHarness {
           )
         }
         if (err instanceof CliInputStallError) {
-          await this.recordCliInputResult(handle, err.control_state, err.report)
+          const isCurrent = (): boolean => this.inputOwnershipRevision(workerId) === inputOwnershipRevision
+          if (isCurrent()) await this.recordCliInputResult(handle, err.control_state, err.report)
           return {
             action: item.raw || err.disposition === 'pending_in_ui' ? 'hold_consumed' : 'hold_requeue',
             reason: err.disposition === 'pending_in_ui' ? 'input_pending' : 'waiting_action',
+            isCurrent,
           } satisfies InboxDeliveryResult
         }
         throw err
@@ -766,6 +785,7 @@ export class WorkerHarness {
         else await this.recordCliInputResult(settledHandle, 'running', undefined, stateChangeRevision)
       }
       if (item.raw) {
+        await inbox.settleConsumed(rawAbandonsComposer(item.text) ? 'dead_letter' : 'delivered')
         inbox.release('waiting_action')
         inbox.release('input_pending')
       }
@@ -789,6 +809,7 @@ export class WorkerHarness {
    * 级改动,留待后续(protocol-agent-v3 §6.1 已知限制)。
    */
   async switchWorkerImpl(workerId: string, impl: WorkerImplId, note?: string): Promise<void> {
+    let restoredDurableReceipt = false
     await this.withLock(workerId, async () => {
       const found = await this.deps.ledger.findWorker(workerId)
       if (!found) throw new WorkerNotFoundError(workerId)
@@ -800,8 +821,10 @@ export class WorkerHarness {
       // 允许切换(等价于"在办任务换实现"续办的合理场景,§5.3),只有 cancelled 硬拒绝。
       if (worker.task.status === 'cancelled') throw new TaskCancelledError(workerId)
       const mainline = requireMainlineIncarnation(worker)
-      await this.handoffIncarnation(dialogObjectId, worker, mainline, impl, note ?? '')
+      restoredDurableReceipt = await this.handoffIncarnation(dialogObjectId, worker, mainline, impl, note ?? '')
     })
+    // The old pane no longer owns a consumed durable receipt; resume its FIFO on the new incarnation.
+    if (restoredDurableReceipt) await this.flushInbox(workerId)
   }
 
   /**
@@ -1030,6 +1053,7 @@ export class WorkerHarness {
       return { ...prev, task: nextTask, incarnations: [...incarnations, newIncarnation], updated_at: now }
     })
 
+    this.bumpInputOwnershipRevision(worker.worker_id)
     const inbox = this.getInbox(worker.worker_id)
     inbox.release()
     if (initialState !== 'exited' && initialInput?.disposition === 'not_pasted') {
@@ -1038,6 +1062,7 @@ export class WorkerHarness {
     } else if (initialState !== 'exited' && initialInput?.disposition === 'pending_in_ui') {
       inbox.hold('input_pending')
     }
+    inbox.requeueConsumed()
     await this.appendEvent(worker.worker_id, newHandle.seq, 'resumed', { from_seq: mainline.seq }, revived?.task.status)
     if (initialInput && (initialInput.disposition !== 'accepted' || initialState === 'exited')) {
       await this.appendEvent(worker.worker_id, newHandle.seq, 'state_changed', cliReportDetail(initialState, initialInput.report), revived?.task.status)
@@ -1055,7 +1080,7 @@ export class WorkerHarness {
     source: Incarnation,
     targetImpl: WorkerImplId,
     input: string,
-  ): Promise<void> {
+  ): Promise<boolean> {
     const sourceAdapter = this.deps.adapters.get(source.impl as WorkerImplId)
     const sourceHandle: IncarnationHandle = {
       worker_id: worker.worker_id,
@@ -1195,6 +1220,7 @@ export class WorkerHarness {
       return { ...prev, task: nextTask, incarnations: [...prev.incarnations, newIncarnation], updated_at: now }
     })
 
+    this.bumpInputOwnershipRevision(worker.worker_id)
     const inbox = this.getInbox(worker.worker_id)
     inbox.release()
     if (initialState !== 'exited' && initialInput?.disposition === 'not_pasted') {
@@ -1203,6 +1229,7 @@ export class WorkerHarness {
     } else if (initialState !== 'exited' && initialInput?.disposition === 'pending_in_ui') {
       inbox.hold('input_pending')
     }
+    const restoredDurableReceipt = inbox.requeueConsumed() > 0
     // 与 reviveIncarnation 收尾时发 'resumed' 事件对称——交接产出的新化身同样是一次"开工",
     // 缺了这个事件会让事件流看不到 handoff 之后新主线是何时、以何种 impl 建起来的。
     await this.appendEvent(
@@ -1215,6 +1242,7 @@ export class WorkerHarness {
     if (initialInput && (initialInput.disposition !== 'accepted' || initialState === 'exited')) {
       await this.appendEvent(worker.worker_id, newHandle.seq, 'state_changed', cliReportDetail(initialState, initialInput.report), handedOff?.task.status)
     }
+    return restoredDurableReceipt
   }
 
   /**
@@ -1958,7 +1986,12 @@ export class WorkerHarness {
       })
       committedStatus = committed?.task.status
     })
-    if (external === 'exited') this.getInbox(h.worker_id).release()
+    if (external === 'exited') {
+      this.bumpInputOwnershipRevision(h.worker_id)
+      const inbox = this.getInbox(h.worker_id)
+      inbox.requeueConsumed()
+      inbox.release()
+    }
     if (report) {
       await this.appendEvent(h.worker_id, h.seq, 'state_changed', cliReportDetail(external, report), committedStatus)
     } else if (external !== 'running') {
@@ -2097,7 +2130,9 @@ export class WorkerHarness {
     })
 
     if (!report?.notification && settledCurrentExit) {
+      this.bumpInputOwnershipRevision(h.worker_id)
       const inbox = this.getInbox(h.worker_id)
+      inbox.requeueConsumed()
       inbox.release()
       await this.flushInbox(h.worker_id)
     } else if (!report?.notification && (state === 'idle' || state === 'running')) {

--- a/crabot-agent/src/workers/harness/inbox.ts
+++ b/crabot-agent/src/workers/harness/inbox.ts
@@ -5,9 +5,9 @@
  * 投递前把关,不属于本类职责);安全态(running / idle)即投,不安全态(provision 中、
  * 模态弹窗、化身交接间隙、僵尸态)暂扣,恢复后按序补投。
  *
- * hold 选择"布尔"而非计数:harness 侧的暂扣场景(provision / 化身交接)是互斥的单一状态,
- * 不存在"多个理由同时暂扣、需要逐个撤销"的嵌套需求;若未来出现需要嵌套暂扣的场景,再改
- * 计数并补测,不在此提前引入复杂度。
+ * hold 使用理由集合：`waiting_action` / `input_pending` 只允许显式 raw 控制键旁路；
+ * provision / handoff 等其它理由属于 exclusive hold，连 raw 也阻断。理由可独立置位和释放，
+ * 运输层 hold 不作为 CLI control state 的第二维持久化。
  *
  * flush 并发安全:用 AsyncMutex 串行化同一信箱的 flush 调用,避免两轮并发 flush 重复投递
  * 同一条(P1 builtin sendInput 双发竞态同型问题)。deliver 抛错时该条留在队首、停止本轮、
@@ -33,6 +33,11 @@ export interface InboxItem {
   readonly onSettled?: (settlement: InboxSettlement) => void | Promise<void>
   /** Prevent a producer retry from enqueueing the same durable item twice in one process. */
   readonly dedupe_key?: string
+}
+
+export interface InboxDeliveryResult {
+  readonly action: 'hold_requeue' | 'hold_consumed'
+  readonly reason: 'waiting_action' | 'input_pending'
 }
 
 export class WorkerInbox {
@@ -63,6 +68,12 @@ export class WorkerInbox {
     }
     this.queue.push(item)
     return true
+  }
+
+  /** 入队首;仅用于首投not_pasted等已经明确未进入pane的所有权恢复。 */
+  enqueueFront(item: InboxItem): number {
+    this.queue.unshift(item)
+    return this.queue.length
   }
 
   /** Mark delivery unsafe. waiting_action/input_pending permit an explicit raw control key. */
@@ -101,7 +112,9 @@ export class WorkerInbox {
    * pending:返回队列中的待投条数。注意:在 await deliver() 期间,该条已从 queue
    * 取出(shift),所以 pending 不计入 in-flight 条目。
    */
-  async flush(deliver: (item: InboxItem) => Promise<InboxSettlement | void>): Promise<number> {
+  async flush(
+    deliver: (item: InboxItem) => Promise<InboxSettlement | InboxDeliveryResult | void>,
+  ): Promise<number> {
     return this.mutex.run(async () => {
       let delivered = 0
       while (this.queue.length > 0) {
@@ -111,10 +124,17 @@ export class WorkerInbox {
         const [item] = this.queue.splice(index, 1)
         this.inFlight = item
         try {
-          const settlement = await deliver(item)
+          const result = await deliver(item)
           this.inFlight = null
+          if (typeof result === 'object') {
+            this.hold(result.reason)
+            if (result.action === 'hold_requeue') {
+              if (this.drainedInFlight !== item) this.queue.unshift(item)
+            } else delivered++
+            break
+          }
           delivered++
-          await this.settle(item, settlement ?? 'delivered')
+          await this.settle(item, typeof result === 'string' ? result : 'delivered')
         } catch (err) {
           this.inFlight = null
           if (this.drainedInFlight === item) {

--- a/crabot-agent/src/workers/harness/inbox.ts
+++ b/crabot-agent/src/workers/harness/inbox.ts
@@ -38,6 +38,8 @@ export interface InboxItem {
 export interface InboxDeliveryResult {
   readonly action: 'hold_requeue' | 'hold_consumed'
   readonly reason: 'waiting_action' | 'input_pending'
+  /** Synchronous ownership check evaluated immediately before committing the hold. */
+  readonly isCurrent?: () => boolean
 }
 
 export class WorkerInbox {
@@ -47,6 +49,8 @@ export class WorkerInbox {
   private drainedInFlight: InboxItem | null = null
   /** flush 正在投递、已从 queue 取出但尚未结算成败的条目;drain 不把它计入结果。 */
   private inFlight: InboxItem | null = null
+  /** Items pasted into a CLI composer: UI owns the text, but durable receipts still need settlement. */
+  private consumedPending: InboxItem[] = []
   private readonly mutex = new AsyncMutex()
 
   constructor(private readonly workerId: string) {}
@@ -62,6 +66,7 @@ export class WorkerInbox {
     if (item.dedupe_key === undefined) throw new Error('enqueueUnique requires dedupe_key')
     if (
       this.inFlight?.dedupe_key === item.dedupe_key ||
+      this.consumedPending.some((consumed) => consumed.dedupe_key === item.dedupe_key) ||
       this.queue.some((queued) => queued.dedupe_key === item.dedupe_key)
     ) {
       return false
@@ -95,7 +100,21 @@ export class WorkerInbox {
   }
 
   get pending(): number {
-    return this.queue.length
+    return this.queue.length + this.consumedPending.length
+  }
+
+  /** Settle durable receipts whose text was pasted and later submitted/abandoned via raw input. */
+  async settleConsumed(settlement: InboxSettlement): Promise<number> {
+    const items = this.consumedPending.splice(0)
+    for (const item of items) await this.settle(item, settlement)
+    return items.length
+  }
+
+  /** A pane incarnation ended; replay consumed durable items in the next incarnation. */
+  requeueConsumed(): number {
+    const items = this.consumedPending.splice(0)
+    if (items.length > 0) this.queue.unshift(...items)
+    return items.length
   }
 
   /**
@@ -127,10 +146,24 @@ export class WorkerInbox {
           const result = await deliver(item)
           this.inFlight = null
           if (typeof result === 'object') {
+            if (result.isCurrent && !result.isCurrent()) {
+              if (this.drainedInFlight === item || item.raw) {
+                await this.settle(item, 'dead_letter')
+                delivered++
+              } else {
+                this.queue.unshift(item)
+              }
+              continue
+            }
             this.hold(result.reason)
             if (result.action === 'hold_requeue') {
               if (this.drainedInFlight !== item) this.queue.unshift(item)
-            } else delivered++
+            } else if (this.drainedInFlight === item) {
+              await this.settle(item, 'dead_letter')
+            } else {
+              if (item.onSettled) this.consumedPending.push(item)
+              delivered++
+            }
             break
           }
           delivered++
@@ -174,13 +207,15 @@ export class WorkerInbox {
   /**
    * 取出全部并清空(化身终结时 dead-letter 用)。同步执行、不走 mutex——化身终结时
    * 可能正有一轮 flush 卡在 deliver 上(如 tmux 命令挂起、长时间不返回),drain 不能
-   * 无限等锁卡住终结流程。返回结果不含 in-flight 条目:它的成败由 flush 自己结算
+   * 无限等锁卡住终结流程。返回结果包含已经 paste、仍等待 raw 决议的 durable receipt，
+   * 但不含当前 in-flight 条目:它的成败由 flush 自己结算
    * (成功计入投递、失败见 flush 的 catch 分支),避免同一条目既投递又进 dead-letter。
    */
   drain(): InboxItem[] {
     // 记录 drain 当刻的 in-flight 条目,以便 flush 的 catch 分支判断是否需要吞掉错误
     this.drainedInFlight = this.inFlight
-    const items = this.queue
+    const items = [...this.consumedPending, ...this.queue]
+    this.consumedPending = []
     this.queue = []
     return items
   }

--- a/crabot-agent/src/workers/harness/inbox.ts
+++ b/crabot-agent/src/workers/harness/inbox.ts
@@ -37,7 +37,7 @@ export interface InboxItem {
 
 export class WorkerInbox {
   private queue: InboxItem[] = []
-  private _held = false
+  private readonly holds = new Set<string>()
   /** drain 当刻正在投递的 in-flight 条目;该条目投递失败时仅告警丢弃,post-drain 的条目失败走正常语义。 */
   private drainedInFlight: InboxItem | null = null
   /** flush 正在投递、已从 queue 取出但尚未结算成败的条目;drain 不把它计入结果。 */
@@ -65,17 +65,22 @@ export class WorkerInbox {
     return true
   }
 
-  /** 标记不安全(如 provision/交接中),期间 flush 不投递 */
-  hold(_reason: string): void {
-    this._held = true
+  /** Mark delivery unsafe. waiting_action/input_pending permit an explicit raw control key. */
+  hold(reason: string): void {
+    this.holds.add(reason)
   }
 
-  release(): void {
-    this._held = false
+  release(reason?: string): void {
+    if (reason) this.holds.delete(reason)
+    else this.holds.clear()
   }
 
   get held(): boolean {
-    return this._held
+    return this.holds.size > 0
+  }
+
+  private get rawBypassOnly(): boolean {
+    return this.holds.size > 0 && [...this.holds].every((reason) => reason === 'waiting_action' || reason === 'input_pending')
   }
 
   get pending(): number {
@@ -99,8 +104,11 @@ export class WorkerInbox {
   async flush(deliver: (item: InboxItem) => Promise<InboxSettlement | void>): Promise<number> {
     return this.mutex.run(async () => {
       let delivered = 0
-      while (this.queue.length > 0 && !this._held) {
-        const item = this.queue.shift()!
+      while (this.queue.length > 0) {
+        if (this.held && !this.rawBypassOnly) break
+        const index = this.held ? this.queue.findIndex((candidate) => candidate.raw) : 0
+        if (index < 0) break
+        const [item] = this.queue.splice(index, 1)
         this.inFlight = item
         try {
           const settlement = await deliver(item)

--- a/crabot-agent/src/workers/tmux/driver.ts
+++ b/crabot-agent/src/workers/tmux/driver.ts
@@ -23,10 +23,6 @@ export interface TmuxSessionSpec {
 
 export interface PaneSnapshot {
   text: string
-  cursor_x: number
-  cursor_y: number
-  width: number
-  height: number
 }
 
 export class TmuxDriver {
@@ -97,16 +93,10 @@ export class TmuxDriver {
     await this.run(['paste-buffer', '-p', '-r', '-d', '-b', bufferName, '-t', name])
   }
 
-  /** Capture only the current viewport plus cursor/pane dimensions. */
+  /** Capture only the current viewport. */
   async capturePane(name: string): Promise<PaneSnapshot> {
-    const [{ stdout: text }, { stdout: cursor }, { stdout: size }] = await Promise.all([
-      this.run(['capture-pane', '-p', '-e', '-J', '-t', name]),
-      this.run(['display-message', '-p', '-t', name, '#{cursor_x},#{cursor_y}']),
-      this.run(['display-message', '-p', '-t', name, '#{pane_width},#{pane_height}']),
-    ])
-    const [cursor_x, cursor_y] = parsePair(cursor, 'cursor')
-    const [width, height] = parsePair(size, 'pane size')
-    return { text, cursor_x, cursor_y, width, height }
+    const { stdout: text } = await this.run(['capture-pane', '-p', '-e', '-J', '-t', name])
+    return { text }
   }
 
   async sendKeys(name: string, keys: string[]): Promise<void> {
@@ -163,12 +153,6 @@ export class TmuxDriver {
       child.stdin.end()
     })
   }
-}
-
-function parsePair(value: string, label: string): [number, number] {
-  const [left, right] = value.trim().split(',').map(Number)
-  if (!Number.isInteger(left) || !Number.isInteger(right)) throw new Error(`tmux returned invalid ${label}: ${value}`)
-  return [left, right]
 }
 
 function shQuote(value: string): string {

--- a/crabot-agent/src/workers/tmux/driver.ts
+++ b/crabot-agent/src/workers/tmux/driver.ts
@@ -21,6 +21,14 @@ export interface TmuxSessionSpec {
   outputFile: string // pipe-pane 追加目标
 }
 
+export interface PaneSnapshot {
+  text: string
+  cursor_x: number
+  cursor_y: number
+  width: number
+  height: number
+}
+
 export class TmuxDriver {
   private readonly tmuxBin: string
 
@@ -77,12 +85,28 @@ export class TmuxDriver {
    * 整条消息。单行文本也走同一路径,不再区分单行/多行。
    */
   async sendText(name: string, text: string): Promise<void> {
-    if (text.length > 0) {
-      const bufferName = `crabot-sendtext-${randomUUID()}`
-      await this.loadBufferFromStdin(bufferName, text)
-      await this.run(['paste-buffer', '-p', '-r', '-d', '-b', bufferName, '-t', name])
-    }
+    await this.pasteText(name, text)
     await this.run(['send-keys', '-t', name, 'Enter'])
+  }
+
+  /** Paste exactly one buffer and deliberately do not commit it. */
+  async pasteText(name: string, text: string): Promise<void> {
+    if (text.length === 0) return
+    const bufferName = `crabot-sendtext-${randomUUID()}`
+    await this.loadBufferFromStdin(bufferName, text)
+    await this.run(['paste-buffer', '-p', '-r', '-d', '-b', bufferName, '-t', name])
+  }
+
+  /** Capture only the current viewport plus cursor/pane dimensions. */
+  async capturePane(name: string): Promise<PaneSnapshot> {
+    const [{ stdout: text }, { stdout: cursor }, { stdout: size }] = await Promise.all([
+      this.run(['capture-pane', '-p', '-e', '-J', '-t', name]),
+      this.run(['display-message', '-p', '-t', name, '#{cursor_x},#{cursor_y}']),
+      this.run(['display-message', '-p', '-t', name, '#{pane_width},#{pane_height}']),
+    ])
+    const [cursor_x, cursor_y] = parsePair(cursor, 'cursor')
+    const [width, height] = parsePair(size, 'pane size')
+    return { text, cursor_x, cursor_y, width, height }
   }
 
   async sendKeys(name: string, keys: string[]): Promise<void> {
@@ -139,6 +163,12 @@ export class TmuxDriver {
       child.stdin.end()
     })
   }
+}
+
+function parsePair(value: string, label: string): [number, number] {
+  const [left, right] = value.trim().split(',').map(Number)
+  if (!Number.isInteger(left) || !Number.isInteger(right)) throw new Error(`tmux returned invalid ${label}: ${value}`)
+  return [left, right]
 }
 
 function shQuote(value: string): string {

--- a/crabot-agent/src/workers/tmux/input-commit.ts
+++ b/crabot-agent/src/workers/tmux/input-commit.ts
@@ -35,6 +35,7 @@ export async function commitInput(
   await driver.pasteText(text)
   snapshot = await waitUntil(driver, timeoutMs, intervalMs, (current) => probe(current, 'after_paste') !== 'empty')
   let currentProbe = probe(snapshot, 'after_paste')
+  if (currentProbe === 'empty') return { disposition: 'not_pasted', snapshot }
   if (currentProbe !== 'pending') return { disposition: 'pending_in_ui', snapshot }
 
   await driver.sendEnter()

--- a/crabot-agent/src/workers/tmux/input-commit.ts
+++ b/crabot-agent/src/workers/tmux/input-commit.ts
@@ -1,0 +1,39 @@
+import type { PaneSnapshot } from './driver.js'
+
+export type InputProbe = 'empty' | 'pending' | 'unavailable'
+export type InputMode = 'primary' | 'steering'
+export type InputCommitDisposition = 'accepted' | 'not_pasted' | 'pending_in_ui'
+
+export interface InputCommitDriver {
+  pasteText(text: string): Promise<void>
+  sendEnter(): Promise<void>
+  capture(): Promise<PaneSnapshot>
+}
+
+/**
+ * Generic paste/commit transaction. The caller supplies implementation-specific probes; this
+ * layer deliberately has no knowledge of CLI text, native transcripts, or control state.
+ */
+export async function commitInput(
+  driver: InputCommitDriver,
+  probe: (snapshot: PaneSnapshot) => InputProbe,
+  accepted: (snapshot: PaneSnapshot) => boolean,
+  text: string,
+): Promise<{ disposition: InputCommitDisposition; snapshot: PaneSnapshot }> {
+  let snapshot = await driver.capture()
+  if (probe(snapshot) !== 'empty') return { disposition: 'not_pasted', snapshot }
+
+  await driver.pasteText(text)
+  snapshot = await driver.capture()
+  if (probe(snapshot) !== 'pending') return { disposition: 'pending_in_ui', snapshot }
+
+  await driver.sendEnter()
+  snapshot = await driver.capture()
+  if (accepted(snapshot)) return { disposition: 'accepted', snapshot }
+  if (probe(snapshot) === 'pending') {
+    await driver.sendEnter()
+    snapshot = await driver.capture()
+    if (accepted(snapshot)) return { disposition: 'accepted', snapshot }
+  }
+  return { disposition: 'pending_in_ui', snapshot }
+}

--- a/crabot-agent/src/workers/tmux/input-commit.ts
+++ b/crabot-agent/src/workers/tmux/input-commit.ts
@@ -3,6 +3,7 @@ import type { PaneSnapshot } from './driver.js'
 export type InputProbe = 'empty' | 'pending' | 'unavailable'
 export type InputMode = 'primary' | 'steering'
 export type InputCommitDisposition = 'accepted' | 'not_pasted' | 'pending_in_ui'
+export type InputProbePhase = 'before_paste' | 'after_paste'
 
 export interface InputCommitDriver {
   pasteText(text: string): Promise<void>
@@ -10,30 +11,81 @@ export interface InputCommitDriver {
   capture(): Promise<PaneSnapshot>
 }
 
-/**
- * Generic paste/commit transaction. The caller supplies implementation-specific probes; this
- * layer deliberately has no knowledge of CLI text, native transcripts, or control state.
- */
+export interface InputCommitOptions {
+  settleTimeoutMs?: number
+  intervalMs?: number
+}
+
+/** Generic guarded paste transaction; implementation-specific UI semantics stay in callbacks. */
 export async function commitInput(
   driver: InputCommitDriver,
-  probe: (snapshot: PaneSnapshot) => InputProbe,
+  probe: (snapshot: PaneSnapshot, phase: InputProbePhase) => InputProbe,
   accepted: (snapshot: PaneSnapshot) => boolean,
   text: string,
+  opts: InputCommitOptions = {},
 ): Promise<{ disposition: InputCommitDisposition; snapshot: PaneSnapshot }> {
+  const timeoutMs = opts.settleTimeoutMs ?? 1_000
+  const intervalMs = opts.intervalMs ?? 25
   let snapshot = await driver.capture()
-  if (probe(snapshot) !== 'empty') return { disposition: 'not_pasted', snapshot }
+  if (snapshot.text.trim() === '' && probe(snapshot, 'before_paste') === 'unavailable') {
+    snapshot = await waitUntil(driver, timeoutMs, intervalMs, (current) => probe(current, 'before_paste') !== 'unavailable')
+  }
+  if (probe(snapshot, 'before_paste') !== 'empty') return { disposition: 'not_pasted', snapshot }
 
   await driver.pasteText(text)
-  snapshot = await driver.capture()
-  if (probe(snapshot) !== 'pending') return { disposition: 'pending_in_ui', snapshot }
+  snapshot = await waitUntil(driver, timeoutMs, intervalMs, (current) => probe(current, 'after_paste') !== 'empty')
+  let currentProbe = probe(snapshot, 'after_paste')
+  if (currentProbe !== 'pending') return { disposition: 'pending_in_ui', snapshot }
 
   await driver.sendEnter()
-  snapshot = await driver.capture()
+  snapshot = await waitUntil(
+    driver,
+    timeoutMs,
+    intervalMs,
+    (current) => accepted(current) || probe(current, 'after_paste') !== 'pending',
+  )
   if (accepted(snapshot)) return { disposition: 'accepted', snapshot }
-  if (probe(snapshot) === 'pending') {
+
+  currentProbe = probe(snapshot, 'after_paste')
+  if (currentProbe === 'pending') {
     await driver.sendEnter()
-    snapshot = await driver.capture()
+    snapshot = await waitUntil(
+      driver,
+      timeoutMs,
+      intervalMs,
+      (current) => accepted(current) || probe(current, 'after_paste') !== 'pending',
+    )
     if (accepted(snapshot)) return { disposition: 'accepted', snapshot }
   }
   return { disposition: 'pending_in_ui', snapshot }
+}
+
+export async function waitForPaneChange(
+  capture: () => Promise<PaneSnapshot>,
+  baselineText: string,
+  timeoutMs = 500,
+  intervalMs = 25,
+): Promise<PaneSnapshot> {
+  const deadline = Date.now() + timeoutMs
+  let snapshot = await capture()
+  while (snapshot.text === baselineText && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, intervalMs))
+    snapshot = await capture()
+  }
+  return snapshot
+}
+
+async function waitUntil(
+  driver: InputCommitDriver,
+  timeoutMs: number,
+  intervalMs: number,
+  predicate: (snapshot: PaneSnapshot) => boolean,
+): Promise<PaneSnapshot> {
+  const deadline = Date.now() + timeoutMs
+  let snapshot = await driver.capture()
+  while (!predicate(snapshot) && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, intervalMs))
+    snapshot = await driver.capture()
+  }
+  return snapshot
 }

--- a/crabot-agent/src/workers/tmux/paste-ready.ts
+++ b/crabot-agent/src/workers/tmux/paste-ready.ts
@@ -163,7 +163,7 @@ export function describeDeliveryStall(opts: { impl: string; timeoutMs: number; t
  * (protocol-agent-v3 §5.5「检测到无法识别的交互界面:暂扣 + 唤醒 manager(附界面内容)」)。
  * 尾部而非头部:启动期日志的头部是终端能力协商,模态框在最后。
  *
- * 这里只负责取字节,ANSI 归一化由调用方做:两个 CLI adapter 在 reportStartupStall 里把结果
+ * 这里只负责取字节,ANSI 归一化由调用方做:两个 CLI adapter 在 initialStartupStall 里把结果
  * 过一遍 `decodeTerminalOutput`,与它们 `readOutput` 的返回路径共用同一个解码器,解码边界因此
  * 统一留在 adapter 那一层(builtin 的输出是纯文本,从不经过这里)。截取起点可能落在一个多字节
  * UTF-8 字符中间,这里丢掉开头的续字节再解码,避免出现替换字符。

--- a/crabot-agent/src/workers/types.ts
+++ b/crabot-agent/src/workers/types.ts
@@ -6,6 +6,12 @@ import type { ResolvedPermissions } from '../types.js'
 
 export type WorkerImplId = 'builtin' | 'claude-code' | 'codex'
 export type WorkerContractState = 'running' | 'idle' | 'exited'
+export type CliControlState =
+  | { readonly kind: 'running' }
+  | { readonly kind: 'waiting_text' }
+  | { readonly kind: 'waiting_action'; readonly reason: string }
+  | { readonly kind: 'exited'; readonly reason?: IncarnationEndReason }
+export type InitialInputDisposition = 'accepted' | 'not_pasted' | 'pending_in_ui'
 export type IncarnationEndReason =
   | 'completed' | 'failed' | 'killed' | 'superseded' | 'crashed' | 'pre_migration'
 
@@ -67,6 +73,8 @@ export interface IncarnationHandle {
    * builtin: 本化身当前 tip node_id;CLI: 原生 session id(resume 沿用 prev 不变;fork 化身
    * 填 fork 自己的引用,不是父化身的)。handle 自描述,调用方无需事后反查(protocol-agent-v3 §6.1)。 */
   readonly session_ref: string
+  /** CLI spawn/resume 首投的事实；builtin/fork 省略并按既有行为处理。 */
+  readonly initial_input?: InitialInputResult
 }
 export interface IncarnationRef {
   readonly worker_id: string
@@ -89,6 +97,12 @@ export interface IncarnationRef {
  * 3. 后续再接新信号(比如 cc 拿到真实终态、或带上本轮耗时)是加一个具名字段,所有调用点
  *    不动。
  */
+export interface InitialInputResult {
+  readonly control_state: CliControlState['kind']
+  readonly disposition: InitialInputDisposition
+  readonly report?: StateChangeReport
+}
+
 export interface StateChangeReport {
   /**
    * 本次转换发生时 worker 最后说的那段 assistant text。只有 builtin 产出(它的输出天然
@@ -126,6 +140,10 @@ export interface StateChangeReport {
    * 判断"卡在哪"的现场素材。
    */
   readonly outputTail?: string
+  /** CLI waiting_action / 投递暂扣的诊断原因。 */
+  readonly waitReason?: string
+  /** cc Notification 的解析载荷；harness 映射为 manager-facing detail。 */
+  readonly notification?: { readonly type: string; readonly message?: string; readonly title?: string }
 }
 
 export interface DetectResult { installed: boolean; activated: boolean; detail?: string }

--- a/crabot-agent/tests/workers/claude-code-adapter.test.ts
+++ b/crabot-agent/tests/workers/claude-code-adapter.test.ts
@@ -610,7 +610,7 @@ class RaceTmux extends TmuxDriver {
   async sendText(_name: string, _text: string): Promise<void> {}
   async sendKeys(_name: string, _keys: string[]): Promise<void> {}
   async capturePane(_name: string) {
-    return { text: '❯ \n? for shortcuts', cursor_x: 0, cursor_y: 0, width: 80, height: 24 }
+    return { text: '❯ \n? for shortcuts' }
   }
   async isAlive(_name: string): Promise<boolean> {
     return new Promise((resolve) => {
@@ -778,7 +778,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — spawn 提交纪律(P2 Tas
           return super.newSession(spec)
         }
         async capturePane(_name: string) {
-          return { text: '❯ \n? for shortcuts', cursor_x: 0, cursor_y: 0, width: 80, height: 24 }
+          return { text: '❯ \n? for shortcuts' }
         }
         async pasteText(_name: string, _text: string): Promise<void> {
           throw new Error('simulated pasteText failure')
@@ -1429,7 +1429,7 @@ class NoopTmux extends TmuxDriver {
     if (keys.includes('Enter')) this.paneText = '❯ \nesc to interrupt'
   }
   async capturePane(_name: string) {
-    return { text: this.paneText, cursor_x: 0, cursor_y: 0, width: 80, height: 24 }
+    return { text: this.paneText }
   }
   async isAlive(_name: string): Promise<boolean> {
     return true
@@ -1812,7 +1812,7 @@ describe('ClaudeCodeAdapter — CLI hook 事件文件监视(被动 push)', () =>
     const workerId = `cctest-${randomUUID().slice(0, 8)}`
     const h = await adapter.spawn({ worker_id: workerId, prompt: '干活', workspace: { root: workspaceRoot } })
 
-    tmux.paneText = 'AskUserQuestion\nSelect an option\n  Yes\n  No'
+    tmux.paneText = 'Claude needs your permission\n1. Yes\n2. No'
     await fs.appendFile(
       eventsFilePath({ root: workspaceRoot }),
       JSON.stringify({

--- a/crabot-agent/tests/workers/claude-code-adapter.test.ts
+++ b/crabot-agent/tests/workers/claude-code-adapter.test.ts
@@ -877,7 +877,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — prompt 投递验证(2026-
     await adapter.kill(h)
   })
 
-  it('弹窗吞掉首条 prompt 时自动 Esc 清理并重投,第二次真正落地(不落 stall)', async () => {
+  it('首条 prompt 未落 session 时不自动 Escape 或重贴', async () => {
     const tmux = new CountingTmux()
     const { adapter, workerId } = await deliveryAdapter([{ output: '任务输出', emitStop: true }], {
       dropSubmitCount: 1,
@@ -888,21 +888,16 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — prompt 投递验证(2026-
     // 关键断言:验证通过,没有走 startup stall 路径;state 迁移是事件驱动的,不在此断言。
     const meta = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8'))
     expect(meta.startup_stalled).toBeUndefined()
-    // Esc 清弹窗必须走 sendKeys(真正发 Escape 键),不能 sendText——sendText 是 paste-buffer
-    // 粘贴文本,粘贴结尾的 Enter 会激活弹窗默认选项(对 MCP 信任窗等于静默授权,与 provision
-    // 的 enabledMcpjsonServers 授权边界相抵)。这条断言钉住实现,改回 sendText 立即挂。
-    expect(tmux.calls.sendKeys).toBe(1)
-    expect(tmux.calls.sendText).toBe(2) // 首投 + 重投
-    // 会话记录里只有重投后的那一条 user 消息(被吞的首条没有落账)
+    // 自动Escape/重贴会污染非空composer；本期只投一次，后续由输入surface门控接管。
+    expect(tmux.calls.sendKeys).toBe(0)
+    expect(tmux.calls.sendText).toBe(1)
     const sessionFile = path.join(claudeProjectsDir, await wsSlug(), `${h.session_ref}.jsonl`)
-    const raw = await fs.readFile(sessionFile, 'utf-8')
-    const userLines = raw.split('\n').filter((l) => l.includes('"type":"user"'))
-    expect(userLines).toHaveLength(1)
+    await expect(fs.readFile(sessionFile, 'utf-8')).rejects.toMatchObject({ code: 'ENOENT' })
 
     await adapter.kill(h)
   })
 
-  it('弹窗持续存在(两次投递都被吞)→ 走 startup stall 暂扣,不静默留下 running', async () => {
+  it('持续未落 session 时不自动 Escape 或重贴', async () => {
     const reports: Array<{ state: string; outputTail?: string }> = []
     const { adapter, workerId } = await deliveryAdapter([{ output: '永远不会输出' }], {
       dropSubmitCount: 10,
@@ -910,15 +905,11 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — prompt 投递验证(2026-
     })
     const h = await adapter.spawn({ worker_id: workerId, prompt: '完整任务', workspace: { root: workspaceRoot } })
 
-    await waitForIdle(adapter, h)
+    // session receipt 缺失不再触发猜测性自动恢复；保持存活会话等待显式控制。
+    expect(reports.find((r) => r.state === 'idle')).toBeUndefined()
     const meta = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8'))
-    expect(meta.state).toBe('idle')
-    expect(meta.startup_stalled).toBe(true)
-    // 暂扣正文必须如实描述投递验证失败(握手已通过、prompt 被吞),不能复用"未就绪/一个字符
-    // 都没投递"的失实描述——否则 manager 按错的现场做决策。
-    const idleReport = reports.find((r) => r.state === 'idle')
-    expect(idleReport?.outputTail).toContain('没有出现在会话记录')
-    expect(idleReport?.outputTail).toContain('自动按 Esc 并重投一次')
+    expect(meta.state).toBe('running')
+    await adapter.kill(h)
   })
 })
 

--- a/crabot-agent/tests/workers/claude-code-adapter.test.ts
+++ b/crabot-agent/tests/workers/claude-code-adapter.test.ts
@@ -484,7 +484,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — 四轮 review PoC 回归:
       const stopHookCmd = channel.hookCommand('stop')
       // 两步都不 exit/emitStop——mock CLI 消费完第一步后挂起原地等下一条 stdin,tmux 会话
       // 因此持续存活,直到显式 kill,给"重连一个仍存活的会话"提供稳定的时间窗口。
-      const claudeBin = claudeBinFor([{ output: '第一段输出' }, { output: '第二段输出' }], stopHookCmd)
+      const claudeBin = claudeBinFor([{ output: '第一段输出', emitStop: true }, { output: '第二段输出' }], stopHookCmd)
 
       const adapterA = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin, promptDeliveryTimeoutMs: 0 })
       await adapterA.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
@@ -492,6 +492,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — 四轮 review PoC 回归:
       const h = await adapterA.spawn({ worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } })
 
       await waitForOutputContains(adapterA, h, '第一段输出')
+      await waitForState(adapterA, h, 'idle')
 
       // "重启":全新 adapter 实例,同一 dataDir,内存 runtimes 为空,从未见过这个化身。
       const adapterB = new ClaudeCodeAdapter({ dataDir, claudeConfigPath: fakeClaudeConfig(dataDir), tmux, claudeBin: 'unused-not-invoked-by-sendInput' })
@@ -538,7 +539,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — 四轮 review PoC 回归:
       // 修复前:sendInput 直接抛通用 Error("no such incarnation...resident in this
       // process")——harness 只对 WorkerExitedError 转透明接续,通用 Error 会原样穿透砸给
       // 调用方,消息永久卡在队首。修复后:ensureRuntime 重建出 runtime(meta 还在),真实
-      // tmux isAlive 探测发现会话已死 → runtime.state 直接是 'exited' → 既有的 syncState
+      // tmux isAlive 探测发现会话已死 → runtime.controlState 直接是 'exited' → 既有的 syncState
       // 快路径产出 WorkerExitedError。
       await expect(adapterB.sendInput(h, '还有件事')).rejects.toBeInstanceOf(WorkerExitedError)
 
@@ -605,8 +606,12 @@ class RaceTmux extends TmuxDriver {
   async newSession(spec: TmuxSessionSpec): Promise<void> {
     await fakeReadyNewSession(spec)
   }
+  async pasteText(_name: string, _text: string): Promise<void> {}
   async sendText(_name: string, _text: string): Promise<void> {}
   async sendKeys(_name: string, _keys: string[]): Promise<void> {}
+  async capturePane(_name: string) {
+    return { text: '❯ \n? for shortcuts', cursor_x: 0, cursor_y: 0, width: 80, height: 24 }
+  }
   async isAlive(_name: string): Promise<boolean> {
     return new Promise((resolve) => {
       this.pending.push(resolve)
@@ -633,11 +638,17 @@ class SwitchableTmuxDriver extends TmuxDriver {
   async newSession(spec: TmuxSessionSpec): Promise<void> {
     return this.current.newSession(spec)
   }
+  async pasteText(name: string, text: string): Promise<void> {
+    return this.current.pasteText(name, text)
+  }
   async sendText(name: string, text: string): Promise<void> {
     return this.current.sendText(name, text)
   }
   async sendKeys(name: string, keys: string[]): Promise<void> {
     return this.current.sendKeys(name, keys)
+  }
+  async capturePane(name: string) {
+    return this.current.capturePane(name)
   }
   async isAlive(name: string): Promise<boolean> {
     return this.current.isAlive(name)
@@ -750,7 +761,8 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — spawn 提交纪律(P2 Tas
 
       const metaRaw = await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8')
       const meta = JSON.parse(metaRaw) as { state: WorkerContractState }
-      expect(meta.state).toBe('running')
+      expect(meta.state).toBe('idle')
+      expect(h.initial_input).toMatchObject({ control_state: 'waiting_action', disposition: 'not_pasted' })
 
       await adapter.kill(h)
     },
@@ -758,15 +770,18 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — spawn 提交纪律(P2 Tas
   )
 
   it(
-    '首条 sendText 失败时,不放任 running——按 kill 路径落 exited(crashed),spawn 仍 reject',
+    '首条 pasteText 失败时,不放任 running——按 kill 路径落 exited(crashed),spawn 仍 reject',
     async () => {
       class NewSessionOkSendTextFailsTmux extends TmuxDriver {
         killed = false
         async newSession(spec: TmuxSessionSpec): Promise<void> {
           return super.newSession(spec)
         }
-        async sendText(_name: string, _text: string): Promise<void> {
-          throw new Error('simulated sendText failure')
+        async capturePane(_name: string) {
+          return { text: '❯ \n? for shortcuts', cursor_x: 0, cursor_y: 0, width: 80, height: 24 }
+        }
+        async pasteText(_name: string, _text: string): Promise<void> {
+          throw new Error('simulated pasteText failure')
         }
         async killSession(name: string): Promise<void> {
           this.killed = true
@@ -779,7 +794,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — spawn 提交纪律(P2 Tas
       const workerId = `cctest-${randomUUID().slice(0, 8)}`
       const spec: SpawnSpec = { worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } }
 
-      await expect(adapter.spawn(spec)).rejects.toThrow('simulated sendText failure')
+      await expect(adapter.spawn(spec)).rejects.toThrow('simulated pasteText failure')
 
       const metaRaw = await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8')
       const meta = JSON.parse(metaRaw) as { state: WorkerContractState; ended_reason?: string }
@@ -888,9 +903,10 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — prompt 投递验证(2026-
     // 关键断言:验证通过,没有走 startup stall 路径;state 迁移是事件驱动的,不在此断言。
     const meta = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8'))
     expect(meta.startup_stalled).toBeUndefined()
-    // 自动Escape/重贴会污染非空composer；本期只投一次，后续由输入surface门控接管。
-    expect(tmux.calls.sendKeys).toBe(0)
-    expect(tmux.calls.sendText).toBe(1)
+    // 只有事务本身的一次paste与一次Enter；没有Escape，也没有第二次paste。
+    expect(tmux.calls.sendKeys).toBe(1)
+    expect(tmux.calls.pasteText).toBe(1)
+    expect(tmux.calls.sendText).toBe(0)
     const sessionFile = path.join(claudeProjectsDir, await wsSlug(), `${h.session_ref}.jsonl`)
     await expect(fs.readFile(sessionFile, 'utf-8')).rejects.toMatchObject({ code: 'ENOENT' })
 
@@ -1126,7 +1142,8 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter.resume', () => {
       }
       // session_ref(cc 会话 uuid)在 resume 前后不变。
       expect(meta2Raw.session_id).toBe(meta1.session_id)
-      expect(meta2Raw.state).toBe('running')
+      expect(meta2Raw.state).toBe('exited')
+      expect(h2.initial_input).toMatchObject({ control_state: 'exited', disposition: 'accepted' })
 
       // resume 出的 mock 进程收到 wakeInput 才会跑 step0(输出+exit);等它收敛到 exited,
       // 确保子进程真的启动过、argv 记录行已经落盘,再读 argvFile——resume() 本身返回时只保证
@@ -1205,11 +1222,15 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter.resume', () => {
 
 /** 转发到内部真实 TmuxDriver 并记调用次数——用于断言 fork() 全程没碰 tmux。 */
 class CountingTmux extends TmuxDriver {
-  calls = { newSession: 0, sendText: 0, sendKeys: 0, killSession: 0 }
+  calls = { newSession: 0, pasteText: 0, sendText: 0, sendKeys: 0, killSession: 0 }
   private readonly real = new TmuxDriver()
   async newSession(spec: TmuxSessionSpec): Promise<void> {
     this.calls.newSession++
     return this.real.newSession(spec)
+  }
+  async pasteText(name: string, text: string): Promise<void> {
+    this.calls.pasteText++
+    return this.real.pasteText(name, text)
   }
   async sendText(name: string, text: string): Promise<void> {
     this.calls.sendText++
@@ -1395,16 +1416,68 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter.fork', () => {
 
 /** 全程无操作的假 TmuxDriver——readTrace 测试只需要一个"常驻 runtime"的化身,不关心 tmux 行为本身。 */
 class NoopTmux extends TmuxDriver {
+  paneText = '❯ \n? for shortcuts'
+
   async newSession(spec: TmuxSessionSpec): Promise<void> {
     await fakeReadyNewSession(spec)
   }
+  async pasteText(_name: string, text: string): Promise<void> {
+    this.paneText = `❯ ${text}\n? for shortcuts`
+  }
   async sendText(_name: string, _text: string): Promise<void> {}
-  async sendKeys(_name: string, _keys: string[]): Promise<void> {}
+  async sendKeys(_name: string, keys: string[]): Promise<void> {
+    if (keys.includes('Enter')) this.paneText = '❯ \nesc to interrupt'
+  }
+  async capturePane(_name: string) {
+    return { text: this.paneText, cursor_x: 0, cursor_y: 0, width: 80, height: 24 }
+  }
   async isAlive(_name: string): Promise<boolean> {
     return true
   }
   async killSession(_name: string): Promise<void> {}
 }
+
+class ExitAfterAcceptedTmux extends NoopTmux {
+  private submissions = 0
+
+  async sendKeys(_name: string, keys: string[]): Promise<void> {
+    if (!keys.includes('Enter')) return
+    this.submissions += 1
+    this.paneText = this.submissions === 1
+      ? '❯ \nesc to interrupt'
+      : 'Queued message\n❯ \nesc to interrupt'
+  }
+
+  async isAlive(_name: string): Promise<boolean> {
+    return this.submissions < 2
+  }
+}
+
+describe('ClaudeCodeAdapter accepted-input synchronous exit settlement', () => {
+  it('sendInput返回前暴露exit report且不发异步callback', async () => {
+    const dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'cc-accepted-exit-data-'))
+    const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'cc-accepted-exit-ws-'))
+    const callbacks: WorkerContractState[] = []
+    const adapter = new ClaudeCodeAdapter({
+      dataDir,
+      tmux: new ExitAfterAcceptedTmux(),
+      claudeConfigPath: fakeClaudeConfig(dataDir),
+      onStateChange: (_h, state) => callbacks.push(state),
+    })
+    try {
+      const h = await adapter.spawn({ worker_id: `cctest-${randomUUID().slice(0, 8)}`, prompt: '第一步', workspace: { root: workspaceRoot } })
+      expect(h.initial_input).toEqual({ control_state: 'running', disposition: 'accepted' })
+
+      await adapter.sendInput(h, '第二步')
+
+      expect(adapter.takeAcceptedInputExit(h)).toEqual({ endReason: 'completed' })
+      expect(callbacks).not.toContain('exited')
+    } finally {
+      await fs.rm(dataDir, { recursive: true, force: true }).catch(() => {})
+      await fs.rm(workspaceRoot, { recursive: true, force: true }).catch(() => {})
+    }
+  })
+})
 
 describe('ClaudeCodeAdapter.readTrace', () => {
   let dataDir: string
@@ -1725,6 +1798,51 @@ describe('ClaudeCodeAdapter — CLI hook 事件文件监视(被动 push)', () =>
     throw new Error('waitFor timeout')
   }
 
+  it('相关Notification仅在当前pane仍是交互界面时进入waiting_action，并保留payload', async () => {
+    const seen: Array<{ state: WorkerContractState; report?: StateChangeReport }> = []
+    const tmux = new NoopTmux()
+    const adapter = new ClaudeCodeAdapter({
+      dataDir,
+      claudeConfigPath: fakeClaudeConfig(dataDir),
+      tmux,
+      claudeBin: 'unused', promptDeliveryTimeoutMs: 0,
+      claudeProjectsDir,
+      onStateChange: (_h, state, report) => seen.push({ state, report }),
+    })
+    const workerId = `cctest-${randomUUID().slice(0, 8)}`
+    const h = await adapter.spawn({ worker_id: workerId, prompt: '干活', workspace: { root: workspaceRoot } })
+
+    tmux.paneText = 'AskUserQuestion\nSelect an option\n  Yes\n  No'
+    await fs.appendFile(
+      eventsFilePath({ root: workspaceRoot }),
+      JSON.stringify({
+        ts: new Date().toISOString(),
+        kind: 'notification',
+        raw: { notification_type: 'permission_prompt', message: 'Choose', title: 'Question' },
+      }) + '\n',
+      'utf-8',
+    )
+    await waitFor(() => seen.length === 1)
+    expect(seen[0]).toEqual({
+      state: 'idle',
+      report: {
+        outputTail: tmux.paneText,
+        waitReason: 'interaction_required',
+        notification: { type: 'permission_prompt', message: 'Choose', title: 'Question' },
+      },
+    })
+
+    tmux.paneText = '❯ \nesc to interrupt'
+    await fs.appendFile(
+      eventsFilePath({ root: workspaceRoot }),
+      JSON.stringify({ ts: new Date().toISOString(), kind: 'notification', raw: { notification_type: 'permission_prompt' } }) + '\n',
+      'utf-8',
+    )
+    await new Promise((resolve) => setTimeout(resolve, 300))
+    expect(seen).toHaveLength(1)
+    await adapter.kill(h)
+  })
+
   it('spawn 之后 hook 往事件文件追加 stop → 无人调用 state()/sendInput() 也能推出 idle 状态回调', async () => {
     const seen: Array<{ seq: number; state: WorkerContractState }> = []
     const tmux = new NoopTmux()
@@ -1878,7 +1996,7 @@ describe('ClaudeCodeAdapter — CLI hook 事件文件监视(被动 push)', () =>
  * 侧问设计上就是在主线还在跑的时候发起的(queryWorker 把 fork 放在锁外、不阻塞主线),
  * 两个症状因此必然成对出现:
  *   ① 主线跑到一半被判成 idle,推一条假的"这一轮干完了"去唤醒 manager;
- *   ② 主线随后真正跑完这一轮时 computed === runtime.state === 'idle',不再产生迁移,
+ *   ② 主线随后真正跑完这一轮时 computed === runtime.controlState === 'idle',不再产生迁移,
  *      真正的轮次边界唤醒被整条吞掉。
  */
 describe('ClaudeCodeAdapter.fork — 侧问收尾不污染主线 stop 计数', () => {
@@ -2082,12 +2200,12 @@ describe('ClaudeCodeAdapter.ensureRuntime — 并发重建不泄漏 watcher', ()
  * 真的走了同一条降级路径,不是模拟出来的。
  */
 describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — 启动期就绪握手(\\e[?2004h)', () => {
-  /** 记录 sendText 调用,其余行为完全走真实 TmuxDriver —— 超时分支要断言的是"一次都没调"。 */
+  /** 记录 pasteText 调用,其余行为完全走真实 TmuxDriver —— 超时分支要断言的是"一次都没调"。 */
   class SpyTmux extends TmuxDriver {
-    readonly sendTextCalls: Array<{ name: string; text: string }> = []
-    async sendText(name: string, text: string): Promise<void> {
-      this.sendTextCalls.push({ name, text })
-      return super.sendText(name, text)
+    readonly pasteTextCalls: Array<{ name: string; text: string }> = []
+    async pasteText(name: string, text: string): Promise<void> {
+      this.pasteTextCalls.push({ name, text })
+      return super.pasteText(name, text)
     }
   }
 
@@ -2159,7 +2277,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — 启动期就绪握手(\\e
       }
 
       expect(await submissions()).toEqual([MULTILINE_PROMPT])
-      expect(tmux.sendTextCalls).toHaveLength(1)
+      expect(tmux.pasteTextCalls).toHaveLength(1)
     },
     30000,
   )
@@ -2171,7 +2289,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — 启动期就绪握手(\\e
       // (§6.3 给"干过活之后自然退出"校准的),而这里开工输入一个字符都没投递过——吃下缺省
       // 就会让 harness 的 taskStatusFromIncarnation 把 task 记成 **completed**,manager 与
       // recovery 从此不再过问一个压根没开工的 worker(正是 #66 修的那类"失败记成成功")。
-      // 把 reportStartupStall 里的 'crashed' 改回缺省,这条用例就挂。
+      // 把 initialStartupStall 里的 'crashed' 改回缺省,这条用例就挂。
       const seen: { state: string; endReason?: string }[] = []
       const adapter = new ClaudeCodeAdapter({
         dataDir,
@@ -2189,13 +2307,18 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — 启动期就绪握手(\\e
       const h = await adapter.spawn({ worker_id: workerId, prompt: MULTILINE_PROMPT, workspace: { root: workspaceRoot } })
       expect(Date.now() - startedAt).toBeLessThan(15_000)
 
-      expect(tmux.sendTextCalls).toEqual([])
+      expect(tmux.pasteTextCalls).toEqual([])
       const meta = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8'))
       expect(meta.state).toBe('exited')
       expect(meta.ended_reason).toBe('crashed')
       expect(await adapter.state(h)).toBe('exited')
-      // 台账那一侧收到的也必须是 crashed —— harness 一律取 adapter 上报的这个真值落 task。
-      expect(seen).toContainEqual({ state: 'exited', endReason: 'crashed' })
+      // spawn返回前的同步终态只通过initial_input结算，不重复发布onStateChange。
+      expect(h.initial_input).toMatchObject({
+        control_state: 'exited',
+        disposition: 'not_pasted',
+        report: { endReason: 'crashed' },
+      })
+      expect(seen).toEqual([])
     },
     40000,
   )
@@ -2223,10 +2346,10 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — 启动期就绪握手(\\e
       const { adapter, workerId } = await makeAdapter({ readyDelayMs: 600_000, pasteReadyTimeoutMs: 2000 })
       const h = await adapter.spawn({ worker_id: workerId, prompt: MULTILINE_PROMPT, workspace: { root: workspaceRoot } })
 
-      expect(tmux.sendTextCalls).toEqual([])
+      expect(tmux.pasteTextCalls).toEqual([])
       // 再等一会儿,确认不是"晚一点才发"——超时分支绝不能退化成降级继续发送。
       await new Promise((r) => setTimeout(r, 500))
-      expect(tmux.sendTextCalls).toEqual([])
+      expect(tmux.pasteTextCalls).toEqual([])
       expect(await submissions()).toEqual([])
       expect(h.session_ref).toMatch(/^[0-9a-f-]{36}$/) // cc 的 session id 是自己定的,不受影响
     },
@@ -2244,10 +2367,15 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — 启动期就绪握手(\\e
       })
       const h = await adapter.spawn({ worker_id: workerId, prompt: MULTILINE_PROMPT, workspace: { root: workspaceRoot } })
 
-      const idle = seen.filter((s) => s.state === 'idle')
-      expect(idle).toHaveLength(1)
-      expect(idle[0].report?.outputTail).toContain(banner)
-      expect(idle[0].report?.outputTail).toContain('一个字符都没有投递')
+      const stalled = h.initial_input
+      expect(stalled).toMatchObject({
+        control_state: 'waiting_action',
+        disposition: 'not_pasted',
+        report: { waitReason: 'startup_stall' },
+      })
+      expect(stalled?.report?.outputTail).toContain(banner)
+      expect(stalled?.report?.outputTail).toContain('一个字符都没有投递')
+      expect(seen).toEqual([])
 
       const meta = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8'))
       expect(meta.state).toBe('idle')
@@ -2260,7 +2388,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — 启动期就绪握手(\\e
   it(
     '这条 idle 粘得住:再调 state() 不会被三源判定翻回 running(pane 活着 + stop 计数恒不涨)',
     async () => {
-      // 五轮 review:去掉 syncState 里维持 startupStalled 的那一支,这条用例就挂——computed
+      // 五轮 review:去掉 syncState 里维持 waiting_action 的那一支,这条用例就挂——computed
       // 恒为 running,刚落的 idle 连同台账一起被翻回"正在干活",而这个 worker 的开工输入
       // 一个字符都没投递过。上一条用例只断言 not.toBe('exited'),观察不到这次翻转。
       const { adapter, workerId } = await makeAdapter({ readyDelayMs: 600_000, pasteReadyTimeoutMs: 2000 })
@@ -2270,7 +2398,9 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — 启动期就绪握手(\\e
       expect(await adapter.state(h)).toBe('idle') // 连续两次都不翻
       const meta = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8'))
       expect(meta.state).toBe('idle')
-      expect(meta.startup_stalled).toBe(true)
+      expect(meta.wait_mode).toBe('action')
+      expect(meta.wait_reason).toBe('startup_stall')
+      expect(meta.startup_stalled).toBeUndefined()
     },
     30000,
   )
@@ -2297,11 +2427,11 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — 启动期就绪握手(\\e
   it(
     '暂扣态置位之后进程才死 → 落 exited(crashed),不吃"非 kill ⇒ completed"的缺省推断',
     async () => {
-      // 七轮 review:上一轮的 deadReason 形参只作用于 reportStartupStall 里的**那一次**
+      // 七轮 review:上一轮的 deadReason 形参只作用于 initialStartupStall 里的**那一次**
       // syncState(握手等待期间就死了)。可暂扣是个持续状态——idle 落定之后进程才死(pane
       // 被外部收走、TUI 自退、机器重启后残留会话消失),后续任何一次 syncState 判到 exited
       // 仍会吃缺省推断,把一个开工输入一个字符都没投递过的 worker 记成"成功完成"终态,
-      // manager 与 recovery 从此不再过问。去掉 syncState exited 分支里的 startupStalled
+      // manager 与 recovery 从此不再过问。去掉 syncState exited 分支里的 waiting_action
       // 判断,这条用例就挂(拿到 'completed')。
       const { adapter, seen, workerId } = await makeAdapter({ readyDelayMs: 600_000, pasteReadyTimeoutMs: 2000 })
       const h = await adapter.spawn({ worker_id: workerId, prompt: MULTILINE_PROMPT, workspace: { root: workspaceRoot } })
@@ -2351,16 +2481,13 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — 启动期就绪握手(\\e
   )
 
   it(
-    'sendInput 投递成功之后才死 → 仍走缺省推断(completed),这条修正不误伤干过活的化身',
+    'manager显式raw Enter后出现active证据，随后进程死亡按completed推断',
     async () => {
-      // 反向钉住"没干过活"与"干过活"的分界:startupStalled 在 sendInput 成功后被清除(连同
-      // 落盘的 startup_stalled),此后的自然退出照旧是 §6.3 的 completed 推断。把上面那条
-      // 判断写成"历史上暂扣过就 crashed"(不清标志、或改看 meta 的历史值),这条用例就挂。
       const { adapter, seen, workerId } = await makeAdapter({ readyDelayMs: 600_000, pasteReadyTimeoutMs: 2000 })
       const h = await adapter.spawn({ worker_id: workerId, prompt: MULTILINE_PROMPT, workspace: { root: workspaceRoot } })
       expect(await adapter.state(h)).toBe('idle')
 
-      await adapter.sendInput(h, 'Enter', { raw: true })
+      await expect(adapter.sendInput(h, 'Enter', { raw: true })).resolves.toBeUndefined()
       expect(await adapter.state(h)).toBe('running')
 
       execFileSync('tmux', ['kill-session', '-t', `crabot-w-${workerId}-1`], { stdio: 'ignore' })
@@ -2374,18 +2501,17 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — 启动期就绪握手(\\e
   )
 
   it(
-    'manager 出手(sendInput)之后暂扣解除:状态回到 running,落盘也不再带 startup_stalled',
+    'startup stall上的raw只发指定键；出现active证据后转running',
     async () => {
       const { adapter, workerId } = await makeAdapter({ readyDelayMs: 600_000, pasteReadyTimeoutMs: 2000 })
       const h = await adapter.spawn({ worker_id: workerId, prompt: MULTILINE_PROMPT, workspace: { root: workspaceRoot } })
       expect(await adapter.state(h)).toBe('idle')
 
-      await adapter.sendInput(h, 'Enter', { raw: true })
-
+      await expect(adapter.sendInput(h, 'Enter', { raw: true })).resolves.toBeUndefined()
       expect(await adapter.state(h)).toBe('running')
       const meta = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8'))
       expect(meta.state).toBe('running')
-      expect(meta.startup_stalled).toBeUndefined()
+      expect(meta.wait_mode).toBeUndefined()
     },
     30000,
   )
@@ -2393,7 +2519,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — 启动期就绪握手(\\e
   it(
     '带给 manager 的 output 尾部是可读文本,不是转义序列——与 read_worker_output 同一形态',
     async () => {
-      // 真实模态框是 TUI 重绘出来的:清屏、逐行绝对定位、SGR 上色。去掉 reportStartupStall 里
+      // 真实模态框是 TUI 重绘出来的:清屏、逐行绝对定位、SGR 上色。去掉 initialStartupStall 里
       // 那次 decodeTerminalOutput,manager 拿到的就是下面这串原样字节——而它同一时刻用
       // read_worker_output 读同一份日志拿到的是解码后的文本,同一份日志两种形态。
       const banner = [
@@ -2407,9 +2533,9 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — 启动期就绪握手(\\e
         pasteReadyTimeoutMs: 2000,
         banner,
       })
-      await adapter.spawn({ worker_id: workerId, prompt: MULTILINE_PROMPT, workspace: { root: workspaceRoot } })
+      const h = await adapter.spawn({ worker_id: workerId, prompt: MULTILINE_PROMPT, workspace: { root: workspaceRoot } })
 
-      const tail = seen.find((s) => s.state === 'idle')?.report?.outputTail
+      const tail = h.initial_input?.report?.outputTail
       expect(tail).toBeTruthy()
       // 一个 ESC 都不该剩:解码器丢掉所有控制序列,只留可见文本。
       expect(tail).not.toContain('\u001b')

--- a/crabot-agent/tests/workers/cli-events.test.ts
+++ b/crabot-agent/tests/workers/cli-events.test.ts
@@ -25,7 +25,7 @@ describe('CliEventChannel', () => {
     const channel = new CliEventChannel(filePath)
     const cmd = channel.hookCommand('stop')
 
-    await execFileAsync('/bin/bash', ['-c', cmd])
+    await execFileAsync('/bin/bash', ['-c', `(${cmd}) </dev/null`])
 
     const events = await channel.readAll()
     expect(events).toHaveLength(1)
@@ -39,11 +39,19 @@ describe('CliEventChannel', () => {
   it('hookCommand 对不同 kind 各自产出可解析的独立事件', async () => {
     const channel = new CliEventChannel(filePath)
 
-    await execFileAsync('/bin/bash', ['-c', channel.hookCommand('notification')])
-    await execFileAsync('/bin/bash', ['-c', channel.hookCommand('session_start')])
+    await execFileAsync('/bin/bash', ['-c', `(${channel.hookCommand('notification')}) </dev/null`])
+    await execFileAsync('/bin/bash', ['-c', `(${channel.hookCommand('session_start')}) </dev/null`])
 
     const events = await channel.readAll()
     expect(events.map((e) => e.kind)).toEqual(['notification', 'session_start'])
+  })
+
+  it('hookCommand keeps a JSON stdin payload as raw', async () => {
+    const channel = new CliEventChannel(filePath)
+    const payload = '{"notification_type":"permission_prompt","message":"needs permission"}'
+    const quoted = `'${payload.replace(/'/g, `'\\''`)}'`
+    await execFileAsync('/bin/bash', ['-c', `printf '%s' ${quoted} | (${channel.hookCommand('notification')})`])
+    expect((await channel.readAll())[0].raw).toEqual(JSON.parse(payload))
   })
 
   it('readAll 对不存在的文件返回空数组', async () => {

--- a/crabot-agent/tests/workers/cli-events.test.ts
+++ b/crabot-agent/tests/workers/cli-events.test.ts
@@ -54,6 +54,15 @@ describe('CliEventChannel', () => {
     expect((await channel.readAll())[0].raw).toEqual(JSON.parse(payload))
   })
 
+  it('preserves a Stop payload while keeping empty Stop input as legacy raw:null', async () => {
+    const channel = new CliEventChannel(filePath)
+    const payload = '{"stop_hook_active":true}'
+    const quoted = `'${payload.replace(/'/g, `'\\''`)}'`
+    await execFileAsync('/bin/bash', ['-c', `printf '%s' ${quoted} | (${channel.hookCommand('stop')})`])
+    await execFileAsync('/bin/bash', ['-c', `(${channel.hookCommand('stop')}) </dev/null`])
+    expect((await channel.readAll()).map((event) => event.raw)).toEqual([JSON.parse(payload), null])
+  })
+
   it('readAll 对不存在的文件返回空数组', async () => {
     const channel = new CliEventChannel(path.join(tempDir, 'does-not-exist.jsonl'))
     const events = await channel.readAll()

--- a/crabot-agent/tests/workers/codex-adapter.test.ts
+++ b/crabot-agent/tests/workers/codex-adapter.test.ts
@@ -226,6 +226,7 @@ describe('CodexWorkerAdapter.provision', () => {
       expect(Array.isArray(parsed.notify)).toBe(true)
       expect(parsed.notify[0]).toBe('/bin/sh')
       expect(parsed.notify.join(' ')).toContain('events-cli.jsonl')
+      expect(parsed.notify[2]).toContain('</dev/null')
 
       // trust_level 必须存在且指向本 workspace 的 realpath
       expect(parsed.projects[realRoot]).toEqual({ trust_level: 'trusted' })
@@ -582,8 +583,12 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter (tmux + mock CLI)', () => {
       const datePath = path.join(String(now.getFullYear()), pad(now.getMonth() + 1), pad(now.getDate()))
       const rolloutFile = path.join(workspaceRoot, '.codex', 'sessions', datePath, rolloutFileNameFor(rolloutUuid))
       const channel = new CliEventChannel(eventsFilePath({ root: workspaceRoot }))
+      const seen: Array<{ state: WorkerContractState; sessionRef?: string }> = []
       const codexBin = codexBinFor(
-        [{ output: '第一段输出', emitStop: true }],
+        [
+          { output: 'raw 清障回合', emitStop: true },
+          { output: '首条任务完成', emitStop: true },
+        ],
         channel.hookCommand('stop'),
         { rolloutFile, rolloutOnSubmit: true, pasteReadyDelayMs: 200 },
       )
@@ -593,6 +598,7 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter (tmux + mock CLI)', () => {
         codexBin,
         pasteReadyTimeoutMs: 50,
         sessionDiscoveryTimeoutMs: 1500,
+        onStateChange: (handle, state) => seen.push({ state, sessionRef: handle.session_ref }),
       })
       await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
       const workerId = `codextest-${randomUUID().slice(0, 8)}`
@@ -608,6 +614,11 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter (tmux + mock CLI)', () => {
       expect(adapter.takeUpdatedSessionRef(h)).toBe(rolloutUuid)
       const meta = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8')) as { session_id: string; session_discovery?: string }
       expect(meta).toMatchObject({ session_id: rolloutUuid, session_discovery: 'discovered' })
+      const deadline = Date.now() + 5000
+      while (!seen.some((event) => event.state === 'idle' && event.sessionRef === rolloutUuid) && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 25))
+      }
+      expect(seen).toContainEqual({ state: 'idle', sessionRef: rolloutUuid })
     },
     15000,
   )

--- a/crabot-agent/tests/workers/codex-adapter.test.ts
+++ b/crabot-agent/tests/workers/codex-adapter.test.ts
@@ -66,10 +66,12 @@ function rolloutFileNameFor(uuid: string): string {
 
 /** 拼一条 `env MOCK_CLI_SCRIPT=... MOCK_CLI_STOP_HOOK_CMD=... [MOCK_CLI_ARGV_FILE=...]
  * [MOCK_CLI_ROLLOUT_FILE=...] node mock-cli.mjs` 命令行,充当测试用的 codexBin。 */
-function codexBinFor(script: MockStep[], stopHookCmd: string, opts?: { argvFile?: string; rolloutFile?: string }): string {
+function codexBinFor(script: MockStep[], stopHookCmd: string, opts?: { argvFile?: string; rolloutFile?: string; rolloutOnSubmit?: boolean; pasteReadyDelayMs?: number }): string {
   const argvEnv = opts?.argvFile ? `MOCK_CLI_ARGV_FILE=${shQuote(opts.argvFile)} ` : ''
   const rolloutEnv = opts?.rolloutFile ? `MOCK_CLI_ROLLOUT_FILE=${shQuote(opts.rolloutFile)} ` : ''
-  return `env MOCK_CLI_SCRIPT=${shQuote(JSON.stringify(script))} MOCK_CLI_STOP_HOOK_CMD=${shQuote(stopHookCmd)} ${argvEnv}${rolloutEnv}node ${shQuote(MOCK_CLI)}`
+  const rolloutTimingEnv = opts?.rolloutOnSubmit ? 'MOCK_CLI_ROLLOUT_ON_SUBMIT=1 ' : ''
+  const readyDelayEnv = opts?.pasteReadyDelayMs ? `MOCK_CLI_PASTE_READY_DELAY_MS=${opts.pasteReadyDelayMs} ` : ''
+  return `env MOCK_CLI_SCRIPT=${shQuote(JSON.stringify(script))} MOCK_CLI_STOP_HOOK_CMD=${shQuote(stopHookCmd)} ${argvEnv}${rolloutEnv}${rolloutTimingEnv}${readyDelayEnv}node ${shQuote(MOCK_CLI)}`
 }
 
 /** 假 TmuxDriver 的 newSession 替身:落一份 output 日志并写入 \e[?2004h。
@@ -334,6 +336,7 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter (tmux + mock CLI)', () => {
     script: MockStep[],
     opts?: {
       withRollout?: boolean
+      rolloutOnSubmit?: boolean
       onStateChange?: (h: IncarnationHandle, state: WorkerContractState, report?: StateChangeReport) => void
     },
   ): Promise<{ adapter: CodexWorkerAdapter; workerId: string; rolloutUuid?: string; rolloutFile?: string }> {
@@ -351,7 +354,7 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter (tmux + mock CLI)', () => {
       rolloutFile = path.join(codexHome, 'sessions', datePath, rolloutFileNameFor(rolloutUuid))
     }
 
-    const codexBin = codexBinFor(script, stopHookCmd, { rolloutFile })
+    const codexBin = codexBinFor(script, stopHookCmd, { rolloutFile, rolloutOnSubmit: opts?.rolloutOnSubmit })
     // 测试用小轮询上限,避免"故意不配置 rollout 文件"的用例拖慢整个套件。
     const adapter = new CodexWorkerAdapter({
       dataDir,
@@ -499,7 +502,12 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter (tmux + mock CLI)', () => {
 
       await waitForState(adapter, h, 'exited')
 
-      expect(seen).toContainEqual({ state: 'exited', endReason: 'completed' })
+      expect(h.initial_input).toMatchObject({
+        control_state: 'exited',
+        disposition: 'accepted',
+        report: { endReason: 'completed' },
+      })
+      expect(seen).toEqual([])
     },
     15000,
   )
@@ -545,6 +553,61 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter (tmux + mock CLI)', () => {
       expect(meta.session_id).toBe(rolloutUuid)
       // 发现成功应该标记为 'discovered'
       expect(meta.session_discovery).toBe('discovered')
+    },
+    15000,
+  )
+
+  it(
+    'session 发现:Codex 0.146 式 rollout 在首条 submit 后才出现，spawn 返回真实 session_ref',
+    async () => {
+      const { adapter, workerId, rolloutUuid } = await provisionedAdapter(
+        [{ output: '第一段输出', emitStop: true }],
+        { withRollout: true, rolloutOnSubmit: true },
+      )
+      const h = await adapter.spawn(makeSpec(workerId, '你好'))
+      expect(h.initial_input).toMatchObject({ disposition: 'accepted' })
+      expect(h.session_ref).toBe(rolloutUuid)
+      const meta = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8')) as { session_id: string; session_discovery?: string }
+      expect(meta).toMatchObject({ session_id: rolloutUuid, session_discovery: 'discovered' })
+    },
+    15000,
+  )
+
+  it(
+    'session 发现:startup stall 经 raw 清障后不编占位 id，首条普通输入接受后才发现 rollout',
+    async () => {
+      const rolloutUuid = randomUUID()
+      const now = new Date()
+      const pad = (n: number) => String(n).padStart(2, '0')
+      const datePath = path.join(String(now.getFullYear()), pad(now.getMonth() + 1), pad(now.getDate()))
+      const rolloutFile = path.join(workspaceRoot, '.codex', 'sessions', datePath, rolloutFileNameFor(rolloutUuid))
+      const channel = new CliEventChannel(eventsFilePath({ root: workspaceRoot }))
+      const codexBin = codexBinFor(
+        [{ output: '第一段输出', emitStop: true }],
+        channel.hookCommand('stop'),
+        { rolloutFile, rolloutOnSubmit: true, pasteReadyDelayMs: 200 },
+      )
+      const adapter = new CodexWorkerAdapter({
+        dataDir,
+        tmux,
+        codexBin,
+        pasteReadyTimeoutMs: 50,
+        sessionDiscoveryTimeoutMs: 1500,
+      })
+      await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
+      const workerId = `codextest-${randomUUID().slice(0, 8)}`
+      const h = await adapter.spawn(makeSpec(workerId, '首条任务'))
+      expect(h).toMatchObject({ session_ref: '', initial_input: { disposition: 'not_pasted', control_state: 'waiting_action' } })
+
+      await new Promise((resolve) => setTimeout(resolve, 250))
+      await adapter.sendInput(h, 'Enter', { raw: true })
+      await waitForState(adapter, h, 'idle')
+      expect((await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8'))).toContain('"session_id":""')
+
+      await adapter.sendInput(h, '首条任务')
+      expect(adapter.takeUpdatedSessionRef(h)).toBe(rolloutUuid)
+      const meta = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8')) as { session_id: string; session_discovery?: string }
+      expect(meta).toMatchObject({ session_id: rolloutUuid, session_discovery: 'discovered' })
     },
     15000,
   )
@@ -664,7 +727,7 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter (tmux + mock CLI)', () => {
   it(
     '对同一个已 exited 的 prev 连续 resume 两次,第二次应被拒绝(先到先得,对齐 builtin,P2 review #2)',
     async () => {
-      const { adapter, workerId } = await provisionedAdapter([{ output: '主线输出', exit: true }])
+      const { adapter, workerId } = await provisionedAdapter([{ output: '主线输出', exit: true }], { withRollout: true })
       const h1 = await adapter.spawn(makeSpec(workerId, '你好'))
       await waitForState(adapter, h1, 'exited')
 
@@ -722,7 +785,8 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter (tmux + mock CLI)', () => {
       const channel = new CliEventChannel(eventsFilePath({ root: workspaceRoot }))
       const stopHookCmd = channel.hookCommand('stop')
       const argvFile = path.join(dataDir, 'resume-argv.jsonl')
-      const codexBin = codexBinFor([{ output: '主线输出', exit: true }], stopHookCmd, { argvFile })
+      const rolloutFile = path.join(workspaceRoot, '.codex', 'sessions', rolloutFileNameFor(randomUUID()))
+      const codexBin = codexBinFor([{ output: '主线输出', exit: true }], stopHookCmd, { argvFile, rolloutFile })
       const adapter = new CodexWorkerAdapter({ dataDir, tmux, codexBin, sessionDiscoveryTimeoutMs: 500 })
       await adapter.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
       const workerId = `codextest-${randomUUID().slice(0, 8)}`
@@ -788,7 +852,7 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter — 四轮 review PoC 回归
     async () => {
       const channel = new CliEventChannel(eventsFilePath({ root: workspaceRoot }))
       const stopHookCmd = channel.hookCommand('stop')
-      const codexBin = codexBinFor([{ output: '第一段输出' }, { output: '第二段输出' }], stopHookCmd)
+      const codexBin = codexBinFor([{ output: '第一段输出', emitStop: true }, { output: '第二段输出' }], stopHookCmd)
 
       const adapterA = new CodexWorkerAdapter({ dataDir, tmux, codexBin, sessionDiscoveryTimeoutMs: 500 })
       await adapterA.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
@@ -796,6 +860,7 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter — 四轮 review PoC 回归
       const h = await adapterA.spawn({ worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } })
 
       await waitForOutputContains(adapterA, h, '第一段输出')
+      await waitForState(adapterA, h, 'idle')
 
       // "重启":全新 adapter 实例,同一 dataDir,内存 runtimes 为空,从未见过这个化身。
       const adapterB = new CodexWorkerAdapter({ dataDir, tmux, codexBin: 'unused-not-invoked-by-sendInput' })
@@ -847,7 +912,8 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter — 四轮 review PoC 回归
       // 每次新起的进程(spawn/resume)都从脚本第 0 步重新跑——mock CLI 每次调用都是全新进程,
       // 不记跨调用状态。这里让脚本第一步就 exit,主线与每一次 resume 都会立刻落 exited,
       // 不需要真的等 notify。
-      const codexBin = codexBinFor([{ output: '输出', exit: true }], stopHookCmd)
+      const rolloutFile = path.join(workspaceRoot, '.codex', 'sessions', rolloutFileNameFor(randomUUID()))
+      const codexBin = codexBinFor([{ output: '输出', exit: true }], stopHookCmd, { rolloutFile })
 
       const adapterA = new CodexWorkerAdapter({ dataDir, tmux, codexBin, sessionDiscoveryTimeoutMs: 500 })
       await adapterA.provision({ root: workspaceRoot }, { skills: [], mcp_servers: [] })
@@ -899,11 +965,17 @@ class SwitchableTmuxDriver extends TmuxDriver {
   async newSession(spec: TmuxSessionSpec): Promise<void> {
     return this.current.newSession(spec)
   }
+  async pasteText(name: string, text: string): Promise<void> {
+    return this.current.pasteText(name, text)
+  }
   async sendText(name: string, text: string): Promise<void> {
     return this.current.sendText(name, text)
   }
   async sendKeys(name: string, keys: string[]): Promise<void> {
     return this.current.sendKeys(name, keys)
+  }
+  async capturePane(name: string) {
+    return this.current.capturePane(name)
   }
   async isAlive(name: string): Promise<boolean> {
     return this.current.isAlive(name)
@@ -950,7 +1022,8 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter — spawn 提交纪律', () 
 
       const metaRaw = await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8')
       const meta = JSON.parse(metaRaw) as { state: WorkerContractState }
-      expect(meta.state).toBe('running')
+      expect(meta.state).toBe('idle')
+      expect(h.initial_input).toMatchObject({ control_state: 'waiting_action', disposition: 'not_pasted' })
 
       await adapter.kill(h)
     },
@@ -958,15 +1031,18 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter — spawn 提交纪律', () 
   )
 
   it(
-    '首条 sendText 失败时,不放任 running——按 kill 路径落 exited(crashed),spawn 仍 reject',
+    '首条 pasteText 失败时,不放任 running——按 kill 路径落 exited(crashed),spawn 仍 reject',
     async () => {
       class NewSessionOkSendTextFailsTmux extends TmuxDriver {
         killed = false
         async newSession(spec: TmuxSessionSpec): Promise<void> {
           return super.newSession(spec)
         }
-        async sendText(_name: string, _text: string): Promise<void> {
-          throw new Error('simulated sendText failure')
+        async capturePane(_name: string) {
+          return { text: '› \n? for shortcuts', cursor_x: 0, cursor_y: 0, width: 80, height: 24 }
+        }
+        async pasteText(_name: string, _text: string): Promise<void> {
+          throw new Error('simulated pasteText failure')
         }
         async killSession(name: string): Promise<void> {
           this.killed = true
@@ -979,7 +1055,7 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter — spawn 提交纪律', () 
       const workerId = `codextest-${randomUUID().slice(0, 8)}`
       const spec: SpawnSpec = { worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } }
 
-      await expect(adapter.spawn(spec)).rejects.toThrow('simulated sendText failure')
+      await expect(adapter.spawn(spec)).rejects.toThrow('simulated pasteText failure')
 
       const metaRaw = await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8')
       const meta = JSON.parse(metaRaw) as { state: WorkerContractState; ended_reason?: string }
@@ -1017,7 +1093,7 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter — spawn 提交纪律', () 
       await adapter.spawn(spec).catch(() => {})
 
       expect(tmux.lastEnv).toBeDefined()
-      expect(tmux.lastEnv!.PATH).toBe(`${toolDir}:${process.env.PATH ?? ''}`)
+      expect(tmux.lastEnv!.PATH).toBe(`${await fs.realpath(toolDir)}:${process.env.PATH ?? ''}`)
       expect(tmux.lastEnv!.CODEX_HOME).toBe(path.join(workspaceRoot, '.codex'))
 
       await fs.rm(toolDir, { recursive: true, force: true }).catch(() => {})
@@ -1066,7 +1142,7 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter — spawn 提交纪律', () 
         const workerId2 = `codextest-${randomUUID().slice(0, 8)}`
         await adapter.spawn({ worker_id: workerId2, prompt: '你好', workspace: { root: workspaceRoot } }).catch(() => {})
         expect(tmux.envs[1]).toBeDefined()
-        expect(tmux.envs[1]!.PATH).toBe(`${toolDir}:${process.env.PATH}`)
+        expect(tmux.envs[1]!.PATH).toBe(`${await fs.realpath(toolDir)}:${process.env.PATH}`)
       } finally {
         process.env.PATH = originalPath
         await fs.rm(toolDir, { recursive: true, force: true }).catch(() => {})
@@ -1245,11 +1321,21 @@ describe('CodexWorkerAdapter.fork — capabilities.fork=false', () => {
 
 /** 全程无操作的假 TmuxDriver——readTrace 测试只需要一个"常驻 runtime"的化身,不关心 tmux 行为本身。 */
 class NoopTmux extends TmuxDriver {
+  paneText = '› \n? for shortcuts'
+
   async newSession(spec: TmuxSessionSpec): Promise<void> {
     await fakeReadyNewSession(spec)
   }
+  async pasteText(_name: string, text: string): Promise<void> {
+    this.paneText = `› ${text}\n? for shortcuts`
+  }
   async sendText(_name: string, _text: string): Promise<void> {}
-  async sendKeys(_name: string, _keys: string[]): Promise<void> {}
+  async sendKeys(_name: string, keys: string[]): Promise<void> {
+    if (keys.includes('Enter')) this.paneText = '› \nWorking (esc to interrupt)'
+  }
+  async capturePane(_name: string) {
+    return { text: this.paneText, cursor_x: 0, cursor_y: 0, width: 80, height: 24 }
+  }
   async isAlive(_name: string): Promise<boolean> {
     return true
   }
@@ -1751,10 +1837,10 @@ describe('CodexWorkerAdapter.ensureRuntime — 并发重建不泄漏 watcher', (
 describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter — 启动期就绪握手(\\e[?2004h)', () => {
   /** 记录 sendText 调用,其余行为完全走真实 TmuxDriver。 */
   class SpyTmux extends TmuxDriver {
-    readonly sendTextCalls: Array<{ name: string; text: string }> = []
-    async sendText(name: string, text: string): Promise<void> {
-      this.sendTextCalls.push({ name, text })
-      return super.sendText(name, text)
+    readonly pasteTextCalls: Array<{ name: string; text: string }> = []
+    async pasteText(name: string, text: string): Promise<void> {
+      this.pasteTextCalls.push({ name, text })
+      return super.pasteText(name, text)
     }
   }
 
@@ -1829,7 +1915,7 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter — 启动期就绪握手(\\
       }
 
       expect(await submissions()).toEqual([MULTILINE_PROMPT])
-      expect(tmux.sendTextCalls).toHaveLength(1)
+      expect(tmux.pasteTextCalls).toHaveLength(1)
     },
     30000,
   )
@@ -1858,9 +1944,9 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter — 启动期就绪握手(\\
       const { adapter, workerId } = await makeAdapter({ readyDelayMs: 600_000, pasteReadyTimeoutMs: 2000 })
       await adapter.spawn({ worker_id: workerId, prompt: MULTILINE_PROMPT, workspace: { root: workspaceRoot } })
 
-      expect(tmux.sendTextCalls).toEqual([])
+      expect(tmux.pasteTextCalls).toEqual([])
       await new Promise((r) => setTimeout(r, 500))
-      expect(tmux.sendTextCalls).toEqual([])
+      expect(tmux.pasteTextCalls).toEqual([])
       expect(await submissions()).toEqual([])
     },
     30000,
@@ -1877,10 +1963,15 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter — 启动期就绪握手(\\
       })
       const h = await adapter.spawn({ worker_id: workerId, prompt: MULTILINE_PROMPT, workspace: { root: workspaceRoot } })
 
-      const idle = seen.filter((s) => s.state === 'idle')
-      expect(idle).toHaveLength(1)
-      expect(idle[0].report?.outputTail).toContain(banner)
-      expect(idle[0].report?.outputTail).toContain('一个字符都没有投递')
+      const stalled = h.initial_input
+      expect(stalled).toMatchObject({
+        control_state: 'waiting_action',
+        disposition: 'not_pasted',
+        report: { waitReason: 'startup_stall' },
+      })
+      expect(stalled?.report?.outputTail).toContain(banner)
+      expect(stalled?.report?.outputTail).toContain('一个字符都没有投递')
+      expect(seen).toEqual([])
 
       const meta = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8'))
       expect(meta.state).toBe('idle')
@@ -1895,7 +1986,7 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter — 启动期就绪握手(\\
       // 六轮 review,与 cc adapter 的同名用例同款:syncState 缺省推断是"非 kill ⇒ completed"
       // (§6.3 给"干过活之后自然退出"校准的),但这条路径上开工输入一个字符都没投递过——吃下
       // 缺省就会让 harness 把 task 记成 **completed**,manager 与 recovery 从此不再过问它
-      // (正是 #66 修的那类"失败记成成功")。把 reportStartupStall 里的 'crashed' 改回缺省,
+      // (正是 #66 修的那类"失败记成成功")。把 initialStartupStall 里的 'crashed' 改回缺省,
       // 这条用例就挂。
       const seen: Array<{ state: WorkerContractState; endReason?: string }> = []
       const adapter = new CodexWorkerAdapter({
@@ -1914,13 +2005,17 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter — 启动期就绪握手(\\
       const h = await adapter.spawn({ worker_id: workerId, prompt: MULTILINE_PROMPT, workspace: { root: workspaceRoot } })
       expect(Date.now() - startedAt).toBeLessThan(15_000)
 
-      expect(tmux.sendTextCalls).toEqual([])
+      expect(tmux.pasteTextCalls).toEqual([])
       const meta = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8'))
       expect(meta.state).toBe('exited')
       expect(meta.ended_reason).toBe('crashed')
       expect(await adapter.state(h)).toBe('exited')
-      // 台账那一侧收到的也必须是 crashed —— harness 一律取 adapter 上报的这个真值落 task。
-      expect(seen).toContainEqual({ state: 'exited', endReason: 'crashed' })
+      expect(h.initial_input).toMatchObject({
+        control_state: 'exited',
+        disposition: 'not_pasted',
+        report: { endReason: 'crashed' },
+      })
+      expect(seen).toEqual([])
     },
     40000,
   )
@@ -1928,7 +2023,7 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter — 启动期就绪握手(\\
   it(
     '这条 idle 粘得住:再调 state() 不会被三源判定翻回 running(pane 活着 + turn-complete 计数恒不涨)',
     async () => {
-      // 与 cc adapter 的同名用例同款(五轮 review):去掉 syncState 里维持 startupStalled 的
+      // 与 cc adapter 的同名用例同款(五轮 review):去掉 syncState 里维持 waiting_action 的
       // 那一支,computed 恒为 running,刚落的 idle 连同台账一起被翻回"正在干活"。
       const { adapter, workerId } = await makeAdapter({ readyDelayMs: 600_000, pasteReadyTimeoutMs: 2000 })
       const h = await adapter.spawn({ worker_id: workerId, prompt: MULTILINE_PROMPT, workspace: { root: workspaceRoot } })
@@ -1937,7 +2032,9 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter — 启动期就绪握手(\\
       expect(await adapter.state(h)).toBe('idle')
       const meta = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8'))
       expect(meta.state).toBe('idle')
-      expect(meta.startup_stalled).toBe(true)
+      expect(meta.wait_mode).toBe('action')
+      expect(meta.wait_reason).toBe('startup_stall')
+      expect(meta.startup_stalled).toBeUndefined()
     },
     30000,
   )
@@ -1961,7 +2058,7 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter — 启动期就绪握手(\\
       // 与 cc adapter 的同名用例同款(七轮 review):deadReason 形参只管住"握手等待期间就死了"
       // 那一个时点,而暂扣是持续状态——idle 落定之后才死的化身,后续任何一次 syncState 判到
       // exited 仍会吃缺省推断,把没投递过一个字符的 worker 记成"成功完成"。去掉 syncState
-      // exited 分支里的 startupStalled 判断,这条用例就挂。
+      // exited 分支里的 waiting_action 判断,这条用例就挂。
       const { adapter, seen, workerId } = await makeAdapter({ readyDelayMs: 600_000, pasteReadyTimeoutMs: 2000 })
       const h = await adapter.spawn({ worker_id: workerId, prompt: MULTILINE_PROMPT, workspace: { root: workspaceRoot } })
       expect(await adapter.state(h)).toBe('idle')
@@ -2006,15 +2103,13 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter — 启动期就绪握手(\\
   )
 
   it(
-    'sendInput 投递成功之后才死 → 仍走缺省推断(completed),这条修正不误伤干过活的化身',
+    'manager显式raw Enter后出现active证据，随后进程死亡按completed推断',
     async () => {
-      // 反向钉住"没干过活"与"干过活"的分界:startupStalled 在 sendInput 成功后被清除(连同
-      // 落盘的 startup_stalled),此后的自然退出照旧是 §6.3 的 completed 推断。
       const { adapter, seen, workerId } = await makeAdapter({ readyDelayMs: 600_000, pasteReadyTimeoutMs: 2000 })
       const h = await adapter.spawn({ worker_id: workerId, prompt: MULTILINE_PROMPT, workspace: { root: workspaceRoot } })
       expect(await adapter.state(h)).toBe('idle')
 
-      await adapter.sendInput(h, 'Enter', { raw: true })
+      await expect(adapter.sendInput(h, 'Enter', { raw: true })).resolves.toBeUndefined()
       expect(await adapter.state(h)).toBe('running')
 
       execFileSync('tmux', ['kill-session', '-t', `crabot-w-${workerId}-1`], { stdio: 'ignore' })
@@ -2028,18 +2123,17 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter — 启动期就绪握手(\\
   )
 
   it(
-    'manager 出手(sendInput)之后暂扣解除:状态回到 running,落盘也不再带 startup_stalled',
+    'startup stall上的raw只发指定键；出现active证据后转running',
     async () => {
       const { adapter, workerId } = await makeAdapter({ readyDelayMs: 600_000, pasteReadyTimeoutMs: 2000 })
       const h = await adapter.spawn({ worker_id: workerId, prompt: MULTILINE_PROMPT, workspace: { root: workspaceRoot } })
       expect(await adapter.state(h)).toBe('idle')
 
-      await adapter.sendInput(h, 'Enter', { raw: true })
-
+      await expect(adapter.sendInput(h, 'Enter', { raw: true })).resolves.toBeUndefined()
       expect(await adapter.state(h)).toBe('running')
       const meta = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8'))
       expect(meta.state).toBe('running')
-      expect(meta.startup_stalled).toBeUndefined()
+      expect(meta.wait_mode).toBeUndefined()
     },
     30000,
   )
@@ -2047,7 +2141,7 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter — 启动期就绪握手(\\
   it(
     '带给 manager 的 output 尾部是可读文本,不是转义序列——与 read_worker_output 同一形态',
     async () => {
-      // 与 cc adapter 的同名用例同款:去掉 reportStartupStall 里那次 decodeTerminalOutput,
+      // 与 cc adapter 的同名用例同款:去掉 initialStartupStall 里那次 decodeTerminalOutput,
       // manager 拿到的就是原样转义字节,而它读同一份日志的另一条路(read_worker_output)
       // 拿到的是解码后的文本。
       const banner = [
@@ -2060,9 +2154,9 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter — 启动期就绪握手(\\
         pasteReadyTimeoutMs: 2000,
         banner,
       })
-      await adapter.spawn({ worker_id: workerId, prompt: MULTILINE_PROMPT, workspace: { root: workspaceRoot } })
+      const h = await adapter.spawn({ worker_id: workerId, prompt: MULTILINE_PROMPT, workspace: { root: workspaceRoot } })
 
-      const tail = seen.find((s) => s.state === 'idle')?.report?.outputTail
+      const tail = h.initial_input?.report?.outputTail
       expect(tail).toBeTruthy()
       expect(tail).not.toContain('\u001b')
       expect(tail).toMatch(/Sign in with ChatGPT\n\s*1\. Provide your own API key/)

--- a/crabot-agent/tests/workers/codex-adapter.test.ts
+++ b/crabot-agent/tests/workers/codex-adapter.test.ts
@@ -1050,7 +1050,7 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter — spawn 提交纪律', () 
           return super.newSession(spec)
         }
         async capturePane(_name: string) {
-          return { text: '› \n? for shortcuts', cursor_x: 0, cursor_y: 0, width: 80, height: 24 }
+          return { text: '› \n? for shortcuts' }
         }
         async pasteText(_name: string, _text: string): Promise<void> {
           throw new Error('simulated pasteText failure')
@@ -1345,7 +1345,7 @@ class NoopTmux extends TmuxDriver {
     if (keys.includes('Enter')) this.paneText = '› \nWorking (esc to interrupt)'
   }
   async capturePane(_name: string) {
-    return { text: this.paneText, cursor_x: 0, cursor_y: 0, width: 80, height: 24 }
+    return { text: this.paneText }
   }
   async isAlive(_name: string): Promise<boolean> {
     return true

--- a/crabot-agent/tests/workers/contract-codex.test.ts
+++ b/crabot-agent/tests/workers/contract-codex.test.ts
@@ -7,13 +7,9 @@
  * 在 caps.fork 为假时只断言 fork() reject,不要求它是特定错误类型——实测 codex adapter
  * 的 fork() 始终抛 CapabilityNotSupportedError,符合契约(细节见报告)。
  *
- * makeSpec 的同步签名与 scriptFile 中转方案,与 contract-claude-code.test.ts 同构,注释见
- * 该文件头。session 发现(spawn 轮询 rollout 文件拿真实 session_id)与本契约套件无关——
- * 不提供 MOCK_CLI_ROLLOUT_FILE,固定走"轮询超时降级为本地占位 uuid"路径,占位 uuid
- * 本身仍是合法 UUID,不影响 resume()/fork() 的 session_ref 契约测试;sessionDiscoveryTimeoutMs
- * 调小避免拖慢每个 spawn。
- *
- * 无 tmux 的环境下整个文件 skip(与 codex-adapter.test.ts 的 skipIf 守卫同一判断)。
+ * makeSpec 的同步签名与 scriptFile 中转方案,与 contract-claude-code.test.ts 同构。fixture
+ * 提供真实 rollout 文件,因为 placeholder session 按当前契约明确不可 resume。
+ * * 无 tmux 的环境下整个文件 skip(与 codex-adapter.test.ts 的 skipIf 守卫同一判断)。
  */
 import { describe, it } from 'vitest'
 import { execFileSync } from 'node:child_process'
@@ -94,7 +90,8 @@ async function makeCodexFixture(): Promise<ContractFixture> {
 
   const channel = new CliEventChannel(eventsFilePath({ root: workspaceRoot }))
   const stopHookCmd = channel.hookCommand('stop')
-  const codexBin = `env MOCK_CLI_SCRIPT_FILE=${shQuote(scriptFile)} MOCK_CLI_STOP_HOOK_CMD=${shQuote(stopHookCmd)} node ${shQuote(MOCK_CLI)}`
+  const rolloutFile = path.join(workspaceRoot, '.codex', 'sessions', 'rollout-2026-08-08T00-00-00-11111111-1111-4111-8111-111111111111.jsonl')
+  const codexBin = `env MOCK_CLI_SCRIPT_FILE=${shQuote(scriptFile)} MOCK_CLI_STOP_HOOK_CMD=${shQuote(stopHookCmd)} MOCK_CLI_ROLLOUT_FILE=${shQuote(rolloutFile)} node ${shQuote(MOCK_CLI)}`
 
   const tmux = new TmuxDriver()
   const adapter = new CodexWorkerAdapter({ dataDir, tmux, codexBin, codexHomeSource, sessionDiscoveryTimeoutMs: 300 })

--- a/crabot-agent/tests/workers/contract-suite.ts
+++ b/crabot-agent/tests/workers/contract-suite.ts
@@ -137,7 +137,8 @@ export function runContractSuite(name: string, makeFixture: MakeFixture): void {
 
         const incremental = await fx.adapter.readOutput(h, before.nextCursor)
         expect(incremental.chunk).toContain('第二段输出')
-        expect(incremental.chunk).not.toContain('第一段输出')
+        // CLI TUI may redraw earlier history while editing/submitting; the cursor contract guarantees
+        // byte/log progression, not semantic de-duplication of terminal redraws.
       },
       15000,
     )

--- a/crabot-agent/tests/workers/fixtures/mock-cli.mjs
+++ b/crabot-agent/tests/workers/fixtures/mock-cli.mjs
@@ -94,7 +94,10 @@ async function runStep() {
 
   if (step.emitStop && stopHookCmd) {
     try {
-      await execAsync(stopHookCmd, { shell: '/bin/bash' })
+      // The real hook receives a closed JSON stdin stream. This interactive mock keeps
+      // its own stdin open for subsequent messages, so explicitly model the empty hook
+      // payload rather than letting the POSIX reader block on the TUI input pipe.
+      await execAsync(`(${stopHookCmd}) </dev/null`, { shell: '/bin/bash' })
     } catch (err) {
       process.stderr.write(`mock-cli: stop hook failed: ${err}\n`)
     }

--- a/crabot-agent/tests/workers/fixtures/mock-cli.mjs
+++ b/crabot-agent/tests/workers/fixtures/mock-cli.mjs
@@ -53,7 +53,7 @@
 // 模拟模态框持续吞输入;DROP_FIRST_SUBMIT 是它的 1 次特例(两者共存时取 COUNT)。
 import { exec } from 'node:child_process'
 import { promisify } from 'node:util'
-import { appendFileSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 
 const execAsync = promisify(exec)
@@ -78,19 +78,54 @@ const argvFile = process.env.MOCK_CLI_ARGV_FILE
 if (argvFile) appendFileSync(argvFile, JSON.stringify(process.argv.slice(2)) + '\n')
 
 const rolloutFile = process.env.MOCK_CLI_ROLLOUT_FILE
-if (rolloutFile) {
+const rolloutOnSubmit = process.env.MOCK_CLI_ROLLOUT_ON_SUBMIT === '1'
+function createRollout() {
+  if (!rolloutFile) return
   mkdirSync(dirname(rolloutFile), { recursive: true })
   writeFileSync(rolloutFile, JSON.stringify({ type: 'session_meta', payload: { timestamp: new Date().toISOString() } }) + '\n')
 }
+if (rolloutFile && !rolloutOnSubmit) createRollout()
 
 let stepIndex = 0
+let lastVisibleOutput = ''
+let active = false
+
+function renderScreen(body) {
+  process.stdout.write(`\x1b[2J\x1b[H${body}`)
+}
+
+const composerGlyph = process.env.CODEX_HOME ? '›' : '❯'
+
+function renderComposer(text = '') {
+  const marker = active ? (process.env.CODEX_HOME ? 'Working (esc to interrupt)' : 'esc to interrupt') : '? for shortcuts'
+  renderScreen(`${lastVisibleOutput ? `${lastVisibleOutput}\n` : ''}${composerGlyph} ${text}\n${marker}`)
+}
+
+function renderPrimaryComposer() {
+  active = false
+  renderComposer()
+}
+
+function renderRunning() {
+  active = true
+  const marker = process.env.CODEX_HOME ? 'Working (esc to interrupt)' : 'esc to interrupt'
+  renderScreen(`${lastVisibleOutput ? `${lastVisibleOutput}\n` : ''}${composerGlyph} \n${marker}`)
+}
+
+function renderQueued() {
+  active = true
+  const queued = process.env.CODEX_HOME ? 'Messages to be submitted after next tool call' : 'Queued message'
+  const marker = process.env.CODEX_HOME ? 'Working (esc to interrupt)' : 'esc to interrupt'
+  renderScreen(`${lastVisibleOutput ? `${lastVisibleOutput}\n` : ''}${queued}\n${composerGlyph} \n${marker}`)
+}
 
 async function runStep() {
   if (stepIndex >= script.length) return
   const step = script[stepIndex]
   stepIndex += 1
 
-  if (step.output) process.stdout.write(step.output + '\n')
+  if (step.output) lastVisibleOutput = step.output
+  renderRunning()
 
   if (step.emitStop && stopHookCmd) {
     try {
@@ -98,6 +133,7 @@ async function runStep() {
       // its own stdin open for subsequent messages, so explicitly model the empty hook
       // payload rather than letting the POSIX reader block on the TUI input pipe.
       await execAsync(`(${stopHookCmd}) </dev/null`, { shell: '/bin/bash' })
+      renderPrimaryComposer()
     } catch (err) {
       process.stderr.write(`mock-cli: stop hook failed: ${err}\n`)
     }
@@ -131,6 +167,7 @@ const pasteReadyDelayMs = Number(process.env.MOCK_CLI_PASTE_READY_DELAY_MS || '0
 
 function announcePasteReady() {
   process.stdout.write('\x1b[?2004h')
+  renderPrimaryComposer()
   const readyFile = process.env.MOCK_CLI_READY_FILE
   if (readyFile) writeFileSync(readyFile, '')
 }
@@ -179,11 +216,18 @@ function writeSessionEntry(content) {
 }
 
 function submit(content) {
+  if (content.length > 0 && rolloutOnSubmit && rolloutFile && !existsSync(rolloutFile)) createRollout()
   submitCount += 1
-  if (submitCount <= dropSubmitCount) return // 启动期模态框吞掉前 N 条输入:不写 session、不推进脚本
+  const steering = active
+  if (submitCount <= dropSubmitCount) {
+    renderRunning()
+    return
+  }
   if (stdinLogFile) appendFileSync(stdinLogFile, JSON.stringify(content) + '\n')
   writeSessionEntry(content)
-  void runStep()
+  if (steering) renderQueued()
+  else renderRunning()
+  setTimeout(() => void runStep(), 0)
 }
 
 process.stdin.on('data', (chunk) => {
@@ -225,6 +269,8 @@ process.stdin.on('data', (chunk) => {
     pending = pending.slice(pending.length - holdBack)
     break
   }
+
+  if (lineBuffer.length > 0) renderComposer(lineBuffer)
 })
 
 // stdin 监听已挂好,现在宣布就绪不丢输入(见上方就绪信号的注释)。

--- a/crabot-agent/tests/workers/harness/harness-continuation.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-continuation.test.ts
@@ -258,6 +258,35 @@ describe('WorkerHarness — 透明接续：revive (capabilities().revive === tru
     expect(resumedEvents[0].seq).toBe(w.incarnations[1].seq)
   })
 
+  it('resume首投accepted后同步completed：新化身与task按endReason落completed', async () => {
+    const { harness, adaptersMap } = await makeHarness()
+    const fake = new FakeAdapter({
+      caps: { revive: true },
+      onStateChange: harness.handleStateChange,
+      resumeBehavior: (prev) => ({
+        worker_id: prev.worker_id,
+        seq: 2,
+        impl: 'builtin',
+        session_ref: `resumed-${prev.worker_id}`,
+        initial_input: {
+          control_state: 'exited',
+          disposition: 'accepted',
+          report: { endReason: 'completed' },
+        },
+      }),
+    })
+    adaptersMap.set('builtin', fake)
+    const worker = await harness.spawnWorker(spawnParams())
+    const h: IncarnationHandle = { worker_id: worker.worker_id, seq: 1, impl: 'builtin', session_ref: `ref-${worker.worker_id}#1` }
+    fake.emitStateChange(h, 'exited')
+    await waitUntil(async () => (await harness.listWorkers(dialogObjectIdForPrivate('friend-1')))[0].task.status === 'completed')
+
+    await harness.sendToWorker(worker.worker_id, 'continue')
+    const [settled] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    expect(settled.task.status).toBe('completed')
+    expect(settled.incarnations[1]).toMatchObject({ state: 'exited', ended_reason: 'completed' })
+  })
+
   it('adapter.sendInput 抛 WorkerExitedError（台账还没追上）→ 同样透明接续，事件 resumed', async () => {
     const { harness, adaptersMap } = await makeHarness()
     const fake = new FakeAdapter({
@@ -449,6 +478,42 @@ describe('WorkerHarness — 透明接续：handoff (capabilities().revive === fa
     expect(handoffEvents[0].seq).toBe(1)
     const supersededEvents = events.filter((e) => e.kind === 'superseded')
     expect(supersededEvents).toHaveLength(1)
+  })
+
+  it('handoff目标首投accepted后同步completed：新化身与task按endReason落completed', async () => {
+    const { harness, adaptersMap } = await makeHarness()
+    const source = new FakeAdapter({
+      caps: { revive: false },
+      onStateChange: harness.handleStateChange,
+      sendInputBehavior: (h) => { throw new WorkerExitedError(h.worker_id, h.seq) },
+    })
+    const target = new FakeAdapter({
+      implId: 'claude-code',
+      onStateChange: harness.handleStateChange,
+      spawnBehavior: (spec) => ({
+        worker_id: spec.worker_id,
+        seq: 1,
+        impl: 'claude-code',
+        session_ref: `target-${spec.worker_id}`,
+        initial_input: {
+          control_state: 'exited',
+          disposition: 'accepted',
+          report: { endReason: 'completed' },
+        },
+      }),
+    })
+    adaptersMap.set('builtin', source)
+    adaptersMap.set('claude-code', target)
+    const worker = await harness.spawnWorker(spawnParams())
+
+    await harness.sendToWorker(worker.worker_id, 'continue')
+    const [settled] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    expect(settled.task.status).toBe('completed')
+    expect(settled.incarnations[settled.incarnations.length - 1]).toMatchObject({
+      impl: 'claude-code',
+      state: 'exited',
+      ended_reason: 'completed',
+    })
   })
 
   it('源化身台账已记 failed 时，HANDOFF.md 的 Previous outcome 写 failed —— 接手化身不会以为上一棒干成了', async () => {

--- a/crabot-agent/tests/workers/harness/harness-continuation.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-continuation.test.ts
@@ -14,7 +14,7 @@ import { LedgerStore } from '../../../src/workers/harness/ledger-store'
 import { WorkspaceManager } from '../../../src/workers/harness/workspace-manager'
 import { dialogObjectIdForPrivate } from '../../../src/workers/harness/ledger-types'
 import type { HarnessEvent } from '../../../src/workers/harness/worker-events'
-import { WorkerExitedError } from '../../../src/workers/errors'
+import { CliInputStallError, WorkerExitedError } from '../../../src/workers/errors'
 import { BuiltinWorkerAdapter } from '../../../src/workers/builtin/adapter'
 import type { BuiltinRuntimeContext } from '../../../src/workers/builtin/runtime'
 import type { LLMAdapter } from '../../../src/engine/llm-adapter-types.js'
@@ -610,6 +610,79 @@ describe('WorkerHarness.switchWorkerImpl — 跨实现切换', () => {
 
     expect(events.filter((e) => e.kind === 'handoff_started')).toHaveLength(1)
     expect(events.filter((e) => e.kind === 'superseded')).toHaveLength(1)
+  })
+
+  it('replays and settles a consumed durable receipt on the target incarnation', async () => {
+    const { harness, adaptersMap } = await makeHarness()
+    const source = new FakeAdapter({
+      implId: 'claude-code',
+      caps: { revive: true },
+      onStateChange: harness.handleStateChange,
+      sendInputBehavior: async (_h, text, opts) => {
+        if (!opts?.raw && text === 'bg') {
+          throw new CliInputStallError('pending_in_ui', 'running', {
+            waitReason: 'input_pending',
+            outputTail: '❯ bg',
+          })
+        }
+      },
+    })
+    const target = new FakeAdapter({ implId: 'codex', caps: { revive: true }, onStateChange: harness.handleStateChange })
+    adaptersMap.set('claude-code', source)
+    adaptersMap.set('codex', target)
+    const worker = await harness.spawnWorker(spawnParams({ impl: 'claude-code' }))
+    const settlements: string[] = []
+
+    await harness.sendToWorker(worker.worker_id, 'bg', {
+      dedupeKey: 'bg-shell:1',
+      onSettled: async (settlement) => { settlements.push(settlement) },
+    })
+    expect(settlements).toEqual([])
+
+    await harness.switchWorkerImpl(worker.worker_id, 'codex', 'move durable notification')
+
+    expect(target.sendInputCalls.filter((call) => call.text === 'bg')).toHaveLength(1)
+    expect(settlements).toEqual(['delivered'])
+  })
+
+  it('replays an in-flight durable stall that resolves after the explicit switch', async () => {
+    const { harness, adaptersMap } = await makeHarness()
+    let markEntered!: () => void
+    const entered = new Promise<void>((resolve) => { markEntered = resolve })
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => { release = resolve })
+    const source = new FakeAdapter({
+      implId: 'claude-code',
+      caps: { revive: true },
+      onStateChange: harness.handleStateChange,
+      sendInputBehavior: async (_h, text, opts) => {
+        if (!opts?.raw && text === 'bg') {
+          markEntered()
+          await gate
+          throw new CliInputStallError('pending_in_ui', 'running', {
+            waitReason: 'input_pending',
+            outputTail: '❯ bg',
+          })
+        }
+      },
+    })
+    const target = new FakeAdapter({ implId: 'codex', caps: { revive: true }, onStateChange: harness.handleStateChange })
+    adaptersMap.set('claude-code', source)
+    adaptersMap.set('codex', target)
+    const worker = await harness.spawnWorker(spawnParams({ impl: 'claude-code' }))
+    const settlements: string[] = []
+
+    const send = harness.sendToWorker(worker.worker_id, 'bg', {
+      dedupeKey: 'bg-shell:1',
+      onSettled: async (settlement) => { settlements.push(settlement) },
+    })
+    await entered
+    await harness.switchWorkerImpl(worker.worker_id, 'codex', 'switch while old send is in flight')
+    release()
+    await send
+
+    expect(target.sendInputCalls.filter((call) => call.text === 'bg')).toHaveLength(1)
+    expect(settlements).toEqual(['delivered'])
   })
 })
 

--- a/crabot-agent/tests/workers/harness/harness-integration.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-integration.test.ts
@@ -318,11 +318,16 @@ describe.skipIf(!tmuxAvailable)('WorkerHarness — 真实 claude-code adapter �
       })
       sessionsToCleanup.push(`crabot-w-${worker.worker_id}-1`)
 
-      expect(worker.task.status).toBe('running')
+      await waitUntil(async () => {
+        const [current] = await harness.listWorkers(dialogObjectId)
+        return current.task.status === 'waiting_input'
+      })
+      const [settledWorker] = await harness.listWorkers(dialogObjectId)
+      expect(settledWorker.task.status).toBe('waiting_input')
       // cc adapter 的真实 session uuid(spawn 返回前即由 adapter 填入,不是台账初始化时的
       // 占位空串),证明 harness 原子补写了 adapter.spawn 返回的真实 handle.session_ref。
-      expect(worker.incarnations[0].session_ref).toBeTruthy()
-      expect(worker.incarnations[0].session_ref).toMatch(/^[0-9a-fA-F-]{36}$/)
+      expect(settledWorker.incarnations[0].session_ref).toBeTruthy()
+      expect(settledWorker.incarnations[0].session_ref).toMatch(/^[0-9a-fA-F-]{36}$/)
 
       // 经 harness.readWorkerOutput 轮询到 mock CLI 真实写入 pipe-pane 的第一段输出——
       // 证明 tmux newSession + pipe-pane + OutputLog 这条真实链路是通的。
@@ -347,9 +352,8 @@ describe.skipIf(!tmuxAvailable)('WorkerHarness — 真实 claude-code adapter �
         return chunk.includes('第二段输出')
       })
 
-      // 真实 adapter 的状态回调(idle→running,可能不止一次)经 handleStateChange 落盘并
-      // 外发——不是 FakeAdapter.emitStateChange 手动触发的。
-      await waitUntil(() => events.filter((e) => e.kind === 'state_changed').length >= 2)
+      // 普通投递先由 harness 落 running；随后 Stop callback 单独结算 waiting_text。
+      await waitUntil(() => events.filter((e) => e.kind === 'state_changed').length >= 1)
 
       await harness.killWorker(worker.worker_id, '冒烟测试收尾')
 

--- a/crabot-agent/tests/workers/harness/harness-lifecycle.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-lifecycle.test.ts
@@ -342,6 +342,55 @@ describe('WorkerHarness.spawnWorker', () => {
     ])
   })
 
+  it('durable receipt pasted into CLI composer settles only after raw submission', async () => {
+    const { harness } = await makeHarness({
+      implId: 'claude-code',
+      sendInputBehavior: async (_h, text, opts) => {
+        if (!opts?.raw && text === 'bg') {
+          throw new CliInputStallError('pending_in_ui', 'running', {
+            waitReason: 'input_pending',
+            outputTail: '❯ bg',
+          })
+        }
+      },
+    })
+    const worker = await harness.spawnWorker({ ...spawnParams(), impl: 'claude-code' })
+    const settlements: string[] = []
+
+    await harness.sendToWorker(worker.worker_id, 'bg', {
+      dedupeKey: 'bg-shell:1',
+      onSettled: async (settlement) => { settlements.push(settlement) },
+    })
+    expect(settlements).toEqual([])
+
+    await harness.sendToWorker(worker.worker_id, 'Enter', { raw: true })
+    expect(settlements).toEqual(['delivered'])
+  })
+
+  it('kill dead-letters a durable receipt already pasted into a CLI composer', async () => {
+    const { harness } = await makeHarness({
+      implId: 'claude-code',
+      sendInputBehavior: async (_h, text, opts) => {
+        if (!opts?.raw && text === 'bg') {
+          throw new CliInputStallError('pending_in_ui', 'running', {
+            waitReason: 'input_pending',
+            outputTail: '❯ bg',
+          })
+        }
+      },
+    })
+    const worker = await harness.spawnWorker({ ...spawnParams(), impl: 'claude-code' })
+    const settlements: string[] = []
+
+    await harness.sendToWorker(worker.worker_id, 'bg', {
+      dedupeKey: 'bg-shell:1',
+      onSettled: async (settlement) => { settlements.push(settlement) },
+    })
+    await harness.killWorker(worker.worker_id, 'test')
+
+    expect(settlements).toEqual(['dead_letter'])
+  })
+
   it('adapter.spawn 失败 → 台账落 failed(经 queued→running→failed)、化身 exited(failed)、事件外发,错误抛给调用方', async () => {
     const boom = new Error('spawn 炸了')
     const { harness } = await makeHarness({ spawnShouldFail: boom })

--- a/crabot-agent/tests/workers/harness/harness-lifecycle.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-lifecycle.test.ts
@@ -803,6 +803,98 @@ describe('WorkerHarness.sendToWorker', () => {
     expect(fake.sendInputCalls).toHaveLength(0)
   })
 
+  it('CLI化身exited时清除旧pane的transport hold', async () => {
+    const { harness, fake } = await makeHarness({ implId: 'claude-code' })
+    const worker = await harness.spawnWorker({ ...spawnParams(), impl: 'claude-code' })
+    const inbox = (harness as any).getInbox(worker.worker_id)
+    inbox.hold('input_pending')
+    expect(inbox.held).toBe(true)
+
+    fake.emitStateChange({
+      worker_id: worker.worker_id,
+      seq: 1,
+      impl: 'claude-code',
+      session_ref: `ref-${worker.worker_id}#1`,
+    }, 'exited', undefined, 'completed')
+    await waitUntil(() => inbox.held === false)
+
+    expect(inbox.held).toBe(false)
+  })
+
+  it('普通CLI投递后的running结算不覆盖并发Stop回调落下的waiting_input', async () => {
+    const { harness } = await makeHarness({ implId: 'claude-code', sendInputState: 'idle' })
+    const worker = await harness.spawnWorker({ ...spawnParams(), impl: 'claude-code' })
+
+    await harness.sendToWorker(worker.worker_id, '很快完成的输入')
+    await waitUntil(async () => {
+      const [current] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+      return current.task.status === 'waiting_input'
+    })
+
+    const [settled] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    expect(settled.incarnations[0].state).toBe('idle')
+  })
+
+  it('主线CLI投递不因并发fork状态回调而丢失running结算', async () => {
+    let fakeRef!: FakeAdapter
+    let currentWorkerId = ''
+    const made = await makeHarness({
+      implId: 'claude-code',
+      caps: { fork: true },
+      sendInputBehavior: () => {
+        fakeRef.emitStateChange({
+          worker_id: currentWorkerId,
+          seq: 2,
+          impl: 'claude-code',
+          session_ref: `fork-ref-${currentWorkerId}#2`,
+        }, 'idle')
+      },
+    })
+    const { harness, fake } = made
+    fakeRef = fake
+    const worker = await harness.spawnWorker({ ...spawnParams(), impl: 'claude-code' })
+    currentWorkerId = worker.worker_id
+    fake.emitStateChange({
+      worker_id: worker.worker_id,
+      seq: 1,
+      impl: 'claude-code',
+      session_ref: `ref-${worker.worker_id}#1`,
+    }, 'idle')
+    await waitUntil(async () => (await harness.listWorkers(dialogObjectIdForPrivate('friend-1')))[0].task.status === 'waiting_input')
+    await harness.queryWorker(worker.worker_id, '侧问一下')
+
+    await harness.sendToWorker(worker.worker_id, '主线继续')
+    await waitUntil(async () => {
+      const [current] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+      return current.incarnations.find((incarnation) => incarnation.seq === 2)?.state === 'idle'
+    })
+
+    const [settled] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    expect(settled.task.status).toBe('running')
+    expect(settled.incarnations.find((incarnation) => incarnation.seq === 1)?.state).toBe('running')
+  })
+
+  it('fork或旧化身的exited回调不清除当前pane的transport hold', async () => {
+    const { harness, fake } = await makeHarness({ implId: 'claude-code', caps: { fork: true } })
+    const worker = await harness.spawnWorker({ ...spawnParams(), impl: 'claude-code' })
+    await harness.queryWorker(worker.worker_id, '侧问一下')
+    const inbox = (harness as any).getInbox(worker.worker_id)
+    inbox.hold('input_pending')
+
+    fake.emitStateChange({
+      worker_id: worker.worker_id,
+      seq: 2,
+      impl: 'claude-code',
+      session_ref: `fork-ref-${worker.worker_id}#2`,
+    }, 'exited', undefined, 'completed')
+    await waitUntil(async () => {
+      const [current] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+      return current.incarnations.find((incarnation) => incarnation.seq === 2)?.state === 'exited'
+    })
+
+    expect(inbox.held).toBe(true)
+  })
+
   it('CLI raw成功后的adapter idle重判落waiting_input，不被harness硬覆盖为running', async () => {
     const { harness } = await makeHarness({ implId: 'claude-code', sendInputState: 'idle' })
     const worker = await harness.spawnWorker({ ...spawnParams(), impl: 'claude-code' })

--- a/crabot-agent/tests/workers/harness/harness-lifecycle.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-lifecycle.test.ts
@@ -7,7 +7,7 @@ import { LedgerStore } from '../../../src/workers/harness/ledger-store'
 import { WorkspaceManager } from '../../../src/workers/harness/workspace-manager'
 import { dialogObjectIdForPrivate } from '../../../src/workers/harness/ledger-types'
 import { WorkerEventLog, type HarnessEvent } from '../../../src/workers/harness/worker-events'
-import { CapabilityNotSupportedError } from '../../../src/workers/errors'
+import { CapabilityNotSupportedError, CliInputStallError } from '../../../src/workers/errors'
 import { describeStartupStall } from '../../../src/workers/tmux/paste-ready'
 import type {
   WorkerAdapter,
@@ -22,7 +22,7 @@ import type {
   OutputCursor,
   CapabilityBundle,
   AdapterCapabilities,
-  DetectResult,
+  InitialInputResult,
 } from '../../../src/workers/types'
 
 // ---- FakeAdapter:实现 WorkerAdapter 契约的可编程桩,不碰 tmux/LLM ----
@@ -38,6 +38,10 @@ interface FakeAdapterOpts {
   readonly spawnShouldFail?: Error
   readonly forkShouldFail?: Error
   readonly sendInputBehavior?: (h: IncarnationHandle, text: string, opts?: { raw?: boolean }) => Promise<void> | void
+  readonly sendInputState?: WorkerContractState
+  readonly acceptedExitReport?: StateChangeReport
+  readonly updatedSessionRef?: string
+  readonly spawnInitialInput?: InitialInputResult
   /** P4 Task 4 第四轮:严格复刻 ClaudeCodeAdapter.fork()(adapter.ts:452-460)的调用顺序——
    * 在 `return handle` 之前就把化身转到 exited 并**同步**调用 onStateChange。用于回归
    * "fork 落地即已终态"这条竞态(见下面 describe 块)。 */
@@ -53,6 +57,8 @@ class FakeAdapter implements WorkerAdapter {
   readonly forkCalls: Array<{ prev: IncarnationRef; forkInput: string }> = []
   readonly readOutputCalls: IncarnationHandle[] = []
   private readonly states = new Map<string, WorkerContractState>()
+  private acceptedExitReport?: StateChangeReport
+  private updatedSessionRef?: string
   private nextForkSeq = 2
 
   constructor(private readonly opts: FakeAdapterOpts = {}) {
@@ -70,7 +76,13 @@ class FakeAdapter implements WorkerAdapter {
   async spawn(spec: SpawnSpec): Promise<IncarnationHandle> {
     this.spawnCalls.push(spec)
     if (this.opts.spawnShouldFail) throw this.opts.spawnShouldFail
-    const handle: IncarnationHandle = { worker_id: spec.worker_id, seq: 1, impl: this.implId, session_ref: `ref-${spec.worker_id}#1` }
+    const handle: IncarnationHandle = {
+      worker_id: spec.worker_id,
+      seq: 1,
+      impl: this.implId,
+      session_ref: `ref-${spec.worker_id}#1`,
+      ...(this.opts.spawnInitialInput ? { initial_input: this.opts.spawnInitialInput } : {}),
+    }
     this.states.set(handleKey(handle), 'running')
     return handle
   }
@@ -104,6 +116,27 @@ class FakeAdapter implements WorkerAdapter {
   async sendInput(h: IncarnationHandle, text: string, opts?: { raw?: boolean }): Promise<void> {
     this.sendInputCalls.push({ h, text, opts })
     if (this.opts.sendInputBehavior) await this.opts.sendInputBehavior(h, text, opts)
+    if (this.opts.updatedSessionRef) this.updatedSessionRef = this.opts.updatedSessionRef
+    if (this.opts.acceptedExitReport) {
+      this.states.set(handleKey(h), 'exited')
+      this.acceptedExitReport = this.opts.acceptedExitReport
+    }
+    if (this.opts.sendInputState) {
+      this.states.set(handleKey(h), this.opts.sendInputState)
+      this.opts.onStateChange?.(h, this.opts.sendInputState)
+    }
+  }
+
+  takeUpdatedSessionRef(): string | undefined {
+    const sessionRef = this.updatedSessionRef
+    this.updatedSessionRef = undefined
+    return sessionRef
+  }
+
+  takeAcceptedInputExit(): StateChangeReport | undefined {
+    const report = this.acceptedExitReport
+    this.acceptedExitReport = undefined
+    return report
   }
 
   async readOutput(h: IncarnationHandle, cursor: OutputCursor): Promise<{ chunk: string; nextCursor: OutputCursor }> {
@@ -240,6 +273,75 @@ describe('WorkerHarness.spawnWorker', () => {
     expect(listed.map((w) => w.worker_id)).toContain(worker.worker_id)
   })
 
+  it('CLI首投accepted后同步completed：task与化身按endReason落completed而非failed', async () => {
+    const { harness } = await makeHarness({
+      implId: 'claude-code',
+      spawnInitialInput: {
+        control_state: 'exited',
+        disposition: 'accepted',
+        report: { endReason: 'completed' },
+      },
+    })
+    const worker = await harness.spawnWorker({ ...spawnParams(), impl: 'claude-code' })
+    expect(worker.task.status).toBe('completed')
+    expect(worker.incarnations[0]).toMatchObject({ state: 'exited', ended_reason: 'completed' })
+    expect(events.find((event) => event.kind === 'state_changed')?.detail).toEqual({
+      to: 'exited',
+      kind: 'initial_input_settled',
+      reason: 'completed',
+    })
+  })
+
+  it('CLI首投not_pasted先落waiting_action，再由raw解除hold并按FIFO只补投一次原prompt', async () => {
+    const { harness, fake } = await makeHarness({
+      implId: 'claude-code',
+      spawnInitialInput: {
+        control_state: 'waiting_action',
+        disposition: 'not_pasted',
+        report: { waitReason: 'input_surface_unavailable', outputTail: 'modal' },
+      },
+    })
+    const worker = await harness.spawnWorker({ ...spawnParams(), impl: 'claude-code', prompt: 'original' })
+    expect(worker.task.status).toBe('waiting_input')
+    expect(worker.incarnations[0].state).toBe('idle')
+
+    await harness.sendToWorker(worker.worker_id, 'later')
+    expect(fake.sendInputCalls).toHaveLength(0)
+
+    await harness.sendToWorker(worker.worker_id, 'Enter', { raw: true })
+    expect(fake.sendInputCalls.map((call) => [call.text, call.opts?.raw ?? false])).toEqual([
+      ['Enter', true],
+      ['original', false],
+      ['later', false],
+    ])
+    expect(events.find((event) => event.kind === 'state_changed')?.detail).toMatchObject({
+      to: 'idle',
+      kind: 'input_delivery_stalled',
+      wait_mode: 'action',
+      wait_reason: 'input_surface_unavailable',
+    })
+  })
+
+  it('CLI首投pending_in_ui不回队首、不重贴；raw处理后仅投递后续普通文本', async () => {
+    const { harness, fake } = await makeHarness({
+      implId: 'claude-code',
+      spawnInitialInput: {
+        control_state: 'waiting_action',
+        disposition: 'pending_in_ui',
+        report: { waitReason: 'input_pending', outputTail: '❯ original' },
+      },
+    })
+    const worker = await harness.spawnWorker({ ...spawnParams(), impl: 'claude-code', prompt: 'original' })
+    await harness.sendToWorker(worker.worker_id, 'later')
+    expect(fake.sendInputCalls).toHaveLength(0)
+
+    await harness.sendToWorker(worker.worker_id, 'Enter', { raw: true })
+    expect(fake.sendInputCalls.map((call) => [call.text, call.opts?.raw ?? false])).toEqual([
+      ['Enter', true],
+      ['later', false],
+    ])
+  })
+
   it('adapter.spawn 失败 → 台账落 failed(经 queued→running→failed)、化身 exited(failed)、事件外发,错误抛给调用方', async () => {
     const boom = new Error('spawn 炸了')
     const { harness } = await makeHarness({ spawnShouldFail: boom })
@@ -321,6 +423,38 @@ describe('WorkerHarness.handleStateChange', () => {
     complete()
     fake.emitStateChange(handle, 'idle')
     await waitUntil(async () => (await harness.listWorkers(dialogObjectIdForPrivate('friend-1')))[0]?.task.status === 'waiting_input')
+  })
+
+  it('CLI交互Notification映射为固定manager-facing detail，不泄漏内部notification对象', async () => {
+    const { harness } = await makeHarness({ implId: 'claude-code' })
+    const worker = await harness.spawnWorker({ ...spawnParams(), impl: 'claude-code' })
+    events.length = 0
+    const h: IncarnationHandle = {
+      worker_id: worker.worker_id,
+      seq: 1,
+      impl: 'claude-code',
+      session_ref: `ref-${worker.worker_id}#1`,
+    }
+
+    harness.handleStateChange(h, 'idle', {
+      waitReason: 'interaction_required',
+      outputTail: 'AskUserQuestion\n  Yes\n  No',
+      notification: { type: 'permission_prompt', message: 'Choose', title: 'Question' },
+    })
+    await waitUntil(() => events.some((event) => event.kind === 'state_changed'))
+
+    const detail = events.find((event) => event.kind === 'state_changed')?.detail
+    expect(detail).toEqual({
+      to: 'idle',
+      kind: 'interaction_required',
+      wait_mode: 'action',
+      wait_reason: 'interaction_required',
+      notification_type: 'permission_prompt',
+      message: 'Choose',
+      title: 'Question',
+      text: 'AskUserQuestion\n  Yes\n  No',
+    })
+    expect(detail).not.toHaveProperty('notification')
   })
 
   // ---- endReason:harness 不再自己猜,一律取 adapter 上报的真值 ----
@@ -667,6 +801,78 @@ describe('WorkerHarness.sendToWorker', () => {
     fake.sendInputCalls.length = 0
     await expect(harness.sendToActiveWorker(worker.worker_id, '迟到反馈')).resolves.toBe(false)
     expect(fake.sendInputCalls).toHaveLength(0)
+  })
+
+  it('CLI raw成功后的adapter idle重判落waiting_input，不被harness硬覆盖为running', async () => {
+    const { harness } = await makeHarness({ implId: 'claude-code', sendInputState: 'idle' })
+    const worker = await harness.spawnWorker({ ...spawnParams(), impl: 'claude-code' })
+
+    await harness.sendToWorker(worker.worker_id, 'Escape', { raw: true })
+    await waitUntil(async () => {
+      const [current] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+      return current.task.status === 'waiting_input'
+    })
+    const [settled] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    expect(settled.task.status).toBe('waiting_input')
+    expect(settled.incarnations[0].state).toBe('idle')
+  })
+
+  it('普通输入接受后同步发现的session_ref由harness写回台账', async () => {
+    const sessionRef = '019fe15f-cbd9-76c1-9a18-e6c2e1d2b2d7'
+    const { harness } = await makeHarness({ implId: 'codex', updatedSessionRef: sessionRef })
+    const worker = await harness.spawnWorker({ ...spawnParams(), impl: 'codex' })
+
+    await harness.sendToWorker(worker.worker_id, '首条任务')
+
+    const [settled] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    expect(settled.incarnations[0].session_ref).toBe(sessionRef)
+  })
+
+  it('accepted input后同步退出由harness在sendToWorker返回前单次结算', async () => {
+    const report: StateChangeReport = { endReason: 'completed' }
+    const { harness } = await makeHarness({ implId: 'claude-code', acceptedExitReport: report })
+    const worker = await harness.spawnWorker({ ...spawnParams(), impl: 'claude-code' })
+    events.length = 0
+
+    await harness.sendToWorker(worker.worker_id, '最后一步')
+
+    const [settled] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    expect(settled.task.status).toBe('completed')
+    expect(settled.incarnations[0]).toMatchObject({ state: 'exited', ended_reason: 'completed' })
+    const stateEvents = events.filter((event) => event.kind === 'state_changed')
+    expect(stateEvents).toHaveLength(1)
+    expect(stateEvents[0].detail).toMatchObject({ to: 'exited', reason: 'completed' })
+  })
+
+  it('同步not_pasted stall由harness单次结算：原item回队首，raw旁路后按FIFO补投且不重复paste', async () => {
+    let stalled = false
+    const { harness, fake } = await makeHarness({
+      implId: 'claude-code',
+      sendInputBehavior: (_h, _text, opts) => {
+        if (!opts?.raw && !stalled) {
+          stalled = true
+          throw new CliInputStallError('not_pasted', 'running', {
+            waitReason: 'input_surface_unavailable',
+            outputTail: 'Working',
+          })
+        }
+      },
+    })
+    const worker = await harness.spawnWorker({ ...spawnParams(), impl: 'claude-code' })
+    events.length = 0
+
+    await harness.sendToWorker(worker.worker_id, 'blocked')
+    await harness.sendToWorker(worker.worker_id, 'later')
+    expect(fake.sendInputCalls.map((call) => call.text)).toEqual(['blocked'])
+
+    await harness.sendToWorker(worker.worker_id, 'Escape', { raw: true })
+    expect(fake.sendInputCalls.map((call) => [call.text, call.opts?.raw ?? false])).toEqual([
+      ['blocked', false],
+      ['Escape', true],
+      ['blocked', false],
+      ['later', false],
+    ])
+    expect(events.filter((event) => event.kind === 'state_changed')).toHaveLength(1)
   })
 
   it('不存在的 worker_id → WorkerNotFoundError', async () => {

--- a/crabot-agent/tests/workers/harness/inbox.test.ts
+++ b/crabot-agent/tests/workers/harness/inbox.test.ts
@@ -198,6 +198,30 @@ describe('WorkerInbox', () => {
     expect(inbox.drain().map((i) => i.text)).toEqual(['b', 'c'])
   })
 
+  it('waiting_action hold lets the earliest raw control item bypass ordinary FIFO items', async () => {
+    const inbox = new WorkerInbox('worker-1')
+    inbox.enqueue(makeItem('normal-a'))
+    inbox.enqueue(makeItem('normal-b'))
+    inbox.enqueue(makeItem('Enter', { raw: true }))
+    inbox.hold('waiting_action')
+    const delivered: string[] = []
+    await inbox.flush(async (item) => { delivered.push(item.text) })
+    expect(delivered).toEqual(['Enter'])
+    expect(inbox.pending).toBe(2)
+    inbox.release('waiting_action')
+    await inbox.flush(async (item) => { delivered.push(item.text) })
+    expect(delivered).toEqual(['Enter', 'normal-a', 'normal-b'])
+  })
+
+  it('an exclusive hold keeps raw controls out of the pane', async () => {
+    const inbox = new WorkerInbox('worker-1')
+    inbox.enqueue(makeItem('Enter', { raw: true }))
+    inbox.hold('provisioning')
+    const delivered: string[] = []
+    await inbox.flush(async (item) => { delivered.push(item.text) })
+    expect(delivered).toEqual([])
+  })
+
   it('drain 在 flush 卡在 deliver 期间调用,不把 in-flight 条目重复计入 dead-letter', async () => {
     // PoC(评审复现):flush 卡在 deliver('a') 时若 drain 直接 this.queue = [] 重新赋值,
     // 会把正在被投递的 'a' 也当作"未投递"一并 drain 出去;'a' 随后投递成功,导致它

--- a/crabot-agent/tests/workers/harness/inbox.test.ts
+++ b/crabot-agent/tests/workers/harness/inbox.test.ts
@@ -222,6 +222,71 @@ describe('WorkerInbox', () => {
     expect(delivered).toEqual([])
   })
 
+  it('hold_consumed retains a durable receipt until raw submission settles it', async () => {
+    const inbox = new WorkerInbox('worker-1')
+    const settled = vi.fn()
+    const item = makeItem('bg', {
+      dedupe_key: 'bg-shell:1',
+      onSettled: settled,
+    })
+    inbox.enqueueUnique(item)
+
+    await inbox.flush(async () => ({ action: 'hold_consumed', reason: 'input_pending' }))
+
+    expect(settled).not.toHaveBeenCalled()
+    expect(inbox.pending).toBe(1)
+    expect(inbox.enqueueUnique(makeItem('duplicate', { dedupe_key: 'bg-shell:1' }))).toBe(false)
+
+    await inbox.settleConsumed('delivered')
+    expect(settled).toHaveBeenCalledOnce()
+    expect(settled).toHaveBeenCalledWith('delivered')
+    expect(inbox.pending).toBe(0)
+  })
+
+  it('requeues a stale hold result against the new pane without installing the old hold', async () => {
+    const inbox = new WorkerInbox('worker-1')
+    inbox.enqueue(makeItem('bg', { onSettled: vi.fn() }))
+    let first = true
+    const delivered: string[] = []
+
+    await inbox.flush(async (item) => {
+      if (first) {
+        first = false
+        return { action: 'hold_consumed', reason: 'input_pending', isCurrent: () => false }
+      }
+      delivered.push(item.text)
+    })
+
+    expect(delivered).toEqual(['bg'])
+    expect(inbox.held).toBe(false)
+    expect(inbox.pending).toBe(0)
+  })
+
+  it('requeues a consumed durable receipt when its pane incarnation exits', async () => {
+    const inbox = new WorkerInbox('worker-1')
+    const settled = vi.fn()
+    inbox.enqueue(makeItem('bg', { onSettled: settled }))
+    await inbox.flush(async () => ({ action: 'hold_consumed', reason: 'input_pending' }))
+
+    expect(inbox.requeueConsumed()).toBe(1)
+    inbox.release()
+    const delivered: string[] = []
+    await inbox.flush(async (item) => { delivered.push(item.text) })
+
+    expect(delivered).toEqual(['bg'])
+    expect(settled).toHaveBeenCalledWith('delivered')
+  })
+
+  it('drain returns consumed durable receipts for kill dead-letter settlement', async () => {
+    const inbox = new WorkerInbox('worker-1')
+    const item = makeItem('bg', { onSettled: vi.fn() })
+    inbox.enqueue(item)
+    await inbox.flush(async () => ({ action: 'hold_consumed', reason: 'input_pending' }))
+
+    expect(inbox.drain()).toEqual([item])
+    expect(inbox.pending).toBe(0)
+  })
+
   it('drain 在 flush 卡在 deliver 期间调用,不把 in-flight 条目重复计入 dead-letter', async () => {
     // PoC(评审复现):flush 卡在 deliver('a') 时若 drain 直接 this.queue = [] 重新赋值,
     // 会把正在被投递的 'a' 也当作"未投递"一并 drain 出去;'a' 随后投递成功,导致它
@@ -309,6 +374,26 @@ describe('WorkerInbox', () => {
     expect(inbox.drain()).toEqual([])
     release()
     await expect(flushPromise).resolves.toBe(0)
+    expect(inbox.pending).toBe(0)
+  })
+
+  it('drain 之后 in-flight durable 条目返回hold_consumed：立即结算 dead-letter', async () => {
+    const inbox = new WorkerInbox('worker-1')
+    const settled = vi.fn()
+    inbox.enqueue(makeItem('bg', { onSettled: settled }))
+
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => { release = resolve })
+    const flushPromise = inbox.flush(async () => {
+      await gate
+      return { action: 'hold_consumed', reason: 'input_pending' }
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    expect(inbox.drain()).toEqual([])
+    release()
+    await expect(flushPromise).resolves.toBe(0)
+    expect(settled).toHaveBeenCalledWith('dead_letter')
     expect(inbox.pending).toBe(0)
   })
 

--- a/crabot-agent/tests/workers/harness/inbox.test.ts
+++ b/crabot-agent/tests/workers/harness/inbox.test.ts
@@ -294,6 +294,24 @@ describe('WorkerInbox', () => {
     warnSpy.mockRestore()
   })
 
+  it('drain 之后 in-flight 条目返回hold_requeue：不把已终结化身的文本复活回队列', async () => {
+    const inbox = new WorkerInbox('worker-1')
+    inbox.enqueue(makeItem('a'))
+
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => { release = resolve })
+    const flushPromise = inbox.flush(async () => {
+      await gate
+      return { action: 'hold_requeue', reason: 'waiting_action' }
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    expect(inbox.drain()).toEqual([])
+    release()
+    await expect(flushPromise).resolves.toBe(0)
+    expect(inbox.pending).toBe(0)
+  })
+
   it('drain → enqueue → flush 且 deliver 失败:新条目应当抛出、留队首(仅吞 drain 当刻的 in-flight)', async () => {
     // 复审 Minor:drain 之后的 enqueue('z') 若投递失败,本应抛出且保留队首,
     // 但当前实现因为 _drained 永久粘性,会错误地吞掉错误。

--- a/crabot-agent/tests/workers/input-commit.test.ts
+++ b/crabot-agent/tests/workers/input-commit.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { commitInput, type InputProbe } from '../../src/workers/tmux/input-commit.js'
 import type { PaneSnapshot } from '../../src/workers/tmux/driver.js'
 
-const snapshot = (text: string): PaneSnapshot => ({ text, cursor_x: 0, cursor_y: 0, width: 80, height: 24 })
+const snapshot = (text: string): PaneSnapshot => ({ text })
 
 describe('commitInput', () => {
   it('pastes once and commits once after empty -> pending', async () => {
@@ -30,6 +30,13 @@ describe('commitInput', () => {
     let pastes = 0; let enters = 0
     const result = await commitInput({ pasteText: async () => { pastes++ }, sendEnter: async () => { enters++ }, capture: async () => frames.shift()! }, frame => frame.text as InputProbe, frame => frame.text === 'accepted', 'task', { settleTimeoutMs: 0 })
     expect(result.disposition).toBe('accepted'); expect(pastes).toBe(1); expect(enters).toBe(2)
+  })
+
+  it('reports not_pasted when the composer is still empty after paste', async () => {
+    const frames = [snapshot('empty'), snapshot('empty')]
+    let pastes = 0; let enters = 0
+    const result = await commitInput({ pasteText: async () => { pastes++ }, sendEnter: async () => { enters++ }, capture: async () => frames.shift() ?? snapshot('empty') }, frame => frame.text as InputProbe, () => false, '   ', { settleTimeoutMs: 0 })
+    expect(result.disposition).toBe('not_pasted'); expect(pastes).toBe(1); expect(enters).toBe(0)
   })
 
   it('does not press Enter when the post-paste surface becomes unavailable', async () => {

--- a/crabot-agent/tests/workers/input-commit.test.ts
+++ b/crabot-agent/tests/workers/input-commit.test.ts
@@ -8,34 +8,41 @@ describe('commitInput', () => {
   it('pastes once and commits once after empty -> pending', async () => {
     const frames = [snapshot('empty'), snapshot('pending'), snapshot('accepted')]
     let pastes = 0; let enters = 0
-    const result = await commitInput({ pasteText: async () => { pastes++ }, sendEnter: async () => { enters++ }, capture: async () => frames.shift()! }, frame => frame.text as InputProbe, frame => frame.text === 'accepted', 'task')
+    const result = await commitInput({ pasteText: async () => { pastes++ }, sendEnter: async () => { enters++ }, capture: async () => frames.shift()! }, frame => frame.text as InputProbe, frame => frame.text === 'accepted', 'task', { settleTimeoutMs: 0 })
+    expect(result.disposition).toBe('accepted'); expect(pastes).toBe(1); expect(enters).toBe(1)
+  })
+
+  it('waits through a blank startup frame before the composer is drawn', async () => {
+    const frames = [snapshot(''), snapshot('empty'), snapshot('pending'), snapshot('accepted')]
+    let pastes = 0; let enters = 0
+    const result = await commitInput({ pasteText: async () => { pastes++ }, sendEnter: async () => { enters++ }, capture: async () => frames.shift()! }, frame => frame.text === '' ? 'unavailable' : frame.text as InputProbe, frame => frame.text === 'accepted', 'task', { settleTimeoutMs: 50, intervalMs: 0 })
     expect(result.disposition).toBe('accepted'); expect(pastes).toBe(1); expect(enters).toBe(1)
   })
 
   it('never pastes or enters when primary surface is unavailable', async () => {
     let pastes = 0; let enters = 0
-    const result = await commitInput({ pasteText: async () => { pastes++ }, sendEnter: async () => { enters++ }, capture: async () => snapshot('modal') }, () => 'unavailable', () => false, 'task')
+    const result = await commitInput({ pasteText: async () => { pastes++ }, sendEnter: async () => { enters++ }, capture: async () => snapshot('modal') }, () => 'unavailable', () => false, 'task', { settleTimeoutMs: 0 })
     expect(result.disposition).toBe('not_pasted'); expect(pastes).toBe(0); expect(enters).toBe(0)
   })
 
   it('retries Enter once without re-pasting', async () => {
     const frames = [snapshot('empty'), snapshot('pending'), snapshot('pending'), snapshot('accepted')]
     let pastes = 0; let enters = 0
-    const result = await commitInput({ pasteText: async () => { pastes++ }, sendEnter: async () => { enters++ }, capture: async () => frames.shift()! }, frame => frame.text as InputProbe, frame => frame.text === 'accepted', 'task')
+    const result = await commitInput({ pasteText: async () => { pastes++ }, sendEnter: async () => { enters++ }, capture: async () => frames.shift()! }, frame => frame.text as InputProbe, frame => frame.text === 'accepted', 'task', { settleTimeoutMs: 0 })
     expect(result.disposition).toBe('accepted'); expect(pastes).toBe(1); expect(enters).toBe(2)
   })
 
   it('does not press Enter when the post-paste surface becomes unavailable', async () => {
     const frames = [snapshot('empty'), snapshot('modal')]
     let pastes = 0; let enters = 0
-    const result = await commitInput({ pasteText: async () => { pastes++ }, sendEnter: async () => { enters++ }, capture: async () => frames.shift()! }, frame => frame.text as InputProbe, () => false, 'task')
+    const result = await commitInput({ pasteText: async () => { pastes++ }, sendEnter: async () => { enters++ }, capture: async () => frames.shift()! }, frame => frame.text as InputProbe, () => false, 'task', { settleTimeoutMs: 0 })
     expect(result.disposition).toBe('pending_in_ui'); expect(pastes).toBe(1); expect(enters).toBe(0)
   })
 
   it('does not paste again after two Enter attempts remain pending', async () => {
     const frames = [snapshot('empty'), snapshot('pending'), snapshot('pending'), snapshot('pending')]
     let pastes = 0; let enters = 0
-    const result = await commitInput({ pasteText: async () => { pastes++ }, sendEnter: async () => { enters++ }, capture: async () => frames.shift()! }, frame => frame.text as InputProbe, () => false, 'task')
+    const result = await commitInput({ pasteText: async () => { pastes++ }, sendEnter: async () => { enters++ }, capture: async () => frames.shift()! }, frame => frame.text as InputProbe, () => false, 'task', { settleTimeoutMs: 0 })
     expect(result.disposition).toBe('pending_in_ui'); expect(pastes).toBe(1); expect(enters).toBe(2)
   })
 })

--- a/crabot-agent/tests/workers/input-commit.test.ts
+++ b/crabot-agent/tests/workers/input-commit.test.ts
@@ -24,4 +24,18 @@ describe('commitInput', () => {
     const result = await commitInput({ pasteText: async () => { pastes++ }, sendEnter: async () => { enters++ }, capture: async () => frames.shift()! }, frame => frame.text as InputProbe, frame => frame.text === 'accepted', 'task')
     expect(result.disposition).toBe('accepted'); expect(pastes).toBe(1); expect(enters).toBe(2)
   })
+
+  it('does not press Enter when the post-paste surface becomes unavailable', async () => {
+    const frames = [snapshot('empty'), snapshot('modal')]
+    let pastes = 0; let enters = 0
+    const result = await commitInput({ pasteText: async () => { pastes++ }, sendEnter: async () => { enters++ }, capture: async () => frames.shift()! }, frame => frame.text as InputProbe, () => false, 'task')
+    expect(result.disposition).toBe('pending_in_ui'); expect(pastes).toBe(1); expect(enters).toBe(0)
+  })
+
+  it('does not paste again after two Enter attempts remain pending', async () => {
+    const frames = [snapshot('empty'), snapshot('pending'), snapshot('pending'), snapshot('pending')]
+    let pastes = 0; let enters = 0
+    const result = await commitInput({ pasteText: async () => { pastes++ }, sendEnter: async () => { enters++ }, capture: async () => frames.shift()! }, frame => frame.text as InputProbe, () => false, 'task')
+    expect(result.disposition).toBe('pending_in_ui'); expect(pastes).toBe(1); expect(enters).toBe(2)
+  })
 })

--- a/crabot-agent/tests/workers/input-commit.test.ts
+++ b/crabot-agent/tests/workers/input-commit.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { commitInput, type InputProbe } from '../../src/workers/tmux/input-commit.js'
+import type { PaneSnapshot } from '../../src/workers/tmux/driver.js'
+
+const snapshot = (text: string): PaneSnapshot => ({ text, cursor_x: 0, cursor_y: 0, width: 80, height: 24 })
+
+describe('commitInput', () => {
+  it('pastes once and commits once after empty -> pending', async () => {
+    const frames = [snapshot('empty'), snapshot('pending'), snapshot('accepted')]
+    let pastes = 0; let enters = 0
+    const result = await commitInput({ pasteText: async () => { pastes++ }, sendEnter: async () => { enters++ }, capture: async () => frames.shift()! }, frame => frame.text as InputProbe, frame => frame.text === 'accepted', 'task')
+    expect(result.disposition).toBe('accepted'); expect(pastes).toBe(1); expect(enters).toBe(1)
+  })
+
+  it('never pastes or enters when primary surface is unavailable', async () => {
+    let pastes = 0; let enters = 0
+    const result = await commitInput({ pasteText: async () => { pastes++ }, sendEnter: async () => { enters++ }, capture: async () => snapshot('modal') }, () => 'unavailable', () => false, 'task')
+    expect(result.disposition).toBe('not_pasted'); expect(pastes).toBe(0); expect(enters).toBe(0)
+  })
+
+  it('retries Enter once without re-pasting', async () => {
+    const frames = [snapshot('empty'), snapshot('pending'), snapshot('pending'), snapshot('accepted')]
+    let pastes = 0; let enters = 0
+    const result = await commitInput({ pasteText: async () => { pastes++ }, sendEnter: async () => { enters++ }, capture: async () => frames.shift()! }, frame => frame.text as InputProbe, frame => frame.text === 'accepted', 'task')
+    expect(result.disposition).toBe('accepted'); expect(pastes).toBe(1); expect(enters).toBe(2)
+  })
+})

--- a/crabot-agent/tests/workers/input-surface.test.ts
+++ b/crabot-agent/tests/workers/input-surface.test.ts
@@ -3,7 +3,7 @@ import { acceptedClaudeInput, hasClaudeInteraction, probeClaudeInput } from '../
 import { acceptedCodexInput, probeCodexInput } from '../../src/workers/codex/input-surface.js'
 import type { PaneSnapshot } from '../../src/workers/tmux/driver.js'
 
-const pane = (text: string): PaneSnapshot => ({ text, cursor_x: 0, cursor_y: 0, width: 100, height: 30 })
+const pane = (text: string): PaneSnapshot => ({ text })
 
 describe('CLI input surfaces', () => {
   it('does not treat a Claude running composer as primary input', () => {
@@ -20,7 +20,18 @@ describe('CLI input surfaces', () => {
 
   it('requires a current Claude interaction surface', () => {
     expect(hasClaudeInteraction('Claude needs your permission\n1. Yes\n2. No')).toBe(true)
-    expect(probeClaudeInput(pane('Claude needs your permission\n❯ '), 'primary')).toBe('unavailable')
+    expect(hasClaudeInteraction('Choose files\n☐ package.json\nEnter to select · ↑/↓ to navigate')).toBe(true)
+    expect(hasClaudeInteraction('Bypass Permissions mode\n❯ 1. No, exit\n  2. Yes, I accept\nEnter to confirm · Esc to cancel')).toBe(true)
+  })
+
+  it('does not let Claude transcript keywords or old selectors impersonate interaction UI', () => {
+    const idle = pane('tool docs mention AskUserQuestion and use arrow keys\nfinished with no exit code\n❯ \n? for shortcuts')
+    expect(hasClaudeInteraction(idle.text)).toBe(false)
+    expect(probeClaudeInput(idle, 'primary')).toBe('empty')
+
+    const oldSelector = pane('old question\n❯ 1. Alpha\n  2. Beta\nEnter to select · ↑/↓ to navigate\nanswer recorded\n❯ \n? for shortcuts')
+    expect(hasClaudeInteraction(oldSelector.text)).toBe(false)
+    expect(probeClaudeInput(oldSelector, 'primary')).toBe('empty')
   })
 
   it('scopes Claude pending evidence to the active composer, not transcript history', () => {

--- a/crabot-agent/tests/workers/input-surface.test.ts
+++ b/crabot-agent/tests/workers/input-surface.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { acceptedClaudeInput, hasClaudeInteraction, probeClaudeInput } from '../../src/workers/claude-code/input-surface.js'
+import { acceptedCodexInput, probeCodexInput } from '../../src/workers/codex/input-surface.js'
+import type { PaneSnapshot } from '../../src/workers/tmux/driver.js'
+
+const pane = (text: string): PaneSnapshot => ({ text, cursor_x: 0, cursor_y: 0, width: 100, height: 30 })
+
+describe('CLI input surfaces', () => {
+  it('does not treat a Claude running composer as primary input', () => {
+    const running = pane('working\nesc to interrupt\n❯ ')
+    expect(probeClaudeInput(running, 'primary')).toBe('unavailable')
+    expect(probeClaudeInput(running, 'steering')).toBe('empty')
+  })
+
+  it('recognizes Claude pending text without changing control state', () => {
+    const pending = pane('working\nesc to interrupt\n❯ 请继续')
+    expect(probeClaudeInput(pending, 'steering', '请继续')).toBe('pending')
+    expect(acceptedClaudeInput(pending, 'steering', '请继续')).toBe(false)
+  })
+
+  it('requires a current Claude interaction surface', () => {
+    expect(hasClaudeInteraction('Claude needs your permission\n1. Yes\n2. No')).toBe(true)
+    expect(probeClaudeInput(pane('Claude needs your permission\n❯ '), 'primary')).toBe('unavailable')
+  })
+
+  it('keeps Codex Working composer in steering mode', () => {
+    const working = pane('Working (esc to interrupt)\n› ')
+    expect(probeCodexInput(working, 'primary')).toBe('unavailable')
+    expect(probeCodexInput(working, 'steering')).toBe('empty')
+  })
+
+  it('does not accept an old Codex queued region as this delivery', () => {
+    const old = 'Working (esc to interrupt)\nMessages to be submitted after next tool call\n› '
+    expect(acceptedCodexInput(pane(old), 'steering', 'new text', old)).toBe(false)
+    const next = `${old}\nMessages to be submitted after next tool call`
+    expect(acceptedCodexInput(pane(next), 'steering', 'new text', old)).toBe(true)
+  })
+})

--- a/crabot-agent/tests/workers/input-surface.test.ts
+++ b/crabot-agent/tests/workers/input-surface.test.ts
@@ -35,12 +35,20 @@ describe('CLI input surfaces', () => {
 
     const multiline = pane(`history\n❯ first line\nsecond line\n? for shortcuts`)
     expect(probeClaudeInput(multiline, 'primary', 'first line\nsecond line')).toBe('pending')
+    expect(probeClaudeInput(pane('❯ [Pasted text #1 +37 lines]\n? for shortcuts'), 'primary', 'very long prompt\n'.repeat(40))).toBe('pending')
+    expect(probeClaudeInput(pane('❯ ending-abcdefghijklmnopqrstuvwx\n? for shortcuts'), 'primary', `beginning-${'x'.repeat(200)}ending-abcdefghijklmnopqrstuvwx`)).toBe('pending')
   })
 
   it('keeps Codex Working composer in steering mode', () => {
     const working = pane('› \nWorking (esc to interrupt)')
     expect(probeCodexInput(working, 'primary')).toBe('unavailable')
     expect(probeCodexInput(working, 'steering')).toBe('empty')
+  })
+
+  it('does not let Codex transcript keywords impersonate active/modal UI', () => {
+    const idle = pane('Permission denied while reading a file\nWorking notes from history\n› \n? for shortcuts')
+    expect(probeCodexInput(idle, 'primary')).toBe('empty')
+    expect(probeCodexInput(idle, 'steering')).toBe('unavailable')
   })
 
   it('scopes Codex pending evidence to the active composer, not transcript history', () => {
@@ -55,6 +63,7 @@ describe('CLI input surfaces', () => {
 
     const multiline = pane(`history\n› first line\nsecond line\n? for shortcuts`)
     expect(probeCodexInput(multiline, 'primary', 'first line\nsecond line')).toBe('pending')
+    expect(probeCodexInput(pane('› [Pasted Content: 2048 chars]\n? for shortcuts'), 'primary', 'long codex prompt\n'.repeat(80))).toBe('pending')
   })
 
   it('does not accept an old Codex queued region as this delivery', () => {

--- a/crabot-agent/tests/workers/input-surface.test.ts
+++ b/crabot-agent/tests/workers/input-surface.test.ts
@@ -7,13 +7,13 @@ const pane = (text: string): PaneSnapshot => ({ text, cursor_x: 0, cursor_y: 0, 
 
 describe('CLI input surfaces', () => {
   it('does not treat a Claude running composer as primary input', () => {
-    const running = pane('working\nesc to interrupt\n❯ ')
+    const running = pane('working\n❯ \nesc to interrupt')
     expect(probeClaudeInput(running, 'primary')).toBe('unavailable')
     expect(probeClaudeInput(running, 'steering')).toBe('empty')
   })
 
   it('recognizes Claude pending text without changing control state', () => {
-    const pending = pane('working\nesc to interrupt\n❯ 请继续')
+    const pending = pane('working\n❯ 请继续\nesc to interrupt')
     expect(probeClaudeInput(pending, 'steering', '请继续')).toBe('pending')
     expect(acceptedClaudeInput(pending, 'steering', '请继续')).toBe(false)
   })
@@ -23,14 +23,42 @@ describe('CLI input surfaces', () => {
     expect(probeClaudeInput(pane('Claude needs your permission\n❯ '), 'primary')).toBe('unavailable')
   })
 
+  it('scopes Claude pending evidence to the active composer, not transcript history', () => {
+    const text = 'repeat this task'
+    const historyOnly = pane(`assistant history: ${text}\n❯ \n? for shortcuts`)
+    expect(probeClaudeInput(historyOnly, 'primary', text)).toBe('empty')
+    expect(probeClaudeInput(pane('❯\u00a0Try "how does <filepath> work?"\n────────────────\n  ⏵⏵ bypass permissions on (shift+tab to cycle)'), 'primary')).toBe('empty')
+    expect(acceptedClaudeInput(historyOnly, 'primary', text)).toBe(true)
+    const selector = pane('transcript\n❯ historical choice\n────────────────\n⏵⏵ bypass permissions on')
+    expect(probeClaudeInput(selector, 'primary', 'new')).toBe('unavailable')
+    expect(acceptedClaudeInput(selector, 'primary', 'new')).toBe(false)
+
+    const multiline = pane(`history\n❯ first line\nsecond line\n? for shortcuts`)
+    expect(probeClaudeInput(multiline, 'primary', 'first line\nsecond line')).toBe('pending')
+  })
+
   it('keeps Codex Working composer in steering mode', () => {
-    const working = pane('Working (esc to interrupt)\n› ')
+    const working = pane('› \nWorking (esc to interrupt)')
     expect(probeCodexInput(working, 'primary')).toBe('unavailable')
     expect(probeCodexInput(working, 'steering')).toBe('empty')
   })
 
+  it('scopes Codex pending evidence to the active composer, not transcript history', () => {
+    const text = 'repeat this task'
+    const historyOnly = pane(`user history: ${text}\n› \n? for shortcuts`)
+    expect(probeCodexInput(historyOnly, 'primary', text)).toBe('empty')
+    expect(probeCodexInput(pane('› Find and fix a bug in @filename\n  gpt-5.6-sol xhigh · /private/tmp/workspace'), 'primary')).toBe('empty')
+    expect(acceptedCodexInput(historyOnly, 'primary', text, historyOnly.text)).toBe(true)
+    const selector = pane('history\n› historical choice\n  gpt-5.6-sol xhigh · /private/tmp/workspace')
+    expect(probeCodexInput(selector, 'primary', 'new')).toBe('unavailable')
+    expect(acceptedCodexInput(selector, 'primary', 'new', selector.text)).toBe(false)
+
+    const multiline = pane(`history\n› first line\nsecond line\n? for shortcuts`)
+    expect(probeCodexInput(multiline, 'primary', 'first line\nsecond line')).toBe('pending')
+  })
+
   it('does not accept an old Codex queued region as this delivery', () => {
-    const old = 'Working (esc to interrupt)\nMessages to be submitted after next tool call\n› '
+    const old = 'Messages to be submitted after next tool call\n› \nWorking (esc to interrupt)'
     expect(acceptedCodexInput(pane(old), 'steering', 'new text', old)).toBe(false)
     const next = `${old}\nMessages to be submitted after next tool call`
     expect(acceptedCodexInput(pane(next), 'steering', 'new text', old)).toBe(true)


### PR DESCRIPTION
## Summary

- migrate Claude Code / Codex workers to the single-layer `running / waiting_text / waiting_action / exited` control contract
- make initial input ownership explicit via `handle.initial_input`; settle spawn/resume/handoff without duplicate callbacks
- add guarded single-paste input commit (`empty → paste → pending → Enter`, at most one Enter retry, never auto re-paste)
- constrain composer evidence to the current footer-anchored input region; support real Claude Code 2.1.226 and Codex 0.146 placeholders
- add reason-aware WorkerInbox holds, raw-only bypass, FIFO/requeue/drain ownership, and synchronous accepted-exit settlement
- defer Codex rollout discovery until the first accepted ordinary prompt (including startup-stall/raw recovery)

This is temporarily stacked on PR #80 because the CLI harness changes depend on its builtin/bg-shell WorkerInbox semantics. After #80 merges, this PR will be retargeted to `main`.

## Docs

Confirmed and pushed in the independent docs repository:

- spec: `c5071f6` — `2026-08-07-cli-interactive-input-commit-design.md`
- protocol v3.0.3: `7bf5d6a` — CLI interaction delivery contract
- implementation plan: `7d6b509` — `2026-08-08-cli-interactive-input-commit-plan.md`

## Validation

- `cd crabot-agent && npm run build` ✅
- focused CLI/harness/contract suite: **292 tests passed** (10 files, serial) ✅
- independent final reviewer after all automated-review fixes: **APPROVED, no blocker/major** ✅
- `git diff --check` ✅
- real tmux black-box (latest diff): Claude Code **2.1.226**, Codex **0.146.0**, tmux **3.3a** ✅
  - Claude spawn, second primary input, active steering, resume all accepted and returned idle
  - Codex spawn and resume produced native rollout user receipts with discovered real session IDs
  - Codex steering reproduced two missed Enters as `pending_in_ui`; no re-paste occurred; explicit raw `Tab` queued the existing composer exactly once
  - Claude AskUserQuestion probe was inconclusive because the configured external model did not execute the tool in this environment; Notification + current-pane corroboration is covered by focused adapter/harness tests and prior real 2.1.224 evidence

Full serial Vitest on the current stacked head: **2573 passed / 2 skipped / 4 failed** (215 files). The remaining four failures are unchanged macOS environment baselines outside this PR: one tmux foreground-command assertion (`zsh` vs `sleep`) and three `/var` → `/private/var` realpath equality assertions. All former PR #80 audit/inbound failures are gone.

## Residual test noise

A few adapter/contract teardowns log non-fatal watcher `ENOENT` messages when temporary worker directories are removed while queued watcher work is finishing. Tests pass; no production state directory is removed this way.


