### PR TITLE
Fix builtin MCP path in source user mode

### DIFF
--- a/crabot-core/src/core-modules.test.ts
+++ b/crabot-core/src/core-modules.test.ts
@@ -24,10 +24,11 @@ function envOf(mods: ReturnType<typeof buildCoreModules>, id: string) {
 }
 
 describe('buildCoreModules：DATA_DIR 顶层契约', () => {
-  it('admin：DATA_DIR=顶层，CRABOT_ADMIN_DATA_DIR=模块级', () => {
+  it('admin：DATA_DIR=顶层，CRABOT_ADMIN_DATA_DIR=模块级，builtin MCP 路径来自代码根', () => {
     const env = envOf(buildCoreModules(OPTS), 'admin-web')
     expect(env.DATA_DIR).toBe('/home/u/.crabot/data')
     expect(env.CRABOT_ADMIN_DATA_DIR).toBe(join('/home/u/.crabot/data', 'admin'))
+    expect(env.CRABOT_MCP_TOOLS_PATH).toBe(join('/repo', 'crabot-mcp-tools'))
   })
 
   it('agent：DATA_DIR=顶层，CRABOT_AGENT_DATA_DIR=模块级，CRABOT_HOME 已注入', () => {

--- a/crabot-core/src/core-modules.ts
+++ b/crabot-core/src/core-modules.ts
@@ -41,6 +41,7 @@ export function buildCoreModules(o: BuildCoreModulesOpts): CoreModule[] {
         // DATA_DIR 全局=顶层；admin 模块级目录走专用 env（与 memory 对称）
         DATA_DIR: o.dataDir,
         CRABOT_ADMIN_DATA_DIR: path.join(o.dataDir, 'admin'),
+        CRABOT_MCP_TOOLS_PATH: path.join(o.crabotRoot, 'crabot-mcp-tools'),
       } as Record<string, string>,
     },
     {


### PR DESCRIPTION
## Summary
- inject `CRABOT_MCP_TOOLS_PATH` into Admin from the actual Crabot code root
- cover source user mode where code and `DATA_DIR` are not siblings
- let the existing builtin registry reconciliation repair persisted MCP paths on restart

## Validation
- `corepack pnpm exec vitest run src/core-modules.test.ts`
- `corepack pnpm exec vitest run` (crabot-core: 125 passed)
- `corepack pnpm run build` (crabot-core)
- `git diff --check`

## Scope
This fixes builtin `computer-use`, `lsp`, and `git`. The custom `market-quotes` entry remains a separate stale local configuration.