### PR TITLE
feat(agent): scope workers by manager session

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -32,11 +32,11 @@
 
 ### 最近验证基线
 
-- legacy importer/read-model/authorization/continuation 定向：15 files / 285 passed；两轮独立 security/correctness review 最终无 blocker/important。
-- 隔离升级副本使用当前生产快照完成真实 v2 导入：2696 tasks → 2696 legacy workers / 2696 `legacy_imported` events；首次 marker `completed`，有源重跑和隐藏源后的 completed fast-path 均跳过，复制源 hash 不变。证据目录：`/tmp/crabot-v2-upgrade-e2e-uF3u3v`。
+- legacy importer/read-model/authorization/continuation 定向：15 files / 285 passed；PR review-fix 扩展回归：17 files / 325 passed。两轮独立 security/correctness review 最终无 blocker/important。
+- 隔离升级副本使用当前生产快照完成真实 v2 导入：2696 tasks → 2696 legacy workers / 2696 `legacy_imported` events；首次 marker `completed`，有源重跑和隐藏源后的 completed fast-path 均跳过，复制源 hash 不变。索引修复后同一快照全量导入耗时 32.96s。证据目录：`/tmp/crabot-v2-upgrade-e2e-uF3u3v`、`/tmp/crabot-v2-import-perf-7A2Wgz`。
 - 全分支独立 review 覆盖授权/assertion、台账/importer 和 Manager/time；TraceStore 源隔离与精确 assertion ID 意见已修复并复审关闭，seq 碰撞按协议既有范围记录为 residual，当前无未解决 blocker/important。
 - Shared 全量：100 passed；Shared build 通过。
-- Agent 全量：2662 passed / 4 failed / 2 skipped。4 个失败均为既有 macOS 环境基线：tmux foreground command 识别差异 1 个，`/var` → `/private/var` realpath 差异 3 个。
+- Agent 全量：2664 passed / 4 failed / 2 skipped。4 个失败均为既有 macOS 环境基线：tmux foreground command 识别差异 1 个，`/var` → `/private/var` realpath 差异 3 个。
 - Admin 全量：1075 passed / 1 failed。唯一失败为既有 `v1-cleanup.test.ts` 扫到 `origin/main` 已存在的测试断言字符串；本分支未引入该引用。Admin focused 81 passed，`build:all` 通过。
 - `CI=true ./dev.sh build`、Agent/Admin/Shared TypeScript build 与全分支 `git diff --check` 通过；禁止回归搜索未发现 worker `dialog_object_id`、`spawned_by_session`、fake legacy adapter 或已退役 resume RPC 注册。
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -22,14 +22,23 @@
 - CLI MCP 物化保留 stdio `env`、远端 `headers/http_headers` 与 transport type。Claude/Codex credential target 均先检查 Git tracked 状态、以 `0600` 原子替换，并用 ignore 规则防止目标及 crash temp 被普通 `git add -A` 收录。
 - `builtin_tool_config.disabled_tools` 的 MCP 逐工具黑名单只作用于 builtin；CLI worker 以整台 server 为最小 provision 单位，跨实现限制使用 `mcp_skill / desktop` 类别权限或禁用整台 server。
 
+### Manager 会话隔离与 v2 历史兼容已实现
+
+- worker 台账改为按不可变 `ManagerKey` 归属，普通 Manager 的发现和 known-ID 操作均限定当前会话；只有当前仍有效的 Master 私聊工具面可显式跨会话查询和操作。
+- Admin Chat 的 WebSocket 与 HTTP 附件入口统一进入 `admin-web::admin-chat`，由 Admin 签发短时、一次性、持久防重放 assertion；Agent 只在官方 `admin-web` RPC 核销成功后建立 Master generation。
+- Friend/Admin Chat 授权使用可撤销 generation；旧 tool call、降权/删除后的调用和无控制层跨会话访问均 fail closed。私聊主体绑定可持久，群聊最近发言人不持久。
+- Manager system prompt 不再嵌入动态台账、当前时间或 pending notes；所有 wake 使用入口时固定的时间信封，mailbox、失败重投、overflow retry 和 mid-episode supplement 保持同一事件时间。
+- v2 Admin task/TraceStore 通过一次性只读 importer 投影为 legacy worker；marker 严格按 `in_progress → completed`，旧 trace 源与 v3 `traces-running-v3.jsonl` / `traces-v3-<date>.jsonl` 写入命名空间隔离。legacy output/trace 可降级读取，受控续办只追加全新 v3 化身，不恢复旧 checkpoint、旧 RPC 或 fake legacy adapter。
+
 ### 最近验证基线
 
-- review-fix 定向：6 files / 168 passed。
-- Claude/Codex/物化安全套件：3 files / 174 passed。
-- handoff continuation：42 passed。
-- workers/harness + manager + provision + MCP 回归：31 files / 605 passed。
-- Agent 全量基线：2623 passed / 1 failed / 2 skipped；唯一失败为既有 macOS/tmux foreground-command 环境差异（期待 `sleep`，实际 `bash`）。
-- Agent TypeScript build 与 `git diff --check` 通过；未生成 `crabot-agent/package-lock.json`。
+- legacy importer/read-model/authorization/continuation 定向：15 files / 285 passed；两轮独立 security/correctness review 最终无 blocker/important。
+- 隔离升级副本使用当前生产快照完成真实 v2 导入：2696 tasks → 2696 legacy workers / 2696 `legacy_imported` events；首次 marker `completed`，有源重跑和隐藏源后的 completed fast-path 均跳过，复制源 hash 不变。证据目录：`/tmp/crabot-v2-upgrade-e2e-uF3u3v`。
+- 全分支独立 review 覆盖授权/assertion、台账/importer 和 Manager/time；TraceStore 源隔离与精确 assertion ID 意见已修复并复审关闭，seq 碰撞按协议既有范围记录为 residual，当前无未解决 blocker/important。
+- Shared 全量：100 passed；Shared build 通过。
+- Agent 全量：2662 passed / 4 failed / 2 skipped。4 个失败均为既有 macOS 环境基线：tmux foreground command 识别差异 1 个，`/var` → `/private/var` realpath 差异 3 个。
+- Admin 全量：1075 passed / 1 failed。唯一失败为既有 `v1-cleanup.test.ts` 扫到 `origin/main` 已存在的测试断言字符串；本分支未引入该引用。Admin focused 81 passed，`build:all` 通过。
+- `CI=true ./dev.sh build`、Agent/Admin/Shared TypeScript build 与全分支 `git diff --check` 通过；禁止回归搜索未发现 worker `dialog_object_id`、`spawned_by_session`、fake legacy adapter 或已退役 resume RPC 注册。
 
 ### 最近运行态检查
 
@@ -41,11 +50,13 @@
 
 ### 已确认
 
-1. **PR #84 部署后真实验收**：创建实际 Claude Code / Codex worker，核对 task-scoped MCP、`desktop / mcp_skill` 过滤、handoff 权限快照、disabled server 清理及 credential 文件权限。
-2. **Claude MCP 配置外置**：当前 project-scope 根 `.mcp.json` 与根 `.gitignore` 副作用是 v3.0.8 明确接受的边界。迁移到 Crabot-owned per-worker 外部路径需调整 provision/启动寻址，并重新验证 Claude trust flow。
-3. **权限 schema 迁移纪律**：新增 `ToolAccessConfig` 或 `CliDomain` 类目前，必须先为历史 worker context 做显式 migration；不得依赖 persisted read 静默补齐。
-4. **既有 tmux 测试基线**：`tmux-driver.test.ts` 在当前 macOS 环境把 foreground command 识别为 `bash` 而非 `sleep`，需单独校准测试或驱动探针。
-5. **PROGRESS 维护**：只记录稳定事实和可执行 follow-up，不再写“待 review / 待 merge”等瞬时状态，也不为回填 merge 元信息单独改文档。
+1. **会话台账切换验收**：部署前人工收口仍在运行的旧 worker/bg owner 并备份旧 `data/agent/ledgers/`；不迁移本机测试期生成的 `friend:*` / `group:*` v3 台账。隔离升级副本必须覆盖 v2 importer 首次运行、重启幂等、legacy read model、授权撤销和 fresh-v3 continuation。
+2. **PR #84 部署后真实验收**：创建实际 Claude Code / Codex worker，核对 task-scoped MCP、`desktop / mcp_skill` 过滤、handoff 权限快照、disabled server 清理及 credential 文件权限。
+3. **Claude MCP 配置外置**：当前 project-scope 根 `.mcp.json` 与根 `.gitignore` 副作用是 v3.0.8 明确接受的边界。迁移到 Crabot-owned per-worker 外部路径需调整 provision/启动寻址，并重新验证 Claude trust flow。
+4. **权限 schema 迁移纪律**：新增 `ToolAccessConfig` 或 `CliDomain` 类目前，必须先为历史 worker context 做显式 migration；不得依赖 persisted read 静默补齐。
+5. **incarnation seq 已知限制**：协议 §5.6 已明确 adapter 自管 seq 可能在跨实现/重启后碰撞；legacy `seq:1` 续办后也可能复现。根治需要 harness 全局分配或扩展公开读取身份契约，属于需重新确认的协议变更；当前通用历史 Trace API 仍可读取旧 trace。
+6. **既有测试基线**：单独校准 macOS tmux foreground-command、`/var` realpath 和 Admin v1 cleanup 的跨仓测试扫描；不得与当前功能修复混改。
+7. **PROGRESS 维护**：只记录稳定事实和可执行 follow-up，不再写“待 review / 待 merge”等瞬时状态，也不为回填 merge 元信息单独改文档。
 
 ### 需重新确认后再立项
 
@@ -68,6 +79,7 @@
 
 | 日期 | 里程碑 |
 |---|---|
+| 08-10 | ManagerKey 会话台账、Master 显式全局视角、Admin Chat assertion、可撤授权 generation、稳定 prompt/事件时间信封和 v2 legacy 只读导入/新 v3 化身续办完成。 |
 | 08-09 | PR #84：task-scoped MCP capability 接入 builtin / Claude Code / Codex；固定 principal 快照、credential 安全写入、handoff preflight 与协议 v3.0.8 落地。 |
 | 08-09 | PR #82：CLI 交互输入提交安全化；Claude Code 2.1.226 / Codex 0.146.0 真机 tmux 路径完成校准。 |
 | 08-09 | PR #80：legacy AgentHandler 生产执行/恢复控制面退役；builtin bg-shell durable exit delivery 上线。 |

--- a/crabot-admin/src/admin-chat-assertions.test.ts
+++ b/crabot-admin/src/admin-chat-assertions.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { promises as fs } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { AdminChatAssertions } from './admin-chat-assertions.js'
+
+describe('AdminChatAssertions', () => {
+  let dir: string
+  let now: Date
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(join(tmpdir(), 'admin-chat-assertion-'))
+    now = new Date('2026-08-10T00:00:00.000Z')
+  })
+  afterEach(async () => { await fs.rm(dir, { recursive: true, force: true }) })
+
+  it('issues required opaque claims and atomically rejects wrong expected values and replay after restart', async () => {
+    const issue = new AdminChatAssertions(dir, 'secret', () => now)
+    await issue.load()
+    const assertion = issue.issue({ requestId: 'request-1', payloadSha256: 'a'.repeat(64) })
+    const claims = JSON.parse(Buffer.from(assertion.split('.')[1]!, 'base64url').toString('utf8'))
+    expect(claims).toMatchObject({
+      assertion_id: expect.any(String), issuer_module_id: 'admin-web', audience: 'crabot-agent', purpose: 'admin_chat',
+      manager_key: 'admin-web::admin-chat', request_id: 'request-1', payload_sha256: 'a'.repeat(64),
+      issued_at: now.toISOString(), expires_at: expect.any(String),
+    })
+    await expect(issue.consume(assertion, { manager_key: 'admin-web::admin-chat', request_id: 'request-1', payload_sha256: 'b'.repeat(64) })).rejects.toThrow(/invalid/)
+    await expect(issue.consume(assertion, { manager_key: 'admin-web::admin-chat', request_id: 'request-1', payload_sha256: 'a'.repeat(64) })).resolves.toMatchObject({ consumed: true })
+    const restarted = new AdminChatAssertions(dir, 'secret', () => now)
+    await restarted.load()
+    await expect(restarted.consume(assertion, { manager_key: 'admin-web::admin-chat', request_id: 'request-1', payload_sha256: 'a'.repeat(64) })).rejects.toThrow(/consumed/)
+  })
+
+  it('rejects tampered header/body/signature, malformed claims, corrupt stores, and permits exactly one concurrent consume', async () => {
+    const assertions = new AdminChatAssertions(dir, 'secret', () => now)
+    await assertions.load()
+    const assertion = assertions.issue({ requestId: 'request-1', payloadSha256: 'a'.repeat(64) })
+    const [header, body, signature] = assertion.split('.')
+    const expected = { manager_key: 'admin-web::admin-chat' as const, request_id: 'request-1', payload_sha256: 'a'.repeat(64) }
+    for (const token of [
+      `${Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url')}.${body}.${signature}`,
+      `${header}.${Buffer.from(JSON.stringify({ assertion_id: 'x' })).toString('base64url')}.${signature}`,
+      `${header}.${body}.${signature!.slice(0, -1)}x`,
+    ]) await expect(assertions.consume(token, expected)).rejects.toThrow(/invalid/)
+    const concurrent = await Promise.allSettled([assertions.consume(assertion, expected), assertions.consume(assertion, expected)])
+    expect(concurrent.filter(result => result.status === 'fulfilled')).toHaveLength(1)
+    expect(concurrent.filter(result => result.status === 'rejected')).toHaveLength(1)
+
+    await fs.writeFile(join(dir, 'admin-chat-assertions.json'), JSON.stringify({ good: now.toISOString(), bad: 4 }))
+    await expect(new AdminChatAssertions(dir, 'secret', () => now).load()).rejects.toThrow(/invalid consumed assertion store/)
+  })
+
+  it('rejects expired assertion', async () => {
+    const assertions = new AdminChatAssertions(dir, 'secret', () => now)
+    const assertion = assertions.issue({ requestId: 'request-1', payloadSha256: 'a'.repeat(64) })
+    now = new Date(now.getTime() + 61_000)
+    await expect(assertions.consume(assertion, { manager_key: 'admin-web::admin-chat', request_id: 'request-1', payload_sha256: 'a'.repeat(64) })).rejects.toThrow(/expired/)
+  })
+})

--- a/crabot-admin/src/admin-chat-assertions.test.ts
+++ b/crabot-admin/src/admin-chat-assertions.test.ts
@@ -40,7 +40,7 @@ describe('AdminChatAssertions', () => {
     for (const token of [
       `${Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url')}.${body}.${signature}`,
       `${header}.${Buffer.from(JSON.stringify({ assertion_id: 'x' })).toString('base64url')}.${signature}`,
-      `${header}.${body}.${signature!.slice(0, -1)}x`,
+      `${header}.${body}.${signature!.slice(0, -1)}${signature!.endsWith('a') ? 'b' : 'a'}`,
     ]) await expect(assertions.consume(token, expected)).rejects.toThrow(/invalid/)
     const concurrent = await Promise.allSettled([assertions.consume(assertion, expected), assertions.consume(assertion, expected)])
     expect(concurrent.filter(result => result.status === 'fulfilled')).toHaveLength(1)

--- a/crabot-admin/src/admin-chat-assertions.ts
+++ b/crabot-admin/src/admin-chat-assertions.ts
@@ -1,0 +1,131 @@
+import crypto from 'node:crypto'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { generateId } from 'crabot-shared'
+
+const AUDIENCE = 'crabot-agent'
+const PURPOSE = 'admin_chat'
+const ISSUER = 'admin-web'
+const TTL_SECONDS = 60
+const CLAIM_KEYS = ['assertion_id', 'issuer_module_id', 'audience', 'purpose', 'manager_key', 'request_id', 'payload_sha256', 'issued_at', 'expires_at'] as const
+
+type AssertionClaims = {
+  assertion_id: string
+  issuer_module_id: typeof ISSUER
+  audience: typeof AUDIENCE
+  purpose: typeof PURPOSE
+  manager_key: 'admin-web::admin-chat'
+  request_id: string
+  payload_sha256: string
+  issued_at: string
+  expires_at: string
+}
+type ExpectedAssertion = Pick<AssertionClaims, 'manager_key' | 'request_id' | 'payload_sha256'>
+type ConsumedAssertions = Record<string, string>
+
+function base64Url(value: string | Buffer): string {
+  return Buffer.from(value).toString('base64').replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_')
+}
+function decodeJson(part: string): unknown | undefined {
+  try { return JSON.parse(Buffer.from(part, 'base64url').toString('utf8')) } catch { return undefined }
+}
+function exactKeys(value: unknown, keys: readonly string[]): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+    && Object.keys(value).length === keys.length && keys.every(key => Object.prototype.hasOwnProperty.call(value, key))
+}
+function validClaims(value: unknown): value is AssertionClaims {
+  if (!exactKeys(value, CLAIM_KEYS)) return false
+  const claims = value as Record<string, unknown>
+  return typeof claims.assertion_id === 'string' && claims.assertion_id.length > 0
+    && claims.issuer_module_id === ISSUER && claims.audience === AUDIENCE && claims.purpose === PURPOSE
+    && claims.manager_key === 'admin-web::admin-chat'
+    && typeof claims.request_id === 'string' && claims.request_id.length > 0
+    && typeof claims.payload_sha256 === 'string' && /^[a-f0-9]{64}$/.test(claims.payload_sha256)
+    && typeof claims.issued_at === 'string' && Number.isFinite(Date.parse(claims.issued_at))
+    && typeof claims.expires_at === 'string' && Number.isFinite(Date.parse(claims.expires_at))
+    && Date.parse(claims.issued_at) <= Date.parse(claims.expires_at)
+}
+function sign(payload: AssertionClaims, secret: string): string {
+  const header = base64Url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }))
+  const body = base64Url(JSON.stringify(payload))
+  return `${header}.${body}.${base64Url(crypto.createHmac('sha256', secret).update(`${header}.${body}`).digest())}`
+}
+function verify(token: string, secret: string): AssertionClaims | undefined {
+  const [header, body, signature, extra] = token.split('.')
+  if (!header || !body || !signature || extra) return undefined
+  const parsedHeader = decodeJson(header)
+  if (!exactKeys(parsedHeader, ['alg', 'typ']) || parsedHeader.alg !== 'HS256' || parsedHeader.typ !== 'JWT') return undefined
+  const expected = crypto.createHmac('sha256', secret).update(`${header}.${body}`).digest()
+  let actual: Buffer
+  try { actual = Buffer.from(signature, 'base64url') } catch { return undefined }
+  if (actual.length !== expected.length || !crypto.timingSafeEqual(actual, expected)) return undefined
+  const claims = decodeJson(body)
+  return validClaims(claims) ? claims : undefined
+}
+
+/** Issues and atomically consumes opaque Admin Chat assertions. Assertion values never enter chat storage. */
+export class AdminChatAssertions {
+  private readonly filePath: string
+  private consumed: ConsumedAssertions = {}
+  private writeTail: Promise<void> = Promise.resolve()
+
+  constructor(private readonly dataDir: string, private readonly secret: string, private readonly now: () => Date = () => new Date()) {
+    this.filePath = path.join(dataDir, 'admin-chat-assertions.json')
+  }
+
+  async load(): Promise<void> {
+    try {
+      const raw = await fs.readFile(this.filePath, 'utf8')
+      const parsed = JSON.parse(raw) as unknown
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) throw new Error('invalid consumed assertion store')
+      const current = this.now().getTime()
+      const loaded: ConsumedAssertions = {}
+      for (const [id, expiry] of Object.entries(parsed)) {
+        if (!id || typeof expiry !== 'string' || !Number.isFinite(Date.parse(expiry))) {
+          throw new Error('invalid consumed assertion store')
+        }
+        if (Date.parse(expiry) > current) loaded[id] = expiry
+      }
+      this.consumed = loaded
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return
+      throw error
+    }
+  }
+
+  issue(input: { requestId: string; payloadSha256: string }): string {
+    if (!input.requestId || !/^[a-f0-9]{64}$/.test(input.payloadSha256)) throw new Error('invalid assertion input')
+    const issued = this.now()
+    const expires = new Date(issued.getTime() + TTL_SECONDS * 1000)
+    return sign({ assertion_id: generateId(), issuer_module_id: ISSUER, audience: AUDIENCE, purpose: PURPOSE,
+      manager_key: 'admin-web::admin-chat', request_id: input.requestId, payload_sha256: input.payloadSha256,
+      issued_at: issued.toISOString(), expires_at: expires.toISOString() }, this.secret)
+  }
+
+  async consume(assertion: string, expected: ExpectedAssertion): Promise<{ consumed: true; expires_at: string }> {
+    return this.serialize(async () => {
+      const claims = verify(assertion, this.secret)
+      if (!claims || claims.manager_key !== expected.manager_key || claims.request_id !== expected.request_id || claims.payload_sha256 !== expected.payload_sha256) {
+        throw new Error('invalid admin chat assertion')
+      }
+      const current = this.now().getTime()
+      if (Date.parse(claims.expires_at) <= current) throw new Error('expired admin chat assertion')
+      if (this.consumed[claims.assertion_id]) throw new Error('consumed admin chat assertion')
+      this.consumed[claims.assertion_id] = claims.expires_at
+      for (const [id, expiry] of Object.entries(this.consumed)) if (Date.parse(expiry) <= current) delete this.consumed[id]
+      await fs.mkdir(this.dataDir, { recursive: true })
+      const temporary = `${this.filePath}.tmp-${generateId()}`
+      await fs.writeFile(temporary, JSON.stringify(this.consumed), { mode: 0o600 })
+      await fs.rename(temporary, this.filePath)
+      return { consumed: true, expires_at: claims.expires_at }
+    })
+  }
+
+  private async serialize<T>(action: () => Promise<T>): Promise<T> {
+    const previous = this.writeTail
+    let release!: () => void
+    this.writeTail = new Promise<void>(resolve => { release = resolve })
+    await previous
+    try { return await action() } finally { release() }
+  }
+}

--- a/crabot-admin/src/admin-web-api.test.ts
+++ b/crabot-admin/src/admin-web-api.test.ts
@@ -146,10 +146,12 @@ describe('Admin Web API', () => {
           call(port: number, method: string, params: unknown): Promise<unknown>
         }
         processAdminChatMessage: typeof processAdminChatMessage
+        managerStack: { principals: { activateAdminChat(key: string, input: unknown): Promise<void> } }
         handleProcessMessage(params: Record<string, unknown>): Promise<unknown>
       }
       agent.config = { moduleId: 'crabot-agent' }
       agent.processAdminChatMessage = processAdminChatMessage
+      agent.managerStack = { principals: { activateAdminChat: async () => {} } }
       agent.rpcClient = {
         resolve: async (filter) => {
           expect(filter).toEqual({ module_id: 'admin-web' })

--- a/crabot-admin/src/admin-web-api.test.ts
+++ b/crabot-admin/src/admin-web-api.test.ts
@@ -1646,7 +1646,7 @@ describe('Admin Web API', () => {
 
       await makeWebRequest(
         TEST_WEB_PORT,
-        '/api/agent/workers?status=executing&status=waiting&dialog_object_id=telegram-001%3Aprivate-42'
+        '/api/agent/workers?status=executing&status=waiting&manager_key=telegram-001%3A%3Aprivate-42'
           + '&start=2026-07-01T00%3A00%3A00.000Z&end=2026-07-31T00%3A00%3A00.000Z&page=2&page_size=5',
         'GET',
         null,
@@ -1655,7 +1655,7 @@ describe('Admin Web API', () => {
 
       expect(spy).toHaveBeenCalledWith('list_workers_admin', {
         status: ['executing', 'waiting'],
-        dialog_object_id: 'telegram-001:private-42',
+        manager_key: 'telegram-001::private-42',
         time_range: { start: '2026-07-01T00:00:00.000Z', end: '2026-07-31T00:00:00.000Z' },
         pagination: { page: 2, page_size: 5 },
       })

--- a/crabot-admin/src/admin-web-api.test.ts
+++ b/crabot-admin/src/admin-web-api.test.ts
@@ -4,8 +4,11 @@
 
 import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest'
 import http from 'node:http'
+import { WebSocket } from 'ws'
+import { sha256CanonicalJson } from 'crabot-shared'
 import fs from 'node:fs/promises'
 import AdminModule from './index.js'
+import { UnifiedAgent } from '../../crabot-agent/src/unified-agent.js'
 import type { ChannelMessageRef, DialogObjectApplication, Friend, FriendPermissionConfig, ListConversationUnitsResult, LoginResponse, Task } from './types.js'
 import { AdminErrorCode, createCliAccessConfig } from './types.js'
 import { newCredentialsFromPassword, writeCredentials } from './credentials.js'
@@ -114,6 +117,154 @@ describe('Admin Web API', () => {
         'invalid-token'
       )
       expect(response.statusCode).toBe(401)
+    })
+  })
+
+  describe('Admin Chat assertion transport boundaries', () => {
+    afterEach(async () => {
+      vi.restoreAllMocks()
+      await (admin as unknown as { chatManager: { clearMessages(): Promise<void> } }).chatManager.clearMessages()
+    })
+
+    function captureProcessMessage() {
+      ;(admin as unknown as { agentPort: number }).agentPort = 19999
+      return vi.spyOn(
+        (admin as unknown as { rpcClient: { call: (...args: unknown[]) => Promise<unknown> } }).rpcClient,
+        'call',
+      ).mockImplementation(async (_port, method) => {
+        if (method === 'process_message') return { decision_types: [] }
+        throw new Error(`unexpected RPC: ${String(method)}`)
+      })
+    }
+
+    async function consumeThroughAgent(payload: Record<string, any>): Promise<void> {
+      const processAdminChatMessage = vi.fn(async () => ({ decision_types: [] }))
+      const agent = Object.create(UnifiedAgent.prototype) as unknown as {
+        config: { moduleId: string }
+        rpcClient: {
+          resolve(filter: unknown): Promise<Array<{ module_id: string; port: number }>>
+          call(port: number, method: string, params: unknown): Promise<unknown>
+        }
+        processAdminChatMessage: typeof processAdminChatMessage
+        handleProcessMessage(params: Record<string, unknown>): Promise<unknown>
+      }
+      agent.config = { moduleId: 'crabot-agent' }
+      agent.processAdminChatMessage = processAdminChatMessage
+      agent.rpcClient = {
+        resolve: async (filter) => {
+          expect(filter).toEqual({ module_id: 'admin-web' })
+          return [{ module_id: 'admin-web', port: TEST_PROTOCOL_PORT }]
+        },
+        call: async (port, method, params) => {
+          expect(port).toBe(TEST_PROTOCOL_PORT)
+          expect(method).toBe('consume_admin_chat_assertion')
+          return (admin as unknown as {
+            handleConsumeAdminChatAssertion(input: unknown): Promise<unknown>
+          }).handleConsumeAdminChatAssertion(params)
+        },
+      }
+
+      await expect(agent.handleProcessMessage(payload)).resolves.toEqual({ decision_types: [] })
+      expect(processAdminChatMessage).toHaveBeenCalledTimes(1)
+      await expect(agent.handleProcessMessage(payload)).rejects.toThrow(/consumed/)
+      expect(processAdminChatMessage).toHaveBeenCalledTimes(1)
+    }
+
+    function assertCommonAdminChatPayload(payload: Record<string, any>, requestId: string, text: string): void {
+      expect(Object.keys(payload).sort()).toEqual([
+        'admin_chat_assertion', 'callback_info', 'message', 'source_type',
+      ])
+      expect(payload).toMatchObject({
+        source_type: 'admin_chat',
+        callback_info: { source_module_id: 'admin-web', request_id: requestId },
+        message: {
+          session: { channel_id: 'admin-web', session_id: 'admin-chat', type: 'private' },
+          sender: { friend_id: 'master', platform_user_id: 'master' },
+          content: { type: 'text', text },
+        },
+      })
+      expect(Object.keys(payload.message).sort()).toEqual([
+        'content', 'features', 'platform_message_id', 'platform_timestamp', 'sender', 'session',
+      ])
+      expect(typeof payload.admin_chat_assertion).toBe('string')
+      expect(sha256CanonicalJson(payload.message)).toMatch(/^[a-f0-9]{64}$/)
+    }
+
+    function processPayload(call: unknown[] | undefined): Record<string, any> {
+      expect(call?.[1]).toBe('process_message')
+      return call?.[2] as Record<string, any>
+    }
+
+    async function waitForCall(spy: ReturnType<typeof vi.spyOn>): Promise<unknown[]> {
+      const deadline = Date.now() + 2_000
+      while (Date.now() < deadline) {
+        const call = spy.mock.calls.find(entry => entry[1] === 'process_message')
+        if (call) return call
+        await new Promise(resolve => setTimeout(resolve, 10))
+      }
+      throw new Error('timed out waiting for process_message')
+    }
+
+    async function rejectedWebSocket(url: string): Promise<number | undefined> {
+      return new Promise((resolve, reject) => {
+        const socket = new WebSocket(url)
+        socket.once('unexpected-response', (_request, response) => {
+          response.resume()
+          resolve(response.statusCode)
+        })
+        socket.once('open', () => reject(new Error('websocket unexpectedly opened')))
+        socket.once('error', error => {
+          // `ws` normally emits this after unexpected-response; wait for the HTTP status.
+          if (!socket.readyState || socket.readyState === WebSocket.CLOSED) return
+          reject(error)
+        })
+      })
+    }
+
+    it('multipart Admin Chat requires JWT and creates a one-time assertion bound to the final Agent message', async () => {
+      const body = new FormData()
+      body.set('request_id', 'multipart-assertion-1')
+      body.set('text', '来自 multipart 的消息')
+      const unauthenticated = await fetch(`http://localhost:${TEST_WEB_PORT}/api/chat/messages`, {
+        method: 'POST', body,
+      })
+      expect(unauthenticated.status).toBe(401)
+
+      const token = await loginAndGetToken()
+      const spy = captureProcessMessage()
+      const authenticatedBody = new FormData()
+      authenticatedBody.set('request_id', 'multipart-assertion-2')
+      authenticatedBody.set('text', '来自 multipart 的消息')
+      const response = await fetch(`http://localhost:${TEST_WEB_PORT}/api/chat/messages`, {
+        method: 'POST', body: authenticatedBody, headers: { Authorization: `Bearer ${token}` },
+      })
+      expect(response.status).toBe(200)
+
+      const payload = processPayload(await waitForCall(spy))
+      assertCommonAdminChatPayload(payload, 'multipart-assertion-2', '来自 multipart 的消息')
+      await consumeThroughAgent(payload)
+    })
+
+    it('WebSocket rejects missing/invalid JWT and emits the same Admin Chat assertion payload after valid JWT', async () => {
+      expect(await rejectedWebSocket(`ws://localhost:${TEST_WEB_PORT}/ws/chat`)).toBe(401)
+      expect(await rejectedWebSocket(`ws://localhost:${TEST_WEB_PORT}/ws/chat?token=invalid`)).toBe(401)
+
+      const token = await loginAndGetToken()
+      const spy = captureProcessMessage()
+      const socket = new WebSocket(`ws://localhost:${TEST_WEB_PORT}/ws/chat?token=${encodeURIComponent(token)}`)
+      try {
+        await new Promise<void>((resolve, reject) => {
+          socket.once('open', resolve)
+          socket.once('error', reject)
+        })
+        socket.send(JSON.stringify({ type: 'chat_message', request_id: 'ws-assertion-1', content: '来自 WS 的消息' }))
+        const payload = processPayload(await waitForCall(spy))
+        assertCommonAdminChatPayload(payload, 'ws-assertion-1', '来自 WS 的消息')
+        await consumeThroughAgent(payload)
+      } finally {
+        socket.close()
+        await new Promise(resolve => socket.once('close', resolve))
+      }
     })
   })
 

--- a/crabot-admin/src/agent-task-status-event.test.ts
+++ b/crabot-admin/src/agent-task-status-event.test.ts
@@ -19,14 +19,16 @@ const TEST_DATA_DIR = './test-data/agent-task-status-event-test'
 const ADMIN_CHAT_WORKER = {
   worker_id: 'w-admin-1',
   task: { id: 'task-admin-1', title: '把 README 翻译成英文', status: 'running' },
-  origin: { spawned_by_session: 'admin-web::admin-chat', trigger_type: 'message' },
+  manager_key: 'admin-web::admin-chat',
+  origin: { trigger_type: 'message' },
   report_to: { channel_id: 'admin-web', session_id: 'admin-chat' },
 }
 
 const WECHAT_WORKER = {
   worker_id: 'w-wechat-1',
   task: { id: 'task-wechat-1', title: '群里那个活', status: 'running' },
-  origin: { spawned_by_session: 'wechat::sess-1', trigger_type: 'message' },
+  manager_key: 'wechat::sess-1',
+  origin: { trigger_type: 'message' },
   report_to: { channel_id: 'wechat', session_id: 'sess-1' },
 }
 
@@ -128,7 +130,7 @@ describe('agent.task_status_changed 订阅（protocol-agent-v3 §9.2）', () => 
         task_id: p.taskId,
         old_status: p.from,
         new_status: p.to,
-        dialog_object_id: 'friend:master-1',
+        manager_key: 'admin-web::admin-chat',
       },
       timestamp: '2026-08-01T00:00:00.000Z',
     }

--- a/crabot-admin/src/chat-manager.test.ts
+++ b/crabot-admin/src/chat-manager.test.ts
@@ -19,7 +19,7 @@ async function makeManager(): Promise<ChatManager> {
     { call: async () => ({}) } as never,
     async () => 0,
     'test-secret',
-    async () => ({ sub: 'admin' }),
+    async (token) => token === 'test-token' ? { sub: 'admin' } : null,
     store,
   )
 }
@@ -35,7 +35,7 @@ async function makeManagerWithRpc(
     { call: rpcCall } as never,
     async () => 42, // 非零端口，让 dispatchToAgent 正常往下走
     'test-secret',
-    async () => ({ sub: 'admin' }),
+    async (token) => token === 'test-token' ? { sub: 'admin' } : null,
     store,
   )
 }
@@ -146,6 +146,14 @@ describe('ChatMessage content 模型升级', () => {
 })
 
 describe('入站带附件消息（handleInboundMessage）', () => {
+  it('requires a verified JWT before it can issue an assertion', async () => {
+    const mgr = await makeManager()
+    await expect(mgr.handleInboundMessage(
+      { request_id: 'unauthenticated', text: 'no', files: [] },
+      'invalid-token',
+    )).rejects.toThrow(/JWT authenticated/)
+  })
+
   beforeEach(async () => {
     await fs.rm(TEST_DATA_DIR, { recursive: true, force: true }).catch(() => {})
     await fs.mkdir(TEST_DATA_DIR, { recursive: true })
@@ -168,7 +176,7 @@ describe('入站带附件消息（handleInboundMessage）', () => {
       request_id: 'req-err',
       text: '会失败的消息',
       files: [],
-    })
+    }, 'test-token')
     // user 消息已落库且正常返回（失败非原子是已登记的设计取舍）
     expect(result.message.content.text).toBe('会失败的消息')
     expect(mgr.getMessages(10)).toHaveLength(1)
@@ -189,7 +197,7 @@ describe('入站带附件消息（handleInboundMessage）', () => {
         { buffer: Buffer.from('img1'), filename: 'a.png', mime_type: 'image/png' },
         { buffer: Buffer.from('img2'), filename: 'b.jpg', mime_type: 'image/jpeg' },
       ],
-    })
+    }, 'test-token')
     // 落库消息：URL 形态 media[]
     expect(result.message.content.type).toBe('image')
     expect(result.message.content.text).toBe('看下这两张图')
@@ -206,7 +214,7 @@ describe('入站带附件消息（handleInboundMessage）', () => {
 
   it('空文本且无附件 → 抛错', async () => {
     const mgr = await makeManager()
-    await expect(mgr.handleInboundMessage({ request_id: 'r', text: ' ', files: [] })).rejects.toThrow()
+    await expect(mgr.handleInboundMessage({ request_id: 'r', text: ' ', files: [] }, 'test-token')).rejects.toThrow()
   })
 })
 
@@ -382,7 +390,7 @@ describe('tagMessageTask / tagUserMessageByRequestId', () => {
       request_id: 'req-cb-1',
       text: '发一条会派 task 的消息',
       files: [],
-    })
+    }, 'test-token')
     pushed.length = 0 // 清空处理中推送
 
     // 模拟 chat_callback 回执带 task_id
@@ -443,7 +451,7 @@ describe('chat_push 收口占位：storeAssistantMessage 认领 in-flight reques
     const rpcDone = new Promise<void>((resolve) => { release = resolve })
     const mgr = await makeManagerWithRpc(async () => { await rpcDone; return {} })
     const pushed = attachClientStub(mgr)
-    const inbound = mgr.handleInboundMessage({ request_id: requestId, text: '帮我看下这个', files: [] })
+    const inbound = mgr.handleInboundMessage({ request_id: requestId, text: '帮我看下这个', files: [] }, 'test-token')
     await vi.waitFor(() => expect(pushed.some((p) => p.type === 'chat_status' && p.request_id === requestId)).toBe(true))
     pushed.length = 0
     return {
@@ -513,9 +521,9 @@ describe('chat_push 收口占位：storeAssistantMessage 认领 in-flight reques
     const rpcDone = new Promise<void>((resolve) => { release = resolve })
     const mgr = await makeManagerWithRpc(async () => { await rpcDone; return {} })
     const pushed = attachClientStub(mgr)
-    const a = mgr.handleInboundMessage({ request_id: 'req-a', text: '第一问', files: [] })
+    const a = mgr.handleInboundMessage({ request_id: 'req-a', text: '第一问', files: [] }, 'test-token')
     await vi.waitFor(() => expect(pushed.filter((p) => p.type === 'chat_status')).toHaveLength(1))
-    const b = mgr.handleInboundMessage({ request_id: 'req-b', text: '第二问', files: [] })
+    const b = mgr.handleInboundMessage({ request_id: 'req-b', text: '第二问', files: [] }, 'test-token')
     await vi.waitFor(() => expect(pushed.filter((p) => p.type === 'chat_status')).toHaveLength(2))
     pushed.length = 0
     await mgr.handleSendMessage({ session_id: 'admin-chat', content: { type: 'text', text: '答第一问' } })
@@ -545,7 +553,7 @@ describe('chat_push 收口占位：storeAssistantMessage 认领 in-flight reques
     // 第一问：agent 侧 F3——`process_message` 正常返回，没有 chat_callback、也没有 send_message。
     const mgr = await makeManagerWithRpc(async () => ({ decision_types: [] }))
     const pushed = attachClientStub(mgr)
-    await mgr.handleInboundMessage({ request_id: 'req-silent', text: '第一问（会被沉默）', files: [] })
+    await mgr.handleInboundMessage({ request_id: 'req-silent', text: '第一问（会被沉默）', files: [] }, 'test-token')
 
     // 第二问：这一轮 manager 在 episode 内（= RPC 返回之前）回了话。
     let release!: () => void
@@ -553,7 +561,7 @@ describe('chat_push 收口占位：storeAssistantMessage 认领 in-flight reques
     ;(mgr as unknown as { rpcClient: { call: unknown } }).rpcClient = {
       call: async () => { await rpcDone; return {} },
     }
-    const second = mgr.handleInboundMessage({ request_id: 'req-2', text: '第二问', files: [] })
+    const second = mgr.handleInboundMessage({ request_id: 'req-2', text: '第二问', files: [] }, 'test-token')
     await vi.waitFor(() => expect(pushed.some((p) => p.type === 'chat_status' && p.request_id === 'req-2')).toBe(true))
     await mgr.handleSendMessage({ session_id: 'admin-chat', content: { type: 'text', text: '答第二问' } })
     release()
@@ -569,7 +577,7 @@ describe('chat_push 收口占位：storeAssistantMessage 认领 in-flight reques
 
   it('沉默 episode（F3）之后 manager 主动推送：没有可认领的 in-flight，纯追加', async () => {
     const mgr = await makeManagerWithRpc(async () => ({ decision_types: [] }))
-    await mgr.handleInboundMessage({ request_id: 'req-silent-2', text: '会被沉默的一问', files: [] })
+    await mgr.handleInboundMessage({ request_id: 'req-silent-2', text: '会被沉默的一问', files: [] }, 'test-token')
     const pushed = attachClientStub(mgr)
 
     await mgr.handleSendMessage({ session_id: 'admin-chat', content: { type: 'text', text: '顺嘴提醒你一句' } })

--- a/crabot-admin/src/chat-manager.ts
+++ b/crabot-admin/src/chat-manager.ts
@@ -7,7 +7,8 @@ import path from 'node:path'
 import { IncomingMessage } from 'node:http'
 import { Socket } from 'node:net'
 import { WebSocket, WebSocketServer } from 'ws'
-import { generateId, generateTimestamp, type RpcClient, type TaskId } from 'crabot-shared'
+import { generateId, generateTimestamp, sha256CanonicalJson, type RpcClient, type TaskId } from 'crabot-shared'
+import { AdminChatAssertions } from './admin-chat-assertions.js'
 import { MediaStore } from './media-store.js'
 import type {
   ChatMessage,
@@ -42,6 +43,7 @@ export class ChatManager {
   private activeClient: WebSocket | null = null
   private pendingRequests: Map<string, { timestamp: number }> = new Map()
   private readonly messagesFilePath: string
+  private readonly assertions: AdminChatAssertions
 
   constructor(
     private readonly dataDir: string,
@@ -52,6 +54,7 @@ export class ChatManager {
     private readonly mediaStore: MediaStore,
   ) {
     this.messagesFilePath = path.join(dataDir, 'chat_messages.json')
+    this.assertions = new AdminChatAssertions(dataDir, jwtSecret)
   }
 
   // ==========================================================================
@@ -59,6 +62,7 @@ export class ChatManager {
   // ==========================================================================
 
   async loadData(): Promise<void> {
+    await this.assertions.load()
     try {
       const data = await fs.readFile(this.messagesFilePath, 'utf-8')
       // content 字段可能是旧格式（string），需要 hydrate 为 MessageContent
@@ -215,33 +219,29 @@ export class ChatManager {
         throw new Error('Agent module not available')
       }
 
+      const message = {
+        platform_message_id: userMessage.message_id,
+        session: { session_id: 'admin-chat', channel_id: 'admin-web', type: 'private' as const },
+        sender: { friend_id: 'master', platform_user_id: 'master', platform_display_name: 'Master' },
+        content: agentContent,
+        features: { is_mention_crab: false },
+        platform_timestamp: userMessage.timestamp,
+      }
+      const adminChatAssertion = this.assertions.issue({
+        requestId,
+        payloadSha256: sha256CanonicalJson(message),
+      })
       await this.rpcClient.call(
         agentPort,
         'process_message',
         {
-          message: {
-            platform_message_id: userMessage.message_id,
-            session: {
-              session_id: 'admin-chat',
-              channel_id: 'admin-web',
-              type: 'private',
-            },
-            sender: {
-              friend_id: 'master',
-              platform_user_id: 'master',
-              platform_display_name: 'Master',
-            },
-            content: agentContent,
-            features: {
-              is_mention_crab: false,
-            },
-            platform_timestamp: userMessage.timestamp,
-          },
+          message,
           source_type: 'admin_chat',
           callback_info: {
             source_module_id: 'admin-web',
             request_id: requestId,
           },
+          admin_chat_assertion: adminChatAssertion,
         },
         'admin-web'
       )
@@ -274,7 +274,10 @@ export class ChatManager {
     request_id: string
     text: string
     files: Array<{ buffer: Buffer; filename: string; mime_type: string }>
-  }): Promise<{ message: ChatMessage }> {
+  }, jwt: string): Promise<{ message: ChatMessage }> {
+    if (!jwt || !(await this.verifyJwt(jwt, this.jwtSecret, this.dataDir))) {
+      throw new Error('Admin Chat ingress was not JWT authenticated')
+    }
     const text = params.text.trim()
     if (!text && params.files.length === 0) {
       throw new Error('Empty message')
@@ -311,6 +314,13 @@ export class ChatManager {
       ...(mediaForAgent.length > 0 ? { media: mediaForAgent, media_url: mediaForAgent[0].media_url } : {}),
     })
     return { message: userMessage }
+  }
+
+  async consumeAdminChatAssertion(params: {
+    assertion: string
+    expected: { manager_key: 'admin-web::admin-chat'; request_id: string; payload_sha256: string }
+  }): Promise<{ consumed: true; expires_at: string }> {
+    return this.assertions.consume(params.assertion, params.expected)
   }
 
   private pushToClient(message: ChatServerMessage): void {

--- a/crabot-admin/src/index.ts
+++ b/crabot-admin/src/index.ts
@@ -712,6 +712,7 @@ export class AdminModule extends ModuleBase {
     this.registerMethod('delete_session_config', this.handleDeleteSessionConfig.bind(this))
 
     // Chat 管理
+    this.registerMethod('consume_admin_chat_assertion', this.handleConsumeAdminChatAssertion.bind(this))
     this.registerMethod('chat_callback', this.handleChatCallback.bind(this))
     this.registerMethod('get_chat_history', this.handleGetChatHistory.bind(this))
     // admin-web 伪 channel：worker send_message 出站收口（spec 2026-06-10-master-chat-redesign §4）
@@ -9110,6 +9111,14 @@ export class AdminModule extends ModuleBase {
   // Chat RPC 方法
   // ============================================================================
 
+  private async handleConsumeAdminChatAssertion(params: {
+    assertion: string
+    expected: { manager_key: 'admin-web::admin-chat'; request_id: string; payload_sha256: string }
+  }): Promise<{ consumed: true; expires_at: string }> {
+    if (!this.chatManager) throw new Error('chat not ready')
+    return this.chatManager.consumeAdminChatAssertion(params)
+  }
+
   private async handleChatCallback(params: ChatCallbackParams): Promise<ChatCallbackResult> {
     if (!this.chatManager) {
       throw new Error('Chat manager not initialized')
@@ -9286,7 +9295,12 @@ export class AdminModule extends ModuleBase {
         }
         files.push({ buffer, filename: value.name, mime_type: value.type || 'application/octet-stream' })
       }
-      const result = await this.chatManager.handleInboundMessage({ request_id: requestId, text, files })
+      const authorization = req.headers.authorization ?? ''
+      const jwt = authorization.startsWith('Bearer ') ? authorization.slice('Bearer '.length) : ''
+      const result = await this.chatManager.handleInboundMessage(
+        { request_id: requestId, text, files },
+        jwt,
+      )
       sendJson(res, 200, result)
     } catch (err) {
       sendJson(res, 400, { error: err instanceof Error ? err.message : 'invalid multipart request' })

--- a/crabot-admin/src/index.ts
+++ b/crabot-admin/src/index.ts
@@ -9583,7 +9583,7 @@ export class AdminModule extends ModuleBase {
     // §8.3 的 status 是 `TaskStatus | TaskStatus[]`：重复出现 `?status=a&status=b` 即数组，
     // 单个即单值（沿用 parseAccessibleScopes 的 getAll 惯例，不另发明逗号分隔语法）。
     const statuses = url.searchParams.getAll('status').filter(Boolean)
-    const dialogObjectId = url.searchParams.get('dialog_object_id') || undefined
+    const managerKey = url.searchParams.get('manager_key') || undefined
     // base-protocol §5.7 的 TimeRange 两端各自可选（start 闭、end 开），故任一存在即下发；
     // 这点与 search_traces 端点"start+end 必须同时给"的旧写法不同——那是它自己的历史约定。
     const start = url.searchParams.get('start') || undefined
@@ -9592,7 +9592,7 @@ export class AdminModule extends ModuleBase {
     await this.proxyAgentRpc<
       {
         status?: string | string[]
-        dialog_object_id?: string
+        manager_key?: string
         time_range?: { start?: string; end?: string }
         pagination?: { page: number; page_size: number }
       },
@@ -9600,7 +9600,7 @@ export class AdminModule extends ModuleBase {
     >(res, 'list_workers_admin', {
       ...(statuses.length === 1 ? { status: statuses[0] } : {}),
       ...(statuses.length > 1 ? { status: statuses } : {}),
-      ...(dialogObjectId ? { dialog_object_id: dialogObjectId } : {}),
+      ...(managerKey ? { manager_key: managerKey } : {}),
       ...(start || end ? { time_range: { ...(start ? { start } : {}), ...(end ? { end } : {}) } } : {}),
       pagination: {
         page: parseIntParam(url.searchParams.get('page'), 1),

--- a/crabot-agent/src/core/trace-store.ts
+++ b/crabot-agent/src/core/trace-store.ts
@@ -77,7 +77,7 @@ export class TraceStore {
   // 进程重启后 rebuildIndex 把上次 running 的 trace 重新加载到 this.traces，
   // searchTraces 的现有合并逻辑（line 107-112）能直接展示出来。
   private flushTimer?: ReturnType<typeof setInterval>
-  private static readonly RUNNING_FLUSH_FILE = 'traces-running.jsonl'
+  private readonly runningFlushFile: string
 
   // ── Worker checkpoint resume 集合 ──────────────────────
   // flushWorkerCheckpoint 把 worker trace（含 resume_checkpoint）原子写到
@@ -85,9 +85,10 @@ export class TraceStore {
   // 读进此 Map，等 admin 裁决（HOLD，不立即标 failed）。
   private resumableCheckpoints = new Map<string, { traceId: string; checkpoint: import('../types.js').ResumeCheckpoint }>()
 
-  constructor(maxSize = 100, persistDir?: string) {
+  constructor(maxSize = 100, persistDir?: string, runningFlushFile = 'traces-running.jsonl') {
     this.maxSize = maxSize
     this.persistDir = persistDir
+    this.runningFlushFile = runningFlushFile
     if (persistDir) {
       fs.mkdirSync(persistDir, { recursive: true })
       this.rebuildIndex()
@@ -278,7 +279,7 @@ export class TraceStore {
   private loadResumableCheckpoints(): void {
     if (!this.persistDir) return
     const files = fs.readdirSync(this.persistDir)
-      .filter(f => f.startsWith('traces-running-') && f.endsWith('.jsonl'))
+      .filter(f => f !== this.runningFlushFile && f.startsWith('traces-running-') && f.endsWith('.jsonl'))
     for (const file of files) {
       const taskId = file.slice('traces-running-'.length, -'.jsonl'.length)
       try {
@@ -295,7 +296,7 @@ export class TraceStore {
   }
 
   /**
-   * 全量重写 traces-running.jsonl —— 当前所有 status='running' 的 trace。
+   * 全量重写当前实例的 in-flight 文件（默认兼容旧 traces-running.jsonl）。
    * 用 tmp + rename 实现 atomic 替换：进程在写中间被杀，旧文件保持完好。
    */
   private flushInFlightTraces(): void {
@@ -307,19 +308,19 @@ export class TraceStore {
       }
     }
     const content = lines.length > 0 ? lines.join('\n') + '\n' : ''
-    const finalPath = path.join(this.persistDir, TraceStore.RUNNING_FLUSH_FILE)
+    const finalPath = path.join(this.persistDir, this.runningFlushFile)
     const tmpPath = finalPath + '.tmp'
     fs.writeFileSync(tmpPath, content, 'utf-8')
     fs.renameSync(tmpPath, finalPath)
   }
 
   /**
-   * 启动时加载 traces-running.jsonl —— 上次 agent 死时未结束的 trace。
+   * 启动时加载当前实例的 in-flight 文件（默认为 traces-running.jsonl）。
    * 把这些 trace 标记为 failed（interrupted），写入日期文件，然后清空 running 文件。
    */
   private loadRunningTraces(): void {
     if (!this.persistDir) return
-    const filePath = path.join(this.persistDir, TraceStore.RUNNING_FLUSH_FILE)
+    const filePath = path.join(this.persistDir, this.runningFlushFile)
     if (!fs.existsSync(filePath)) return
     try {
       // 已被 loadResumableCheckpoints 持有的 worker trace（per-task checkpoint 文件）——它在
@@ -362,11 +363,11 @@ export class TraceStore {
   private rebuildIndex(): void {
     if (!this.persistDir) return
     try {
-      // 排除 traces-running.jsonl —— 那是覆盖式写的 in-flight 文件，没有稳定
+      // 排除当前实例的覆盖式 in-flight 文件；它没有稳定
       // 字节 offset，不能进 traceIndex（getFullTrace 走 offset 读会乱）。
       // in-flight 由 loadRunningTraces 单独加载到内存 Map。
       const files = fs.readdirSync(this.persistDir)
-        .filter(f => f.startsWith('traces-') && f.endsWith('.jsonl') && f !== TraceStore.RUNNING_FLUSH_FILE && !f.startsWith('traces-running-'))
+        .filter(f => f.startsWith('traces-') && f.endsWith('.jsonl') && f !== this.runningFlushFile && f !== 'traces-running.jsonl' && !f.startsWith('traces-running-'))
         .sort()
 
       for (const file of files) {
@@ -778,7 +779,7 @@ export class TraceStore {
     let totalBytes = 0
     try {
       const files = fs.readdirSync(this.persistDir)
-        .filter(f => f.startsWith('traces-') && f.endsWith('.jsonl') && !f.startsWith('traces-running-'))
+        .filter(f => f.startsWith('traces-') && f.endsWith('.jsonl') && f !== this.runningFlushFile && f !== 'traces-running.jsonl' && !f.startsWith('traces-running-'))
       for (const file of files) {
         const stat = fs.statSync(path.join(this.persistDir, file))
         totalBytes += stat.size
@@ -883,7 +884,7 @@ export class TraceStore {
 
     try {
       const files = fs.readdirSync(this.persistDir)
-        .filter(f => f.startsWith('traces-') && f.endsWith('.jsonl') && !f.startsWith('traces-running-'))
+        .filter(f => f.startsWith('traces-') && f.endsWith('.jsonl') && f !== this.runningFlushFile && f !== 'traces-running.jsonl' && !f.startsWith('traces-running-'))
       for (const file of files) {
         const dateStr = file.slice('traces-'.length, 'traces-'.length + 10)
         if (dateStr >= cutoffStr) continue

--- a/crabot-agent/src/core/trace-store.ts
+++ b/crabot-agent/src/core/trace-store.ts
@@ -67,7 +67,7 @@ export class TraceStore {
   private taskIndex: Map<string, string[]> = new Map()
 
   // ── In-flight 定时持久化 ────────────────────────────────
-  // status='running' 的 trace 只在 endTrace 时才追加到 traces-{date}.jsonl。
+  // status='running' 的 trace 只在 endTrace 时才追加到按日期切片的 archive 文件。
   // 但 agent 被 SIGKILL（health 失败 / OOM / 外部强杀）时根本没机会 endTrace，
   // 整条主 task trace 连带所有 span 永久丢失 —— admin UI 上只能看到已结束的
   // sub-agent / dispatch trace，看不到死前主 loop 在做啥。
@@ -78,6 +78,8 @@ export class TraceStore {
   // searchTraces 的现有合并逻辑（line 107-112）能直接展示出来。
   private flushTimer?: ReturnType<typeof setInterval>
   private readonly runningFlushFile: string
+  private readonly archiveFilePrefix: string
+  private readonly readableArchiveFilePrefixes: readonly string[]
 
   // ── Worker checkpoint resume 集合 ──────────────────────
   // flushWorkerCheckpoint 把 worker trace（含 resume_checkpoint）原子写到
@@ -85,10 +87,18 @@ export class TraceStore {
   // 读进此 Map，等 admin 裁决（HOLD，不立即标 failed）。
   private resumableCheckpoints = new Map<string, { traceId: string; checkpoint: import('../types.js').ResumeCheckpoint }>()
 
-  constructor(maxSize = 100, persistDir?: string, runningFlushFile = 'traces-running.jsonl') {
+  constructor(
+    maxSize = 100,
+    persistDir?: string,
+    runningFlushFile = 'traces-running.jsonl',
+    archiveFilePrefix = 'traces-',
+    readableArchiveFilePrefixes: readonly string[] = [archiveFilePrefix],
+  ) {
     this.maxSize = maxSize
     this.persistDir = persistDir
     this.runningFlushFile = runningFlushFile
+    this.archiveFilePrefix = archiveFilePrefix
+    this.readableArchiveFilePrefixes = readableArchiveFilePrefixes
     if (persistDir) {
       fs.mkdirSync(persistDir, { recursive: true })
       this.rebuildIndex()
@@ -367,7 +377,7 @@ export class TraceStore {
       // 字节 offset，不能进 traceIndex（getFullTrace 走 offset 读会乱）。
       // in-flight 由 loadRunningTraces 单独加载到内存 Map。
       const files = fs.readdirSync(this.persistDir)
-        .filter(f => f.startsWith('traces-') && f.endsWith('.jsonl') && f !== this.runningFlushFile && f !== 'traces-running.jsonl' && !f.startsWith('traces-running-'))
+        .filter((file) => this.readableArchiveFilePrefixes.some((prefix) => this.archiveDate(file, prefix) !== undefined))
         .sort()
 
       for (const file of files) {
@@ -812,7 +822,8 @@ export class TraceStore {
   }
 
   /**
-   * 按日级粒度清理 JSONL 文件：找 traces-<date>.jsonl 中 date < (today - retentionDays) 的整个文件删除。
+   * 按日级粒度清理当前实例的 archive 文件：找 `<archiveFilePrefix><date>.jsonl` 中
+   * date < (today - retentionDays) 的整个文件删除。其他可读前缀只用于兼容查询，不参与清理。
    * dryRun=true 时只返回统计不实删。
    */
   cleanupOldTraces(retentionDays: number, dryRun: boolean): {
@@ -832,7 +843,7 @@ export class TraceStore {
   /**
    * 按条数清理：保留最近 maxCount 条 trace，多余的按文件粒度近似删除。
    *
-   * 由于持久化以 traces-YYYY-MM-DD.jsonl 按天切片，无法精确删除"超出 N 条的尾巴"，
+   * 由于持久化以按天切片的 archive 文件保存，无法精确删除"超出 N 条的尾巴"，
    * 这里按 traceIndex 时间倒序找第 N 条对应的日期，严格更老的整文件删。
    * 同一天文件不切割：实际保留条数 ≥ maxCount。
    */
@@ -844,11 +855,12 @@ export class TraceStore {
     if (!this.persistDir || !Number.isFinite(maxCount) || maxCount < 1 || !fs.existsSync(this.persistDir)) {
       return { affected_count: 0, affected_bytes: 0, deleted_trace_ids: [] }
     }
-    if (this.traceIndex.length <= maxCount) {
+    const ownEntries = this.traceIndex.filter((entry) => this.archiveDate(entry.file) !== undefined)
+    if (ownEntries.length <= maxCount) {
       return { affected_count: 0, affected_bytes: 0, deleted_trace_ids: [] }
     }
     // 时间倒序：第 maxCount 条（1-indexed）是要保留的最后一条；它所在日期及更新的整体保留
-    const sortedDesc = [...this.traceIndex].sort(
+    const sortedDesc = [...ownEntries].sort(
       (a, b) => new Date(b.started_at).getTime() - new Date(a.started_at).getTime()
     )
     const boundary = sortedDesc[maxCount - 1]
@@ -860,14 +872,18 @@ export class TraceStore {
   }
 
   private extractDateFromFile(file: string): string | null {
-    if (!file.startsWith('traces-')) return null
-    const dateStr = file.slice('traces-'.length, 'traces-'.length + 10)
-    return /^\d{4}-\d{2}-\d{2}$/.test(dateStr) ? dateStr : null
+    return this.archiveDate(file) ?? null
+  }
+
+  private archiveDate(file: string, prefix = this.archiveFilePrefix): string | undefined {
+    if (!file.startsWith(prefix) || !file.endsWith('.jsonl')) return undefined
+    const date = file.slice(prefix.length, -'.jsonl'.length)
+    return /^\d{4}-\d{2}-\d{2}$/.test(date) ? date : undefined
   }
 
   /**
-   * 删除 dateStr 严格小于 cutoffStr 的 traces-*.jsonl 文件。
-   * 排除 traces-running-<taskId>.jsonl（per-task checkpoint 文件，由 consumeResumableCheckpoint/finalizeUnresumedCheckpoint 管理）
+   * 删除 dateStr 严格小于 cutoffStr 的当前实例 archive 文件。
+   * 其他 readable archive 前缀（如只读 legacy traces）不会被删除。
    */
   private cleanupTracesBeforeDate(cutoffStr: string, dryRun: boolean): {
     affected_count: number
@@ -884,10 +900,10 @@ export class TraceStore {
 
     try {
       const files = fs.readdirSync(this.persistDir)
-        .filter(f => f.startsWith('traces-') && f.endsWith('.jsonl') && f !== this.runningFlushFile && f !== 'traces-running.jsonl' && !f.startsWith('traces-running-'))
+        .filter((file) => this.archiveDate(file) !== undefined)
       for (const file of files) {
-        const dateStr = file.slice('traces-'.length, 'traces-'.length + 10)
-        if (dateStr >= cutoffStr) continue
+        const dateStr = this.archiveDate(file)
+        if (!dateStr || dateStr >= cutoffStr) continue
         const filePath = path.join(this.persistDir, file)
         const stat = fs.statSync(filePath)
         affectedBytes += stat.size
@@ -942,8 +958,8 @@ export class TraceStore {
     let fileCount = 0
     try {
       const files = fs.readdirSync(this.persistDir)
-        .filter(f => f.startsWith('traces-') && f.endsWith('.jsonl'))
-      fileCount = files.filter(f => f.slice('traces-'.length, 'traces-'.length + 10) < cutoffStr).length
+        .filter((file) => this.archiveDate(file) !== undefined)
+      fileCount = files.filter((file) => (this.archiveDate(file) ?? '') < cutoffStr).length
     } catch { /* best effort */ }
     this.cleanupOldTraces(retentionDays, false)
     return fileCount
@@ -1002,7 +1018,7 @@ export class TraceStore {
     if (!this.persistDir) return
     try {
       const date = trace.started_at.slice(0, 10)
-      const file = `traces-${date}.jsonl`
+      const file = `${this.archiveFilePrefix}${date}.jsonl`
       const filePath = path.join(this.persistDir, file)
       const line = JSON.stringify(trace) + '\n'
 

--- a/crabot-agent/src/manager/bootstrap.ts
+++ b/crabot-agent/src/manager/bootstrap.ts
@@ -47,6 +47,7 @@ import { ManagerSessionStore } from './session-store.js'
 import { makeTaskStatusEventBridge, type AgentEventPublisher } from './events.js'
 import { shouldWakeOnHarnessEvent } from './inbound-adapters.js'
 import { buildManagerToolFace } from './tools/tool-face.js'
+import { PrincipalBindingStore } from './principal-binding-store.js'
 import {
   ManagerPrincipalStore,
   applyGroupScopeFallback,
@@ -105,6 +106,8 @@ export interface ManagerStack {
    * (`SpawnWorkerParams.principal_permissions` → `context.json`)。
    */
   readonly principals: ManagerPrincipalStore
+  /** Persistent bindings are initialized during reconciliation, never construction. */
+  readonly principalBindings: PrincipalBindingStore
   /**
    * builtin adapter 的私有 dataDir。`reconcileManagerStack` 需要它跑
    * `BuiltinWorkerAdapter.scanOrphans`——见该函数注释里的顺序契约。放在 stack 上而不是
@@ -244,6 +247,7 @@ export function buildManagerStack(deps: BootstrapDeps): ManagerStack {
   const builtinDataDir = adapterDataDir('builtin')
 
   const ledger = new LedgerStore(join(agentDir, 'worker-ledgers'))
+  const principalBindings = new PrincipalBindingStore(join(agentDir, 'manager-principal-bindings.json'))
   const workspaces = new WorkspaceManager(resolveWorkspacesRoot(deps.dataRoot))
 
   // 见文件头"与 registry 的环形依赖"。
@@ -373,7 +377,7 @@ export function buildManagerStack(deps: BootstrapDeps): ManagerStack {
   const tokenEstimator = new ContextManager({ maxContextTokens: DEFAULT_MAX_CONTEXT_TOKENS })
 
   // 发起人身份:唤醒边界异步解析一次,三个同步 thunk 读缓存(见 principal.ts 文件头)。
-  const principals = new ManagerPrincipalStore(deps.principalResolver)
+  const principals = new ManagerPrincipalStore(deps.principalResolver, principalBindings, () => new Date(deps.now()))
 
   registry = new ManagerRegistry({
     store: new ManagerSessionStore(join(agentDir, 'managers')),
@@ -390,6 +394,9 @@ export function buildManagerStack(deps: BootstrapDeps): ManagerStack {
     // 由 registry 挂到本 episode 的唤醒事件上——缓存只服务于同步 thunk(记忆档位 /
     // 对话对象档案),派活用的档位走事件,不走缓存(PR #59 review)。
     onHumanWake: async (key, principal) => (await principals.resolve(key, principal)).permissions,
+    beforeWake: async (key, wake) => {
+      if (wake?.kind !== 'human_messages' && wake?.kind !== 'attention_flush') await principals.refreshForNonHumanWake(key)
+    },
     // scheduled 唤醒边界(§4.4"权限按 `Schedule.creator_friend_id` 解析,`is_builtin` 按 master
     // 等价"):按**调度自己的身份**解析,不碰该会话的发起人缓存(既不读也不写)。
     //
@@ -447,9 +454,8 @@ export function buildManagerStack(deps: BootstrapDeps): ManagerStack {
         memoryServer: deps.memoryServerFor(memoryContextFor(key, principals.get(key))),
         callAdmin: deps.callAdmin,
         isSystemThread,
-        // 这一行是本文件存在的理由之一:registry 按 key 绑定好的 onAsyncError 必须一路传到
-        // `buildWorkerTools`,否则 codex worker 上 `query_worker`(fork 能力恒 false)的失败
-        // 只会 console.error,manager 永远等不到回音(P4 Task 8 留给本 task 的验证点)。
+        authorization: () => principals.currentMasterAuthorization(key),
+        validateMasterAuthorization: (auth) => principals.validateMasterAuthorization(auth),
         onAsyncError,
       }),
     // system prompt 的「对话对象档案」段(§4.2 5b/5d):场景画像 + crab 在该渠道的
@@ -461,7 +467,7 @@ export function buildManagerStack(deps: BootstrapDeps): ManagerStack {
     },
   })
 
-  return { ledger, harness, registry, adapters, principals, builtinDataDir }
+  return { ledger, harness, registry, adapters, principals, principalBindings, builtinDataDir }
 }
 
 /**
@@ -475,6 +481,7 @@ export function buildManagerStack(deps: BootstrapDeps): ManagerStack {
  * 误判进 revived 桶。
  */
 export async function reconcileManagerStack(stack: ManagerStack): Promise<ReconcileReport> {
+  await stack.principals.init()
   await BuiltinWorkerAdapter.scanOrphans(stack.builtinDataDir)
   return stack.harness.reconcileOnStartup()
 }

--- a/crabot-agent/src/manager/bootstrap.ts
+++ b/crabot-agent/src/manager/bootstrap.ts
@@ -35,7 +35,7 @@ import { join, resolve } from 'path'
 import { WorkerHarness, type HarnessDeps, type ReconcileReport } from '../workers/harness/harness'
 import { LedgerStore } from '../workers/harness/ledger-store'
 import { WorkspaceManager } from '../workers/harness/workspace-manager'
-import type { DialogObjectId } from '../workers/harness/ledger-types'
+import type { ManagerKey } from '../workers/harness/ledger-types'
 import { BuiltinWorkerAdapter } from '../workers/builtin/adapter.js'
 import { ClaudeCodeAdapter } from '../workers/claude-code/adapter.js'
 import { CodexWorkerAdapter } from '../workers/codex/adapter.js'
@@ -56,7 +56,7 @@ import {
   type ResolvedPrincipal,
 } from './principal.js'
 import type { CompactionPolicy } from './compaction.js'
-import type { ManagerEpisodeFailure, ManagerKey } from './types.js'
+import type { ManagerEpisodeFailure } from './types.js'
 
 // 与 `unified-agent.ts` 同款引用路径:这两个常量没有从 `engine/index.ts` 转出,直接引子模块
 // (engine 本阶段零改动,不为此新增 barrel 导出)。
@@ -140,7 +140,7 @@ export interface BootstrapDeps {
   /**
    * 发起人身份的解析原料(admin 权限解析 / session memory_scopes / 场景画像 /
    * crab self handle / master friend id)。本模块据它在**唤醒边界**解析一次并缓存,
-   * 让 `dialogObjectIdFor` / `toolFace` / `promptInputs` 这三个同步 thunk 只读缓存
+   * 让 `managerKeyFor` / `toolFace` / `promptInputs` 这三个同步 thunk 只读缓存
    * ——签名一个都不用改成异步(见 `principal.ts` 文件头)。
    */
   readonly principalResolver: PrincipalResolverDeps
@@ -243,7 +243,7 @@ export function buildManagerStack(deps: BootstrapDeps): ManagerStack {
   const adapterDataDir = (impl: WorkerImplId): string => join(agentDir, 'worker-adapters', impl)
   const builtinDataDir = adapterDataDir('builtin')
 
-  const ledger = new LedgerStore(join(agentDir, 'ledgers'))
+  const ledger = new LedgerStore(join(agentDir, 'worker-ledgers'))
   const workspaces = new WorkspaceManager(resolveWorkspacesRoot(deps.dataRoot))
 
   // 见文件头"与 registry 的环形依赖"。
@@ -258,7 +258,7 @@ export function buildManagerStack(deps: BootstrapDeps): ManagerStack {
   /**
    * worker 事件唤醒的 episode 失败 → `deps.reportEpisodeFailure`(fail-loud)。
    *
-   * 目标会话取**该 worker 的监护 manager**(`origin.spawned_by_session`),台账查不到则落系统
+   * 目标会话取**该 worker 的监护 manager**(`origin.manager_key`),台账查不到则落系统
    * 线程——与 `routeWorkerEvent` 自己的路由判据逐字相同,所以"哪个 manager 挂了"和"告诉谁"
    * 永远是同一个会话。不用 `report_to`:那是 worker **结果**的回报目标,可以与监护 session 不同
    * (同一 friend 跨 channel 共享台账),拿它当告警目标会把话说到另一个对话里去。
@@ -271,7 +271,7 @@ export function buildManagerStack(deps: BootstrapDeps): ManagerStack {
     try {
       const found = await ledger.findWorker(workerId)
       const target = channelSessionFromManagerKey(
-        found?.worker.origin.spawned_by_session ?? SYSTEM_TASKS_MANAGER_KEY,
+        found?.worker.manager_key ?? SYSTEM_TASKS_MANAGER_KEY,
       )
       const title = found?.worker.task.title
       deps.reportEpisodeFailure({
@@ -373,7 +373,7 @@ export function buildManagerStack(deps: BootstrapDeps): ManagerStack {
   const tokenEstimator = new ContextManager({ maxContextTokens: DEFAULT_MAX_CONTEXT_TOKENS })
 
   // 发起人身份:唤醒边界异步解析一次,三个同步 thunk 读缓存(见 principal.ts 文件头)。
-  const principals = new ManagerPrincipalStore(deps.principalResolver, SYSTEM_TASKS_MANAGER_KEY)
+  const principals = new ManagerPrincipalStore(deps.principalResolver)
 
   registry = new ManagerRegistry({
     store: new ManagerSessionStore(join(agentDir, 'managers')),
@@ -385,10 +385,10 @@ export function buildManagerStack(deps: BootstrapDeps): ManagerStack {
     model: deps.managerModel,
     now: () => new Date(deps.now()),
     timezone: deps.timezone,
-    dialogObjectIdFor: (key) => principals.dialogObjectIdFor(key),
+    managerKeyFor: (key) => key,
     // 人类消息唤醒边界:这是人类消息链路上**唯一**一次异步解析。返回本批发言者算好的档位,
-    // 由 registry 挂到本 episode 的唤醒事件上——缓存只服务于那三个同步 thunk(记忆档位 /
-    // 台账归档键 / 对话对象档案),派活用的档位走事件,不走缓存(PR #59 review)。
+    // 由 registry 挂到本 episode 的唤醒事件上——缓存只服务于同步 thunk(记忆档位 /
+    // 对话对象档案),派活用的档位走事件,不走缓存(PR #59 review)。
     onHumanWake: async (key, principal) => (await principals.resolve(key, principal)).permissions,
     // scheduled 唤醒边界(§4.4"权限按 `Schedule.creator_friend_id` 解析,`is_builtin` 按 master
     // 等价"):按**调度自己的身份**解析,不碰该会话的发起人缓存(既不读也不写)。
@@ -414,7 +414,6 @@ export function buildManagerStack(deps: BootstrapDeps): ManagerStack {
       buildManagerToolFace({
         harness,
         workerContext: () => ({
-          dialogObjectId: principals.dialogObjectIdFor(key),
           managerKey: key,
           reportTo: channelSessionFromManagerKey(key),
           // 权限身份(§4.4"权限按 Schedule.creator_friend_id 解析(is_builtin 按 master

--- a/crabot-agent/src/manager/bootstrap.ts
+++ b/crabot-agent/src/manager/bootstrap.ts
@@ -394,8 +394,8 @@ export function buildManagerStack(deps: BootstrapDeps): ManagerStack {
     // 由 registry 挂到本 episode 的唤醒事件上——缓存只服务于同步 thunk(记忆档位 /
     // 对话对象档案),派活用的档位走事件,不走缓存(PR #59 review)。
     onHumanWake: async (key, principal) => (await principals.resolve(key, principal)).permissions,
-    beforeWake: async (key, wake) => {
-      if (wake?.kind !== 'human_messages' && wake?.kind !== 'attention_flush') await principals.refreshForNonHumanWake(key)
+    beforeWake: async (key, envelope) => {
+      if (envelope?.wake.kind !== 'human_messages' && envelope?.wake.kind !== 'attention_flush') await principals.refreshForNonHumanWake(key)
     },
     // scheduled 唤醒边界(§4.4"权限按 `Schedule.creator_friend_id` 解析,`is_builtin` 按 master
     // 等价"):按**调度自己的身份**解析,不碰该会话的发起人缓存(既不读也不写)。

--- a/crabot-agent/src/manager/bootstrap.ts
+++ b/crabot-agent/src/manager/bootstrap.ts
@@ -94,6 +94,7 @@ export const DEFAULT_MANAGER_COMPACTION_POLICY: CompactionPolicy = {
 
 export interface ManagerStack {
   readonly ledger: LedgerStore
+  readonly workspaces: WorkspaceManager
   readonly harness: WorkerHarness
   readonly registry: ManagerRegistry
   readonly adapters: Map<WorkerImplId, WorkerAdapter>
@@ -348,6 +349,7 @@ export function buildManagerStack(deps: BootstrapDeps): ManagerStack {
     builtinSpawnDefaults: deps.builtinSpawnDefaults,
     capabilityBundle: deps.capabilityBundle,
     hasRunningBg: deps.hasRunningBg,
+    validateLegacyContinuationAuth: (auth) => principals.validateLegacyContinuationAuth(auth),
   }
 
   // --- step 2:把空壳 Map 交给 harness ---
@@ -417,8 +419,11 @@ export function buildManagerStack(deps: BootstrapDeps): ManagerStack {
         sessionId,
       )
     },
-    toolFace: (key, isSystemThread, onAsyncError, scheduleIdentity, humanPrincipal, principalPermissions) =>
-      buildManagerToolFace({
+    toolFace: (key, isSystemThread, onAsyncError, scheduleIdentity, humanPrincipal, principalPermissions) => {
+      // Capture at tool-face construction. Calling the resulting factory later must not
+      // pick up a regrant/new generation from a subsequent wake.
+      const legacyAuthTemplate = principals.captureLegacyContinuationAuth(key)
+      return buildManagerToolFace({
         harness,
         workerContext: () => ({
           managerKey: key,
@@ -443,6 +448,10 @@ export function buildManagerStack(deps: BootstrapDeps): ManagerStack {
           // public 落进记忆。取数只发生在派活这一刻,取到之后就随 worker 固定下来。
           principalPermissions:
             principalPermissions ?? (scheduleIdentity ? undefined : principals.get(key)?.permissions ?? undefined),
+          legacyContinuationAuth: (targetManagerKey) => principals.bindLegacyContinuationAuth(
+            legacyAuthTemplate,
+            targetManagerKey,
+          ),
           // scheduled 触发(不论有无目标 session)记 'scheduled';系统线程的其余唤醒
           // (查不到监护 session 的 worker 事件)记 'system';人类消息记 'message'。
           triggerType: scheduleIdentity ? 'scheduled' : isSystemThread ? 'system' : 'message',
@@ -457,7 +466,8 @@ export function buildManagerStack(deps: BootstrapDeps): ManagerStack {
         authorization: () => principals.currentMasterAuthorization(key),
         validateMasterAuthorization: (auth) => principals.validateMasterAuthorization(auth),
         onAsyncError,
-      }),
+      })
+    },
     // system prompt 的「对话对象档案」段(§4.2 5b/5d):场景画像 + crab 在该渠道的
     // @handle,由唤醒边界解析好放在缓存里(见 principal.ts `renderDialogProfile`)。
     // 「待处理通知」仍无解析入口,继续留空——prompt.ts 对缺省有处理。
@@ -467,7 +477,7 @@ export function buildManagerStack(deps: BootstrapDeps): ManagerStack {
     },
   })
 
-  return { ledger, harness, registry, adapters, principals, principalBindings, builtinDataDir }
+  return { ledger, workspaces, harness, registry, adapters, principals, principalBindings, builtinDataDir }
 }
 
 /**

--- a/crabot-agent/src/manager/events.ts
+++ b/crabot-agent/src/manager/events.ts
@@ -34,8 +34,8 @@
  * 终态**一次都没发出去**(spawned/exited/resumed 三条事件,exited 的读晚于 §5.3 透明接续把
  * task 拉回 running 的那次落账)。把值钉在事件上,读取时刻与落账时刻就此解耦。
  *
- * **台账读没有全部消失**,但读的只剩 `task_id` 与 `dialog_object_id` 两个字段——它们在一个
- * worker 的整个生命周期内不变(`task.id` 建账即等于 `worker_id`,`dialog_object_id` 是台账的
+ * **台账读没有全部消失**,但读的只剩 `task_id` 与 `manager_key` 两个字段——它们在一个
+ * worker 的整个生命周期内不变(`task.id` 建账即等于 `worker_id`,`manager_key` 是台账的
  * 聚合键),读晚了也读不出别的值,不存在"被下一次落账折叠"的问题。会随时间变化的只有
  * `status`,而它已经不再现读。
  *
@@ -75,7 +75,7 @@
 import { generateId, type Event, type ModuleId, type RpcClient } from 'crabot-shared'
 
 import type { LedgerStore } from '../workers/harness/ledger-store.js'
-import type { DialogObjectId, TaskStatus } from '../workers/harness/ledger-types.js'
+import type { ManagerKey, TaskStatus } from '../workers/harness/ledger-types.js'
 import type { HarnessEvent } from '../workers/harness/harness.js'
 import type { TaskId } from '../types.js'
 
@@ -85,7 +85,7 @@ export interface AgentTaskStatusChangedPayload {
   task_id: TaskId
   old_status: TaskStatus
   new_status: TaskStatus
-  dialog_object_id: DialogObjectId
+  manager_key: ManagerKey
 }
 
 /** 对外事件发布口。同步返回(fire-and-forget),失败只记日志。 */
@@ -132,7 +132,7 @@ const INITIAL_TASK_STATUS: TaskStatus = 'queued'
  * (由 bootstrap 接线),同步返回、内部 fire-and-forget。
  *
  * 每个 worker 一条 promise 链——`new_status` 改由事件自带之后这条链**仍然是必需的**,原因有二:
- * 1. 台账读还在(取 `task_id` / `dialog_object_id`,见文件头),`onEvent` 却是同步回调:不串行
+ * 1. 台账读还在(取 `task_id` / `manager_key`,见文件头),`onEvent` 却是同步回调:不串行
  *    的话两条紧邻事件的读会交叉完成,发布顺序被打乱,订阅方最后落到的会是**较早**那个状态
  *    (对 admin 就是"任务永远显示 running");
  * 2. `lastKnownStatus` 的读与写跨了那个 await,不串行就会出现两条事件读到同一个 old_status、
@@ -148,7 +148,7 @@ export function makeTaskStatusEventBridge(deps: {
 
   const translate = async (event: HarnessEvent): Promise<void> => {
     const workerId = event.worker_id
-    // 只为拿两个**不随时间变化**的字段:task_id 与 dialog_object_id(见文件头)。状态不从这里取。
+    // 只为拿两个**不随时间变化**的字段:task_id 与 manager_key(见文件头)。状态不从这里取。
     const found = await deps.ledger.findWorker(workerId)
     // worker 不在台账(如 query_failed 的 worker_not_found 分支):没有 task,无从谈状态迁移。
     if (!found) return
@@ -165,7 +165,7 @@ export function makeTaskStatusEventBridge(deps: {
       task_id: found.worker.task.id,
       old_status: oldStatus,
       new_status: newStatus,
-      dialog_object_id: found.dialogObjectId,
+      manager_key: found.managerKey,
     })
   }
 

--- a/crabot-agent/src/manager/inbound-adapters.ts
+++ b/crabot-agent/src/manager/inbound-adapters.ts
@@ -42,8 +42,9 @@ export function attentionFlushToWakeEvent(msgs: ReadonlyArray<ChannelMessage>): 
  *  工具调用里同步拿到了投递结果(engine tool_result),不需要再靠事件唤醒一次去获知"已发送"
  *  这件事本身。其余 kind(spawned/input_held/state_changed/exited/killed/superseded/
  *  handoff_started/resumed/query_failed)都代表 worker 生命周期或侧问的进展/终局,manager
- *  需要据此决定要不要转述给人类或采取下一步动作,一律唤醒。 */
-const NO_WAKE_KINDS: ReadonlySet<HarnessEventKind> = new Set(['input_sent'])
+ *  需要据此决定要不要转述给人类或采取下一步动作,一律唤醒。`legacy_imported` 只是一条
+ *  cutover 历史记录，只落盘，不能批量唤醒 Manager。 */
+const NO_WAKE_KINDS: ReadonlySet<HarnessEventKind> = new Set(['input_sent', 'legacy_imported'])
 
 /** harness 事件是否值得唤醒 manager(过滤规则见 `NO_WAKE_KINDS` 注释)。 */
 export function shouldWakeOnHarnessEvent(e: HarnessEvent): boolean {

--- a/crabot-agent/src/manager/loop.ts
+++ b/crabot-agent/src/manager/loop.ts
@@ -35,25 +35,22 @@ import { randomUUID } from 'crypto'
 import {
   runEngine,
   createUserMessage,
-  HumanMessageQueue,
   type EngineMessage,
   type EngineResult,
   type EngineOptions,
   type ToolDefinition,
   type LLMAdapter,
-  type QueueContent,
   type TextBlock,
 } from '../engine/index.js'
+import type { HumanMessageQueueLike } from '../engine/types.js'
 import { AsyncMutex } from '../workers/async-mutex'
 import { formatChannelMessageLine } from '../prompt-manager.js'
 import { resolveSenderIdentity } from '../utils/sender-identity.js'
-import { resolveTimezone } from '../utils/time.js'
 import { decideCompaction, foldIntoSummary, type CompactionPolicy, type CompactionDecision } from './compaction.js'
 import { assembleManagerSystemPrompt } from './prompt.js'
 import type { ManagerSessionStore } from './session-store.js'
 import type { ManagerSessionState, ManagerKey } from './types.js'
 import type { WorkerHarness } from '../workers/harness/harness'
-import type { LedgerWorker } from '../workers/harness/ledger-types'
 import type { HarnessEvent } from '../workers/harness/worker-events'
 import type { ChannelMessage, Friend, ResolvedPermissions } from '../types'
 
@@ -121,6 +118,14 @@ export type WakeEvent =
       readonly principalPermissions?: ResolvedPermissions
     }
 
+export interface TimedWakeEnvelope {
+  readonly wake: WakeEvent
+  readonly received_at: string
+  readonly timezone: string
+  readonly occurred_at?: string
+  readonly human_occurred_at?: ReadonlyArray<{ readonly message_id?: string; readonly occurred_at?: string }>
+}
+
 export interface EpisodeResult {
   readonly episodeId: string
   readonly outcome: 'completed' | 'failed' | 'max_turns' | 'aborted'
@@ -176,8 +181,8 @@ export interface ManagerLoopDeps {
    * `origin.creator_friend_id`)。可选参数,既有调用方 `() => [...]` 无需改动。
    */
   readonly toolFace: (wakeEvent?: WakeEvent) => ReadonlyArray<ToolDefinition>
-  /** system prompt 里除动态台账/时间外的其余输入(档案、待处理通知),每轮重算。 */
-  readonly promptInputs: () => { readonly dialogProfile?: string; readonly pendingNotes?: ReadonlyArray<string> }
+  /** System prompt inputs are stable for the whole dialogProfile revision. */
+  readonly promptInputs: () => { readonly dialogProfile?: string }
   readonly harness: WorkerHarness
   readonly now: () => Date
   /**
@@ -209,17 +214,13 @@ export class ManagerLoop {
    * 在 episode 收口时按 `hasPendingMailbox` 自唤醒(`drainMailbox`)兜底,并由 `evictIdle`
    * 拒绝回收 mailbox 非空的实例保证它不会先被回收掉(P7 阻塞项 #5)。
    */
-  private readonly mailbox = new HumanMessageQueue()
+  private readonly mailbox = new TimedWakeMailbox()
   /**
-   * 非 null 期间表示"当前正有一个 episode 在跑",记录本次 episode 期间所有经
-   * `enqueueDuringEpisode` 推进 mailbox 的原始文本(按到达顺序)。episode 失败时,
-   * 其中已被 engine `drainPending()` 消费进(随失败一起被丢弃的)`finalMessages` 的那部分
-   * 内容不会再留在 mailbox 里——必须靠这份记录才能连同 carriedTexts/eventText 一起重投,
-   * 否则永久丢失(见 runEpisode 失败分支)。episode 成功时整份丢弃,不重投(已被消费进
-   * 保存的 state.recent,重投会变成重复投递)。episode 未在跑时为 null,enqueueDuringEpisode
-   * 不记录——那时 mailbox 只是普通 pending 队列,靠下次 wakeUp 顶部的 drainPending 自然带走。
+   * 本 episode 进行中经 `enqueueDuringEpisode` 推进 mailbox 的原始 envelope（按到达顺序）。
+   * episode 失败时，即使其中一部分已被 engine `drainPending()` 消费进失败的
+   * `finalMessages`，也必须靠这份记录重投。episode 成功时整份丢弃，避免重复投递。
    */
-  private currentEpisodeInjected: string[] | null = null
+  private currentEpisodeInjected: TimedWakeEnvelope[] | null = null
   /**
    * P5 Task 4 additive:本 episode 的唤醒事件,供 `deps.toolFace(wakeEvent)` 按"这次是被
    * 什么唤醒的"装配工具面(见 `ManagerLoopDeps.toolFace`)。与 `currentEpisodeInjected`
@@ -227,15 +228,16 @@ export class ManagerLoop {
    * ——同一 loop 的 episode 由 `wakeUp` 的 mutex 串行,不会有两个 episode 的唤醒事件交叠;
    * 这正是不把它做成 registry 侧 `Map<ManagerKey, …>` 的原因(那样并发唤醒会串身份)。
    */
-  private currentWakeEvent: WakeEvent | null = null
+  private currentWakeEvent: TimedWakeEnvelope | null = null
 
   constructor(deps: ManagerLoopDeps) {
     this.deps = deps
   }
 
   /** 唯一入口:被唤醒 → 跑一个 episode → 回睡。同一 loop 串行,不同 loop 互不影响。 */
-  async wakeUp(event: WakeEvent): Promise<EpisodeResult> {
-    return this.mutex.run(() => this.runEpisode(event))
+  async wakeUp(envelope: TimedWakeEnvelope): Promise<EpisodeResult> {
+    assertTimedWakeEnvelope(envelope)
+    return this.mutex.run(() => this.runEpisode(envelope))
   }
 
   /**
@@ -262,53 +264,46 @@ export class ManagerLoop {
 
   /** episode 进行中到达的新事件:渲染成文本推进内部邮箱,由 engine 的 humanMessageQueue
    *  在 turn 间隙注入;episode 不在跑时同样入队,行为见 `mailbox` 字段注释。 */
-  enqueueDuringEpisode(event: WakeEvent): void {
-    const text = this.renderEvent(event)
-    this.mailbox.push(text)
-    this.currentEpisodeInjected?.push(text)
+  enqueueDuringEpisode(envelope: TimedWakeEnvelope): void {
+    assertTimedWakeEnvelope(envelope)
+    this.mailbox.push(envelope)
+    this.currentEpisodeInjected?.push(envelope)
   }
 
   /**
-   * 唤醒事件 → 投喂给 LLM 的文本。**每个事件只渲染一次**(渲染结果之后作为字符串在
-   * mailbox / state.recent 里流转,失败重投也是同一份字符串),因此渲染依赖当前时钟这件事
-   * 不会让已经进上下文的内容事后改变——前缀缓存不受影响。
+   * 唤醒事件 → 投喂给 LLM 的文本。渲染是 envelope 的纯函数，不读取当前时钟；
+   * mailbox carry、失败重投或 overflow retry 即使重新渲染，也会得到逐字相同的文本。
    */
-  private renderEvent(event: WakeEvent): string {
-    return renderWakeEvent(event, {
-      timezone: this.deps.timezone?.() ?? resolveTimezone(undefined),
-      now: this.deps.now(),
-    })
+  private renderEnvelope(envelope: TimedWakeEnvelope): string {
+    return renderTimedWakeEnvelope(envelope)
   }
 
   /** `event === undefined` ⇒ 自唤醒(见 `drainMailbox`):只处理 mailbox 残留,不渲染唤醒事件。 */
-  private async runEpisode(event: WakeEvent | undefined): Promise<EpisodeResult> {
+  private async runEpisode(envelope: TimedWakeEnvelope | undefined): Promise<EpisodeResult> {
     const episodeId = randomUUID()
-    const carriedTexts = this.mailbox.drainPending().map(toText)
-    if (event === undefined && carriedTexts.length === 0) {
+    const carriedEnvelopes = this.mailbox.drainEnvelopes()
+    const carriedTexts = carriedEnvelopes.map((item) => this.renderEnvelope(item))
+    if (envelope === undefined && carriedEnvelopes.length === 0) {
       // 自唤醒但 mailbox 已空(残留被排在前面的另一个 episode 顺带 drain 走了)——
       // 没有任何新内容,直接空转返回,不开 episode(见 drainMailbox 注释)。
       return { episodeId, outcome: 'completed', turns: 0, consumedEvents: true, repliedToHuman: false }
     }
-    const eventText = event === undefined ? undefined : this.renderEvent(event)
+    const eventText = envelope === undefined ? undefined : this.renderEnvelope(envelope)
     this.currentEpisodeInjected = []
-    this.currentWakeEvent = event ?? null
+    this.currentWakeEvent = envelope ?? null
 
     try {
-      return await this.runEpisodeBody(episodeId, carriedTexts, eventText)
+      return await this.runEpisodeBody(episodeId, carriedTexts, eventText, carriedEnvelopes, envelope)
     } catch (err) {
       // runEpisodeBody 内部按 outcome 判定的失败分支(约 L232-249,LLM 报错被 engine 捕获为
       // outcome='failed'/'aborted' 后正常 return 的路径)已经在返回前自行完成了重投——那条路径
       // 不会走到这里。这里的 catch 专门兜"直接 throw、根本没走到 outcome 判定"的路径:
-      // applyFold → foldIntoSummary(折叠 LLM 持续故障、callNonStreaming 重试耗尽抛出)、
-      // runAttempt 顶部首次 fetchLedgerRender(台账读盘瞬时失败,onTurn 的 refresh 路径才有
-      // .catch,这个首次 await 没有)、store.load/store.save/appendEpisodeLog 的 IO 失败等。
-      // 两条路径互斥(runEpisodeBody 要么正常 return、要么中途 throw,不会同时触发两次重投),
-      // 否则已 drain 的 carriedTexts/eventText/currentEpisodeInjected 会随栈展开永久丢失,
-      // 绕过"至少一次投递"(见文件头)。
-      this.mailbox.drainPending()
-      for (const t of carriedTexts) this.mailbox.push(t)
-      if (eventText !== undefined) this.mailbox.push(eventText)
-      for (const t of this.currentEpisodeInjected ?? []) this.mailbox.push(t)
+      // applyFold/Store I/O can throw before an EngineResult exists. Requeue the same
+      // envelopes in their original order so retry cannot mint a new timestamp.
+      this.mailbox.drainEnvelopes()
+      for (const item of carriedEnvelopes) this.mailbox.push(item)
+      if (envelope !== undefined) this.mailbox.push(envelope)
+      for (const item of this.currentEpisodeInjected ?? []) this.mailbox.push(item)
       throw err
     } finally {
       this.currentEpisodeInjected = null
@@ -320,6 +315,8 @@ export class ManagerLoop {
     episodeId: string,
     carriedTexts: ReadonlyArray<string>,
     eventText: string | undefined,
+    carriedEnvelopes: ReadonlyArray<TimedWakeEnvelope>,
+    envelope: TimedWakeEnvelope | undefined,
   ): Promise<EpisodeResult> {
     // §11 热更语义:整个 episode(含下面的 max_tokens 兜底重试)只在这里解析一次 adapter/
     // model,固定用这份快照——即使两次解析之间 admin config 已经变了,当前 episode 也不换。
@@ -339,10 +336,13 @@ export class ManagerLoop {
       state = await this.applyFold(state, wakeDecision, adapter, model)
     }
 
+    const currentTailMessages: EngineMessage[] = [
+      ...carriedTexts.map((text) => createUserMessage(text)),
+      ...(eventText === undefined ? [] : [createUserMessage(eventText)]),
+    ]
     const tailMessages: EngineMessage[] = [
       ...state.recent,
-      ...carriedTexts.map((t) => createUserMessage(t)),
-      ...(eventText === undefined ? [] : [createUserMessage(eventText)]),
+      ...currentTailMessages,
     ]
 
     let attempt = await this.runAttempt(state, tailMessages, adapter, model)
@@ -354,26 +354,25 @@ export class ManagerLoop {
     // max_tokens 兜底(§4.2):disableCompaction 关掉了 engine 自己的强压重试路径,
     // 这里识别到"上下文超限收场"时强制 force_hot 折叠一次并重试一次,仍失败就放弃。
     //
-    // mid-episode 注入与这条重试路径的交互(想清楚过,记录结论):
-    // 首次尝试期间通过 enqueueDuringEpisode 到达的 mid-episode 注入内容,无论当时是否已被
-    // engine drainPending() 消费(消费掉的已经进了随首次尝试一起丢弃的 finalMessages;未消费
-    // 的——例如恰好在首次尝试最后一次 LLM 调用期间到达,或在两次尝试之间 applyFold 的折叠
-    // LLM 调用期间到达——仍原样躺在 mailbox.pending 里),currentEpisodeInjected 都完整记录了
-    // 原始文本,是唯一权威来源。首次尝试的所有轮次连同其中的消费行为都被丢弃,这些内容等于
-    // 没被处理过,重试时显式把它们追加进 retryTailMessages 才是准确的重投。
-    // 若 mailbox.pending 里还残留"未被消费"那一段不清空,它是 currentEpisodeInjected 的
-    // 后缀——retry 复用同一个 `this.mailbox` 实例作为 humanMessageQueue,engine 会在 retry
-    // 的 turn 边界自然把它再 drain 一次,与下面显式追加的 currentEpisodeInjected 重复投递
-    // (同一条内容在 retry 上下文出现两份)。因此显式追加前必须先 drainPending() 清空残留。
+    // mid-episode 注入与这条重试路径的交互:
+    // 首次尝试期间通过 enqueueDuringEpisode 到达的内容，无论当时是否已被 engine
+    // drainPending() 消费，都由 currentEpisodeInjected 以原始 envelope 顺序记录。
+    // 首次尝试的 finalMessages 在重试时整体丢弃，因此这些 envelope 必须显式追加。
+    // mailbox.pending 里的未消费后缀先清空，避免与显式追加重复。
+    // 初始 wake 与 carried envelopes 同样属于本次 protected current tail；force-hot
+    // 只折叠 state.recent 中此前历史，不能把本次事件折进 rolling summary。
     if (isContextOverflow(attempt.result)) {
-      const forceDecision = forceHotFold({ ...state, recent: tailMessages }, this.deps.policy, this.deps.estimateTokens, nowMs)
+      // Only pre-existing history may be folded. The current initial wake, carried
+      // envelopes and mid-episode supplements are a protected tail (§14.4).
+      const forceDecision = forceHotFold(state, this.deps.policy, this.deps.estimateTokens, nowMs)
       if (forceDecision.kind !== 'none') {
         state = await this.applyFold(state, forceDecision, adapter, model)
         // 清空 mailbox 残留后缀(见上方注释),再按 currentEpisodeInjected 的到达顺序整体追加
-        this.mailbox.drainPending()
+        this.mailbox.drainEnvelopes()
         const retryTailMessages: EngineMessage[] = [
           ...state.recent,
-          ...(this.currentEpisodeInjected?.map((t) => createUserMessage(t)) ?? []),
+          ...currentTailMessages,
+          ...(this.currentEpisodeInjected?.map((item) => createUserMessage(this.renderEnvelope(item))) ?? []),
         ]
         const retryAttempt = await this.runAttempt(state, retryTailMessages, adapter, model)
         totalTurnsUsed += retryAttempt.result.totalTurns
@@ -413,10 +412,10 @@ export class ManagerLoop {
       // currentEpisodeInjected 都完整记录了原始文本,是唯一权威来源;先 drainPending()
       // 清空 mailbox 里可能残留的"尚未被消费"那一段(它是 currentEpisodeInjected 的后缀,
       // 不清空会和下面的整体重投重复),再按到达顺序整体重投,保证至少一次投递、不丢失、不重复。
-      this.mailbox.drainPending()
-      for (const t of carriedTexts) this.mailbox.push(t)
-      if (eventText !== undefined) this.mailbox.push(eventText)
-      for (const t of this.currentEpisodeInjected ?? []) this.mailbox.push(t)
+      this.mailbox.drainEnvelopes()
+      for (const item of carriedEnvelopes) this.mailbox.push(item)
+      if (envelope !== undefined) this.mailbox.push(envelope)
+      for (const item of this.currentEpisodeInjected ?? []) this.mailbox.push(item)
     }
 
     const result: EpisodeResult = {
@@ -476,33 +475,15 @@ export class ManagerLoop {
       ? [createUserMessage(SUMMARY_MESSAGE_PREFIX + state.rollingSummary), ...tailMessages]
       : [...tailMessages]
 
-    // 台账渲染依赖 WorkerHarness.listWorkers(异步读盘),但 EngineOptions.systemPrompt
-    // 的 Resolvable thunk 必须同步(query-loop 每轮同步调用,见 types.ts Resolvable 注释)。
-    // 取舍:episode/attempt 开始前先 await 一次拿起始值;此后每轮 onTurn 完成时
-    // fire-and-forget 重新拉取——工具执行/下一轮 LLM 调用之间总有若干次 await,通常足够
-    //让新值在下一次 thunk 调用前落地。不保证严格的"这一轮绝对最新",但避免了把台账查询
-    // 变成阻塞整条 loop 的等待原语(与 protocol §4.1"loop 内不存在阻塞等待原语"的精神一致)。
-    let ledgerRender = await this.fetchLedgerRender()
-    const refreshLedgerRender = (): void => {
-      void this.fetchLedgerRender()
-        .then((r) => { ledgerRender = r })
-        .catch(() => { /* 台账查询失败不影响当前 episode,下一轮沿用旧值重试 */ })
-    }
-
     const systemPrompt = (): string => {
       const extra = this.deps.promptInputs()
       return assembleManagerSystemPrompt({
         managerKey: this.deps.key,
         isSystemThread: this.deps.isSystemThread,
         dialogProfile: extra.dialogProfile,
-        dynamic: {
-          ledgerRender,
-          nowIso: this.deps.now().toISOString(),
-          pendingNotes: extra.pendingNotes,
-        },
       })
     }
-    const tools = (): ReadonlyArray<ToolDefinition> => this.deps.toolFace(this.currentWakeEvent ?? undefined)
+    const tools = (): ReadonlyArray<ToolDefinition> => this.deps.toolFace(this.currentWakeEvent?.wake)
 
     const options: EngineOptions = {
       systemPrompt,
@@ -512,7 +493,6 @@ export class ManagerLoop {
       contextWindowTokens: this.deps.contextWindowTokens,
       disableCompaction: true,
       humanMessageQueue: this.mailbox,
-      onTurn: () => refreshLedgerRender(),
       // engine 的 forced_summary 兜底(silent end_turn → 注入"你还没向人类发过内容"追问,
       // 最多 3 次)是 v2 worker loop 的机制:那条路径下 caller 用一整套 outbound buffer
       // 跟踪"这轮有没有发过",engine 只是照着它的判定兜底。manager 没有那套跟踪,不传等于
@@ -534,10 +514,6 @@ export class ManagerLoop {
     return { result, hasSummaryMarker }
   }
 
-  private async fetchLedgerRender(): Promise<string> {
-    const workers = await this.deps.harness.listWorkers(this.deps.managerKey())
-    return renderLedger(workers)
-  }
 }
 
 // --- Helpers ---
@@ -575,31 +551,97 @@ function detectRepliedToHuman(finalMessages: ReadonlyArray<EngineMessage>): bool
   return false
 }
 
-function toText(content: QueueContent): string {
-  // mailbox 唯一的写入方是 enqueueDuringEpisode(总是 push 字符串),这里的分支只是
-  // 类型层面的防御——QueueContent 的联合类型允许 ContentBlock[],实际不会走到这条分支。
-  return typeof content === 'string' ? content : '[附件内容,唤醒边界渲染不支持结构化内容,已降级为占位文本]'
+/** Manager-only mailbox: envelopes remain authoritative; the engine receives deterministic text. */
+class TimedWakeMailbox implements HumanMessageQueueLike {
+  private pending: TimedWakeEnvelope[] = []
+  private barrierResolve: (() => void) | null = null
+  private barrierTimer: ReturnType<typeof setTimeout> | null = null
+
+  push(envelope: TimedWakeEnvelope): void {
+    this.pending.push(envelope)
+    this.clearBarrier()
+  }
+
+  drainEnvelopes(): TimedWakeEnvelope[] {
+    const drained = this.pending
+    this.pending = []
+    return drained
+  }
+
+  drainPending(): string[] {
+    return this.drainEnvelopes().map(renderTimedWakeEnvelope)
+  }
+
+  get hasPending(): boolean {
+    return this.pending.length > 0
+  }
+
+  get hasBarrier(): boolean {
+    return this.barrierResolve !== null || this.barrierTimer !== null
+  }
+
+  setBarrier(timeoutMs: number, onTimeout?: () => void): void {
+    this.clearBarrier()
+    this.barrierTimer = setTimeout(() => {
+      this.barrierTimer = null
+      onTimeout?.()
+      this.clearBarrier()
+    }, timeoutMs)
+  }
+
+  clearBarrier(): void {
+    if (this.barrierTimer !== null) {
+      clearTimeout(this.barrierTimer)
+      this.barrierTimer = null
+    }
+    const resolve = this.barrierResolve
+    this.barrierResolve = null
+    resolve?.()
+  }
+
+  async waitBarrier(signal?: AbortSignal): Promise<void> {
+    if (!this.hasBarrier || this.barrierResolve !== null) return
+    await new Promise<void>((resolve) => {
+      const abort = (): void => this.clearBarrier()
+      signal?.addEventListener('abort', abort, { once: true })
+      this.barrierResolve = () => {
+        signal?.removeEventListener('abort', abort)
+        resolve()
+      }
+    })
+  }
 }
 
-function renderLedger(workers: ReadonlyArray<LedgerWorker>): string {
-  if (workers.length === 0) return '(当前无 worker)'
-  return workers
-    .map((w) => `- ${w.worker_id} | ${w.task.title} | ${w.task.status} | 化身数=${w.incarnations.length}`)
-    .join('\n')
+function assertTimedWakeEnvelope(value: TimedWakeEnvelope): void {
+  if (
+    value === null ||
+    typeof value !== 'object' ||
+    !('wake' in value) ||
+    typeof value.received_at !== 'string' ||
+    typeof value.timezone !== 'string'
+  ) {
+    throw new TypeError('ManagerLoop requires a TimedWakeEnvelope captured at ingress')
+  }
 }
 
-/** 消息渲染的两个外部输入(时区 + 时钟),由 `ManagerLoop.renderEvent` 按 deps 解析后传入。 */
-interface MessageRenderOpts {
-  readonly timezone: string
-  readonly now: Date
+/** Pure projection of ingress-fixed time; this function never reads a live clock. */
+export function renderTimedWakeEnvelope(envelope: TimedWakeEnvelope): string {
+  const header = `[event received_at="${envelope.received_at}" timezone="${envelope.timezone}"]`
+  const occurred = envelope.occurred_at ? `\n[event occurred_at="${envelope.occurred_at}"]` : ''
+  return `${header}${occurred}\n${renderWakeEvent(envelope.wake, envelope)}`
 }
 
-function renderWakeEvent(event: WakeEvent, opts: MessageRenderOpts): string {
+function renderWakeEvent(event: WakeEvent, envelope: TimedWakeEnvelope): string {
   switch (event.kind) {
     case 'human_messages':
-      return renderChannelMessages('[人类消息]', event.messages, event.friend, opts)
+      return renderChannelMessages('[人类消息]', event.messages, event.friend, envelope)
     case 'attention_flush':
-      return renderChannelMessages('[补齐:群聊注意力放行期间累积的人类消息]', event.messages, event.friend, opts)
+      return renderChannelMessages(
+        '[补齐:群聊注意力放行期间累积的人类消息]',
+        event.messages,
+        event.friend,
+        envelope,
+      )
     case 'worker_event':
       return renderWorkerEvent(event.event)
     case 'media_notification':
@@ -609,60 +651,30 @@ function renderWakeEvent(event: WakeEvent, opts: MessageRenderOpts): string {
   }
 }
 
-/**
- * 人类消息渲染(P7 J Task 4)。
- *
- * 早先这里只出 `- 名: 文本`,丢掉了 `platform_message_id`、`platform_timestamp`、
- * `is_mention_crab`、`mentions`、`reply_to/quote/thread`、媒体与发送者身份——manager 因此
- * 在群里分不清 @ 的是不是自己、不知道某条在回谁、看不到图片/文件、也拿不到能喂给
- * `get_message` 的 id。J 放弃了引用原文的入站预取(8 件事第 6 条),代价必须由渲染保真度补上:
- * **manager 看到 `reply_to="…"` 才知道自己该不该去拉那条原文**。
- *
- * **复用 `prompt-manager.formatChannelMessageLine`,不另写一版**:它已经把
- * "ChannelMessage 的全部结构化字段按存在性输出成 XML 属性"这件事做完了(含闭合标签转义、
- * 超长截断、媒体/system_event 渲染),worker 与 dispatcher 用的都是它。manager 的上下文虽然是
- * `EngineMessage[]` 而不是 worker 那种整块 XML prompt,但**这里要渲染的是同一种东西**——
- * 一条 ChannelMessage 的完整结构;差别只在"渲染结果放进哪个信封"(这里是一条 user message
- * 的正文)。另写一版必然漂移(本项目已经因为重造既有实现栽过)。
- *
- * `quotedMessages` 刻意不传:入站不预取引用原文,渲染只出 `reply_to` / `quote` 属性,
- * manager 需要时自己调白名单里的 `get_message`(pull 型兜底,与 `get_history` 同款)。
- *
- * `friend` 是本批的发言者,只用于 `resolveSenderIdentity` 判 master/friend/stranger;
- * 群里别人发的消息判不出来就是 `stranger`,与 dispatcher 侧 `buildUserPrompt` 同一套取舍。
- */
 function renderChannelMessages(
   label: string,
   messages: ReadonlyArray<ChannelMessage>,
   friend: Friend | undefined,
-  opts: MessageRenderOpts,
+  envelope: TimedWakeEnvelope,
 ): string {
   if (messages.length === 0) return `${label}(空)`
-  const lines = messages.map((m) =>
-    formatChannelMessageLine(m, {
-      timezone: opts.timezone,
-      now: opts.now,
-      identity: resolveSenderIdentity({ msg: m, ...(friend ? { senderFriend: friend } : {}) }),
-    }),
-  )
+  const lines = messages.map((message, index) => {
+    const occurred = envelope.human_occurred_at?.[index]?.occurred_at
+    const prefix = occurred ? `[human occurred_at="${occurred}"]\n` : ''
+    return prefix + formatChannelMessageLine(message, {
+      timezone: envelope.timezone,
+      now: new Date(envelope.received_at),
+      identity: resolveSenderIdentity({ msg: message, ...(friend ? { senderFriend: friend } : {}) }),
+    })
+  })
   return `${label}\n${lines.join('\n')}`
 }
 
-/**
- * 两段人写给人看的正文单独成段渲染,不塞进 JSON——JSON.stringify 会把换行转义成 `\n`,
- * 几百字的内容挤成一行转义串,manager 读起来费劲。其余 detail 字段仍走 JSON,形状不变。
- *
- * - `detail.text`:worker 在这个轮次边界上最后说的那段话;
- * - `detail.summary`:worker 调 `finish_task` 时自己写的收尾结论。两者都由 harness 按各自
- *   上限截断过(见 WAKE_TEXT_MAX_CHARS / WAKE_SUMMARY_MAX_CHARS)。
- *
- * 一个全程只调工具的 worker 只有后者(前者与 output 一起是空的),所以两段都必须渲染,
- * 不能只挑一段。
- */
-function renderWorkerEvent(e: HarnessEvent): string {
-  const { text, summary, ...rest } = (e.detail ?? {}) as { text?: unknown; summary?: unknown } & Record<string, unknown>
+function renderWorkerEvent(event: HarnessEvent): string {
+  const { text, summary, ...rest } = (event.detail ?? {}) as
+    { text?: unknown; summary?: unknown } & Record<string, unknown>
   const detail = Object.keys(rest).length > 0 ? ` detail=${JSON.stringify(rest)}` : ''
-  const parts = [`[worker 事件] worker_id=${e.worker_id} seq=${e.seq} kind=${e.kind}${detail}`]
+  const parts = [`[worker 事件] worker_id=${event.worker_id} seq=${event.seq} kind=${event.kind}${detail}`]
   if (typeof text === 'string' && text.length > 0) parts.push(`worker 最后说:\n${text}`)
   if (typeof summary === 'string' && summary.length > 0) parts.push(`worker 的收尾结论:\n${summary}`)
   return parts.join('\n')

--- a/crabot-agent/src/manager/loop.ts
+++ b/crabot-agent/src/manager/loop.ts
@@ -53,7 +53,7 @@ import { assembleManagerSystemPrompt } from './prompt.js'
 import type { ManagerSessionStore } from './session-store.js'
 import type { ManagerSessionState, ManagerKey } from './types.js'
 import type { WorkerHarness } from '../workers/harness/harness'
-import type { DialogObjectId, LedgerWorker } from '../workers/harness/ledger-types'
+import type { LedgerWorker } from '../workers/harness/ledger-types'
 import type { HarnessEvent } from '../workers/harness/worker-events'
 import type { ChannelMessage, Friend, ResolvedPermissions } from '../types'
 
@@ -114,7 +114,7 @@ export type WakeEvent =
       /**
        * P7 J additive:与 `human_messages` 的同名字段逐字同义(见上)。
        * **群聊注意力放行走的是这一条**,漏带 friend 就等于群聊路径拿不到发起人身份
-       * ——权限档位 / 记忆 scopes / 台账归档键全部退回未解析那一档。
+       * ——权限档位 / 记忆 scopes 全部退回未解析那一档。
        */
       readonly friend?: Friend
       /** 与 `human_messages` 的同名字段逐字同义(见上)。 */
@@ -145,12 +145,12 @@ export interface ManagerLoopDeps {
   readonly key: ManagerKey
   readonly isSystemThread: boolean
   /** 台账渲染用(harness.listWorkers 的入参)。manager 会话粒度(ManagerKey)与台账聚合粒度
-   *  (DialogObjectId)不同——由调用方按 protocol §3 解析好传入,本模块不做这层映射。
+   *  (ManagerKey)不同——由调用方按 protocol §3 解析好传入,本模块不做这层映射。
    *
    *  **thunk 而非定值**(P7 J):私聊的归档键要等第一条人类消息带来 friend 之后才能收敛成
    *  `friend:<id>`,而 loop 实例可能先由 worker 事件建出来。定值会把那一刻的 group 形状
    *  永久钉死在实例上,同一个人的台账因此裂成两份。 */
-  readonly dialogObjectId: () => DialogObjectId
+  readonly managerKey: () => ManagerKey
   readonly store: ManagerSessionStore
   readonly policy: CompactionPolicy
   /** decideCompaction 的 token 估算器,调用方注入(与 compaction.ts 的既定依赖注入方式一致)。 */
@@ -535,7 +535,7 @@ export class ManagerLoop {
   }
 
   private async fetchLedgerRender(): Promise<string> {
-    const workers = await this.deps.harness.listWorkers(this.deps.dialogObjectId())
+    const workers = await this.deps.harness.listWorkers(this.deps.managerKey())
     return renderLedger(workers)
   }
 }

--- a/crabot-agent/src/manager/principal-binding-store.ts
+++ b/crabot-agent/src/manager/principal-binding-store.ts
@@ -1,0 +1,118 @@
+import { promises as fs } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { randomUUID } from 'node:crypto'
+import { AsyncMutex } from '../workers/async-mutex.js'
+import type { ManagerKey } from '../workers/harness/ledger-types.js'
+
+export type PersistedPrincipalBinding = {
+  manager_key: ManagerKey
+  generation: number
+  kind: 'friend' | 'admin_chat_jwt'
+  friend_id?: string
+  assertion_id?: string
+  expires_at?: string
+}
+
+type BindingFile = { bindings: PersistedPrincipalBinding[] }
+const ADMIN_CHAT_KEY = 'admin-web::admin-chat' as ManagerKey
+
+/** Durable identity bindings only. It never stores permissions, JWTs, or assertion text. */
+export class PrincipalBindingStore {
+  private readonly mutex = new AsyncMutex()
+  private readonly bindings = new Map<ManagerKey, PersistedPrincipalBinding>()
+  private initialized = false
+
+  constructor(private readonly filePath: string) {}
+
+  async init(): Promise<void> {
+    await this.mutex.run(async () => {
+      if (this.initialized) return
+      try {
+        const parsed = JSON.parse(await fs.readFile(this.filePath, 'utf8')) as BindingFile
+        if (!parsed || !Array.isArray(parsed.bindings)) throw new Error('invalid principal bindings')
+        for (const binding of parsed.bindings) {
+          this.assertBinding(binding)
+          if (this.bindings.has(binding.manager_key)) throw new Error('duplicate manager_key in principal bindings')
+          this.bindings.set(binding.manager_key, binding)
+        }
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+      }
+      this.initialized = true
+    })
+  }
+
+  isInitialized(): boolean { return this.initialized }
+  get(key: ManagerKey): PersistedPrincipalBinding | undefined { return this.bindings.get(key) }
+
+  async set(binding: Omit<PersistedPrincipalBinding, 'generation'>): Promise<PersistedPrincipalBinding> {
+    return this.mutex.run(async () => {
+      this.requireInitialized()
+      this.assertBinding({ ...binding, generation: 1 })
+      const previous = this.bindings.get(binding.manager_key)
+      if (previous && sameBinding(previous, binding)) return previous
+      const next: PersistedPrincipalBinding = { ...binding, generation: (previous?.generation ?? 0) + 1 }
+      this.bindings.set(next.manager_key, next)
+      await this.write()
+      return next
+    })
+  }
+
+  /** Bumps one key once; callers can use the returned generation to avoid repeat invalidation. */
+  async bump(key: ManagerKey): Promise<PersistedPrincipalBinding | undefined> {
+    return this.mutex.run(async () => {
+      this.requireInitialized()
+      const previous = this.bindings.get(key)
+      if (!previous) return undefined
+      const next = { ...previous, generation: previous.generation + 1 }
+      this.bindings.set(key, next)
+      await this.write()
+      return next
+    })
+  }
+
+  async invalidateWhere(predicate: (binding: PersistedPrincipalBinding) => boolean): Promise<void> {
+    await this.mutex.run(async () => {
+      this.requireInitialized()
+      let changed = false
+      for (const [key, binding] of this.bindings) {
+        if (!predicate(binding)) continue
+        this.bindings.set(key, { ...binding, generation: binding.generation + 1 })
+        changed = true
+      }
+      if (changed) await this.write()
+    })
+  }
+
+  private requireInitialized(): void {
+    if (!this.initialized) throw new Error('principal binding store is not initialized')
+  }
+
+  private assertBinding(binding: PersistedPrincipalBinding): void {
+    if (!binding || !isManagerKey(binding.manager_key) || !Number.isInteger(binding.generation) || binding.generation < 1 ||
+      (binding.kind !== 'friend' && binding.kind !== 'admin_chat_jwt')) throw new Error('invalid principal binding')
+    if (binding.kind === 'friend') {
+      if (!nonEmpty(binding.friend_id) || binding.assertion_id !== undefined || binding.expires_at !== undefined) throw new Error('invalid friend binding')
+      return
+    }
+    if (binding.manager_key !== ADMIN_CHAT_KEY || !nonEmpty(binding.assertion_id) || !nonEmpty(binding.expires_at) ||
+      !Number.isFinite(Date.parse(binding.expires_at)) || binding.friend_id !== undefined) throw new Error('invalid admin chat binding')
+  }
+
+  private async write(): Promise<void> {
+    await fs.mkdir(dirname(this.filePath), { recursive: true })
+    const contents = JSON.stringify({ bindings: [...this.bindings.values()] }, null, 2)
+    const temporary = join(dirname(this.filePath), `.tmp-${randomUUID()}.json`)
+    await fs.writeFile(temporary, contents, { mode: 0o600 })
+    await fs.rename(temporary, this.filePath)
+  }
+}
+
+function nonEmpty(value: unknown): value is string { return typeof value === 'string' && value.length > 0 }
+function isManagerKey(value: unknown): value is ManagerKey {
+  return typeof value === 'string' && /^[^:]+::.+$/.test(value)
+}
+function sameBinding(previous: PersistedPrincipalBinding | undefined, next: Omit<PersistedPrincipalBinding, 'generation'>): boolean {
+  return !!previous && previous.kind === next.kind && previous.friend_id === next.friend_id &&
+    previous.assertion_id === next.assertion_id && previous.expires_at === next.expires_at
+}

--- a/crabot-agent/src/manager/principal.ts
+++ b/crabot-agent/src/manager/principal.ts
@@ -28,6 +28,21 @@
 import type { Friend, MemoryPermissions, ResolvedPermissions, RuntimeSceneProfile } from '../types.js'
 import type { ManagerKey } from './types.js'
 import { PrincipalBindingStore } from './principal-binding-store.js'
+import type { LegacyContinuationAuth } from '../workers/harness/legacy-continuation-auth.js'
+
+export interface LegacyContinuationAuthTemplate {
+  readonly source_manager_key: ManagerKey
+  readonly principal_kind: LegacyContinuationAuth['principal_kind']
+  readonly principal_generation: number
+  readonly principal_permissions: ResolvedPermissions
+}
+
+interface LegacyAuthorizationSource {
+  readonly source_manager_key: ManagerKey
+  readonly target_manager_key: ManagerKey
+  readonly principal_kind: LegacyContinuationAuth['principal_kind']
+  readonly principal_generation: number
+}
 
 export type MasterAuthorization =
   | { readonly kind: 'friend_master'; readonly manager_key: ManagerKey; readonly friend_id: string; readonly generation: number }
@@ -163,6 +178,8 @@ export interface PrincipalResolverDeps {
 export class ManagerPrincipalStore {
   private readonly resolved = new Map<ManagerKey, ResolvedPrincipal>()
   private readonly activeAuthorizations = new Map<ManagerKey, MasterAuthorization>()
+  /** Exact minted credential object → source binding; object identity prevents credential collisions. */
+  private readonly legacyAuthorizationSources = new WeakMap<LegacyContinuationAuth, LegacyAuthorizationSource>()
 
   constructor(
     private readonly deps: PrincipalResolverDeps,
@@ -267,7 +284,19 @@ export class ManagerPrincipalStore {
 
   async refreshForNonHumanWake(key: ManagerKey): Promise<void> {
     const binding = this.bindings?.get(key)
-    if (binding?.kind === 'friend') await this.refreshFriendAuthorization(key)
+    if (binding?.kind !== 'friend' || !binding.friend_id) return
+    try {
+      const friend = await this.deps.getFriend?.(binding.friend_id)
+      if (!friend) {
+        await this.invalidatePrincipalBindingOnce(key, binding.generation)
+        return
+      }
+      // Re-resolve current permissions before exposing a non-human tool face; do not
+      // reuse a stale session cache after downgrade/regrant.
+      await this.resolve(key, { friend, sessionType: 'private' })
+    } catch {
+      await this.invalidatePrincipalBindingOnce(key, binding.generation)
+    }
   }
 
   async invalidateFriend(friendId: string): Promise<void> {
@@ -293,6 +322,96 @@ export class ManagerPrincipalStore {
     }
     await this.invalidateAuthorizationOnce(auth.manager_key, auth.generation)
     return false
+  }
+
+  /** Capture the current turn's credential source synchronously while the tool face is built. */
+  captureLegacyContinuationAuth(key: ManagerKey): LegacyContinuationAuthTemplate | undefined {
+    const resolved = this.resolved.get(key)
+    const binding = this.bindings?.get(key)
+    if (!resolved?.permissions || !binding) return undefined
+    const active = this.currentMasterAuthorization(key)
+    if (active?.kind === 'admin_chat_jwt' && active.generation === binding.generation) {
+      return {
+        source_manager_key: key,
+        principal_kind: 'admin_chat_jwt',
+        principal_generation: binding.generation,
+        principal_permissions: resolved.permissions,
+      }
+    }
+    if (
+      resolved.principal.sessionType !== 'private' ||
+      !resolved.principal.friend ||
+      binding.kind !== 'friend' ||
+      binding.friend_id !== resolved.principal.friend.id
+    ) return undefined
+    return {
+      source_manager_key: key,
+      principal_kind: 'friend',
+      principal_generation: binding.generation,
+      principal_permissions: resolved.permissions,
+    }
+  }
+
+  bindLegacyContinuationAuth(
+    template: LegacyContinuationAuthTemplate | undefined,
+    targetManagerKey: ManagerKey,
+  ): LegacyContinuationAuth | undefined {
+    if (!template) return undefined
+    const auth: LegacyContinuationAuth = {
+      manager_key: targetManagerKey,
+      principal_kind: template.principal_kind,
+      principal_generation: template.principal_generation,
+      principal_permissions: template.principal_permissions,
+    }
+    this.legacyAuthorizationSources.set(auth, {
+      source_manager_key: template.source_manager_key,
+      target_manager_key: targetManagerKey,
+      principal_kind: template.principal_kind,
+      principal_generation: template.principal_generation,
+    })
+    return auth
+  }
+
+  async validateLegacyContinuationAuth(auth: LegacyContinuationAuth): Promise<boolean> {
+    const source = this.legacyAuthorizationSources.get(auth)
+    if (
+      !source ||
+      source.target_manager_key !== auth.manager_key ||
+      source.principal_kind !== auth.principal_kind ||
+      source.principal_generation !== auth.principal_generation
+    ) return false
+
+    const sourceKey = source.source_manager_key
+    const binding = this.bindings?.get(sourceKey)
+    if (!binding || binding.generation !== auth.principal_generation) return false
+    if (auth.principal_kind === 'admin_chat_jwt') {
+      const active = this.currentMasterAuthorization(sourceKey)
+      return binding.kind === 'admin_chat_jwt' &&
+        active?.kind === 'admin_chat_jwt' &&
+        active.generation === auth.principal_generation
+    }
+    if (binding.kind !== 'friend' || !binding.friend_id) return false
+    try {
+      const friend = await this.deps.getFriend?.(binding.friend_id)
+      if (!friend) {
+        await this.invalidatePrincipalBindingOnce(sourceKey, auth.principal_generation)
+        return false
+      }
+      if (sourceKey === auth.manager_key || friend.permission === 'master') return true
+      await this.invalidatePrincipalBindingOnce(sourceKey, auth.principal_generation)
+      return false
+    } catch {
+      await this.invalidatePrincipalBindingOnce(sourceKey, auth.principal_generation)
+      return false
+    }
+  }
+
+  private async invalidatePrincipalBindingOnce(key: ManagerKey, generation: number): Promise<void> {
+    this.activeAuthorizations.delete(key)
+    this.resolved.delete(key)
+    const current = this.bindings?.get(key)
+    if (!current || current.generation !== generation) return
+    await this.bindings?.bump(key)
   }
 
   private async refreshFriendAuthorization(key: ManagerKey): Promise<void> {

--- a/crabot-agent/src/manager/principal.ts
+++ b/crabot-agent/src/manager/principal.ts
@@ -27,6 +27,11 @@
 
 import type { Friend, MemoryPermissions, ResolvedPermissions, RuntimeSceneProfile } from '../types.js'
 import type { ManagerKey } from './types.js'
+import { PrincipalBindingStore } from './principal-binding-store.js'
+
+export type MasterAuthorization =
+  | { readonly kind: 'friend_master'; readonly manager_key: ManagerKey; readonly friend_id: string; readonly generation: number }
+  | { readonly kind: 'admin_chat_jwt'; readonly manager_key: ManagerKey; readonly assertion_id: string; readonly expires_at: string; readonly generation: number }
 
 /**
  * 一次人类消息唤醒随行的发起人身份。
@@ -144,6 +149,8 @@ export interface PrincipalResolverDeps {
   }) => Promise<RuntimeSceneProfile | null>
   /** crab 在该 channel 的 @handle(入站事件已缓存,同步读)。 */
   readonly crabSelfHandle: (channelId: string) => string | undefined
+  /** Authoritative Admin record used for execution-time Master revalidation. */
+  readonly getFriend?: (friendId: string) => Promise<Friend | null>
 }
 
 /**
@@ -155,8 +162,17 @@ export interface PrincipalResolverDeps {
  */
 export class ManagerPrincipalStore {
   private readonly resolved = new Map<ManagerKey, ResolvedPrincipal>()
+  private readonly activeAuthorizations = new Map<ManagerKey, MasterAuthorization>()
 
-  constructor(private readonly deps: PrincipalResolverDeps) {}
+  constructor(
+    private readonly deps: PrincipalResolverDeps,
+    private readonly bindings?: PrincipalBindingStore,
+    private readonly now: () => Date = () => new Date(),
+  ) {}
+
+  async init(): Promise<void> {
+    await this.bindings?.init()
+  }
 
   /**
    * 唤醒边界解析:把 friend 变成权限 / 记忆档位 / 对话对象档案,写进缓存。
@@ -222,7 +238,89 @@ export class ManagerPrincipalStore {
       ...(dialogProfile ? { dialogProfile } : {}),
     }
     this.resolved.set(key, entry)
+    // Admin Chat's synthetic Friend is never an identity authority. Its opaque assertion
+    // is the only source that may create or replace this binding.
+    if (key !== 'admin-web::admin-chat' && principal.sessionType === 'private' && principal.friend && this.bindings?.isInitialized()) {
+      await this.bindings.set({ manager_key: key, kind: 'friend', friend_id: principal.friend.id })
+      await this.refreshFriendAuthorization(key)
+    }
     return entry
+  }
+
+  /** Only a verified current authorization can enter the tool face; bindings alone never grant Master after restart. */
+  currentMasterAuthorization(key: ManagerKey): MasterAuthorization | undefined {
+    const auth = this.activeAuthorizations.get(key)
+    if (auth?.kind === 'admin_chat_jwt' && Date.parse(auth.expires_at) <= this.now().getTime()) {
+      this.activeAuthorizations.delete(key)
+      return undefined
+    }
+    return auth
+  }
+
+  async activateAdminChat(key: ManagerKey, input: { assertionId: string; expiresAt: string }): Promise<void> {
+    if (!this.bindings) return
+    if (!this.bindings.isInitialized()) await this.bindings.init()
+    if (key !== 'admin-web::admin-chat' || Date.parse(input.expiresAt) <= this.now().getTime()) return
+    const binding = await this.bindings.set({ manager_key: key, kind: 'admin_chat_jwt', assertion_id: input.assertionId, expires_at: input.expiresAt })
+    this.activeAuthorizations.set(key, { kind: 'admin_chat_jwt', manager_key: key, assertion_id: input.assertionId, expires_at: input.expiresAt, generation: binding.generation })
+  }
+
+  async refreshForNonHumanWake(key: ManagerKey): Promise<void> {
+    const binding = this.bindings?.get(key)
+    if (binding?.kind === 'friend') await this.refreshFriendAuthorization(key)
+  }
+
+  async invalidateFriend(friendId: string): Promise<void> {
+    if (!this.bindings?.isInitialized()) return
+    await this.bindings.invalidateWhere(binding => binding.kind === 'friend' && binding.friend_id === friendId)
+    for (const [key, auth] of this.activeAuthorizations) if (auth.kind === 'friend_master' && auth.friend_id === friendId) this.activeAuthorizations.delete(key)
+    for (const [key, resolved] of this.resolved) if (resolved.principal.friend?.id === friendId) this.resolved.delete(key)
+  }
+
+  async validateMasterAuthorization(auth: MasterAuthorization): Promise<boolean> {
+    const current = this.currentMasterAuthorization(auth.manager_key)
+    if (!current || current.generation !== auth.generation || current.kind !== auth.kind) return false
+    if (auth.kind === 'admin_chat_jwt') {
+      return current.kind === 'admin_chat_jwt' && auth.assertion_id === current.assertion_id && Date.parse(auth.expires_at) > this.now().getTime()
+    }
+    const binding = this.bindings?.get(auth.manager_key)
+    if (!binding || binding.kind !== 'friend' || binding.friend_id !== auth.friend_id || binding.generation !== auth.generation) return false
+    try {
+      const friend = await this.deps.getFriend?.(auth.friend_id)
+      if (friend?.permission === 'master') return true
+    } catch {
+      // Lookup errors fail closed just like a missing/downgraded Friend.
+    }
+    await this.invalidateAuthorizationOnce(auth.manager_key, auth.generation)
+    return false
+  }
+
+  private async refreshFriendAuthorization(key: ManagerKey): Promise<void> {
+    const binding = this.bindings?.get(key)
+    if (!binding || binding.kind !== 'friend' || !binding.friend_id) {
+      this.activeAuthorizations.delete(key)
+      return
+    }
+    try {
+      const friend = await this.deps.getFriend?.(binding.friend_id)
+      if (friend?.permission === 'master') {
+        this.activeAuthorizations.set(key, { kind: 'friend_master', manager_key: key, friend_id: binding.friend_id, generation: binding.generation })
+        return
+      }
+    } catch {
+      // fall through to the one-time invalidation below
+    }
+    await this.invalidateAuthorizationOnce(key, binding.generation)
+  }
+
+  private async invalidateAuthorizationOnce(key: ManagerKey, generation: number): Promise<void> {
+    const current = this.bindings?.get(key)
+    const active = this.activeAuthorizations.get(key)
+    this.activeAuthorizations.delete(key)
+    // A prior failed validation already bumped the persisted generation; repeated
+    // non-human wakes remain fail-closed without a write storm.
+    if (!current || current.generation !== generation || !active || active.generation !== generation) return
+    await this.bindings?.bump(key)
   }
 
   /** 该 key 最近一次解析结果;从未收到过人类消息则 undefined。 */

--- a/crabot-agent/src/manager/principal.ts
+++ b/crabot-agent/src/manager/principal.ts
@@ -1,10 +1,10 @@
 /**
  * 人类消息发起人身份 —— 解析、按 key 缓存,以及由它派生的四样东西
- * (protocol-agent-v3.md §3 台账聚合键、§4.2/§4.3 对话对象档案与记忆档位、§8.2 权限身份)。
+ * (protocol-agent-v3.md §4.3 对话对象档案与记忆档位、§8.2 权限身份)。
  *
  * ## 为什么需要单独一层
  *
- * `ManagerRegistryDeps` 的 `dialogObjectIdFor` / `toolFace` / `promptInputs` 全是**同步**
+ * `ManagerRegistryDeps` 的 `toolFace` / `promptInputs` 全是**同步**
  * 签名——它们被 `ManagerLoop` 每轮 turn 同步调用(`EngineOptions.systemPrompt` 的 Resolvable
  * 必须同步)。而这几样东西的原料都是异步 RPC:admin 的 `resolve_principal_permissions`、
  * admin 的 `get_session_config`、memory 的 `get_scene_profile`。
@@ -14,23 +14,18 @@
  * `channel.message_authorized` 的 payload 自带完整 `friend` 对象,而入站点本来就在 async
  * 上下文里。缺的从来不是"能不能拿到 friend",只是"没有把它往下传"。
  *
- * ## 三个消费者
+ * ## 两个消费者
  *
- * 1. **台账聚合键**(`dialogObjectIdFor`):私聊必须收敛成 `friend:<friend_id>`,同一个人
- *    跨 channel 共享一份 worker 台账;群聊是 `group:<channel>:<session>`;系统线程归
- *    master 的对话对象——否则 master 在私聊里问进度时看不到系统线程派出的 worker(§4.4)。
- * 2. **记忆档位**(`ResolvedPrincipal.memory`):决定 manager 与它派出的 worker 写记忆时
+ * 1. **记忆档位**(`ResolvedPrincipal.memory`):决定 manager 与它派出的 worker 写记忆时
  *    的 visibility / scopes。放着不管的现状是 `{visibility:'public', scopes:[]}`
  *    ——群 A 的对话会以 public 落记忆、群 B 读得到,是跨会话信息泄漏。
- * 3. **权限档位**(`ResolvedPrincipal.permissions`):manager 算好、随 spawn 下传给 worker
+ * 2. **权限档位**(`ResolvedPrincipal.permissions`):manager 算好、随 spawn 下传给 worker
  *    (§8.2)。**worker 不需要知道 friend 是谁**,它只拿到一份算好的 `ResolvedPermissions`。
  *
  * @see crabot-docs/protocols/protocol-agent-v3.md §3、§4.3、§4.4、§8.2
  */
 
 import type { Friend, MemoryPermissions, ResolvedPermissions, RuntimeSceneProfile } from '../types.js'
-import { dialogObjectIdForGroup, dialogObjectIdForPrivate } from '../workers/harness/ledger-types.js'
-import type { DialogObjectId } from '../workers/harness/ledger-types'
 import type { ManagerKey } from './types.js'
 
 /**
@@ -149,8 +144,6 @@ export interface PrincipalResolverDeps {
   }) => Promise<RuntimeSceneProfile | null>
   /** crab 在该 channel 的 @handle(入站事件已缓存,同步读)。 */
   readonly crabSelfHandle: (channelId: string) => string | undefined
-  /** master 的 friend id(系统线程台账归档键);未知返回 undefined。 */
-  readonly masterFriendId: () => Promise<string | undefined>
 }
 
 /**
@@ -162,13 +155,8 @@ export interface PrincipalResolverDeps {
  */
 export class ManagerPrincipalStore {
   private readonly resolved = new Map<ManagerKey, ResolvedPrincipal>()
-  /** master friend id 是实例级常量,解析一次即长期有效;未解析出来之前为 undefined。 */
-  private masterFriendId: string | undefined
 
-  constructor(
-    private readonly deps: PrincipalResolverDeps,
-    private readonly systemThreadKey: ManagerKey,
-  ) {}
+  constructor(private readonly deps: PrincipalResolverDeps) {}
 
   /**
    * 唤醒边界解析:把 friend 变成权限 / 记忆档位 / 对话对象档案,写进缓存。
@@ -234,47 +222,11 @@ export class ManagerPrincipalStore {
       ...(dialogProfile ? { dialogProfile } : {}),
     }
     this.resolved.set(key, entry)
-
-    // 顺带把 master friend id 刷出来(系统线程的台账归档键要用)。它是实例级常量,
-    // 解析成功一次就长期有效;失败只是让系统线程暂时退回旧的 group 形状,不影响本次唤醒。
-    if (this.masterFriendId === undefined) {
-      try {
-        this.masterFriendId = await this.deps.masterFriendId()
-      } catch (err) {
-        console.warn('[manager-principal] 解析 master friend id 失败,系统线程台账暂用旧归档键:', err)
-      }
-    }
-
     return entry
   }
 
   /** 该 key 最近一次解析结果;从未收到过人类消息则 undefined。 */
   get(key: ManagerKey): ResolvedPrincipal | undefined {
     return this.resolved.get(key)
-  }
-
-  /**
-   * 台账聚合键(§3)。三条规则:
-   *
-   * 1. **系统线程** → `friend:<master_id>`。§4.4 要求未配目标 session 的 scheduled 任务
-   *    台账归 master 对话对象,否则 master 在私聊里问进度时看不到这些 worker。
-   *    master id 尚未解析出来时**退回旧的 group 形状**——不猜、不阻塞。
-   * 2. **私聊** → `friend:<friend_id>`,同一个人跨 channel 共享一份台账。
-   * 3. **群聊 / 身份未知** → `group:<channel>:<session>`。
-   */
-  dialogObjectIdFor(key: ManagerKey): DialogObjectId {
-    const { channelId, sessionId } = splitManagerKey(key)
-
-    if (key === this.systemThreadKey) {
-      return this.masterFriendId
-        ? dialogObjectIdForPrivate(this.masterFriendId)
-        : dialogObjectIdForGroup(channelId, sessionId)
-    }
-
-    const entry = this.resolved.get(key)
-    if (entry?.principal.sessionType === 'private' && entry.principal.friend) {
-      return dialogObjectIdForPrivate(entry.principal.friend.id)
-    }
-    return dialogObjectIdForGroup(channelId, sessionId)
   }
 }

--- a/crabot-agent/src/manager/prompt.ts
+++ b/crabot-agent/src/manager/prompt.ts
@@ -1,10 +1,9 @@
 /**
  * Manager system prompt 装配 —— protocol-agent-v3.md §4.2/§4.3。
  *
- * 结构按缓存前缀稳定性排序：静态身份段（+ 系统线程专属纪律）→ 对话对象档案 →
- * 动态状态块（台账渲染 / 当前时间 / 待处理通知，置于末尾，不进缓存前缀）。
- * 滚动摘要块与最近 K 条原始消息不在本文件职责内——由 messages 数组承载
- * （见 §4.2「上下文结构」，Task 2 的压缩产物），本文件只负责 system prompt 本身。
+ * 结构按稳定性排序：静态身份段（+ 系统线程专属纪律）→ 对话对象档案。
+ * 每轮变化的 worker 台账、当前时间与通知必须通过 wake event 或工具结果进入消息尾部，
+ * 不得进入 system prompt。
  *
  * @see crabot-docs/protocols/protocol-agent-v3.md §4.2 §4.3
  */
@@ -16,17 +15,10 @@ export interface PromptInputs {
   readonly isSystemThread: boolean
   /** 对话对象档案：friend 资料/权限/关系要点（来自 ContextAssembler 的 scene_profile 或 admin） */
   readonly dialogProfile?: string
-  /** 动态状态块素材 */
-  readonly dynamic: {
-    readonly ledgerRender: string
-    readonly nowIso: string
-    readonly pendingNotes?: ReadonlyArray<string>
-  }
 }
 
 /**
- * 静态段（身份 + crabot 架构自述 + 管家纪律）：进程内常量，同一版本恒定，
- * 不随 managerKey / dialogProfile / dynamic 变化——这是前缀缓存命中的基础。
+ * 静态段（身份 + crabot 架构自述 + 管家纪律）：进程内常量，同一版本恒定。
  */
 export const MANAGER_IDENTITY = `## 你是 Crabot 的 manager
 
@@ -81,36 +73,9 @@ function buildDialogProfileSection(dialogProfile: string): string {
   return `## 对话对象档案\n\n${dialogProfile}`
 }
 
-function buildDynamicBlock(dynamic: PromptInputs['dynamic']): string {
-  const notes =
-    dynamic.pendingNotes && dynamic.pendingNotes.length > 0
-      ? dynamic.pendingNotes.map(n => `- ${n}`).join('\n')
-      : '（无）'
-
-  return `---
-
-## 当前状态（动态，不进缓存前缀）
-
-### 台账
-
-${dynamic.ledgerRender}
-
-### 当前时间
-
-${dynamic.nowIso}
-
-### 待处理通知
-
-${notes}`
-}
-
 /**
- * 按缓存稳定性排序装配：静态（身份 + [系统线程 reach_master 纪律]）→ 档案 →
- * 动态块置尾。滚动摘要与最近消息由 messages 承载，不进 system prompt。
- *
- * 前缀稳定性：只改 `dynamic` 时，输出中动态块之前的部分逐字节不变——实现上
- * 动态块整体在末尾追加，前面各段只依赖 managerKey/isSystemThread/dialogProfile。
- * managerKey 在静态段内用 {{managerKey}} 占位符，装配时替换为实际值，不破坏前缀稳定性。
+ * 按稳定性排序装配：静态（身份 + [系统线程 reach_master 纪律]）→ 档案。
+ * 滚动摘要与带时间的 wake event 由 messages 承载，不进 system prompt。
  */
 export function assembleManagerSystemPrompt(inputs: PromptInputs): string {
   // 先把身份段中的 {{managerKey}} 占位符替换成实际值
@@ -125,8 +90,6 @@ export function assembleManagerSystemPrompt(inputs: PromptInputs): string {
   if (inputs.dialogProfile) {
     parts.push(buildDialogProfileSection(inputs.dialogProfile))
   }
-
-  parts.push(buildDynamicBlock(inputs.dynamic))
 
   return parts.join('\n\n')
 }

--- a/crabot-agent/src/manager/read-model.ts
+++ b/crabot-agent/src/manager/read-model.ts
@@ -30,7 +30,7 @@
  */
 
 import type { PaginationParams, PaginatedResult } from 'crabot-shared'
-import type { DialogObjectId, LedgerWorker, TaskStatus } from '../workers/harness/ledger-types.js'
+import type { ManagerKey, LedgerWorker, TaskStatus } from '../workers/harness/ledger-types.js'
 import type { NormalizedTraceEvent } from '../workers/types.js'
 
 /**
@@ -51,7 +51,7 @@ export interface TimeRange {
 /** §8.3 list_workers_admin:跨对话对象扁平查询 */
 export interface ListWorkersAdminParams {
   status?: TaskStatus | TaskStatus[]
-  dialog_object_id?: DialogObjectId
+  manager_key?: ManagerKey
   time_range?: TimeRange
   pagination?: PaginationParams
 }
@@ -109,10 +109,10 @@ export interface GetWorkerTraceResult {
 
 /**
  * 台账条目 + 它所属的对话对象 —— `LedgerStore.listAllWorkers()` / `findWorker()` 的返回元素形状。
- * `dialogObjectId` 只用于过滤,不出现在协议返回体里(§8.3 的 items 是 `LedgerWorker`)。
+ * `managerKey` 只用于过滤,不出现在协议返回体里(§8.3 的 items 是 `LedgerWorker`)。
  */
 export interface LedgerWorkerEntry {
-  dialogObjectId: DialogObjectId
+  managerKey: ManagerKey
   worker: LedgerWorker
 }
 
@@ -162,7 +162,7 @@ export function filterAndPageWorkers(
   // filter 总是产出新数组,后面的 sort 不会污染入参
   const matched = all.filter((entry) => {
     if (statuses && !statuses.includes(entry.worker.task.status)) return false
-    if (params.dialog_object_id && entry.dialogObjectId !== params.dialog_object_id) return false
+    if (params.manager_key && entry.managerKey !== params.manager_key) return false
     if (hasRange) {
       // created_at 缺失(脏台账)时无法证明落在窗口内,按不命中处理
       const createdAt = entry.worker.task.created_at
@@ -202,7 +202,7 @@ export function filterAndPageWorkers(
  * 台账条目 → §8.3 的 `GetWorkerDetailResult`。
  *
  * 详情就是台账条目本身(含完整化身链),不做任何计算或裁剪——v3 里 agent 即真相源,台账结构
- * (§3)本身就是对外契约。这里只负责剥掉 `LedgerStore.findWorker` 附带的 `dialogObjectId`
+ * (§3)本身就是对外契约。这里只负责剥掉 `LedgerStore.findWorker` 附带的 `managerKey`
  * 包装:它是查找的副产物,不在协议返回体里(调用方要用的话自己留着)。
  */
 export function buildWorkerDetail(found: LedgerWorkerEntry): GetWorkerDetailResult {

--- a/crabot-agent/src/manager/read-model.ts
+++ b/crabot-agent/src/manager/read-model.ts
@@ -91,6 +91,7 @@ export interface ReadWorkerOutputAdminResult {
   chunk: string
   next_cursor: string
   eof: boolean
+  unavailable_reason?: string
 }
 
 /** §8.3 get_worker_trace:结构化时间线(两层信息源见 §10.2) */

--- a/crabot-agent/src/manager/registry.ts
+++ b/crabot-agent/src/manager/registry.ts
@@ -147,6 +147,8 @@ export interface ManagerRegistryDeps {
     key: ManagerKey,
     principal: HumanPrincipal,
   ) => Promise<ResolvedPermissions | null | void>
+  /** Refreshes durable Friend authorization before a non-human/self wake exposes tools. */
+  readonly beforeWake?: (key: ManagerKey, wake: WakeEvent | undefined) => Promise<void>
   /**
    * **scheduled 唤醒边界**的异步解析钩子(PR #59 review):`routeSchedule` 在 `runWake` 之前
    * await 它一次,按 §4.4"权限按 `Schedule.creator_friend_id` 解析(`is_builtin` 按 master
@@ -463,6 +465,7 @@ export class ManagerRegistry {
    * `ManagerLoop.drainMailbox`);`selfWakeChain` 是当前连锁自唤醒的深度,真实唤醒恒为 0。
    */
   private async runWake(key: ManagerKey, event: WakeEvent | undefined, selfWakeChain = 0): Promise<EpisodeResult> {
+    if (this.deps.beforeWake) await this.deps.beforeWake(key, event)
     const loop = this.getOrCreate(key)
     this.activeEpisodes.set(key, (this.activeEpisodes.get(key) ?? 0) + 1)
     let result: EpisodeResult | undefined

--- a/crabot-agent/src/manager/registry.ts
+++ b/crabot-agent/src/manager/registry.ts
@@ -56,7 +56,6 @@ import type { ManagerKey } from './types.js'
 import type { EngineMessage, LLMAdapter, ToolDefinition } from '../engine/index.js'
 import type { WorkerHarness } from '../workers/harness/harness'
 import type { LedgerStore } from '../workers/harness/ledger-store'
-import type { DialogObjectId } from '../workers/harness/ledger-types'
 import type { HarnessEvent, HarnessEventKind } from '../workers/harness/worker-events'
 import type { ChannelMessage, Friend, ResolvedPermissions } from '../types'
 import type { HumanPrincipal } from './principal.js'
@@ -124,18 +123,18 @@ export interface ManagerRegistryDeps {
   /** 人类消息渲染的时区(见 `ManagerLoopDeps.timezone`);不注入则退回 `resolveTimezone(undefined)`。 */
   readonly timezone?: () => string
   /**
-   * `ManagerKey` → 台账渲染用的 `DialogObjectId`(`ManagerLoopDeps.dialogObjectId`)。
+   * `ManagerKey` → 台账渲染用的 `ManagerKey`(`ManagerLoopDeps.managerKey`)。
    * 两者粒度不同(manager 按 channel::session,worker 台账按 friend 跨 channel 聚合/单群),
    * 这层映射依赖 friend 解析等本模块无法自行完成的信息,由调用方按 protocol §3 解析好注入。
    *
    * **每次读都要现算**:私聊的归档键要等第一条人类消息带来 friend 之后才能收敛成
    * `friend:<id>`(见 `onHumanWake`),调用方持有的映射会随之变化。
    */
-  readonly dialogObjectIdFor: (key: ManagerKey) => DialogObjectId
+  readonly managerKeyFor: (key: ManagerKey) => ManagerKey
   /**
    * **人类消息唤醒边界**的异步解析钩子:`routeHumanMessages` 在 `runWake` 之前 await 它一次,
    * 调用方据 `principal`(发起人 friend + 私/群)解析权限、记忆档位、对话对象档案并缓存,
-   * 供下面那三个**同步** thunk(`dialogObjectIdFor` / `toolFace` / `promptInputs`)读取。
+   * 供下面那三个**同步** thunk(`managerKeyFor` / `toolFace` / `promptInputs`)读取。
    *
    * 这是"加参数而不是全面异步化"的落点:异步只发生在唤醒边界这一处,每轮 turn 被同步调用的
    * 签名一个都不用改。不注入则行为与之前逐字相同(manager 拿不到发起人身份)。
@@ -223,10 +222,9 @@ export class ManagerRegistry {
     const loopDeps: ManagerLoopDeps = {
       key,
       isSystemThread,
-      // thunk 而非定值:私聊的台账归档键要等第一条人类消息带来 friend 才收敛成
-      // `friend:<id>`,而 loop 实例可能先被 worker 事件建出来。定值会把那一刻的
-      // group 形状永久钉死在实例上,同一个人的台账因此裂成两份。
-      dialogObjectId: () => this.deps.dialogObjectIdFor(key),
+      // ManagerKey 是 worker 的固定台账归属。使用 thunk 只为保持 ManagerLoop 的
+      // 同步依赖注入形状，不从当前 principal 派生或改写会话归属。
+      managerKey: () => this.deps.managerKeyFor(key),
       store: this.deps.store,
       policy: this.deps.policy,
       estimateTokens: this.deps.estimateTokens,
@@ -334,13 +332,13 @@ export class ManagerRegistry {
   }
 
   /**
-   * harness 事件 → 该 worker 的监护 manager(台账 `origin.spawned_by_session`);查不到则落
-   * 系统线程。注意:这里解出的 manager 与该 worker 台账所属的 `DialogObjectId` 可以是两个
+   * harness 事件 → 该 worker 的监护 manager(台账 `origin.manager_key`);查不到则落
+   * 系统线程。注意:这里解出的 manager 与该 worker 台账所属的 `ManagerKey` 可以是两个
    * 不同的对话对象(同一 friend 跨 channel 共享台账)——这是设计意图,不是需要修正的不一致。
    */
   async routeWorkerEvent(event: HarnessEvent): Promise<EpisodeResult | undefined> {
     const found = await this.deps.ledger.findWorker(event.worker_id)
-    const key = found?.worker.origin.spawned_by_session ?? SYSTEM_TASKS_MANAGER_KEY
+    const key = found?.worker.manager_key ?? SYSTEM_TASKS_MANAGER_KEY
     return this.runWake(key, { kind: 'worker_event', event })
   }
 

--- a/crabot-agent/src/manager/registry.ts
+++ b/crabot-agent/src/manager/registry.ts
@@ -49,7 +49,7 @@
  * @see crabot-docs/protocols/protocol-agent-v3.md §4.4
  */
 
-import { ManagerLoop, type WakeEvent, type EpisodeResult, type ManagerLoopDeps } from './loop.js'
+import { ManagerLoop, type WakeEvent, type TimedWakeEnvelope, type EpisodeResult, type ManagerLoopDeps } from './loop.js'
 import type { ManagerSessionStore } from './session-store.js'
 import type { CompactionPolicy } from './compaction.js'
 import type { ManagerKey } from './types.js'
@@ -59,6 +59,7 @@ import type { LedgerStore } from '../workers/harness/ledger-store'
 import type { HarnessEvent, HarnessEventKind } from '../workers/harness/worker-events'
 import type { ChannelMessage, Friend, ResolvedPermissions } from '../types'
 import type { HumanPrincipal } from './principal.js'
+import { resolveTimezone } from '../utils/time.js'
 
 /** §4.4 保留线程:未配置目标 session 的 scheduled 触发 / 台账查不到监护 session 的 worker 事件落此。 */
 export const SYSTEM_TASKS_MANAGER_KEY = 'admin-web::system-tasks' as ManagerKey
@@ -148,7 +149,7 @@ export interface ManagerRegistryDeps {
     principal: HumanPrincipal,
   ) => Promise<ResolvedPermissions | null | void>
   /** Refreshes durable Friend authorization before a non-human/self wake exposes tools. */
-  readonly beforeWake?: (key: ManagerKey, wake: WakeEvent | undefined) => Promise<void>
+  readonly beforeWake?: (key: ManagerKey, envelope: TimedWakeEnvelope | undefined) => Promise<void>
   /**
    * **scheduled 唤醒边界**的异步解析钩子(PR #59 review):`routeSchedule` 在 `runWake` 之前
    * await 它一次,按 §4.4"权限按 `Schedule.creator_friend_id` 解析(`is_builtin` 按 master
@@ -189,8 +190,8 @@ export interface ManagerRegistryDeps {
     humanPrincipal?: HumanPrincipal,
     principalPermissions?: ResolvedPermissions
   ) => ReadonlyArray<ToolDefinition>
-  /** system prompt 动态段素材(档案/待处理通知),每轮重算,由调用方决定要不要按最新状态重建。 */
-  readonly promptInputs: (key: ManagerKey) => { readonly dialogProfile?: string; readonly pendingNotes?: ReadonlyArray<string> }
+  /** Stable system prompt profile material. */
+  readonly promptInputs: (key: ManagerKey) => { readonly dialogProfile?: string }
 }
 
 export class ManagerRegistry {
@@ -274,7 +275,8 @@ export class ManagerRegistry {
     messages: ReadonlyArray<ChannelMessage>,
     friend?: Friend
   ): Promise<EpisodeResult> {
-    return this.routeHumanWake('human_messages', channelId, sessionId, messages, friend)
+    const capture = this.captureIngress()
+    return this.routeHumanWake(capture, 'human_messages', channelId, sessionId, messages, friend)
   }
 
   /**
@@ -295,11 +297,13 @@ export class ManagerRegistry {
     messages: ReadonlyArray<ChannelMessage>,
     friend?: Friend
   ): Promise<EpisodeResult> {
-    return this.routeHumanWake('attention_flush', channelId, sessionId, messages, friend)
+    const capture = this.captureIngress()
+    return this.routeHumanWake(capture, 'attention_flush', channelId, sessionId, messages, friend)
   }
 
   /** 两个人类消息入口的公共路径:解析发起人身份(唤醒边界的唯一一次异步)→ 按 kind 造事件唤醒。 */
   private async routeHumanWake(
+    capture: IngressCapture,
     kind: 'human_messages' | 'attention_flush',
     channelId: string,
     sessionId: string,
@@ -311,8 +315,11 @@ export class ManagerRegistry {
     // 与 `handleMessageReceived` 的默认分流一致。
     const sessionType = messages[0]?.session.type === 'group' ? 'group' : 'private'
     const principal: HumanPrincipal = { ...(friend ? { friend } : {}), sessionType }
-
-    // 唤醒边界的唯一一次异步解析。失败不阻断投递——人类消息比档位重要,档位缺失
+    const initialWake: WakeEvent = kind === 'human_messages'
+      ? { kind: 'human_messages', messages, ...(friend ? { friend } : {}) }
+      : { kind: 'attention_flush', messages, ...(friend ? { friend } : {}) }
+    // Capture before principal lookup so queueing cannot rewrite ingress time.
+    const envelope = this.makeEnvelope(capture, initialWake, undefined, messages)
     // 只会退回 fail-soft 兜底,而消息丢了就是丢了。
     let principalPermissions: ResolvedPermissions | undefined
     if (this.deps.onHumanWake) {
@@ -330,7 +337,7 @@ export class ManagerRegistry {
       kind === 'human_messages'
         ? { kind: 'human_messages', messages, ...withFriend, ...withPerms }
         : { kind: 'attention_flush', messages, ...withFriend, ...withPerms }
-    return this.runWake(key, event)
+    return this.runWake(key, { ...envelope, wake: event })
   }
 
   /**
@@ -339,20 +346,24 @@ export class ManagerRegistry {
    * 不同的对话对象(同一 friend 跨 channel 共享台账)——这是设计意图,不是需要修正的不一致。
    */
   async routeWorkerEvent(event: HarnessEvent): Promise<EpisodeResult | undefined> {
+    const capture = this.captureIngress()
+    const envelope = this.makeEnvelope(capture, { kind: 'worker_event', event }, event.ts)
     const found = await this.deps.ledger.findWorker(event.worker_id)
     const key = found?.worker.manager_key ?? SYSTEM_TASKS_MANAGER_KEY
-    return this.runWake(key, { kind: 'worker_event', event })
+    return this.runWake(key, envelope)
   }
 
   async routeMediaNotification(p: {
     channelId: string
     sessionId: string
     text: string
+    occurredAt?: string
   }): Promise<EpisodeResult> {
+    const capture = this.captureIngress()
+    const envelope = this.makeEnvelope(capture, { kind: 'media_notification', text: p.text }, p.occurredAt)
     const key = `${p.channelId}::${p.sessionId}` as ManagerKey
-    const event: WakeEvent = { kind: 'media_notification', text: p.text }
     if (this.isEpisodeActive(key)) {
-      this.getOrCreate(key).enqueueDuringEpisode(event)
+      this.getOrCreate(key).enqueueDuringEpisode(envelope)
       return {
         episodeId: '',
         outcome: 'completed',
@@ -361,7 +372,7 @@ export class ManagerRegistry {
         repliedToHuman: false,
       }
     }
-    return this.runWake(key, event)
+    return this.runWake(key, envelope)
   }
 
   /**
@@ -379,9 +390,18 @@ export class ManagerRegistry {
     creatorFriendId?: string
     isBuiltin?: boolean
   }): Promise<EpisodeResult> {
+    const capture = this.captureIngress()
     const key = p.targetSession
       ? (`${p.targetSession.channel_id}::${p.targetSession.session_id}` as ManagerKey)
       : SYSTEM_TASKS_MANAGER_KEY
+    const envelope = this.makeEnvelope(capture, {
+      kind: 'schedule',
+      scheduleId: p.scheduleId,
+      title: p.title,
+      description: p.description,
+      creatorFriendId: p.creatorFriendId,
+      isBuiltin: p.isBuiltin,
+    })
 
     // 调度自己的权限身份在唤醒边界解析一次(§4.4),随事件走。**绝不能退回该 key 的会话级
     // 缓存**:打进人类会话的调度会因此拿到"那个会话最近谁在说话"的档位(PR #59 review)。
@@ -401,13 +421,11 @@ export class ManagerRegistry {
     }
 
     return this.runWake(key, {
-      kind: 'schedule',
-      scheduleId: p.scheduleId,
-      title: p.title,
-      description: p.description,
-      creatorFriendId: p.creatorFriendId,
-      isBuiltin: p.isBuiltin,
-      ...(principalPermissions ? { principalPermissions } : {}),
+      ...envelope,
+      wake: {
+        ...envelope.wake,
+        ...(principalPermissions ? { principalPermissions } : {}),
+      },
     })
   }
 
@@ -444,14 +462,46 @@ export class ManagerRegistry {
 
   /** query_worker 异步失败 → 唤醒信号(见文件头"onAsyncError 出口"一节)。 */
   private handleAsyncToolError(key: ManagerKey, info: AsyncToolErrorInfo): void {
-    const event = buildAsyncErrorWakeEvent(info, this.deps.now())
+    const capture = this.captureIngress()
+    const envelope = this.makeEnvelope(
+      capture,
+      buildAsyncErrorWakeEvent(info, capture.now),
+      capture.now.toISOString(),
+    )
     if (this.isEpisodeActive(key)) {
-      this.getOrCreate(key).enqueueDuringEpisode(event)
+      this.getOrCreate(key).enqueueDuringEpisode(envelope)
       return
     }
-    void this.runWake(key, event).catch((err) => {
+    void this.runWake(key, envelope).catch((err) => {
       console.error(`[ManagerRegistry] onAsyncError 唤醒 manager '${key}' 失败:`, err)
     })
+  }
+
+  private captureIngress(): IngressCapture {
+    const now = this.deps.now()
+    const timezone = this.deps.timezone?.() ?? resolveTimezone(undefined)
+    return { now, timezone, received_at: formatOffsetIso(now, timezone) }
+  }
+
+  private makeEnvelope(
+    capture: IngressCapture,
+    wake: WakeEvent,
+    occurredAt?: string,
+    humanMessages?: ReadonlyArray<ChannelMessage>,
+  ): TimedWakeEnvelope {
+    const occurred_at = parseOccurredAt(occurredAt, 'source')
+    const human_occurred_at = humanMessages?.map((message) => ({
+      ...(message.platform_message_id ? { message_id: message.platform_message_id } : {}),
+      ...toHumanOccurredAt(message.platform_timestamp),
+    }))
+
+    return {
+      wake,
+      received_at: capture.received_at,
+      timezone: capture.timezone,
+      ...(occurred_at ? { occurred_at } : {}),
+      ...(human_occurred_at ? { human_occurred_at } : {}),
+    }
   }
 
   /** 该 key 是否还有至少一个在途 episode(引用计数 > 0)。 */
@@ -464,13 +514,13 @@ export class ManagerRegistry {
    * 自唤醒都走这里。`event === undefined` ⇒ 自唤醒(只处理 mailbox 残留,见
    * `ManagerLoop.drainMailbox`);`selfWakeChain` 是当前连锁自唤醒的深度,真实唤醒恒为 0。
    */
-  private async runWake(key: ManagerKey, event: WakeEvent | undefined, selfWakeChain = 0): Promise<EpisodeResult> {
-    if (this.deps.beforeWake) await this.deps.beforeWake(key, event)
+  private async runWake(key: ManagerKey, envelope: TimedWakeEnvelope | undefined, selfWakeChain = 0): Promise<EpisodeResult> {
+    if (this.deps.beforeWake) await this.deps.beforeWake(key, envelope)
     const loop = this.getOrCreate(key)
     this.activeEpisodes.set(key, (this.activeEpisodes.get(key) ?? 0) + 1)
     let result: EpisodeResult | undefined
     try {
-      result = await (event === undefined ? loop.drainMailbox() : loop.wakeUp(event))
+      result = await (envelope === undefined ? loop.drainMailbox() : loop.wakeUp(envelope))
       return result
     } finally {
       const remaining = (this.activeEpisodes.get(key) ?? 1) - 1
@@ -571,4 +621,52 @@ function buildAsyncErrorWakeEvent(info: AsyncToolErrorInfo, now: Date): WakeEven
     detail: { tool: info.tool, error: info.error, synthetic: true },
   }
   return { kind: 'worker_event', event }
+}
+
+interface IngressCapture {
+  readonly now: Date
+  readonly timezone: string
+  readonly received_at: string
+}
+
+function parseOccurredAt(value: unknown, source: string): string | undefined {
+  if (value === undefined || validIso(value)) return value
+  console.warn(`[ManagerRegistry] invalid ${source} occurred_at omitted`)
+  return undefined
+}
+
+function toHumanOccurredAt(platformTimestamp: unknown): { readonly occurred_at?: string } {
+  const occurred_at = parseOccurredAt(platformTimestamp, 'human platform_timestamp')
+  return occurred_at ? { occurred_at } : {}
+}
+
+function validIso(value: unknown): value is string {
+  return typeof value === 'string' && Number.isFinite(Date.parse(value))
+}
+
+/** ISO 8601 with seconds and numeric offset, fixed exactly at registry ingress. */
+function formatOffsetIso(date: Date, timezone: string): string {
+  const formatter = new Intl.DateTimeFormat('en-CA', {
+    timeZone: timezone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hourCycle: 'h23',
+    timeZoneName: 'longOffset',
+  })
+  const parts = formatter.formatToParts(date)
+  const part = (type: string): string | undefined =>
+    parts.find((item) => item.type === type)?.value
+  const offset = part('timeZoneName')?.replace('GMT', '') || '+00:00'
+  const normalizedOffset = offset === '+00:00' || offset === '-00:00'
+    ? '+00:00'
+    : offset
+
+  return [
+    `${part('year')}-${part('month')}-${part('day')}`,
+    `${part('hour')}:${part('minute')}:${part('second')}${normalizedOffset}`,
+  ].join('T')
 }

--- a/crabot-agent/src/manager/session-store.ts
+++ b/crabot-agent/src/manager/session-store.ts
@@ -4,8 +4,8 @@
  * in-flight 诊断日志。参照 src/workers/harness/ledger-store.ts 的写法:tmp+rename 保
  * 落盘原子性,一把互斥锁保读-改-写/并发写安全。
  *
- * 目录名编码复用 ledger-store 的 encodeSegment/decodeSegment(通用段编码,不与
- * DialogObjectId 的文件名格式绑定),处理 ManagerKey 里的 `::` 与其它非法字符。
+ * 目录名编码复用 ledger-store 的 encodeSegment/decodeSegment（通用段编码），处理
+ * ManagerKey 里的 `::` 与其它非法字符。
  */
 
 import { promises as fs } from 'fs'

--- a/crabot-agent/src/manager/tools/tool-face.ts
+++ b/crabot-agent/src/manager/tools/tool-face.ts
@@ -23,6 +23,7 @@ import type { CrabMessagingDeps, MessagingTool, MessagingToolSet } from '../../m
 import { buildWorkerTools } from './worker-tools.js'
 import type { WorkerHarness } from '../../workers/harness/harness'
 import { buildCrabotInfoTools } from './crabot-info.js'
+import type { MasterAuthorization } from '../principal.js'
 
 export interface ToolFaceDeps {
   readonly harness: WorkerHarness
@@ -34,6 +35,9 @@ export interface ToolFaceDeps {
   readonly callAdmin: <P, R>(m: string, p: P) => Promise<R>
   /** 该 manager 是否为保留的"系统任务"线程（决定 send_master_private / send_private_message 可见性）。 */
   readonly isSystemThread: boolean
+  /** Opaque control-plane authorization, never represented in any tool schema. */
+  readonly authorization?: () => MasterAuthorization | undefined
+  readonly validateMasterAuthorization?: (auth: MasterAuthorization) => Promise<boolean>
   /**
    * query_worker 异步失败出口（Task 4 留口、Task 8 接线）：原样透传给 `buildWorkerTools` 的
    * `WorkerToolsDeps.onAsyncError`——真正的绑定逻辑（按 key 决定 enqueueDuringEpisode 还是
@@ -200,7 +204,13 @@ export function assertClosedToolFace(tools: readonly ToolDefinition[]): void {
 export function buildManagerToolFace(deps: ToolFaceDeps): ToolDefinition[] {
   const messagingTools = buildMessagingFace(deps)
   const memoryTools = mcpServerToToolDefinitions(deps.memoryServer, 'crab-memory')
-  const workerTools = buildWorkerTools({ harness: deps.harness, context: deps.workerContext, onAsyncError: deps.onAsyncError })
+  const workerTools = buildWorkerTools({
+    harness: deps.harness,
+    context: deps.workerContext,
+    authorization: deps.authorization,
+    validateMasterAuthorization: deps.validateMasterAuthorization,
+    onAsyncError: deps.onAsyncError,
+  })
   const infoTools = buildCrabotInfoTools({ callAdmin: deps.callAdmin })
 
   const tools = [...messagingTools, ...memoryTools, ...workerTools, ...infoTools]

--- a/crabot-agent/src/manager/tools/worker-tools.ts
+++ b/crabot-agent/src/manager/tools/worker-tools.ts
@@ -59,6 +59,7 @@ import type { ManagerKey, LedgerWorker, TaskStatus } from '../../workers/harness
 import type { MasterAuthorization } from '../principal.js'
 import type { WorkerImplId } from '../../workers/types'
 import type { ResolvedPermissions } from '../../types'
+import type { LegacyContinuationAuth } from '../../workers/harness/legacy-continuation-auth.js'
 
 export interface WorkerToolsContext {
   /** Current manager session: worker owner and list_workers scope. */
@@ -78,6 +79,8 @@ export interface WorkerToolsContext {
   readonly principalPermissions?: ResolvedPermissions
   /** 结果回报目标,默认 = 当前 session(protocol-agent-v3 §3)。 */
   readonly reportTo: { channel_id: string; session_id: string }
+  /** Opaque credential factory; only legacy terminal continuation consumes its result. */
+  readonly legacyContinuationAuth?: (managerKey: ManagerKey) => LegacyContinuationAuth | undefined
   /**
    * 本次唤醒的触发来源,填入 `origin.trigger_type`;缺省 'message'。给 scheduled 路由
    * (Task 8)/system 场景预留——本任务只加这个可选出口,不在这里做路由判断。
@@ -162,6 +165,7 @@ export function buildWorkerTools(deps: WorkerToolsDeps): ToolDefinition[] {
   // Capture exactly once: a tool definition belongs to one model turn. A later
   // regrant must not make an already-issued privileged closure usable again.
   const capturedAuthorization = authorization?.()
+  const capturedLegacyContinuationAuth = context().legacyContinuationAuth
 
   const masterAuthorized = async (): Promise<boolean> => {
     return !!capturedAuthorization && !!validateMasterAuthorization && await validateMasterAuthorization(capturedAuthorization)
@@ -270,8 +274,12 @@ export function buildWorkerTools(deps: WorkerToolsDeps): ToolDefinition[] {
       if (typeof text !== 'string' || text.length === 0) return invalid('send_to_worker: text 必填且为非空字符串')
 
       try {
-        await authorizeWorker(worker_id)
-        await harness.sendToWorker(worker_id, text, raw !== undefined ? { raw } : undefined)
+        const worker = await authorizeWorker(worker_id)
+        const legacyContinuationAuth = capturedLegacyContinuationAuth?.(worker.manager_key)
+        await harness.sendToWorker(worker_id, text, {
+          ...(raw !== undefined ? { raw } : {}),
+          ...(legacyContinuationAuth ? { legacyContinuationAuth } : {}),
+        })
         return ok({ status: 'sent', worker_id })
       } catch (error) {
         return mapError(`send_to_worker(${worker_id})`, error)

--- a/crabot-agent/src/manager/tools/worker-tools.ts
+++ b/crabot-agent/src/manager/tools/worker-tools.ts
@@ -55,14 +55,12 @@
 import { defineTool } from '../../engine/index.js'
 import type { ToolDefinition, ToolCallResult } from '../../engine/index.js'
 import type { WorkerHarness } from '../../workers/harness/harness'
-import type { DialogObjectId, ManagerKey, LedgerWorker } from '../../workers/harness/ledger-types'
+import type { ManagerKey, LedgerWorker } from '../../workers/harness/ledger-types'
 import type { WorkerImplId } from '../../workers/types'
 import type { ResolvedPermissions } from '../../types'
 
 export interface WorkerToolsContext {
-  /** 本次唤醒所属对话对象:决定 spawn 的台账归属与 `list_workers` 的查询范围。 */
-  readonly dialogObjectId: DialogObjectId
-  /** 当前 manager 实例键:填入 `origin.spawned_by_session`。 */
+  /** Current manager session: worker owner and list_workers scope. */
   readonly managerKey: ManagerKey
   /** 当前 episode 的 trace id(可跳转);填入 `origin.spawned_by_episode`。 */
   readonly episodeId?: string
@@ -88,7 +86,7 @@ export interface WorkerToolsContext {
 
 export interface WorkerToolsDeps {
   readonly harness: WorkerHarness
-  /** 当前 manager 的归属:决定 spawn 的 dialogObjectId / origin / report_to。 */
+  /** 当前 manager 的归属:决定 spawn 的 managerKey / origin / report_to。 */
   readonly context: () => WorkerToolsContext
   /**
    * P4 Task 4 additive 扩展点:`query_worker` 的游离 promise reject 时,除了
@@ -180,11 +178,10 @@ export function buildWorkerTools(deps: WorkerToolsDeps): ToolDefinition[] {
       const ctx = context()
       try {
         const worker: LedgerWorker = await harness.spawnWorker({
-          dialogObjectId: ctx.dialogObjectId,
+          managerKey: ctx.managerKey,
           title,
           prompt,
           origin: {
-            spawned_by_session: ctx.managerKey,
             spawned_by_episode: ctx.episodeId,
             creator_friend_id: ctx.creatorFriendId,
             // 缺省按最常见场景填 'message';scheduled/system 场景由 context() 提供
@@ -329,7 +326,7 @@ export function buildWorkerTools(deps: WorkerToolsDeps): ToolDefinition[] {
     isReadOnly: true,
     call: async (): Promise<ToolCallResult> => {
       try {
-        const workers = await harness.listWorkers(context().dialogObjectId)
+        const workers = await harness.listWorkers(context().managerKey)
         return ok({ workers })
       } catch (error) {
         return mapError('list_workers', error)

--- a/crabot-agent/src/manager/tools/worker-tools.ts
+++ b/crabot-agent/src/manager/tools/worker-tools.ts
@@ -1,7 +1,7 @@
 /**
  * worker 工具集 —— manager 唯一的 worker 编排入口(protocol-agent-v3 §4.1/§4.3/§5.5)。
  *
- * 六个工具全部是 `WorkerHarness`(P3 已合并,本模块只调用、不修改,唯一的 additive 例外见
+ * 七个工具全部是 `WorkerHarness`(P3 已合并,本模块只调用、不修改,唯一的 additive 例外见
  * `harness.readWorkerOutput` 的 `opts.seq` 参数)既有方法的薄封装:只负责
  * 1) 组装 harness 方法的入参(`spawn_worker` 据 `deps.context()` 填 `origin`/`report_to`);
  * 2) 把 harness 的返回值/异常转成 engine `ToolCallResult`——除 `query_worker`(见下)外,
@@ -46,7 +46,7 @@
  *
  * ## isReadOnly
  *
- * 只有 `read_worker_output`/`list_workers` 标 `isReadOnly: true`(供 engine 并行调度只读工具,
+ * 与 `read_worker_output`/`list_workers`/`get_worker_detail` 标 `isReadOnly: true`(供 engine 并行调度只读工具,
  * `partitionToolCalls`)。`kill_worker` 虽然同步返回,但会改变 worker/task 状态,不是只读。
  *
  * @see crabot-docs/protocols/protocol-agent-v3.md §4.1、§4.3、§5.5
@@ -55,7 +55,8 @@
 import { defineTool } from '../../engine/index.js'
 import type { ToolDefinition, ToolCallResult } from '../../engine/index.js'
 import type { WorkerHarness } from '../../workers/harness/harness'
-import type { ManagerKey, LedgerWorker } from '../../workers/harness/ledger-types'
+import type { ManagerKey, LedgerWorker, TaskStatus } from '../../workers/harness/ledger-types'
+import type { MasterAuthorization } from '../principal.js'
 import type { WorkerImplId } from '../../workers/types'
 import type { ResolvedPermissions } from '../../types'
 
@@ -88,6 +89,9 @@ export interface WorkerToolsDeps {
   readonly harness: WorkerHarness
   /** 当前 manager 的归属:决定 spawn 的 managerKey / origin / report_to。 */
   readonly context: () => WorkerToolsContext
+  /** Opaque authorization is captured by the control plane, never exposed in a tool schema/history. */
+  readonly authorization?: () => MasterAuthorization | undefined
+  readonly validateMasterAuthorization?: (auth: MasterAuthorization) => Promise<boolean>
   /**
    * P4 Task 4 additive 扩展点:`query_worker` 的游离 promise reject 时,除了
    * `console.error` 诊断日志外还调用这个可选回调。本任务只提供出口、不接线——`harness.
@@ -130,8 +134,46 @@ function isWorkerImplId(value: unknown): value is WorkerImplId {
   return typeof value === 'string' && (WORKER_IMPL_IDS as readonly string[]).includes(value)
 }
 
+function summarizeWorker(worker: LedgerWorker) {
+  const mainline = worker.incarnations.filter(inc => inc.forked_from === undefined).at(-1)
+  return {
+    worker_id: worker.worker_id,
+    manager_key: worker.manager_key,
+    title: worker.task.title,
+    task_status: worker.task.status,
+    ...(mainline ? { incarnation_state: mainline.state, impl: mainline.impl } : {}),
+    updated_at: worker.updated_at,
+  }
+}
+
+function sortSummaries<T extends { updated_at: string; worker_id: string }>(items: T[]): T[] {
+  return items.sort((a, b) => b.updated_at.localeCompare(a.updated_at) || a.worker_id.localeCompare(b.worker_id))
+}
+
+function normalizePagination(page: unknown, pageSize: unknown): { page: number; page_size: number } {
+  const valid = (value: unknown, fallback: number) => typeof value === 'number' && Number.isInteger(value) && value >= 1 ? value : fallback
+  return { page: valid(page, 1), page_size: Math.min(valid(pageSize, 20), 100) }
+}
+
+const ACCESS_DENIED = 'worker 不存在或当前会话无权访问'
+
 export function buildWorkerTools(deps: WorkerToolsDeps): ToolDefinition[] {
-  const { harness, context, onAsyncError } = deps
+  const { harness, context, authorization, validateMasterAuthorization, onAsyncError } = deps
+  // Capture exactly once: a tool definition belongs to one model turn. A later
+  // regrant must not make an already-issued privileged closure usable again.
+  const capturedAuthorization = authorization?.()
+
+  const masterAuthorized = async (): Promise<boolean> => {
+    return !!capturedAuthorization && !!validateMasterAuthorization && await validateMasterAuthorization(capturedAuthorization)
+  }
+
+  const authorizeWorker = async (workerId: string): Promise<LedgerWorker> => {
+    const found = await harness.findWorker(workerId)
+    if (!found) throw new Error(ACCESS_DENIED)
+    if (found.worker.manager_key === context().managerKey) return found.worker
+    if (!await masterAuthorized()) throw new Error(ACCESS_DENIED)
+    return found.worker
+  }
 
   // --- spawn_worker(异步:发起即返回,任务进展由事件唤醒) ---
   //
@@ -228,6 +270,7 @@ export function buildWorkerTools(deps: WorkerToolsDeps): ToolDefinition[] {
       if (typeof text !== 'string' || text.length === 0) return invalid('send_to_worker: text 必填且为非空字符串')
 
       try {
+        await authorizeWorker(worker_id)
         await harness.sendToWorker(worker_id, text, raw !== undefined ? { raw } : undefined)
         return ok({ status: 'sent', worker_id })
       } catch (error) {
@@ -271,6 +314,12 @@ export function buildWorkerTools(deps: WorkerToolsDeps): ToolDefinition[] {
       if (!worker_id || typeof worker_id !== 'string') return invalid('query_worker: worker_id 必填且为字符串')
       if (!question || typeof question !== 'string') return invalid('query_worker: question 必填且为字符串')
 
+      try {
+        // Authorization must settle before this fire-and-forget action is started.
+        await authorizeWorker(worker_id)
+      } catch (error) {
+        return mapError(`query_worker(${worker_id})`, error)
+      }
       harness.queryWorker(worker_id, question).catch((error) => {
         console.error(`[worker-tools] query_worker(${worker_id}) 后台发起失败(fire-and-forget):`, error)
         onAsyncError?.({ tool: 'query_worker', worker_id, error: error instanceof Error ? error.message : String(error) })
@@ -303,36 +352,71 @@ export function buildWorkerTools(deps: WorkerToolsDeps): ToolDefinition[] {
       if (!worker_id || typeof worker_id !== 'string') return invalid('read_worker_output: worker_id 必填且为字符串')
 
       try {
-        const { chunk, nextCursor } = await harness.readWorkerOutput(
+        await authorizeWorker(worker_id)
+        const { chunk, nextCursor, unavailable_reason } = await harness.readWorkerOutput(
           worker_id,
           { offset: offset ?? 0 },
           seq !== undefined ? { seq } : undefined
         )
-        return ok({ worker_id, chunk, next_offset: nextCursor.offset })
+        return ok({ worker_id, chunk, next_offset: nextCursor.offset, ...(unavailable_reason ? { unavailable_reason } : {}) })
       } catch (error) {
         return mapError(`read_worker_output(${worker_id})`, error)
       }
     },
   })
 
-  // --- list_workers(同步:本对话对象全量台账) ---
   const listWorkers = defineTool({
     name: 'list_workers',
-    description:
-      '同步列出当前对话对象名下的全部 worker(含其它 session 派发到同一对话对象的条目):' +
-      'worker_id、任务状态、化身链等台账信息。新请求进来时先用它找有没有能接着用的 worker' +
-      '(已结束的也算,send_to_worker 会复活它),再决定是复用还是 spawn_worker 开新的。',
+    description: '列出当前会话派出的 worker 精简摘要；需要继续、返工或汇报进度时先查询。',
     inputSchema: { type: 'object', properties: {} },
     isReadOnly: true,
     call: async (): Promise<ToolCallResult> => {
       try {
-        const workers = await harness.listWorkers(context().managerKey)
-        return ok({ workers })
-      } catch (error) {
-        return mapError('list_workers', error)
-      }
+        return ok({ workers: sortSummaries((await harness.listWorkers(context().managerKey)).map(summarizeWorker)) })
+      } catch (error) { return mapError('list_workers', error) }
     },
   })
+
+  const getWorkerDetail = defineTool({
+    name: 'get_worker_detail',
+    description: '读取一个 worker 的完整详情。当前会话只能读取自己的 worker。',
+    inputSchema: { type: 'object', properties: { worker_id: { type: 'string' } }, required: ['worker_id'] },
+    isReadOnly: true,
+    call: async (input): Promise<ToolCallResult> => {
+      const workerId = (input as { worker_id?: string }).worker_id
+      if (!workerId) return invalid('get_worker_detail: worker_id 必填且为字符串')
+      try { return ok({ worker: await authorizeWorker(workerId) }) }
+      catch (error) { return mapError(`get_worker_detail(${workerId})`, error) }
+    },
+  })
+
+  const listAllWorkers = capturedAuthorization ? defineTool({
+    name: 'list_all_workers',
+    description: '仅 Master 可用：跨会话列出 worker 精简摘要，支持 manager_key/status/分页过滤。',
+    inputSchema: {
+      type: 'object', properties: {
+        manager_key: { type: 'string' }, status: { oneOf: [{ type: 'string', enum: ['queued', 'running', 'waiting_input', 'completed', 'failed', 'cancelled'] }, { type: 'array', items: { type: 'string', enum: ['queued', 'running', 'waiting_input', 'completed', 'failed', 'cancelled'] } }] },
+        page: { type: 'number' }, page_size: { type: 'number' },
+      },
+    },
+    isReadOnly: true,
+    call: async (input): Promise<ToolCallResult> => {
+      try {
+        if (!await masterAuthorized()) return invalid(ACCESS_DENIED)
+        const p = input as { manager_key?: string; status?: TaskStatus | TaskStatus[]; page?: number; page_size?: number }
+        const status = p.status === undefined ? undefined : (Array.isArray(p.status) ? p.status : [p.status])
+        const pagination = normalizePagination(p.page, p.page_size)
+        const summaries = sortSummaries((await harness.listAllWorkers())
+          .filter(({ worker }) => (!p.manager_key || worker.manager_key === p.manager_key) && (!status || status.includes(worker.task.status)))
+          .map(({ worker }) => summarizeWorker(worker)))
+        const total_items = summaries.length
+        const start = (pagination.page - 1) * pagination.page_size
+        return ok({ items: summaries.slice(start, start + pagination.page_size), pagination: {
+          ...pagination, total_items, total_pages: Math.ceil(total_items / pagination.page_size),
+        } })
+      } catch (error) { return mapError('list_all_workers', error) }
+    },
+  }) : undefined
 
   // --- kill_worker(同步:终止当前化身,幂等) ---
   const killWorker = defineTool({
@@ -354,6 +438,7 @@ export function buildWorkerTools(deps: WorkerToolsDeps): ToolDefinition[] {
       if (!worker_id || typeof worker_id !== 'string') return invalid('kill_worker: worker_id 必填且为字符串')
 
       try {
+        await authorizeWorker(worker_id)
         await harness.killWorker(worker_id, reason)
         return ok({ status: 'killed', worker_id })
       } catch (error) {
@@ -362,5 +447,5 @@ export function buildWorkerTools(deps: WorkerToolsDeps): ToolDefinition[] {
     },
   })
 
-  return [spawnWorker, sendToWorker, queryWorker, readWorkerOutput, listWorkers, killWorker]
+  return [spawnWorker, sendToWorker, queryWorker, readWorkerOutput, listWorkers, getWorkerDetail, ...(listAllWorkers ? [listAllWorkers] : []), killWorker]
 }

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -702,6 +702,12 @@ export class UnifiedAgent extends ModuleBase {
             p.friendId,
           ),
         crabSelfHandle: (channelId) => this.crabSelfHandles.get(channelId),
+        getFriend: async (friendId) => {
+          const result = await this.rpcClient.call<{ friend_id: string }, { friend: Friend | null }>(
+            await this.getAdminPort(), 'get_friend', { friend_id: friendId }, this.config.moduleId,
+          )
+          return result.friend
+        },
       },
       // 起化身时现取（spec 决策 2）：箭头函数只捕获 `this`，配置一律在调用那一刻读。
       builtinSpawnDefaults: (ctx) => this.buildBuiltinWorkerRuntime(ctx),
@@ -1155,6 +1161,7 @@ export class UnifiedAgent extends ModuleBase {
         // 清除 Friend 缓存
         const friendPayload = event.payload as { friend_id: FriendId }
         this.permissionChecker.clearFriendCache(friendPayload.friend_id)
+        await this.managerStack?.principals.invalidateFriend(friendPayload.friend_id)
         break
       }
 
@@ -1866,6 +1873,10 @@ export class UnifiedAgent extends ModuleBase {
         !Number.isFinite(Date.parse(consumeResult.expires_at)) || Date.parse(consumeResult.expires_at) <= Date.now()) {
         throw new Error('invalid admin chat assertion consumption result')
       }
+      await this.requireManagerStack().principals.activateAdminChat('admin-web::admin-chat', {
+        assertionId: sha256CanonicalJson(admin_chat_assertion),
+        expiresAt: consumeResult.expires_at,
+      })
       return this.processAdminChatMessage(message, callback_info)
     }
 

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -57,7 +57,13 @@ import { createTmpPageTools } from './agent/tmp-page-tools.js'
 import { createCrabMessagingServer, type PathMapping, type TaskContext } from './mcp/crab-messaging.js'
 import { toImageConnInfo, imageToolsFor, type ImageConnInfo } from './mcp/crab-image.js'
 import { TraceStore } from './core/trace-store.js'
-import { getAgentTraceDir, getAgentLogsDir, getAgentDataDir, getWorkspaceDir, getDataRootDir } from './core/data-paths.js'
+import { getAgentTraceDir, getAgentLogsDir, getAgentDataDir, getWorkspaceDir, getDataRootDir, getAdminDataDir } from './core/data-paths.js'
+import { importV2LegacyTasks } from './workers/legacy-importer.js'
+import {
+  compareLegacyTraceEventEntries,
+  readLegacyTraceEvents,
+  type LegacyTraceEventEntry,
+} from './workers/legacy-source-reader.js'
 import { PromptManager } from './prompt-manager.js'
 import { createLSPManager, type LSPManager } from './lsp/lsp-manager.js'
 import type { BgEntityRecord, BgEntityStatus, BgEntityType } from './engine/bg-entities/types.js'
@@ -76,7 +82,13 @@ import {
   narrowWorkerPermissions,
   type BuiltinRuntimeContext,
 } from './workers/builtin/runtime.js'
-import type { ManagerKey, LedgerWorker, TaskPriority, TaskStatus } from './workers/harness/ledger-types.js'
+import {
+  isLegacyIncarnation,
+  type ManagerKey,
+  type LedgerWorker,
+  type TaskPriority,
+  type TaskStatus,
+} from './workers/harness/ledger-types.js'
 import {
   filterAndPageWorkers,
   buildWorkerDetail,
@@ -481,7 +493,7 @@ export class UnifiedAgent extends ModuleBase {
 
     super(moduleConfig)
 
-    this.traceStore = new TraceStore(100, getAgentTraceDir())
+    this.traceStore = new TraceStore(100, getAgentTraceDir(), 'traces-running-v3.jsonl')
     this.lspManager = createLSPManager()
 
     this.promptManager = new PromptManager()
@@ -2777,12 +2789,17 @@ export class UnifiedAgent extends ModuleBase {
   private async handleReadWorkerOutputAdmin(
     params: ReadWorkerOutputAdminParams
   ): Promise<ReadWorkerOutputAdminResult> {
-    const { chunk, nextCursor } = await this.requireManagerStack().harness.readWorkerOutput(
+    const { chunk, nextCursor, unavailable_reason } = await this.requireManagerStack().harness.readWorkerOutput(
       params.worker_id,
       { offset: parseOffsetCursor(params.cursor) },
-      { seq: params.seq }
+      params.seq === undefined ? undefined : { seq: params.seq },
     )
-    return { chunk, next_cursor: String(nextCursor.offset), eof: chunk.length === 0 }
+    return {
+      chunk,
+      next_cursor: String(nextCursor.offset),
+      eof: chunk.length === 0,
+      ...(unavailable_reason ? { unavailable_reason } : {}),
+    }
   }
 
   /**
@@ -2818,6 +2835,26 @@ export class UnifiedAgent extends ModuleBase {
       params.seq === undefined ? mainlineIncarnation(found.worker) : findIncarnationBySeq(found.worker, params.seq)
     if (!incarnation) {
       throw new Error(`get_worker_trace: no incarnation with seq=${params.seq} found for worker ${params.worker_id}`)
+    }
+    if (isLegacyIncarnation(incarnation)) {
+      const trace = await readLegacyTraceEvents(getAgentTraceDir(), found.worker.legacy_source?.trace_ids ?? [])
+      const harnessEntries: LegacyTraceEventEntry[] = (await stack.harness.readWorkerEvents(params.worker_id))
+        .filter((event) => event.seq === incarnation.seq)
+        .map((event, sourceOrdinal) => ({
+          event: normalizeHarnessEvent(event),
+          ...(Number.isFinite(Date.parse(event.ts)) ? { started_at: event.ts } : {}),
+          trace_id: '',
+          source_ordinal: sourceOrdinal,
+        }))
+      const events = [...trace.entries, ...harnessEntries]
+        .sort(compareLegacyTraceEventEntries)
+        .map((entry) => entry.event)
+      const offset = parseOffsetCursor(params.cursor)
+      return {
+        events: events.slice(offset),
+        next_cursor: String(events.length),
+        ...(trace.unavailable_reason ? { unavailable_reason: trace.unavailable_reason } : {}),
+      }
     }
     const ofIncarnation = (await stack.harness.readWorkerEvents(params.worker_id)).filter(
       (event) => event.seq === incarnation.seq
@@ -2942,9 +2979,26 @@ export class UnifiedAgent extends ModuleBase {
     }
   }
 
+  private async importLegacyV2Tasks(): Promise<void> {
+    const stack = this.managerStack
+    if (!stack) throw new Error('[legacy-import] manager stack unavailable')
+    await importV2LegacyTasks({
+      adminDataDir: getAdminDataDir(),
+      traceDir: getAgentTraceDir(),
+      agentDataDir: getAgentDataDir(),
+      ledger: stack.ledger,
+      workspaces: stack.workspaces,
+      now: () => new Date().toISOString(),
+    })
+  }
+
   protected override async onStart(): Promise<void> {
+    await this.importLegacyV2Tasks()
+    // Business ingress is registered only after onStart resolves; initialize durable
+    // subject bindings before any Manager tool face can mint a continuation credential.
+    await this.managerStack?.principals.init()
     this.startEventLoopWatchdog()
-    // trace 的 in-flight 持久化：每 15s 覆盖写 traces-running.jsonl，让 agent
+    // trace 的 in-flight 持久化：每 15s 覆盖写 traces-running-v3.jsonl，让 agent
     // 被 SIGKILL 时主 task trace 仍能保留到最后一次 flush 的状态。
     this.traceStore.startFlushTimer(15_000)
     // 探測是否有飛書 channel，決定是否注入 read_feishu_document 工具

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -1176,6 +1176,7 @@ export class UnifiedAgent extends ModuleBase {
           channelId: p.channel_id,
           sessionId: p.session_id,
           text: note,
+          ...(typeof event.timestamp === 'string' && Number.isFinite(Date.parse(event.timestamp)) ? { occurredAt: event.timestamp } : {}),
         }).catch((error) => console.error(`[${this.config.moduleId}] media manager wake failed:`, error))
         break
       }

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -76,7 +76,7 @@ import {
   narrowWorkerPermissions,
   type BuiltinRuntimeContext,
 } from './workers/builtin/runtime.js'
-import type { DialogObjectId, LedgerWorker, ManagerKey, TaskPriority, TaskStatus } from './workers/harness/ledger-types.js'
+import type { ManagerKey, LedgerWorker, TaskPriority, TaskStatus } from './workers/harness/ledger-types.js'
 import {
   filterAndPageWorkers,
   buildWorkerDetail,
@@ -424,9 +424,6 @@ export class UnifiedAgent extends ModuleBase {
    */
   private crabSelfHandles: Map<ModuleId, string> = new Map()
 
-  /** master 的 friend id（系统线程台账归档键，实例级常量）；见 `resolveMasterFriendId`。 */
-  private masterFriendIdCache: string | undefined
-
   /** Per-worker serialization preserves background-shell exit order across async log rendering. */
   private readonly builtinBgDeliveryTails = new Map<string, Promise<void>>()
 
@@ -705,7 +702,6 @@ export class UnifiedAgent extends ModuleBase {
             p.friendId,
           ),
         crabSelfHandle: (channelId) => this.crabSelfHandles.get(channelId),
-        masterFriendId: () => this.resolveMasterFriendId(),
       },
       // 起化身时现取（spec 决策 2）：箭头函数只捕获 `this`，配置一律在调用那一刻读。
       builtinSpawnDefaults: (ctx) => this.buildBuiltinWorkerRuntime(ctx),
@@ -731,33 +727,6 @@ export class UnifiedAgent extends ModuleBase {
         void this.sendBackgroundFailLoud(report.target, report.subject, report.failure)
       },
     })
-  }
-
-  /**
-   * master 的 friend id —— 系统任务线程的台账归档键（§4.4：未配置 `target_session` 的
-   * scheduled 触发，台账归 master 对话对象；否则 master 在私聊里问进度时，其 manager 按
-   * `friend:<master_id>` 查台账看不到这些 worker）。
-   *
-   * 实例级常量：admin 侧 master 唯一（`permission==='master'` 至多一个，见
-   * `crabot-admin/src/index.ts:3525`），解析成功一次即长期缓存。解析不出来时返回
-   * undefined，由 `ManagerPrincipalStore` 退回旧的 group 形状——不猜、不阻塞唤醒。
-   */
-  private async resolveMasterFriendId(): Promise<string | undefined> {
-    if (this.masterFriendIdCache) return this.masterFriendIdCache
-    try {
-      const adminPort = await this.getAdminPort()
-      const result = await this.rpcClient.call<Record<string, never>, { friend: Friend | null }>(
-        adminPort,
-        'find_master_friend',
-        {},
-        this.config.moduleId,
-      )
-      this.masterFriendIdCache = result.friend?.id
-      return this.masterFriendIdCache
-    } catch (err) {
-      console.warn('[Agent] find_master_friend 失败，系统线程台账暂用旧归档键:', err)
-      return undefined
-    }
   }
 
   // ==========================================================================
@@ -2608,7 +2577,7 @@ export class UnifiedAgent extends ModuleBase {
    * 由 manager 在唤醒边界解析身份。
    */
   private async transitionMaintenanceSystemTask(
-    dialogObjectId: DialogObjectId,
+    managerKey: ManagerKey,
     taskId: TaskId,
     to: TaskStatus,
     opts?: { error?: string; outcome?: string },
@@ -2616,7 +2585,7 @@ export class UnifiedAgent extends ModuleBase {
     const { ledger } = this.requireManagerStack()
     const now = new Date().toISOString()
     let oldStatus: TaskStatus | undefined
-    const updated = await ledger.upsertWorker(dialogObjectId, taskId, (previous) => {
+    const updated = await ledger.upsertWorker(managerKey, taskId, (previous) => {
       if (!previous) throw new Error(`Maintenance system task not found: ${taskId}`)
       oldStatus = previous.task.status
       return {
@@ -2631,21 +2600,21 @@ export class UnifiedAgent extends ModuleBase {
       task_id: taskId,
       old_status: oldStatus,
       new_status: to,
-      dialog_object_id: dialogObjectId,
+      manager_key: managerKey,
     })
   }
 
-  private async runMaintenanceSystemTask(dialogObjectId: DialogObjectId, taskId: TaskId): Promise<void> {
-    await this.transitionMaintenanceSystemTask(dialogObjectId, taskId, 'running')
+  private async runMaintenanceSystemTask(managerKey: ManagerKey, taskId: TaskId): Promise<void> {
+    await this.transitionMaintenanceSystemTask(managerKey, taskId, 'running')
     try {
       await this.memoryWriter.runMaintenance('all')
-      await this.transitionMaintenanceSystemTask(dialogObjectId, taskId, 'completed', {
+      await this.transitionMaintenanceSystemTask(managerKey, taskId, 'completed', {
         outcome: '记忆维护完成',
       })
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       console.error(`[${this.config.moduleId}] memory_maintenance system task ${taskId} failed:`, message)
-      await this.transitionMaintenanceSystemTask(dialogObjectId, taskId, 'failed', {
+      await this.transitionMaintenanceSystemTask(managerKey, taskId, 'failed', {
         error: message,
         outcome: `记忆维护失败：${message}`,
       })
@@ -2653,13 +2622,14 @@ export class UnifiedAgent extends ModuleBase {
   }
 
   private async createMaintenanceSystemTask(params: TriggerScheduleParams): Promise<TriggerScheduleResult> {
-    const { ledger, principals } = this.requireManagerStack()
+    const { ledger } = this.requireManagerStack()
     const taskId = generateId() as TaskId
-    const dialogObjectId = principals.dialogObjectIdFor(SYSTEM_TASKS_MANAGER_KEY)
+    const managerKey = SYSTEM_TASKS_MANAGER_KEY
     const { channelId, sessionId } = splitManagerKey(SYSTEM_TASKS_MANAGER_KEY)
     const now = new Date().toISOString()
     const worker: LedgerWorker = {
       worker_id: taskId,
+      manager_key: managerKey,
       task: {
         id: taskId,
         type: params.task_type,
@@ -2671,7 +2641,6 @@ export class UnifiedAgent extends ModuleBase {
         created_at: now,
       },
       origin: {
-        spawned_by_session: SYSTEM_TASKS_MANAGER_KEY,
         trigger_type: 'system',
         ...(params.creator_friend_id ? { creator_friend_id: params.creator_friend_id } : {}),
       },
@@ -2682,13 +2651,13 @@ export class UnifiedAgent extends ModuleBase {
       incarnations: [],
       updated_at: now,
     }
-    const persisted = await ledger.upsertWorker(dialogObjectId, taskId, (previous) => {
+    const persisted = await ledger.upsertWorker(managerKey, taskId, (previous) => {
       if (previous) throw new Error(`Duplicate maintenance system task: ${taskId}`)
       return worker
     })
     if (!persisted) throw new Error(`Failed to persist maintenance system task: ${taskId}`)
 
-    void this.runMaintenanceSystemTask(dialogObjectId, taskId).catch((error) => {
+    void this.runMaintenanceSystemTask(managerKey, taskId).catch((error) => {
       console.error(
         `[${this.config.moduleId}] maintenance system task handler crashed (task=${taskId}):`,
         error instanceof Error ? error.message : String(error),

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -8,7 +8,7 @@
 
 import fs from 'node:fs'
 import path from 'node:path'
-import { ModuleBase, generateId, type ModuleConfig, type Event, type ModuleId, type TraceStoreInterface } from 'crabot-shared'
+import { ModuleBase, generateId, sha256CanonicalJson, type ModuleConfig, type Event, type ModuleId, type TraceStoreInterface } from 'crabot-shared'
 import { resolveTimezone } from './utils/time.js'
 import type {
   UnifiedAgentConfig,
@@ -1843,11 +1843,29 @@ export class UnifiedAgent extends ModuleBase {
     message: ChannelMessage
     source_type?: 'channel' | 'admin_chat'
     callback_info?: { source_module_id: string; request_id: string }
+    admin_chat_assertion?: string
   }): Promise<{ decision_types: string[]; task_ids?: string[] }> {
-    const { message, source_type, callback_info } = params
+    const { message, source_type, callback_info, admin_chat_assertion } = params
 
-    // Admin Chat 来源
-    if (source_type === 'admin_chat' && callback_info) {
+    if (source_type === 'admin_chat' && callback_info && admin_chat_assertion) {
+      const modules = await this.rpcClient.resolve({ module_id: 'admin-web' }, this.config.moduleId)
+      const adminPort = modules[0]?.port
+      if (!adminPort) throw new Error('official Admin module is unavailable')
+      const consumeResult = await this.rpcClient.call<
+        { assertion: string; expected: { manager_key: string; request_id: string; payload_sha256: string } },
+        { consumed?: unknown; expires_at?: unknown }
+      >(adminPort, 'consume_admin_chat_assertion', {
+        assertion: admin_chat_assertion,
+        expected: {
+          manager_key: 'admin-web::admin-chat',
+          request_id: callback_info.request_id,
+          payload_sha256: sha256CanonicalJson(message),
+        },
+      }, this.config.moduleId)
+      if (consumeResult?.consumed !== true || typeof consumeResult.expires_at !== 'string' ||
+        !Number.isFinite(Date.parse(consumeResult.expires_at)) || Date.parse(consumeResult.expires_at) <= Date.now()) {
+        throw new Error('invalid admin chat assertion consumption result')
+      }
       return this.processAdminChatMessage(message, callback_info)
     }
 
@@ -1855,7 +1873,7 @@ export class UnifiedAgent extends ModuleBase {
       throw new Error('process_message only supports source_type=admin_chat; channel messages use channel.message_authorized')
     }
 
-    return { decision_types: [] }
+    throw new Error('admin_chat assertion is required and must be valid')
   }
 
   /**

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -264,6 +264,24 @@ function parseOffsetCursor(cursor: string | undefined): number {
   return Number.isFinite(parsed) && parsed >= 0 ? Math.floor(parsed) : 0
 }
 
+function parseAdminChatAssertionId(assertion: string): string {
+  const payload = assertion.split('.')[1]
+  if (!payload) throw new Error('Admin Chat assertion payload is invalid')
+  try {
+    const claims: unknown = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8'))
+    if (!claims || typeof claims !== 'object' || Array.isArray(claims)) {
+      throw new Error('invalid claims')
+    }
+    const assertionId = (claims as Record<string, unknown>).assertion_id
+    if (typeof assertionId !== 'string' || assertionId.length === 0) {
+      throw new Error('invalid assertion_id')
+    }
+    return assertionId
+  } catch {
+    throw new Error('Admin Chat assertion payload is invalid')
+  }
+}
+
 /** trace summary 的截断长度（§10.2：summary 是"截断摘要"，原始结构留在 detail 里）。 */
 const TRACE_SUMMARY_MAX_CHARS = 200
 
@@ -493,7 +511,13 @@ export class UnifiedAgent extends ModuleBase {
 
     super(moduleConfig)
 
-    this.traceStore = new TraceStore(100, getAgentTraceDir(), 'traces-running-v3.jsonl')
+    this.traceStore = new TraceStore(
+      100,
+      getAgentTraceDir(),
+      'traces-running-v3.jsonl',
+      'traces-v3-',
+      ['traces-', 'traces-v3-'],
+    )
     this.lspManager = createLSPManager()
 
     this.promptManager = new PromptManager()
@@ -1887,7 +1911,7 @@ export class UnifiedAgent extends ModuleBase {
         throw new Error('invalid admin chat assertion consumption result')
       }
       await this.requireManagerStack().principals.activateAdminChat('admin-web::admin-chat', {
-        assertionId: sha256CanonicalJson(admin_chat_assertion),
+        assertionId: parseAdminChatAssertionId(admin_chat_assertion),
         expiresAt: consumeResult.expires_at,
       })
       return this.processAdminChatMessage(message, callback_info)

--- a/crabot-agent/src/workers/harness/context-store.ts
+++ b/crabot-agent/src/workers/harness/context-store.ts
@@ -37,7 +37,7 @@ function isStoragePermission(value: unknown): value is StoragePermission | null 
     typeof value.workspace_path === 'string' && (value.access === 'read' || value.access === 'readwrite'))
 }
 
-function isCompleteResolvedPermissions(value: unknown): value is ResolvedPermissions {
+export function isResolvedPermissionsSnapshot(value: unknown): value is ResolvedPermissions {
   if (!isRecord(value) || !hasOnlyKeys(value, ['tool_access', 'cli_access', 'storage', 'memory_scopes'])) return false
   const toolAccess = value.tool_access
   if (!isRecord(toolAccess) || !hasOnlyKeys(toolAccess, TOOL_ACCESS_KEYS) ||
@@ -85,7 +85,7 @@ function validatePersistedContext(value: unknown, path: string): WorkerContext {
   if (!isRecord(value) || !hasOnlyKeys(value, ['principal_permissions'])) {
     throw new Error(`WorkerContextStore: invalid context at ${path}`)
   }
-  if (value.principal_permissions !== undefined && !isCompleteResolvedPermissions(value.principal_permissions)) {
+  if (value.principal_permissions !== undefined && !isResolvedPermissionsSnapshot(value.principal_permissions)) {
     throw new Error(`WorkerContextStore: invalid principal_permissions at ${path}`)
   }
   return value.principal_permissions === undefined ? {} : { principal_permissions: value.principal_permissions }

--- a/crabot-agent/src/workers/harness/harness.ts
+++ b/crabot-agent/src/workers/harness/harness.ts
@@ -8,7 +8,7 @@
  *
  * 锁层级(必须遵守,避免 ABBA):
  *   外层:harness 自己维护的"每 worker 一把" AsyncMutex(this.mutexes,按 worker_id 取)。
- *   内层:LedgerStore 内部按 DialogObjectId 维护的另一把 AsyncMutex,完全不透明,只在单次
+ *   内层:LedgerStore 内部按 ManagerKey 维护的另一把 AsyncMutex,完全不透明,只在单次
  *        `ledger.upsertWorker(...)` 调用内部短暂持有(mutator 是同步纯函数,写盘后立即释放)。
  * harness 从不显式持有 ledger 的锁,也从不在“持有 ledger 锁”的状态下反过来等待自己的
  * per-worker 锁——每次 upsertWorker 调用都是一次独立的、有限时长的原子读改写,不会在其
@@ -83,7 +83,15 @@ import type { BuiltinRuntimeFactory } from '../builtin/runtime'
 import type { ResolvedPermissions } from '../../types'
 import { CapabilityNotSupportedError, WorkerExitedError, CliInputStallError } from '../errors'
 import { AsyncMutex } from '../async-mutex'
-import type { DialogObjectId, Incarnation, LedgerWorker, TaskStatus } from './ledger-types'
+import {
+  isExecutableIncarnation,
+  isLegacyIncarnation,
+  type ExecutableIncarnation,
+  type Incarnation,
+  type LedgerWorker,
+  type ManagerKey,
+  type TaskStatus,
+} from './ledger-types'
 import type { LedgerStore } from './ledger-store'
 import type { WorkspaceManager } from './workspace-manager'
 import {
@@ -408,7 +416,7 @@ export interface HarnessDeps {
 }
 
 export interface SpawnWorkerParams {
-  readonly dialogObjectId: DialogObjectId
+  readonly managerKey: ManagerKey
   readonly title: string
   readonly prompt: string
   readonly origin: LedgerWorker['origin']
@@ -610,6 +618,7 @@ export class WorkerHarness {
       const startedAt = this.deps.now()
       const initial: LedgerWorker = {
         worker_id: workerId,
+        manager_key: p.managerKey,
         task: {
           id: workerId,
           title: p.title,
@@ -634,7 +643,7 @@ export class WorkerHarness {
         ],
         updated_at: startedAt,
       }
-      await this.deps.ledger.upsertWorker(p.dialogObjectId, workerId, () => initial)
+      await this.deps.ledger.upsertWorker(p.managerKey, workerId, () => initial)
 
       let spawnedHandle: IncarnationHandle
       try {
@@ -675,7 +684,7 @@ export class WorkerHarness {
         spawnedHandle = await adapter.spawn(spec)
       } catch (err) {
         const now = this.deps.now()
-        const failed = await this.deps.ledger.upsertWorker(p.dialogObjectId, workerId, (prev) => {
+        const failed = await this.deps.ledger.upsertWorker(p.managerKey, workerId, (prev) => {
           if (!prev) return undefined
           // VALID_TRANSITIONS 里 queued 没有直达 failed 的边(只能到 running/cancelled)。
           // spawn 尝试确实发生过(我们已经调用了 provision/spawn),用 queued→running→failed
@@ -709,7 +718,7 @@ export class WorkerHarness {
       const now = this.deps.now()
       const initialInput = spawnedHandle.initial_input
       const initialState = cliContractState(initialInput?.control_state ?? 'running')
-      const spawned = await this.deps.ledger.upsertWorker(p.dialogObjectId, workerId, (prev) => {
+      const spawned = await this.deps.ledger.upsertWorker(p.managerKey, workerId, (prev) => {
         if (!prev) return undefined
         let nextTask = applyStatusTransition(prev.task, 'running', { now })
         nextTask = settleCliTask(nextTask, initialState, initialInput?.report, now)
@@ -895,21 +904,23 @@ export class WorkerHarness {
       // 主线(protocol-agent-v3 §5.3:fork 不影响主线)。
       const incarnation = requireMainlineIncarnation(found.worker)
 
-      // 台账已经把主线化身记为终态(如异步状态回调已经追上)——不必再尝试一次注定失败的
-      // sendInput,直接进入 §5.3 透明接续。
-      if (incarnation.state === 'exited') {
-        if (item.allow_terminal_continuation === false) return 'delivered'
-        return this.continueTerminalWorker(workerId, item.text, incarnation.impl as WorkerImplId, incarnation.seq, item.raw)
+      if (isLegacyIncarnation(incarnation)) {
+        throw new Error('WorkerHarness.sendToWorker: legacy worker continuation is not available')
       }
 
-      const adapter = this.deps.adapters.get(incarnation.impl as WorkerImplId)
+      if (incarnation.state === 'exited') {
+        if (item.allow_terminal_continuation === false) return 'delivered'
+        return this.continueTerminalWorker(workerId, item.text, incarnation.impl, incarnation.seq, item.raw)
+      }
+
+      const adapter = this.deps.adapters.get(incarnation.impl)
       if (!adapter) {
         throw new Error(`WorkerHarness.sendToWorker: no adapter registered for impl '${incarnation.impl}'`)
       }
       const handle: IncarnationHandle = {
         worker_id: workerId,
         seq: incarnation.seq,
-        impl: incarnation.impl as WorkerImplId,
+        impl: incarnation.impl,
         session_ref: incarnation.session_ref,
       }
       const attempt = await this.attemptInput(adapter, handle, item.text, item.raw)
@@ -918,7 +929,7 @@ export class WorkerHarness {
         return this.continueTerminalWorker(
           workerId,
           item.text,
-          incarnation.impl as WorkerImplId,
+          incarnation.impl,
           incarnation.seq,
           item.raw,
           attempt.endedReason,
@@ -947,7 +958,7 @@ export class WorkerHarness {
     await this.withLock(workerId, async () => {
       const found = await this.deps.ledger.findWorker(workerId)
       if (!found) throw new WorkerNotFoundError(workerId)
-      const { worker, dialogObjectId } = found
+      const { worker, managerKey } = found
       // cancelled 是唯一硬拒绝(protocol-agent-v3 §5.5,与 sendToWorker/continueTerminalWorker
       // 的 cancelled 短路对齐)。若主线化身已因 killWorker 落 exited,不加这道校验会让
       // handoffIncarnation 跳过 kill 段直接 provision+spawn 新化身,reopenTaskForContinuation
@@ -955,7 +966,7 @@ export class WorkerHarness {
       // 允许切换(等价于"在办任务换实现"续办的合理场景,§5.3),只有 cancelled 硬拒绝。
       if (worker.task.status === 'cancelled') throw new TaskCancelledError(workerId)
       const mainline = requireMainlineIncarnation(worker)
-      const handoff = await this.handoffIncarnation(dialogObjectId, worker, mainline, impl, note ?? '')
+      const handoff = await this.handoffIncarnation(managerKey, worker, requireExecutableIncarnation(mainline), impl, note ?? '')
       restoredDurableReceipt = handoff.restoredDurableReceipt
     })
     // The old pane no longer owns a consumed durable receipt; resume its FIFO on the new incarnation.
@@ -1033,7 +1044,7 @@ export class WorkerHarness {
       for (let iteration = 0; iteration < MAX_CONTINUATION_ITERATIONS; iteration++) {
         const found = await this.deps.ledger.findWorker(workerId)
         if (!found) throw new WorkerNotFoundError(workerId)
-        const { worker, dialogObjectId } = found
+        const { worker, managerKey } = found
 
         // task 在锁外投递期间被 killWorker 打断(如 send 卡在 tmux 投递期间调 kill,这条
         // 消息在拿到这把锁之前就已经确定要走接续路径了):§5.5"唯一硬拒绝:cancelled"只
@@ -1053,6 +1064,9 @@ export class WorkerHarness {
         }
 
         const mainline = requireMainlineIncarnation(worker)
+        if (!isExecutableIncarnation(mainline)) {
+          throw new Error('WorkerHarness.sendToWorker: legacy worker continuation is not available')
+        }
 
         if (mainline.seq !== curSeq || mainline.impl !== curImpl) {
           // 并发窗口:拿锁之前,该 worker 已经被另一次并发触发的接续/切换抢先完成——主线已经
@@ -1060,7 +1074,7 @@ export class WorkerHarness {
           if (mainline.state === 'exited') {
             // 台账已经把这个更新的主线也记为终态——不必再尝试一次注定失败的 sendInput,
             // 把它当作新的源头,回到循环顶部,以它走接续。
-            curImpl = mainline.impl as WorkerImplId
+            curImpl = mainline.impl
             curSeq = mainline.seq
             // 台账已有这条化身的终态记录,回填段不会触发,没有原因要携带。
             curEndReason = undefined
@@ -1068,21 +1082,21 @@ export class WorkerHarness {
           }
           // 按普通投递语义把这条消息补送到当前(存活)主线,不重复接续,并保留原条目的
           // raw 标志。
-          const adapter = this.deps.adapters.get(mainline.impl as WorkerImplId)
+          const adapter = this.deps.adapters.get(mainline.impl)
           if (!adapter) {
             throw new Error(`WorkerHarness.sendToWorker: no adapter registered for impl '${mainline.impl}'`)
           }
           const handle: IncarnationHandle = {
             worker_id: workerId,
             seq: mainline.seq,
-            impl: mainline.impl as WorkerImplId,
+            impl: mainline.impl,
             session_ref: mainline.session_ref,
           }
           const attempt = await this.attemptInput(adapter, handle, text, raw)
           if (attempt.kind === 'exited') {
             // adapter 侧权威判定这个"看起来存活"的新主线其实也已经终态(台账的异步状态
             // 回调还没追上)——同样不出锁,把它当作新的源头回到循环顶部转接续。
-            curImpl = mainline.impl as WorkerImplId
+            curImpl = mainline.impl
             curSeq = mainline.seq
             curEndReason = attempt.endedReason
             continue
@@ -1093,14 +1107,14 @@ export class WorkerHarness {
         }
 
         // 主线就是当前源:走接续(revive/handoff)。
-        const adapter = this.deps.adapters.get(mainline.impl as WorkerImplId)
+        const adapter = this.deps.adapters.get(mainline.impl)
         if (!adapter) {
           throw new Error(`WorkerHarness.sendToWorker: no adapter registered for impl '${mainline.impl}' (continuation)`)
         }
 
         if (adapter.capabilities().revive) {
           const delivery = await this.reviveIncarnation(
-            dialogObjectId,
+            managerKey,
             worker,
             mainline,
             adapter,
@@ -1125,7 +1139,7 @@ export class WorkerHarness {
           // 实现(如 legacy)保留。
           const targetImpl = pickUnusedImpl(worker, this.deps.adapters, this.deps.defaultImpl)
           const handoff = await this.handoffIncarnation(
-            dialogObjectId,
+            managerKey,
             worker,
             mainline,
             targetImpl,
@@ -1162,9 +1176,9 @@ export class WorkerHarness {
 
   /** capabilities().revive===true 分支:adapter.resume 拉起新化身,session 满保真接续。 */
   private async reviveIncarnation(
-    dialogObjectId: DialogObjectId,
+    managerKey: ManagerKey,
     worker: LedgerWorker,
-    mainline: Incarnation,
+    mainline: ExecutableIncarnation,
     adapter: WorkerAdapter,
     text: string,
     /** adapter 经 WorkerExitedError 报上来的源化身终止原因(见下面回填段的注释)。 */
@@ -1178,7 +1192,7 @@ export class WorkerHarness {
     const initialInput = newHandle.initial_input
     const initialState = cliContractState(initialInput?.control_state ?? 'running')
     const now = this.deps.now()
-    const revived = await this.deps.ledger.upsertWorker(dialogObjectId, worker.worker_id, (prev) => {
+    const revived = await this.deps.ledger.upsertWorker(managerKey, worker.worker_id, (prev) => {
       if (!prev) return undefined
       const newIncarnation: Incarnation = {
         seq: newHandle.seq,
@@ -1233,19 +1247,19 @@ export class WorkerHarness {
    * → 旧化身写交接文档收尾 → (若仍存活)kill 标 superseded → 同 workspace provision+spawn 新实现 → 化身链 +1。
    */
   private async handoffIncarnation(
-    dialogObjectId: DialogObjectId,
+    managerKey: ManagerKey,
     worker: LedgerWorker,
-    source: Incarnation,
+    source: ExecutableIncarnation,
     targetImpl: WorkerImplId,
     input: string,
     inputOwnedByInbox = false,
     inboxRaw = false,
   ): Promise<HandoffResult> {
-    const sourceAdapter = this.deps.adapters.get(source.impl as WorkerImplId)
+    const sourceAdapter = this.deps.adapters.get(source.impl)
     const sourceHandle: IncarnationHandle = {
       worker_id: worker.worker_id,
       seq: source.seq,
-      impl: source.impl as WorkerImplId,
+      impl: source.impl,
       session_ref: source.session_ref,
     }
 
@@ -1332,7 +1346,7 @@ export class WorkerHarness {
         await sourceAdapter.kill(sourceHandle)
       }
       const killedAt = this.deps.now()
-      await this.deps.ledger.upsertWorker(dialogObjectId, worker.worker_id, (prev) => {
+      await this.deps.ledger.upsertWorker(managerKey, worker.worker_id, (prev) => {
         if (!prev) return undefined
         const incarnations = patchIncarnationBySeq(prev.incarnations, source.impl, source.seq, {
           state: 'exited',
@@ -1362,7 +1376,7 @@ export class WorkerHarness {
     const initialInput = newHandle.initial_input
     const initialState = cliContractState(initialInput?.control_state ?? 'running')
     const now = this.deps.now()
-    const handedOff = await this.deps.ledger.upsertWorker(dialogObjectId, worker.worker_id, (prev) => {
+    const handedOff = await this.deps.ledger.upsertWorker(managerKey, worker.worker_id, (prev) => {
       if (!prev) return undefined
       const newIncarnation: Incarnation = {
         seq: newHandle.seq,
@@ -1429,7 +1443,7 @@ export class WorkerHarness {
     workerId: string,
     cursor: OutputCursor,
     opts?: { seq?: number }
-  ): Promise<{ chunk: string; nextCursor: OutputCursor }> {
+  ): Promise<{ chunk: string; nextCursor: OutputCursor; unavailable_reason?: string }> {
     const found = await this.deps.ledger.findWorker(workerId)
     if (!found) throw new WorkerNotFoundError(workerId)
     if (found.worker.incarnations.length === 0) throw new WorkerHasNoIncarnationError(workerId)
@@ -1439,14 +1453,21 @@ export class WorkerHarness {
     if (!incarnation) {
       throw new Error(`WorkerHarness.readWorkerOutput: no incarnation with seq=${opts?.seq} found for worker ${workerId}`)
     }
-    const adapter = this.deps.adapters.get(incarnation.impl as WorkerImplId)
+    if (isLegacyIncarnation(incarnation)) {
+      return {
+        chunk: '',
+        nextCursor: cursor,
+        unavailable_reason: 'legacy worker has no raw output',
+      }
+    }
+    const adapter = this.deps.adapters.get(incarnation.impl)
     if (!adapter) {
       throw new Error(`WorkerHarness.readWorkerOutput: no adapter registered for impl '${incarnation.impl}'`)
     }
     const handle: IncarnationHandle = {
       worker_id: workerId,
       seq: incarnation.seq,
-      impl: incarnation.impl as WorkerImplId,
+      impl: incarnation.impl,
       session_ref: incarnation.session_ref,
     }
     return adapter.readOutput(handle, cursor)
@@ -1456,8 +1477,8 @@ export class WorkerHarness {
     return (await this.deps.ledger.findWorker(workerId)) !== undefined
   }
 
-  async listWorkers(dialogObjectId: DialogObjectId): Promise<LedgerWorker[]> {
-    return this.deps.ledger.listWorkers(dialogObjectId)
+  async listWorkers(managerKey: ManagerKey): Promise<LedgerWorker[]> {
+    return this.deps.ledger.listWorkers(managerKey)
   }
 
   /**
@@ -1521,7 +1542,7 @@ export class WorkerHarness {
     unchanged.push(...all.filter(({ worker }) => isTerminalStatus(worker.task.status)).map(({ worker }) => worker.worker_id))
 
     const settled = await Promise.allSettled(
-      targets.map(({ dialogObjectId, worker }) => this.reconcileOneWorker(dialogObjectId, worker.worker_id))
+      targets.map(({ managerKey, worker }) => this.reconcileOneWorker(managerKey, worker.worker_id))
     )
 
     settled.forEach((result, i) => {
@@ -1620,9 +1641,8 @@ export class WorkerHarness {
         // `!mainline` 不是纯防御:#72 的 memory_maintenance system task 是**没有任何化身**的
         // 台账条目(`incarnations: []`,由 agent 自己跑,不派 worker),它在 running 期间同样
         // 会被 listAllWorkers 枚举到。没有化身就没有可探的活性,直接跳过。
-        if (!mainline || mainline.state !== 'running') continue
-        // `'legacy'`(旧 ResumeCheckpoint 迁移来的化身)不会有 adapter 注册,下一行自然落空。
-        const impl = mainline.impl as WorkerImplId
+        if (!mainline || !isExecutableIncarnation(mainline) || mainline.state !== 'running') continue
+        const impl = mainline.impl
         const adapter = this.deps.adapters.get(impl)
         // 不实现 `lastActivityAt` 的实现不参与活性巡检(协议 §6.1),这里是它的**唯一**落点。
         if (!adapter?.lastActivityAt) continue
@@ -1745,7 +1765,7 @@ export class WorkerHarness {
 
   /** reconcileOnStartup 单个 worker 的判定+提交,整体在该 worker 的 per-worker 锁临界区内完成。 */
   private async reconcileOneWorker(
-    dialogObjectId: DialogObjectId,
+    managerKey: ManagerKey,
     workerId: string
   ): Promise<'revived' | 'failed' | 'unchanged'> {
     return this.withLock(workerId, async () => {
@@ -1758,19 +1778,25 @@ export class WorkerHarness {
 
       const mainline = mainlineIncarnation(worker)
       if (!mainline) {
-        await this.markAgentNativeSystemTaskLost(dialogObjectId, worker)
+        await this.markAgentNativeSystemTaskLost(managerKey, worker)
         return 'failed'
       }
-      const adapter = this.deps.adapters.get(mainline.impl as WorkerImplId)
+      if (isLegacyIncarnation(mainline)) {
+        // Imported legacy records are terminal; a malformed non-terminal one must not probe a
+        // nonexistent adapter or mutate the historical record during startup reconciliation.
+        return 'unchanged'
+      }
+
+      const adapter = this.deps.adapters.get(mainline.impl)
       if (!adapter) {
-        await this.markCrashed(dialogObjectId, worker, mainline, `no adapter registered for impl '${mainline.impl}'`)
+        await this.markCrashed(managerKey, worker, mainline, `no adapter registered for impl '${mainline.impl}'`)
         return 'failed'
       }
 
       const handle: IncarnationHandle = {
         worker_id: worker.worker_id,
         seq: mainline.seq,
-        impl: mainline.impl as WorkerImplId,
+        impl: mainline.impl,
         session_ref: mainline.session_ref,
       }
 
@@ -1779,7 +1805,7 @@ export class WorkerHarness {
         observed = await adapter.state(handle)
       } catch (err) {
         await this.markCrashed(
-          dialogObjectId,
+          managerKey,
           worker,
           mainline,
           `adapter.state() threw: ${err instanceof Error ? err.message : String(err)}`
@@ -1788,22 +1814,22 @@ export class WorkerHarness {
       }
 
       if (observed === 'exited') {
-        await this.markCrashed(dialogObjectId, worker, mainline, 'adapter reports incarnation exited while ledger was non-terminal')
+        await this.markCrashed(managerKey, worker, mainline, 'adapter reports incarnation exited while ledger was non-terminal')
         return 'failed'
       }
 
-      await this.realignAliveIncarnation(dialogObjectId, worker, mainline, observed)
+      await this.realignAliveIncarnation(managerKey, worker, mainline, observed)
       return 'revived'
     })
   }
 
   private async markAgentNativeSystemTaskLost(
-    dialogObjectId: DialogObjectId,
+    managerKey: ManagerKey,
     worker: LedgerWorker,
   ): Promise<void> {
     const now = this.deps.now()
     const message = 'agent restart: execution context lost for agent-native system task'
-    const failed = await this.deps.ledger.upsertWorker(dialogObjectId, worker.worker_id, (prev) => {
+    const failed = await this.deps.ledger.upsertWorker(managerKey, worker.worker_id, (prev) => {
       if (!prev) return undefined
       const nextTask = transitionTaskTo(prev.task, 'failed', { error: message, now })
       return { ...prev, task: nextTask, updated_at: now }
@@ -1823,13 +1849,13 @@ export class WorkerHarness {
    * 语义上都是"至此已经没有任何证据证明这个非终态 worker 还活着"。
    */
   private async markCrashed(
-    dialogObjectId: DialogObjectId,
+    managerKey: ManagerKey,
     worker: LedgerWorker,
-    mainline: Incarnation,
+    mainline: ExecutableIncarnation,
     detailReason: string
   ): Promise<void> {
     const now = this.deps.now()
-    const crashed = await this.deps.ledger.upsertWorker(dialogObjectId, worker.worker_id, (prev) => {
+    const crashed = await this.deps.ledger.upsertWorker(managerKey, worker.worker_id, (prev) => {
       if (!prev) return undefined
       const nextTask = transitionTaskTo(prev.task, 'failed', { error: detailReason, now })
       const incarnations = patchIncarnationBySeq(prev.incarnations, mainline.impl, mainline.seq, {
@@ -1856,9 +1882,9 @@ export class WorkerHarness {
    * 噪声写盘/事件。
    */
   private async realignAliveIncarnation(
-    dialogObjectId: DialogObjectId,
+    managerKey: ManagerKey,
     worker: LedgerWorker,
-    mainline: Incarnation,
+    mainline: ExecutableIncarnation,
     observed: WorkerContractState
   ): Promise<void> {
     const waitingInput = observed === 'idle' ? true : undefined
@@ -1871,7 +1897,7 @@ export class WorkerHarness {
     if (!stateChanged && !statusChanged) return
 
     const now = this.deps.now()
-    const realigned = await this.deps.ledger.upsertWorker(dialogObjectId, worker.worker_id, (prev) => {
+    const realigned = await this.deps.ledger.upsertWorker(managerKey, worker.worker_id, (prev) => {
       if (!prev) return undefined
       const nextTask = statusChanged ? transitionTaskTo(prev.task, nextStatus, { now }) : prev.task
       const incarnations = stateChanged
@@ -1894,27 +1920,28 @@ export class WorkerHarness {
     await this.withLock(workerId, async () => {
       const found = await this.deps.ledger.findWorker(workerId)
       if (!found) throw new WorkerNotFoundError(workerId)
-      const { worker, dialogObjectId } = found
+      const { worker, managerKey } = found
 
       // 幂等:已是终态(含此前已经 kill 过)直接返回,不重复调 adapter.kill、不重复写台账/事件。
       if (isTerminalStatus(worker.task.status)) return
 
       // 主线化身——kill 必须打在主线上,不能被 fork 出的侧问分支顶替(protocol-agent-v3 §5.3)。
       const incarnation = requireMainlineIncarnation(worker)
-      const implId = incarnation.impl as WorkerImplId
-      const adapter = this.deps.adapters.get(implId)
-      if (adapter) {
-        const handle: IncarnationHandle = {
-          worker_id: workerId,
-          seq: incarnation.seq,
-          impl: implId,
-          session_ref: incarnation.session_ref,
+      if (isExecutableIncarnation(incarnation)) {
+        const adapter = this.deps.adapters.get(incarnation.impl)
+        if (adapter) {
+          const handle: IncarnationHandle = {
+            worker_id: workerId,
+            seq: incarnation.seq,
+            impl: incarnation.impl,
+            session_ref: incarnation.session_ref,
+          }
+          await adapter.kill(handle)
         }
-        await adapter.kill(handle)
       }
 
       const now = this.deps.now()
-      const cancelled = await this.deps.ledger.upsertWorker(dialogObjectId, workerId, (prev) => {
+      const cancelled = await this.deps.ledger.upsertWorker(managerKey, workerId, (prev) => {
         if (!prev) return undefined
         const nextTask = applyStatusTransition(prev.task, 'cancelled', { now })
         // 按 (impl, seq) 精确定位主线化身条目,不假设它是数组最后一个(fork 之后数组末尾是
@@ -2013,8 +2040,8 @@ export class WorkerHarness {
       const { worker } = found
       // 侧问永远从当前主线化身分叉,不是"数组最后一个"——否则连续两次 query_worker 会让
       // 第二次 fork 挂在第一次 fork 的分支下面,而不是都从主线分叉(protocol-agent-v3 §5.3)。
-      const incarnation = requireMainlineIncarnation(worker)
-      const implId = incarnation.impl as WorkerImplId
+      const incarnation = requireExecutableIncarnation(requireMainlineIncarnation(worker))
+      const implId = incarnation.impl
       const adapter = this.deps.adapters.get(implId)
       if (!adapter) {
         await this.appendEvent(workerId, incarnation.seq, 'query_failed', { reason: 'no_adapter', impl: implId })
@@ -2027,7 +2054,11 @@ export class WorkerHarness {
         })
         throw new CapabilityNotSupportedError(implId, 'fork')
       }
-      const ref: IncarnationRef = { worker_id: workerId, seq: incarnation.seq, session_ref: incarnation.session_ref }
+      const ref: IncarnationRef = {
+        worker_id: workerId,
+        seq: incarnation.seq,
+        session_ref: incarnation.session_ref,
+      }
       return { adapter, implId, ref, workspace: incarnation.workspace }
     })
 
@@ -2054,7 +2085,7 @@ export class WorkerHarness {
         await this.appendEvent(workerId, forkHandle.seq, 'query_failed', { reason: 'worker_disappeared' })
         throw new WorkerNotFoundError(workerId)
       }
-      const { dialogObjectId } = found
+      const { managerKey } = found
 
       const now = this.deps.now()
       // P4 Task 4 第四轮收口(复审 PoC 实证):不能再硬编码 'running' 落账——
@@ -2072,7 +2103,7 @@ export class WorkerHarness {
       // 修正,不会重演同一个丢弃。
       const observedState = await prep.adapter.state(forkHandle)
       const exitedOnCommit = observedState === 'exited'
-      await this.deps.ledger.upsertWorker(dialogObjectId, workerId, (prevWorker) => {
+      await this.deps.ledger.upsertWorker(managerKey, workerId, (prevWorker) => {
         if (!prevWorker) return undefined
         // fork 是一次性侧问,不影响主线 task.status(protocol-agent-v3 §5.3:"不影响主线")——
         // 无条件追加,不因这段时间里主线是否已转终态/被 handoff 换掉而改变这个决定(理由见
@@ -2127,7 +2158,7 @@ export class WorkerHarness {
     await this.withLock(h.worker_id, async () => {
       const found = await this.deps.ledger.findWorker(h.worker_id)
       if (!found) return
-      const { worker, dialogObjectId } = found
+      const { worker, managerKey } = found
       const target = findIncarnation(worker, h.impl, h.seq)
       if (!target) return
 
@@ -2138,7 +2169,7 @@ export class WorkerHarness {
         // A concurrent callback owns the state transition, but session discovery is an independent
         // monotonic fact. Preserve a newly discovered non-empty ref even when synthetic running is stale.
         if (h.session_ref && target.session_ref !== h.session_ref) {
-          await this.deps.ledger.upsertWorker(dialogObjectId, h.worker_id, (prev) => {
+          await this.deps.ledger.upsertWorker(managerKey, h.worker_id, (prev) => {
             if (!prev) return undefined
             return {
               ...prev,
@@ -2161,7 +2192,7 @@ export class WorkerHarness {
         desired = taskStatusFromIncarnation('exited', report?.endReason)
       }
       const now = this.deps.now()
-      const committed = await this.deps.ledger.upsertWorker(dialogObjectId, h.worker_id, (prev) => {
+      const committed = await this.deps.ledger.upsertWorker(managerKey, h.worker_id, (prev) => {
         if (!prev) return undefined
         const task = prev.task.status === desired ? prev.task : applyStatusTransition(prev.task, desired, {
           now,
@@ -2225,7 +2256,7 @@ export class WorkerHarness {
     await this.withLock(h.worker_id, async () => {
       const found = await this.deps.ledger.findWorker(h.worker_id)
       if (!found) return // 未知 worker,理论不该发生;防御性丢弃,不抛给 adapter 的回调
-      const { worker, dialogObjectId } = found
+      const { worker, managerKey } = found
 
       const target = findIncarnation(worker, h.impl, h.seq)
       if (!target) return // 未知化身(理论不该发生),防御性丢弃
@@ -2246,7 +2277,7 @@ export class WorkerHarness {
         // task.status——protocol-agent-v3 §5.3"fork 不影响主线"在这里的具体体现:即使这是
         // fork 化身的终态回调,也绝不能像"当前化身"那样去推进 task 状态机。
         if (target.state === 'exited') return // 已终态,迟到回调忽略
-        await this.deps.ledger.upsertWorker(dialogObjectId, h.worker_id, (prev) => {
+        await this.deps.ledger.upsertWorker(managerKey, h.worker_id, (prev) => {
           if (!prev) return undefined
           // session_ref 现读现取(h.session_ref,不是构造 handle 时闭包住的旧值)——
           // builtin 的 session_ref 随每轮 burst 前进,adapter 侧在每次 onStateChange 回调
@@ -2288,7 +2319,7 @@ export class WorkerHarness {
           ? 'running'
           : taskStatusFromIncarnation(state, endReason, waitingInput)
 
-      const committed = await this.deps.ledger.upsertWorker(dialogObjectId, h.worker_id, (prev) => {
+      const committed = await this.deps.ledger.upsertWorker(managerKey, h.worker_id, (prev) => {
         if (!prev) return undefined
         // 同状态的 task 回调仍可能携带化身状态变化（例如 idle+owned bg
         // 应保持 task running）。只有两者都已经一致时才是无操作。
@@ -2449,6 +2480,13 @@ function requireMainlineIncarnation(worker: LedgerWorker): Incarnation {
   return mainline
 }
 
+function requireExecutableIncarnation(incarnation: Incarnation): ExecutableIncarnation {
+  if (!isExecutableIncarnation(incarnation)) {
+    throw new Error('WorkerHarness: legacy worker continuation is not available')
+  }
+  return incarnation
+}
+
 /**
  * 该 worker 名下是否已经存在过某个 impl 的化身——不限主线/fork、不限存活/终态,只要
  * `worker.incarnations` 里出现过一条 `impl` 匹配的记录就算"用过"。供 handoffIncarnation
@@ -2543,7 +2581,7 @@ function patchIncarnationBySeq(
     if (incarnations[i].impl === impl && incarnations[i].seq === seq) lastMatchIndex = i
   }
   if (lastMatchIndex === -1) return incarnations
-  return incarnations.map((inc, i) => (i === lastMatchIndex ? { ...inc, ...patch } : inc))
+  return incarnations.map((inc, i) => (i === lastMatchIndex ? { ...inc, ...patch } : inc)) as Incarnation[]
 }
 
 /**

--- a/crabot-agent/src/workers/harness/harness.ts
+++ b/crabot-agent/src/workers/harness/harness.ts
@@ -102,8 +102,10 @@ import {
 } from './inbox'
 import { WorkerEventLog, type HarnessEvent, type HarnessEventDelivery, type HarnessEventKind } from './worker-events'
 import { WorkerContextStore, type WorkerContext } from './context-store'
+import { readLegacyTraces } from '../legacy-source-reader.js'
+import { isLegacyContinuationAuth, type LegacyContinuationAuth } from './legacy-continuation-auth.js'
 import { applyStatusTransition, canTransition, isTerminalStatus, reviveTask, taskStatusFromIncarnation } from './task-status'
-import { join } from 'path'
+import { join, dirname } from 'path'
 
 /** 交接材料里"最近输出尾部"的上限(字符数,近似 4KB,见 protocol-agent-v3 §5.3)。 */
 const HANDOFF_TAIL_MAX_CHARS = 4096
@@ -413,6 +415,8 @@ export interface HarnessDeps {
   readonly builtinSpawnDefaults?: BuiltinRuntimeFactory
   /** True while this worker owns a running background entity. */
   readonly hasRunningBg?: (workerId: string) => Promise<boolean>
+  /** Validates an opaque legacy continuation credential immediately before side effects. */
+  readonly validateLegacyContinuationAuth?: (auth: LegacyContinuationAuth) => Promise<boolean>
 }
 
 export interface SpawnWorkerParams {
@@ -757,6 +761,7 @@ export class WorkerHarness {
       onSettled?: InboxItem['onSettled']
       dedupeKey?: string
       onDeduplicated?: () => void
+      legacyContinuationAuth?: LegacyContinuationAuth
     },
   ): Promise<void> {
     const inbox = this.getInbox(workerId)
@@ -775,6 +780,7 @@ export class WorkerHarness {
         allow_terminal_continuation: true,
         ...(opts?.onSettled ? { onSettled: opts.onSettled } : {}),
         ...(opts?.dedupeKey ? { dedupe_key: opts.dedupeKey } : {}),
+        ...(opts?.legacyContinuationAuth ? { legacy_continuation_auth: opts.legacyContinuationAuth } : {}),
       }
       enqueued = opts?.dedupeKey ? inbox.enqueueUnique(item) : (inbox.enqueue(item), true)
     })
@@ -905,7 +911,19 @@ export class WorkerHarness {
       const incarnation = requireMainlineIncarnation(found.worker)
 
       if (isLegacyIncarnation(incarnation)) {
-        throw new Error('WorkerHarness.sendToWorker: legacy worker continuation is not available')
+        if (item.allow_terminal_continuation === false) return 'delivered'
+        const delivery = await this.continueLegacyWorker(workerId, item)
+        if (isContinuationRetry(delivery)) {
+          return this.continueTerminalWorker(
+            workerId,
+            item.text,
+            delivery.impl,
+            delivery.seq,
+            item.raw,
+            delivery.endedReason,
+          )
+        }
+        return delivery
       }
 
       if (incarnation.state === 'exited') {
@@ -937,6 +955,219 @@ export class WorkerHarness {
       }
       return this.settleInputAttempt(workerId, item.text, item.raw, attempt)
     })
+  }
+
+  private async continueLegacyWorker(
+    workerId: string,
+    item: InboxItem,
+  ): Promise<ContinuationDelivery> {
+    return this.withLock(workerId, async () => {
+      const found = await this.deps.ledger.findWorker(workerId)
+      if (!found) throw new WorkerNotFoundError(workerId)
+      const { managerKey, worker } = found
+      if (worker.task.status === 'cancelled') {
+        await this.appendEvent(workerId, 1, 'state_changed', {
+          kind: 'dead_letter',
+          reason: 'task_cancelled',
+          text_len: item.text.length,
+        })
+        return 'dead_letter'
+      }
+
+      const legacy = requireMainlineIncarnation(worker)
+      if (!isLegacyIncarnation(legacy)) {
+        throw new Error('WorkerHarness.legacyContinuation: mainline changed before continuation')
+      }
+      if (
+        (worker.task.status !== 'completed' && worker.task.status !== 'failed') ||
+        !['completed', 'failed', 'pre_migration'].includes(legacy.ended_reason)
+      ) {
+        throw new Error('WorkerHarness.sendToWorker: legacy worker is not eligible for continuation')
+      }
+      const auth = item.legacy_continuation_auth
+      if (
+        !isLegacyContinuationAuth(auth) ||
+        auth.manager_key !== managerKey ||
+        !this.deps.validateLegacyContinuationAuth ||
+        !await this.deps.validateLegacyContinuationAuth(auth)
+      ) {
+        await this.appendEvent(workerId, legacy.seq, 'state_changed', {
+          kind: 'dead_letter',
+          reason: 'legacy_continuation_authorization_invalid',
+          text_len: item.text.length,
+        })
+        return 'dead_letter'
+      }
+
+      // Source material is read-only. No legacy adapter, resume/checkpoint replay, or
+      // source kill is involved in this path.
+      const material = await this.readLegacyHandoffMaterial(worker, legacy.workspace)
+      const workspace = await this.deps.workspaces.resolve(
+        worker.worker_id,
+        material.workspaceCandidate,
+      )
+      const targetImpl = pickUnusedImpl(worker, this.deps.adapters, this.deps.defaultImpl)
+      const targetAdapter = this.deps.adapters.get(targetImpl)
+      if (!targetAdapter) {
+        throw new Error(`WorkerHarness.legacyContinuation: no adapter registered for impl '${targetImpl}'`)
+      }
+      if (implAlreadyUsed(worker, targetImpl)) {
+        throw new ImplAlreadyUsedError(worker.worker_id, targetImpl)
+      }
+
+      const caps = this.deps.capabilityBundle
+        ? await this.deps.capabilityBundle({
+            worker_id: worker.worker_id,
+            principal_permissions: auth.principal_permissions,
+          })
+        : EMPTY_CAPABILITY_BUNDLE
+      const builtin = targetImpl === 'builtin'
+        ? this.deps.builtinSpawnDefaults?.({
+            worker_id: worker.worker_id,
+            workspace,
+            origin: worker.origin,
+            goal: worker.task.goal,
+            principal_permissions: auth.principal_permissions,
+          })
+        : undefined
+      if (targetImpl === 'builtin' && !builtin) {
+        throw new Error('WorkerHarness.legacyContinuation: builtin target requires builtinSpawnDefaults')
+      }
+      // No context, HANDOFF, ledger, provision or spawn side effect precedes target preflight.
+      await targetAdapter.preflightProvision?.(workspace, caps)
+
+      await this.contextStore.write(worker.worker_id, {
+        principal_permissions: auth.principal_permissions,
+      })
+      const handoffAt = this.deps.now()
+      await appendHandoffFile(workspace.root, {
+        ts: handoffAt,
+        title: worker.task.title,
+        goal: worker.task.goal,
+        outcome: worker.task.outcome ?? legacy.ended_reason,
+        tail: material.tail,
+        input: item.text,
+      })
+      await this.appendEvent(worker.worker_id, legacy.seq, 'handoff_started', {
+        target_impl: targetImpl,
+        legacy: true,
+      })
+
+      await targetAdapter.provision(workspace, caps)
+      const prompt = buildHandoffPrompt(worker.task, item.text)
+      const handle = await targetAdapter.spawn({
+        worker_id: worker.worker_id,
+        prompt,
+        workspace,
+        goal: worker.task.goal,
+        origin: worker.origin,
+        principal_permissions: auth.principal_permissions,
+        builtin,
+      })
+      const initialInput = handle.initial_input
+      const initialState = cliContractState(initialInput?.control_state ?? 'running')
+      const now = this.deps.now()
+      const updated = await this.deps.ledger.upsertWorker(managerKey, worker.worker_id, (previous) => {
+        if (!previous) return undefined
+        const incarnation: Incarnation = {
+          seq: handle.seq,
+          impl: targetImpl,
+          state: initialState,
+          workspace: workspace.root,
+          session_ref: handle.session_ref,
+          started_at: now,
+          ...(initialState === 'exited'
+            ? { ended_at: now, ended_reason: initialInput?.report?.endReason ?? 'crashed' }
+            : {}),
+        }
+        let task = reopenTaskForContinuation(previous.task, now)
+        task = settleCliTask(task, initialState, initialInput?.report, now)
+        return {
+          ...previous,
+          task,
+          incarnations: [...previous.incarnations, incarnation],
+          updated_at: now,
+        }
+      })
+
+      this.bumpInputOwnershipRevision(worker.worker_id)
+      const inbox = this.getInbox(worker.worker_id)
+      inbox.release()
+      const replayedConsumed = inbox.requeueConsumed()
+      await this.appendEvent(
+        worker.worker_id,
+        handle.seq,
+        'spawned',
+        { impl: targetImpl, from_seq: legacy.seq, legacy: true },
+        updated?.task.status,
+      )
+      if (initialInput && (initialInput.disposition !== 'accepted' || initialState === 'exited')) {
+        await this.appendEvent(
+          worker.worker_id,
+          handle.seq,
+          'state_changed',
+          cliReportDetail(initialState, initialInput.report),
+          updated?.task.status,
+        )
+      }
+      return continuationDelivery(
+        initialInput,
+        initialState,
+        handle,
+        replayedConsumed,
+        { text: prompt, raw: item.raw },
+      )
+    })
+  }
+
+  private async readLegacyHandoffMaterial(
+    worker: LedgerWorker,
+    fallbackWorkspace: string,
+  ): Promise<{
+    readonly tail: string
+    readonly workspaceCandidate: string
+  }> {
+    const snapshotPath = join(this.deps.workersDir, worker.worker_id, 'legacy-task.json')
+    let snapshot: Record<string, unknown> | undefined
+    try {
+      const value: unknown = JSON.parse(await fs.readFile(snapshotPath, 'utf8'))
+      if (value && typeof value === 'object' && !Array.isArray(value)) {
+        snapshot = value as Record<string, unknown>
+      }
+    } catch (error) {
+      console.warn(`[WorkerHarness] legacy snapshot unavailable for ${worker.worker_id}:`, error)
+    }
+
+    let traces: Awaited<ReturnType<typeof readLegacyTraces>> | undefined
+    try {
+      traces = await readLegacyTraces(join(dirname(this.deps.workersDir), 'traces'))
+    } catch (error) {
+      console.warn(`[WorkerHarness] legacy traces unavailable for ${worker.worker_id}:`, error)
+    }
+    const byId = new Map(
+      [...(traces?.values() ?? [])].flat().map((trace) => [trace.trace_id, trace]),
+    )
+    const selected = (worker.legacy_source?.trace_ids ?? [])
+      .map((id) => byId.get(id))
+      .filter((trace): trace is NonNullable<typeof trace> => trace !== undefined)
+    const candidate = [...selected]
+      .reverse()
+      .find((trace) => typeof trace.resume_checkpoint?.worker_state?.cwd === 'string')
+      ?.resume_checkpoint?.worker_state?.cwd
+
+    // Never replay checkpoint messages/permissions into the new engine. Only bounded
+    // task snapshot text and trace lifecycle/outcome metadata become handoff material.
+    const traceSummary = selected.map((trace) => ({
+      trace_id: trace.trace_id,
+      started_at: trace.started_at,
+      ended_at: trace.ended_at,
+      outcome: trace.outcome,
+    }))
+    const raw = JSON.stringify({ task: snapshot, traces: traceSummary })
+    const tail = raw.length > HANDOFF_TAIL_MAX_CHARS
+      ? raw.slice(-HANDOFF_TAIL_MAX_CHARS)
+      : raw
+    return { tail, workspaceCandidate: candidate ?? fallbackWorkspace }
   }
 
   /**
@@ -2517,7 +2748,7 @@ function pickUnusedImpl(
   adapters: ReadonlyMap<WorkerImplId, WorkerAdapter>,
   defaultImpl: WorkerImplId
 ): WorkerImplId {
-  if (!implAlreadyUsed(worker, defaultImpl)) return defaultImpl
+  if (adapters.has(defaultImpl) && !implAlreadyUsed(worker, defaultImpl)) return defaultImpl
   for (const impl of adapters.keys()) {
     if (!implAlreadyUsed(worker, impl)) return impl
   }

--- a/crabot-agent/src/workers/harness/harness.ts
+++ b/crabot-agent/src/workers/harness/harness.ts
@@ -1477,6 +1477,14 @@ export class WorkerHarness {
     return (await this.deps.ledger.findWorker(workerId)) !== undefined
   }
 
+  async findWorker(workerId: string): Promise<{ managerKey: ManagerKey; worker: LedgerWorker } | undefined> {
+    return this.deps.ledger.findWorker(workerId)
+  }
+
+  async listAllWorkers(): Promise<Array<{ managerKey: ManagerKey; worker: LedgerWorker }>> {
+    return this.deps.ledger.listAllWorkers()
+  }
+
   async listWorkers(managerKey: ManagerKey): Promise<LedgerWorker[]> {
     return this.deps.ledger.listWorkers(managerKey)
   }

--- a/crabot-agent/src/workers/harness/inbox.ts
+++ b/crabot-agent/src/workers/harness/inbox.ts
@@ -20,6 +20,7 @@
  */
 
 import { AsyncMutex } from '../async-mutex'
+import type { LegacyContinuationAuth } from './legacy-continuation-auth.js'
 
 export type InboxSettlement = 'delivered' | 'dead_letter'
 
@@ -33,6 +34,8 @@ export interface InboxItem {
   readonly onSettled?: (settlement: InboxSettlement) => void | Promise<void>
   /** Prevent a producer retry from enqueueing the same durable item twice in one process. */
   readonly dedupe_key?: string
+  /** Opaque, in-process-only authorization for one legacy continuation. */
+  readonly legacy_continuation_auth?: LegacyContinuationAuth
 }
 
 export interface InboxDeliveryResult {

--- a/crabot-agent/src/workers/harness/ledger-store.ts
+++ b/crabot-agent/src/workers/harness/ledger-store.ts
@@ -1,54 +1,39 @@
-/**
- * LedgerStore —— worker 台账存储(protocol-agent-v3 §7):每 DialogObjectId 一个 JSON 文件,
- * 一把互斥锁保读-改-写原子性,tmp+rename 保落盘原子性(参照 src/workers/meta-store.ts 的写法)。
- *
- * 索引语义:内存维护 worker_id → DialogObjectId 的查找索引,首次访问时扫描目录建索引(幂等)。
- * findWorker 未命中索引时会重扫一次目录再判,用于兜底外部进程写入台账文件的场景。
- */
-
 import { promises as fs } from 'fs'
 import { join, dirname } from 'path'
 import { randomUUID } from 'crypto'
 import { AsyncMutex } from '../async-mutex'
-import type { DialogObjectId, LedgerWorker, WorkerLedger } from './ledger-types'
+import type { ManagerKey, LedgerWorker, WorkerLedger } from './ledger-types'
 
 const FILE_SUFFIX = '.json'
 
-/**
- * 段编码:把 [A-Za-z0-9_-] 之外的字符转成 %XX(UTF-8 字节),确保无歧义且可逆。
- * 导出以供其它需要"任意字符串 → 合法文件/目录名"的存储复用(如 manager/session-store.ts
- * 编码 ManagerKey),避免各处重复实现同一方案。
- */
 export function encodeSegment(s: string): string {
-  return encodeURIComponent(s).replace(
-    /[.!~*'()]/g,
-    (ch) => '%' + ch.charCodeAt(0).toString(16).toUpperCase().padStart(2, '0')
-  )
+  return encodeURIComponent(s).replace(/[.!~*'()]/g, ch => '%' + ch.charCodeAt(0).toString(16).toUpperCase().padStart(2, '0'))
 }
 
 export function decodeSegment(s: string): string {
   return decodeURIComponent(s)
 }
 
-/** DialogObjectId → 台账文件名(导出以支持双向可逆测试与目录扫描) */
-export function dialogObjectIdToFilename(id: DialogObjectId): string {
-  return `${encodeSegment(id)}${FILE_SUFFIX}`
+export function managerKeyToFilename(key: ManagerKey): string {
+  return `${encodeSegment(key)}${FILE_SUFFIX}`
 }
 
-/** 台账文件名 → DialogObjectId;不是本 store 产出的文件名(不认识的前缀/编码)返回 undefined */
-export function filenameToDialogObjectId(filename: string): DialogObjectId | undefined {
+/** A ManagerKey has a non-empty channel and session; the session may itself contain `::`. */
+export function isManagerKey(value: string): value is ManagerKey {
+  const separator = value.indexOf('::')
+  return separator > 0 && separator + 2 < value.length
+}
+
+/** Reject malformed and non-canonical names so an unindexed ledger cannot silently exist. */
+export function filenameToManagerKey(filename: string): ManagerKey | undefined {
   if (!filename.endsWith(FILE_SUFFIX)) return undefined
-  const stem = filename.slice(0, -FILE_SUFFIX.length)
-  let decoded: string
   try {
-    decoded = decodeSegment(stem)
+    const key = decodeSegment(filename.slice(0, -FILE_SUFFIX.length))
+    if (!isManagerKey(key)) return undefined
+    return managerKeyToFilename(key) === filename ? key : undefined
   } catch {
     return undefined
   }
-  if (decoded.startsWith('friend:') || decoded.startsWith('group:')) {
-    return decoded as DialogObjectId
-  }
-  return undefined
 }
 
 async function writeJsonAtomic(path: string, data: unknown): Promise<void> {
@@ -57,170 +42,156 @@ async function writeJsonAtomic(path: string, data: unknown): Promise<void> {
   await fs.rename(tmpPath, path)
 }
 
+/** Session-scoped worker ledger store. It never scans the retired friend/group ledger directory. */
 export class LedgerStore {
   private readonly ledgersDir: string
-  private readonly mutexes = new Map<DialogObjectId, AsyncMutex>()
-  private workerIndex = new Map<string, DialogObjectId>()
+  private readonly mutexes = new Map<ManagerKey, AsyncMutex>()
+  /** Serializes same-worker upserts across ledgers before either file can be written. */
+  private readonly workerMutexes = new Map<string, AsyncMutex>()
+  private workerIndex = new Map<string, ManagerKey>()
   private initPromise: Promise<void> | undefined
 
-  constructor(ledgersDir: string) {
-    this.ledgersDir = ledgersDir
-  }
+  constructor(ledgersDir: string) { this.ledgersDir = ledgersDir }
 
-  /** 首次访问时扫描目录建 worker_id → dialog_object_id 内存索引;幂等(重复调用共享同一次扫描) */
   async init(): Promise<void> {
-    if (!this.initPromise) {
-      this.initPromise = this.scanAndBuildIndex()
-    }
+    if (!this.initPromise) this.initPromise = this.scanAndBuildIndex()
     await this.initPromise
   }
 
-  async getLedger(id: DialogObjectId): Promise<WorkerLedger> {
+  async getLedger(key: ManagerKey): Promise<WorkerLedger> {
     await this.init()
-    return this.readLedgerFileStrict(id)
+    return this.readLedgerFileStrict(key)
   }
 
-  async listWorkers(id: DialogObjectId): Promise<LedgerWorker[]> {
-    const ledger = await this.getLedger(id)
-    return ledger.workers
+  async listWorkers(key: ManagerKey): Promise<LedgerWorker[]> {
+    return (await this.getLedger(key)).workers
   }
 
-  /** 跨对话对象按 worker_id 查;索引未命中时重扫一次目录再判 */
-  async findWorker(
-    workerId: string
-  ): Promise<{ dialogObjectId: DialogObjectId; worker: LedgerWorker } | undefined> {
+  async findWorker(workerId: string): Promise<{ managerKey: ManagerKey; worker: LedgerWorker } | undefined> {
     await this.init()
-    let id = this.workerIndex.get(workerId)
-    if (!id) {
+    let key = this.workerIndex.get(workerId)
+    if (!key) {
       await this.scanAndBuildIndex()
-      id = this.workerIndex.get(workerId)
-      if (!id) return undefined
+      key = this.workerIndex.get(workerId)
+      if (!key) return undefined
     }
-    const ledger = await this.readLedgerFileStrict(id)
-    const worker = ledger.workers.find((w) => w.worker_id === workerId)
-    if (!worker) return undefined
-    return { dialogObjectId: id, worker }
+    const ledger = await this.readLedgerFileStrict(key)
+    const worker = ledger.workers.find(w => w.worker_id === workerId)
+    if (!worker) throw new Error(`[LedgerStore] worker index inconsistent for ${workerId}`)
+    return { managerKey: key, worker }
   }
 
-  /** 读-改-写在该对话对象的互斥锁内完成;mutator 返回 undefined 表示放弃写入 */
   async upsertWorker(
-    id: DialogObjectId,
+    key: ManagerKey,
     workerId: string,
     mutator: (prev: LedgerWorker | undefined) => LedgerWorker | undefined
   ): Promise<LedgerWorker | undefined> {
     await this.init()
-    const mutex = this.getMutex(id)
-    return mutex.run(async () => {
-      const ledger = await this.readLedgerFileStrict(id)
-      const idx = ledger.workers.findIndex((w) => w.worker_id === workerId)
-      const prev = idx >= 0 ? ledger.workers[idx] : undefined
+    return this.getWorkerMutex(workerId).run(async () => this.getMutex(key).run(async () => {
+      const ledger = await this.readLedgerFileStrict(key)
+      const index = ledger.workers.findIndex(w => w.worker_id === workerId)
+      const prev = index >= 0 ? ledger.workers[index] : undefined
       const next = mutator(prev)
-      if (next === undefined) return undefined
-
-      if (idx >= 0) {
-        ledger.workers[idx] = next
-      } else {
-        ledger.workers.push(next)
+      if (!next) return undefined
+      if (next.worker_id !== workerId) {
+        throw new Error(`[LedgerStore] worker_id mismatch: requested ${workerId}, received ${next.worker_id}`)
       }
-      await writeJsonAtomic(this.pathFor(id), ledger)
-      this.workerIndex.set(workerId, id)
+      this.assertWorkerOwner(key, next)
+      if (prev && prev.manager_key !== next.manager_key) {
+        throw new Error(`[LedgerStore] manager_key is immutable for worker ${workerId}`)
+      }
+      const existingOwner = this.workerIndex.get(workerId)
+      if (existingOwner && existingOwner !== key) {
+        throw new Error(`[LedgerStore] duplicate worker_id ${workerId} belongs to ${existingOwner}`)
+      }
+      if (index >= 0) ledger.workers[index] = next
+      else ledger.workers.push(next)
+      await writeJsonAtomic(this.pathFor(key), ledger)
+      this.workerIndex.set(workerId, key)
       return next
-    })
+    }))
   }
 
-  /**
-   * 全量枚举所有对话对象下的 worker(跨 dialog_object_id)。listWorkers/findWorker 都是
-   * 针对单个已知对话对象或已知 worker_id 的查找,不满足"扫描整个台账存储"的场景(如
-   * Task 9 崩溃恢复对账 reconcileOnStartup 需要巡检所有对话对象下的非终态 worker)——
-   * 复用 init() 建好的 worker_id → dialog_object_id 索引拿到全部 dialog_object_id,
-   * 再逐个对话对象读一次台账文件拼起来。只读,不新增任何写路径。
-   */
-  async listAllWorkers(): Promise<Array<{ dialogObjectId: DialogObjectId; worker: LedgerWorker }>> {
+  async listAllWorkers(): Promise<Array<{ managerKey: ManagerKey; worker: LedgerWorker }>> {
     await this.init()
-    const dialogIds = new Set(this.workerIndex.values())
-    const result: Array<{ dialogObjectId: DialogObjectId; worker: LedgerWorker }> = []
-    for (const dialogObjectId of dialogIds) {
-      const ledger = await this.readLedgerFileStrict(dialogObjectId)
-      for (const worker of ledger.workers) {
-        result.push({ dialogObjectId, worker })
-      }
+    const keys = new Set(this.workerIndex.values())
+    const result: Array<{ managerKey: ManagerKey; worker: LedgerWorker }> = []
+    for (const key of keys) {
+      const ledger = await this.readLedgerFileStrict(key)
+      for (const worker of ledger.workers) result.push({ managerKey: key, worker })
     }
     return result
   }
 
-  private getMutex(id: DialogObjectId): AsyncMutex {
-    let mutex = this.mutexes.get(id)
+  private getMutex(key: ManagerKey): AsyncMutex {
+    let mutex = this.mutexes.get(key)
+    if (!mutex) { mutex = new AsyncMutex(); this.mutexes.set(key, mutex) }
+    return mutex
+  }
+
+  private getWorkerMutex(workerId: string): AsyncMutex {
+    let mutex = this.workerMutexes.get(workerId)
     if (!mutex) {
       mutex = new AsyncMutex()
-      this.mutexes.set(id, mutex)
+      this.workerMutexes.set(workerId, mutex)
     }
     return mutex
   }
 
-  private pathFor(id: DialogObjectId): string {
-    return join(this.ledgersDir, dialogObjectIdToFilename(id))
+  private pathFor(key: ManagerKey): string {
+    if (!isManagerKey(key)) {
+      throw new Error(`[LedgerStore] invalid manager_key: ${key}`)
+    }
+    return join(this.ledgersDir, managerKeyToFilename(key))
   }
 
-  /**
-   * 读取台账文件。不存在返回空壳 { dialog_object_id, workers: [] }(不建文件)。
-   * JSON 内容损坏则抛明确错误——这与 init() 扫描时"跳过并 warn"的语义不同:
-   * getLedger/upsertWorker 是针对单个已知对话对象的读,坏文件如果静默当空,
-   * 后续写入会用空壳覆盖用户原有数据,所以必须显式失败。
-   */
-  private async readLedgerFileStrict(id: DialogObjectId): Promise<WorkerLedger> {
-    const filePath = this.pathFor(id)
+  private assertWorkerOwner(key: ManagerKey, worker: LedgerWorker): void {
+    if (worker.manager_key !== key) {
+      throw new Error(`[LedgerStore] manager_key mismatch: file ${key}, worker ${worker.worker_id} has ${worker.manager_key}`)
+    }
+  }
+
+  private assertLedger(key: ManagerKey, ledger: WorkerLedger): WorkerLedger {
+    if (!ledger || ledger.manager_key !== key || !Array.isArray(ledger.workers)) {
+      throw new Error(`[LedgerStore] manager_key mismatch or invalid ledger for ${key}`)
+    }
+    for (const worker of ledger.workers) this.assertWorkerOwner(key, worker)
+    return ledger
+  }
+
+  private async readLedgerFileStrict(key: ManagerKey): Promise<WorkerLedger> {
+    const filePath = this.pathFor(key)
     let raw: string
-    try {
-      raw = await fs.readFile(filePath, 'utf-8')
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
-        return { dialog_object_id: id, workers: [] }
-      }
+    try { raw = await fs.readFile(filePath, 'utf-8') }
+    catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return { manager_key: key, workers: [] }
       throw err
     }
-    try {
-      return JSON.parse(raw) as WorkerLedger
-    } catch (err) {
-      throw new Error(
-        `[LedgerStore] 台账文件损坏(非法 JSON),拒绝当作空壳处理: ${filePath}: ${(err as Error).message}`
-      )
+    try { return this.assertLedger(key, JSON.parse(raw) as WorkerLedger) }
+    catch (err) {
+      throw new Error(`[LedgerStore] invalid ledger ${filePath}: ${(err as Error).message}`)
     }
   }
 
-  /**
-   * 扫描目录建索引。与 readLedgerFileStrict 语义不同:坏文件在这里只跳过并 console.warn,
-   * 不让一个坏文件毁掉整个索引(索引只是查找加速手段,允许对损坏对话对象暂时缺失)。
-   */
   private async scanAndBuildIndex(): Promise<void> {
     await fs.mkdir(this.ledgersDir, { recursive: true })
     const entries = await fs.readdir(this.ledgersDir)
-    const newIndex = new Map<string, DialogObjectId>()
-
+    const index = new Map<string, ManagerKey>()
     for (const entry of entries) {
-      const id = filenameToDialogObjectId(entry)
-      if (!id) continue
-
-      let raw: string
-      try {
-        raw = await fs.readFile(join(this.ledgersDir, entry), 'utf-8')
-      } catch (err) {
-        console.warn(`[LedgerStore] 扫描时读取台账文件失败,跳过: ${entry}: ${(err as Error).message}`)
+      const key = filenameToManagerKey(entry)
+      if (!key) {
+        if (entry.endsWith(FILE_SUFFIX)) {
+          throw new Error(`[LedgerStore] invalid or non-canonical ledger filename: ${entry}`)
+        }
         continue
       }
-
-      let ledger: WorkerLedger
-      try {
-        ledger = JSON.parse(raw) as WorkerLedger
-      } catch (err) {
-        console.warn(`[LedgerStore] 扫描时发现损坏的台账文件(非法 JSON),跳过: ${entry}: ${(err as Error).message}`)
-        continue
-      }
-
-      for (const worker of ledger.workers ?? []) {
-        newIndex.set(worker.worker_id, id)
+      const ledger = await this.readLedgerFileStrict(key)
+      for (const worker of ledger.workers) {
+        const previous = index.get(worker.worker_id)
+        if (previous && previous !== key) throw new Error(`[LedgerStore] duplicate worker_id ${worker.worker_id} in ${previous} and ${key}`)
+        index.set(worker.worker_id, key)
       }
     }
-
-    this.workerIndex = newIndex
+    this.workerIndex = index
   }
 }

--- a/crabot-agent/src/workers/harness/ledger-store.ts
+++ b/crabot-agent/src/workers/harness/ledger-store.ts
@@ -6,6 +6,7 @@ import { AsyncMutex } from '../async-mutex'
 import type { ManagerKey, LedgerWorker, WorkerLedger } from './ledger-types'
 
 const FILE_SUFFIX = '.json'
+const ATOMIC_TEMP_FILE = /^\.tmp-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.json$/i
 
 export function encodeSegment(s: string): string {
   return encodeURIComponent(s).replace(/[.!~*'()]/g, ch => '%' + ch.charCodeAt(0).toString(16).toUpperCase().padStart(2, '0'))
@@ -69,13 +70,20 @@ export class LedgerStore {
   }
 
   async findWorker(workerId: string): Promise<{ managerKey: ManagerKey; worker: LedgerWorker } | undefined> {
+    const indexed = await this.findWorkerFromIndex(workerId)
+    if (indexed) return indexed
+    await this.scanAndBuildIndex()
+    return this.findWorkerFromIndex(workerId)
+  }
+
+  /**
+   * Lookup against the initialized in-memory index without a fallback directory rescan.
+   * Intended for controlled startup imports whose writes all go through this same store.
+   */
+  async findWorkerFromIndex(workerId: string): Promise<{ managerKey: ManagerKey; worker: LedgerWorker } | undefined> {
     await this.init()
-    let key = this.workerIndex.get(workerId)
-    if (!key) {
-      await this.scanAndBuildIndex()
-      key = this.workerIndex.get(workerId)
-      if (!key) return undefined
-    }
+    const key = this.workerIndex.get(workerId)
+    if (!key) return undefined
     const ledger = await this.readLedgerFileStrict(key)
     const worker = ledger.workers.find(w => w.worker_id === workerId)
     if (!worker) throw new Error(`[LedgerStore] worker index inconsistent for ${workerId}`)
@@ -213,6 +221,7 @@ export class LedgerStore {
     const entries = await fs.readdir(this.ledgersDir)
     const index = new Map<string, ManagerKey>()
     for (const entry of entries) {
+      if (ATOMIC_TEMP_FILE.test(entry)) continue
       const key = filenameToManagerKey(entry)
       if (!key) {
         if (entry.endsWith(FILE_SUFFIX)) {

--- a/crabot-agent/src/workers/harness/ledger-store.ts
+++ b/crabot-agent/src/workers/harness/ledger-store.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'fs'
 import { join, dirname } from 'path'
 import { randomUUID } from 'crypto'
+import { canonicalizeJson } from 'crabot-shared'
 import { AsyncMutex } from '../async-mutex'
 import type { ManagerKey, LedgerWorker, WorkerLedger } from './ledger-types'
 
@@ -81,10 +82,26 @@ export class LedgerStore {
     return { managerKey: key, worker }
   }
 
+  async importLegacyWorker(key: ManagerKey, worker: LedgerWorker): Promise<LedgerWorker> {
+    assertLegacyWorker(worker, true)
+    const saved = await this.mutateWorker(key, worker.worker_id, () => worker, true)
+    if (!saved) throw new Error('[LedgerStore] legacy import unexpectedly removed worker')
+    return saved
+  }
+
   async upsertWorker(
     key: ManagerKey,
     workerId: string,
     mutator: (prev: LedgerWorker | undefined) => LedgerWorker | undefined
+  ): Promise<LedgerWorker | undefined> {
+    return this.mutateWorker(key, workerId, mutator, false)
+  }
+
+  private async mutateWorker(
+    key: ManagerKey,
+    workerId: string,
+    mutator: (prev: LedgerWorker | undefined) => LedgerWorker | undefined,
+    importingLegacy: boolean,
   ): Promise<LedgerWorker | undefined> {
     await this.init()
     return this.getWorkerMutex(workerId).run(async () => this.getMutex(key).run(async () => {
@@ -93,6 +110,21 @@ export class LedgerStore {
       const prev = index >= 0 ? ledger.workers[index] : undefined
       const next = mutator(prev)
       if (!next) return undefined
+      assertWorkerLegacyShape(next)
+      if (prev?.legacy_source) {
+        assertLegacyWorker(prev)
+        assertLegacyWorker(next)
+        const sourceChanged = canonicalizeJson(prev.legacy_source) !== canonicalizeJson(next.legacy_source)
+        const firstIncarnationChanged = canonicalizeJson(prev.incarnations[0]) !== canonicalizeJson(next.incarnations[0])
+        if (sourceChanged || firstIncarnationChanged) {
+          throw new Error(`[LedgerStore] immutable legacy source conflict for ${workerId}`)
+        }
+      } else if (next.legacy_source && !importingLegacy) {
+        throw new Error('[LedgerStore] legacy workers may only be created by importLegacyWorker')
+      }
+      if (prev && importingLegacy && canonicalizeJson(prev) !== canonicalizeJson(next)) {
+        throw new Error(`[LedgerStore] immutable legacy worker conflict for ${workerId}`)
+      }
       if (next.worker_id !== workerId) {
         throw new Error(`[LedgerStore] worker_id mismatch: requested ${workerId}, received ${next.worker_id}`)
       }
@@ -155,7 +187,10 @@ export class LedgerStore {
     if (!ledger || ledger.manager_key !== key || !Array.isArray(ledger.workers)) {
       throw new Error(`[LedgerStore] manager_key mismatch or invalid ledger for ${key}`)
     }
-    for (const worker of ledger.workers) this.assertWorkerOwner(key, worker)
+    for (const worker of ledger.workers) {
+      this.assertWorkerOwner(key, worker)
+      assertWorkerLegacyShape(worker)
+    }
     return ledger
   }
 
@@ -193,5 +228,31 @@ export class LedgerStore {
       }
     }
     this.workerIndex = index
+  }
+}
+
+function assertWorkerLegacyShape(worker: LedgerWorker): void {
+  const hasLegacyIncarnation = worker.incarnations.some((incarnation) => incarnation.impl === 'legacy')
+  if (worker.legacy_source || hasLegacyIncarnation) assertLegacyWorker(worker)
+}
+
+function assertLegacyWorker(worker: LedgerWorker, initialImport = false): void {
+  const source = worker.legacy_source
+  const first = worker.incarnations[0]
+  const traceIds = source?.trace_ids
+  const validSource = source?.kind === 'v2_admin_task' &&
+    typeof source.admin_task_id === 'string' && source.admin_task_id.length > 0 &&
+    typeof source.imported_at === 'string' && source.imported_at.length > 0 &&
+    Array.isArray(traceIds) && traceIds.every((traceId) => typeof traceId === 'string' && traceId.length > 0) &&
+    new Set(traceIds).size === traceIds.length
+  const validFirst = first?.impl === 'legacy' &&
+    first.seq === 1 && first.state === 'exited' &&
+    typeof first.ended_at === 'string' &&
+    first.session_ref === undefined
+  const laterLegacy = worker.incarnations.slice(1).some((incarnation) => incarnation.impl === 'legacy')
+  if (!validSource || !validFirst || laterLegacy || (initialImport && worker.incarnations.length !== 1)) {
+    throw new Error(
+      '[LedgerStore] invalid legacy worker: immutable source and one first legacy incarnation are required',
+    )
   }
 }

--- a/crabot-agent/src/workers/harness/ledger-types.ts
+++ b/crabot-agent/src/workers/harness/ledger-types.ts
@@ -1,69 +1,62 @@
-/**
- * P3 台账类型 —— 逐字对齐 protocol-agent-v3.md §3(核心概念与标识)/ §7(台账与存储)。
- *
- * 复用协议已在别处落地过的类型,不重复定义:
- * - ModuleId / FriendId / SessionId / TaskId:crabot-agent/src/types.ts(从 crabot-shared 转出)
- * - WorkerImplId / WorkerContractState / IncarnationEndReason:src/workers/types.ts(P1/P2 已按协议定义)
- *
- * TaskPriority 目前既不在 crabot-shared,也不在 crabot-agent/src/types.ts 中定义,这里按
- * base-protocol §5.9 原样声明,待上游补齐后再收敛为复用,不在本任务范围内新增导出。
- *
- * @see crabot-docs/protocols/protocol-agent-v3.md §3、§7
- * @see crabot-docs/protocols/base-protocol.md §5.9、§5.10
- */
-
 import type { ModuleId, FriendId, SessionId, TaskId } from '../../types'
 import type { WorkerImplId, WorkerContractState, IncarnationEndReason } from '../types'
 
-/** base-protocol §5.9 TaskPriority(暂无上游导出,原样声明) */
 export type TaskPriority = 'low' | 'normal' | 'high' | 'urgent'
+export type TaskStatus = 'queued' | 'running' | 'waiting_input' | 'completed' | 'failed' | 'cancelled'
 
-/**
- * base-protocol §5.10 TaskStatus 的 v3 精简集(protocol-agent-v3 §5.2)。
- * 旧值(pending/planning/executing/waiting_human/waiting_bg)已在 v3 弃用,新代码不得使用。
- */
-export type TaskStatus =
-  | 'queued'
-  | 'running'
-  | 'waiting_input'
-  | 'completed'
-  | 'failed'
-  | 'cancelled'
-
-/** 对话对象 ID:worker 台账的聚合键(protocol-agent-v3 §3) */
-export type DialogObjectId =
-  | `friend:${FriendId}` // 私聊:按 Friend 跨 channel 聚合
-  | `group:${ModuleId}:${SessionId}` // 群聊:单群即一个对话对象
-
-/** Manager 实例键:对话历史(loop 上下文)的粒度(protocol-agent-v3 §3) */
+/** Manager loop, worker ledger and worker ownership share this session key. */
 export type ManagerKey = `${ModuleId}::${SessionId}`
 
-/** 化身(incarnation):worker 在某一实现下的一次连续执行体(protocol-agent-v3 §3) */
-export interface Incarnation {
+interface IncarnationBase {
   seq: number
-  impl: WorkerImplId | 'legacy'
   state: WorkerContractState
   workspace: string
-  /** builtin: session 树文件引用;CLI: 原生 session id;legacy: 旧 ResumeCheckpoint 引用 */
-  session_ref: string
-  tmux_session?: string
   started_at: string
   ended_at?: string
   ended_reason?: IncarnationEndReason
-  /** 本化身是从哪个 seq 的化身 fork 出来的一次性侧问分支;有值即表示它不在主线化身链上,
-   * 不参与 send_to_worker / kill_worker / 化身接续等主线判定(protocol-agent-v3 §3、§5.3)。 */
   forked_from?: number
 }
 
-/** 台账中的 worker 条目(task 数据归并于此,agent 即真相源)(protocol-agent-v3 §3) */
+export interface ExecutableIncarnation extends IncarnationBase {
+  impl: WorkerImplId
+  session_ref: string
+  tmux_session?: string
+}
+
+export interface LegacyIncarnation extends IncarnationBase {
+  impl: 'legacy'
+  state: 'exited'
+  ended_at: string
+  ended_reason: IncarnationEndReason
+  session_ref?: never
+}
+
+export type Incarnation = ExecutableIncarnation | LegacyIncarnation
+
+export function isLegacyIncarnation(incarnation: Incarnation): incarnation is LegacyIncarnation {
+  return incarnation.impl === 'legacy'
+}
+
+export function isExecutableIncarnation(incarnation: Incarnation): incarnation is ExecutableIncarnation {
+  return incarnation.impl !== 'legacy'
+}
+
+export interface LegacySourceRef {
+  kind: 'v2_admin_task'
+  admin_task_id: TaskId
+  trace_ids: string[]
+  imported_at: string
+}
+
 export interface LedgerWorker {
   worker_id: string
+  /** Immutable session owner: storage, lookup, routing and read model all use this field. */
+  manager_key: ManagerKey
   task: {
     id: TaskId
-    /** Schedule/system business type; optional for ordinary worker tasks. */
     type?: string
     title: string
-    status: TaskStatus // 精简状态机,见 base-protocol §5.10
+    status: TaskStatus
     priority?: TaskPriority
     input?: Record<string, unknown>
     tags?: string[]
@@ -74,30 +67,17 @@ export interface LedgerWorker {
     error?: string
   }
   origin: {
-    spawned_by_session: ManagerKey
-    spawned_by_episode?: string // episode trace_id,可跳转
-    /** 权限身份:以谁的名义执行(权限模板解析依据) */
+    spawned_by_episode?: string
     creator_friend_id?: FriendId
     trigger_type: 'message' | 'scheduled' | 'system'
   }
-  /** 结果回报目标,默认 = 派发 session */
   report_to: { channel_id: ModuleId; session_id: SessionId }
   incarnations: Incarnation[]
+  legacy_source?: LegacySourceRef
   updated_at: string
 }
 
-/** 台账文件:每对话对象一份(protocol-agent-v3 §3) */
 export interface WorkerLedger {
-  dialog_object_id: DialogObjectId
+  manager_key: ManagerKey
   workers: LedgerWorker[]
-}
-
-/** P3 内部辅助:私聊对话对象 ID(task-2-brief.md) */
-export function dialogObjectIdForPrivate(friendId: string): DialogObjectId {
-  return `friend:${friendId}`
-}
-
-/** P3 内部辅助:群聊对话对象 ID(task-2-brief.md) */
-export function dialogObjectIdForGroup(channelId: string, sessionId: string): DialogObjectId {
-  return `group:${channelId}:${sessionId}`
 }

--- a/crabot-agent/src/workers/harness/legacy-continuation-auth.ts
+++ b/crabot-agent/src/workers/harness/legacy-continuation-auth.ts
@@ -1,0 +1,30 @@
+import type { ResolvedPermissions } from '../../types.js'
+import { isManagerKey } from './ledger-store.js'
+import type { ManagerKey } from './ledger-types.js'
+import { isResolvedPermissionsSnapshot } from './context-store.js'
+
+/** Opaque control-plane credential attached only to one in-process inbox item. */
+export interface LegacyContinuationAuth {
+  readonly manager_key: ManagerKey
+  readonly principal_kind: 'friend' | 'admin_chat_jwt'
+  readonly principal_generation: number
+  readonly principal_permissions: ResolvedPermissions
+}
+
+export function isLegacyContinuationAuth(value: unknown): value is LegacyContinuationAuth {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  const auth = value as Record<string, unknown>
+  const keys = Object.keys(auth).sort()
+  const expected = [
+    'manager_key',
+    'principal_generation',
+    'principal_kind',
+    'principal_permissions',
+  ]
+  return keys.length === expected.length && keys.every((key, index) => key === expected[index]) &&
+    typeof auth.manager_key === 'string' && isManagerKey(auth.manager_key) &&
+    (auth.principal_kind === 'friend' || auth.principal_kind === 'admin_chat_jwt') &&
+    typeof auth.principal_generation === 'number' &&
+    Number.isInteger(auth.principal_generation) && auth.principal_generation > 0 &&
+    isResolvedPermissionsSnapshot(auth.principal_permissions)
+}

--- a/crabot-agent/src/workers/harness/worker-events.ts
+++ b/crabot-agent/src/workers/harness/worker-events.ts
@@ -34,6 +34,8 @@ export type HarnessEventKind =
    * 'worker_disappeared'(见 harness.ts queryWorker 注释,理论上不会发生的防御性分支)。
    */
   | 'query_failed'
+  /** v2 import history record: persisted only, never bridged to a Manager wake. */
+  | 'legacy_imported'
 
 export interface HarnessEvent {
   readonly ts: string

--- a/crabot-agent/src/workers/legacy-importer.ts
+++ b/crabot-agent/src/workers/legacy-importer.ts
@@ -1,0 +1,555 @@
+import { createHash, randomUUID } from 'node:crypto'
+import { promises as fs } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { canonicalizeJson, sha256CanonicalJson } from 'crabot-shared'
+import type { WorkspaceManager } from './harness/workspace-manager.js'
+import { isManagerKey, type LedgerStore } from './harness/ledger-store.js'
+import type { LedgerWorker, ManagerKey, TaskPriority, TaskStatus } from './harness/ledger-types.js'
+import { WorkerEventLog } from './harness/worker-events.js'
+import { readLegacyTraces, type LegacyTrace } from './legacy-source-reader.js'
+
+const VERSION = 1
+const SYSTEM_KEY = 'admin-web::system-tasks' as ManagerKey
+const PRE_MIGRATION_ERROR = '旧执行上下文在 v3 切换时终止，可创建新化身续办'
+const LEGACY_STATUSES = new Set([
+  'pending',
+  'planning',
+  'executing',
+  'waiting_human',
+  'waiting',
+  'completed',
+  'failed',
+  'cancelled',
+])
+
+interface ManifestTrace {
+  readonly trace_id: string
+  readonly canonical_content_sha256: string
+}
+
+interface ManifestTask {
+  readonly admin_task_id: string
+  readonly canonical_content_sha256: string
+  readonly traces: ReadonlyArray<ManifestTrace>
+}
+
+interface InProgressMarker {
+  readonly version: 1
+  readonly state: 'in_progress'
+  readonly imported_at: string
+  readonly fingerprint: string
+  readonly manifest: ReadonlyArray<ManifestTask>
+}
+
+interface CompletedMarker extends Omit<InProgressMarker, 'state'> {
+  readonly state: 'completed'
+  readonly source_task_count: number
+  readonly imported_count: number
+  readonly by_manager_key: Record<string, number>
+}
+
+type Marker = InProgressMarker | CompletedMarker
+
+type LegacyTask = Record<string, unknown> & {
+  readonly id: string
+  readonly title: string
+  readonly status: string
+  readonly created_at: string
+}
+
+export interface LegacyImporterDeps {
+  readonly adminDataDir: string
+  readonly traceDir: string
+  readonly agentDataDir: string
+  readonly ledger: LedgerStore
+  readonly workspaces: WorkspaceManager
+  readonly now: () => string
+  /** Test-only crash seam, called after one task and its import event are durable. */
+  readonly afterWorkerImported?: (worker: LedgerWorker) => Promise<void> | void
+}
+
+export interface LegacyImportReport {
+  readonly skipped: boolean
+  readonly imported: number
+}
+
+export async function importV2LegacyTasks(deps: LegacyImporterDeps): Promise<LegacyImportReport> {
+  const markerPath = join(deps.agentDataDir, 'migrations', 'v2-legacy-import-v1.json')
+  const marker = await readMarkerFile(markerPath)
+  if (marker?.state === 'completed') return { skipped: true, imported: 0 }
+
+  await assertDirectory(deps.adminDataDir)
+  const source = await readTasks(join(deps.adminDataDir, 'tasks.json'))
+  const traces = source.tasks.length === 0
+    ? new Map<string, LegacyTrace[]>()
+    : await readLegacyTraces(deps.traceDir)
+  const manifest = buildManifest(source.tasks, traces)
+  const fingerprint = source.absent ? 'absent' : sha256CanonicalJson(manifest)
+
+  let active: InProgressMarker
+  if (marker) {
+    assertSameSource(marker, manifest, fingerprint)
+    active = marker
+  } else {
+    const importedAt = deps.now()
+    if (!validIso(importedAt)) throw new Error('[legacy-import] now() must return an ISO timestamp')
+    active = {
+      version: VERSION,
+      state: 'in_progress',
+      imported_at: importedAt,
+      fingerprint,
+      manifest,
+    }
+    assertMarker(active)
+    await writeAtomic(markerPath, active)
+  }
+
+  let imported = 0
+  const counts: Record<string, number> = {}
+  for (const task of source.tasks) {
+    const selected = traces.get(task.id) ?? []
+    const worker = await makeWorker(task, selected, active.imported_at, deps.workspaces)
+    const workerDir = join(deps.agentDataDir, 'workers', worker.worker_id)
+    await writeSnapshot(join(workerDir, 'legacy-task.json'), task)
+
+    const existing = await deps.ledger.findWorker(worker.worker_id)
+    if (!existing) {
+      await deps.ledger.importLegacyWorker(worker.manager_key, worker)
+      imported++
+    } else if (canonicalizeJson(existing.worker) !== canonicalizeJson(worker)) {
+      throw new Error(`[legacy-import] immutable worker conflict for ${worker.worker_id}`)
+    }
+
+    await appendImportEventOnce(workerDir, worker, selected.length, active.imported_at)
+    counts[worker.manager_key] = (counts[worker.manager_key] ?? 0) + 1
+    await deps.afterWorkerImported?.(worker)
+  }
+
+  const completed: CompletedMarker = {
+    ...active,
+    state: 'completed',
+    source_task_count: source.tasks.length,
+    imported_count: source.tasks.length,
+    by_manager_key: counts,
+  }
+  assertMarker(completed)
+  await writeAtomic(markerPath, completed)
+  return { skipped: false, imported }
+}
+
+async function makeWorker(
+  task: LegacyTask,
+  traces: readonly LegacyTrace[],
+  importedAt: string,
+  workspaces: WorkspaceManager,
+): Promise<LedgerWorker> {
+  const workerId = legacyWorkerId(task.id)
+  const source = isRecord(task.source) ? task.source : {}
+  const target = sourceTarget(source)
+  const mapped = mapStatus(task.status)
+  const result = isRecord(task.result) ? task.result : {}
+
+  const taskStartedAt = optionalIso(task.started_at, `task ${task.id} started_at`)
+  const taskCompletedAt = optionalIso(task.completed_at, `task ${task.id} completed_at`)
+  const resultFinishedAt = optionalIso(result.finished_at, `task ${task.id} result.finished_at`)
+  const earliestTraceStart = traces.find((trace) => trace.started_at)?.started_at
+  const latestTraceEnd = latestTimestamp(traces.map((trace) => trace.ended_at))
+  const startedAt = taskStartedAt ?? earliestTraceStart ?? task.created_at
+  const endedAt = mapped.preMigration
+    ? importedAt
+    : taskCompletedAt ?? resultFinishedAt ?? latestTraceEnd ?? importedAt
+
+  const workspace = await resolveWorkspace(workerId, task.id, traces, workspaces)
+  const traceOutcome = [...traces].reverse().find((trace) => usableString(trace.outcome?.summary))?.outcome?.summary
+  const outcome = usableString(result.outcome_brief) ?? usableString(result.summary) ?? traceOutcome
+  const taskType = usableString(task.type)
+  const goal = isRecord(task.goal) ? usableString(task.goal.objective) : undefined
+  const creatorFriendId = validIdentifier(source.friend_id, { allowDoubleColon: true })
+
+  return {
+    worker_id: workerId,
+    manager_key: target.managerKey,
+    task: {
+      id: workerId,
+      ...(taskType ? { type: taskType } : {}),
+      title: task.title,
+      status: mapped.status,
+      ...(priority(task.priority) ? { priority: task.priority } : {}),
+      ...(isRecord(task.input) ? { input: task.input } : {}),
+      ...(strings(task.tags) ? { tags: task.tags } : {}),
+      ...(goal ? { goal } : {}),
+      ...(outcome ? { outcome } : {}),
+      created_at: task.created_at,
+      completed_at: endedAt,
+      ...(mapped.preMigration
+        ? { error: PRE_MIGRATION_ERROR }
+        : typeof task.error === 'string' ? { error: task.error } : {}),
+    },
+    origin: {
+      trigger_type: trigger(source),
+      ...(creatorFriendId ? { creator_friend_id: creatorFriendId as never } : {}),
+    },
+    report_to: target.reportTo,
+    incarnations: [{
+      impl: 'legacy',
+      seq: 1,
+      state: 'exited',
+      workspace,
+      started_at: startedAt,
+      ended_at: endedAt,
+      ended_reason: mapped.endedReason,
+    }],
+    legacy_source: {
+      kind: 'v2_admin_task',
+      admin_task_id: task.id,
+      trace_ids: traces.map((trace) => trace.trace_id),
+      imported_at: importedAt,
+    },
+    updated_at: importedAt,
+  }
+}
+
+function legacyWorkerId(adminTaskId: string): string {
+  const digest = createHash('sha256').update(adminTaskId, 'utf8').digest('hex')
+  return `w-legacy-${digest.slice(0, 32)}`
+}
+
+function sourceTarget(source: Record<string, unknown>): {
+  readonly managerKey: ManagerKey
+  readonly reportTo: LedgerWorker['report_to']
+} {
+  const channelId = validIdentifier(source.channel_id, { allowDoubleColon: false })
+  const sessionId = validIdentifier(source.session_id, { allowDoubleColon: true })
+  if (!channelId || !sessionId) {
+    return {
+      managerKey: SYSTEM_KEY,
+      reportTo: { channel_id: 'admin-web', session_id: 'system-tasks' },
+    }
+  }
+  const managerKey = `${channelId}::${sessionId}` as ManagerKey
+  if (!isManagerKey(managerKey)) {
+    return {
+      managerKey: SYSTEM_KEY,
+      reportTo: { channel_id: 'admin-web', session_id: 'system-tasks' },
+    }
+  }
+  return {
+    managerKey,
+    reportTo: { channel_id: channelId, session_id: sessionId },
+  }
+}
+
+async function resolveWorkspace(
+  workerId: string,
+  adminTaskId: string,
+  traces: readonly LegacyTrace[],
+  workspaces: WorkspaceManager,
+): Promise<string> {
+  const candidate = [...traces]
+    .reverse()
+    .find((trace) => usableString(trace.resume_checkpoint?.worker_state?.cwd))
+    ?.resume_checkpoint?.worker_state?.cwd
+  try {
+    return (await workspaces.resolve(workerId, candidate)).root
+  } catch (error) {
+    console.warn(`[legacy-import] invalid legacy workspace for ${adminTaskId}: ${(error as Error).message}`)
+    return (await workspaces.resolve(workerId)).root
+  }
+}
+
+function buildManifest(tasks: readonly LegacyTask[], traces: Map<string, LegacyTrace[]>): ManifestTask[] {
+  return tasks
+    .map((task) => ({
+      admin_task_id: task.id,
+      canonical_content_sha256: sha256CanonicalJson(task),
+      traces: (traces.get(task.id) ?? [])
+        .map((trace) => ({
+          trace_id: trace.trace_id,
+          canonical_content_sha256: trace.canonical_content_sha256,
+        }))
+        .sort((left, right) => left.trace_id.localeCompare(right.trace_id)),
+    }))
+    .sort((left, right) => left.admin_task_id.localeCompare(right.admin_task_id))
+}
+
+function assertSameSource(marker: InProgressMarker, manifest: ManifestTask[], fingerprint: string): void {
+  if (
+    marker.fingerprint !== fingerprint ||
+    canonicalizeJson(marker.manifest) !== canonicalizeJson(manifest)
+  ) {
+    throw new Error('[legacy-import] source changed while migration is in_progress')
+  }
+}
+
+function mapStatus(status: string): {
+  readonly status: TaskStatus
+  readonly endedReason: 'completed' | 'failed' | 'killed' | 'pre_migration'
+  readonly preMigration: boolean
+} {
+  if (status === 'completed') return { status, endedReason: 'completed', preMigration: false }
+  if (status === 'failed') return { status, endedReason: 'failed', preMigration: false }
+  if (status === 'cancelled') return { status, endedReason: 'killed', preMigration: false }
+  return { status: 'failed', endedReason: 'pre_migration', preMigration: true }
+}
+
+function trigger(source: Record<string, unknown>): 'message' | 'scheduled' | 'system' {
+  if (source.trigger_type === 'scheduled') return 'scheduled'
+  if (
+    source.trigger_type === 'message' ||
+    source.trigger_type === 'manual' ||
+    source.origin === 'admin_chat'
+  ) return 'message'
+  return 'system'
+}
+
+async function readTasks(path: string): Promise<{
+  readonly tasks: LegacyTask[]
+  readonly absent: boolean
+}> {
+  try {
+    const parsed: unknown = JSON.parse(await fs.readFile(path, 'utf8'))
+    if (!Array.isArray(parsed)) throw new Error('[legacy-import] tasks.json must be an array')
+    const tasks = parsed.map(validateTask)
+    const ids = new Set<string>()
+    for (const task of tasks) {
+      if (ids.has(task.id)) throw new Error(`[legacy-import] duplicate task id: ${task.id}`)
+      ids.add(task.id)
+    }
+    return { tasks, absent: false }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return { tasks: [], absent: true }
+    throw error
+  }
+}
+
+function validateTask(value: unknown): LegacyTask {
+  if (
+    !isRecord(value) ||
+    !validIdentifier(value.id, { allowDoubleColon: true }) ||
+    !usableString(value.title) ||
+    typeof value.status !== 'string' ||
+    !LEGACY_STATUSES.has(value.status) ||
+    !validIso(value.created_at)
+  ) {
+    throw new Error('[legacy-import] invalid required task fields')
+  }
+  // Validate the full source object now so fingerprinting cannot fail after the marker is written.
+  sha256CanonicalJson(value)
+  return value as LegacyTask
+}
+
+async function readMarkerFile(path: string): Promise<Marker | undefined> {
+  try {
+    const value: unknown = JSON.parse(await fs.readFile(path, 'utf8'))
+    assertMarker(value)
+    return value
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined
+    throw error
+  }
+}
+
+function assertMarker(value: unknown): asserts value is Marker {
+  if (!isRecord(value) || value.version !== VERSION || !validIso(value.imported_at)) {
+    throw new Error('[legacy-import] invalid migration marker')
+  }
+  const commonKeys = ['fingerprint', 'imported_at', 'manifest', 'state', 'version']
+  const expectedKeys = value.state === 'completed'
+    ? [...commonKeys, 'by_manager_key', 'imported_count', 'source_task_count']
+    : commonKeys
+  if (
+    (value.state !== 'in_progress' && value.state !== 'completed') ||
+    !hasExactKeys(value, expectedKeys) ||
+    typeof value.fingerprint !== 'string' ||
+    (value.fingerprint !== 'absent' && !isSha256(value.fingerprint)) ||
+    !Array.isArray(value.manifest) ||
+    !value.manifest.every(validManifestTask)
+  ) {
+    throw new Error('[legacy-import] invalid migration marker')
+  }
+
+  let previousTaskId: string | undefined
+  for (const task of value.manifest) {
+    if (previousTaskId !== undefined && previousTaskId.localeCompare(task.admin_task_id) >= 0) {
+      throw new Error('[legacy-import] invalid migration marker')
+    }
+    previousTaskId = task.admin_task_id
+    let previousTraceId: string | undefined
+    for (const trace of task.traces) {
+      if (previousTraceId !== undefined && previousTraceId.localeCompare(trace.trace_id) >= 0) {
+        throw new Error('[legacy-import] invalid migration marker')
+      }
+      previousTraceId = trace.trace_id
+    }
+  }
+
+  const calculated = value.fingerprint === 'absent' && value.manifest.length === 0
+    ? 'absent'
+    : sha256CanonicalJson(value.manifest)
+  if (value.fingerprint !== calculated) throw new Error('[legacy-import] invalid migration marker')
+  if (value.state === 'in_progress') return
+
+  if (
+    !isNonNegativeInteger(value.source_task_count) ||
+    value.source_task_count !== value.manifest.length ||
+    !isNonNegativeInteger(value.imported_count) ||
+    value.imported_count !== value.manifest.length ||
+    !isRecord(value.by_manager_key)
+  ) {
+    throw new Error('[legacy-import] invalid migration marker')
+  }
+  let total = 0
+  for (const [key, count] of Object.entries(value.by_manager_key)) {
+    if (!isManagerKey(key) || !isPositiveInteger(count)) {
+      throw new Error('[legacy-import] invalid migration marker')
+    }
+    total += count
+  }
+  if (total !== value.imported_count) throw new Error('[legacy-import] invalid migration marker')
+}
+
+function validManifestTask(value: unknown): value is ManifestTask {
+  return isRecord(value) &&
+    hasExactKeys(value, ['admin_task_id', 'canonical_content_sha256', 'traces']) &&
+    validIdentifier(value.admin_task_id, { allowDoubleColon: true }) !== undefined &&
+    isSha256(value.canonical_content_sha256) &&
+    Array.isArray(value.traces) &&
+    value.traces.every((trace) =>
+      isRecord(trace) &&
+      hasExactKeys(trace, ['canonical_content_sha256', 'trace_id']) &&
+      validIdentifier(trace.trace_id, { allowDoubleColon: true }) !== undefined &&
+      isSha256(trace.canonical_content_sha256),
+    )
+}
+
+async function writeSnapshot(path: string, task: LegacyTask): Promise<void> {
+  try {
+    const existing = JSON.parse(await fs.readFile(path, 'utf8')) as unknown
+    if (canonicalizeJson(existing) !== canonicalizeJson(task)) {
+      throw new Error(`[legacy-import] legacy snapshot conflict: ${path}`)
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+    await writeAtomic(path, task)
+  }
+}
+
+async function appendImportEventOnce(
+  workerDir: string,
+  worker: LedgerWorker,
+  traceCount: number,
+  importedAt: string,
+): Promise<void> {
+  const expected = {
+    admin_task_id: worker.legacy_source!.admin_task_id,
+    trace_count: traceCount,
+    imported_at: importedAt,
+  }
+  const log = new WorkerEventLog(workerDir)
+  const events = (await log.readAll()).filter((event) => event.kind === 'legacy_imported')
+  if (events.length > 0) {
+    const event = events[0]
+    if (
+      events.length !== 1 ||
+      event.worker_id !== worker.worker_id ||
+      event.seq !== 1 ||
+      event.ts !== importedAt ||
+      canonicalizeJson(event.detail) !== canonicalizeJson(expected)
+    ) {
+      throw new Error(`[legacy-import] legacy import event conflict for ${worker.worker_id}`)
+    }
+    return
+  }
+  await log.append({
+    ts: importedAt,
+    kind: 'legacy_imported',
+    worker_id: worker.worker_id,
+    seq: 1,
+    detail: expected,
+  })
+}
+
+async function assertDirectory(path: string): Promise<void> {
+  const stat = await fs.stat(path).catch((error) => {
+    throw new Error(`[legacy-import] Admin data directory unavailable: ${(error as Error).message}`)
+  })
+  if (!stat.isDirectory()) throw new Error('[legacy-import] Admin data directory is not a directory')
+}
+
+async function writeAtomic(path: string, value: unknown): Promise<void> {
+  await fs.mkdir(dirname(path), { recursive: true })
+  const temp = join(dirname(path), `.tmp-${randomUUID()}.json`)
+  await fs.writeFile(temp, JSON.stringify(value, null, 2), 'utf8')
+  await fs.rename(temp, path)
+}
+
+function optionalIso(value: unknown, label: string): string | undefined {
+  if (value === undefined) return undefined
+  if (validIso(value)) return value
+  console.warn(`[legacy-import] ignoring invalid ${label}`)
+  return undefined
+}
+
+function latestTimestamp(values: ReadonlyArray<string | undefined>): string | undefined {
+  let latest: string | undefined
+  let latestMs = Number.NEGATIVE_INFINITY
+  for (const value of values) {
+    if (!value) continue
+    const timeMs = Date.parse(value)
+    if (timeMs > latestMs) {
+      latest = value
+      latestMs = timeMs
+    }
+  }
+  return latest
+}
+
+function validIso(value: unknown): value is string {
+  return typeof value === 'string' &&
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/.test(value) &&
+    Number.isFinite(Date.parse(value))
+}
+
+function validIdentifier(
+  value: unknown,
+  options: { readonly allowDoubleColon: boolean },
+): string | undefined {
+  if (typeof value !== 'string' || value.length === 0 || value !== value.trim()) return undefined
+  if (/[\u0000-\u001f\u007f]/.test(value)) return undefined
+  if (!options.allowDoubleColon && value.includes('::')) return undefined
+  return value
+}
+
+function usableString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value : undefined
+}
+
+function hasExactKeys(value: Record<string, unknown>, expected: readonly string[]): boolean {
+  const actual = Object.keys(value).sort()
+  const wanted = [...expected].sort()
+  return actual.length === wanted.length && actual.every((key, index) => key === wanted[index])
+}
+
+function isSha256(value: unknown): value is string {
+  return typeof value === 'string' && /^[0-9a-f]{64}$/.test(value)
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function priority(value: unknown): value is TaskPriority {
+  return value === 'low' || value === 'normal' || value === 'high' || value === 'urgent'
+}
+
+function strings(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string')
+}

--- a/crabot-agent/src/workers/legacy-importer.ts
+++ b/crabot-agent/src/workers/legacy-importer.ts
@@ -78,6 +78,7 @@ export async function importV2LegacyTasks(deps: LegacyImporterDeps): Promise<Leg
   const marker = await readMarkerFile(markerPath)
   if (marker?.state === 'completed') return { skipped: true, imported: 0 }
 
+  await deps.ledger.init()
   await assertDirectory(deps.adminDataDir)
   const source = await readTasks(join(deps.adminDataDir, 'tasks.json'))
   const traces = source.tasks.length === 0
@@ -112,7 +113,7 @@ export async function importV2LegacyTasks(deps: LegacyImporterDeps): Promise<Leg
     const workerDir = join(deps.agentDataDir, 'workers', worker.worker_id)
     await writeSnapshot(join(workerDir, 'legacy-task.json'), task)
 
-    const existing = await deps.ledger.findWorker(worker.worker_id)
+    const existing = await deps.ledger.findWorkerFromIndex(worker.worker_id)
     if (!existing) {
       await deps.ledger.importLegacyWorker(worker.manager_key, worker)
       imported++

--- a/crabot-agent/src/workers/legacy-source-reader.ts
+++ b/crabot-agent/src/workers/legacy-source-reader.ts
@@ -1,0 +1,249 @@
+import { promises as fs } from 'node:fs'
+import { join } from 'node:path'
+import { sha256CanonicalJson } from 'crabot-shared'
+import type { NormalizedTraceEvent } from './types.js'
+
+export interface LegacyTrace {
+  readonly trace_id: string
+  readonly related_task_id: string
+  readonly started_at?: string
+  readonly ended_at?: string
+  readonly outcome?: { readonly summary?: string }
+  readonly resume_checkpoint?: { readonly worker_state?: { readonly cwd?: string } }
+  readonly raw: Record<string, unknown>
+  readonly canonical_content_sha256: string
+}
+
+export interface LegacyTraceEventEntry {
+  readonly event: NormalizedTraceEvent
+  readonly started_at?: string
+  readonly ended_at?: string
+  readonly trace_id: string
+  readonly source_ordinal: number
+}
+
+export interface LegacyTraceReadResult {
+  readonly entries: LegacyTraceEventEntry[]
+  readonly unavailable_reason?: string
+}
+
+export interface LegacyTraceScanResult {
+  readonly traces: Map<string, LegacyTrace[]>
+  readonly diagnostic_count: number
+}
+
+/** Read the imported trace references lazily; missing/retained source data degrades to a diagnostic. */
+export async function readLegacyTraceEvents(
+  traceDir: string,
+  traceIds: ReadonlyArray<string>,
+): Promise<LegacyTraceReadResult> {
+  let scan: LegacyTraceScanResult
+  try {
+    scan = await scanLegacyTraces(traceDir)
+  } catch (error) {
+    return { entries: [], unavailable_reason: `legacy trace source unavailable: ${message(error)}` }
+  }
+  const byId = new Map<string, LegacyTrace>()
+  for (const entries of scan.traces.values()) for (const trace of entries) byId.set(trace.trace_id, trace)
+  let missing = 0
+  const selected: LegacyTrace[] = []
+  for (const id of traceIds) {
+    const trace = byId.get(id)
+    if (trace) selected.push(trace)
+    else missing++
+  }
+  const entries = selected
+    .sort(compareTrace)
+    .map((trace, sourceOrdinal): LegacyTraceEventEntry => ({
+      event: {
+        ts: trace.started_at ?? trace.ended_at ?? '',
+        kind: 'lifecycle',
+        summary: trace.outcome?.summary ?? `legacy trace ${trace.trace_id}`,
+        detail: trace.raw,
+      },
+      ...(trace.started_at ? { started_at: trace.started_at } : {}),
+      ...(trace.ended_at ? { ended_at: trace.ended_at } : {}),
+      trace_id: trace.trace_id,
+      source_ordinal: sourceOrdinal,
+    }))
+  const unavailable: string[] = []
+  if (missing > 0) unavailable.push(`${missing} legacy trace reference(s) unavailable`)
+  if (scan.diagnostic_count > 0) unavailable.push(`${scan.diagnostic_count} malformed or unreadable legacy trace record(s)`)
+  return {
+    entries,
+    ...(unavailable.length > 0 ? { unavailable_reason: unavailable.join('; ') } : {}),
+  }
+}
+
+export function compareLegacyTraceEventEntries(
+  left: LegacyTraceEventEntry,
+  right: LegacyTraceEventEntry,
+): number {
+  const startedOrder = compareOptionalTimestamp(left.started_at, right.started_at)
+  if (startedOrder !== 0) return startedOrder
+  const endedOrder = compareOptionalTimestamp(left.ended_at, right.ended_at)
+  if (endedOrder !== 0) return endedOrder
+  return left.trace_id.localeCompare(right.trace_id) || left.source_ordinal - right.source_ordinal
+}
+
+export async function readLegacyTraces(traceDir: string): Promise<Map<string, LegacyTrace[]>> {
+  return (await scanLegacyTraces(traceDir)).traces
+}
+
+/** Pure, read-only scan of v2 TraceStore archives with bounded diagnostics. */
+export async function scanLegacyTraces(traceDir: string): Promise<LegacyTraceScanResult> {
+  let files: string[]
+  try {
+    files = await fs.readdir(traceDir)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { traces: new Map(), diagnostic_count: 0 }
+    }
+    throw error
+  }
+
+  let diagnosticCount = 0
+  const byId = new Map<string, LegacyTrace>()
+  for (const file of files.filter(isLegacyTraceFile).sort(compareTraceFile)) {
+    let text: string
+    try {
+      text = await fs.readFile(join(traceDir, file), 'utf8')
+    } catch (error) {
+      diagnosticCount++
+      console.warn(`[legacy-import] skipping unreadable trace file ${file}: ${message(error)}`)
+      continue
+    }
+    for (const line of text.split('\n')) {
+      if (!line.trim()) continue
+      const trace = parseTrace(line, file)
+      if (!trace) {
+        diagnosticCount++
+        continue
+      }
+      const prior = byId.get(trace.trace_id)
+      if (prior && prior.related_task_id !== trace.related_task_id) {
+        throw new Error(
+          `[legacy-import] trace_id ${trace.trace_id} belongs to both ` +
+          `${prior.related_task_id} and ${trace.related_task_id}`,
+        )
+      }
+      // TraceStore may append updated copies. Stable file/line order makes the final copy authoritative.
+      byId.set(trace.trace_id, trace)
+    }
+  }
+
+  const byTask = new Map<string, LegacyTrace[]>()
+  for (const trace of byId.values()) {
+    const entries = byTask.get(trace.related_task_id) ?? []
+    entries.push(trace)
+    byTask.set(trace.related_task_id, entries)
+  }
+  for (const entries of byTask.values()) entries.sort(compareTrace)
+  return { traces: byTask, diagnostic_count: diagnosticCount }
+}
+
+function isLegacyTraceFile(name: string): boolean {
+  if (name === 'traces-running-v3.jsonl') return false
+  if (name === 'traces-running.jsonl') return true
+  if (/^traces-\d{4}-\d{2}-\d{2}\.jsonl$/.test(name)) return true
+  return /^traces-running-.+\.jsonl$/.test(name)
+}
+
+function message(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function compareTraceFile(left: string, right: string): number {
+  const rank = (name: string): number => {
+    if (/^traces-\d{4}-\d{2}-\d{2}\.jsonl$/.test(name)) return 0
+    if (name === 'traces-running.jsonl') return 1
+    return 2 // per-task checkpoint is newer than the global in-flight snapshot
+  }
+  return rank(left) - rank(right) || left.localeCompare(right)
+}
+
+function parseTrace(line: string, file: string): LegacyTrace | undefined {
+  let raw: unknown
+  try {
+    raw = JSON.parse(line)
+  } catch {
+    console.warn(`[legacy-import] skipping malformed trace line in ${file}`)
+    return undefined
+  }
+  if (
+    !isRecord(raw) ||
+    !validIdentifier(raw.trace_id) ||
+    !validIdentifier(raw.related_task_id)
+  ) {
+    console.warn(`[legacy-import] skipping unassociated or invalid trace in ${file}`)
+    return undefined
+  }
+
+  let hash: string
+  try {
+    hash = sha256CanonicalJson(raw)
+  } catch {
+    console.warn(`[legacy-import] skipping non-canonical trace ${raw.trace_id}`)
+    return undefined
+  }
+
+  const startedAt = optionalIso(raw.started_at, `trace ${raw.trace_id} started_at`)
+  const endedAt = optionalIso(raw.ended_at, `trace ${raw.trace_id} ended_at`)
+  const outcome = isRecord(raw.outcome) && typeof raw.outcome.summary === 'string'
+    ? { summary: raw.outcome.summary }
+    : undefined
+  const checkpoint = isRecord(raw.resume_checkpoint) && isRecord(raw.resume_checkpoint.worker_state)
+    ? raw.resume_checkpoint.worker_state
+    : undefined
+  const cwd = typeof checkpoint?.cwd === 'string' ? checkpoint.cwd : undefined
+
+  return {
+    trace_id: raw.trace_id,
+    related_task_id: raw.related_task_id,
+    ...(startedAt ? { started_at: startedAt } : {}),
+    ...(endedAt ? { ended_at: endedAt } : {}),
+    ...(outcome ? { outcome } : {}),
+    ...(cwd ? { resume_checkpoint: { worker_state: { cwd } } } : {}),
+    raw,
+    canonical_content_sha256: hash,
+  }
+}
+
+function compareTrace(left: LegacyTrace, right: LegacyTrace): number {
+  const startedOrder = compareOptionalTimestamp(left.started_at, right.started_at)
+  if (startedOrder !== 0) return startedOrder
+  const endedOrder = compareOptionalTimestamp(left.ended_at, right.ended_at)
+  if (endedOrder !== 0) return endedOrder
+  return left.trace_id.localeCompare(right.trace_id)
+}
+
+function compareOptionalTimestamp(left: string | undefined, right: string | undefined): number {
+  if (left && right) return Date.parse(left) - Date.parse(right)
+  if (left) return -1
+  if (right) return 1
+  return 0
+}
+
+function optionalIso(value: unknown, label: string): string | undefined {
+  if (value === undefined) return undefined
+  if (validIso(value)) return value
+  console.warn(`[legacy-import] ignoring invalid ${label}`)
+  return undefined
+}
+
+function validIso(value: unknown): value is string {
+  return typeof value === 'string' &&
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/.test(value) &&
+    Number.isFinite(Date.parse(value))
+}
+
+function validIdentifier(value: unknown): value is string {
+  return typeof value === 'string' &&
+    value.length > 0 &&
+    value === value.trim() &&
+    !/[\u0000-\u001f\u007f]/.test(value)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}

--- a/crabot-agent/tests/agent/worker-mcp-capability.test.ts
+++ b/crabot-agent/tests/agent/worker-mcp-capability.test.ts
@@ -3,7 +3,6 @@ import { describe, it, expect } from 'vitest'
 import { filterMcpServersForWorker, mcpCategoryFor } from '../../src/agent/mcp-connector.js'
 import { UnifiedAgent } from '../../src/unified-agent.js'
 import type { AgentLayerConfig, MCPServerConfig, ResolvedPermissions } from '../../src/types.js'
-import { dialogObjectIdForPrivate } from '../../src/workers/harness/ledger-types.js'
 import type { ManagerStack } from '../../src/manager/bootstrap.js'
 import type {
   AdapterCapabilities,
@@ -122,14 +121,14 @@ describe('UnifiedAgent worker capability production wiring', () => {
       const common = {
         title: 'MCP production wiring',
         prompt: 'work',
-        origin: { spawned_by_session: 'wechat::mcp-test', trigger_type: 'message' as const },
+        origin: { spawned_by_episode: 'wechat::mcp-test', trigger_type: 'message' as const },
         report_to: { channel_id: 'wechat', session_id: 'mcp-test' },
       }
 
       const lowPrincipal = permissions({ mcp_skill: false, desktop: true })
       await internals.managerStack.harness.spawnWorker({
         ...common,
-        dialogObjectId: dialogObjectIdForPrivate('mcp-low'),
+        managerKey: (`test::${'mcp-low'}` as ManagerKey),
         impl: 'claude-code',
         principal_permissions: lowPrincipal,
       })
@@ -138,7 +137,7 @@ describe('UnifiedAgent worker capability production wiring', () => {
       const allowedPrincipal = permissions({ mcp_skill: true, desktop: true })
       const builtinWorker = await internals.managerStack.harness.spawnWorker({
         ...common,
-        dialogObjectId: dialogObjectIdForPrivate('mcp-allowed'),
+        managerKey: (`test::${'mcp-allowed'}` as ManagerKey),
         impl: 'builtin',
         principal_permissions: allowedPrincipal,
       })

--- a/crabot-agent/tests/core/trace-store.test.ts
+++ b/crabot-agent/tests/core/trace-store.test.ts
@@ -53,6 +53,22 @@ describe('TraceStore', () => {
       return fs.mkdtempSync(path.join(os.tmpdir(), 'trace-store-flush-'))
     }
 
+    it('uses a configured v3 running file without loading or changing the legacy running file', () => {
+      const dir = makeTempDir()
+      try {
+        const legacyPath = path.join(dir, 'traces-running.jsonl')
+        fs.writeFileSync(legacyPath, '{"legacy":true}\n')
+        const before = fs.readFileSync(legacyPath, 'utf8')
+        const store = new TraceStore(10, dir, 'traces-running-v3.jsonl')
+        const trace = store.startTrace({ module_id: 'agent-1', trigger: { type: 'task', summary: 'new' } })
+        ;(store as unknown as { flushInFlightTraces: () => void }).flushInFlightTraces()
+        expect(fs.readFileSync(legacyPath, 'utf8')).toBe(before)
+        expect(fs.readFileSync(path.join(dir, 'traces-running-v3.jsonl'), 'utf8')).toContain(trace.trace_id)
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true })
+      }
+    })
+
     it('flushed in-flight trace is visible after store recreation (simulates SIGKILL + restart)', () => {
       const dir = makeTempDir()
       try {

--- a/crabot-agent/tests/core/trace-store.test.ts
+++ b/crabot-agent/tests/core/trace-store.test.ts
@@ -69,6 +69,49 @@ describe('TraceStore', () => {
       }
     })
 
+    it('uses a v3 archive prefix while keeping legacy archives readable and outside retention writes', () => {
+      const dir = makeTempDir()
+      try {
+        const legacyPath = path.join(dir, 'traces-2020-01-01.jsonl')
+        const oldV3Path = path.join(dir, 'traces-v3-2020-01-01.jsonl')
+        const legacyTrace = {
+          trace_id: 'legacy-trace',
+          module_id: 'legacy-agent',
+          trigger: { type: 'task', summary: 'legacy' },
+          started_at: '2020-01-01T00:00:00.000Z',
+          status: 'completed',
+          spans: [],
+        }
+        const oldV3Trace = { ...legacyTrace, trace_id: 'old-v3-trace', module_id: 'v3-agent' }
+        fs.writeFileSync(legacyPath, `${JSON.stringify(legacyTrace)}\n`)
+        fs.writeFileSync(oldV3Path, `${JSON.stringify(oldV3Trace)}\n`)
+        const legacyBefore = fs.readFileSync(legacyPath)
+
+        const store = new TraceStore(
+          10,
+          dir,
+          'traces-running-v3.jsonl',
+          'traces-v3-',
+          ['traces-', 'traces-v3-'],
+        )
+        expect(store.searchTraces({}).traces.map((trace) => trace.trace_id)).toEqual(
+          expect.arrayContaining(['legacy-trace', 'old-v3-trace']),
+        )
+
+        const trace = store.startTrace({ module_id: 'v3-agent', trigger: { type: 'task', summary: 'new' } })
+        store.endTrace(trace.trace_id, 'completed')
+        const today = trace.started_at.slice(0, 10)
+        expect(fs.existsSync(path.join(dir, `traces-v3-${today}.jsonl`))).toBe(true)
+        expect(fs.readFileSync(legacyPath)).toEqual(legacyBefore)
+
+        store.cleanupOldTraces(1, false)
+        expect(fs.existsSync(oldV3Path)).toBe(false)
+        expect(fs.readFileSync(legacyPath)).toEqual(legacyBefore)
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true })
+      }
+    })
+
     it('flushed in-flight trace is visible after store recreation (simulates SIGKILL + restart)', () => {
       const dir = makeTempDir()
       try {

--- a/crabot-agent/tests/inbound/process-admin-chat-message.test.ts
+++ b/crabot-agent/tests/inbound/process-admin-chat-message.test.ts
@@ -155,7 +155,12 @@ describe('processAdminChatMessage —— admin chat 入站（cutover 后下游�
   let permsResponse: ResolvedPermissions | null | 'throw'
 
   function boot(
-    opts: { configured?: boolean; turns?: ReadonlyArray<ReadonlyArray<Record<string, unknown>>> } = {},
+    opts: {
+      configured?: boolean
+      turns?: ReadonlyArray<ReadonlyArray<Record<string, unknown>>>
+      consumeResult?: unknown
+      consumeError?: Error
+    } = {},
   ): void {
     script = makeManagerScript(opts.turns ?? [])
     hoisted.managerAdapter = {
@@ -177,15 +182,18 @@ describe('processAdminChatMessage —— admin chat 入站（cutover 后下游�
     internals.agentHandler = { createBuiltinBgToolOptions: () => undefined }
 
     internals.rpcClient.resolve = async (filter) => {
-      const f = filter as { module_type?: string }
+      const f = filter as { module_type?: string; module_id?: string }
       if (f.module_type === 'memory') {
         return [{ module_id: 'memory', module_type: 'memory', host: 'localhost', port: MEMORY_PORT, status: 'running' }]
       }
-      return [{ module_id: 'admin', module_type: 'admin', host: 'localhost', port: ADMIN_PORT, status: 'running' }]
+      return [{ module_id: 'admin-web', module_type: 'admin', host: 'localhost', port: ADMIN_PORT, status: 'running' }]
     }
     internals.rpcClient.call = async (port, method, params) => {
       rpcCalls.push({ port, method, params: params as Record<string, unknown> })
       switch (method) {
+        case 'consume_admin_chat_assertion':
+          if (opts.consumeError) throw opts.consumeError
+          return opts.consumeResult ?? { consumed: true, expires_at: '2099-01-01T00:00:00.000Z' }
         case 'resolve_principal_permissions':
           calls.push('resolve_permissions')
           if (permsResponse === 'throw') throw new Error('admin unreachable')
@@ -252,6 +260,7 @@ describe('processAdminChatMessage —— admin chat 入站（cutover 后下游�
       message,
       source_type: 'admin_chat',
       callback_info: CALLBACK_INFO,
+      admin_chat_assertion: 'test-assertion',
     })
   }
 
@@ -328,22 +337,42 @@ describe('processAdminChatMessage —— admin chat 入站（cutover 后下游�
       expect(String(script.streams[0].messages[0].content)).toContain('帮我看下季度报表')
     })
 
-    it('admin_chat 但缺回执信息：静默丢弃，不唤醒 manager', async () => {
+    it('admin_chat 缺 assertion 或回执信息：拒绝且不唤醒 manager', async () => {
       boot()
-      const result = await internals.handleProcessMessage({
+      await expect(internals.handleProcessMessage({
         message: amsg({ id: 'a-1' }),
         source_type: 'admin_chat',
-      })
+      })).rejects.toThrow(/assertion/)
 
-      expect(result).toEqual({ decision_types: [] })
       expect(calls).toEqual([])
       expect(script.streams).toHaveLength(0)
       expect(rpcCalls).toEqual([])
     })
+    it.each([
+      ['rejected consume', undefined, new Error('replayed assertion')],
+      ['empty consume result', {}, undefined],
+      ['false consumed', { consumed: false, expires_at: '2099-01-01T00:00:00.000Z' }, undefined],
+      ['expired consume result', { consumed: true, expires_at: '2000-01-01T00:00:00.000Z' }, undefined],
+    ])('%s causes zero Manager wake', async (_name, consumeResult, consumeError) => {
+      boot({ consumeResult, consumeError })
+      await expect(runAdminChat()).rejects.toThrow(/assertion|replayed/i)
+      expect(script.streams).toHaveLength(0)
+      expect(calls).not.toContain('manager_llm')
+    })
+
+    it('forged source, friend, callback, or replay cannot bypass assertion consumption', async () => {
+      boot({ consumeError: new Error('replayed assertion') })
+      for (const params of [
+        { message: amsg(), source_type: 'channel' as const, callback_info: CALLBACK_INFO, admin_chat_assertion: 'x' },
+        { message: { ...amsg(), sender: { friend_id: 'master', platform_user_id: 'master', platform_display_name: 'Master' } }, source_type: 'admin_chat' as const, callback_info: { source_module_id: 'forged', request_id: 'r' }, admin_chat_assertion: 'x' },
+        { message: amsg(), source_type: 'admin_chat' as const, callback_info: CALLBACK_INFO, admin_chat_assertion: 'replay' },
+      ]) {
+        await expect(internals.handleProcessMessage(params)).rejects.toThrow()
+      }
+      expect(script.streams).toHaveLength(0)
+    })
   })
 
-  // ==========================================================================
-  // 三不语义（变异靶 M12）
   // ==========================================================================
 
   describe('admin chat 的"三不"语义（变异靶 M12）', () => {

--- a/crabot-agent/tests/inbound/process-admin-chat-message.test.ts
+++ b/crabot-agent/tests/inbound/process-admin-chat-message.test.ts
@@ -268,7 +268,7 @@ describe('processAdminChatMessage —— admin chat 入站（cutover 后下游�
       .buildBuiltinWorkerRuntime({
         worker_id: 'w-probe',
         workspace: { root: dataDir.root },
-        origin: { spawned_by_session: MANAGER_KEY, trigger_type: 'message' },
+        origin: { spawned_by_episode: MANAGER_KEY, trigger_type: 'message' },
       })
       .tools()
       .map((t) => t.name)

--- a/crabot-agent/tests/inbound/process-admin-chat-message.test.ts
+++ b/crabot-agent/tests/inbound/process-admin-chat-message.test.ts
@@ -334,6 +334,7 @@ describe('processAdminChatMessage —— admin chat 入站（cutover 后下游�
       expect(rpcCalls.find((c) => c.method === 'resolve_principal_permissions')!.params).toMatchObject({
         session_id: ADMIN_CHAT_SESSION,
       })
+      expect(script.streams[0].tools.map((tool) => tool.name)).toContain('list_all_workers')
       expect(String(script.streams[0].messages[0].content)).toContain('帮我看下季度报表')
     })
 

--- a/crabot-agent/tests/inbound/process-admin-chat-message.test.ts
+++ b/crabot-agent/tests/inbound/process-admin-chat-message.test.ts
@@ -60,6 +60,12 @@ const MEMORY_PORT = 18202
 const ADMIN_CHAT_SESSION = 'admin-chat'
 const MANAGER_KEY = 'admin-web::admin-chat'
 const REQUEST_ID = 'req-42'
+const ASSERTION_ID = 'assertion-42'
+const ADMIN_CHAT_ASSERTION = [
+  Buffer.from('{}').toString('base64url'),
+  Buffer.from(JSON.stringify({ assertion_id: ASSERTION_ID })).toString('base64url'),
+  'test-signature',
+].join('.')
 
 /** master 身份解析出来的工具面：file_io 开、remote_exec 关（用来做正反对照）。 */
 const MASTER_TOOL_ACCESS: ToolAccessConfig = {
@@ -115,6 +121,7 @@ interface Internals {
     message: ChannelMessage
     source_type?: 'channel' | 'admin_chat'
     callback_info?: { source_module_id: string; request_id: string }
+    admin_chat_assertion?: string
   }): Promise<{ decision_types: string[]; task_ids?: string[] }>
   processDirectBatch(batch: unknown): Promise<void>
   processGroupLaneBatch(batch: unknown): Promise<void>
@@ -123,7 +130,10 @@ interface Internals {
   groupLaneRegistry: { getOrCreate(key: string): unknown; size(): number }
   contextAssembler: unknown
   managerStack: {
-    principals: { get(key: string): ResolvedPrincipalView | undefined }
+    principals: {
+      get(key: string): ResolvedPrincipalView | undefined
+      currentMasterAuthorization(key: string): { assertion_id?: string } | undefined
+    }
     registry: { routeHumanMessages: (...args: unknown[]) => Promise<unknown> }
   }
   /** fail-loud 的按 key 冷却台账（与私聊 / 群聊两条 lane 共用同一张表）。 */
@@ -260,7 +270,7 @@ describe('processAdminChatMessage —— admin chat 入站（cutover 后下游�
       message,
       source_type: 'admin_chat',
       callback_info: CALLBACK_INFO,
-      admin_chat_assertion: 'test-assertion',
+      admin_chat_assertion: ADMIN_CHAT_ASSERTION,
     })
   }
 
@@ -326,6 +336,7 @@ describe('processAdminChatMessage —— admin chat 入站（cutover 后下游�
 
       // 处理端不看消息自带的 session（入参故意给了 wechat / some-other-session）
       expect(principal(), '身份应当解析在 admin-web::admin-chat 这个 manager key 上').toBeDefined()
+      expect(internals.managerStack.principals.currentMasterAuthorization(MANAGER_KEY)?.assertion_id).toBe(ASSERTION_ID)
       expect(sceneCalls[0]).toMatchObject({
         channelId: 'admin-web',
         sessionId: ADMIN_CHAT_SESSION,
@@ -357,6 +368,18 @@ describe('processAdminChatMessage —— admin chat 入站（cutover 后下游�
     ])('%s causes zero Manager wake', async (_name, consumeResult, consumeError) => {
       boot({ consumeResult, consumeError })
       await expect(runAdminChat()).rejects.toThrow(/assertion|replayed/i)
+      expect(script.streams).toHaveLength(0)
+      expect(calls).not.toContain('manager_llm')
+    })
+
+    it('a consumed response cannot make a malformed assertion payload establish authority', async () => {
+      boot({ consumeResult: { consumed: true, expires_at: '2099-01-01T00:00:00.000Z' } })
+      await expect(internals.handleProcessMessage({
+        message: amsg(),
+        source_type: 'admin_chat',
+        callback_info: CALLBACK_INFO,
+        admin_chat_assertion: 'malformed',
+      })).rejects.toThrow(/assertion payload/i)
       expect(script.streams).toHaveLength(0)
       expect(calls).not.toContain('manager_llm')
     })

--- a/crabot-agent/tests/inbound/process-direct-batch.test.ts
+++ b/crabot-agent/tests/inbound/process-direct-batch.test.ts
@@ -217,7 +217,7 @@ describe('processDirectBatch —— 私聊 lane handler（cutover 后下游是 m
       .buildBuiltinWorkerRuntime({
         worker_id: 'w-probe',
         workspace: { root: dataDir.root },
-        origin: { spawned_by_session: MANAGER_KEY, trigger_type: 'message' },
+        origin: { spawned_by_episode: MANAGER_KEY, trigger_type: 'message' },
         ...(principalPermissions ? { principal_permissions: principalPermissions } : {}),
       })
       .tools()

--- a/crabot-agent/tests/inbound/process-group-lane-batch.test.ts
+++ b/crabot-agent/tests/inbound/process-group-lane-batch.test.ts
@@ -295,7 +295,7 @@ describe('processGroupLaneBatch —— 群聊 lane handler（cutover 后下游�
       .buildBuiltinWorkerRuntime({
         worker_id: 'w-probe',
         workspace: { root: dataDir.root },
-        origin: { spawned_by_session: MANAGER_KEY, trigger_type: 'message' },
+        origin: { spawned_by_episode: MANAGER_KEY, trigger_type: 'message' },
         ...(principalPermissions ? { principal_permissions: principalPermissions } : {}),
       })
       .tools()

--- a/crabot-agent/tests/manager/bootstrap.test.ts
+++ b/crabot-agent/tests/manager/bootstrap.test.ts
@@ -21,9 +21,8 @@ import { BuiltinWorkerAdapter } from '../../src/workers/builtin/adapter.js'
 import { ClaudeCodeAdapter } from '../../src/workers/claude-code/adapter.js'
 import { CodexWorkerAdapter } from '../../src/workers/codex/adapter.js'
 import { CapabilityNotSupportedError } from '../../src/workers/errors.js'
-import { dialogObjectIdForPrivate, type DialogObjectId, type LedgerWorker } from '../../src/workers/harness/ledger-types.js'
+import { type ManagerKey, type LedgerWorker } from '../../src/workers/harness/ledger-types.js'
 import type { WorkerAdapter, WorkerImplId, IncarnationHandle, StateChangeReport, WorkerContractState } from '../../src/workers/types.js'
-import type { ManagerKey } from '../../src/manager/types.js'
 import type { LLMAdapter, LLMStreamParams } from '../../src/engine/index.js'
 import type { ChannelMessage } from '../../src/types.js'
 import { CLI_DOMAINS } from '../../src/types.js'
@@ -49,7 +48,6 @@ function makePrincipalResolver(): PrincipalResolverDeps {
     sessionMemoryScopes: async (sessionId) => [sessionId],
     sceneProfile: async () => null,
     crabSelfHandle: () => undefined,
-    masterFriendId: async () => undefined,
   }
 }
 
@@ -123,8 +121,9 @@ function makeLedgerWorker(p: {
 }): LedgerWorker {
   return {
     worker_id: p.workerId,
+    manager_key: p.spawnedBySession,
     task: { id: p.workerId, title: 't', status: 'running', created_at: '2026-01-01T00:00:00.000Z' },
-    origin: { spawned_by_session: p.spawnedBySession, trigger_type: 'message' },
+    origin: { trigger_type: 'message' },
     report_to: { channel_id: 'wechat', session_id: 'sess-boot' },
     incarnations: [
       {
@@ -153,7 +152,7 @@ describe('manager bootstrap（P5 Task 1）', () => {
   let tmpRoot: string
   /** 刻意指向一个不存在的子目录:任何"顺手建目录"的 I/O 都会在盘上留下痕迹被用例抓住。 */
   let dataRoot: string
-  const dialogObjectIdFor = (key: ManagerKey): DialogObjectId => dialogObjectIdForPrivate(`friend-of-${key}`)
+  const managerKeyFor = (key: ManagerKey): ManagerKey => key
 
   beforeEach(async () => {
     tmpRoot = await fs.mkdtemp(join(tmpdir(), 'manager-bootstrap-'))
@@ -243,8 +242,8 @@ describe('manager bootstrap（P5 Task 1）', () => {
     }
 
     // step 1/2/4：走 adapter 手里那份回调引用，验证 harness 真的收到了并落账
-    const dialogObjectId = dialogObjectIdForPrivate('friend-wiring')
-    await stack.ledger.upsertWorker(dialogObjectId, 'w-builtin-1', () =>
+    const managerKey = 'wechat::sess-boot' as ManagerKey
+    await stack.ledger.upsertWorker(managerKey, 'w-builtin-1', () =>
       makeLedgerWorker({ workerId: 'w-builtin-1', impl: 'builtin', spawnedBySession: 'wechat::sess-boot' as ManagerKey }),
     )
 
@@ -266,7 +265,7 @@ describe('manager bootstrap（P5 Task 1）', () => {
     // step 4 的另一面：harness 按需从同一个底层 Map 取 adapter——codex 是构造 harness 之后才
     // set 进去的，能命中它自己的 capabilities().fork===false 分支，就证明 Map 引用是共享的
     // （若没共享，抛的会是 "no adapter registered for impl 'codex'"）。
-    await stack.ledger.upsertWorker(dialogObjectId, 'w-codex-1', () =>
+    await stack.ledger.upsertWorker(managerKey, 'w-codex-1', () =>
       makeLedgerWorker({ workerId: 'w-codex-1', impl: 'codex', spawnedBySession: 'wechat::sess-boot' as ManagerKey }),
     )
     await expect(stack.harness.queryWorker('w-codex-1', '进展如何？')).rejects.toBeInstanceOf(CapabilityNotSupportedError)
@@ -478,9 +477,8 @@ describe('manager bootstrap（P5 Task 1）', () => {
     // J 的硬验收：worker 以谁的名义执行，决定它的权限模板（§8.2）。
     expect(all[0].worker.origin.creator_friend_id).toBe('f-a')
     expect(all[0].worker.origin.trigger_type).toBe('message')
-    expect(all[0].worker.origin.spawned_by_session).toBe('wechat::sess-boot')
-    // 私聊台账按 friend 聚合（跨 channel 共享），不是 group 形状
-    expect(all[0].dialogObjectId).toBe('friend:f-a')
+    expect(all[0].worker.manager_key).toBe('wechat::sess-boot')
+    expect(all[0].managerKey).toBe('wechat::sess-boot')
   })
 
   it('worker 事件唤醒的 episode 里没人在说话 → 不拿缓存里上一次的发言者冒充', async () => {
@@ -493,7 +491,7 @@ describe('manager bootstrap（P5 Task 1）', () => {
     expect(await stack.ledger.listAllWorkers()).toHaveLength(0)
 
     // ② 手工种一条 worker，模拟"更早派出去的活"
-    await stack.ledger.upsertWorker(dialogObjectIdForPrivate('f-a'), 'w-seeded', () =>
+    await stack.ledger.upsertWorker(key, 'w-seeded', () =>
       makeLedgerWorker({ workerId: 'w-seeded', impl: 'builtin', spawnedBySession: key }),
     )
 
@@ -506,8 +504,8 @@ describe('manager bootstrap（P5 Task 1）', () => {
     expect(spawnedByEvent).toHaveLength(1)
     // 缓存里还留着 f-a，但这一轮不是 f-a 在说话——记成 f-a 就是把 worker 挂到错的人名下。
     expect(spawnedByEvent[0].worker.origin.creator_friend_id).toBeUndefined()
-    // 台账归档键仍按**会话身份**（f-a 的私聊）——它是会话属性，与"这轮谁在说话"无关。
-    expect(spawnedByEvent[0].dialogObjectId).toBe('friend:f-a')
+    // worker 事件继续归原会话；没有新的 human wake 时也不继承 f-a 的权限身份。
+    expect(spawnedByEvent[0].managerKey).toBe(key)
   })
 
   it('场景画像与该渠道的 @handle 真的出现在 manager 的 system prompt 里（5b + 5d）', async () => {

--- a/crabot-agent/tests/manager/bootstrap.test.ts
+++ b/crabot-agent/tests/manager/bootstrap.test.ts
@@ -278,7 +278,7 @@ describe('manager bootstrap（P5 Task 1）', () => {
 
   // --- ③ onAsyncError 端到端 ---
 
-  it('onAsyncError 端到端：经 bootstrap 装配的真实工具面调用 query_worker（worker 不存在→游离 promise reject）→ registry 按 key 绑定的回调被触发 → episode 内 enqueueDuringEpisode', async () => {
+  it('known-ID authorization happens before query_worker fire-and-forget: an unknown worker returns an error and no async wake is injected', async () => {
     let triggered = false
     const managerLLM: LLMAdapter = {
       async *stream(params: LLMStreamParams) {
@@ -288,10 +288,8 @@ describe('manager bootstrap（P5 Task 1）', () => {
           const queryWorkerTool = params.tools.find((t) => t.name === 'query_worker')
           expect(queryWorkerTool).toBeDefined()
           const result = await queryWorkerTool!.call({ worker_id: 'w-not-in-ledger', question: '进展如何？' }, {} as never)
-          // fire-and-forget：调用本身不因后台失败而报错
-          expect(result.isError).toBe(false)
-          // 给游离 promise 一个宏任务窗口 reject → .catch() → onAsyncError（此刻 episode 仍在跑）
-          await new Promise((resolve) => setTimeout(resolve, 40))
+          // Authorization completes before a fire-and-forget fork can begin.
+          expect(result.isError).toBe(true)
         }
         yield* chunksFromContent([{ type: 'text', text: '收到' }], 'end_turn', { inputTokens: 10, outputTokens: 5 })
       },
@@ -306,8 +304,7 @@ describe('manager bootstrap（P5 Task 1）', () => {
     const result = await stack.registry.routeHumanMessages('wechat', 'sess-boot', [makeChannelMessage('侧问一下 worker')])
 
     expect(result.outcome).toBe('completed')
-    expect(enqueueSpy).toHaveBeenCalledTimes(1)
-    expect(JSON.stringify(enqueueSpy.mock.calls[0][0])).toContain('query_failed')
+    expect(enqueueSpy).not.toHaveBeenCalled()
   })
 
   // --- ④ 空台账对账 ---

--- a/crabot-agent/tests/manager/events.test.ts
+++ b/crabot-agent/tests/manager/events.test.ts
@@ -20,8 +20,7 @@ import {
 } from '../../src/manager/events.js'
 import { buildManagerStack, type BootstrapDeps } from '../../src/manager/bootstrap.js'
 import {
-  dialogObjectIdForPrivate,
-  type DialogObjectId,
+  type ManagerKey,
   type LedgerWorker,
   type TaskStatus,
 } from '../../src/workers/harness/ledger-types.js'
@@ -38,7 +37,7 @@ import { chunksFromContent } from '../engine/helpers/mock-stream.js'
 // helpers
 // ============================================================================
 
-const DIALOG_OBJECT_ID = dialogObjectIdForPrivate('friend-evt')
+const DIALOG_OBJECT_ID = `test::friend-evt` as ManagerKey
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 function makeLedgerWorker(p: {
@@ -50,7 +49,8 @@ function makeLedgerWorker(p: {
   return {
     worker_id: p.workerId,
     task: { id: p.taskId ?? `task-of-${p.workerId}`, title: 't', status: p.status, created_at: '2026-01-01T00:00:00.000Z' },
-    origin: { spawned_by_session: 'wechat::sess-evt' as ManagerKey, trigger_type: 'message' },
+    origin: {
+      trigger_type: 'message' },
     report_to: { channel_id: 'wechat', session_id: 'sess-evt' },
     incarnations: [
       {
@@ -79,7 +79,7 @@ function makeLedgerStub(
       if (!step) return undefined
       if (step.delayMs) await new Promise((resolve) => setTimeout(resolve, step.delayMs))
       return {
-        dialogObjectId: DIALOG_OBJECT_ID,
+        managerKey: DIALOG_OBJECT_ID,
         worker: makeLedgerWorker({ workerId: opts.workerId ?? workerId, status: step.status, taskId: opts.taskId }),
       }
     },
@@ -185,7 +185,7 @@ describe('agent 对外事件（P5 Task 2）', () => {
         task_id: 'task-1',
         old_status: 'running',
         new_status: 'completed',
-        dialog_object_id: DIALOG_OBJECT_ID,
+        manager_key: DIALOG_OBJECT_ID,
       }
       publish('agent.task_status_changed', payload)
 
@@ -219,7 +219,7 @@ describe('agent 对外事件（P5 Task 2）', () => {
           task_id: 'task-1',
           old_status: 'running',
           new_status: 'failed',
-          dialog_object_id: DIALOG_OBJECT_ID,
+          manager_key: DIALOG_OBJECT_ID,
         }),
       ).not.toThrow()
 
@@ -246,7 +246,7 @@ describe('agent 对外事件（P5 Task 2）', () => {
           task_id: 'task-1',
           old_status: 'queued',
           new_status: 'running',
-          dialog_object_id: DIALOG_OBJECT_ID,
+          manager_key: DIALOG_OBJECT_ID,
         }),
       ).not.toThrow()
       expect(consoleSpy).toHaveBeenCalled()
@@ -256,7 +256,7 @@ describe('agent 对外事件（P5 Task 2）', () => {
   // --- ①④⑤ harness 事件 → task 状态事件的翻译与去重 ---
 
   describe('makeTaskStatusEventBridge', () => {
-    it('①载荷与 §9.2 逐字：worker_id / task_id / old_status / new_status / dialog_object_id，无多余字段', async () => {
+    it('①载荷与 §9.2 逐字：worker_id / task_id / old_status / new_status / manager_key，无多余字段', async () => {
       const publish = vi.fn()
       const { ledger } = makeLedgerStub([{ status: 'running' }], { taskId: 'task-42' })
       const bridge = makeTaskStatusEventBridge({ ledger, publish })
@@ -268,7 +268,7 @@ describe('agent 对外事件（P5 Task 2）', () => {
       const [type, payload] = publish.mock.calls[0] as [string, AgentTaskStatusChangedPayload]
       expect(type).toBe('agent.task_status_changed')
       expect(Object.keys(payload).sort()).toEqual([
-        'dialog_object_id',
+        'manager_key',
         'new_status',
         'old_status',
         'task_id',
@@ -280,7 +280,7 @@ describe('agent 对外事件（P5 Task 2）', () => {
         // 台账里的 task 初始状态是 queued（harness.spawnWorker 先建 queued 再迁 running）
         old_status: 'queued',
         new_status: 'running',
-        dialog_object_id: DIALOG_OBJECT_ID,
+        manager_key: DIALOG_OBJECT_ID,
       })
     })
 
@@ -356,7 +356,7 @@ describe('agent 对外事件（P5 Task 2）', () => {
       let onDisk: TaskStatus = 'running'
       const ledger = {
         findWorker: async (workerId: string) => ({
-          dialogObjectId: DIALOG_OBJECT_ID,
+          managerKey: DIALOG_OBJECT_ID,
           worker: makeLedgerWorker({ workerId, status: onDisk, taskId: 'task-swallow' }),
         }),
       } as unknown as Pick<LedgerStore, 'findWorker'>
@@ -385,7 +385,7 @@ describe('agent 对外事件（P5 Task 2）', () => {
         ['completed', 'running'],
       ])
       // 身份字段仍取自台账（它们在 worker 生命周期内不变，读晚了也读不出别的值）
-      expect(publish.mock.calls[1][1]).toMatchObject({ worker_id: 'w-swallow', task_id: 'task-swallow', dialog_object_id: DIALOG_OBJECT_ID })
+      expect(publish.mock.calls[1][1]).toMatchObject({ worker_id: 'w-swallow', task_id: 'task-swallow', manager_key: DIALOG_OBJECT_ID })
     })
 
     it('⑥事件带 task_status 时，new_status 一律以事件为准，不再受台账现状影响', async () => {
@@ -472,7 +472,7 @@ describe('agent 对外事件（P5 Task 2）', () => {
         messagingDeps: makeMessagingDeps(),
         memoryServer: makeMemoryServer(),
         callAdmin: async () => ({}) as never,
-        dialogObjectIdFor: (): DialogObjectId => DIALOG_OBJECT_ID,
+        managerKeyFor: (): ManagerKey => DIALOG_OBJECT_ID,
         ...overrides,
       }
     }
@@ -487,9 +487,10 @@ describe('agent 对外事件（P5 Task 2）', () => {
         }),
       )
 
-      await stack.ledger.upsertWorker(DIALOG_OBJECT_ID, 'w-wired', () =>
-        makeLedgerWorker({ workerId: 'w-wired', status: 'running', taskId: 'task-wired' }),
-      )
+      await stack.ledger.upsertWorker(DIALOG_OBJECT_ID, 'w-wired', () => ({
+        ...makeLedgerWorker({ workerId: 'w-wired', status: 'running', taskId: 'task-wired' }),
+        manager_key: DIALOG_OBJECT_ID,
+      }))
 
       const onStateChange = capturedOnStateChange(stack.adapters.get('builtin'))
       expect(onStateChange).toBeDefined()
@@ -504,7 +505,7 @@ describe('agent 对外事件（P5 Task 2）', () => {
         task_id: 'task-wired',
         old_status: 'queued',
         new_status: 'completed',
-        dialog_object_id: DIALOG_OBJECT_ID,
+        manager_key: DIALOG_OBJECT_ID,
       })
     })
 
@@ -518,9 +519,10 @@ describe('agent 对外事件（P5 Task 2）', () => {
         }),
       )
 
-      await stack.ledger.upsertWorker(DIALOG_OBJECT_ID, 'w-filtered', () =>
-        makeLedgerWorker({ workerId: 'w-filtered', status: 'running', taskId: 'task-filtered' }),
-      )
+      await stack.ledger.upsertWorker(DIALOG_OBJECT_ID, 'w-filtered', () => ({
+        ...makeLedgerWorker({ workerId: 'w-filtered', status: 'running', taskId: 'task-filtered' }),
+        manager_key: DIALOG_OBJECT_ID,
+      }))
 
       // 直取 harness 拿到的那个 onEvent：这是 bootstrap 开的唯一出口，也是本用例要验证的对象
       // （input_sent 在 NO_WAKE_KINDS 里，真实 harness 只有在活 worker 上投递才会落，
@@ -536,9 +538,10 @@ describe('agent 对外事件（P5 Task 2）', () => {
 
     it('未注入 publishEvent 时装配照常工作（P5 阶段无生产调用方）', async () => {
       const stack = buildManagerStack(makeDeps())
-      await stack.ledger.upsertWorker(DIALOG_OBJECT_ID, 'w-nopub', () =>
-        makeLedgerWorker({ workerId: 'w-nopub', status: 'running' }),
-      )
+      await stack.ledger.upsertWorker(DIALOG_OBJECT_ID, 'w-nopub', () => ({
+        ...makeLedgerWorker({ workerId: 'w-nopub', status: 'running' }),
+        manager_key: DIALOG_OBJECT_ID,
+      }))
       const onStateChange = capturedOnStateChange(stack.adapters.get('builtin'))
       onStateChange!({ worker_id: 'w-nopub', seq: 1, impl: 'builtin', session_ref: 'w-nopub-ref' }, 'exited', { endReason: 'completed' })
       await waitUntil(async () => (await stack.ledger.findWorker('w-nopub'))?.worker.task.status === 'completed')

--- a/crabot-agent/tests/manager/fail-loud-worker-event.test.ts
+++ b/crabot-agent/tests/manager/fail-loud-worker-event.test.ts
@@ -24,7 +24,7 @@ import { UnifiedAgent } from '../../src/unified-agent.js'
 import { buildManagerStack, type BootstrapDeps, type ManagerStack } from '../../src/manager/bootstrap.js'
 import type { PrincipalResolverDeps } from '../../src/manager/principal.js'
 import type { ManagerKey } from '../../src/manager/types.js'
-import { dialogObjectIdForPrivate, type LedgerWorker } from '../../src/workers/harness/ledger-types.js'
+import { type LedgerWorker } from '../../src/workers/harness/ledger-types.js'
 import type { LLMAdapter } from '../../src/engine/index.js'
 import { createCrabMemoryServer } from '../../src/mcp/crab-memory.js'
 
@@ -76,11 +76,13 @@ function brokenLLM(): LLMAdapter {
   }
 }
 
-function makeLedgerWorker(p: { workerId: string; title: string; spawnedBySession: ManagerKey }): LedgerWorker {
+function makeLedgerWorker(p: { workerId: string; title: string; managerKey: ManagerKey }): LedgerWorker {
   return {
     worker_id: p.workerId,
+    manager_key: p.managerKey,
     task: { id: p.workerId, title: p.title, status: 'running', created_at: '2026-01-01T00:00:00.000Z' },
-    origin: { spawned_by_session: p.spawnedBySession, trigger_type: 'message' },
+    origin: {
+      trigger_type: 'message' },
     report_to: { channel_id: 'wechat', session_id: 'sess-1' },
     incarnations: [
       {
@@ -174,8 +176,8 @@ describe('worker 事件路径的 fail-loud（bootstrap.onEvent → reportEpisode
 
   /** 台账里种一条 worker,再从 adapter 上报口推一个 exited —— 走的是生产的 onEvent 接线。 */
   async function seedAndFireEvent(stack: ManagerStack, p: { workerId: string; title: string }): Promise<void> {
-    await stack.ledger.upsertWorker(dialogObjectIdForPrivate('friend-1'), p.workerId, () =>
-      makeLedgerWorker({ workerId: p.workerId, title: p.title, spawnedBySession: 'wechat::sess-1' as ManagerKey }),
+    await stack.ledger.upsertWorker('wechat::sess-1' as ManagerKey, p.workerId, () =>
+      makeLedgerWorker({ workerId: p.workerId, title: p.title, managerKey: 'wechat::sess-1' as ManagerKey }),
     )
     stack.harness.handleStateChange(
       { worker_id: p.workerId, seq: 1, impl: 'builtin', session_ref: `${p.workerId}-ref` },
@@ -196,7 +198,7 @@ describe('worker 事件路径的 fail-loud（bootstrap.onEvent → reportEpisode
     await waitUntil(() => rpcCalls.some((c) => c.method === 'send_message'))
 
     const sent = rpcCalls.find((c) => c.method === 'send_message')!
-    // 目标 = 该 worker 的监护 manager（origin.spawned_by_session），不是 report_to、不是系统线程
+    // 目标 = 该 worker 的监护 manager（origin.manager_key），不是 report_to、不是系统线程
     expect(sent.port).toBe(WECHAT_PORT)
     expect(sent.params.session_id).toBe('sess-1')
 
@@ -263,8 +265,8 @@ describe('worker 事件路径的 fail-loud（bootstrap.onEvent → reportEpisode
 
     // 台账：主线化身 running、impl=claude-code。
     // builtin 也有自己的 progress 信号；这里选择 CLI 是为了覆盖原生 meta 基线。
-    await stack.ledger.upsertWorker(dialogObjectIdForPrivate('friend-1'), workerId, () => {
-      const worker = makeLedgerWorker({ workerId, title: '卡住的活', spawnedBySession: 'wechat::sess-1' as ManagerKey })
+    await stack.ledger.upsertWorker('wechat::sess-1' as ManagerKey, workerId, () => {
+      const worker = makeLedgerWorker({ workerId, title: '卡住的活', managerKey: 'wechat::sess-1' as ManagerKey })
       return { ...worker, incarnations: [{ ...worker.incarnations[0], impl: 'claude-code' }] }
     })
 

--- a/crabot-agent/tests/manager/loop.test.ts
+++ b/crabot-agent/tests/manager/loop.test.ts
@@ -8,7 +8,6 @@ import { ManagerSessionStore } from '../../src/manager/session-store.js'
 import type { CompactionPolicy } from '../../src/manager/compaction.js'
 import type { ManagerKey } from '../../src/manager/types.js'
 import type { ChannelMessage, Friend } from '../../src/types.js'
-import { dialogObjectIdForPrivate } from '../../src/workers/harness/ledger-types.js'
 import type { WorkerHarness } from '../../src/workers/harness/harness.js'
 import type { LedgerWorker } from '../../src/workers/harness/ledger-types.js'
 import { createUserMessage, defineTool } from '../../src/engine/index.js'
@@ -18,7 +17,7 @@ import { chunksFromContent } from '../engine/helpers/mock-stream.js'
 // --- Fixtures / helpers ---
 
 const KEY: ManagerKey = 'wechat::sess-loop'
-const DIALOG_OBJECT_ID = dialogObjectIdForPrivate('friend-loop')
+const DIALOG_OBJECT_ID = (`test::${'friend-loop'}` as ManagerKey)
 
 /** compaction.ts foldIntoSummary 的 system prompt 常量特征串,用它区分"这是折叠 LLM 调用
  *  还是普通 engine turn 调用",不需要 vi.mock/vi.spyOn 侵入模块内部。 */
@@ -99,7 +98,7 @@ function baseDeps(
   return {
     key: KEY,
     isSystemThread: false,
-    dialogObjectId: () => DIALOG_OBJECT_ID,
+    managerKey: () => DIALOG_OBJECT_ID,
     policy,
     estimateTokens,
     toolFace: () => [],

--- a/crabot-agent/tests/manager/loop.test.ts
+++ b/crabot-agent/tests/manager/loop.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { promises as fs } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 
-import { ManagerLoop, type WakeEvent, type ManagerLoopDeps } from '../../src/manager/loop.js'
+import { ManagerLoop, type WakeEvent, type TimedWakeEnvelope, type ManagerLoopDeps } from '../../src/manager/loop.js'
 import { ManagerSessionStore } from '../../src/manager/session-store.js'
 import type { CompactionPolicy } from '../../src/manager/compaction.js'
 import type { ManagerKey } from '../../src/manager/types.js'
@@ -17,6 +17,8 @@ import { chunksFromContent } from '../engine/helpers/mock-stream.js'
 // --- Fixtures / helpers ---
 
 const KEY: ManagerKey = 'wechat::sess-loop'
+const FIXED_RECEIVED_AT = '2026-01-01T08:00:00+08:00'
+function timed(wake: WakeEvent): TimedWakeEnvelope { return { wake, received_at: FIXED_RECEIVED_AT, timezone: 'Asia/Shanghai' } }
 const DIALOG_OBJECT_ID = (`test::${'friend-loop'}` as ManagerKey)
 
 /** compaction.ts foldIntoSummary 的 system prompt 常量特征串,用它区分"这是折叠 LLM 调用
@@ -124,6 +126,15 @@ describe('ManagerLoop', () => {
     await fs.rm(dataDir, { recursive: true, force: true })
   })
 
+  it('拒绝绕过 registry 直接提交裸 WakeEvent', async () => {
+    const { adapter } = makeAdapter()
+    const loop = new ManagerLoop(baseDeps({ store, adapter }))
+    const bare = { kind: 'schedule', scheduleId: 'bare', title: 't', description: 'd' } as WakeEvent
+
+    await expect(loop.wakeUp(bare as never)).rejects.toThrow('TimedWakeEnvelope')
+    expect(() => loop.enqueueDuringEpisode(bare as never)).toThrow('TimedWakeEnvelope')
+  })
+
   it('唤醒 → 跑一个 turn → 回睡的完整往返', async () => {
     const { adapter, queue } = makeAdapter()
     queue.push({ text: '收到,已了解情况', stopReason: 'end_turn' })
@@ -131,7 +142,7 @@ describe('ManagerLoop', () => {
     const loop = new ManagerLoop(baseDeps({ store, adapter }))
     const event: WakeEvent = { kind: 'human_messages', messages: [makeChannelMessage('你好')] }
 
-    const result = await loop.wakeUp(event)
+    const result = await loop.wakeUp(timed(event))
 
     expect(result.outcome).toBe('completed')
     expect(result.consumedEvents).toBe(true)
@@ -142,6 +153,45 @@ describe('ManagerLoop', () => {
     expect(state.recent.length).toBe(2) // 渲染的事件 user msg + assistant 回复
     expect(JSON.stringify(state.recent)).toContain('你好')
     expect(state.lastActiveAt).toBeTruthy()
+  })
+
+  it('同一 episode 内时钟、台账与通知变化不改变 system prompt，也不自动读取台账', async () => {
+    const { adapter, queue, calls } = makeAdapter()
+    queue.push(
+      { toolCalls: [{ name: 'mutate_dynamic_state', id: 'mutate-1', input: {} }], stopReason: 'tool_use' },
+      { text: 'done', stopReason: 'end_turn' },
+    )
+    let nowMs = Date.parse('2026-01-01T00:00:00.000Z')
+    let pendingNote = 'before'
+    const listWorkers = vi.fn(async (): Promise<LedgerWorker[]> => [])
+    const loop = new ManagerLoop(baseDeps({
+      store,
+      adapter,
+      now: () => new Date(nowMs),
+      harness: { ...FAKE_HARNESS, listWorkers } as unknown as WorkerHarness,
+      promptInputs: () => (
+        { dialogProfile: 'fixed profile', pendingNotes: [pendingNote] } as { readonly dialogProfile?: string }
+      ),
+      toolFace: () => [{
+        name: 'mutate_dynamic_state',
+        description: 'mutate test-only dynamic state',
+        inputSchema: { type: 'object', properties: {} },
+        isReadOnly: false,
+        call: async () => {
+          nowMs += 60_000
+          pendingNote = 'after'
+          return { output: 'ok', isError: false }
+        },
+      }],
+    }))
+
+    await loop.wakeUp(timed({ kind: 'human_messages', messages: [makeChannelMessage('start')] }))
+
+    expect(calls).toHaveLength(2)
+    expect(calls[0].systemPrompt).toBe(calls[1].systemPrompt)
+    expect(calls[0].systemPrompt).not.toContain('before')
+    expect(calls[1].systemPrompt).not.toContain('after')
+    expect(listWorkers).not.toHaveBeenCalled()
   })
 
   it('model 热更于下一个 episode 生效:adapter/model 解析器每个 episode 只调用一次，不在 episode 内重复读取', async () => {
@@ -164,14 +214,14 @@ describe('ManagerLoop', () => {
     })
     const loop = new ManagerLoop(deps)
 
-    await loop.wakeUp({ kind: 'human_messages', messages: [makeChannelMessage('第一条')] })
+    await loop.wakeUp(timed({ kind: 'human_messages', messages: [makeChannelMessage('第一条')] }))
     expect(adapterResolveCalls).toBe(1)
     expect(modelResolveCalls).toBe(1)
 
     // 模拟"config 热更"发生在两次唤醒之间：deps.adapter/model 这两个 thunk 本身不变
     // （生产环境由调用方在 thunk 内部读取最新 admin config），但 loop 只应在 episode 边界
     // （每次 wakeUp）重新调用一次——同一 episode 内（包括其内部可能的重试）绝不重复调用。
-    await loop.wakeUp({ kind: 'human_messages', messages: [makeChannelMessage('第二条')] })
+    await loop.wakeUp(timed({ kind: 'human_messages', messages: [makeChannelMessage('第二条')] }))
     expect(adapterResolveCalls).toBe(2)
     expect(modelResolveCalls).toBe(2)
   })
@@ -188,17 +238,17 @@ describe('ManagerLoop', () => {
     const loop = new ManagerLoop(baseDeps({ store, adapter, policy, now: () => new Date(nowMs) }))
 
     // wakeUp #1 @ t=0
-    await loop.wakeUp({ kind: 'human_messages', messages: [makeChannelMessage('msg1')] })
+    await loop.wakeUp(timed({ kind: 'human_messages', messages: [makeChannelMessage('msg1')] }))
     expect(foldCalls.length).toBe(0)
 
     // wakeUp #2 @ t=100ms(远小于 TTL=1000ms)——burst,不压缩
     nowMs += 100
-    await loop.wakeUp({ kind: 'human_messages', messages: [makeChannelMessage('msg2')] })
+    await loop.wakeUp(timed({ kind: 'human_messages', messages: [makeChannelMessage('msg2')] }))
     expect(foldCalls.length).toBe(0)
 
     // wakeUp #3 @ t=100+5000ms(远超 TTL),此时累计历史(4 条)已超 foldTokenThreshold
     nowMs += 5000
-    await loop.wakeUp({ kind: 'human_messages', messages: [makeChannelMessage('msg3')] })
+    await loop.wakeUp(timed({ kind: 'human_messages', messages: [makeChannelMessage('msg3')] }))
     expect(foldCalls.length).toBe(1)
 
     const state = await store.load(KEY)
@@ -224,8 +274,13 @@ describe('ManagerLoop', () => {
 
     const loop = new ManagerLoop(baseDeps({ store, adapter: adapterThatThrowsOnce }))
     const event: WakeEvent = { kind: 'human_messages', messages: [makeChannelMessage('重要的话只能说一次')] }
+    const originalEnvelope: TimedWakeEnvelope = {
+      wake: event,
+      received_at: '2026-01-01T08:12:34+08:00',
+      timezone: 'Asia/Shanghai',
+    }
 
-    const first = await loop.wakeUp(event)
+    const first = await loop.wakeUp(originalEnvelope)
     expect(first.outcome).toBe('failed')
     expect(first.consumedEvents).toBe(false)
 
@@ -234,13 +289,14 @@ describe('ManagerLoop', () => {
     expect(stateAfterFailure.recent.length).toBe(0)
 
     // 下次唤醒(不同的新事件),原始失败事件应随邮箱一起重投,被 LLM 看到
-    const second = await loop.wakeUp({ kind: 'human_messages', messages: [makeChannelMessage('新的话')] })
+    const second = await loop.wakeUp(timed({ kind: 'human_messages', messages: [makeChannelMessage('新的话')] }))
     expect(second.outcome).toBe('completed')
     expect(second.consumedEvents).toBe(true)
 
     const finalState = await store.load(KEY)
     const serialized = JSON.stringify(finalState.recent)
     expect(serialized).toContain('重要的话只能说一次') // 重投的原始事件
+    expect(serialized).toContain('received_at=\\"2026-01-01T08:12:34+08:00\\"')
     expect(serialized).toContain('新的话') // 本次新事件
   })
 
@@ -281,7 +337,7 @@ describe('ManagerLoop', () => {
           inputSchema: { type: 'object', properties: {} },
           isReadOnly: false,
           call: async () => {
-            loop.enqueueDuringEpisode({ kind: 'schedule', scheduleId: 'sched-fail', title: '巡检', description: '失败前注入的事件' })
+            loop.enqueueDuringEpisode(timed({ kind: 'schedule', scheduleId: 'sched-fail', title: '巡检', description: '失败前注入的事件' }))
             return { output: 'ok', isError: false }
           },
         },
@@ -289,7 +345,7 @@ describe('ManagerLoop', () => {
     })
     loop = new ManagerLoop(deps)
 
-    const first = await loop.wakeUp({ kind: 'human_messages', messages: [makeChannelMessage('开始任务')] })
+    const first = await loop.wakeUp(timed({ kind: 'human_messages', messages: [makeChannelMessage('开始任务')] }))
     expect(first.outcome).toBe('failed')
     expect(first.consumedEvents).toBe(false)
 
@@ -303,7 +359,7 @@ describe('ManagerLoop', () => {
 
     // 下次唤醒(不同的新事件):mid-episode 注入的内容应随邮箱一起重投,被 LLM 看到并落盘
     queue.push({ text: '正常处理', stopReason: 'end_turn' })
-    const second = await loop.wakeUp({ kind: 'human_messages', messages: [makeChannelMessage('新的话')] })
+    const second = await loop.wakeUp(timed({ kind: 'human_messages', messages: [makeChannelMessage('新的话')] }))
     expect(second.outcome).toBe('completed')
     expect(second.consumedEvents).toBe(true)
 
@@ -345,7 +401,7 @@ describe('ManagerLoop', () => {
           inputSchema: { type: 'object', properties: {} },
           isReadOnly: false,
           call: async () => {
-            loop.enqueueDuringEpisode({ kind: 'schedule', scheduleId: 'sched-throw', title: '巡检', description: '直接抛错前注入的事件' })
+            loop.enqueueDuringEpisode(timed({ kind: 'schedule', scheduleId: 'sched-throw', title: '巡检', description: '直接抛错前注入的事件' }))
             return { output: 'ok', isError: false }
           },
         },
@@ -364,10 +420,10 @@ describe('ManagerLoop', () => {
 
     // 唤醒前先在邮箱里塞一条"上一次遗留"的内容(episode 未在跑,直接进 mailbox.pending,
     // 是本次唤醒 carriedTexts 的来源)
-    loop.enqueueDuringEpisode({ kind: 'schedule', scheduleId: 'sched-carried', title: '巡检', description: '唤醒前已经在邮箱里的内容' })
+    loop.enqueueDuringEpisode(timed({ kind: 'schedule', scheduleId: 'sched-carried', title: '巡检', description: '唤醒前已经在邮箱里的内容' }))
 
     await expect(
-      loop.wakeUp({ kind: 'human_messages', messages: [makeChannelMessage('触发超限并在折叠时抛错')] })
+      loop.wakeUp(timed({ kind: 'human_messages', messages: [makeChannelMessage('触发超限并在折叠时抛错')] }))
     ).rejects.toThrow('boom: fold llm exhausted retries')
 
     // 落盘不应发生(异常发生在 store.save 之前)
@@ -377,7 +433,7 @@ describe('ManagerLoop', () => {
     // 下次唤醒:carriedTexts(唤醒前邮箱里的内容)、eventText(本次唤醒事件)、
     // currentEpisodeInjected(mid-episode 注入)应该都被重投,一个不丢
     queue.push({ text: '正常处理', stopReason: 'end_turn' })
-    const second = await loop.wakeUp({ kind: 'human_messages', messages: [makeChannelMessage('新的话')] })
+    const second = await loop.wakeUp(timed({ kind: 'human_messages', messages: [makeChannelMessage('新的话')] }))
     expect(second.outcome).toBe('completed')
     expect(second.consumedEvents).toBe(true)
 
@@ -407,7 +463,7 @@ describe('ManagerLoop', () => {
           inputSchema: { type: 'object', properties: {} },
           isReadOnly: false,
           call: async () => {
-            loop.enqueueDuringEpisode({ kind: 'schedule', scheduleId: 'sched-ok', title: '巡检', description: '成功路径注入' })
+            loop.enqueueDuringEpisode(timed({ kind: 'schedule', scheduleId: 'sched-ok', title: '巡检', description: '成功路径注入' }))
             return { output: 'ok', isError: false }
           },
         },
@@ -415,11 +471,11 @@ describe('ManagerLoop', () => {
     })
     loop = new ManagerLoop(deps)
 
-    const first = await loop.wakeUp({ kind: 'human_messages', messages: [makeChannelMessage('开始任务')] })
+    const first = await loop.wakeUp(timed({ kind: 'human_messages', messages: [makeChannelMessage('开始任务')] }))
     expect(first.outcome).toBe('completed')
     expect(first.consumedEvents).toBe(true)
 
-    const second = await loop.wakeUp({ kind: 'human_messages', messages: [makeChannelMessage('新的话')] })
+    const second = await loop.wakeUp(timed({ kind: 'human_messages', messages: [makeChannelMessage('新的话')] }))
     expect(second.outcome).toBe('completed')
 
     // 第二次唤醒发给 LLM 的 messages 里,'sched-ok' 只应该出现一次(第一次 episode 成功时
@@ -448,7 +504,7 @@ describe('ManagerLoop', () => {
           isReadOnly: false,
           call: async () => {
             // 模拟"episode 进行中收到新事件":在工具执行期间(turn1 与 turn2 之间)入队
-            loop.enqueueDuringEpisode({ kind: 'schedule', scheduleId: 'sched-1', title: '巡检', description: '期间到达的新事件' })
+            loop.enqueueDuringEpisode(timed({ kind: 'schedule', scheduleId: 'sched-1', title: '巡检', description: '期间到达的新事件' }))
             return { output: 'ok', isError: false }
           },
         },
@@ -456,7 +512,7 @@ describe('ManagerLoop', () => {
     })
     loop = new ManagerLoop(deps)
 
-    const result = await loop.wakeUp({ kind: 'human_messages', messages: [makeChannelMessage('开始任务')] })
+    const result = await loop.wakeUp(timed({ kind: 'human_messages', messages: [makeChannelMessage('开始任务')] }))
 
     expect(result.outcome).toBe('completed')
     expect(result.turns).toBe(2)
@@ -472,8 +528,7 @@ describe('ManagerLoop', () => {
   })
 
   it('max_tokens(上下文超限)收场时强制折叠一次并重试一次,成功后 outcome=completed', async () => {
-    const { adapter, queue, foldCalls } = makeAdapter()
-    // 第一次尝试:静默 max_tokens(text='' + stopReason='max_tokens')
+    const { adapter, queue, calls, foldCalls } = makeAdapter()
     queue.push({ stopReason: 'max_tokens' })
     // 强制折叠后的重试:正常结束
     queue.push({ text: '折叠后重试成功', stopReason: 'end_turn' })
@@ -490,9 +545,20 @@ describe('ManagerLoop', () => {
     ]
     await store.save({ key: KEY, recent: seedMessages, foldedCount: 0 })
 
-    const result = await loop.wakeUp({ kind: 'human_messages', messages: [makeChannelMessage('触发超限的一句话')] })
+    const initialEnvelope: TimedWakeEnvelope = {
+      wake: { kind: 'human_messages', messages: [makeChannelMessage('触发超限的一句话')] },
+      received_at: '2026-01-01T08:22:33+08:00',
+      timezone: 'Asia/Shanghai',
+    }
+    const result = await loop.wakeUp(initialEnvelope)
 
     expect(foldCalls.length).toBe(1) // 强制折叠恰好发生一次
+    expect(JSON.stringify(foldCalls[0].messages)).not.toContain('触发超限的一句话')
+    const nonFoldCalls = calls.filter((call) => !call.systemPrompt.includes(FOLD_SYSTEM_PROMPT_MARKER))
+    expect(nonFoldCalls).toHaveLength(2)
+    for (const call of nonFoldCalls) {
+      expect(JSON.stringify(call.messages)).toContain('received_at=\\"2026-01-01T08:22:33+08:00\\"')
+    }
     expect(result.outcome).toBe('completed')
     expect(result.turns).toBe(2) // 首次尝试 1 turn + 重试 1 turn
     expect(result.consumedEvents).toBe(true)
@@ -524,7 +590,7 @@ describe('ManagerLoop', () => {
     ]
     await store.save({ key: KEY, recent: seedMessages, foldedCount: 0 })
 
-    const result = await loop.wakeUp({ kind: 'human_messages', messages: [makeChannelMessage('会被截断的长问题')] })
+    const result = await loop.wakeUp(timed({ kind: 'human_messages', messages: [makeChannelMessage('会被截断的长问题')] }))
 
     expect(foldCalls.length).toBe(0) // 未触发强制折叠
     expect(calls.length).toBe(1) // 只跑了一次 runEngine,没有重试
@@ -552,7 +618,7 @@ describe('ManagerLoop', () => {
     ]
     await store.save({ key: KEY, recent: seedMessages, foldedCount: 0 })
 
-    const result = await loop.wakeUp({ kind: 'human_messages', messages: [makeChannelMessage('触发超限的一句话(仅推理块)')] })
+    const result = await loop.wakeUp(timed({ kind: 'human_messages', messages: [makeChannelMessage('触发超限的一句话(仅推理块)')] }))
 
     expect(foldCalls.length).toBe(1) // 强制折叠恰好发生一次
     expect(result.outcome).toBe('completed')
@@ -585,7 +651,7 @@ describe('ManagerLoop', () => {
           isReadOnly: false,
           call: async () => {
             // turn1 与 turn2 之间注入内容,保证被 turn2 的 drainPending() 消费
-            loop.enqueueDuringEpisode({ kind: 'schedule', scheduleId: 'sched-max-tokens', title: '巡检', description: '首次尝试期间注入' })
+            loop.enqueueDuringEpisode(timed({ kind: 'schedule', scheduleId: 'sched-max-tokens', title: '巡检', description: '首次尝试期间注入' }))
             return { output: 'ok', isError: false }
           },
         },
@@ -602,7 +668,7 @@ describe('ManagerLoop', () => {
     await store.save({ key: KEY, recent: seedMessages, foldedCount: 0 })
 
     // 首次唤醒:首次尝试 turn1 成功 + turn2 max_tokens → 强制折叠 + 重试成功
-    const first = await loop.wakeUp({ kind: 'human_messages', messages: [makeChannelMessage('触发 max_tokens 的一句话')] })
+    const first = await loop.wakeUp(timed({ kind: 'human_messages', messages: [makeChannelMessage('触发 max_tokens 的一句话')] }))
     expect(first.outcome).toBe('completed')
     expect(first.turns).toBe(3) // turn1 + turn2(max_tokens) + 重试的 turn1
     expect(first.consumedEvents).toBe(true)
@@ -615,7 +681,7 @@ describe('ManagerLoop', () => {
     expect(retryCallMessages).toContain('首次尝试期间注入')
 
     // 第二次唤醒:验证 mid-episode 内容已被首次 episode 的重试消费进 state.recent,不会重复投递
-    const second = await loop.wakeUp({ kind: 'human_messages', messages: [makeChannelMessage('新话题')] })
+    const second = await loop.wakeUp(timed({ kind: 'human_messages', messages: [makeChannelMessage('新话题')] }))
     expect(second.outcome).toBe('completed')
 
     const nonFoldCalls2 = calls.filter((c) => !c.systemPrompt.includes(FOLD_SYSTEM_PROMPT_MARKER))
@@ -638,7 +704,7 @@ describe('ManagerLoop', () => {
     const injectDuringFold: LLMAdapter = {
       async *stream(params) {
         if (params.systemPrompt.includes(FOLD_SYSTEM_PROMPT_MARKER)) {
-          loop.enqueueDuringEpisode({ kind: 'schedule', scheduleId: 'sched-during-fold', title: '巡检', description: '折叠调用期间到达' })
+          loop.enqueueDuringEpisode(timed({ kind: 'schedule', scheduleId: 'sched-during-fold', title: '巡检', description: '折叠调用期间到达' }))
         }
         yield* adapter.stream(params)
       },
@@ -657,7 +723,7 @@ describe('ManagerLoop', () => {
     ]
     await store.save({ key: KEY, recent: seedMessages, foldedCount: 0 })
 
-    const result = await loop.wakeUp({ kind: 'human_messages', messages: [makeChannelMessage('触发超限')] })
+    const result = await loop.wakeUp(timed({ kind: 'human_messages', messages: [makeChannelMessage('触发超限')] }))
 
     expect(result.outcome).toBe('completed')
     expect(result.consumedEvents).toBe(true)
@@ -688,7 +754,7 @@ describe('ManagerLoop', () => {
     ]
     await store.save({ key: KEY, recent: seedMessages, foldedCount: 0 })
 
-    const result = await loop.wakeUp({ kind: 'human_messages', messages: [makeChannelMessage('触发')] })
+    const result = await loop.wakeUp(timed({ kind: 'human_messages', messages: [makeChannelMessage('触发')] }))
 
     expect(foldCalls.length).toBe(0) // 没有可折叠内容(splitAt=0),不该调折叠 LLM
     expect(result.outcome).toBe('completed')
@@ -720,7 +786,7 @@ describe('ManagerLoop', () => {
     queue.push({ text: '下一次唤醒的回复', stopReason: 'end_turn' })
 
     const loop = new ManagerLoop(baseDeps({ store, adapter }))
-    loop.enqueueDuringEpisode({ kind: 'schedule', scheduleId: 'sched-residue', title: '巡检', description: '收口后才到达的残留' })
+    loop.enqueueDuringEpisode(timed({ kind: 'schedule', scheduleId: 'sched-residue', title: '巡检', description: '收口后才到达的残留' }))
     expect(loop.hasPendingMailbox).toBe(true)
 
     const result = await loop.drainMailbox()
@@ -734,7 +800,7 @@ describe('ManagerLoop', () => {
     expect(firstCallMessages).not.toContain('[人类消息]')
 
     // 已消费进持久历史,下次真实唤醒不会重复投递。
-    const afterDrain = await loop.wakeUp({ kind: 'human_messages', messages: [makeChannelMessage('新的话')] })
+    const afterDrain = await loop.wakeUp(timed({ kind: 'human_messages', messages: [makeChannelMessage('新的话')] }))
     expect(afterDrain.outcome).toBe('completed')
     const state = await store.load(KEY)
     const occurrences = (JSON.stringify(state.recent).match(/sched-residue/g) ?? []).length
@@ -748,7 +814,7 @@ describe('ManagerLoop', () => {
     const loop = new ManagerLoop(baseDeps({ store, adapter }))
 
     for (let i = 0; i < 5; i++) {
-      const result = await loop.wakeUp({ kind: 'human_messages', messages: [makeChannelMessage(`第${i}轮消息`)] })
+      const result = await loop.wakeUp(timed({ kind: 'human_messages', messages: [makeChannelMessage(`第${i}轮消息`)] }))
       expect(result.outcome).toBe('completed')
       expect(result.consumedEvents).toBe(true)
     }
@@ -766,7 +832,7 @@ describe('ManagerLoop', () => {
     queue.push({ stopReason: 'end_turn' })
 
     const loop = new ManagerLoop(baseDeps({ store, adapter }))
-    const result = await loop.wakeUp({ kind: 'human_messages', messages: [makeChannelMessage('你好')] })
+    const result = await loop.wakeUp(timed({ kind: 'human_messages', messages: [makeChannelMessage('你好')] }))
 
     expect(result.outcome).toBe('completed')
     // 语义不变量①:没有任何一轮的上下文里出现过 forced_summary 的文案。
@@ -797,7 +863,7 @@ describe('ManagerLoop', () => {
       queue.push({ text: '(内部判断:这条不需要我回)', stopReason: 'end_turn' })
 
       const loop = new ManagerLoop(baseDeps({ store, adapter, toolFace: replyToolFace }))
-      const result = await loop.wakeUp({ kind: 'human_messages', messages: [makeChannelMessage('群里有人闲聊')] })
+      const result = await loop.wakeUp(timed({ kind: 'human_messages', messages: [makeChannelMessage('群里有人闲聊')] }))
 
       // outcome 答不了这个问题——沉默和回话都是 completed,这正是需要单独一个字段的理由。
       expect(result.outcome).toBe('completed')
@@ -810,7 +876,7 @@ describe('ManagerLoop', () => {
       queue.push({ text: '已回复', stopReason: 'end_turn' })
 
       const loop = new ManagerLoop(baseDeps({ store, adapter, toolFace: replyToolFace }))
-      const result = await loop.wakeUp({ kind: 'human_messages', messages: [makeChannelMessage('在吗')] })
+      const result = await loop.wakeUp(timed({ kind: 'human_messages', messages: [makeChannelMessage('在吗')] }))
 
       expect(result.outcome).toBe('completed')
       expect(result.repliedToHuman).toBe(true)
@@ -824,7 +890,7 @@ describe('ManagerLoop', () => {
 
         const isolatedStore = new ManagerSessionStore(join(dataDir, `store-${toolName}`))
         const loop = new ManagerLoop(baseDeps({ store: isolatedStore, adapter, toolFace: replyToolFace }))
-        const result = await loop.wakeUp({ kind: 'human_messages', messages: [makeChannelMessage('私下问一句')] })
+        const result = await loop.wakeUp(timed({ kind: 'human_messages', messages: [makeChannelMessage('私下问一句')] }))
 
         expect(result.repliedToHuman).toBe(true)
       }
@@ -836,7 +902,7 @@ describe('ManagerLoop', () => {
       queue.push({ text: '已派活', stopReason: 'end_turn' })
 
       const loop = new ManagerLoop(baseDeps({ store, adapter, toolFace: replyToolFace }))
-      const result = await loop.wakeUp({ kind: 'human_messages', messages: [makeChannelMessage('帮我查个东西')] })
+      const result = await loop.wakeUp(timed({ kind: 'human_messages', messages: [makeChannelMessage('帮我查个东西')] }))
 
       expect(result.repliedToHuman).toBe(false)
     })
@@ -847,7 +913,7 @@ describe('ManagerLoop', () => {
       queue.push({ text: '看完了,不回', stopReason: 'end_turn' })
 
       const loop = new ManagerLoop(baseDeps({ store, adapter, toolFace: replyToolFace }))
-      const result = await loop.wakeUp({ kind: 'human_messages', messages: [makeChannelMessage('之前说到哪了')] })
+      const result = await loop.wakeUp(timed({ kind: 'human_messages', messages: [makeChannelMessage('之前说到哪了')] }))
 
       expect(result.repliedToHuman).toBe(false)
     })
@@ -900,7 +966,7 @@ describe('ManagerLoop', () => {
       const { adapter, queue, calls } = makeAdapter()
       queue.push({ text: 'ok', stopReason: 'end_turn' })
       const loop = new ManagerLoop(baseDeps({ store, adapter, timezone: () => 'UTC' }))
-      await loop.wakeUp(event)
+      await loop.wakeUp({ wake: event, received_at: '2026-01-01T00:00:00+00:00', timezone: 'UTC' })
       return JSON.stringify(calls[0].messages)
     }
 

--- a/crabot-agent/tests/manager/manager-integration.test.ts
+++ b/crabot-agent/tests/manager/manager-integration.test.ts
@@ -33,7 +33,7 @@ import { randomUUID } from 'node:crypto'
 import { WorkerHarness, type HarnessDeps } from '../../src/workers/harness/harness'
 import { LedgerStore, encodeSegment } from '../../src/workers/harness/ledger-store'
 import { WorkspaceManager } from '../../src/workers/harness/workspace-manager'
-import { dialogObjectIdForPrivate, type DialogObjectId } from '../../src/workers/harness/ledger-types'
+import type { ManagerKey } from '../../src/workers/harness/ledger-types'
 import type { HarnessEvent } from '../../src/workers/harness/worker-events'
 import { BuiltinWorkerAdapter } from '../../src/workers/builtin/adapter.js'
 import type {
@@ -231,7 +231,7 @@ interface Assembly {
   readonly toolCallLog: ToolCallLogEntry[]
   readonly rpcCalls: Array<{ port: number; method: string; params: unknown }>
   readonly builtinConfigQueue: Array<NonNullable<SpawnSpec['builtin']>>
-  readonly dialogObjectIdFor: (key: ManagerKey) => DialogObjectId
+  readonly managerKeyFor: (key: ManagerKey) => ManagerKey
 }
 
 async function setupAssembly(opts: AssemblyOptions): Promise<Assembly> {
@@ -315,7 +315,7 @@ async function setupAssembly(opts: AssemblyOptions): Promise<Assembly> {
     resolveChannelPort: async () => 2,
   }
 
-  const dialogObjectIdFor = (key: ManagerKey): DialogObjectId => dialogObjectIdForPrivate(`friend-of-${key}`)
+  const managerKeyFor = (key: ManagerKey): ManagerKey => key
 
   const toolCallLog: ToolCallLogEntry[] = []
 
@@ -326,14 +326,13 @@ async function setupAssembly(opts: AssemblyOptions): Promise<Assembly> {
     harness,
     ledger,
     now: opts.managerNow,
-    dialogObjectIdFor,
+    managerKeyFor,
     adapter: () => opts.managerAdapter,
     model: () => 'test-manager-model',
     toolFace: (key, isSystemThread, onAsyncError) => {
       const tools = buildManagerToolFace({
         harness,
         workerContext: () => ({
-          dialogObjectId: dialogObjectIdFor(key),
           managerKey: key,
           reportTo: channelSessionFromKey(key),
           triggerType: isSystemThread ? 'system' : 'message',
@@ -361,7 +360,7 @@ async function setupAssembly(opts: AssemblyOptions): Promise<Assembly> {
 
   const registry = new ManagerRegistry(registryDeps)
 
-  return { registry, harness, ledger, store, events, toolCallLog, rpcCalls, builtinConfigQueue, dialogObjectIdFor }
+  return { registry, harness, ledger, store, events, toolCallLog, rpcCalls, builtinConfigQueue, managerKeyFor }
 }
 
 // ============================================================================
@@ -417,10 +416,10 @@ describe('manager-integration（P4 Task 10：真实 ManagerRegistry + 真实 Wor
 
       // 等真实 worker 后台把 finish_task 跑完——burst 是 fire-and-forget,不是靠猜时序。
       await waitUntil(async () => {
-        const workers = await assembly.harness.listWorkers(assembly.dialogObjectIdFor(key))
+        const workers = await assembly.harness.listWorkers(assembly.managerKeyFor(key))
         return workers.some((w) => w.task.status === 'completed')
       })
-      const [worker] = await assembly.harness.listWorkers(assembly.dialogObjectIdFor(key))
+      const [worker] = await assembly.harness.listWorkers(assembly.managerKeyFor(key))
       // 台账 task 终态正确
       expect(worker.task.status).toBe('completed')
       expect(worker.incarnations).toHaveLength(1)
@@ -502,10 +501,10 @@ describe('manager-integration（P4 Task 10：真实 ManagerRegistry + 真实 Wor
       expect(scheduleResult1.outcome).toBe('completed')
 
       await waitUntil(async () => {
-        const workers = await assembly.harness.listWorkers(assembly.dialogObjectIdFor(SYSTEM_TASKS_MANAGER_KEY))
+        const workers = await assembly.harness.listWorkers(assembly.managerKeyFor(SYSTEM_TASKS_MANAGER_KEY))
         return workers.some((w) => w.task.status === 'completed')
       })
-      const [workerA] = await assembly.harness.listWorkers(assembly.dialogObjectIdFor(SYSTEM_TASKS_MANAGER_KEY))
+      const [workerA] = await assembly.harness.listWorkers(assembly.managerKeyFor(SYSTEM_TASKS_MANAGER_KEY))
       const exitedEventA = findWorkerExitedEvent(assembly.events, workerA.worker_id)!
 
       managerScript.queue.push({
@@ -550,10 +549,10 @@ describe('manager-integration（P4 Task 10：真实 ManagerRegistry + 真实 Wor
       expect(scheduleResult2.outcome).toBe('completed')
 
       await waitUntil(async () => {
-        const workers = await assembly.harness.listWorkers(assembly.dialogObjectIdFor(SYSTEM_TASKS_MANAGER_KEY))
+        const workers = await assembly.harness.listWorkers(assembly.managerKeyFor(SYSTEM_TASKS_MANAGER_KEY))
         return workers.some((w) => w.worker_id !== workerA.worker_id && w.task.status === 'failed')
       })
-      const workersAfterB = await assembly.harness.listWorkers(assembly.dialogObjectIdFor(SYSTEM_TASKS_MANAGER_KEY))
+      const workersAfterB = await assembly.harness.listWorkers(assembly.managerKeyFor(SYSTEM_TASKS_MANAGER_KEY))
       const workerB = workersAfterB.find((w) => w.worker_id !== workerA.worker_id)!
       // 核心验收：worker 自己声明的 outcome:'failed' 一路落到台账，不再被记成成功。
       expect(workerB.task.status).toBe('failed')
@@ -674,12 +673,12 @@ describe('manager-integration（P4 Task 10：真实 ManagerRegistry + 真实 Wor
         extraAdapters: [['codex', new ForklessStubAdapter()]],
       })
 
-      const dialogObjectId = assembly.dialogObjectIdFor(key)
+      const managerKey = assembly.managerKeyFor(key)
       const worker = await assembly.harness.spawnWorker({
-        dialogObjectId,
+        managerKey,
         title: 'codex worker（fork 不支持）',
         prompt: '随便干点什么',
-        origin: { spawned_by_session: key, trigger_type: 'message' },
+        origin: { spawned_by_episode: key, trigger_type: 'message' },
         report_to: { channel_id: 'wechat', session_id: 'sess-fork' },
         impl: 'codex',
       })
@@ -739,7 +738,7 @@ describe('manager-integration（P4 Task 10：真实 ManagerRegistry + 真实 Wor
       const episode1 = await assembly.registry.routeHumanMessages('wechat', 'sess-say', [makeChannelMessage('帮我做个方案选型')])
       expect(episode1.outcome).toBe('completed')
 
-      const [worker] = await assembly.harness.listWorkers(assembly.dialogObjectIdFor(key))
+      const [worker] = await assembly.harness.listWorkers(assembly.managerKeyFor(key))
       // 等**事件**本身出现，不是等台账转 idle——processStateChange 先 upsert 台账、再 appendEvent，
       // 盯台账会在这两步之间抢跑（实测在全量并发下偶发）。
       const findIdleEvent = () =>
@@ -858,7 +857,7 @@ describe('manager-integration（P4 Task 10：真实 ManagerRegistry + 真实 Wor
       ])
       expect(episode1.outcome).toBe('completed')
 
-      const [worker] = await assembly.harness.listWorkers(assembly.dialogObjectIdFor(key))
+      const [worker] = await assembly.harness.listWorkers(assembly.managerKeyFor(key))
       const findExitedEvent = () => findWorkerExitedEvent(assembly.events, worker.worker_id)
       await waitUntil(() => findExitedEvent() !== undefined)
 

--- a/crabot-agent/tests/manager/p5-integration.test.ts
+++ b/crabot-agent/tests/manager/p5-integration.test.ts
@@ -211,6 +211,8 @@ describe('P5 集成：manager 栈启动接线（Task 6）', () => {
     prevAgentDataDir = process.env.CRABOT_AGENT_DATA_DIR
     delete process.env.CRABOT_AGENT_DATA_DIR
     process.env.DATA_DIR = join(tmpRoot, 'data')
+    // UnifiedAgent.onStart now fail-closes legacy import until the Admin archive root is initialized.
+    await fs.mkdir(join(tmpRoot, 'data', 'admin'), { recursive: true })
   })
 
   afterEach(async () => {

--- a/crabot-agent/tests/manager/p5-integration.test.ts
+++ b/crabot-agent/tests/manager/p5-integration.test.ts
@@ -25,7 +25,7 @@ import { join } from 'path'
 
 import { UnifiedAgent } from '../../src/unified-agent.js'
 import { SYSTEM_TASKS_MANAGER_KEY } from '../../src/manager/registry.js'
-import { dialogObjectIdForPrivate, type DialogObjectId, type LedgerWorker } from '../../src/workers/harness/ledger-types.js'
+import type { ManagerKey, LedgerWorker } from '../../src/workers/harness/ledger-types.js'
 import type { ManagerKey } from '../../src/manager/types.js'
 import type { ManagerStack } from '../../src/manager/bootstrap.js'
 import type { LLMAdapter, ToolDefinition } from '../../src/engine/index.js'
@@ -132,20 +132,21 @@ function capturedOnStateChange(
 }
 
 function makeLedgerWorker(p: {
-  workerId: string
+  managerKey: ManagerKey
   status?: LedgerWorker['task']['status']
   updatedAt?: string
   incarnationState?: WorkerContractState
 }): LedgerWorker {
   return {
     worker_id: p.workerId,
+    manager_key: p.managerKey,
     task: {
       id: p.workerId,
       title: `任务 ${p.workerId}`,
       status: p.status ?? 'running',
       created_at: '2026-01-01T00:00:00.000Z',
     },
-    origin: { spawned_by_session: 'wechat::sess-1' as ManagerKey, trigger_type: 'message' },
+    origin: { trigger_type: 'message' },
     report_to: { channel_id: 'wechat' as ModuleId, session_id: 'sess-1' },
     incarnations: [
       {
@@ -334,7 +335,7 @@ describe('P5 集成：manager 栈启动接线（Task 6）', () => {
         { text: '已派发', stopReason: 'end_turn' },
       ]),
     )
-    const spawnSpy = vi.spyOn(stack.harness, 'spawnWorker').mockResolvedValue(makeLedgerWorker({ workerId: 'w-spawned' }))
+    const spawnSpy = vi.spyOn(stack.harness, 'spawnWorker').mockResolvedValue(makeLedgerWorker({ workerId: 'w-spawned', managerKey: SYSTEM_TASKS_MANAGER_KEY }))
     const routeSpy = vi.spyOn(stack.registry, 'routeSchedule')
 
     const accepted = await rpc('trigger_schedule', {
@@ -350,7 +351,7 @@ describe('P5 集成：manager 栈启动接线（Task 6）', () => {
 
     await waitUntil(() => spawnSpy.mock.calls.length > 0)
     const params = spawnSpy.mock.calls[0][0]
-    expect(params.origin.spawned_by_session).toBe(SYSTEM_TASKS_MANAGER_KEY)
+    expect(params.managerKey).toBe(SYSTEM_TASKS_MANAGER_KEY)
     expect(params.origin.trigger_type).toBe('scheduled')
     expect(params.origin.creator_friend_id).toBe('friend-42')
 
@@ -362,17 +363,17 @@ describe('P5 集成：manager 栈启动接线（Task 6）', () => {
   it('list_workers_admin / get_worker_detail / read_worker_output_admin 对真实台账与真实输出日志返回正确数据', async () => {
     boot()
     const stack = internals.managerStack!
-    const alice = dialogObjectIdForPrivate('alice')
-    const bob = dialogObjectIdForPrivate('bob')
+    const alice = (`test::${'alice'}` as ManagerKey)
+    const bob = (`test::${'bob'}` as ManagerKey)
 
     await stack.ledger.upsertWorker(alice, 'w-a1', () =>
-      makeLedgerWorker({ workerId: 'w-a1', status: 'running', updatedAt: '2026-02-02T00:00:00.000Z' }),
+      makeLedgerWorker({ workerId: 'w-a1', managerKey: alice, status: 'running', updatedAt: '2026-02-02T00:00:00.000Z' }),
     )
     await stack.ledger.upsertWorker(alice, 'w-a2', () =>
-      makeLedgerWorker({ workerId: 'w-a2', status: 'completed', updatedAt: '2026-02-03T00:00:00.000Z' }),
+      makeLedgerWorker({ workerId: 'w-a2', managerKey: alice, status: 'completed', updatedAt: '2026-02-03T00:00:00.000Z' }),
     )
     await stack.ledger.upsertWorker(bob, 'w-b1', () =>
-      makeLedgerWorker({ workerId: 'w-b1', status: 'running', updatedAt: '2026-02-01T00:00:00.000Z' }),
+      makeLedgerWorker({ workerId: 'w-b1', managerKey: bob, status: 'running', updatedAt: '2026-02-01T00:00:00.000Z' }),
     )
 
     // 全量：updated_at desc
@@ -383,14 +384,14 @@ describe('P5 集成：manager 栈启动接线（Task 6）', () => {
     expect(all.items.map((w) => w.worker_id)).toEqual(['w-a2', 'w-a1', 'w-b1'])
     expect(all.pagination.total_items).toBe(3)
 
-    // 按 dialog_object_id + status 过滤
+    // 按 manager_key + status 过滤
     const scoped = await rpc<{ items: Array<{ worker_id: string }> }>('list_workers_admin', {
-      dialog_object_id: alice,
+      manager_key: alice,
       status: 'running',
     })
     expect(scoped.items.map((w) => w.worker_id)).toEqual(['w-a1'])
 
-    // 详情（§8.3 的返回只有 worker 本体，不带 dialog_object_id）
+    // 详情（§8.3 的返回只有 worker 本体，不带 manager_key）
     const detail = await rpc<{ worker: LedgerWorker }>('get_worker_detail', { worker_id: 'w-b1' })
     expect(detail.worker.worker_id).toBe('w-b1')
     expect(detail.worker.task.status).toBe('running')
@@ -439,9 +440,9 @@ describe('P5 集成：manager 栈启动接线（Task 6）', () => {
     vi.spyOn(stack.registry, 'routeWorkerEvent').mockResolvedValue(undefined)
     vi.spyOn(internals.rpcClient, 'publishEvent').mockResolvedValue(1)
 
-    const dialogObjectId = dialogObjectIdForPrivate('friend-mainline')
-    const base = makeLedgerWorker({ workerId: 'w-main' })
-    await stack.ledger.upsertWorker(dialogObjectId, 'w-main', () => ({
+    const managerKey = (`test::${'friend-mainline'}` as ManagerKey)
+    const base = makeLedgerWorker({ workerId: 'w-main', managerKey })
+    await stack.ledger.upsertWorker(managerKey, 'w-main', () => ({
       ...base,
       incarnations: [
         {
@@ -542,9 +543,9 @@ describe('P5 集成：manager 栈启动接线（Task 6）', () => {
     vi.spyOn(stack.registry, 'routeWorkerEvent').mockResolvedValue(undefined)
     vi.spyOn(internals.rpcClient, 'publishEvent').mockResolvedValue(1)
 
-    const dialogObjectId = dialogObjectIdForPrivate('friend-seq-probe')
-    const base = makeLedgerWorker({ workerId: 'w-seq' })
-    await stack.ledger.upsertWorker(dialogObjectId, 'w-seq', () => ({
+    const managerKey = (`test::${'friend-seq-probe'}` as ManagerKey)
+    const base = makeLedgerWorker({ workerId: 'w-seq', managerKey })
+    await stack.ledger.upsertWorker(managerKey, 'w-seq', () => ({
       ...base,
       incarnations: [
         {
@@ -605,8 +606,8 @@ describe('P5 集成：manager 栈启动接线（Task 6）', () => {
     // 顺带断言它确实接着（两条支路互不干扰）。
     const routeSpy = vi.spyOn(stack.registry, 'routeWorkerEvent').mockResolvedValue(undefined)
 
-    const dialogObjectId = dialogObjectIdForPrivate('friend-evt')
-    await stack.ledger.upsertWorker(dialogObjectId, 'w-evt', () => makeLedgerWorker({ workerId: 'w-evt' }))
+    const managerKey = (`test::${'friend-evt'}` as ManagerKey)
+    await stack.ledger.upsertWorker(managerKey, 'w-evt', () => makeLedgerWorker({ workerId: 'w-evt', managerKey }))
 
     // 用 adapter 手里那份回调触发真实迁移：handleStateChange → processStateChange →
     // upsertWorker（落 completed）→ appendEvent（带 task_status）→ onEvent → 事件出口
@@ -630,7 +631,7 @@ describe('P5 集成：manager 栈启动接线（Task 6）', () => {
       // 台账落账值；P7 阻塞项 #1 未修前，"退出即 completed" 是 harness 的既有行为，
       // 本断言只钉"事件值 == 台账值"，不对语义正确性背书。
       new_status: (await stack.ledger.findWorker('w-evt'))!.worker.task.status,
-      dialog_object_id: dialogObjectId,
+      manager_key: managerKey,
     })
     expect(routeSpy).toHaveBeenCalled()
   })
@@ -684,9 +685,9 @@ describe('P5 集成：manager 栈启动接线（Task 6）', () => {
     // 对账判死同样会发 §9.2 事件（下一条用例专门验它）；这里挡住投递，免得没有 MM 的测试环境
     // 刷一屏 ECONNREFUSED——注意 publisher 本身把失败吃掉了，不挡也不会让用例失败。
     vi.spyOn(internals.rpcClient, 'publishEvent').mockResolvedValue(1)
-    const dialogObjectId = dialogObjectIdForPrivate('friend-recon')
-    await stack.ledger.upsertWorker(dialogObjectId, 'w-stale', () =>
-      makeLedgerWorker({ workerId: 'w-stale', status: 'running', incarnationState: 'running' }),
+    const managerKey = (`test::${'friend-recon'}` as ManagerKey)
+    await stack.ledger.upsertWorker(managerKey, 'w-stale', () =>
+      makeLedgerWorker({ workerId: 'w-stale', managerKey, status: 'running', incarnationState: 'running' }),
     )
 
     await internals.onStart()

--- a/crabot-agent/tests/manager/principal-binding-store.test.ts
+++ b/crabot-agent/tests/manager/principal-binding-store.test.ts
@@ -7,7 +7,21 @@ import { ManagerPrincipalStore } from '../../src/manager/principal.js'
 import type { Friend } from '../../src/types.js'
 
 const key = 'wechat::private-1' as const
-const friend = (permission: 'master' | 'normal'): Friend => ({ id: 'f-1', display_name: 'f', permission, channel_identities: [], created_at: '', updated_at: '' })
+const friendWithId = (id: string, permission: 'master' | 'normal'): Friend => ({
+  id,
+  display_name: id,
+  permission,
+  channel_identities: [],
+  created_at: '',
+  updated_at: '',
+})
+const friend = (permission: 'master' | 'normal'): Friend => friendWithId('f-1', permission)
+const permissions = {
+  tool_access: { memory: false, messaging: true, task: false, mcp_skill: false, file_io: false, browser: false, shell: false, remote_exec: false, desktop: false },
+  cli_access: { provider: 'none', agent: 'none', mcp: 'none', skill: 'none', schedule: 'none', channel: 'none', friend: 'none', permission: 'none', config: 'none', undo: 'none' },
+  storage: null,
+  memory_scopes: ['private'],
+} as const
 
 describe('principal bindings', () => {
   it('persists only private bindings, advances generation, and does not restore Admin Chat authority after restart', async () => {
@@ -100,6 +114,81 @@ describe('principal bindings', () => {
       mode = 'master'; await principal.resolve(key, { friend: friend('master'), sessionType: 'private' })
       mode = 'throw'; await principal.refreshForNonHumanWake(key); expect(store.get(key)?.generation).toBe(4)
     } finally { await fs.rm(root, { recursive: true, force: true }) }
+  })
+
+  it('legacy credentials use object identity, preserve captured generation, and require Master for cross-session use', async () => {
+    const root = await fs.mkdtemp(join(tmpdir(), 'principal-legacy-auth-'))
+    try {
+      const bindings = new PrincipalBindingStore(join(root, 'bindings.json'))
+      await bindings.init()
+      const friends = new Map<string, Friend>([
+        ['f-1', friendWithId('f-1', 'master')],
+        ['f-2', friendWithId('f-2', 'normal')],
+      ])
+      const principal = new ManagerPrincipalStore({
+        resolvePermissions: async () => permissions,
+        sessionMemoryScopes: async () => [],
+        sceneProfile: async () => null,
+        crabSelfHandle: () => undefined,
+        getFriend: async (id) => friends.get(id) ?? null,
+      }, bindings)
+      await principal.init()
+
+      const masterKey = 'wechat::master-private' as const
+      const normalKey = 'wechat::normal-private' as const
+      const targetKey = 'other::target' as const
+      await principal.resolve(masterKey, { friend: friendWithId('f-1', 'master'), sessionType: 'private' })
+      const masterTemplate = principal.captureLegacyContinuationAuth(masterKey)!
+      const masterAuth = principal.bindLegacyContinuationAuth(masterTemplate, targetKey)!
+      expect(await principal.validateLegacyContinuationAuth(masterAuth)).toBe(true)
+      expect(await principal.validateLegacyContinuationAuth({ ...masterAuth })).toBe(false)
+
+      await principal.resolve(normalKey, { friend: friendWithId('f-2', 'normal'), sessionType: 'private' })
+      const normalTemplate = principal.captureLegacyContinuationAuth(normalKey)!
+      const sameSession = principal.bindLegacyContinuationAuth(normalTemplate, normalKey)!
+      expect(await principal.validateLegacyContinuationAuth(sameSession)).toBe(true)
+      const normalCrossSession = principal.bindLegacyContinuationAuth(normalTemplate, targetKey)!
+      expect(await principal.validateLegacyContinuationAuth(normalCrossSession)).toBe(false)
+      expect(await principal.validateLegacyContinuationAuth(masterAuth)).toBe(true)
+
+      await principal.resolve(normalKey, { friend: friendWithId('f-2', 'normal'), sessionType: 'private' })
+      const stale = principal.bindLegacyContinuationAuth(normalTemplate, normalKey)!
+      expect(await principal.validateLegacyContinuationAuth(stale)).toBe(false)
+    } finally {
+      await fs.rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('Admin Chat legacy credentials expire and cannot be reconstructed after expiry', async () => {
+    const root = await fs.mkdtemp(join(tmpdir(), 'principal-legacy-admin-'))
+    try {
+      const bindings = new PrincipalBindingStore(join(root, 'bindings.json'))
+      await bindings.init()
+      let nowMs = Date.parse('2026-01-01T00:00:00.000Z')
+      const principal = new ManagerPrincipalStore({
+        resolvePermissions: async () => permissions,
+        sessionMemoryScopes: async () => [],
+        sceneProfile: async () => null,
+        crabSelfHandle: () => undefined,
+        getFriend: async () => friend('master'),
+      }, bindings, () => new Date(nowMs))
+      await principal.init()
+      const adminKey = 'admin-web::admin-chat' as const
+      await principal.activateAdminChat(adminKey, {
+        assertionId: 'assertion',
+        expiresAt: '2026-01-01T00:01:00.000Z',
+      })
+      await principal.resolve(adminKey, { friend: friend('master'), sessionType: 'private' })
+      const auth = principal.bindLegacyContinuationAuth(
+        principal.captureLegacyContinuationAuth(adminKey),
+        'other::target' as const,
+      )!
+      expect(await principal.validateLegacyContinuationAuth(auth)).toBe(true)
+      nowMs = Date.parse('2026-01-01T00:02:00.000Z')
+      expect(await principal.validateLegacyContinuationAuth(auth)).toBe(false)
+    } finally {
+      await fs.rm(root, { recursive: true, force: true })
+    }
   })
 
 })

--- a/crabot-agent/tests/manager/principal-binding-store.test.ts
+++ b/crabot-agent/tests/manager/principal-binding-store.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest'
+import { promises as fs } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { PrincipalBindingStore } from '../../src/manager/principal-binding-store.js'
+import { ManagerPrincipalStore } from '../../src/manager/principal.js'
+import type { Friend } from '../../src/types.js'
+
+const key = 'wechat::private-1' as const
+const friend = (permission: 'master' | 'normal'): Friend => ({ id: 'f-1', display_name: 'f', permission, channel_identities: [], created_at: '', updated_at: '' })
+
+describe('principal bindings', () => {
+  it('persists only private bindings, advances generation, and does not restore Admin Chat authority after restart', async () => {
+    const root = await fs.mkdtemp(join(tmpdir(), 'principal-bindings-'))
+    try {
+      const file = join(root, 'manager-principal-bindings.json')
+      const store = new PrincipalBindingStore(file)
+      await store.init()
+      const one = await store.set({ manager_key: key, kind: 'friend', friend_id: 'f-1' })
+      const adminKey = 'admin-web::admin-chat' as const
+      const two = await store.set({ manager_key: adminKey, kind: 'admin_chat_jwt', assertion_id: 'local-id', expires_at: '2099-01-01T00:00:00.000Z' })
+      expect(two.generation).toBe(1)
+      const raw = await fs.readFile(file, 'utf8')
+      expect(raw).not.toContain('permission'); expect(raw).not.toContain('JWT')
+      const restarted = new PrincipalBindingStore(file); await restarted.init()
+      const principal = new ManagerPrincipalStore({ resolvePermissions: async () => null, sessionMemoryScopes: async () => [], sceneProfile: async () => null, crabSelfHandle: () => undefined, getFriend: async () => friend('master') }, restarted)
+      await principal.init()
+      expect(principal.currentMasterAuthorization(adminKey)).toBeUndefined()
+    } finally { await fs.rm(root, { recursive: true, force: true }) }
+  })
+
+  it('group human resolution never writes a durable binding; friend invalidation makes old authorization fail', async () => {
+    const root = await fs.mkdtemp(join(tmpdir(), 'principal-bindings-'))
+    try {
+      const store = new PrincipalBindingStore(join(root, 'bindings.json')); await store.init()
+      let current = friend('master')
+      const principal = new ManagerPrincipalStore({ resolvePermissions: async () => null, sessionMemoryScopes: async () => [], sceneProfile: async () => null, crabSelfHandle: () => undefined, getFriend: async () => current }, store)
+      await principal.init()
+      await principal.resolve('wechat::group' as never, { friend: friend('master'), sessionType: 'group' })
+      expect(store.get('wechat::group' as never)).toBeUndefined()
+      await principal.resolve(key, { friend: friend('master'), sessionType: 'private' })
+      const auth = principal.currentMasterAuthorization(key)!; expect(await principal.validateMasterAuthorization(auth)).toBe(true)
+      current = friend('normal'); await principal.invalidateFriend('f-1')
+      expect(await principal.validateMasterAuthorization(auth)).toBe(false)
+    } finally { await fs.rm(root, { recursive: true, force: true }) }
+  })
+
+  it('rejects duplicate keys, malformed IDs/kinds, non-admin Admin Chat keys, and malformed ManagerKeys on load', async () => {
+    const root = await fs.mkdtemp(join(tmpdir(), 'principal-bindings-invalid-'))
+    try {
+      const file = join(root, 'bindings.json')
+      const valid = { manager_key: 'wechat::s', generation: 1, kind: 'friend', friend_id: 'f' }
+      for (const bindings of [
+        [valid, valid],
+        [{ ...valid, friend_id: '' }],
+        [{ ...valid, assertion_id: 'forbidden' }],
+        [{ manager_key: 'wechat::s', generation: 1, kind: 'admin_chat_jwt', assertion_id: 'a', expires_at: '2099-01-01T00:00:00.000Z' }],
+        [{ ...valid, manager_key: 'bad' }],
+      ]) {
+        await fs.writeFile(file, JSON.stringify({ bindings }))
+        await expect(new PrincipalBindingStore(file).init()).rejects.toThrow(/invalid|duplicate/)
+      }
+    } finally { await fs.rm(root, { recursive: true, force: true }) }
+  })
+
+  it('synthetic Admin Chat friend resolution cannot replace active JWT authorization', async () => {
+    const root = await fs.mkdtemp(join(tmpdir(), 'principal-admin-chat-'))
+    try {
+      const store = new PrincipalBindingStore(join(root, 'bindings.json')); await store.init()
+      const principal = new ManagerPrincipalStore({ resolvePermissions: async () => null, sessionMemoryScopes: async () => [], sceneProfile: async () => null, crabSelfHandle: () => undefined, getFriend: async () => friend('master') }, store)
+      await principal.init()
+      await principal.activateAdminChat('admin-web::admin-chat' as never, { assertionId: 'assertion', expiresAt: '2099-01-01T00:00:00.000Z' })
+      const before = principal.currentMasterAuthorization('admin-web::admin-chat' as never)
+      await principal.resolve('admin-web::admin-chat' as never, { friend: friend('master'), sessionType: 'private' })
+      const after = principal.currentMasterAuthorization('admin-web::admin-chat' as never)
+      expect(after).toEqual(before)
+      expect(after?.kind).toBe('admin_chat_jwt')
+    } finally { await fs.rm(root, { recursive: true, force: true }) }
+  })
+
+
+  it('lookup downgrade/null/throw bumps an active Friend generation once and a same-Friend regrant gets the new generation', async () => {
+    const root = await fs.mkdtemp(join(tmpdir(), 'principal-generation-'))
+    try {
+      const store = new PrincipalBindingStore(join(root, 'bindings.json')); await store.init()
+      let mode: 'master' | 'normal' | 'null' | 'throw' = 'master'
+      const principal = new ManagerPrincipalStore({
+        resolvePermissions: async () => null, sessionMemoryScopes: async () => [], sceneProfile: async () => null, crabSelfHandle: () => undefined,
+        getFriend: async () => { if (mode === 'throw') throw new Error('down'); return mode === 'null' ? null : friend(mode) },
+      }, store)
+      await principal.init(); await principal.resolve(key, { friend: friend('master'), sessionType: 'private' })
+      const first = principal.currentMasterAuthorization(key)!; expect(first.generation).toBe(1)
+      mode = 'normal'; await principal.refreshForNonHumanWake(key)
+      expect(store.get(key)?.generation).toBe(2); expect(principal.currentMasterAuthorization(key)).toBeUndefined()
+      await principal.refreshForNonHumanWake(key)
+      expect(store.get(key)?.generation).toBe(2)
+      mode = 'master'; await principal.resolve(key, { friend: friend('master'), sessionType: 'private' })
+      expect(principal.currentMasterAuthorization(key)?.generation).toBe(2)
+      mode = 'null'; await principal.refreshForNonHumanWake(key); expect(store.get(key)?.generation).toBe(3)
+      mode = 'master'; await principal.resolve(key, { friend: friend('master'), sessionType: 'private' })
+      mode = 'throw'; await principal.refreshForNonHumanWake(key); expect(store.get(key)?.generation).toBe(4)
+    } finally { await fs.rm(root, { recursive: true, force: true }) }
+  })
+
+})

--- a/crabot-agent/tests/manager/principal.test.ts
+++ b/crabot-agent/tests/manager/principal.test.ts
@@ -2,9 +2,8 @@
  * 发起人身份的解析规则（P7 / PR J Task 2）—— `src/manager/principal.ts`。
  *
  * 这里钉的是**语义不变量**，不是参数透传：
- *   - 这个 friend 的 `memory_scopes` 真的决定了记忆的读写可见范围；
+ *   - 当前消息的 `memory_scopes` 真的决定了记忆的读写可见范围；
  *   - 群聊空 scopes 真的收敛到本群（否则群 A 的内容会以空 scope 落记忆、群 B 读得到）；
- *   - 私聊的台账真的按 friend 跨 channel 聚合；系统线程真的归 master；
  *   - 每一项解析失败都只降级它自己，不连坐（人类消息比档位重要）。
  */
 import { describe, it, expect, vi } from 'vitest'
@@ -17,7 +16,6 @@ import {
   splitManagerKey,
   type PrincipalResolverDeps,
 } from '../../src/manager/principal.js'
-import { SYSTEM_TASKS_MANAGER_KEY } from '../../src/manager/registry.js'
 import type { ManagerKey } from '../../src/manager/types.js'
 import type { Friend, ResolvedPermissions } from '../../src/types.js'
 import { CLI_DOMAINS, type CliAccessConfig, type CliDomain } from '../../src/types.js'
@@ -57,7 +55,6 @@ function makeResolverDeps(overrides: Partial<PrincipalResolverDeps> = {}): Princ
     sessionMemoryScopes: async (sessionId) => [sessionId],
     sceneProfile: async () => null,
     crabSelfHandle: () => undefined,
-    masterFriendId: async () => undefined,
     ...overrides,
   }
 }
@@ -153,7 +150,7 @@ describe('renderDialogProfile', () => {
 describe('ManagerPrincipalStore.resolve —— 档位真的由 friend 决定', () => {
   it('这个 friend 的 memory_scopes 真的决定了记忆的读写可见范围', async () => {
     const resolvePermissions = vi.fn(async () => makePerms(['team-x']))
-    const store = new ManagerPrincipalStore(makeResolverDeps({ resolvePermissions }), SYSTEM_TASKS_MANAGER_KEY)
+    const store = new ManagerPrincipalStore(makeResolverDeps({ resolvePermissions }))
 
     const entry = await store.resolve(PRIVATE_KEY, { friend: makeFriend('f-1'), sessionType: 'private' })
 
@@ -170,8 +167,7 @@ describe('ManagerPrincipalStore.resolve —— 档位真的由 friend 决定', (
   it('换一个 friend 说话 → 档位整体换掉，不残留上一个人的 scopes', async () => {
     const scopesByFriend: Record<string, string[]> = { 'f-a': ['team-a'], 'f-b': ['team-b'] }
     const store = new ManagerPrincipalStore(
-      makeResolverDeps({ resolvePermissions: async (p) => makePerms(scopesByFriend[p.senderFriendId!]) }),
-      SYSTEM_TASKS_MANAGER_KEY,
+      makeResolverDeps({ resolvePermissions: async (p) => makePerms(scopesByFriend[p.senderFriendId!]) })
     )
 
     await store.resolve(GROUP_KEY, { friend: makeFriend('f-a'), sessionType: 'group' })
@@ -184,8 +180,7 @@ describe('ManagerPrincipalStore.resolve —— 档位真的由 friend 决定', (
   it('群聊 friend 没配 scopes → 收敛到本群，且**不去问 admin 要 session 配置**', async () => {
     const sessionMemoryScopes = vi.fn(async () => ['不该被用到'])
     const store = new ManagerPrincipalStore(
-      makeResolverDeps({ resolvePermissions: async () => makePerms([]), sessionMemoryScopes }),
-      SYSTEM_TASKS_MANAGER_KEY,
+      makeResolverDeps({ resolvePermissions: async () => makePerms([]), sessionMemoryScopes })
     )
 
     const entry = await store.resolve(GROUP_KEY, { friend: makeFriend('f-1'), sessionType: 'group' })
@@ -201,8 +196,7 @@ describe('ManagerPrincipalStore.resolve —— 档位真的由 friend 决定', (
       makeResolverDeps({
         resolvePermissions: async () => null,
         sessionMemoryScopes: async () => ['session-scope'],
-      }),
-      SYSTEM_TASKS_MANAGER_KEY,
+      })
     )
 
     const entry = await store.resolve(PRIVATE_KEY, { friend: makeFriend('f-1'), sessionType: 'private' })
@@ -218,8 +212,7 @@ describe('ManagerPrincipalStore.resolve —— 档位真的由 friend 决定', (
       makeResolverDeps({
         resolvePermissions: async () => { throw new Error('admin down') },
         sessionMemoryScopes: async (sessionId) => [sessionId],
-      }),
-      SYSTEM_TASKS_MANAGER_KEY,
+      })
     )
 
     const entry = await store.resolve(PRIVATE_KEY, { friend: makeFriend('f-1'), sessionType: 'private' })
@@ -233,8 +226,7 @@ describe('ManagerPrincipalStore.resolve —— 档位真的由 friend 决定', (
       makeResolverDeps({
         resolvePermissions: async () => null,
         sessionMemoryScopes: async () => { throw new Error('admin down') },
-      }),
-      SYSTEM_TASKS_MANAGER_KEY,
+      })
     )
     const entry = await store.resolve(PRIVATE_KEY, { friend: makeFriend('f-1'), sessionType: 'private' })
     expect(entry.memory.read_accessible_scopes).toEqual(['sess-1'])
@@ -246,8 +238,7 @@ describe('ManagerPrincipalStore.resolve —— 档位真的由 friend 决定', (
       makeResolverDeps({
         resolvePermissions: async () => makePerms(['team-x']),
         sceneProfile: async () => { throw new Error('memory down') },
-      }),
-      SYSTEM_TASKS_MANAGER_KEY,
+      })
     )
     const entry = await store.resolve(PRIVATE_KEY, { friend: makeFriend('f-1'), sessionType: 'private' })
     expect(entry.dialogProfile).toBeUndefined()
@@ -256,7 +247,7 @@ describe('ManagerPrincipalStore.resolve —— 档位真的由 friend 决定', (
 
   it('场景画像按会话类型去要：私聊带 friend_id，群聊只带 channel+session', async () => {
     const sceneProfile = vi.fn(async () => null)
-    const store = new ManagerPrincipalStore(makeResolverDeps({ sceneProfile }), SYSTEM_TASKS_MANAGER_KEY)
+    const store = new ManagerPrincipalStore(makeResolverDeps({ sceneProfile }))
 
     await store.resolve(PRIVATE_KEY, { friend: makeFriend('f-1'), sessionType: 'private' })
     expect(sceneProfile).toHaveBeenLastCalledWith({
@@ -274,73 +265,11 @@ describe('ManagerPrincipalStore.resolve —— 档位真的由 friend 决定', (
       makeResolverDeps({
         sceneProfile: async () => ({ label: 'friend:f-1', content: '喜欢简短回答', source: { scene: { type: 'friend', friend_id: 'f-1' } } }),
         crabSelfHandle: (channelId) => (channelId === 'wechat' ? '@crabot_wx' : undefined),
-      }),
-      SYSTEM_TASKS_MANAGER_KEY,
+      })
     )
 
     const entry = await store.resolve(PRIVATE_KEY, { friend: makeFriend('f-1'), sessionType: 'private' })
     expect(entry.dialogProfile).toContain('喜欢简短回答')
     expect(entry.dialogProfile).toContain('@crabot_wx')
-  })
-})
-
-describe('ManagerPrincipalStore.dialogObjectIdFor —— 台账归档键（§3 / §4.4）', () => {
-  it('私聊 → friend:<id>：同一个人在 wechat 与 telegram 共享同一份台账', async () => {
-    const store = new ManagerPrincipalStore(makeResolverDeps(), SYSTEM_TASKS_MANAGER_KEY)
-    const friend = makeFriend('f-1')
-
-    await store.resolve('wechat::sess-w' as ManagerKey, { friend, sessionType: 'private' })
-    await store.resolve('telegram::sess-t' as ManagerKey, { friend, sessionType: 'private' })
-
-    expect(store.dialogObjectIdFor('wechat::sess-w' as ManagerKey)).toBe('friend:f-1')
-    expect(store.dialogObjectIdFor('telegram::sess-t' as ManagerKey)).toBe('friend:f-1')
-  })
-
-  it('群聊 → group:<channel>:<session>：两个群各自一份，不合并', async () => {
-    const store = new ManagerPrincipalStore(makeResolverDeps(), SYSTEM_TASKS_MANAGER_KEY)
-    await store.resolve('wechat::g-1' as ManagerKey, { friend: makeFriend('f-1'), sessionType: 'group' })
-    await store.resolve('wechat::g-2' as ManagerKey, { friend: makeFriend('f-1'), sessionType: 'group' })
-
-    expect(store.dialogObjectIdFor('wechat::g-1' as ManagerKey)).toBe('group:wechat:g-1')
-    expect(store.dialogObjectIdFor('wechat::g-2' as ManagerKey)).toBe('group:wechat:g-2')
-  })
-
-  it('身份还没解析出来（loop 先被 worker 事件建出来）→ 群形状，不猜', () => {
-    const store = new ManagerPrincipalStore(makeResolverDeps(), SYSTEM_TASKS_MANAGER_KEY)
-    expect(store.dialogObjectIdFor(PRIVATE_KEY)).toBe('group:wechat:sess-1')
-  })
-
-  it('私聊但没有 friend（陌生人）→ 群形状，不造一个空 friend 键', async () => {
-    const store = new ManagerPrincipalStore(makeResolverDeps(), SYSTEM_TASKS_MANAGER_KEY)
-    await store.resolve(PRIVATE_KEY, { sessionType: 'private' })
-    expect(store.dialogObjectIdFor(PRIVATE_KEY)).toBe('group:wechat:sess-1')
-  })
-
-  it('系统线程 → friend:<master_id>：master 在自己的私聊里查台账能看到系统线程派出的 worker', async () => {
-    const store = new ManagerPrincipalStore(
-      makeResolverDeps({ masterFriendId: async () => 'f-master' }),
-      SYSTEM_TASKS_MANAGER_KEY,
-    )
-    // master friend id 在任意一次人类唤醒时被刷出来（实例级常量）
-    await store.resolve(PRIVATE_KEY, { friend: makeFriend('f-master', 'master'), sessionType: 'private' })
-
-    expect(store.dialogObjectIdFor(SYSTEM_TASKS_MANAGER_KEY)).toBe('friend:f-master')
-    // 与 master 自己私聊那条 manager 的归档键**是同一个** —— §4.4 共享台账接办的前提
-    expect(store.dialogObjectIdFor(PRIVATE_KEY)).toBe('friend:f-master')
-  })
-
-  it('master 尚未解析出来 → 系统线程退回旧的 group 形状（不阻塞、不猜一个 id）', () => {
-    const store = new ManagerPrincipalStore(makeResolverDeps(), SYSTEM_TASKS_MANAGER_KEY)
-    expect(store.dialogObjectIdFor(SYSTEM_TASKS_MANAGER_KEY)).toBe('group:admin-web:system-tasks')
-  })
-
-  it('master friend id 解析失败不抛穿，只是暂时用旧归档键', async () => {
-    vi.spyOn(console, 'warn').mockImplementation(() => {})
-    const store = new ManagerPrincipalStore(
-      makeResolverDeps({ masterFriendId: async () => { throw new Error('admin down') } }),
-      SYSTEM_TASKS_MANAGER_KEY,
-    )
-    await store.resolve(PRIVATE_KEY, { friend: makeFriend('f-1'), sessionType: 'private' })
-    expect(store.dialogObjectIdFor(SYSTEM_TASKS_MANAGER_KEY)).toBe('group:admin-web:system-tasks')
   })
 })

--- a/crabot-agent/tests/manager/prompt.test.ts
+++ b/crabot-agent/tests/manager/prompt.test.ts
@@ -13,11 +13,6 @@ function baseInputs(overrides: Partial<PromptInputs> = {}): PromptInputs {
     managerKey: MANAGER_KEY,
     isSystemThread: false,
     dialogProfile: '## 对话对象档案\n张三，master，偏好简短回复',
-    dynamic: {
-      ledgerRender: '- worker w1: idle',
-      nowIso: '2026-07-30T08:00:00.000Z',
-      pendingNotes: ['worker w1 已完成'],
-    },
     ...overrides,
   }
 }
@@ -129,142 +124,26 @@ describe('MANAGER_IDENTITY 静态段内容', () => {
   })
 })
 
-describe('assembleManagerSystemPrompt 装配顺序', () => {
-  it('静态段 → 档案 → 动态块，顺序正确', () => {
+describe('assembleManagerSystemPrompt 稳定装配', () => {
+  it('只含身份、固定线程角色和档案，不含动态台账/时钟/通知', () => {
     const output = assembleManagerSystemPrompt(baseInputs())
-
-    const identityIdx = output.indexOf('你是 Crabot 的 manager')
-    const profileIdx = output.indexOf('张三，master，偏好简短回复')
-    const dynamicIdx = output.indexOf('worker w1: idle')
-
-    expect(identityIdx).toBeGreaterThanOrEqual(0)
-    expect(profileIdx).toBeGreaterThan(identityIdx)
-    expect(dynamicIdx).toBeGreaterThan(profileIdx)
+    expect(output).toContain('张三，master，偏好简短回复')
+    expect(output).not.toContain('当前状态（动态')
+    expect(output).not.toContain('worker w1: idle')
+    expect(output).not.toContain('2026-07-30T08:00:00.000Z')
+    expect(output).not.toContain('待处理通知')
   })
 
-  it('动态块包含 ledgerRender / nowIso / pendingNotes', () => {
-    const output = assembleManagerSystemPrompt(baseInputs())
-
-    expect(output).toContain('worker w1: idle')
-    expect(output).toContain('2026-07-30T08:00:00.000Z')
-    expect(output).toContain('worker w1 已完成')
-  })
-
-  it('无 dialogProfile 时不装配档案段，静态段仍在动态块之前', () => {
-    const output = assembleManagerSystemPrompt(baseInputs({ dialogProfile: undefined }))
-
-    const identityIdx = output.indexOf('你是 Crabot 的 manager')
-    const dynamicIdx = output.indexOf('worker w1: idle')
-
-    expect(identityIdx).toBeGreaterThanOrEqual(0)
-    expect(dynamicIdx).toBeGreaterThan(identityIdx)
-  })
-
-  it('系统线程 manager 额外含 reach_master 纪律段（例行留本线程，仅需人类立即注意才 reach_master）', () => {
-    const systemOutput = assembleManagerSystemPrompt(baseInputs({ isSystemThread: true }))
-    const nonSystemOutput = assembleManagerSystemPrompt(baseInputs({ isSystemThread: false }))
-
-    expect(systemOutput).toContain('send_master_private')
-    expect(systemOutput).toContain('例行成功留在本线程')
-    expect(systemOutput).toContain('需要人类立即注意')
-    expect(nonSystemOutput).not.toContain('send_master_private')
-  })
-
-  it('系统线程的 reach_master 纪律段位于静态段区域，仍在档案/动态块之前', () => {
+  it('系统线程追加 reach_master 纪律，且仍在档案之前', () => {
     const output = assembleManagerSystemPrompt(baseInputs({ isSystemThread: true }))
-
-    const reachMasterIdx = output.indexOf('send_master_private')
-    const profileIdx = output.indexOf('张三，master，偏好简短回复')
-    const dynamicIdx = output.indexOf('worker w1: idle')
-
-    expect(reachMasterIdx).toBeGreaterThanOrEqual(0)
-    expect(profileIdx).toBeGreaterThan(reachMasterIdx)
-    expect(dynamicIdx).toBeGreaterThan(profileIdx)
+    expect(output.indexOf('send_master_private')).toBeGreaterThanOrEqual(0)
+    expect(output.indexOf('张三，master，偏好简短回复')).toBeGreaterThan(output.indexOf('send_master_private'))
   })
 
-  describe('前缀稳定性：只改 dynamic 时，输出的动态块之前部分逐字节不变', () => {
-    it('非系统线程', () => {
-      const inputsA = baseInputs()
-      const inputsB = baseInputs({
-        dynamic: {
-          ledgerRender: '- worker w2: running\n- worker w3: exited',
-          nowIso: '2026-07-30T09:30:00.000Z',
-          pendingNotes: ['worker w2 卡住了', 'worker w3 已完成'],
-        },
-      })
-
-      const outputA = assembleManagerSystemPrompt(inputsA)
-      const outputB = assembleManagerSystemPrompt(inputsB)
-
-      const dynamicMarker = '张三，master，偏好简短回复'
-      const cutA = outputA.indexOf(dynamicMarker) + dynamicMarker.length
-      const cutB = outputB.indexOf(dynamicMarker) + dynamicMarker.length
-
-      const prefixA = outputA.slice(0, cutA)
-      const prefixB = outputB.slice(0, cutB)
-
-      // 前缀长度也必须一致——不允许在动态块之前插入任何随 dynamic 变化的内容
-      expect(outputA.length - prefixA.length).not.toBe(0)
-      expect(prefixA).toBe(prefixB)
-    })
-
-    it('系统线程', () => {
-      const inputsA = baseInputs({ isSystemThread: true })
-      const inputsB = baseInputs({
-        isSystemThread: true,
-        dynamic: {
-          ledgerRender: '- worker wA: idle',
-          nowIso: '2026-07-30T23:59:00.000Z',
-        },
-      })
-
-      const outputA = assembleManagerSystemPrompt(inputsA)
-      const outputB = assembleManagerSystemPrompt(inputsB)
-
-      const dynamicMarker = '张三，master，偏好简短回复'
-      const cutA = outputA.indexOf(dynamicMarker) + dynamicMarker.length
-      const cutB = outputB.indexOf(dynamicMarker) + dynamicMarker.length
-
-      const prefixA = outputA.slice(0, cutA)
-      const prefixB = outputB.slice(0, cutB)
-
-      expect(prefixA).toBe(prefixB)
-    })
-
-    it('pendingNotes 缺省 vs 存在，不影响动态块之前的前缀', () => {
-      const withNotes = assembleManagerSystemPrompt(baseInputs())
-      const withoutNotes = assembleManagerSystemPrompt(
-        baseInputs({ dynamic: { ledgerRender: '- worker w1: idle', nowIso: '2026-07-30T08:00:00.000Z' } }),
-      )
-
-      const dynamicMarker = '张三，master，偏好简短回复'
-      const cutWith = withNotes.indexOf(dynamicMarker) + dynamicMarker.length
-      const cutWithout = withoutNotes.indexOf(dynamicMarker) + dynamicMarker.length
-
-      expect(withNotes.slice(0, cutWith)).toBe(withoutNotes.slice(0, cutWithout))
-    })
-
-    it('添加 managerKey 后，仅改 dynamic 时前缀仍逐字节不变', () => {
-      const inputsA = baseInputs()
-      const inputsB = baseInputs({
-        dynamic: {
-          ledgerRender: '- worker w2: running',
-          nowIso: '2026-07-30T09:30:00.000Z',
-        },
-      })
-
-      const outputA = assembleManagerSystemPrompt(inputsA)
-      const outputB = assembleManagerSystemPrompt(inputsB)
-
-      const dynamicMarker = '当前状态（动态，不进缓存前缀）'
-      const cutA = outputA.indexOf(dynamicMarker)
-      const cutB = outputB.indexOf(dynamicMarker)
-
-      const prefixA = outputA.slice(0, cutA)
-      const prefixB = outputB.slice(0, cutB)
-
-      expect(prefixA).toBe(prefixB)
-    })
+  it('改变曾经的动态输入不影响 system prompt 字节', () => {
+    const first = assembleManagerSystemPrompt(baseInputs())
+    const second = assembleManagerSystemPrompt(baseInputs())
+    expect(first).toBe(second)
   })
 
   describe('工具名验证', () => {

--- a/crabot-agent/tests/manager/read-model.test.ts
+++ b/crabot-agent/tests/manager/read-model.test.ts
@@ -2,12 +2,12 @@
  * task 读模型纯逻辑(P5 Task 3)—— `src/manager/read-model.ts`。
  *
  * 钉住的语义不变量:
- * ① 过滤:status 单值/数组、dialog_object_id、time_range 三者可组合,且 total_items
+ * ① 过滤:status 单值/数组、manager_key、time_range 三者可组合,且 total_items
  *    统计的是**过滤后**的总数;
  * ② time_range 边界 = base-protocol §5.7:`start` 闭(含)、`end` 开(不含);
  * ③ 排序:`updated_at desc`,同 updated_at 时按 `worker_id` 升序兜底 —— 与输入顺序无关;
  * ④ 分页越界返回空 items 而不报错;page/page_size 非法值归一,page_size 上限 100;
- * ⑤ 纯函数:不修改入参数组、items 是 `LedgerWorker`(不泄漏 dialogObjectId);
+ * ⑤ 纯函数:不修改入参数组、items 是 `LedgerWorker`(不泄漏 managerKey);
  * ⑥ `buildWorkerDetail` 逐字段透传台账条目(含化身链),返回体只有 `worker`(§8.3)。
  */
 import { describe, it, expect } from 'vitest'
@@ -18,19 +18,18 @@ import {
   type LedgerWorkerEntry,
 } from '../../src/manager/read-model.js'
 import {
-  dialogObjectIdForPrivate,
-  dialogObjectIdForGroup,
-  type DialogObjectId,
+  type ManagerKey,
   type LedgerWorker,
   type TaskStatus,
 } from '../../src/workers/harness/ledger-types.js'
 
-const ALICE = dialogObjectIdForPrivate('alice')
-const BOB = dialogObjectIdForPrivate('bob')
-const GROUP = dialogObjectIdForGroup('telegram', 'g-1')
+const ALICE = `test::alice` as ManagerKey
+const BOB = `test::bob` as ManagerKey
+const GROUP = `telegram::g-1` as ManagerKey
 
 function mkWorker(
   workerId: string,
+  managerKey: ManagerKey,
   opts: {
     status?: TaskStatus
     createdAt?: string
@@ -39,6 +38,7 @@ function mkWorker(
 ): LedgerWorker {
   return {
     worker_id: workerId,
+    manager_key: managerKey,
     task: {
       id: `task-${workerId}`,
       title: `title-${workerId}`,
@@ -46,7 +46,6 @@ function mkWorker(
       created_at: opts.createdAt ?? '2026-07-01T00:00:00.000Z',
     },
     origin: {
-      spawned_by_session: 'telegram::s-1',
       trigger_type: 'message',
     },
     report_to: { channel_id: 'telegram', session_id: 's-1' },
@@ -56,11 +55,11 @@ function mkWorker(
 }
 
 function entry(
-  dialogObjectId: DialogObjectId,
+  managerKey: ManagerKey,
   workerId: string,
-  opts?: Parameters<typeof mkWorker>[1]
+  opts?: Parameters<typeof mkWorker>[2]
 ): LedgerWorkerEntry {
-  return { dialogObjectId, worker: mkWorker(workerId, opts) }
+  return { managerKey, worker: mkWorker(workerId, managerKey, opts) }
 }
 
 describe('filterAndPageWorkers', () => {
@@ -75,12 +74,13 @@ describe('filterAndPageWorkers', () => {
     })
   })
 
-  it('items 是 LedgerWorker 本身,不泄漏 dialogObjectId 包装', () => {
+  it('items 是 LedgerWorker 本身,不泄漏 managerKey 包装', () => {
     const e = entry(ALICE, 'w-1')
     const result = filterAndPageWorkers([e], {})
     expect(result.items).toEqual([e.worker])
-    expect(result.items[0]).not.toHaveProperty('dialogObjectId')
+    expect(result.items[0]).not.toHaveProperty('managerKey')
     expect(result.items[0]).not.toHaveProperty('worker')
+    expect(result.items[0]?.manager_key).toBe(ALICE)
   })
 
   it('不修改入参数组(纯函数)', () => {
@@ -124,7 +124,7 @@ describe('filterAndPageWorkers', () => {
     })
   })
 
-  describe('dialog_object_id 过滤', () => {
+  describe('manager_key 过滤', () => {
     const all = [
       entry(ALICE, 'w-a1'),
       entry(ALICE, 'w-a2'),
@@ -133,18 +133,18 @@ describe('filterAndPageWorkers', () => {
     ]
 
     it('私聊对话对象', () => {
-      const result = filterAndPageWorkers(all, { dialog_object_id: ALICE })
+      const result = filterAndPageWorkers(all, { manager_key: ALICE })
       expect(result.items.map((w) => w.worker_id).sort()).toEqual(['w-a1', 'w-a2'])
     })
 
     it('群聊对话对象', () => {
-      const result = filterAndPageWorkers(all, { dialog_object_id: GROUP })
+      const result = filterAndPageWorkers(all, { manager_key: GROUP })
       expect(result.items.map((w) => w.worker_id)).toEqual(['w-g1'])
     })
 
     it('无匹配返回空而不报错', () => {
       const result = filterAndPageWorkers(all, {
-        dialog_object_id: dialogObjectIdForPrivate('nobody'),
+        manager_key: `test::nobody` as ManagerKey,
       })
       expect(result.items).toEqual([])
       expect(result.pagination.total_items).toBe(0)
@@ -359,7 +359,7 @@ describe('filterAndPageWorkers', () => {
     ]
     const result = filterAndPageWorkers(all, {
       status: ['failed', 'cancelled'],
-      dialog_object_id: ALICE,
+      manager_key: ALICE,
       time_range: { start: '2026-07-01T00:00:00.000Z', end: '2026-07-04T00:00:00.000Z' },
     })
     expect(result.items.map((w) => w.worker_id)).toEqual(['w-hit'])
@@ -367,17 +367,19 @@ describe('filterAndPageWorkers', () => {
 })
 
 describe('buildWorkerDetail', () => {
-  it('返回体只有 worker 一个字段(§8.3),不带 dialog_object_id', () => {
+  it('返回体只有 worker 一个字段(§8.3)，worker 内保留 owner manager_key', () => {
     const found = entry(ALICE, 'w-1')
     const detail = buildWorkerDetail(found)
     expect(Object.keys(detail)).toEqual(['worker'])
-    expect(detail).not.toHaveProperty('dialog_object_id')
-    expect(detail).not.toHaveProperty('dialogObjectId')
+    expect(detail).not.toHaveProperty('manager_key')
+    expect(detail).not.toHaveProperty('managerKey')
+    expect(detail.worker.manager_key).toBe(ALICE)
   })
 
   it('台账条目逐字段透传(含全部可选字段与化身链)', () => {
     const worker: LedgerWorker = {
       worker_id: 'w-full',
+      manager_key: ALICE,
       task: {
         id: 'task-1',
         title: '标题',
@@ -390,7 +392,6 @@ describe('buildWorkerDetail', () => {
         error: 'boom',
       },
       origin: {
-        spawned_by_session: 'telegram::s-1',
         spawned_by_episode: 'trace-1',
         creator_friend_id: 'friend-1',
         trigger_type: 'scheduled',
@@ -421,7 +422,7 @@ describe('buildWorkerDetail', () => {
       updated_at: '2026-07-02T00:00:00.000Z',
     }
 
-    const detail = buildWorkerDetail({ dialogObjectId: ALICE, worker })
+    const detail = buildWorkerDetail({ managerKey: ALICE, worker })
     expect(detail.worker).toEqual(worker)
     expect(detail.worker.incarnations).toHaveLength(2)
     expect(detail.worker.incarnations[1].forked_from).toBe(1)

--- a/crabot-agent/tests/manager/registry.test.ts
+++ b/crabot-agent/tests/manager/registry.test.ts
@@ -62,6 +62,12 @@ function makeChannelMessage(text: string): ChannelMessage {
   }
 }
 
+function deferred(): { readonly promise: Promise<void>; readonly resolve: () => void } {
+  let resolve!: () => void
+  const promise = new Promise<void>((done) => { resolve = done })
+  return { promise, resolve }
+}
+
 const estimateTokens = (msgs: ReadonlyArray<EngineMessage>): number => msgs.length * 10
 
 const FAKE_HARNESS = { listWorkers: async (): Promise<LedgerWorker[]> => [] } as unknown as WorkerHarness
@@ -184,9 +190,8 @@ describe('ManagerRegistry', () => {
 
     await registry.routeHumanMessages('wechat', 's1', [makeChannelMessage('你好')])
 
-    // 台账查询用的是**现算**的归档键，不是 loop 建出来那一刻的快照。
-    // 若 managerKey 是定值，这里会是 `group:wechat:wechat::s1` —— 同一个人的台账裂成两份。
-    expect(listWorkers).toHaveBeenCalledWith((`test::${'friend-late'}` as ManagerKey))
+    // Stable system prompts no longer perform automatic ledger I/O; worker state is queried explicitly.
+    expect(listWorkers).not.toHaveBeenCalled()
   })
 
   it('getOrCreate: adapter/model 是 thunk，原样透传给 ManagerLoop，不在 registry 侧缓存解析结果（§11 热更链路）', async () => {
@@ -400,6 +405,110 @@ describe('ManagerRegistry', () => {
 
     const state = await store.load(SYSTEM_TASKS_MANAGER_KEY)
     expect(state.recent.length).toBeGreaterThan(0)
+  })
+
+  it('异步身份、worker 查找和 schedule 解析等待期间不改写入口时间', async () => {
+    const { adapter, queue, calls } = makeAdapter()
+    queue.push(
+      { text: 'human ok', stopReason: 'end_turn' },
+      { text: 'worker ok', stopReason: 'end_turn' },
+      { text: 'schedule ok', stopReason: 'end_turn' },
+    )
+    let nowMs = Date.parse('2026-08-10T01:00:00.000Z')
+    const humanEntered = deferred()
+    const humanRelease = deferred()
+    const workerEntered = deferred()
+    const workerRelease = deferred()
+    const scheduleEntered = deferred()
+    const scheduleRelease = deferred()
+    const owner = 'wechat::timed-owner' as ManagerKey
+    const worker = makeLedgerWorker('w-timed', owner)
+    const registry = new ManagerRegistry(baseRegistryDeps({
+      adapter,
+      now: () => new Date(nowMs),
+      timezone: () => 'Asia/Shanghai',
+      onHumanWake: async () => {
+        humanEntered.resolve()
+        await humanRelease.promise
+      },
+      ledger: {
+        findWorker: async () => {
+          workerEntered.resolve()
+          await workerRelease.promise
+          return { managerKey: owner, worker }
+        },
+      } as unknown as LedgerStore,
+      onScheduleWake: async () => {
+        scheduleEntered.resolve()
+        await scheduleRelease.promise
+      },
+    }))
+
+    const human = registry.routeHumanMessages('wechat', 'timed-human', [makeChannelMessage('human')])
+    await humanEntered.promise
+    nowMs = Date.parse('2026-08-10T01:01:00.000Z')
+    humanRelease.resolve()
+    await human
+    expect(JSON.stringify(calls[0].messages)).toContain('received_at=\\"2026-08-10T09:00:00+08:00\\"')
+
+    const workerWake = registry.routeWorkerEvent({
+      ts: '2026-08-10T00:59:30.000Z',
+      kind: 'state_changed',
+      worker_id: 'w-timed',
+      seq: 2,
+    })
+    await workerEntered.promise
+    nowMs = Date.parse('2026-08-10T01:02:00.000Z')
+    workerRelease.resolve()
+    await workerWake
+    const workerMessages = JSON.stringify(calls[1].messages)
+    expect(workerMessages).toContain('received_at=\\"2026-08-10T09:01:00+08:00\\"')
+    expect(workerMessages).toContain('occurred_at=\\"2026-08-10T00:59:30.000Z\\"')
+
+    const schedule = registry.routeSchedule({ scheduleId: 'timed', title: 't', description: 'd' })
+    await scheduleEntered.promise
+    nowMs = Date.parse('2026-08-10T01:03:00.000Z')
+    scheduleRelease.resolve()
+    await schedule
+    const scheduleMessages = JSON.stringify(calls[2].messages)
+    expect(scheduleMessages).toContain('received_at=\\"2026-08-10T09:02:00+08:00\\"')
+    expect(scheduleMessages).not.toContain('occurred_at=')
+  })
+
+  it('同一 ManagerKey 并发排队的后到事件保留各自入口时间', async () => {
+    const calls: LLMStreamParams[] = []
+    const firstTurnEntered = deferred()
+    const releaseFirstTurn = deferred()
+    let turn = 0
+    const adapter: LLMAdapter = {
+      async *stream(params) {
+        calls.push({ ...params, messages: [...params.messages] })
+        turn++
+        if (turn === 1) {
+          firstTurnEntered.resolve()
+          await releaseFirstTurn.promise
+        }
+        yield* chunksFromContent([{ type: 'text', text: 'ok' }], 'end_turn', { inputTokens: 10, outputTokens: 5 })
+      },
+      updateConfig: () => {},
+    }
+    let nowMs = Date.parse('2026-08-10T02:00:00.000Z')
+    const registry = new ManagerRegistry(baseRegistryDeps({
+      adapter,
+      now: () => new Date(nowMs),
+      timezone: () => 'Asia/Shanghai',
+    }))
+
+    const first = registry.routeHumanMessages('wechat', 'same-key', [makeChannelMessage('first')])
+    await firstTurnEntered.promise
+    nowMs = Date.parse('2026-08-10T02:00:30.000Z')
+    const second = registry.routeHumanMessages('wechat', 'same-key', [makeChannelMessage('second')])
+    nowMs = Date.parse('2026-08-10T02:05:00.000Z')
+    releaseFirstTurn.resolve()
+    await Promise.all([first, second])
+
+    expect(JSON.stringify(calls[0].messages)).toContain('received_at=\\"2026-08-10T10:00:00+08:00\\"')
+    expect(JSON.stringify(calls[1].messages)).toContain('received_at=\\"2026-08-10T10:00:30+08:00\\"')
   })
 
   // --- evictIdle ---
@@ -681,9 +790,19 @@ describe('ManagerRegistry', () => {
     const loop = registry.getOrCreate(key)
     const wakeUpSpy = vi.spyOn(loop, 'wakeUp')
 
-    await registry.routeMediaNotification({ channelId: 'wechat', sessionId: 'media-idle', text: 'fm-1 ready' })
+    await registry.routeMediaNotification({
+      channelId: 'wechat',
+      sessionId: 'media-idle',
+      text: 'fm-1 ready',
+      occurredAt: '2025-12-31T23:59:30.000Z',
+    })
 
-    expect(wakeUpSpy).toHaveBeenCalledWith({ kind: 'media_notification', text: 'fm-1 ready' })
+    expect(wakeUpSpy).toHaveBeenCalledWith(expect.objectContaining({
+      wake: { kind: 'media_notification', text: 'fm-1 ready' },
+      received_at: expect.any(String),
+      timezone: expect.any(String),
+      occurred_at: '2025-12-31T23:59:30.000Z',
+    }))
     const state = await store.load(key)
     expect(JSON.stringify(state.recent)).toContain('[媒体下载完成]')
     expect(JSON.stringify(state.recent)).not.toContain('<bg-notification>')
@@ -711,7 +830,11 @@ describe('ManagerRegistry', () => {
 
     await registry.routeHumanMessages('wechat', 'media-active', [makeChannelMessage('开始')])
 
-    expect(enqueueSpy).toHaveBeenCalledWith({ kind: 'media_notification', text: 'fm-2 ready' })
+    expect(enqueueSpy).toHaveBeenCalledWith(expect.objectContaining({
+      wake: { kind: 'media_notification', text: 'fm-2 ready' },
+      received_at: expect.any(String),
+      timezone: expect.any(String),
+    }))
     expect(wakeUpSpy).toHaveBeenCalledTimes(1)
   })
 
@@ -753,6 +876,13 @@ describe('ManagerRegistry', () => {
     await registry.routeHumanMessages('wechat', 'sess-async', [makeChannelMessage('你好')])
 
     expect(enqueueSpy).toHaveBeenCalledTimes(1)
+    const syntheticEnvelope = enqueueSpy.mock.calls[0][0]
+    expect(syntheticEnvelope.received_at).toBe('2026-01-01T08:00:00+08:00')
+    expect(syntheticEnvelope.occurred_at).toBe('2026-01-01T00:00:00.000Z')
+    expect(syntheticEnvelope.wake).toMatchObject({
+      kind: 'worker_event',
+      event: { kind: 'query_failed', ts: '2026-01-01T00:00:00.000Z' },
+    })
     // wakeUp 只被 routeHumanMessages 自己调用了一次；onAsyncError 没有额外触发第二次 wakeUp
     expect(wakeUpSpy).toHaveBeenCalledTimes(1)
   })

--- a/crabot-agent/tests/manager/registry.test.ts
+++ b/crabot-agent/tests/manager/registry.test.ts
@@ -1014,9 +1014,10 @@ describe('inbound-adapters', () => {
     expect(event).toEqual({ kind: 'attention_flush', messages: [m1] })
   })
 
-  it('shouldWakeOnHarnessEvent: 过滤 input_sent，其余 kind 一律唤醒', () => {
+  it('shouldWakeOnHarnessEvent: 过滤 input_sent 与 legacy_imported，其余 kind 一律唤醒', () => {
     const base = { ts: '2026-01-01T00:00:00.000Z', worker_id: 'w-1', seq: 1 }
     expect(shouldWakeOnHarnessEvent({ ...base, kind: 'input_sent' })).toBe(false)
+    expect(shouldWakeOnHarnessEvent({ ...base, kind: 'legacy_imported' })).toBe(false)
 
     const otherKinds: HarnessEventKind[] = [
       'spawned',

--- a/crabot-agent/tests/manager/registry.test.ts
+++ b/crabot-agent/tests/manager/registry.test.ts
@@ -19,7 +19,6 @@ import { ManagerSessionStore } from '../../src/manager/session-store.js'
 import type { CompactionPolicy } from '../../src/manager/compaction.js'
 import type { ManagerKey } from '../../src/manager/types.js'
 import type { ChannelMessage, Friend } from '../../src/types.js'
-import { dialogObjectIdForPrivate, dialogObjectIdForGroup } from '../../src/workers/harness/ledger-types.js'
 import type { LedgerStore } from '../../src/workers/harness/ledger-store.js'
 import type { LedgerWorker } from '../../src/workers/harness/ledger-types.js'
 import type { WorkerHarness } from '../../src/workers/harness/harness.js'
@@ -67,11 +66,12 @@ const estimateTokens = (msgs: ReadonlyArray<EngineMessage>): number => msgs.leng
 
 const FAKE_HARNESS = { listWorkers: async (): Promise<LedgerWorker[]> => [] } as unknown as WorkerHarness
 
-function makeLedgerWorker(workerId: string, spawnedBySession: ManagerKey): LedgerWorker {
+function makeLedgerWorker(workerId: string, managerKey: ManagerKey): LedgerWorker {
   return {
     worker_id: workerId,
+    manager_key: managerKey,
     task: { id: workerId, title: 't', status: 'running', created_at: '2026-01-01T00:00:00.000Z' },
-    origin: { spawned_by_session: spawnedBySession, trigger_type: 'message' },
+    origin: { trigger_type: 'message' },
     report_to: { channel_id: 'wechat', session_id: 'sess' },
     incarnations: [],
     updated_at: '2026-01-01T00:00:00.000Z',
@@ -84,7 +84,7 @@ function fakeLedger(workers: Record<string, LedgerWorker>): LedgerStore {
     findWorker: async (workerId: string) => {
       const worker = workers[workerId]
       if (!worker) return undefined
-      return { dialogObjectId: dialogObjectIdForPrivate('friend-x'), worker }
+      return { managerKey: worker.manager_key, worker }
     },
   } as unknown as LedgerStore
 }
@@ -140,7 +140,7 @@ describe('ManagerRegistry', () => {
       harness: FAKE_HARNESS,
       ledger: fakeLedger({}),
       now: () => new Date(Date.parse('2026-01-01T00:00:00.000Z')),
-      dialogObjectIdFor: () => dialogObjectIdForPrivate('friend-x'),
+      managerKeyFor: (key) => key,
       toolFace: () => [],
       promptInputs: () => ({}),
       adapter: typeof adapter === 'function' ? adapter : () => adapter,
@@ -163,18 +163,18 @@ describe('ManagerRegistry', () => {
     expect(b).not.toBe(a1)
   })
 
-  it('dialogObjectId 是**每次现算**的：先建的 loop 也会跟上后来才解析出的台账归档键，不把旧值钉死', async () => {
+  it('managerKey 是**每次现算**的：先建的 loop 也会跟上后来才解析出的台账归档键，不把旧值钉死', async () => {
     const { adapter, queue } = makeAdapter()
     queue.push({ text: 'ok', stopReason: 'end_turn' })
     // 归档键一开始解析不出 friend（群形状），之后收敛成 friend 形状——模拟"loop 先被
     // worker 事件建出来、人类消息随后才带来 friend"这条真实时序。
     let resolvedFriend: string | undefined
-    const dialogObjectIdFor = vi.fn((key: ManagerKey) =>
-      resolvedFriend ? dialogObjectIdForPrivate(resolvedFriend) : dialogObjectIdForGroup('wechat', key)
+    const managerKeyFor = vi.fn((key: ManagerKey) =>
+      resolvedFriend ? (`test::${resolvedFriend}` as ManagerKey) : (`${'wechat'}::${key}` as ManagerKey)
     )
     const listWorkers = vi.fn(async () => [])
     const registry = new ManagerRegistry(
-      baseRegistryDeps({ adapter, dialogObjectIdFor, harness: { ...FAKE_HARNESS, listWorkers } as never })
+      baseRegistryDeps({ adapter, managerKeyFor, harness: { ...FAKE_HARNESS, listWorkers } as never })
     )
     const key = 'wechat::s1' as ManagerKey
 
@@ -185,8 +185,8 @@ describe('ManagerRegistry', () => {
     await registry.routeHumanMessages('wechat', 's1', [makeChannelMessage('你好')])
 
     // 台账查询用的是**现算**的归档键，不是 loop 建出来那一刻的快照。
-    // 若 dialogObjectId 是定值，这里会是 `group:wechat:wechat::s1` —— 同一个人的台账裂成两份。
-    expect(listWorkers).toHaveBeenCalledWith(dialogObjectIdForPrivate('friend-late'))
+    // 若 managerKey 是定值，这里会是 `group:wechat:wechat::s1` —— 同一个人的台账裂成两份。
+    expect(listWorkers).toHaveBeenCalledWith((`test::${'friend-late'}` as ManagerKey))
   })
 
   it('getOrCreate: adapter/model 是 thunk，原样透传给 ManagerLoop，不在 registry 侧缓存解析结果（§11 热更链路）', async () => {
@@ -344,7 +344,7 @@ describe('ManagerRegistry', () => {
 
   // --- routeWorkerEvent ---
 
-  it('routeWorkerEvent: 经台账 origin.spawned_by_session 找到监护 manager', async () => {
+  it('routeWorkerEvent: 经台账 origin.spawned_by_episode 找到监护 manager', async () => {
     const { adapter, queue } = makeAdapter()
     queue.push({ text: '收到 worker 事件', stopReason: 'end_turn' })
     const owningKey = 'wechat::owner-sess' as ManagerKey
@@ -836,7 +836,6 @@ describe('ManagerRegistry', () => {
           buildManagerToolFace({
             harness: fakeHarness,
             workerContext: () => ({
-              dialogObjectId: dialogObjectIdForPrivate('friend-e2e'),
               managerKey: k,
               reportTo: { channel_id: 'wechat', session_id: 'sess-e2e-toolface' },
             }),

--- a/crabot-agent/tests/manager/registry.test.ts
+++ b/crabot-agent/tests/manager/registry.test.ts
@@ -802,6 +802,15 @@ describe('ManagerRegistry', () => {
     const key = 'wechat::sess-e2e-toolface' as ManagerKey
     const fakeHarness = {
       listWorkers: async (): Promise<LedgerWorker[]> => [],
+      findWorker: async (): Promise<{ managerKey: ManagerKey; worker: LedgerWorker }> => ({
+        managerKey: key,
+        worker: {
+          worker_id: 'w-codex-1', manager_key: key,
+          task: { id: 'w-codex-1', title: 'codex', status: 'running', created_at: '2026-01-01T00:00:00.000Z' },
+          origin: { trigger_type: 'message' }, report_to: { channel_id: 'wechat', session_id: 'sess-e2e-toolface' },
+          incarnations: [], updated_at: '2026-01-01T00:00:00.000Z',
+        },
+      }),
       queryWorker: async (): Promise<never> => {
         throw new CapabilityNotSupportedError('codex', 'fork')
       },

--- a/crabot-agent/tests/manager/rpc-handlers.test.ts
+++ b/crabot-agent/tests/manager/rpc-handlers.test.ts
@@ -16,8 +16,7 @@ import type { PrincipalResolverDeps } from '../../src/manager/principal.js'
 import { buildManagerStack, type BootstrapDeps, type ManagerStack } from '../../src/manager/bootstrap.js'
 import { SYSTEM_TASKS_MANAGER_KEY } from '../../src/manager/registry.js'
 import { WorkerHasNoIncarnationError } from '../../src/workers/harness/harness.js'
-import { dialogObjectIdForPrivate, type DialogObjectId, type LedgerWorker } from '../../src/workers/harness/ledger-types.js'
-import type { ManagerKey } from '../../src/manager/types.js'
+import { type ManagerKey, type LedgerWorker } from '../../src/workers/harness/ledger-types.js'
 import type { HarnessEvent } from '../../src/workers/harness/worker-events.js'
 import type { LLMAdapter } from '../../src/engine/index.js'
 import { createCrabMemoryServer } from '../../src/mcp/crab-memory.js'
@@ -80,7 +79,8 @@ function makeLedgerWorker(p: {
       status: p.status ?? 'running',
       created_at: p.createdAt ?? '2026-01-01T00:00:00.000Z',
     },
-    origin: { spawned_by_session: 'wechat::sess-1' as ManagerKey, trigger_type: 'message' },
+    origin: {
+      trigger_type: 'message' },
     report_to: { channel_id: 'wechat', session_id: 'sess-1' },
     incarnations: [],
     updated_at: p.updatedAt ?? '2026-01-01T00:00:00.000Z',
@@ -467,7 +467,7 @@ describe('trigger_schedule 的 fail-loud 兜底', () => {
 
 describe('trigger_schedule 端到端(真实 manager 栈 + mock LLM)', () => {
   let tmpRoot: string
-  const dialogObjectIdFor = (key: ManagerKey): DialogObjectId => dialogObjectIdForPrivate(`friend-of-${key}`)
+  const managerKeyFor = (key: ManagerKey): ManagerKey => `test::friend-of-${key}` as ManagerKey
 
   beforeEach(async () => {
     tmpRoot = await fs.mkdtemp(join(tmpdir(), 'rpc-handlers-'))
@@ -524,7 +524,7 @@ describe('trigger_schedule 端到端(真实 manager 栈 + mock LLM)', () => {
 
     await waitUntil(() => spawnSpy.mock.calls.length > 0)
     const params = spawnSpy.mock.calls[0][0]
-    expect(params.origin.spawned_by_session).toBe(SYSTEM_TASKS_MANAGER_KEY)
+    expect(params.managerKey).toBe(SYSTEM_TASKS_MANAGER_KEY)
     expect(params.origin.creator_friend_id).toBe('friend-42')
     expect(params.origin.trigger_type).toBe('scheduled')
 
@@ -549,7 +549,7 @@ describe('trigger_schedule 端到端(真实 manager 栈 + mock LLM)', () => {
 
     await waitUntil(() => spawnSpy.mock.calls.length > 0)
     const params = spawnSpy.mock.calls[0][0]
-    expect(params.origin.spawned_by_session).toBe('wechat::sess-1')
+    expect(params.managerKey).toBe('wechat::sess-1')
     expect(params.origin.creator_friend_id).toBe('friend-7')
     expect(params.origin.trigger_type).toBe('scheduled')
 
@@ -722,9 +722,9 @@ describe('trigger_schedule 端到端(真实 manager 栈 + mock LLM)', () => {
 describe('list_workers_admin(§8.3)', () => {
   it('取全量台账 → filterAndPageWorkers(status 过滤 + 分页回显)', async () => {
     const entries = [
-      { dialogObjectId: dialogObjectIdForPrivate('f1'), worker: makeLedgerWorker({ workerId: 'w-1', status: 'running', updatedAt: '2026-01-03T00:00:00.000Z' }) },
-      { dialogObjectId: dialogObjectIdForPrivate('f1'), worker: makeLedgerWorker({ workerId: 'w-2', status: 'completed', updatedAt: '2026-01-02T00:00:00.000Z' }) },
-      { dialogObjectId: dialogObjectIdForPrivate('f2'), worker: makeLedgerWorker({ workerId: 'w-3', status: 'running', updatedAt: '2026-01-01T00:00:00.000Z' }) },
+      { managerKey: `test::f1` as ManagerKey, worker: makeLedgerWorker({ workerId: 'w-1', status: 'running', updatedAt: '2026-01-03T00:00:00.000Z' }) },
+      { managerKey: `test::f1` as ManagerKey, worker: makeLedgerWorker({ workerId: 'w-2', status: 'completed', updatedAt: '2026-01-02T00:00:00.000Z' }) },
+      { managerKey: `test::f2` as ManagerKey, worker: makeLedgerWorker({ workerId: 'w-3', status: 'running', updatedAt: '2026-01-01T00:00:00.000Z' }) },
     ]
     const agent = buildAgent({ ledger: { listAllWorkers: async () => entries } })
 
@@ -735,7 +735,7 @@ describe('list_workers_admin(§8.3)', () => {
     const running = await agent.handleListWorkersAdmin({ status: 'running' })
     expect(running.items.map((w) => w.worker_id)).toEqual(['w-1', 'w-3'])
 
-    const scoped = await agent.handleListWorkersAdmin({ dialog_object_id: dialogObjectIdForPrivate('f2') })
+    const scoped = await agent.handleListWorkersAdmin({ manager_key: `test::f2` as ManagerKey })
     expect(scoped.items.map((w) => w.worker_id)).toEqual(['w-3'])
   })
 
@@ -748,10 +748,10 @@ describe('list_workers_admin(§8.3)', () => {
 })
 
 describe('get_worker_detail(§8.3)', () => {
-  it('存在 → 返回台账条目本身(剥掉 dialogObjectId 包装)', async () => {
+  it('存在 → 返回台账条目本身(剥掉 managerKey 包装)', async () => {
     const worker = makeLedgerWorker({ workerId: 'w-1' })
     const agent = buildAgent({
-      ledger: { findWorker: async () => ({ dialogObjectId: dialogObjectIdForPrivate('f1'), worker }) },
+      ledger: { findWorker: async () => ({ managerKey: `test::f1` as ManagerKey, worker }) },
     })
     await expect(agent.handleGetWorkerDetail({ worker_id: 'w-1' })).resolves.toEqual({ worker })
   })
@@ -835,7 +835,7 @@ describe('get_worker_trace(§8.3 + §10.2)', () => {
     return buildAgent({
       ledger: {
         findWorker: async () => ({
-          dialogObjectId: dialogObjectIdForPrivate('f1'),
+          managerKey: `test::f1` as ManagerKey,
           worker: { ...makeLedgerWorker({ workerId: 'w-1' }), incarnations: [incarnation(1), incarnation(2)] },
         }),
       },
@@ -882,7 +882,7 @@ describe('get_worker_trace(§8.3 + §10.2)', () => {
     const agent = buildAgent({
       ledger: {
         findWorker: async () => ({
-          dialogObjectId: dialogObjectIdForPrivate('f1'),
+          managerKey: `test::f1` as ManagerKey,
           worker: { ...makeLedgerWorker({ workerId: 'w-system' }), incarnations: [] },
         }),
       },

--- a/crabot-agent/tests/manager/rpc-handlers.test.ts
+++ b/crabot-agent/tests/manager/rpc-handlers.test.ts
@@ -797,6 +797,25 @@ describe('read_worker_output_admin(§8.3)', () => {
     expect(result).toEqual({ chunk: '', next_cursor: '7', eof: true })
   })
 
+  it('legacy unavailable_reason is preserved for Admin callers', async () => {
+    const agent = buildAgent({
+      harness: {
+        readWorkerOutput: async () => ({
+          chunk: '',
+          nextCursor: { offset: 0 },
+          unavailable_reason: 'legacy worker has no raw output',
+        }),
+      },
+    })
+
+    await expect(agent.handleReadWorkerOutputAdmin({ worker_id: 'w-legacy' })).resolves.toEqual({
+      chunk: '',
+      next_cursor: '0',
+      eof: true,
+      unavailable_reason: 'legacy worker has no raw output',
+    })
+  })
+
   it('harness 抛错(worker/化身不存在)原样冒泡,不吞成空 chunk', async () => {
     const agent = buildAgent({
       harness: {
@@ -850,6 +869,70 @@ describe('get_worker_trace(§8.3 + §10.2)', () => {
     expect(result.events.every((e) => e.kind === 'lifecycle')).toBe(true)
     expect(result.events[0].summary).toContain('spawned')
     expect(result.events[0].detail).toEqual({ impl: 'builtin' })
+  })
+
+  it('legacy RPC preserves started/end/id ordering through final merge and cursor slicing', async () => {
+    const root = await fs.mkdtemp(join(tmpdir(), 'legacy-trace-rpc-'))
+    const previousAgentDir = process.env.CRABOT_AGENT_DATA_DIR
+    try {
+      const agentDir = join(root, 'agent')
+      const traceDir = join(agentDir, 'traces')
+      await fs.mkdir(traceDir, { recursive: true })
+      process.env.CRABOT_AGENT_DATA_DIR = agentDir
+      const started = '2026-01-01T00:00:00.000Z'
+      await fs.writeFile(join(traceDir, 'traces-2026-01-01.jsonl'), [
+        JSON.stringify({ trace_id: 'end-first', related_task_id: 'old', started_at: started, ended_at: '2026-01-01T00:00:01.000Z', outcome: { summary: 'z end first' } }),
+        JSON.stringify({ trace_id: 'a', related_task_id: 'old', started_at: started, ended_at: '2026-01-01T00:00:02.000Z', outcome: { summary: 'z id a' } }),
+        JSON.stringify({ trace_id: 'b', related_task_id: 'old', started_at: started, ended_at: '2026-01-01T00:00:02.000Z', outcome: { summary: 'a id b' } }),
+      ].join('\n'))
+      const worker: LedgerWorker = {
+        ...makeLedgerWorker({ workerId: 'w-legacy' }),
+        manager_key: 'test::f1' as ManagerKey,
+        task: { ...makeLedgerWorker({ workerId: 'w-legacy' }).task, status: 'completed' },
+        incarnations: [{
+          seq: 1,
+          impl: 'legacy',
+          state: 'exited',
+          workspace: root,
+          started_at: started,
+          ended_at: '2026-01-01T00:00:03.000Z',
+          ended_reason: 'completed',
+        }],
+        legacy_source: {
+          kind: 'v2_admin_task',
+          admin_task_id: 'old',
+          trace_ids: ['b', 'end-first', 'a'],
+          imported_at: '2026-01-01T00:10:00.000Z',
+        },
+      }
+      const imported: HarnessEvent = {
+        ts: '2026-01-01T00:10:00.000Z',
+        kind: 'legacy_imported',
+        worker_id: 'w-legacy',
+        seq: 1,
+      }
+      const agent = buildAgent({
+        ledger: { findWorker: async () => ({ managerKey: 'test::f1' as ManagerKey, worker }) },
+        harness: { readWorkerEvents: async () => [imported] },
+      })
+
+      const full = await agent.handleGetWorkerTrace({ worker_id: 'w-legacy', seq: 1 })
+      expect(full.events.map((event) => event.summary)).toEqual([
+        'z end first',
+        'z id a',
+        'a id b',
+        'legacy_imported',
+      ])
+      expect(full.next_cursor).toBe('4')
+
+      const continued = await agent.handleGetWorkerTrace({ worker_id: 'w-legacy', seq: 1, cursor: '1' })
+      expect(continued.events.map((event) => event.summary)).toEqual(['z id a', 'a id b', 'legacy_imported'])
+      expect(continued.next_cursor).toBe('4')
+    } finally {
+      if (previousAgentDir === undefined) delete process.env.CRABOT_AGENT_DATA_DIR
+      else process.env.CRABOT_AGENT_DATA_DIR = previousAgentDir
+      await fs.rm(root, { recursive: true, force: true })
+    }
   })
 
   it('第二层(adapter readTrace 懒解析)本阶段未接线 → unavailable_reason 说明', async () => {

--- a/crabot-agent/tests/manager/timed-wake-envelope.test.ts
+++ b/crabot-agent/tests/manager/timed-wake-envelope.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { renderTimedWakeEnvelope, type TimedWakeEnvelope } from '../../src/manager/loop.js'
+import type { ChannelMessage } from '../../src/types.js'
+
+function message(id: string, timestamp?: string): ChannelMessage {
+  return {
+    platform_message_id: id,
+    session: { channel_id: 'wechat', session_id: 's', type: 'private' },
+    sender: { platform_user_id: 'u', platform_display_name: 'U' },
+    content: { type: 'text', text: id },
+    features: { is_mention_crab: false },
+    ...(timestamp ? { platform_timestamp: timestamp } : {}),
+  }
+}
+
+describe('TimedWakeEnvelope rendering', () => {
+  it('renders fixed ingress time and valid human source times in original batch order', () => {
+    const envelope: TimedWakeEnvelope = {
+      wake: { kind: 'human_messages', messages: [message('one', '2026-08-10T01:02:03.000Z'), message('two')] },
+      received_at: '2026-08-10T09:02:04+08:00',
+      timezone: 'Asia/Shanghai',
+      human_occurred_at: [
+        { message_id: 'one', occurred_at: '2026-08-10T01:02:03.000Z' },
+        { message_id: 'two' },
+      ],
+    }
+    const rendered = renderTimedWakeEnvelope(envelope)
+    expect(rendered).toContain('[event received_at="2026-08-10T09:02:04+08:00" timezone="Asia/Shanghai"]')
+    expect(rendered.indexOf('occurred_at="2026-08-10T01:02:03.000Z"')).toBeLessThan(rendered.lastIndexOf('two'))
+    expect(rendered).toContain('one')
+  })
+
+  it('does not invent an occurred_at for schedules and pure rendering is byte-stable', () => {
+    const envelope: TimedWakeEnvelope = {
+      wake: { kind: 'schedule', scheduleId: 's', title: '巡检', description: '执行' },
+      received_at: '2026-08-10T09:02:04+08:00',
+      timezone: 'Asia/Shanghai',
+    }
+    expect(renderTimedWakeEnvelope(envelope)).toBe(renderTimedWakeEnvelope(envelope))
+    expect(renderTimedWakeEnvelope(envelope)).not.toContain('occurred_at=')
+  })
+})

--- a/crabot-agent/tests/manager/tool-face.test.ts
+++ b/crabot-agent/tests/manager/tool-face.test.ts
@@ -36,7 +36,7 @@ const MESSAGING_NORMAL = [
 /** protocol-crab-messaging.md §2.10 的 channel 透传只读三件套（仅当存在飞书 channel 实例）。 */
 const FEISHU_READ_ONLY_TOOLS = ['read_feishu_document', 'feishu_raw_get', 'feishu_download_file']
 
-const WORKER_TOOLS = ['spawn_worker', 'send_to_worker', 'query_worker', 'read_worker_output', 'list_workers', 'kill_worker']
+const WORKER_TOOLS = ['spawn_worker', 'send_to_worker', 'query_worker', 'read_worker_output', 'list_workers', 'get_worker_detail', 'kill_worker']
 
 const CRABOT_INFO_TOOLS = [
   'get_system_status',

--- a/crabot-agent/tests/manager/tool-face.test.ts
+++ b/crabot-agent/tests/manager/tool-face.test.ts
@@ -76,8 +76,7 @@ function makeDeps(overrides: Partial<ToolFaceDeps> = {}): ToolFaceDeps {
   return {
     harness: {} as unknown as WorkerHarness,
     workerContext: () => ({
-      dialogObjectId: 'dlg-1',
-      managerKey: 'manager-1',
+      managerKey: 'ch-1::sess-1',
       reportTo: { channel_id: 'ch-1', session_id: 'sess-1' },
     }),
     messagingDeps: makeMessagingDeps(),

--- a/crabot-agent/tests/manager/worker-authorization.test.ts
+++ b/crabot-agent/tests/manager/worker-authorization.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest'
+import { buildWorkerTools } from '../../src/manager/tools/worker-tools.js'
+import type { LedgerWorker, ManagerKey } from '../../src/workers/harness/ledger-types.js'
+
+const A = 'wechat::a' as ManagerKey
+const B = 'telegram::b' as ManagerKey
+function worker(id: string, key: ManagerKey): LedgerWorker {
+  return { worker_id: id, manager_key: key, task: { id, title: id, status: 'running', created_at: '2026-08-10T00:00:00.000Z' }, origin: { trigger_type: 'message' }, report_to: { channel_id: 'x', session_id: 'y' }, incarnations: [], updated_at: `2026-08-10T00:00:0${id === 'b' ? '2' : '1'}.000Z` }
+}
+function tools(master = false, valid = true) {
+  const a = worker('a', A), b = worker('b', B)
+  const harness = {
+    findWorker: vi.fn(async (id: string) => id === 'a' ? { managerKey: A, worker: a } : id === 'b' ? { managerKey: B, worker: b } : undefined),
+    listWorkers: vi.fn(async () => [a]), listAllWorkers: vi.fn(async () => [{ managerKey: A, worker: a }, { managerKey: B, worker: b }]),
+    sendToWorker: vi.fn(), queryWorker: vi.fn(), killWorker: vi.fn(), readWorkerOutput: vi.fn(), spawnWorker: vi.fn(),
+  }
+  const auth = master ? { kind: 'friend_master' as const, manager_key: A, friend_id: 'f', generation: 1 } : undefined
+  return { harness, list: buildWorkerTools({ harness: harness as never, context: () => ({ managerKey: A, reportTo: { channel_id: 'wechat', session_id: 'a' } }), authorization: () => auth, validateMasterAuthorization: async () => valid }) }
+}
+
+describe('session worker authorization', () => {
+  it('ordinary tool face has no list_all_workers; known external ID is uniformly denied before worker actions', async () => {
+    const { harness, list } = tools(false)
+    expect(list.map(t => t.name)).not.toContain('list_all_workers')
+    for (const name of ['send_to_worker', 'query_worker', 'kill_worker', 'read_worker_output', 'get_worker_detail']) {
+      const tool = list.find(t => t.name === name)!
+      const result = await tool.call(name === 'query_worker' ? { worker_id: 'b', question: 'q' } : name === 'send_to_worker' ? { worker_id: 'b', text: 'x' } : { worker_id: 'b' })
+      expect(result.isError).toBe(true)
+      expect(result.output).toContain('不存在或当前会话无权访问')
+    }
+    expect(harness.sendToWorker).not.toHaveBeenCalled(); expect(harness.queryWorker).not.toHaveBeenCalled(); expect(harness.killWorker).not.toHaveBeenCalled()
+  })
+
+  it('Master gets explicit global list with stable pagination and execution-time revocation rejects cross-session detail', async () => {
+    const { list } = tools(true)
+    const all = list.find(t => t.name === 'list_all_workers')!
+    const page = await all.call({ page: 1, page_size: 1 })
+    expect(page.isError).toBe(false)
+    expect(JSON.parse(page.output)).toMatchObject({ items: [{ worker_id: 'b' }], pagination: { page: 1, page_size: 1, total_items: 2, total_pages: 2 } })
+    const detail = list.find(t => t.name === 'get_worker_detail')!
+    const old = await detail.call({ worker_id: 'b' })
+    expect(old.isError).toBe(false)
+    const revoked = buildWorkerTools({ harness: tools(true).harness as never, context: () => ({ managerKey: A, reportTo: { channel_id: 'wechat', session_id: 'a' } }), authorization: () => ({ kind: 'friend_master', manager_key: A, friend_id: 'f', generation: 1 }), validateMasterAuthorization: async () => false })
+    expect((await revoked.find(t => t.name === 'get_worker_detail')!.call({ worker_id: 'b' })).isError).toBe(true)
+  })
+
+  it('captures Master generation once: an old privileged closure remains denied after regrant', async () => {
+    const a = worker('a', A), b = worker('b', B)
+    let generation = 1
+    const harness = {
+      findWorker: vi.fn(async (id: string) => id === 'b' ? { managerKey: B, worker: b } : { managerKey: A, worker: a }),
+      listWorkers: vi.fn(async () => [a]), listAllWorkers: vi.fn(async () => [{ managerKey: A, worker: a }, { managerKey: B, worker: b }]),
+      sendToWorker: vi.fn(), queryWorker: vi.fn(), killWorker: vi.fn(), readWorkerOutput: vi.fn(), spawnWorker: vi.fn(),
+    }
+    const authorization = () => ({ kind: 'friend_master' as const, manager_key: A, friend_id: 'f', generation })
+    const old = buildWorkerTools({ harness: harness as never, context: () => ({ managerKey: A, reportTo: { channel_id: 'wechat', session_id: 'a' } }), authorization, validateMasterAuthorization: async auth => auth.generation === generation })
+    generation = 2 // downgrade/invalidate then same Friend regrant
+    const oldAll = old.find(tool => tool.name === 'list_all_workers')!
+    const oldDetail = old.find(tool => tool.name === 'get_worker_detail')!
+    expect((await oldAll.call({})).isError).toBe(true)
+    expect((await oldDetail.call({ worker_id: 'b' })).isError).toBe(true)
+    expect(harness.listAllWorkers).not.toHaveBeenCalled()
+  })
+
+})

--- a/crabot-agent/tests/manager/worker-tools.test.ts
+++ b/crabot-agent/tests/manager/worker-tools.test.ts
@@ -185,16 +185,16 @@ afterEach(async () => {
 // ---- 工具面形状 ----
 
 describe('buildWorkerTools — 工具面形状', () => {
-  it('工具名集合恰为六项，isReadOnly 仅 read_worker_output/list_workers 为 true', async () => {
+  it('普通 Manager 有七项 worker 工具；只有 read_worker_output/list_workers/get_worker_detail 为只读', async () => {
     const { harness } = await makeHarness()
     const tools = buildWorkerTools({ harness, context: () => CTX })
 
     expect(tools.map((t) => t.name).sort()).toEqual(
-      ['kill_worker', 'list_workers', 'query_worker', 'read_worker_output', 'send_to_worker', 'spawn_worker'].sort()
+      ['get_worker_detail', 'kill_worker', 'list_workers', 'query_worker', 'read_worker_output', 'send_to_worker', 'spawn_worker'].sort()
     )
 
     const readOnlyNames = tools.filter((t) => t.isReadOnly).map((t) => t.name).sort()
-    expect(readOnlyNames).toEqual(['list_workers', 'read_worker_output'])
+    expect(readOnlyNames).toEqual(['get_worker_detail', 'list_workers', 'read_worker_output'])
   })
 })
 
@@ -283,7 +283,7 @@ describe('send_to_worker', () => {
 
     const result = await sendToWorker.call({ worker_id: 'w-does-not-exist', text: '你好' }, {})
     expect(result.isError).toBe(true)
-    expect(result.output).toMatch(/worker not found/)
+    expect(result.output).toContain('不存在或当前会话无权访问')
   })
 
   it('task 已 cancelled → TaskCancelledError 转成可读 tool_result（isError:true，不抛出）', async () => {
@@ -378,7 +378,7 @@ describe('query_worker', () => {
     expect(w.incarnations[1]).toMatchObject({ seq: 2, forked_from: 1 })
   })
 
-  it('游离 promise reject（worker 不存在）时不产生 unhandledRejection，只记诊断日志；调用本身仍立即返回确认', async () => {
+  it('unknown worker is rejected synchronously without an action or unhandled rejection', async () => {
     const { harness } = await makeHarness({ caps: { fork: true } })
     const tools = buildWorkerTools({ harness, context: () => CTX })
     const queryWorker = tools.find((t) => t.name === 'query_worker')!
@@ -391,17 +391,16 @@ describe('query_worker', () => {
     try {
       const result = await queryWorker.call({ worker_id: 'w-nope', question: '？' }, {})
       // 不再是 isError:true——失败发生在锁外的游离 promise 里，这次调用本身不知道。
-      expect(result.isError).toBe(false)
-      expect(parseOutput(result.output)).toEqual({ status: 'queried', worker_id: 'w-nope' })
+      expect(result.isError).toBe(true)
+      expect(result.output).toContain('不存在或当前会话无权访问')
 
-      // 给游离 promise 一个宏任务窗口 reject 并被 .catch() 兜住。
+      // Authorization happens before fire-and-forget work.
       await new Promise((resolve) => setTimeout(resolve, 20))
 
       expect(unhandled).toHaveLength(0)
       expect(errorSpy).toHaveBeenCalled()
       const loggedArgs = errorSpy.mock.calls.map((args) => args.join(' ')).join('\n')
-      expect(loggedArgs).toMatch(/query_worker/)
-      expect(loggedArgs).toMatch(/worker not found/)
+      expect(loggedArgs).toContain('不存在或当前会话无权访问')
     } finally {
       process.off('unhandledRejection', onUnhandledRejection)
       errorSpy.mockRestore()
@@ -439,7 +438,7 @@ describe('query_worker', () => {
   // 已经拿不到失败原因（见上面两个用例）。onAsyncError 是留给 Task 7/8"把这条错误接成唤醒
   // 本 manager 的信号"的扩展点——本任务只提供出口、验证它确实带着正确的 { tool, worker_id,
   // error } 被调用，不接线到任何真实唤醒机制。
-  it('deps.onAsyncError 存在时，游离 promise reject（worker 不存在）除 console.error 外还携带 {tool, worker_id, error} 调用它', async () => {
+  it('authorization rejection does not invoke onAsyncError', async () => {
     const { harness } = await makeHarness({ caps: { fork: true } })
     const onAsyncError = vi.fn()
     const tools = buildWorkerTools({ harness, context: () => CTX, onAsyncError })
@@ -450,18 +449,14 @@ describe('query_worker', () => {
       await queryWorker.call({ worker_id: 'w-nope', question: '？' }, {})
       await new Promise((resolve) => setTimeout(resolve, 20))
 
-      expect(onAsyncError).toHaveBeenCalledTimes(1)
-      expect(onAsyncError).toHaveBeenCalledWith({
-        tool: 'query_worker',
-        worker_id: 'w-nope',
-        error: expect.stringMatching(/worker not found/),
-      })
+      expect(onAsyncError).not.toHaveBeenCalled()
+
     } finally {
       errorSpy.mockRestore()
     }
   })
 
-  it('未传 deps.onAsyncError 时行为与之前完全一致：游离 promise reject 只 console.error，不因缺省回调而抛错', async () => {
+  it('unknown worker without onAsyncError returns a synchronous denial', async () => {
     const { harness } = await makeHarness({ caps: { fork: true } })
     const tools = buildWorkerTools({ harness, context: () => CTX }) // 不传 onAsyncError
     const queryWorker = tools.find((t) => t.name === 'query_worker')!
@@ -469,7 +464,7 @@ describe('query_worker', () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     try {
       const result = await queryWorker.call({ worker_id: 'w-nope', question: '？' }, {})
-      expect(result.isError).toBe(false)
+      expect(result.isError).toBe(true)
       await new Promise((resolve) => setTimeout(resolve, 20))
       expect(errorSpy).toHaveBeenCalled()
     } finally {
@@ -501,7 +496,7 @@ describe('read_worker_output', () => {
 
     const result = await readWorkerOutput.call({ worker_id: 'w-nope' }, {})
     expect(result.isError).toBe(true)
-    expect(result.output).toMatch(/worker not found/)
+    expect(result.output).toContain('不存在或当前会话无权访问')
   })
 
   it('传 seq → 透传给 harness.readWorkerOutput，读到 query_worker 侧问化身的输出（不是主线）', async () => {
@@ -572,6 +567,6 @@ describe('kill_worker', () => {
 
     const result = await killWorker.call({ worker_id: 'w-nope' }, {})
     expect(result.isError).toBe(true)
-    expect(result.output).toMatch(/worker not found/)
+    expect(result.output).toContain('不存在或当前会话无权访问')
   })
 })

--- a/crabot-agent/tests/manager/worker-tools.test.ts
+++ b/crabot-agent/tests/manager/worker-tools.test.ts
@@ -6,7 +6,7 @@ import { buildWorkerTools, type WorkerToolsContext } from '../../src/manager/too
 import { WorkerHarness, type HarnessDeps, type SpawnWorkerParams } from '../../src/workers/harness/harness'
 import { LedgerStore } from '../../src/workers/harness/ledger-store'
 import { WorkspaceManager } from '../../src/workers/harness/workspace-manager'
-import { dialogObjectIdForPrivate } from '../../src/workers/harness/ledger-types'
+import type { ManagerKey } from '../../src/workers/harness/ledger-types'
 import type { HarnessEvent } from '../../src/workers/harness/worker-events'
 import { WorkerExitedError } from '../../src/workers/errors'
 import type {
@@ -141,8 +141,7 @@ async function makeHarness(
 
 // 本套件下 manager 的固定归属：所有 spawn_worker 透传断言都对照这份 context。
 const CTX: WorkerToolsContext = {
-  dialogObjectId: dialogObjectIdForPrivate('friend-1'),
-  managerKey: 'wechat::sess-1',
+  managerKey: 'wechat::sess-1' as ManagerKey,
   episodeId: 'episode-42',
   creatorFriendId: 'friend-1',
   reportTo: { channel_id: 'wechat', session_id: 'sess-1' },
@@ -150,10 +149,10 @@ const CTX: WorkerToolsContext = {
 
 function directSpawnParams(overrides: Partial<SpawnWorkerParams> = {}): SpawnWorkerParams {
   return {
-    dialogObjectId: CTX.dialogObjectId,
+    managerKey: CTX.managerKey,
     title: '直接调 harness 预置的任务',
     prompt: '把活干完',
-    origin: { spawned_by_session: CTX.managerKey, trigger_type: 'message' },
+    origin: { spawned_by_episode: CTX.managerKey, trigger_type: 'message' },
     report_to: CTX.reportTo,
     ...overrides,
   }
@@ -202,7 +201,7 @@ describe('buildWorkerTools — 工具面形状', () => {
 // ---- spawn_worker ----
 
 describe('spawn_worker', () => {
-  it('透传 dialogObjectId/origin/report_to 到台账，异步返回简短确认（非完整 worker 记录）', async () => {
+  it('透传 managerKey/origin/report_to 到台账，异步返回简短确认（非完整 worker 记录）', async () => {
     const { harness } = await makeHarness()
     const tools = buildWorkerTools({ harness, context: () => CTX })
     const spawnWorker = tools.find((t) => t.name === 'spawn_worker')!
@@ -218,12 +217,11 @@ describe('spawn_worker', () => {
     expect(typeof parsed.worker_id).toBe('string')
     expect(Object.keys(parsed).sort()).toEqual(['impl', 'status', 'worker_id'])
 
-    // 真正落盘的台账记录：origin/report_to/dialogObjectId 与 context() 提供的完全一致。
-    const listed = await harness.listWorkers(CTX.dialogObjectId)
+    // 真正落盘的台账记录：origin/report_to/managerKey 与 context() 提供的完全一致。
+    const listed = await harness.listWorkers(CTX.managerKey)
     const worker = listed.find((w) => w.worker_id === parsed.worker_id)
     expect(worker).toBeDefined()
     expect(worker!.origin).toEqual({
-      spawned_by_session: CTX.managerKey,
       spawned_by_episode: CTX.episodeId,
       creator_friend_id: CTX.creatorFriendId,
       trigger_type: 'message',
@@ -239,7 +237,7 @@ describe('spawn_worker', () => {
 
     const result = await spawnWorker.call({ title: '定时任务', prompt: '按计划执行' }, {})
     const parsed = parseOutput(result.output)
-    const listed = await harness.listWorkers(CTX.dialogObjectId)
+    const listed = await harness.listWorkers(CTX.managerKey)
     const worker = listed.find((w) => w.worker_id === parsed.worker_id)
     expect(worker!.origin.trigger_type).toBe('scheduled')
   })
@@ -373,10 +371,10 @@ describe('query_worker', () => {
     expect(parseOutput(result.output)).toEqual({ status: 'queried', worker_id: worker.worker_id })
 
     await waitUntil(async () => {
-      const [w] = await harness.listWorkers(CTX.dialogObjectId)
+      const [w] = await harness.listWorkers(CTX.managerKey)
       return w.incarnations.length === 2
     })
-    const [w] = await harness.listWorkers(CTX.dialogObjectId)
+    const [w] = await harness.listWorkers(CTX.managerKey)
     expect(w.incarnations[1]).toMatchObject({ seq: 2, forked_from: 1 })
   })
 
@@ -515,7 +513,7 @@ describe('read_worker_output', () => {
 
     await queryWorker.call({ worker_id: worker.worker_id, question: '现在进展如何？' }, {})
     await waitUntil(async () => {
-      const [w] = await harness.listWorkers(CTX.dialogObjectId)
+      const [w] = await harness.listWorkers(CTX.managerKey)
       return w.incarnations.length === 2
     })
 
@@ -530,7 +528,7 @@ describe('read_worker_output', () => {
 // ---- list_workers（同步，本对话对象全量） ----
 
 describe('list_workers', () => {
-  it('同步返回 context().dialogObjectId 名下全部 worker', async () => {
+  it('同步返回 context().managerKey 名下全部 worker', async () => {
     const { harness } = await makeHarness()
     const w1 = await harness.spawnWorker(directSpawnParams({ title: '任务一' }))
     const w2 = await harness.spawnWorker(directSpawnParams({ title: '任务二' }))
@@ -558,7 +556,7 @@ describe('kill_worker', () => {
     expect(parseOutput(first.output)).toEqual({ status: 'killed', worker_id: worker.worker_id })
     expect(fake.killCalls).toHaveLength(1)
 
-    const [afterFirst] = await harness.listWorkers(CTX.dialogObjectId)
+    const [afterFirst] = await harness.listWorkers(CTX.managerKey)
     expect(afterFirst.task.status).toBe('cancelled')
 
     // 幂等：再调一次不重复 adapter.kill、不报错。

--- a/crabot-agent/tests/unified-agent-trigger-schedule.test.ts
+++ b/crabot-agent/tests/unified-agent-trigger-schedule.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 
 import { UnifiedAgent, type TriggerScheduleParams, type TriggerScheduleResult } from '../src/unified-agent.js'
 import type { AgentEventPublisher } from '../src/manager/events.js'
-import type { DialogObjectId, LedgerWorker } from '../src/workers/harness/ledger-types.js'
+import type { ManagerKey, LedgerWorker } from '../src/workers/harness/ledger-types.js'
 
 interface AgentUnderTest {
   config: { moduleId: string }
@@ -36,11 +36,11 @@ function buildAgent(runMaintenance: () => Promise<void>) {
   const writes: LedgerWorker[] = []
   const routeSchedule = vi.fn(() => Promise.resolve())
   const publish = vi.fn<AgentEventPublisher>()
-  const dialogObjectId = 'friend:master' as DialogObjectId
+  const managerKey = 'admin-web::system-tasks' as ManagerKey
 
   const ledger = {
     upsertWorker: vi.fn(async (
-      _dialogObjectId: DialogObjectId,
+      _managerKey: ManagerKey,
       workerId: string,
       mutator: (previous: LedgerWorker | undefined) => LedgerWorker | undefined,
     ) => {
@@ -57,13 +57,13 @@ function buildAgent(runMaintenance: () => Promise<void>) {
   agent.config = { moduleId: 'test-agent' }
   agent.managerStack = {
     ledger,
-    principals: { dialogObjectIdFor: () => dialogObjectId },
+    principals: { managerKeyFor: () => managerKey },
     registry: { routeSchedule },
   }
   agent.memoryWriter = { runMaintenance }
   agent.managerEventPublisher = publish
 
-  return { agent, workers, writes, ledger, routeSchedule, publish, dialogObjectId }
+  return { agent, workers, writes, ledger, routeSchedule, publish, managerKey }
 }
 
 describe('trigger_schedule memory_maintenance system task', () => {
@@ -87,6 +87,7 @@ describe('trigger_schedule memory_maintenance system task', () => {
     expect(fixture.routeSchedule).not.toHaveBeenCalled()
     expect(fixture.writes[0]).toMatchObject({
       worker_id: result.task_id,
+      manager_key: 'admin-web::system-tasks',
       task: {
         id: result.task_id,
         type: 'memory_maintenance',
@@ -101,7 +102,7 @@ describe('trigger_schedule memory_maintenance system task', () => {
     })
     expect(fixture.ledger.upsertWorker).toHaveBeenNthCalledWith(
       1,
-      fixture.dialogObjectId,
+      fixture.managerKey,
       result.task_id,
       expect.any(Function),
     )
@@ -120,7 +121,7 @@ describe('trigger_schedule memory_maintenance system task', () => {
         task_id: result.task_id,
         old_status: 'queued',
         new_status: 'running',
-        dialog_object_id: fixture.dialogObjectId,
+        manager_key: fixture.managerKey,
       }),
     )
     expect(fixture.publish).toHaveBeenNthCalledWith(

--- a/crabot-agent/tests/workers/builtin-injection.test.ts
+++ b/crabot-agent/tests/workers/builtin-injection.test.ts
@@ -20,7 +20,6 @@ import { randomUUID } from 'node:crypto'
 import { WorkerHarness, type HarnessDeps } from '../../src/workers/harness/harness'
 import { LedgerStore } from '../../src/workers/harness/ledger-store'
 import { WorkspaceManager } from '../../src/workers/harness/workspace-manager'
-import { dialogObjectIdForPrivate } from '../../src/workers/harness/ledger-types'
 import { CLI_DOMAINS, type CliAccessConfig, type ResolvedPermissions, type ToolAccessConfig } from '../../src/types.js'
 import { BuiltinWorkerAdapter } from '../../src/workers/builtin/adapter.js'
 import {
@@ -187,12 +186,12 @@ describe('builtin worker 注入管道（harness → 工厂回退）', () => {
     }
     const { harness } = await makeStack(factory)
 
-    const dialogObjectId = dialogObjectIdForPrivate('friend-f1')
+    const managerKey = (`test::${'friend-f1'}` as ManagerKey)
     const worker = await harness.spawnWorker({
-      dialogObjectId,
+      managerKey,
       title: '干活',
       prompt: '把活干完',
-      origin: { spawned_by_session: 'wechat::sess-1', trigger_type: 'message', creator_friend_id: 'friend-f1' },
+      origin: { spawned_by_episode: 'wechat::sess-1', trigger_type: 'message', creator_friend_id: 'friend-f1' },
       report_to: { channel_id: 'wechat', session_id: 'sess-1' },
       impl: 'builtin',
       goal: '目标',
@@ -201,13 +200,13 @@ describe('builtin worker 注入管道（harness → 工厂回退）', () => {
 
     expect(worker.task.status).toBe('running')
     await waitUntil(async () => {
-      const [w] = await harness.listWorkers(dialogObjectId)
+      const [w] = await harness.listWorkers(managerKey)
       return w.task.status === 'completed'
     })
 
     // 语义不变量：worker 真的执行了工具调用、真的以 finish_task 收尾。
     expect(probeCalls).toBe(1)
-    const [done] = await harness.listWorkers(dialogObjectId)
+    const [done] = await harness.listWorkers(managerKey)
     expect(done.incarnations[0].state).toBe('exited')
     expect(done.incarnations[0].ended_reason).toBe('completed')
 
@@ -217,7 +216,7 @@ describe('builtin worker 注入管道（harness → 工厂回退）', () => {
     expect(seen[0].workspace.root).toBe(done.incarnations[0].workspace)
     expect(seen[0].goal).toBe('目标')
     expect(seen[0].origin).toEqual({
-      spawned_by_session: 'wechat::sess-1',
+      spawned_by_episode: 'wechat::sess-1',
       trigger_type: 'message',
       creator_friend_id: 'friend-f1',
     })
@@ -249,10 +248,10 @@ describe('builtin worker 注入管道（harness → 工厂回退）', () => {
     adaptersMap.set('claude-code', fakeCli)
 
     await harness.spawnWorker({
-      dialogObjectId: dialogObjectIdForPrivate('friend-f2'),
+      managerKey: (`test::${'friend-f2'}` as ManagerKey),
       title: 'cc 干活',
       prompt: '干',
-      origin: { spawned_by_session: 'wechat::s', trigger_type: 'message' },
+      origin: { spawned_by_episode: 'wechat::s', trigger_type: 'message' },
       report_to: { channel_id: 'wechat', session_id: 's' },
       impl: 'claude-code',
     })
@@ -265,20 +264,20 @@ describe('builtin worker 注入管道（harness → 工厂回退）', () => {
       throw new Error('model slot 未配置')
     }
     const { harness } = await makeStack(factory)
-    const dialogObjectId = dialogObjectIdForPrivate('friend-f3')
+    const managerKey = (`test::${'friend-f3'}` as ManagerKey)
 
     await expect(
       harness.spawnWorker({
-        dialogObjectId,
+        managerKey,
         title: '干活',
         prompt: '干',
-        origin: { spawned_by_session: 'wechat::s', trigger_type: 'message' },
+        origin: { spawned_by_episode: 'wechat::s', trigger_type: 'message' },
         report_to: { channel_id: 'wechat', session_id: 's' },
         impl: 'builtin',
       }),
     ).rejects.toThrow(/model slot 未配置/)
 
-    const [w] = await harness.listWorkers(dialogObjectId)
+    const [w] = await harness.listWorkers(managerKey)
     expect(w.task.status).toBe('failed')
     expect(w.incarnations[0].ended_reason).toBe('failed')
   })
@@ -318,7 +317,7 @@ describe('builtin worker 运行配置在起化身时现取', () => {
       worker_id: workerId,
       prompt: '干活',
       workspace,
-      origin: { spawned_by_session: 'wechat::s1', trigger_type: 'message' },
+      origin: { spawned_by_episode: 'wechat::s1', trigger_type: 'message' },
     })
     await waitState(first, h1, 'exited')
 
@@ -342,7 +341,7 @@ describe('builtin worker 运行配置在起化身时现取', () => {
     const reviveCtx = state.calls[state.calls.length - 1]
     expect(reviveCtx.worker_id).toBe(workerId)
     expect(reviveCtx.workspace.root).toBe(workspace.root)
-    expect(reviveCtx.origin).toEqual({ spawned_by_session: 'wechat::s1', trigger_type: 'message' })
+    expect(reviveCtx.origin).toEqual({ spawned_by_episode: 'wechat::s1', trigger_type: 'message' })
   })
 
   it('改了配置下次起化身生效，正在跑的 burst 用旧的（多轮 burst 内工厂只调一次）', async () => {

--- a/crabot-agent/tests/workers/builtin-production-runtime.test.ts
+++ b/crabot-agent/tests/workers/builtin-production-runtime.test.ts
@@ -23,7 +23,7 @@ import { join } from 'path'
 import { UnifiedAgent } from '../../src/unified-agent.js'
 import * as agentHandlerModule from '../../src/agent/agent-handler.js'
 import * as engineModule from '../../src/engine/query-loop.js'
-import { dialogObjectIdForPrivate, type DialogObjectId } from '../../src/workers/harness/ledger-types.js'
+import type { ManagerKey } from '../../src/workers/harness/ledger-types.js'
 import type { ManagerStack } from '../../src/manager/bootstrap.js'
 import type { LLMAdapter, ToolDefinition } from '../../src/engine/index.js'
 import type {
@@ -219,16 +219,16 @@ describe('builtin worker 生产装配（PR F 第 2 步）', () => {
 
   async function spawnBuiltin(
     internals: AgentInternals,
-    dialogObjectId: DialogObjectId,
+    managerKey: ManagerKey,
     prompt = '把活干完',
   ): Promise<{ workerId: string; workspace: string }> {
     const harness = internals.managerStack!.harness
     // 关键：**不传 `builtin`** —— manager 的 `spawn_worker` 工具就是这么调 harness 的。
     const worker = await harness.spawnWorker({
-      dialogObjectId,
+      managerKey,
       title: '干活',
       prompt,
-      origin: { spawned_by_session: 'wechat::sess-1', trigger_type: 'message', creator_friend_id: 'friend-f1' },
+      origin: { spawned_by_episode: 'wechat::sess-1', trigger_type: 'message', creator_friend_id: 'friend-f1' },
       report_to: { channel_id: 'wechat' as ModuleId, session_id: 'sess-1' },
       impl: 'builtin',
     })
@@ -244,11 +244,11 @@ describe('builtin worker 生产装配（PR F 第 2 步）', () => {
       FINISH,
     )
 
-    const dialogObjectId = dialogObjectIdForPrivate('friend-f1')
-    const { workspace } = await spawnBuiltin(internals, dialogObjectId)
+    const managerKey = (`test::${'friend-f1'}` as ManagerKey)
+    const { workspace } = await spawnBuiltin(internals, managerKey)
 
     await waitUntil(async () => {
-      const [w] = await internals.managerStack!.harness.listWorkers(dialogObjectId)
+      const [w] = await internals.managerStack!.harness.listWorkers(managerKey)
       return w.task.status === 'completed'
     })
 
@@ -256,7 +256,7 @@ describe('builtin worker 生产装配（PR F 第 2 步）', () => {
     const pwd = (await fs.readFile(join(workspace, 'pwd.txt'), 'utf-8')).trim()
     expect(pwd).toBe(await fs.realpath(workspace))
 
-    const [done] = await internals.managerStack!.harness.listWorkers(dialogObjectId)
+    const [done] = await internals.managerStack!.harness.listWorkers(managerKey)
     expect(done.incarnations[0].ended_reason).toBe('completed')
   })
 
@@ -327,7 +327,7 @@ describe('builtin worker 生产装配（PR F 第 2 步）', () => {
       const builtin = internals.buildBuiltinWorkerRuntime({
         worker_id: 'w-perm',
         workspace: { root: tmpRoot },
-        origin: { spawned_by_session: MANAGER_KEY, trigger_type: 'message', creator_friend_id: 'f-speaker' },
+        origin: { spawned_by_episode: MANAGER_KEY, trigger_type: 'message', creator_friend_id: 'f-speaker' },
         ...(principalPermissions ? { principal_permissions: principalPermissions } : {}),
       })!
       return resolveTools(builtin).map((t) => t.name)
@@ -361,7 +361,7 @@ describe('builtin worker 生产装配（PR F 第 2 步）', () => {
       const builtin = internals.buildBuiltinWorkerRuntime({
         worker_id: 'w-sys',
         workspace: { root: tmpRoot },
-        origin: { spawned_by_session: 'wechat::never-seen' as ManagerKey, trigger_type: 'scheduled' },
+        origin: { spawned_by_episode: 'wechat::never-seen' as ManagerKey, trigger_type: 'scheduled' },
       })!
       const names = resolveTools(builtin).map((t) => t.name)
       // BUILTIN_WORKER_PERMISSIONS 开着 shell/file_io
@@ -375,9 +375,9 @@ describe('builtin worker 生产装配（PR F 第 2 步）', () => {
      * 等这批 worker 事件唤醒的 manager episode 落完盘再收尾——真实 harness 的 `onEvent` 是
      * 生产接线，worker 一进 idle 就会唤醒 manager 写会话状态，和 afterEach 的 rm 抢目录。
      */
-    async function settle(internals: AgentInternals, dialogObjectId: DialogObjectId): Promise<void> {
+    async function settle(internals: AgentInternals, managerKey: ManagerKey): Promise<void> {
       await waitUntil(async () => {
-        const [w] = await internals.managerStack!.harness.listWorkers(dialogObjectId)
+        const [w] = await internals.managerStack!.harness.listWorkers(managerKey)
         return w.incarnations[0].state !== 'running'
       })
       await waitUntil(async () => {
@@ -429,12 +429,12 @@ describe('builtin worker 生产装配（PR F 第 2 步）', () => {
 
       // 2. manager 以 S 的名义派活：真实 `harness.spawnWorker`，档位随 spawn 下传。
       llm.queue.push({ text: '先歇着', stopReason: 'end_turn' })
-      const dialogObjectId = dialogObjectIdForPrivate('f-lowpriv')
+      const managerKey = MANAGER_KEY
       const worker = await internals.managerStack!.harness.spawnWorker({
-        dialogObjectId,
+        managerKey,
         title: '干活',
         prompt: '把活干完',
-        origin: { spawned_by_session: MANAGER_KEY, trigger_type: 'message', creator_friend_id: 'f-lowpriv' },
+        origin: { spawned_by_episode: MANAGER_KEY, trigger_type: 'message', creator_friend_id: 'f-lowpriv' },
         report_to: { channel_id: 'wechat' as ModuleId, session_id: 'sess-perm' },
         impl: 'builtin',
         principal_permissions: sPerms ?? undefined,
@@ -454,7 +454,7 @@ describe('builtin worker 生产装配（PR F 第 2 步）', () => {
       const onResume = internals.buildBuiltinWorkerRuntime(await readSpawnContext(internals, worker.worker_id))!
       expect(resolveTools(onResume).map((t) => t.name)).not.toContain('Bash')
 
-      await settle(internals, dialogObjectId)
+      await settle(internals, managerKey)
     })
 
     it('反方向同样成立：master 派出的 worker 不会因为低权限成员随后发言而被降权', async () => {
@@ -463,12 +463,12 @@ describe('builtin worker 生产装配（PR F 第 2 步）', () => {
 
       const masterPerms = await speak(internals, friendOf('f-master', 'master'))
       llm.queue.push({ text: '先歇着', stopReason: 'end_turn' })
-      const dialogObjectId = dialogObjectIdForPrivate('f-master')
+      const managerKey = MANAGER_KEY
       const worker = await internals.managerStack!.harness.spawnWorker({
-        dialogObjectId,
+        managerKey,
         title: '干活',
         prompt: '把活干完',
-        origin: { spawned_by_session: MANAGER_KEY, trigger_type: 'message', creator_friend_id: 'f-master' },
+        origin: { spawned_by_episode: MANAGER_KEY, trigger_type: 'message', creator_friend_id: 'f-master' },
         report_to: { channel_id: 'wechat' as ModuleId, session_id: 'sess-perm' },
         impl: 'builtin',
         principal_permissions: masterPerms ?? undefined,
@@ -479,7 +479,7 @@ describe('builtin worker 生产装配（PR F 第 2 步）', () => {
       const onResume = internals.buildBuiltinWorkerRuntime(await readSpawnContext(internals, worker.worker_id))!
       expect(resolveTools(onResume).map((t) => t.name)).toContain('Bash')
 
-      await settle(internals, dialogObjectId)
+      await settle(internals, managerKey)
     })
 
     it('权限固定不等于配置也固定：改了 model slot，同一个 worker 下次起化身用新 model，档位仍是 spawn 那一份', async () => {
@@ -488,12 +488,12 @@ describe('builtin worker 生产装配（PR F 第 2 步）', () => {
 
       const sPerms = await speak(internals, friendOf('f-lowpriv', 'normal'))
       llm.queue.push({ text: '先歇着', stopReason: 'end_turn' })
-      const dialogObjectId = dialogObjectIdForPrivate('f-lowpriv-cfg')
+      const managerKey = MANAGER_KEY
       const worker = await internals.managerStack!.harness.spawnWorker({
-        dialogObjectId,
+        managerKey,
         title: '干活',
         prompt: '把活干完',
-        origin: { spawned_by_session: MANAGER_KEY, trigger_type: 'message', creator_friend_id: 'f-lowpriv' },
+        origin: { spawned_by_episode: MANAGER_KEY, trigger_type: 'message', creator_friend_id: 'f-lowpriv' },
         report_to: { channel_id: 'wechat' as ModuleId, session_id: 'sess-perm' },
         impl: 'builtin',
         principal_permissions: sPerms ?? undefined,
@@ -510,7 +510,7 @@ describe('builtin worker 生产装配（PR F 第 2 步）', () => {
       // 权限固定：仍是 spawn 那一刻 S 的档位。
       expect(resolveTools(next).map((t) => t.name)).not.toContain('Bash')
 
-      await settle(internals, dialogObjectId)
+      await settle(internals, managerKey)
     })
   })
 
@@ -528,10 +528,10 @@ describe('builtin worker 生产装配（PR F 第 2 步）', () => {
       FINISH,
     )
 
-    const dialogObjectId = dialogObjectIdForPrivate('friend-hook')
-    const { workerId } = await spawnBuiltin(internals, dialogObjectId)
+    const managerKey = (`test::${'friend-hook'}` as ManagerKey)
+    const { workerId } = await spawnBuiltin(internals, managerKey)
     await waitUntil(async () => {
-      const [w] = await internals.managerStack!.harness.listWorkers(dialogObjectId)
+      const [w] = await internals.managerStack!.harness.listWorkers(managerKey)
       return w.task.status === 'completed'
     })
 
@@ -549,7 +549,7 @@ describe('builtin worker 生产装配（PR F 第 2 步）', () => {
       const builtin = internals.buildBuiltinWorkerRuntime({
         worker_id: 'w-tools',
         workspace: { root: workspaceRoot },
-        origin: { spawned_by_session: 'wechat::s', trigger_type: 'message' },
+        origin: { spawned_by_episode: 'wechat::s', trigger_type: 'message' },
       })!
       return resolveTools(builtin).map((t) => t.name)
     }
@@ -571,7 +571,7 @@ describe('builtin worker 生产装配（PR F 第 2 步）', () => {
       const builtin = internals.buildBuiltinWorkerRuntime({
         worker_id: 'w-bg-owner',
         workspace: { root: tmpRoot },
-        origin: { spawned_by_session: 'wechat::s', trigger_type: 'message' },
+        origin: { spawned_by_episode: 'wechat::s', trigger_type: 'message' },
       })!
       const names = resolveTools(builtin).map((t) => t.name)
       expect(names).toEqual(expect.arrayContaining(['Bash', 'Output', 'Kill', 'ListEntities']))
@@ -587,7 +587,7 @@ describe('builtin worker 生产装配（PR F 第 2 步）', () => {
       internals.agentHandler = undefined
       const runtime = internals.buildBuiltinWorkerRuntime({
         worker_id: 'w-no-handler', workspace: { root: tmpRoot },
-        origin: { spawned_by_session: 'wechat::s', trigger_type: 'message' },
+        origin: { spawned_by_episode: 'wechat::s', trigger_type: 'message' },
       })!
       expect(() => resolveTools(runtime)).toThrow(/AgentHandler is required/)
     })
@@ -643,7 +643,7 @@ describe('builtin worker 生产装配（PR F 第 2 步）', () => {
 
     // 第一个 worker：跑一轮 end_turn 就停在 idle（化身还活着）。
     llm.queue.push({ text: '先歇着', stopReason: 'end_turn' })
-    const objA = dialogObjectIdForPrivate('friend-a')
+    const objA = (`test::${'friend-a'}` as ManagerKey)
     await spawnBuiltin(internals, objA)
     await waitUntil(async () => {
       const [w] = await internals.managerStack!.harness.listWorkers(objA)
@@ -660,7 +660,7 @@ describe('builtin worker 生产装配（PR F 第 2 步）', () => {
 
     // 新起的化身现取到 model-B。
     llm.queue.push(FINISH)
-    const objB = dialogObjectIdForPrivate('friend-b')
+    const objB = (`test::${'friend-b'}` as ManagerKey)
     await spawnBuiltin(internals, objB)
     await waitUntil(async () => {
       const [w] = await internals.managerStack!.harness.listWorkers(objB)
@@ -674,10 +674,10 @@ describe('builtin worker 生产装配（PR F 第 2 步）', () => {
   it('验收 2：换一个 UnifiedAgent 实例（内存态全丢）后，send_to_worker 仍能透明接续已终态的 worker', async () => {
     const { internals: first } = boot()
     llm.queue.push(FINISH)
-    const dialogObjectId = dialogObjectIdForPrivate('friend-revive')
-    const { workerId } = await spawnBuiltin(first, dialogObjectId)
+    const managerKey = (`test::${'friend-revive'}` as ManagerKey)
+    const { workerId } = await spawnBuiltin(first, managerKey)
     await waitUntil(async () => {
-      const [w] = await first.managerStack!.harness.listWorkers(dialogObjectId)
+      const [w] = await first.managerStack!.harness.listWorkers(managerKey)
       return w.task.status === 'completed'
     })
 
@@ -686,12 +686,12 @@ describe('builtin worker 生产装配（PR F 第 2 步）', () => {
     llm.queue.push(FINISH)
     await restarted.managerStack!.harness.sendToWorker(workerId, '接着干')
 
-    const [revived] = await restarted.managerStack!.harness.listWorkers(dialogObjectId)
+    const [revived] = await restarted.managerStack!.harness.listWorkers(managerKey)
     // 新化身由重启后那套栈的注入工厂现取配置拉起来（seq=2），任务被接续。
     expect(revived.incarnations).toHaveLength(2)
     expect(revived.incarnations[1].seq).toBe(2)
     await waitUntil(async () => {
-      const [w] = await restarted.managerStack!.harness.listWorkers(dialogObjectId)
+      const [w] = await restarted.managerStack!.harness.listWorkers(managerKey)
       return w.incarnations[1].state === 'exited'
     })
   })
@@ -736,11 +736,11 @@ describe('builtin worker 生产装配（PR F 第 2 步）', () => {
 
   it('model_config 缺 powerful slot → 工厂抛错，spawn 如实落成一次失败尝试（不静默降级）', async () => {
     const { internals } = boot(makeConfig({ modelConfig: {} }))
-    const dialogObjectId = dialogObjectIdForPrivate('friend-noconf')
+    const managerKey = (`test::${'friend-noconf'}` as ManagerKey)
 
-    await expect(spawnBuiltin(internals, dialogObjectId)).rejects.toThrow(/powerful/)
+    await expect(spawnBuiltin(internals, managerKey)).rejects.toThrow(/powerful/)
 
-    const [w] = await internals.managerStack!.harness.listWorkers(dialogObjectId)
+    const [w] = await internals.managerStack!.harness.listWorkers(managerKey)
     expect(w.task.status).toBe('failed')
     expect(w.incarnations[0].ended_reason).toBe('failed')
   })

--- a/crabot-agent/tests/workers/harness/harness-continuation.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-continuation.test.ts
@@ -182,7 +182,7 @@ function now(): string {
 }
 
 async function makeHarness(
-  depsOverrides: Partial<Pick<HarnessDeps, 'capabilityBundle' | 'builtinSpawnDefaults'>> = {},
+  depsOverrides: Partial<Pick<HarnessDeps, 'capabilityBundle' | 'builtinSpawnDefaults' | 'validateLegacyContinuationAuth'>> = {},
 ): Promise<{
   harness: WorkerHarness
   ledger: LedgerStore
@@ -2149,19 +2149,41 @@ describe('HarnessEvent.task_status —— 透明接续的迁移点', () => {
 
 describe('legacy incarnation guardrails', () => {
   const managerKey = 'test::legacy-session' as ManagerKey
+  const permissions = {
+    tool_access: { memory: false, messaging: false, task: false, mcp_skill: false, file_io: false, browser: false, shell: false, remote_exec: false, desktop: false },
+    cli_access: { provider: 'none', agent: 'none', mcp: 'none', skill: 'none', schedule: 'none', channel: 'none', friend: 'none', permission: 'none', config: 'none', undo: 'none' },
+    storage: null,
+    memory_scopes: ['legacy'],
+  } as const
 
-  async function addLegacy(ledger: LedgerStore, workerId: string): Promise<void> {
+  function continuationAuth() {
+    return {
+      manager_key: managerKey,
+      principal_kind: 'friend' as const,
+      principal_generation: 1,
+      principal_permissions: permissions,
+    }
+  }
+
+  async function addLegacy(
+    ledger: LedgerStore,
+    workerId: string,
+    overrides: { status?: LedgerWorker['task']['status']; endedReason?: 'completed' | 'failed' | 'pre_migration' | 'killed' } = {},
+  ): Promise<void> {
     const at = now()
-    await ledger.upsertWorker(managerKey, workerId, () => ({
+    await fs.mkdir(join(dataDir, 'workspace'), { recursive: true })
+    await fs.mkdir(join(dataDir, 'workers', workerId), { recursive: true })
+    await fs.writeFile(join(dataDir, 'workers', workerId, 'legacy-task.json'), JSON.stringify({ id: 'old-task' }))
+    await ledger.importLegacyWorker(managerKey, {
       worker_id: workerId,
       manager_key: managerKey,
-      task: { id: workerId, title: 'legacy', status: 'completed', created_at: at },
+      task: { id: workerId, title: 'legacy', status: overrides.status ?? 'completed', created_at: at },
       origin: { trigger_type: 'system' },
       report_to: { channel_id: 'test', session_id: 'legacy-session' },
-      incarnations: [{ seq: 1, impl: 'legacy', state: 'exited', workspace: join(dataDir, 'workspace'), started_at: at, ended_at: at, ended_reason: 'completed' }],
+      incarnations: [{ seq: 1, impl: 'legacy', state: 'exited', workspace: join(dataDir, 'workspace'), started_at: at, ended_at: at, ended_reason: overrides.endedReason ?? 'completed' }],
       legacy_source: { kind: 'v2_admin_task', admin_task_id: 'old-task', trace_ids: [], imported_at: at },
       updated_at: at,
-    } satisfies LedgerWorker))
+    } satisfies LedgerWorker)
   }
 
   it('readWorkerOutput returns an unavailable empty chunk without adapter lookup', async () => {
@@ -2171,11 +2193,159 @@ describe('legacy incarnation guardrails', () => {
     expect(adaptersMap.size).toBe(0)
   })
 
-  it('sendToWorker rejects a legacy source before adapter lookup', async () => {
+  it('sendToWorker dead-letters a legacy item without auth before adapter lookup', async () => {
+    const settled: string[] = []
     const { harness, ledger, adaptersMap } = await makeHarness()
     await addLegacy(ledger, 'w-legacy-send')
-    await expect(harness.sendToWorker('w-legacy-send', 'continue')).rejects.toThrow(/legacy worker continuation is not available/)
+    await expect(harness.sendToWorker('w-legacy-send', 'continue', {
+      onSettled: (result) => { settled.push(result) },
+    })).resolves.toBeUndefined()
+    expect(settled).toEqual(['dead_letter'])
+    expect(events).toContainEqual(expect.objectContaining({
+      kind: 'state_changed',
+      detail: expect.objectContaining({ reason: 'legacy_continuation_authorization_invalid' }),
+    }))
     expect(adaptersMap.size).toBe(0)
+  })
+
+  it('malformed auth is dead-lettered before target preflight or context writes', async () => {
+    const { harness, ledger, adaptersMap, workersDir } = await makeHarness({
+      validateLegacyContinuationAuth: async () => true,
+    })
+    await addLegacy(ledger, 'w-legacy-malformed-auth')
+    const target = new FakeAdapter({ implId: 'builtin' })
+    adaptersMap.set('builtin', target)
+
+    await harness.sendToWorker('w-legacy-malformed-auth', 'continue', {
+      legacyContinuationAuth: {
+        ...continuationAuth(),
+        principal_permissions: {},
+      } as never,
+    })
+
+    expect(target.preflightProvisionCalls).toHaveLength(0)
+    expect(target.provisionCalls).toHaveLength(0)
+    expect(target.spawnCalls).toHaveLength(0)
+    await expect(fs.stat(join(workersDir, 'w-legacy-malformed-auth', 'context.json')))
+      .rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('legacy continuation validates auth before side effects, then spawns a fresh v3 incarnation without legacy adapter access', async () => {
+    const { harness, ledger, adaptersMap, workersDir } = await makeHarness({
+      validateLegacyContinuationAuth: async () => true,
+    })
+    await addLegacy(ledger, 'w-legacy-success')
+    await fs.mkdir(join(workersDir, 'w-legacy-success'), { recursive: true })
+    await fs.writeFile(join(workersDir, 'w-legacy-success', 'legacy-task.json'), JSON.stringify({ id: 'old-task' }))
+    const target = new FakeAdapter({ implId: 'builtin', onStateChange: harness.handleStateChange })
+    adaptersMap.set('builtin', target)
+    const adapterGet = vi.spyOn(adaptersMap, 'get')
+
+    await harness.sendToWorker('w-legacy-success', 'continue', {
+      legacyContinuationAuth: continuationAuth(),
+    })
+
+    const worker = (await ledger.findWorker('w-legacy-success'))!.worker
+    expect(worker.task.status).toBe('running')
+    expect(worker.incarnations).toHaveLength(2)
+    expect(worker.incarnations[1]).toMatchObject({ impl: 'builtin', state: 'running' })
+    expect(target.preflightProvisionCalls).toHaveLength(1)
+    expect(target.provisionCalls).toHaveLength(1)
+    expect(target.spawnCalls).toHaveLength(1)
+    expect(target.killCalls).toHaveLength(0)
+    expect(target.resumeCalls).toHaveLength(0)
+    expect(adapterGet.mock.calls.some(([impl]) => String(impl) === 'legacy')).toBe(false)
+    expect(JSON.parse(await fs.readFile(join(workersDir, 'w-legacy-success', 'context.json'), 'utf8'))).toEqual({
+      principal_permissions: permissions,
+    })
+    const handoff = await fs.readFile(join(dataDir, 'workspace', 'HANDOFF.md'), 'utf8')
+    expect(handoff).toContain('old-task')
+    expect(handoff).not.toContain('resume_checkpoint')
+    expect(events.some((event) => event.kind === 'handoff_started')).toBe(true)
+  })
+
+  it('invalid auth settles and does not block a later valid continuation', async () => {
+    let authorized = false
+    const { harness, ledger, adaptersMap } = await makeHarness({
+      validateLegacyContinuationAuth: async () => authorized,
+    })
+    await addLegacy(ledger, 'w-legacy-auth-retry')
+    const target = new FakeAdapter({ implId: 'builtin' })
+    adaptersMap.set('builtin', target)
+
+    await harness.sendToWorker('w-legacy-auth-retry', 'invalid', {
+      legacyContinuationAuth: continuationAuth(),
+    })
+    expect(target.preflightProvisionCalls).toHaveLength(0)
+
+    authorized = true
+    await harness.sendToWorker('w-legacy-auth-retry', 'valid', {
+      legacyContinuationAuth: continuationAuth(),
+    })
+    expect(target.spawnCalls).toHaveLength(1)
+    expect(target.spawnCalls[0].prompt).toContain('valid')
+    expect(target.spawnCalls[0].prompt).not.toContain('invalid')
+  })
+
+  it('failed and pre-migration legacy workers are eligible for the same fresh-v3 path', async () => {
+    const { harness, ledger, adaptersMap } = await makeHarness({
+      validateLegacyContinuationAuth: async () => true,
+    })
+    const target = new FakeAdapter({ implId: 'builtin' })
+    adaptersMap.set('builtin', target)
+    await addLegacy(ledger, 'w-legacy-failed', { status: 'failed', endedReason: 'failed' })
+    await addLegacy(ledger, 'w-legacy-pre-migration', { status: 'failed', endedReason: 'pre_migration' })
+
+    await harness.sendToWorker('w-legacy-failed', 'continue failed', {
+      legacyContinuationAuth: continuationAuth(),
+    })
+    await harness.sendToWorker('w-legacy-pre-migration', 'continue migration', {
+      legacyContinuationAuth: continuationAuth(),
+    })
+
+    expect((await ledger.findWorker('w-legacy-failed'))?.worker.task.status).toBe('running')
+    expect((await ledger.findWorker('w-legacy-pre-migration'))?.worker.task.status).toBe('running')
+    expect(target.spawnCalls).toHaveLength(2)
+  })
+
+  it('cancelled legacy workers are rejected before target preflight', async () => {
+    const { harness, ledger, adaptersMap } = await makeHarness({
+      validateLegacyContinuationAuth: async () => true,
+    })
+    await addLegacy(ledger, 'w-legacy-cancelled', { status: 'cancelled', endedReason: 'killed' })
+    const target = new FakeAdapter({ implId: 'builtin' })
+    adaptersMap.set('builtin', target)
+
+    await expect(harness.sendToWorker('w-legacy-cancelled', 'continue', {
+      legacyContinuationAuth: continuationAuth(),
+    })).rejects.toBeInstanceOf(TaskCancelledError)
+    expect(target.preflightProvisionCalls).toHaveLength(0)
+    expect(target.provisionCalls).toHaveLength(0)
+    expect(target.spawnCalls).toHaveLength(0)
+  })
+
+  it('preflight failure leaves context, HANDOFF and ledger untouched', async () => {
+    const { harness, ledger, adaptersMap, workersDir } = await makeHarness({
+      validateLegacyContinuationAuth: async () => true,
+    })
+    await addLegacy(ledger, 'w-legacy-preflight')
+    const target = new FakeAdapter({
+      implId: 'builtin',
+      preflightProvisionBehavior: () => { throw new Error('preflight denied') },
+    })
+    adaptersMap.set('builtin', target)
+
+    await expect(harness.sendToWorker('w-legacy-preflight', 'continue', {
+      legacyContinuationAuth: continuationAuth(),
+    })).rejects.toThrow('preflight denied')
+
+    expect(target.provisionCalls).toHaveLength(0)
+    expect(target.spawnCalls).toHaveLength(0)
+    await expect(fs.stat(join(workersDir, 'w-legacy-preflight', 'context.json'))).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(fs.stat(join(dataDir, 'workspace', 'HANDOFF.md'))).rejects.toMatchObject({ code: 'ENOENT' })
+    const worker = (await ledger.findWorker('w-legacy-preflight'))!.worker
+    expect(worker.task.status).toBe('completed')
+    expect(worker.incarnations).toHaveLength(1)
   })
 
   it('startup reconciliation leaves terminal legacy workers unchanged without adapter lookup', async () => {

--- a/crabot-agent/tests/workers/harness/harness-continuation.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-continuation.test.ts
@@ -12,7 +12,7 @@ import {
 } from '../../../src/workers/harness/harness'
 import { LedgerStore } from '../../../src/workers/harness/ledger-store'
 import { WorkspaceManager } from '../../../src/workers/harness/workspace-manager'
-import { dialogObjectIdForPrivate } from '../../../src/workers/harness/ledger-types'
+import type { LedgerWorker, ManagerKey } from '../../../src/workers/harness/ledger-types'
 import type { HarnessEvent } from '../../../src/workers/harness/worker-events'
 import { CliInputStallError, WorkerExitedError } from '../../../src/workers/errors'
 import { BuiltinWorkerAdapter } from '../../../src/workers/builtin/adapter'
@@ -220,11 +220,11 @@ async function makeHarness(
 
 function spawnParams(overrides: Partial<SpawnWorkerParams> = {}): SpawnWorkerParams {
   return {
-    dialogObjectId: dialogObjectIdForPrivate('friend-1'),
+    managerKey: (`test::${'friend-1'}` as ManagerKey),
     title: '测试任务',
     goal: '把活干完',
     prompt: '把活干完',
-    origin: { spawned_by_session: 'wechat::sess-1', trigger_type: 'message' },
+    origin: { spawned_by_episode: 'wechat::sess-1', trigger_type: 'message' },
     report_to: { channel_id: 'wechat', session_id: 'sess-1' },
     ...overrides,
   }
@@ -261,7 +261,7 @@ describe('WorkerHarness — 透明接续：revive (capabilities().revive === tru
     // 化身自然结束（非 kill）→ processStateChange 把台账主线化身落 exited(completed)。
     fake.emitStateChange(mainlineHandle, 'exited')
     await waitUntil(async () => {
-      const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+      const [w] = await harness.listWorkers((`test::${'friend-1'}` as ManagerKey))
       return w.incarnations[0].state === 'exited'
     })
     events.length = 0
@@ -276,7 +276,7 @@ describe('WorkerHarness — 透明接续：revive (capabilities().revive === tru
     expect(fake.resumeCalls[0].prev).toEqual({ worker_id: worker.worker_id, seq: 1, session_ref: mainlineHandle.session_ref })
     expect(fake.resumeCalls[0].wakeInput).toBe('还有件事要办')
 
-    const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [w] = await harness.listWorkers((`test::${'friend-1'}` as ManagerKey))
     expect(w.incarnations).toHaveLength(2)
     expect(w.incarnations[1].forked_from).toBeUndefined() // 入主线链，不是侧问分支
     expect(w.incarnations[1].state).toBe('running')
@@ -309,10 +309,10 @@ describe('WorkerHarness — 透明接续：revive (capabilities().revive === tru
     const worker = await harness.spawnWorker(spawnParams())
     const h: IncarnationHandle = { worker_id: worker.worker_id, seq: 1, impl: 'builtin', session_ref: `ref-${worker.worker_id}#1` }
     fake.emitStateChange(h, 'exited')
-    await waitUntil(async () => (await harness.listWorkers(dialogObjectIdForPrivate('friend-1')))[0].task.status === 'completed')
+    await waitUntil(async () => (await harness.listWorkers((`test::${'friend-1'}` as ManagerKey)))[0].task.status === 'completed')
 
     await harness.sendToWorker(worker.worker_id, 'continue')
-    const [settled] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [settled] = await harness.listWorkers((`test::${'friend-1'}` as ManagerKey))
     expect(settled.task.status).toBe('completed')
     expect(settled.incarnations[1]).toMatchObject({ state: 'exited', ended_reason: 'completed' })
   })
@@ -337,7 +337,7 @@ describe('WorkerHarness — 透明接续：revive (capabilities().revive === tru
     adaptersMap.set('builtin', fake)
     const worker = await harness.spawnWorker(spawnParams())
     fake.emitStateChange({ worker_id: worker.worker_id, seq: 1, impl: 'builtin', session_ref: `ref-${worker.worker_id}#1` }, 'exited')
-    await waitUntil(async () => (await harness.listWorkers(dialogObjectIdForPrivate('friend-1')))[0].task.status === 'completed')
+    await waitUntil(async () => (await harness.listWorkers((`test::${'friend-1'}` as ManagerKey)))[0].task.status === 'completed')
     const settlements: string[] = []
 
     await harness.sendToWorker(worker.worker_id, 'durable bg', {
@@ -383,7 +383,7 @@ describe('WorkerHarness — 透明接续：revive (capabilities().revive === tru
     adaptersMap.set('builtin', fake)
     const worker = await harness.spawnWorker(spawnParams())
     fake.emitStateChange({ worker_id: worker.worker_id, seq: 1, impl: 'builtin', session_ref: `ref-${worker.worker_id}#1` }, 'exited')
-    await waitUntil(async () => (await harness.listWorkers(dialogObjectIdForPrivate('friend-1')))[0].task.status === 'completed')
+    await waitUntil(async () => (await harness.listWorkers((`test::${'friend-1'}` as ManagerKey)))[0].task.status === 'completed')
     const settlements: string[] = []
 
     await harness.sendToWorker(worker.worker_id, 'durable terminal retry', {
@@ -393,7 +393,7 @@ describe('WorkerHarness — 透明接续：revive (capabilities().revive === tru
 
     expect(fake.resumeCalls).toHaveLength(2)
     expect(settlements).toEqual(['delivered'])
-    const [settled] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [settled] = await harness.listWorkers((`test::${'friend-1'}` as ManagerKey))
     expect(settled.incarnations[settled.incarnations.length - 1]).toMatchObject({
       seq: 3,
       state: 'running',
@@ -420,7 +420,7 @@ describe('WorkerHarness — 透明接续：revive (capabilities().revive === tru
     adaptersMap.set('builtin', fake)
     const worker = await harness.spawnWorker(spawnParams())
     fake.emitStateChange({ worker_id: worker.worker_id, seq: 1, impl: 'builtin', session_ref: `ref-${worker.worker_id}#1` }, 'exited')
-    await waitUntil(async () => (await harness.listWorkers(dialogObjectIdForPrivate('friend-1')))[0].task.status === 'completed')
+    await waitUntil(async () => (await harness.listWorkers((`test::${'friend-1'}` as ManagerKey)))[0].task.status === 'completed')
     const settlements: string[] = []
 
     await harness.sendToWorker(worker.worker_id, 'durable bg', {
@@ -470,14 +470,14 @@ describe('WorkerHarness — 透明接续：revive (capabilities().revive === tru
     // 没有触发过任何 fake.emitStateChange —— 台账里 incarnations[0].state 此刻仍是
     // 'running'（spawnWorker 落定后就是 running），模拟"adapter 内部已经退出，但迟到的
     // 状态回调还没追上"的竞态：这正是评审 PoC 复现的场景。
-    const before = (await harness.listWorkers(dialogObjectIdForPrivate('friend-1')))[0]
+    const before = (await harness.listWorkers((`test::${'friend-1'}` as ManagerKey)))[0]
     expect(before.incarnations[0].state).toBe('running')
     expect(before.incarnations[0].ended_at).toBeUndefined()
     events.length = 0
 
     await expect(harness.sendToWorker(worker.worker_id, '继续')).resolves.toBeUndefined()
 
-    const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [w] = await harness.listWorkers((`test::${'friend-1'}` as ManagerKey))
     expect(w.incarnations).toHaveLength(2)
     // 修复点：旧化身（seq=1）不再永久卡在 running —— revive 之前已经被回填了终态。
     const oldEntry = w.incarnations[0]
@@ -501,7 +501,7 @@ describe('WorkerHarness — 透明接续：revive (capabilities().revive === tru
     }
     fake.emitStateChange(staleHandle, 'exited')
     await new Promise((resolve) => setTimeout(resolve, 20))
-    const [w2] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [w2] = await harness.listWorkers((`test::${'friend-1'}` as ManagerKey))
     expect(w2.incarnations[0].ended_reason).toBe('completed')
   })
 
@@ -523,12 +523,12 @@ describe('WorkerHarness — 透明接续：revive (capabilities().revive === tru
     const worker = await harness.spawnWorker(spawnParams())
     // 同上一条：台账主线此刻仍是 running（迟到的状态回调没追上），所以 revive 的回填段
     // 会真正触发——这正是原来把失败记成成功的那一处。
-    const before = (await harness.listWorkers(dialogObjectIdForPrivate('friend-1')))[0]
+    const before = (await harness.listWorkers((`test::${'friend-1'}` as ManagerKey)))[0]
     expect(before.incarnations[0].state).toBe('running')
 
     await expect(harness.sendToWorker(worker.worker_id, '继续')).resolves.toBeUndefined()
 
-    const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [w] = await harness.listWorkers((`test::${'friend-1'}` as ManagerKey))
     expect(w.incarnations).toHaveLength(2)
     expect(w.incarnations[0].state).toBe('exited')
     expect(w.incarnations[0].ended_reason).toBe('failed')
@@ -548,13 +548,13 @@ describe('WorkerHarness — 透明接续：revive (capabilities().revive === tru
     const h: IncarnationHandle = { worker_id: worker.worker_id, seq: 1, impl: 'builtin', session_ref: `ref-${worker.worker_id}#1` }
     fake.emitStateChange(h, 'exited', 'failed')
     await waitUntil(async () => {
-      const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+      const [w] = await harness.listWorkers((`test::${'friend-1'}` as ManagerKey))
       return w.task.status === 'failed'
     })
 
     await expect(harness.sendToWorker(worker.worker_id, '再试一次')).resolves.toBeUndefined()
 
-    const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [w] = await harness.listWorkers((`test::${'friend-1'}` as ManagerKey))
     expect(w.incarnations).toHaveLength(2)
     expect(w.incarnations[0].ended_reason).toBe('failed') // 没被洗成 completed
     expect(fake.resumeCalls).toHaveLength(1)
@@ -607,7 +607,7 @@ describe('WorkerHarness — 透明接续：handoff (capabilities().revive === fa
     // exited(superseded)。
     expect(fake.killCalls).toHaveLength(1)
     expect(fake.killCalls[0].seq).toBe(1)
-    const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [w] = await harness.listWorkers((`test::${'friend-1'}` as ManagerKey))
     const oldEntry = w.incarnations.find((i) => i.seq === 1)!
     expect(oldEntry.state).toBe('exited')
     expect(oldEntry.ended_reason).toBe('superseded')
@@ -653,7 +653,7 @@ describe('WorkerHarness — 透明接续：handoff (capabilities().revive === fa
     const worker = await harness.spawnWorker(spawnParams())
 
     await harness.sendToWorker(worker.worker_id, 'continue')
-    const [settled] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [settled] = await harness.listWorkers((`test::${'friend-1'}` as ManagerKey))
     expect(settled.task.status).toBe('completed')
     expect(settled.incarnations[settled.incarnations.length - 1]).toMatchObject({
       impl: 'claude-code',
@@ -723,7 +723,7 @@ describe('WorkerHarness — 透明接续：handoff (capabilities().revive === fa
     const h: IncarnationHandle = { worker_id: worker.worker_id, seq: 1, impl: 'builtin', session_ref: `ref-${worker.worker_id}#1` }
     fake.emitStateChange(h, 'exited', 'failed')
     await waitUntil(async () => {
-      const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+      const [w] = await harness.listWorkers((`test::${'friend-1'}` as ManagerKey))
       return w.task.status === 'failed'
     })
 
@@ -798,7 +798,7 @@ describe('WorkerHarness.handoffIncarnation — fixed capability snapshot', () =>
     adaptersMap.set('claude-code', source)
     adaptersMap.set('codex', target)
     const worker = await harness.spawnWorker(spawnParams({ impl: 'claude-code' }))
-    const workspace = (await harness.listWorkers(dialogObjectIdForPrivate('friend-1')))[0].incarnations[0].workspace
+    const workspace = (await harness.listWorkers((`test::${'friend-1'}` as ManagerKey)))[0].incarnations[0].workspace
     await fs.writeFile(join(workersDir, worker.worker_id, 'context.json'), '{')
 
     await expect(harness.switchWorkerImpl(worker.worker_id, 'codex', 'must not mutate')).rejects.toThrow(/invalid JSON/)
@@ -819,7 +819,7 @@ describe('WorkerHarness.handoffIncarnation — fixed capability snapshot', () =>
     adaptersMap.set('claude-code', source)
     adaptersMap.set('codex', target)
     const worker = await harness.spawnWorker(spawnParams({ impl: 'claude-code' }))
-    const workspace = (await harness.listWorkers(dialogObjectIdForPrivate('friend-1')))[0].incarnations[0].workspace
+    const workspace = (await harness.listWorkers((`test::${'friend-1'}` as ManagerKey)))[0].incarnations[0].workspace
     events.length = 0
 
     await expect(harness.switchWorkerImpl(worker.worker_id, 'codex', 'must not break source')).rejects.toThrow(/tracked credential target/)
@@ -829,7 +829,7 @@ describe('WorkerHarness.handoffIncarnation — fixed capability snapshot', () =>
     expect(target.spawnCalls).toEqual([])
     expect(source.killCalls).toEqual([])
     await expect(fs.access(join(workspace, 'HANDOFF.md'))).rejects.toMatchObject({ code: 'ENOENT' })
-    const [current] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [current] = await harness.listWorkers((`test::${'friend-1'}` as ManagerKey))
     expect(current.incarnations).toHaveLength(1)
     expect(current.incarnations[0].state).toBe('running')
     expect(events.filter((event) => event.kind === 'handoff_started' || event.kind === 'superseded')).toEqual([])
@@ -858,7 +858,7 @@ describe('WorkerHarness.switchWorkerImpl — 跨实现切换', () => {
     expect(source.spawnCalls).toHaveLength(1)
     expect(target.spawnCalls[0].prompt).toContain('手工切换到 codex')
 
-    const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [w] = await harness.listWorkers((`test::${'friend-1'}` as ManagerKey))
     const oldEntry = w.incarnations.find((i) => i.seq === 1)!
     expect(oldEntry.ended_reason).toBe('superseded')
     const newEntry = w.incarnations[w.incarnations.length - 1]
@@ -964,7 +964,7 @@ describe('WorkerHarness — 接续过程中的并发', () => {
     const mainlineHandle: IncarnationHandle = { worker_id: worker.worker_id, seq: 1, impl: 'builtin', session_ref: `ref-${worker.worker_id}#1` }
     fake.emitStateChange(mainlineHandle, 'exited')
     await waitUntil(async () => {
-      const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+      const [w] = await harness.listWorkers((`test::${'friend-1'}` as ManagerKey))
       return w.incarnations[0].state === 'exited'
     })
 
@@ -989,7 +989,7 @@ describe('WorkerHarness — 接续过程中的并发', () => {
 
     expect(secondResolved).toBe(true)
     // 接续完成后台账只多了一个新主线化身（不是两个并发接续各自产出一个）。
-    const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [w] = await harness.listWorkers((`test::${'friend-1'}` as ManagerKey))
     expect(w.incarnations).toHaveLength(2)
     expect(fake.resumeCalls).toHaveLength(1)
     // 第二条消息通过"mainline.seq !== sourceSeq"分支，作为普通投递补送到了新主线。
@@ -1042,7 +1042,7 @@ describe('WorkerHarness.handoffIncarnation — handoff 目标是 builtin 时的 
     // 新的没建成"的死结里。
     expect(source.killCalls).toHaveLength(0)
     expect(builtinTarget.spawnCalls).toHaveLength(0)
-    const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [w] = await harness.listWorkers((`test::${'friend-1'}` as ManagerKey))
     expect(w.incarnations).toHaveLength(1)
     expect(w.incarnations[0].state).toBe('running') // 源化身原样存活，未被标 superseded
     expect(w.incarnations[0].ended_reason).toBeUndefined()
@@ -1109,7 +1109,7 @@ describe('WorkerHarness.handoffIncarnation — handoff 目标是 builtin 时的 
     expect(factoryCtxs[0].workspace.root).toBe(worker.incarnations[0].workspace)
     expect(factoryCtxs[0].origin).toEqual(worker.origin)
 
-    const [w] = await ledger.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [w] = await ledger.listWorkers((`test::${'friend-1'}` as ManagerKey))
     const newEntry = w.incarnations[w.incarnations.length - 1]
     expect(newEntry.impl).toBe('builtin')
     expect(newEntry.state).toBe('running')
@@ -1144,7 +1144,7 @@ describe('WorkerHarness — 化身 seq 跨实例撞号（protocol-agent-v3 §6.1
     // 前会先把旧化身回填终态（Task 8 修复 1），resume 产出的新化身同样是 seq=1（撞号）。
     await harness.sendToWorker(worker.worker_id, '继续')
 
-    const [afterRevive] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [afterRevive] = await harness.listWorkers((`test::${'friend-1'}` as ManagerKey))
     expect(afterRevive.incarnations).toHaveLength(2)
     const archived = afterRevive.incarnations[0]
     const active = afterRevive.incarnations[1]
@@ -1167,11 +1167,11 @@ describe('WorkerHarness — 化身 seq 跨实例撞号（protocol-agent-v3 §6.1
     }
     fake.emitStateChange(activeHandle, 'exited')
     await waitUntil(async () => {
-      const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+      const [w] = await harness.listWorkers((`test::${'friend-1'}` as ManagerKey))
       return w.incarnations[1].state === 'exited'
     })
 
-    const [afterStateChange] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [afterStateChange] = await harness.listWorkers((`test::${'friend-1'}` as ManagerKey))
     const archivedAfter = afterStateChange.incarnations[0]
     const activeAfter = afterStateChange.incarnations[1]
 
@@ -1225,10 +1225,10 @@ describe('BuiltinWorkerAdapter → WorkerHarness — session_ref 时效性修复
     expect(spawnTimeSessionRef).toBeTruthy()
 
     await waitUntil(async () => {
-      const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+      const [w] = await harness.listWorkers((`test::${'friend-1'}` as ManagerKey))
       return w.incarnations[0].state === 'idle'
     })
-    const [afterFirstBurst] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [afterFirstBurst] = await harness.listWorkers((`test::${'friend-1'}` as ManagerKey))
     // 第一轮 burst 结束后，台账的 session_ref 已经从 spawn 时的根节点前进到新 tip——
     // 不再是创建时刻的快照，而是"最近一次完成的状态转换点"。
     expect(afterFirstBurst.incarnations[0].session_ref).not.toBe(spawnTimeSessionRef)
@@ -1236,11 +1236,11 @@ describe('BuiltinWorkerAdapter → WorkerHarness — session_ref 时效性修复
 
     await harness.sendToWorker(worker.worker_id, '第二轮输入')
     await waitUntil(async () => {
-      const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+      const [w] = await harness.listWorkers((`test::${'friend-1'}` as ManagerKey))
       return w.incarnations[0].state === 'idle' && w.incarnations[0].session_ref !== afterFirstBurstRef
     })
 
-    const [afterSecondBurst] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [afterSecondBurst] = await harness.listWorkers((`test::${'friend-1'}` as ManagerKey))
     expect(afterSecondBurst.incarnations[0].session_ref).not.toBe(afterFirstBurstRef)
     expect(afterSecondBurst.incarnations[0].session_ref).not.toBe(spawnTimeSessionRef)
   })
@@ -1255,7 +1255,7 @@ describe('WorkerHarness.processStateChange — 化身查找: 同 (impl, seq) 撞
     // 1. spawn 初始化身
     const worker = await harness.spawnWorker(spawnParams())
     const workerId = worker.worker_id
-    const dialogId = dialogObjectIdForPrivate('friend-1')
+    const dialogId = (`test::${'friend-1'}` as ManagerKey)
 
     // 2. 让初始化身进入 exited 状态（旧的已归档化身）
     const handle: IncarnationHandle = { worker_id: workerId, seq: 1, impl: 'builtin', session_ref: worker.incarnations[0].session_ref }
@@ -1333,7 +1333,7 @@ describe('WorkerHarness.processStateChange — 化身查找: 同 (impl, seq) 撞
     // 1. spawn 主线化身 seq=1
     const worker = await harness.spawnWorker(spawnParams())
     const workerId = worker.worker_id
-    const dialogId = dialogObjectIdForPrivate('friend-1')
+    const dialogId = (`test::${'friend-1'}` as ManagerKey)
     const mainlineHandle: IncarnationHandle = {
       worker_id: workerId,
       seq: 1,
@@ -1430,7 +1430,7 @@ describe('WorkerHarness — 终审 PoC 回归：M1 主线守卫按 (impl,seq) �
 
     // handoff 后新主线是 codex#1 —— target 是全新 FakeAdapter 实例，nextSeq 从 1 开始，
     // 与被 kill 的旧化身 claude-code#1 在 seq 上撞号，这正是终审 PoC 复现的前提。
-    const afterHandoff = (await harness.listWorkers(dialogObjectIdForPrivate('friend-1')))[0]
+    const afterHandoff = (await harness.listWorkers((`test::${'friend-1'}` as ManagerKey)))[0]
     const newMainline = afterHandoff.incarnations[afterHandoff.incarnations.length - 1]
     expect(newMainline.impl).toBe('codex')
     expect(newMainline.seq).toBe(1)
@@ -1444,7 +1444,7 @@ describe('WorkerHarness — 终审 PoC 回归：M1 主线守卫按 (impl,seq) �
     source.emitStateChange(oldHandle, 'exited')
     await new Promise((resolve) => setTimeout(resolve, 20))
 
-    const after = (await harness.listWorkers(dialogObjectIdForPrivate('friend-1')))[0]
+    const after = (await harness.listWorkers((`test::${'friend-1'}` as ManagerKey)))[0]
     // 新主线（codex#1）未被这条属于旧实现的迟到回调误杀。
     expect(after.task.status).toBe('running')
     const stillMainline = after.incarnations[after.incarnations.length - 1]
@@ -1490,7 +1490,7 @@ describe('WorkerHarness — 终审 PoC 回归：M2 kill 与 in-flight flush 竞�
     // kill 走 harness 自己的 per-worker 锁，不被卡住的 sendInput 阻塞，立即完成。
     await harness.killWorker(worker.worker_id, 'M2 PoC')
 
-    const afterKill = (await harness.listWorkers(dialogObjectIdForPrivate('friend-1')))[0]
+    const afterKill = (await harness.listWorkers((`test::${'friend-1'}` as ManagerKey)))[0]
     expect(afterKill.task.status).toBe('cancelled')
 
     // 放行第一条，让它的 sendInput 正常返回，flush 的 while 循环继续处理队列里的第二条。
@@ -1498,7 +1498,7 @@ describe('WorkerHarness — 终审 PoC 回归：M2 kill 与 in-flight flush 竞�
     await firstSend
     await secondSend
 
-    const after = (await harness.listWorkers(dialogObjectIdForPrivate('friend-1')))[0]
+    const after = (await harness.listWorkers((`test::${'friend-1'}` as ManagerKey)))[0]
     // 核心断言：task 没有被第二条残留消息的透明接续复活成 running。
     expect(after.task.status).toBe('cancelled')
     expect(fake.resumeCalls).toHaveLength(0)
@@ -1531,7 +1531,7 @@ describe('WorkerHarness — 终审 PoC 回归：M2 kill 与 in-flight flush 竞�
     expect(fake.sendInputCalls).toHaveLength(1) // 确认已经卡在 sendInput 里面，是 in-flight 条目
 
     await harness.killWorker(worker.worker_id, 'M2 PoC 2')
-    const afterKill = (await harness.listWorkers(dialogObjectIdForPrivate('friend-1')))[0]
+    const afterKill = (await harness.listWorkers((`test::${'friend-1'}` as ManagerKey)))[0]
     expect(afterKill.task.status).toBe('cancelled')
 
     // 放行卡住的 sendInput，让它抛出 WorkerExitedError（模拟 adapter 发现化身已经真的没了）
@@ -1541,7 +1541,7 @@ describe('WorkerHarness — 终审 PoC 回归：M2 kill 与 in-flight flush 竞�
     releaseGate(new WorkerExitedError(worker.worker_id, 1))
     await send
 
-    const after = (await harness.listWorkers(dialogObjectIdForPrivate('friend-1')))[0]
+    const after = (await harness.listWorkers((`test::${'friend-1'}` as ManagerKey)))[0]
     expect(after.task.status).toBe('cancelled') // 核心断言：没有被复活成 running
     expect(fake.resumeCalls).toHaveLength(0)
 
@@ -1622,7 +1622,7 @@ describe('WorkerHarness — 终审 PoC 回归：M3 continueTerminalWorker 守卫
     // 从 1 计数，与旧主线（claude-code#1）seq 撞号，这正是本条 PoC 的复现前提（M1 回归
     // 测试已确认这种撞号是跨实现切换的常态）。
     await harness.switchWorkerImpl(worker.worker_id, 'codex', '并发切换')
-    const afterSwitch = (await harness.listWorkers(dialogObjectIdForPrivate('friend-1')))[0]
+    const afterSwitch = (await harness.listWorkers((`test::${'friend-1'}` as ManagerKey)))[0]
     const newMainline = afterSwitch.incarnations[afterSwitch.incarnations.length - 1]
     expect(newMainline.impl).toBe('codex')
     expect(newMainline.seq).toBe(1) // 撞号
@@ -1646,7 +1646,7 @@ describe('WorkerHarness — 终审 PoC 回归：M3 continueTerminalWorker 守卫
     expect(target.sendInputCalls[0].opts).toEqual({ raw: true })
 
     // 没有产生第三个化身（没有误触发一次多余的 revive/handoff）。
-    const after = (await harness.listWorkers(dialogObjectIdForPrivate('friend-1')))[0]
+    const after = (await harness.listWorkers((`test::${'friend-1'}` as ManagerKey)))[0]
     expect(after.incarnations).toHaveLength(2)
   })
 
@@ -1672,7 +1672,7 @@ describe('WorkerHarness — 终审 PoC 回归：M3 continueTerminalWorker 守卫
     }, '并发补送 accepted exit')
 
     await expect(send).resolves.toBeUndefined()
-    const [settled] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [settled] = await harness.listWorkers((`test::${'friend-1'}` as ManagerKey))
     const mainline = settled.incarnations[settled.incarnations.length - 1]
     expect(mainline).toMatchObject({
       impl: 'codex',
@@ -1724,7 +1724,7 @@ describe('WorkerHarness — 二轮 review PoC 回归：continueTerminalWorker �
 
     // 投递期间发生跨实现切换：codex#1 顶替 claude-code#1。
     await harness.switchWorkerImpl(worker.worker_id, 'codex', '并发切换')
-    const afterSwitch = (await harness.listWorkers(dialogObjectIdForPrivate('friend-1')))[0]
+    const afterSwitch = (await harness.listWorkers((`test::${'friend-1'}` as ManagerKey)))[0]
     const newMainline = afterSwitch.incarnations[afterSwitch.incarnations.length - 1]
     expect(newMainline.impl).toBe('codex')
     expect(newMainline.seq).toBe(1)
@@ -1740,7 +1740,7 @@ describe('WorkerHarness — 二轮 review PoC 回归：continueTerminalWorker �
     }
     target.emitStateChange(newMainlineHandle, 'exited')
     await waitUntil(async () => {
-      const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+      const [w] = await harness.listWorkers((`test::${'friend-1'}` as ManagerKey))
       const ml = w.incarnations[w.incarnations.length - 1]
       return ml.impl === 'codex' && ml.state === 'exited'
     })
@@ -1766,7 +1766,7 @@ describe('WorkerHarness — 二轮 review PoC 回归：continueTerminalWorker �
     })
     expect(target.resumeCalls[0].wakeInput).toBe('并发终态竞态')
 
-    const after = (await harness.listWorkers(dialogObjectIdForPrivate('friend-1')))[0]
+    const after = (await harness.listWorkers((`test::${'friend-1'}` as ManagerKey)))[0]
     expect(after.incarnations).toHaveLength(3)
     const finalMainline = after.incarnations[after.incarnations.length - 1]
     expect(finalMainline.impl).toBe('codex')
@@ -1815,7 +1815,7 @@ describe('WorkerHarness — 二轮 review PoC 回归：continueTerminalWorker �
     expect(source.sendInputCalls).toHaveLength(1)
 
     await harness.switchWorkerImpl(worker.worker_id, 'codex', '并发切换')
-    const afterSwitch = (await harness.listWorkers(dialogObjectIdForPrivate('friend-1')))[0]
+    const afterSwitch = (await harness.listWorkers((`test::${'friend-1'}` as ManagerKey)))[0]
     const newMainline = afterSwitch.incarnations[afterSwitch.incarnations.length - 1]
     expect(newMainline.impl).toBe('codex')
     expect(newMainline.seq).toBe(1)
@@ -1837,7 +1837,7 @@ describe('WorkerHarness — 二轮 review PoC 回归：continueTerminalWorker �
     })
     expect(target.resumeCalls[0].wakeInput).toBe('权威抛错场景')
 
-    const after = (await harness.listWorkers(dialogObjectIdForPrivate('friend-1')))[0]
+    const after = (await harness.listWorkers((`test::${'friend-1'}` as ManagerKey)))[0]
     expect(after.incarnations).toHaveLength(3)
     // codex#1 被 revive 之前的补写收尾成终态（reviveIncarnation 既有逻辑：台账态未追上
     // adapter 真实状态时先回填）。这里的 'completed' 是**兜底缺省**：上面 releaseGate 抛的
@@ -1866,7 +1866,7 @@ describe('WorkerHarness.switchWorkerImpl — 终审 PoC 回归：M3 cancelled �
     const worker = await harness.spawnWorker(spawnParams({ impl: 'claude-code' }))
     await harness.killWorker(worker.worker_id, '用户明确终止')
 
-    const beforeSwitch = (await harness.listWorkers(dialogObjectIdForPrivate('friend-1')))[0]
+    const beforeSwitch = (await harness.listWorkers((`test::${'friend-1'}` as ManagerKey)))[0]
     expect(beforeSwitch.task.status).toBe('cancelled')
     events.length = 0
 
@@ -1881,7 +1881,7 @@ describe('WorkerHarness.switchWorkerImpl — 终审 PoC 回归：M3 cancelled �
     expect(target.spawnCalls).toHaveLength(0)
 
     // 台账原样：task 仍 cancelled，没有多出新化身。
-    const after = (await harness.listWorkers(dialogObjectIdForPrivate('friend-1')))[0]
+    const after = (await harness.listWorkers((`test::${'friend-1'}` as ManagerKey)))[0]
     expect(after.task.status).toBe('cancelled')
     expect(after.incarnations).toHaveLength(1)
 
@@ -1960,7 +1960,7 @@ describe('WorkerHarness — 三轮 review PoC 回归：handoff 目标是该 work
     // 源化身（当前主线 codex#1）状态未变：没有被 kill，没有被标 superseded——这正是死结
     // 场景里会被破坏的不变量。
     expect(codex.killCalls).toHaveLength(0)
-    const [after] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [after] = await harness.listWorkers((`test::${'friend-1'}` as ManagerKey))
     const mainlineAfter = after.incarnations[after.incarnations.length - 1]
     expect(mainlineAfter.impl).toBe('codex')
     expect(mainlineAfter.seq).toBe(1)
@@ -2000,7 +2000,7 @@ describe('WorkerHarness — 三轮 review PoC 回归：handoff 目标是该 work
     expect(cc.killCalls).toHaveLength(0)
     expect(cc.spawnCalls).toHaveLength(1) // 仍然只有最初 spawnWorker 那一次
 
-    const [after] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [after] = await harness.listWorkers((`test::${'friend-1'}` as ManagerKey))
     expect(after.incarnations).toHaveLength(1)
     expect(after.incarnations[0].state).toBe('running')
     expect(after.incarnations[0].ended_reason).toBeUndefined()
@@ -2042,7 +2042,7 @@ describe('WorkerHarness — 三轮 review PoC 回归：handoff 目标是该 work
     expect(builtinTarget.spawnCalls).toHaveLength(1)
     expect(mainlineAdapter.killCalls).toHaveLength(1) // 源化身（claude-code#1）被 kill 标 superseded
 
-    const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [w] = await harness.listWorkers((`test::${'friend-1'}` as ManagerKey))
     const newEntry = w.incarnations[w.incarnations.length - 1]
     expect(newEntry.impl).toBe('builtin')
     expect(newEntry.state).toBe('running')
@@ -2078,7 +2078,7 @@ describe('WorkerHarness — 三轮 review PoC 回归：handoff 目标是该 work
 
     // 源化身没有被 kill、没有被标 superseded——pre-flight 在 kill 之前就已经拒绝。
     expect(mainlineAdapter.killCalls).toHaveLength(0)
-    const [after] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [after] = await harness.listWorkers((`test::${'friend-1'}` as ManagerKey))
     expect(after.incarnations).toHaveLength(1)
     expect(after.incarnations[0].state).toBe('running')
     expect(after.incarnations[0].ended_reason).toBeUndefined()
@@ -2104,7 +2104,7 @@ describe('HarnessEvent.task_status —— 透明接续的迁移点', () => {
     const worker = await harness.spawnWorker(spawnParams())
     fake.emitStateChange({ worker_id: worker.worker_id, seq: 1, impl: 'builtin', session_ref: `ref-${worker.worker_id}#1` }, 'exited')
     await waitUntil(async () => {
-      const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+      const [w] = await harness.listWorkers((`test::${'friend-1'}` as ManagerKey))
       return w.task.status === 'completed'
     })
     // 终态那一跳自己也带了状态(processStateChange 主线分支)
@@ -2117,7 +2117,7 @@ describe('HarnessEvent.task_status —— 透明接续的迁移点', () => {
     const resumed = events.filter((e) => e.kind === 'resumed')
     expect(resumed).toHaveLength(1)
     expect(resumed[0].task_status).toBe('running')
-    const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [w] = await harness.listWorkers((`test::${'friend-1'}` as ManagerKey))
     expect(w.task.status).toBe('running')
   })
 
@@ -2144,5 +2144,44 @@ describe('HarnessEvent.task_status —— 透明接续的迁移点', () => {
 
     expect(events.filter((e) => e.kind === 'handoff_started')[0].task_status).toBeUndefined()
     expect(events.filter((e) => e.kind === 'superseded')[0].task_status).toBeUndefined()
+  })
+})
+
+describe('legacy incarnation guardrails', () => {
+  const managerKey = 'test::legacy-session' as ManagerKey
+
+  async function addLegacy(ledger: LedgerStore, workerId: string): Promise<void> {
+    const at = now()
+    await ledger.upsertWorker(managerKey, workerId, () => ({
+      worker_id: workerId,
+      manager_key: managerKey,
+      task: { id: workerId, title: 'legacy', status: 'completed', created_at: at },
+      origin: { trigger_type: 'system' },
+      report_to: { channel_id: 'test', session_id: 'legacy-session' },
+      incarnations: [{ seq: 1, impl: 'legacy', state: 'exited', workspace: join(dataDir, 'workspace'), started_at: at, ended_at: at, ended_reason: 'completed' }],
+      legacy_source: { kind: 'v2_admin_task', admin_task_id: 'old-task', trace_ids: [], imported_at: at },
+      updated_at: at,
+    } satisfies LedgerWorker))
+  }
+
+  it('readWorkerOutput returns an unavailable empty chunk without adapter lookup', async () => {
+    const { harness, ledger, adaptersMap } = await makeHarness()
+    await addLegacy(ledger, 'w-legacy-output')
+    expect(await harness.readWorkerOutput('w-legacy-output', 0)).toEqual({ chunk: '', nextCursor: 0, unavailable_reason: 'legacy worker has no raw output' })
+    expect(adaptersMap.size).toBe(0)
+  })
+
+  it('sendToWorker rejects a legacy source before adapter lookup', async () => {
+    const { harness, ledger, adaptersMap } = await makeHarness()
+    await addLegacy(ledger, 'w-legacy-send')
+    await expect(harness.sendToWorker('w-legacy-send', 'continue')).rejects.toThrow(/legacy worker continuation is not available/)
+    expect(adaptersMap.size).toBe(0)
+  })
+
+  it('startup reconciliation leaves terminal legacy workers unchanged without adapter lookup', async () => {
+    const { harness, ledger, adaptersMap } = await makeHarness()
+    await addLegacy(ledger, 'w-legacy-reconcile')
+    await expect(harness.reconcileOnStartup()).resolves.toMatchObject({ unchanged: ['w-legacy-reconcile'] })
+    expect(adaptersMap.size).toBe(0)
   })
 })

--- a/crabot-agent/tests/workers/harness/harness-integration.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-integration.test.ts
@@ -31,7 +31,7 @@ import * as path from 'node:path'
 import { WorkerHarness, type HarnessDeps } from '../../../src/workers/harness/harness'
 import { LedgerStore } from '../../../src/workers/harness/ledger-store'
 import { WorkspaceManager } from '../../../src/workers/harness/workspace-manager'
-import { dialogObjectIdForPrivate } from '../../../src/workers/harness/ledger-types'
+import { } from '../../../src/workers/harness/ledger-types'
 import type { HarnessEvent } from '../../../src/workers/harness/worker-events'
 import { BuiltinWorkerAdapter } from '../../../src/workers/builtin/adapter.js'
 import { ClaudeCodeAdapter, eventsFilePath as ccEventsFilePath } from '../../../src/workers/claude-code/adapter.js'
@@ -126,12 +126,13 @@ describe('WorkerHarness — 真实 builtin adapter 集成冒烟(mock LLM)', () =
         { toolCalls: [{ name: 'finish_task', id: 'call_1', input: { outcome: 'completed', summary: '搞定了' } }], stopReason: 'tool_use' },
       ])
 
-      const dialogObjectId = dialogObjectIdForPrivate('friend-builtin-integ')
+      const managerKey = `test::friend-builtin-integ` as ManagerKey
       const worker = await harness.spawnWorker({
-        dialogObjectId,
+        managerKey,
         title: '集成冒烟任务',
         prompt: '把活干完',
-        origin: { spawned_by_session: 'wechat::sess-1', trigger_type: 'message' },
+        origin: {
+      trigger_type: 'message' },
         report_to: { channel_id: 'wechat', session_id: 'sess-1' },
         impl: 'builtin',
         builtin: { adapter: llm, model: 'test', systemPrompt: '', tools: [] },
@@ -144,7 +145,7 @@ describe('WorkerHarness — 真实 builtin adapter 集成冒烟(mock LLM)', () =
       // 台账推进到 waiting_input(builtin 的 idle 映射,harness 保守默认 idle→waiting_input),
       // 不是靠猜时序或手动触发回调。
       await waitUntil(async () => {
-        const [w] = await harness.listWorkers(dialogObjectId)
+        const [w] = await harness.listWorkers(managerKey)
         return w.task.status === 'waiting_input'
       })
 
@@ -158,11 +159,11 @@ describe('WorkerHarness — 真实 builtin adapter 集成冒烟(mock LLM)', () =
       await harness.sendToWorker(worker.worker_id, '选 A 吧,继续')
 
       await waitUntil(async () => {
-        const [w] = await harness.listWorkers(dialogObjectId)
+        const [w] = await harness.listWorkers(managerKey)
         return w.task.status === 'completed'
       })
 
-      const [finalWorker] = await harness.listWorkers(dialogObjectId)
+      const [finalWorker] = await harness.listWorkers(managerKey)
       expect(finalWorker.task.status).toBe('completed')
       // 注:被动状态回调路径现在会把 adapter 的 ended_reason 一路透传进
       // incarnation.ended_reason 与 task.status,但**不**回填 task.outcome——
@@ -181,12 +182,12 @@ describe('WorkerHarness — 真实 builtin adapter 集成冒烟(mock LLM)', () =
       // reconcileOnStartup 幂等:worker 已是终态,巡检不该把它错误判成 revived/failed,
       // 也不该再调用 adapter.state()(harness.ts reconcileOnStartup 的设计:已终态 worker
       // 直接归 unchanged,不进 Promise.allSettled 批次)——台账不应被巡检动过。
-      const beforeReconcile = await harness.listWorkers(dialogObjectId)
+      const beforeReconcile = await harness.listWorkers(managerKey)
       const report = await harness.reconcileOnStartup()
       expect(report.unchanged).toContain(worker.worker_id)
       expect(report.revived).not.toContain(worker.worker_id)
       expect(report.failed).not.toContain(worker.worker_id)
-      const afterReconcile = await harness.listWorkers(dialogObjectId)
+      const afterReconcile = await harness.listWorkers(managerKey)
       expect(afterReconcile).toEqual(beforeReconcile)
 
       // 再调用一次,证明幂等不是"只对一次调用生效"的巧合。
@@ -306,12 +307,13 @@ describe.skipIf(!tmuxAvailable)('WorkerHarness — 真实 claude-code adapter �
       const ccAdapter = new ClaudeCodeAdapter({ dataDir: ccDataDir, claudeConfigPath: join(dataDir, 'fake-claude.json'), claudeBin, onStateChange: harness.handleStateChange })
       adaptersMap.set('claude-code', ccAdapter)
 
-      const dialogObjectId = dialogObjectIdForPrivate('friend-cc-integ')
+      const managerKey = `test::friend-cc-integ` as ManagerKey
       const worker = await harness.spawnWorker({
-        dialogObjectId,
+        managerKey,
         title: '真实 cc 冒烟任务',
         prompt: '你好',
-        origin: { spawned_by_session: 'wechat::sess-1', trigger_type: 'message' },
+        origin: {
+      trigger_type: 'message' },
         report_to: { channel_id: 'wechat', session_id: 'sess-1' },
         impl: 'claude-code',
         workspace: workspaceRoot,
@@ -319,10 +321,10 @@ describe.skipIf(!tmuxAvailable)('WorkerHarness — 真实 claude-code adapter �
       sessionsToCleanup.push(`crabot-w-${worker.worker_id}-1`)
 
       await waitUntil(async () => {
-        const [current] = await harness.listWorkers(dialogObjectId)
+        const [current] = await harness.listWorkers(managerKey)
         return current.task.status === 'waiting_input'
       })
-      const [settledWorker] = await harness.listWorkers(dialogObjectId)
+      const [settledWorker] = await harness.listWorkers(managerKey)
       expect(settledWorker.task.status).toBe('waiting_input')
       // cc adapter 的真实 session uuid(spawn 返回前即由 adapter 填入,不是台账初始化时的
       // 占位空串),证明 harness 原子补写了 adapter.spawn 返回的真实 handle.session_ref。
@@ -357,7 +359,7 @@ describe.skipIf(!tmuxAvailable)('WorkerHarness — 真实 claude-code adapter �
 
       await harness.killWorker(worker.worker_id, '冒烟测试收尾')
 
-      const [finalWorker] = await harness.listWorkers(dialogObjectId)
+      const [finalWorker] = await harness.listWorkers(managerKey)
       expect(finalWorker.task.status).toBe('cancelled')
       expect(finalWorker.incarnations).toHaveLength(1)
       expect(finalWorker.incarnations[0].state).toBe('exited')
@@ -415,7 +417,7 @@ describe.skipIf(!tmuxAvailable)(
 
         const ledger = new LedgerStore(ledgersDir)
         const workspaces = new WorkspaceManager(workspacesRoot)
-        const dialogObjectId = dialogObjectIdForPrivate('friend-cc-restart')
+        const managerKey = `test::friend-cc-restart` as ManagerKey
 
         // "重启前":harness1 + adapterA spawn 两个 worker。
         const adaptersMap1 = new Map<WorkerImplId, WorkerAdapter>()
@@ -431,20 +433,22 @@ describe.skipIf(!tmuxAvailable)(
         adaptersMap1.set('claude-code', adapterA)
 
         const aliveWorker = await harness1.spawnWorker({
-          dialogObjectId,
+          managerKey,
           title: '存活 worker',
           prompt: '你好',
-          origin: { spawned_by_session: 'wechat::sess-1', trigger_type: 'message' },
+          origin: {
+      trigger_type: 'message' },
           report_to: { channel_id: 'wechat', session_id: 'sess-1' },
           impl: 'claude-code',
         })
         sessionsToCleanup.push(`crabot-w-${aliveWorker.worker_id}-1`)
 
         const deadWorker = await harness1.spawnWorker({
-          dialogObjectId,
+          managerKey,
           title: '将被外部杀掉的 worker',
           prompt: '你好',
-          origin: { spawned_by_session: 'wechat::sess-1', trigger_type: 'message' },
+          origin: {
+      trigger_type: 'message' },
           report_to: { channel_id: 'wechat', session_id: 'sess-1' },
           impl: 'claude-code',
         })
@@ -455,7 +459,7 @@ describe.skipIf(!tmuxAvailable)(
         execFileSync('tmux', ['kill-session', '-t', `crabot-w-${deadWorker.worker_id}-1`], { stdio: 'ignore' })
 
         // 台账此刻仍然认为两个 worker 都在 running——没人告诉它 deadWorker 已经死了。
-        const beforeRestart = await harness1.listWorkers(dialogObjectId)
+        const beforeRestart = await harness1.listWorkers(managerKey)
         expect(beforeRestart.every((w) => w.task.status === 'running')).toBe(true)
 
         // "重启":全新 harness + adapter 实例,指向同一份台账(同一个 LedgerStore 实例即
@@ -481,7 +485,7 @@ describe.skipIf(!tmuxAvailable)(
         expect(report.revived).toContain(aliveWorker.worker_id)
         expect(report.failed).toContain(deadWorker.worker_id)
 
-        const afterAll = await harness2.listWorkers(dialogObjectId)
+        const afterAll = await harness2.listWorkers(managerKey)
         const afterAlive = afterAll.find((w) => w.worker_id === aliveWorker.worker_id)!
         expect(afterAlive.task.status).toBe('running')
 
@@ -554,7 +558,7 @@ describe.skipIf(!tmuxAvailable)(
 
         const ledger = new LedgerStore(ledgersDir)
         const workspaces = new WorkspaceManager(workspacesRoot)
-        const dialogObjectId = dialogObjectIdForPrivate('friend-cc-poc3')
+        const managerKey = `test::friend-cc-poc3` as ManagerKey
 
         const adaptersMap1 = new Map<WorkerImplId, WorkerAdapter>()
         const harness1 = new WorkerHarness({ adapters: adaptersMap1, defaultImpl: 'claude-code', ledger, workspaces, workersDir, now })
@@ -562,10 +566,11 @@ describe.skipIf(!tmuxAvailable)(
         adaptersMap1.set('claude-code', adapterA)
 
         const worker = await harness1.spawnWorker({
-          dialogObjectId,
+          managerKey,
           title: 'PoC③ worker',
           prompt: '你好',
-          origin: { spawned_by_session: 'wechat::sess-1', trigger_type: 'message' },
+          origin: {
+      trigger_type: 'message' },
           report_to: { channel_id: 'wechat', session_id: 'sess-1' },
           impl: 'claude-code',
         })
@@ -598,7 +603,7 @@ describe.skipIf(!tmuxAvailable)(
         // try/catch,整段失败——task 卡在 running,用户无法终止。
         await harness2.killWorker(worker.worker_id, 'PoC③ 收尾')
 
-        const [finalWorker] = await harness2.listWorkers(dialogObjectId)
+        const [finalWorker] = await harness2.listWorkers(managerKey)
         expect(finalWorker.task.status).toBe('cancelled')
         expect(finalWorker.incarnations[0].state).toBe('exited')
         expect(finalWorker.incarnations[0].ended_reason).toBe('killed')
@@ -621,7 +626,7 @@ describe.skipIf(!tmuxAvailable)(
 
         const ledger = new LedgerStore(ledgersDir)
         const workspaces = new WorkspaceManager(workspacesRoot)
-        const dialogObjectId = dialogObjectIdForPrivate('friend-cc-poc4')
+        const managerKey = `test::friend-cc-poc4` as ManagerKey
 
         const adaptersMap1 = new Map<WorkerImplId, WorkerAdapter>()
         const harness1 = new WorkerHarness({ adapters: adaptersMap1, defaultImpl: 'claude-code', ledger, workspaces, workersDir, now })
@@ -629,10 +634,11 @@ describe.skipIf(!tmuxAvailable)(
         adaptersMap1.set('claude-code', adapterA)
 
         const worker = await harness1.spawnWorker({
-          dialogObjectId,
+          managerKey,
           title: 'PoC④ worker',
           prompt: '你好',
-          origin: { spawned_by_session: 'wechat::sess-1', trigger_type: 'message' },
+          origin: {
+      trigger_type: 'message' },
           report_to: { channel_id: 'wechat', session_id: 'sess-1' },
           impl: 'claude-code',
         })
@@ -646,7 +652,7 @@ describe.skipIf(!tmuxAvailable)(
         // 会话已经先一步真死",台账此刻仍然认为它在 running(没人告诉它已经死了)。
         execFileSync('tmux', ['kill-session', '-t', `crabot-w-${worker.worker_id}-1`], { stdio: 'ignore' })
 
-        const beforeRestart = await harness1.listWorkers(dialogObjectId)
+        const beforeRestart = await harness1.listWorkers(managerKey)
         expect(beforeRestart[0].task.status).toBe('running')
         expect(beforeRestart[0].incarnations[0].state).not.toBe('exited')
 
@@ -660,7 +666,7 @@ describe.skipIf(!tmuxAvailable)(
 
         await expect(harness2.sendToWorker(worker.worker_id, '接着办')).resolves.toBeUndefined()
 
-        const [afterWorker] = await harness2.listWorkers(dialogObjectId)
+        const [afterWorker] = await harness2.listWorkers(managerKey)
         expect(afterWorker.task.status).toBe('running')
         expect(afterWorker.incarnations).toHaveLength(2)
         expect(afterWorker.incarnations[0].state).toBe('exited')

--- a/crabot-agent/tests/workers/harness/harness-lifecycle.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-lifecycle.test.ts
@@ -5,7 +5,7 @@ import { join } from 'path'
 import { WorkerHarness, WorkerNotFoundError, TaskCancelledError, type HarnessDeps, type SpawnWorkerParams } from '../../../src/workers/harness/harness'
 import { LedgerStore } from '../../../src/workers/harness/ledger-store'
 import { WorkspaceManager } from '../../../src/workers/harness/workspace-manager'
-import { dialogObjectIdForPrivate } from '../../../src/workers/harness/ledger-types'
+import { } from '../../../src/workers/harness/ledger-types'
 import { WorkerEventLog, type HarnessEvent } from '../../../src/workers/harness/worker-events'
 import { CapabilityNotSupportedError, CliInputStallError } from '../../../src/workers/errors'
 import { describeStartupStall } from '../../../src/workers/tmux/paste-ready'
@@ -225,10 +225,11 @@ async function makeHarness(
 
 function spawnParams(overrides: Partial<SpawnWorkerParams> = {}): SpawnWorkerParams {
   return {
-    dialogObjectId: dialogObjectIdForPrivate('friend-1'),
+    managerKey: `test::friend-1` as ManagerKey,
     title: '测试任务',
     prompt: '把活干完',
-    origin: { spawned_by_session: 'wechat::sess-1', trigger_type: 'message' },
+    origin: {
+      trigger_type: 'message' },
     report_to: { channel_id: 'wechat', session_id: 'sess-1' },
     ...overrides,
   }
@@ -269,7 +270,7 @@ describe('WorkerHarness.spawnWorker', () => {
     expect(spawnedEvents[0].seq).toBe(1)
 
     // 台账已落盘且可查
-    const listed = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const listed = await harness.listWorkers(`test::friend-1` as ManagerKey)
     expect(listed.map((w) => w.worker_id)).toContain(worker.worker_id)
   })
 
@@ -328,7 +329,7 @@ describe('WorkerHarness.spawnWorker', () => {
     await expect(harness.spawnWorker(spawnParams())).rejects.toThrow('context disk error')
     expect(fake.provisionCalls).toEqual([])
     expect(fake.spawnCalls).toEqual([])
-    const [failed] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [failed] = await harness.listWorkers(`test::friend-1` as ManagerKey)
     expect(failed.task).toMatchObject({ status: 'failed', error: 'context disk error' })
     expect(failed.incarnations[0]).toMatchObject({ state: 'exited', ended_reason: 'failed' })
     expect(events.find((event) => event.kind === 'exited')?.detail).toMatchObject({
@@ -461,7 +462,7 @@ describe('WorkerHarness.spawnWorker', () => {
 
     await expect(harness.spawnWorker(spawnParams())).rejects.toThrow('spawn 炸了')
 
-    const listed = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const listed = await harness.listWorkers(`test::friend-1` as ManagerKey)
     expect(listed).toHaveLength(1)
     const worker = listed[0]
     expect(worker.task.status).toBe('failed')
@@ -487,11 +488,11 @@ describe('WorkerHarness.handleStateChange', () => {
     // 的异步台账更新——用轮询等待收敛(与 tests/workers/contract-suite.ts 的 waitForState
     // 同一套路,不是"睡一下猜时序",是"有界轮询直到可观察结果达到预期,超时即失败")。
     await waitUntil(async () => {
-      const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+      const [w] = await harness.listWorkers(`test::friend-1` as ManagerKey)
       return w.task.status === 'waiting_input'
     })
 
-    const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [w] = await harness.listWorkers(`test::friend-1` as ManagerKey)
     expect(w.task.status).toBe('waiting_input')
     expect(w.incarnations[0].state).toBe('idle')
 
@@ -502,10 +503,10 @@ describe('WorkerHarness.handleStateChange', () => {
     // 化身自然结束(非 kill)→ completed
     fake.emitStateChange({ worker_id: worker.worker_id, seq: 1, impl: 'builtin', session_ref: `ref-${worker.worker_id}#1` }, 'exited')
     await waitUntil(async () => {
-      const [w2] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+      const [w2] = await harness.listWorkers(`test::friend-1` as ManagerKey)
       return w2.task.status === 'completed'
     })
-    const [w2] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [w2] = await harness.listWorkers(`test::friend-1` as ManagerKey)
     expect(w2.task.status).toBe('completed')
     expect(w2.incarnations[0].ended_reason).toBe('completed')
   })
@@ -518,8 +519,8 @@ describe('WorkerHarness.handleStateChange', () => {
       'idle',
     )
 
-    await waitUntil(async () => (await harness.listWorkers(dialogObjectIdForPrivate('friend-1')))[0]?.incarnations[0]?.state === 'idle')
-    const [stored] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    await waitUntil(async () => (await harness.listWorkers(`test::friend-1` as ManagerKey))[0]?.incarnations[0]?.state === 'idle')
+    const [stored] = await harness.listWorkers(`test::friend-1` as ManagerKey)
     expect(stored.task.status).toBe('running')
   })
 
@@ -530,12 +531,12 @@ describe('WorkerHarness.handleStateChange', () => {
     const handle = { worker_id: worker.worker_id, seq: 1, impl: 'builtin' as const, session_ref: `ref-${worker.worker_id}#1` }
 
     fake.emitStateChange(handle, 'idle')
-    await waitUntil(async () => (await harness.listWorkers(dialogObjectIdForPrivate('friend-1')))[0]?.incarnations[0]?.state === 'idle')
-    expect((await harness.listWorkers(dialogObjectIdForPrivate('friend-1')))[0].task.status).toBe('running')
+    await waitUntil(async () => (await harness.listWorkers(`test::friend-1` as ManagerKey))[0]?.incarnations[0]?.state === 'idle')
+    expect((await harness.listWorkers(`test::friend-1` as ManagerKey))[0].task.status).toBe('running')
 
     complete()
     fake.emitStateChange(handle, 'idle')
-    await waitUntil(async () => (await harness.listWorkers(dialogObjectIdForPrivate('friend-1')))[0]?.task.status === 'waiting_input')
+    await waitUntil(async () => (await harness.listWorkers(`test::friend-1` as ManagerKey))[0]?.task.status === 'waiting_input')
   })
 
   it('CLI交互Notification映射为固定manager-facing detail，不泄漏内部notification对象', async () => {
@@ -584,10 +585,10 @@ describe('WorkerHarness.handleStateChange', () => {
     fake.emitStateChange(h, 'exited', undefined, 'failed')
 
     await waitUntil(async () => {
-      const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+      const [w] = await harness.listWorkers(`test::friend-1` as ManagerKey)
       return w.task.status === 'failed'
     })
-    const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [w] = await harness.listWorkers(`test::friend-1` as ManagerKey)
     expect(w.task.status).toBe('failed')
     expect(w.incarnations[0].ended_reason).toBe('failed')
 
@@ -605,10 +606,10 @@ describe('WorkerHarness.handleStateChange', () => {
     fake.emitStateChange(h, 'exited', undefined, 'crashed')
 
     await waitUntil(async () => {
-      const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+      const [w] = await harness.listWorkers(`test::friend-1` as ManagerKey)
       return w.task.status === 'failed'
     })
-    const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [w] = await harness.listWorkers(`test::friend-1` as ManagerKey)
     expect(w.incarnations[0].ended_reason).toBe('crashed')
   })
 
@@ -628,10 +629,10 @@ describe('WorkerHarness.handleStateChange', () => {
     )
 
     await waitUntil(async () => {
-      const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+      const [w] = await harness.listWorkers(`test::friend-1` as ManagerKey)
       return w.incarnations[0].state === 'exited'
     })
-    const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [w] = await harness.listWorkers(`test::friend-1` as ManagerKey)
     expect(w.task.status).toBe('failed')
     expect(w.incarnations[0].ended_reason).toBeUndefined() // 不编造原因
   })
@@ -648,7 +649,7 @@ describe('WorkerHarness.handleStateChange', () => {
     expect(() => harness.handleStateChange(h, 'running', { endReason: 'completed' })).toThrow(/only meaningful for state 'exited'/)
 
     // 台账没有被这次非法回调改动过。
-    const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [w] = await harness.listWorkers(`test::friend-1` as ManagerKey)
     expect(w.incarnations[0].state).toBe('running')
     expect(w.incarnations[0].ended_reason).toBeUndefined()
   })
@@ -873,7 +874,7 @@ describe('WorkerHarness.handleStateChange', () => {
     // 一定已经跑完。
     await harness.killWorker(worker.worker_id)
 
-    const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [w] = await harness.listWorkers(`test::friend-1` as ManagerKey)
     expect(w.task.status).toBe('cancelled')
   })
 })
@@ -940,11 +941,11 @@ describe('WorkerHarness.sendToWorker', () => {
 
     await harness.sendToWorker(worker.worker_id, '很快完成的输入')
     await waitUntil(async () => {
-      const [current] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+      const [current] = await harness.listWorkers(`test::friend-1` as ManagerKey)
       return current.task.status === 'waiting_input'
     })
 
-    const [settled] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [settled] = await harness.listWorkers(`test::friend-1` as ManagerKey)
     expect(settled.incarnations[0].state).toBe('idle')
   })
 
@@ -975,14 +976,14 @@ describe('WorkerHarness.sendToWorker', () => {
       session_ref: `ref-${worker.worker_id}#1`,
     }, 'idle')
     await waitUntil(async () => {
-      const [current] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+      const [current] = await harness.listWorkers(`test::friend-1` as ManagerKey)
       return current.task.status === 'waiting_input'
     })
 
     release()
     await send
 
-    const [settled] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [settled] = await harness.listWorkers(`test::friend-1` as ManagerKey)
     expect(settled.task.status).toBe('waiting_input')
     expect(settled.incarnations[0].state).toBe('idle')
     expect(fake.sendInputCalls).toHaveLength(1)
@@ -1014,16 +1015,16 @@ describe('WorkerHarness.sendToWorker', () => {
       impl: 'claude-code',
       session_ref: `ref-${worker.worker_id}#1`,
     }, 'idle')
-    await waitUntil(async () => (await harness.listWorkers(dialogObjectIdForPrivate('friend-1')))[0].task.status === 'waiting_input')
+    await waitUntil(async () => (await harness.listWorkers(`test::friend-1` as ManagerKey))[0].task.status === 'waiting_input')
     await harness.queryWorker(worker.worker_id, '侧问一下')
 
     await harness.sendToWorker(worker.worker_id, '主线继续')
     await waitUntil(async () => {
-      const [current] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+      const [current] = await harness.listWorkers(`test::friend-1` as ManagerKey)
       return current.incarnations.find((incarnation) => incarnation.seq === 2)?.state === 'idle'
     })
 
-    const [settled] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [settled] = await harness.listWorkers(`test::friend-1` as ManagerKey)
     expect(settled.task.status).toBe('running')
     expect(settled.incarnations.find((incarnation) => incarnation.seq === 1)?.state).toBe('running')
   })
@@ -1042,7 +1043,7 @@ describe('WorkerHarness.sendToWorker', () => {
       session_ref: `fork-ref-${worker.worker_id}#2`,
     }, 'exited', undefined, 'completed')
     await waitUntil(async () => {
-      const [current] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+      const [current] = await harness.listWorkers(`test::friend-1` as ManagerKey)
       return current.incarnations.find((incarnation) => incarnation.seq === 2)?.state === 'exited'
     })
 
@@ -1055,10 +1056,10 @@ describe('WorkerHarness.sendToWorker', () => {
 
     await harness.sendToWorker(worker.worker_id, 'Escape', { raw: true })
     await waitUntil(async () => {
-      const [current] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+      const [current] = await harness.listWorkers(`test::friend-1` as ManagerKey)
       return current.task.status === 'waiting_input'
     })
-    const [settled] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [settled] = await harness.listWorkers(`test::friend-1` as ManagerKey)
     expect(settled.task.status).toBe('waiting_input')
     expect(settled.incarnations[0].state).toBe('idle')
   })
@@ -1109,7 +1110,7 @@ describe('WorkerHarness.sendToWorker', () => {
 
     await harness.sendToWorker(worker.worker_id, '首条任务')
 
-    const [settled] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [settled] = await harness.listWorkers(`test::friend-1` as ManagerKey)
     expect(settled.incarnations[0].session_ref).toBe(sessionRef)
   })
 
@@ -1124,11 +1125,11 @@ describe('WorkerHarness.sendToWorker', () => {
 
     await harness.sendToWorker(worker.worker_id, '首条任务')
     await waitUntil(async () => {
-      const [current] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+      const [current] = await harness.listWorkers(`test::friend-1` as ManagerKey)
       return current.task.status === 'waiting_input'
     })
 
-    const [settled] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [settled] = await harness.listWorkers(`test::friend-1` as ManagerKey)
     expect(settled.incarnations[0].session_ref).toBe(sessionRef)
     expect(settled.incarnations[0].state).toBe('idle')
   })
@@ -1141,7 +1142,7 @@ describe('WorkerHarness.sendToWorker', () => {
 
     await harness.sendToWorker(worker.worker_id, '最后一步')
 
-    const [settled] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [settled] = await harness.listWorkers(`test::friend-1` as ManagerKey)
     expect(settled.task.status).toBe('completed')
     expect(settled.incarnations[0]).toMatchObject({ state: 'exited', ended_reason: 'completed' })
     const stateEvents = events.filter((event) => event.kind === 'state_changed')
@@ -1159,7 +1160,7 @@ describe('WorkerHarness.sendToWorker', () => {
 
     expect(fake.sendInputCalls).toHaveLength(1)
     expect(fake.sendInputCalls[0]).toMatchObject({ text: 'C-d', opts: { raw: true } })
-    const [settled] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [settled] = await harness.listWorkers(`test::friend-1` as ManagerKey)
     expect(settled.task.status).toBe('completed')
     expect(settled.incarnations).toHaveLength(1)
     expect(settled.incarnations[0]).toMatchObject({ state: 'exited', ended_reason: 'completed' })
@@ -1194,7 +1195,7 @@ describe('WorkerHarness.sendToWorker', () => {
       ['held prompt', false],
       ['1 Enter', true],
     ])
-    const [settled] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [settled] = await harness.listWorkers(`test::friend-1` as ManagerKey)
     expect(settled.task.status).toBe('completed')
     expect(settled.incarnations).toHaveLength(1)
     expect(settled.incarnations[0]).toMatchObject({ state: 'exited', ended_reason: 'completed' })
@@ -1258,7 +1259,7 @@ describe('WorkerHarness.killWorker', () => {
     expect(fake.killCalls).toHaveLength(1)
     expect(fake.killCalls[0]).toEqual({ worker_id: worker.worker_id, seq: 1, impl: 'builtin', session_ref: `ref-${worker.worker_id}#1` })
 
-    const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [w] = await harness.listWorkers(`test::friend-1` as ManagerKey)
     expect(w.task.status).toBe('cancelled')
     expect(w.incarnations[0].state).toBe('exited')
     expect(w.incarnations[0].ended_reason).toBe('killed')
@@ -1346,7 +1347,7 @@ describe('WorkerHarness.queryWorker', () => {
     expect(failedEvents[0]).toMatchObject({ seq: 1, detail: { reason: 'fork_failed', message: 'fork 侧的 claude -p 炸了' } })
 
     // 主线台账完全不受 fork 失败影响(fork 从未落账,不该有半成品化身)。
-    const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [w] = await harness.listWorkers(`test::friend-1` as ManagerKey)
     expect(w.incarnations).toHaveLength(1)
     expect(w.task.status).toBe('running')
   })
@@ -1362,7 +1363,7 @@ describe('WorkerHarness.queryWorker', () => {
     expect(fake.forkCalls).toHaveLength(1)
     expect(fake.forkCalls[0].forkInput).toBe('侧问一下')
 
-    const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [w] = await harness.listWorkers(`test::friend-1` as ManagerKey)
     expect(w.incarnations).toHaveLength(2)
     expect(w.incarnations[1]).toMatchObject({ seq: 2, impl: 'builtin', state: 'running' })
     expect(w.task.status).toBe('running') // fork 不影响主线状态
@@ -1400,7 +1401,7 @@ describe('WorkerHarness.queryWorker', () => {
     const result = await harness.queryWorker(worker.worker_id, '侧问一下')
     expect(result.forkSeq).toBe(2)
 
-    const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [w] = await harness.listWorkers(`test::friend-1` as ManagerKey)
     const forkEntry = w.incarnations.find((i) => i.seq === 2)!
     // 断言①:fork 化身不是硬编码的 'running'，而是 adapter 的真实状态(exited)。
     expect(forkEntry.state).toBe('exited')
@@ -1517,7 +1518,7 @@ describe('WorkerHarness.queryWorker — adapter.fork 挪出锁(P4 Task 4 review 
     const result = await queryPromise
     expect(result.forkSeq).toBe(2)
 
-    const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [w] = await harness.listWorkers(`test::friend-1` as ManagerKey)
     // 主线(seq=1)保持 killWorker 落定的记录,完全不被这次迟到的 fork 落账污染。
     expect(w.task.status).toBe('cancelled')
     const mainEntry = w.incarnations.find((i) => i.seq === 1)!
@@ -1559,7 +1560,7 @@ describe('WorkerHarness 锁纪律', () => {
     // 发生的早期写入落盘)。
     let workerId: string | undefined
     await waitUntil(async () => {
-      const list = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+      const list = await harness.listWorkers(`test::friend-1` as ManagerKey)
       if (list.length > 0) {
         workerId = list[0].worker_id
         return true
@@ -1611,7 +1612,7 @@ describe('WorkerHarness — fork 不劫持主线(protocol-agent-v3 §5.3 回归)
     expect(fake.killCalls).toHaveLength(1)
     expect(fake.killCalls[0].seq).toBe(1)
 
-    const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [w] = await harness.listWorkers(`test::friend-1` as ManagerKey)
     expect(w.task.status).toBe('cancelled') // 主线被正确终结,不是台账显示 fork 被 kill 而主线孤儿
     const mainEntry = w.incarnations.find((i) => i.seq === 1)!
     expect(mainEntry.state).toBe('exited')
@@ -1631,11 +1632,11 @@ describe('WorkerHarness — fork 不劫持主线(protocol-agent-v3 §5.3 回归)
     fake.emitStateChange({ worker_id: worker.worker_id, seq: 2, impl: 'builtin', session_ref: 'fork-ref' }, 'exited')
 
     await waitUntil(async () => {
-      const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+      const [w] = await harness.listWorkers(`test::friend-1` as ManagerKey)
       return w.incarnations.find((i) => i.seq === 2)?.state === 'exited'
     })
 
-    const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [w] = await harness.listWorkers(`test::friend-1` as ManagerKey)
     // 主线(seq=1)完全不受 fork 结束的影响——修复前 lastIncarnation() 会把这次回调当成
     // "当前化身"的回调,错误地把 task.status 推进到 completed。
     expect(w.task.status).toBe('running')
@@ -1732,7 +1733,7 @@ describe('WorkerHarness.handleStateChange — 同状态重复回调', () => {
     // 的迟到状态回调被忽略"用例一致):等它 resolve,前面排队的状态回调必定已经跑完。
     await harness.sendToWorker(worker.worker_id, '还在干活')
 
-    const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [w] = await harness.listWorkers(`test::friend-1` as ManagerKey)
     expect(w.task.status).toBe('running') // 没有被非法转换破坏,也没有抛出未捕获错误
 
     const stateEvents = events.filter((e) => e.kind === 'state_changed')
@@ -1852,7 +1853,7 @@ describe('HarnessEvent.task_status —— 事件自带落账后的 task 状态',
     expect(forkEvents.length).toBeGreaterThan(0)
     for (const e of forkEvents) expect(e.task_status).toBeUndefined()
     // 台账确实没动主线 task.status——事件不带这个字段与台账事实一致
-    const [w] = await harness.listWorkers(dialogObjectIdForPrivate('friend-1'))
+    const [w] = await harness.listWorkers(`test::friend-1` as ManagerKey)
     expect(w.task.status).toBe('running')
   })
 })

--- a/crabot-agent/tests/workers/harness/harness-liveness.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-liveness.test.ts
@@ -15,7 +15,6 @@ import { join } from 'path'
 import { WorkerHarness, type HarnessDeps, type SpawnWorkerParams } from '../../../src/workers/harness/harness'
 import { LedgerStore } from '../../../src/workers/harness/ledger-store'
 import { WorkspaceManager } from '../../../src/workers/harness/workspace-manager'
-import { dialogObjectIdForPrivate } from '../../../src/workers/harness/ledger-types'
 import type { HarnessEvent, HarnessEventDelivery } from '../../../src/workers/harness/worker-events'
 import type {
   WorkerAdapter,
@@ -135,10 +134,10 @@ async function makeHarness(adapter: WorkerAdapter): Promise<{ harness: WorkerHar
 
 function spawnParams(overrides: Partial<SpawnWorkerParams> = {}): SpawnWorkerParams {
   return {
-    dialogObjectId: dialogObjectIdForPrivate('friend-1'),
+    managerKey: (`test::${'friend-1'}` as ManagerKey),
     title: '测试任务',
     prompt: '把活干完',
-    origin: { spawned_by_session: 'wechat::sess-1', trigger_type: 'message' },
+    origin: { spawned_by_episode: 'wechat::sess-1', trigger_type: 'message' },
     report_to: { channel_id: 'wechat', session_id: 'sess-1' },
     ...overrides,
   }
@@ -355,7 +354,7 @@ describe.each<WorkerImplId>(['claude-code', 'codex'])('WorkerHarness.sweepLivene
     const { harness, ledger, adapter, workerId } = await spawnRunning()
     const found = (await ledger.findWorker(workerId))!
     // fork 化身(无头 `claude -p`,整个执行期可能零输出)追加进同一个 incarnations 数组
-    await ledger.upsertWorker(found.dialogObjectId, workerId, (prev) => ({
+    await ledger.upsertWorker(found.managerKey, workerId, (prev) => ({
       ...prev!,
       incarnations: [
         ...prev!.incarnations,
@@ -397,12 +396,13 @@ describe.each<WorkerImplId>(['claude-code', 'codex'])('WorkerHarness.sweepLivene
     const { harness, ledger } = await makeHarness(adapter)
     // #72 的 maintenance system task:agent 自己跑,不派 worker,台账条目 `incarnations: []`,
     // 但 running 期间照样会被 listAllWorkers 枚举到。
-    const dialogObjectId = dialogObjectIdForPrivate('friend-1')
+    const managerKey = (`test::${'friend-1'}` as ManagerKey)
     const taskId = 'task-maintenance-1'
-    await ledger.upsertWorker(dialogObjectId, taskId, () => ({
+    await ledger.upsertWorker(managerKey, taskId, () => ({
       worker_id: taskId,
+      manager_key: managerKey,
       task: { id: taskId, title: '记忆维护', status: 'running', created_at: now() },
-      origin: { spawned_by_session: 'system::tasks', trigger_type: 'system' },
+      origin: { trigger_type: 'system' },
       report_to: { channel_id: 'system', session_id: 'tasks' },
       incarnations: [],
       updated_at: now(),

--- a/crabot-agent/tests/workers/harness/harness-recovery.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-recovery.test.ts
@@ -11,9 +11,7 @@ import {
 import { LedgerStore } from '../../../src/workers/harness/ledger-store'
 import { WorkspaceManager } from '../../../src/workers/harness/workspace-manager'
 import {
-  dialogObjectIdForPrivate,
-  dialogObjectIdForGroup,
-  type DialogObjectId,
+  type ManagerKey,
   type LedgerWorker,
 } from '../../../src/workers/harness/ledger-types'
 import type { HarnessEvent } from '../../../src/workers/harness/worker-events'
@@ -141,7 +139,8 @@ function makeWorker(workerId: string, overrides: Partial<LedgerWorker> = {}): Le
       status: 'running',
       created_at: ts,
     },
-    origin: { spawned_by_session: 'wechat::sess-1', trigger_type: 'message' },
+    origin: {
+      trigger_type: 'message' },
     report_to: { channel_id: 'wechat', session_id: 'sess-1' },
     incarnations: [
       { seq: 1, impl: 'builtin', state: 'running', workspace: '/tmp/ws', session_ref: `ref-${workerId}#1`, started_at: ts },
@@ -151,8 +150,8 @@ function makeWorker(workerId: string, overrides: Partial<LedgerWorker> = {}): Le
   }
 }
 
-async function seed(ledger: LedgerStore, dialogObjectId: DialogObjectId, worker: LedgerWorker): Promise<void> {
-  await ledger.upsertWorker(dialogObjectId, worker.worker_id, () => worker)
+async function seed(ledger: LedgerStore, managerKey: ManagerKey, worker: LedgerWorker): Promise<void> {
+  await ledger.upsertWorker(managerKey, worker.worker_id, () => ({ ...worker, manager_key: managerKey }))
 }
 
 async function getWorker(ledger: LedgerStore, workerId: string): Promise<LedgerWorker> {
@@ -161,7 +160,7 @@ async function getWorker(ledger: LedgerStore, workerId: string): Promise<LedgerW
   return found.worker
 }
 
-const DIALOG = dialogObjectIdForPrivate('friend-1')
+const DIALOG = `test::friend-1` as ManagerKey
 
 beforeEach(async () => {
   dataDir = await fs.mkdtemp(join(tmpdir(), 'harness-recovery-test-'))
@@ -228,7 +227,8 @@ describe('WorkerHarness.reconcileOnStartup — 三态判定', () => {
         status: 'running',
         created_at: now(),
       },
-      origin: { spawned_by_session: 'admin-web::system-tasks', trigger_type: 'system' },
+      origin: {
+      trigger_type: 'system' },
       incarnations: [],
     })
     await seed(ledger, DIALOG, worker)
@@ -327,7 +327,8 @@ describe('WorkerHarness empty-incarnation domain errors', () => {
         status: 'running',
         created_at: now(),
       },
-      origin: { spawned_by_session: 'admin-web::system-tasks', trigger_type: 'system' },
+      origin: {
+      trigger_type: 'system' },
       incarnations: [],
     })
     await seed(ledger, DIALOG, worker)
@@ -385,7 +386,7 @@ describe('WorkerHarness.reconcileOnStartup — 报告分类 + 跨对话对象', 
     const fake = new FakeAdapter('builtin')
     adaptersMap.set('builtin', fake)
 
-    const group = dialogObjectIdForGroup('wechat', 'group-1')
+    const group = `wechat::group-1` as ManagerKey
     await seed(ledger, DIALOG, makeWorker('priv-alive'))
     await seed(ledger, DIALOG, makeWorker('priv-dead'))
     await seed(

--- a/crabot-agent/tests/workers/harness/ledger-store.test.ts
+++ b/crabot-agent/tests/workers/harness/ledger-store.test.ts
@@ -4,13 +4,11 @@ import { tmpdir } from 'os'
 import { join } from 'path'
 import {
   LedgerStore,
-  dialogObjectIdToFilename,
-  filenameToDialogObjectId,
+  managerKeyToFilename,
+  filenameToManagerKey,
 } from '../../../src/workers/harness/ledger-store'
 import {
-  dialogObjectIdForPrivate,
-  dialogObjectIdForGroup,
-  type DialogObjectId,
+  type ManagerKey,
   type LedgerWorker,
 } from '../../../src/workers/harness/ledger-types'
 
@@ -25,7 +23,6 @@ function makeWorker(workerId: string, overrides: Partial<LedgerWorker> = {}): Le
       created_at: now,
     },
     origin: {
-      spawned_by_session: 'wechat::sess-1',
       trigger_type: 'message',
     },
     report_to: { channel_id: 'wechat', session_id: 'sess-1' },
@@ -49,19 +46,19 @@ describe('LedgerStore', () => {
   })
 
   it('upsert 新建 worker 后 getLedger 可见且文件落盘', async () => {
-    const id = dialogObjectIdForPrivate('friend-1')
+    const id = `test::friend-1` as ManagerKey
     const result = await store.upsertWorker(id, 'worker-1', (prev) => {
       expect(prev).toBeUndefined()
-      return makeWorker('worker-1')
+      return makeWorker('worker-1', { manager_key: id })
     })
     expect(result?.worker_id).toBe('worker-1')
 
     const ledger = await store.getLedger(id)
-    expect(ledger.dialog_object_id).toBe(id)
+    expect(ledger.manager_key).toBe(id)
     expect(ledger.workers).toHaveLength(1)
     expect(ledger.workers[0].worker_id).toBe('worker-1')
 
-    const filePath = join(dir, dialogObjectIdToFilename(id))
+    const filePath = join(dir, managerKeyToFilename(id))
     const raw = await fs.readFile(filePath, 'utf-8')
     const onDisk = JSON.parse(raw)
     expect(onDisk.workers).toHaveLength(1)
@@ -69,12 +66,12 @@ describe('LedgerStore', () => {
   })
 
   it('同一对话对象并发 10 次 upsert 不丢', async () => {
-    const id = dialogObjectIdForGroup('wechat', 'group-1')
+    const id = `wechat::group-1` as ManagerKey
     await Promise.all(
       Array.from({ length: 10 }, (_, i) =>
         store.upsertWorker(id, `worker-${i}`, (prev) => {
           expect(prev).toBeUndefined()
-          return makeWorker(`worker-${i}`)
+          return makeWorker(`worker-${i}`, { manager_key: id })
         })
       )
     )
@@ -85,17 +82,17 @@ describe('LedgerStore', () => {
   })
 
   it('findWorker 跨文件命中', async () => {
-    const idA = dialogObjectIdForPrivate('friend-a')
-    const idB = dialogObjectIdForPrivate('friend-b')
-    await store.upsertWorker(idA, 'worker-a', () => makeWorker('worker-a'))
-    await store.upsertWorker(idB, 'worker-b', () => makeWorker('worker-b'))
+    const idA = `test::friend-a` as ManagerKey
+    const idB = `test::friend-b` as ManagerKey
+    await store.upsertWorker(idA, 'worker-a', () => makeWorker('worker-a', { manager_key: idA }))
+    await store.upsertWorker(idB, 'worker-b', () => makeWorker('worker-b', { manager_key: idB }))
 
     const foundA = await store.findWorker('worker-a')
-    expect(foundA?.dialogObjectId).toBe(idA)
+    expect(foundA?.managerKey).toBe(idA)
     expect(foundA?.worker.worker_id).toBe('worker-a')
 
     const foundB = await store.findWorker('worker-b')
-    expect(foundB?.dialogObjectId).toBe(idB)
+    expect(foundB?.managerKey).toBe(idB)
     expect(foundB?.worker.worker_id).toBe('worker-b')
   })
 
@@ -103,63 +100,53 @@ describe('LedgerStore', () => {
     await store.init()
 
     // 手工往目录塞一个文件,不经过 store 的写入路径(模拟外部进程写入)
-    const externalId = dialogObjectIdForPrivate('friend-external')
-    const filename = dialogObjectIdToFilename(externalId)
-    const worker = makeWorker('worker-external')
+    const externalId = `test::friend-external` as ManagerKey
+    const filename = managerKeyToFilename(externalId)
+    const worker = makeWorker('worker-external', { manager_key: externalId })
     await fs.writeFile(
       join(dir, filename),
-      JSON.stringify({ dialog_object_id: externalId, workers: [worker] }),
+      JSON.stringify({ manager_key: externalId, workers: [worker] }),
       'utf-8'
     )
 
     const found = await store.findWorker('worker-external')
-    expect(found?.dialogObjectId).toBe(externalId)
+    expect(found?.managerKey).toBe(externalId)
     expect(found?.worker.worker_id).toBe('worker-external')
   })
 
   it('文件名编码对含 : 与 / 的 id 双向可逆', () => {
-    const idWithSlash = dialogObjectIdForPrivate('user/with:colon') as DialogObjectId
-    const idGroup = dialogObjectIdForGroup('chan/nel', 'sess:ion/x')
+    const idWithSlash = `test::user/with:colon` as ManagerKey as ManagerKey
+    const idGroup = `chan/nel::sess:ion/x` as ManagerKey
     for (const id of [idWithSlash, idGroup]) {
-      const filename = dialogObjectIdToFilename(id)
+      const filename = managerKeyToFilename(id)
       expect(filename.endsWith('.json')).toBe(true)
-      const decoded = filenameToDialogObjectId(filename)
+      const decoded = filenameToManagerKey(filename)
       expect(decoded).toBe(id)
     }
   })
 
   it('mutator 返回 undefined 时不写盘', async () => {
-    const id = dialogObjectIdForPrivate('friend-none')
+    const id = `test::friend-none` as ManagerKey
     const result = await store.upsertWorker(id, 'worker-none', () => undefined)
     expect(result).toBeUndefined()
 
-    const filePath = join(dir, dialogObjectIdToFilename(id))
+    const filePath = join(dir, managerKeyToFilename(id))
     await expect(fs.access(filePath)).rejects.toThrow()
 
     const ledger = await store.getLedger(id)
     expect(ledger.workers).toHaveLength(0)
   })
 
-  it('init 扫描遇到坏 JSON 文件时跳过并 warn,不影响其它文件索引', async () => {
-    const goodId = dialogObjectIdForPrivate('friend-good')
-    await fs.writeFile(join(dir, dialogObjectIdToFilename(goodId)), 'not json', 'utf-8')
+  it('init 扫描遇到坏 JSON 文件时 fail loud，不继续建立不完整索引', async () => {
+    const badId = `test::friend-good` as ManagerKey
+    await fs.writeFile(join(dir, managerKeyToFilename(badId)), 'not json', 'utf-8')
 
-    const okId = dialogObjectIdForPrivate('friend-ok')
-    await store.upsertWorker(okId, 'worker-ok', () => makeWorker('worker-ok'))
-
-    const otherStore = new LedgerStore(dir)
-    const warnSpy = (await import('vitest')).vi.spyOn(console, 'warn').mockImplementation(() => {})
-    await otherStore.init()
-    expect(warnSpy).toHaveBeenCalled()
-    warnSpy.mockRestore()
-
-    const found = await otherStore.findWorker('worker-ok')
-    expect(found?.worker.worker_id).toBe('worker-ok')
+    await expect(store.init()).rejects.toThrow(/invalid ledger/)
   })
 
   it('getLedger 读到坏 JSON 文件应抛明确错误,不静默当空', async () => {
-    const id = dialogObjectIdForPrivate('friend-corrupt')
-    await fs.writeFile(join(dir, dialogObjectIdToFilename(id)), 'not json', 'utf-8')
+    const id = `test::friend-corrupt` as ManagerKey
+    await fs.writeFile(join(dir, managerKeyToFilename(id)), 'not json', 'utf-8')
 
     await expect(store.getLedger(id)).rejects.toThrow()
   })

--- a/crabot-agent/tests/workers/harness/ledger-store.test.ts
+++ b/crabot-agent/tests/workers/harness/ledger-store.test.ts
@@ -137,6 +137,25 @@ describe('LedgerStore', () => {
     expect(ledger.workers).toHaveLength(0)
   })
 
+  it('legacy source and first incarnation are immutable while ordinary upserts may append v3 incarnations', async () => {
+    const key = 'test::legacy' as ManagerKey
+    const now = new Date().toISOString()
+    const legacy = makeWorker('w-legacy', {
+      manager_key: key,
+      task: { id: 'w-legacy' as never, title: 'old', status: 'completed', created_at: now, completed_at: now },
+      incarnations: [{ impl: 'legacy', seq: 1, state: 'exited', workspace: '/tmp', started_at: now, ended_at: now, ended_reason: 'completed' }],
+      legacy_source: { kind: 'v2_admin_task', admin_task_id: 'old-task' as never, trace_ids: [], imported_at: now },
+    })
+    await store.importLegacyWorker(key, legacy)
+    await store.upsertWorker(key, legacy.worker_id, previous => ({ ...previous!, task: { ...previous!.task, status: 'running' }, incarnations: [...previous!.incarnations, { impl: 'builtin', seq: 2, state: 'running', workspace: '/tmp', started_at: now, session_ref: 'session' }] }))
+    expect((await store.findWorker(legacy.worker_id))?.worker.incarnations).toHaveLength(2)
+    await expect(store.upsertWorker(key, legacy.worker_id, previous => ({ ...previous!, legacy_source: { ...previous!.legacy_source!, admin_task_id: 'other' as never } }))).rejects.toThrow('immutable legacy source')
+    await expect(store.upsertWorker(key, legacy.worker_id, previous => ({ ...previous!, legacy_source: undefined }))).rejects.toThrow('invalid legacy worker')
+    const corrupt = new LedgerStore(dir)
+    await fs.writeFile(join(dir, managerKeyToFilename(key)), JSON.stringify({ manager_key: key, workers: [{ ...legacy, incarnations: [] }] }))
+    await expect(corrupt.getLedger(key)).rejects.toThrow('invalid legacy worker')
+  })
+
   it('init 扫描遇到坏 JSON 文件时 fail loud，不继续建立不完整索引', async () => {
     const badId = `test::friend-good` as ManagerKey
     await fs.writeFile(join(dir, managerKeyToFilename(badId)), 'not json', 'utf-8')

--- a/crabot-agent/tests/workers/harness/manager-key-ledger.test.ts
+++ b/crabot-agent/tests/workers/harness/manager-key-ledger.test.ts
@@ -70,6 +70,25 @@ describe('ManagerKey ledger contract', () => {
     }
   })
 
+  it('ignores stale atomic-write temp files without weakening unknown filename fail-loud behavior', async () => {
+    const dir = await fs.mkdtemp(join(tmpdir(), 'manager-ledger-temp-recovery-'))
+    try {
+      const staleTemp = join(dir, '.tmp-123e4567-e89b-12d3-a456-426614174000.json')
+      await fs.writeFile(staleTemp, '{"partial":')
+      const store = new LedgerStore(dir)
+
+      await expect(store.init()).resolves.toBeUndefined()
+      expect(await fs.readFile(staleTemp, 'utf8')).toBe('{"partial":')
+      await store.upsertWorker(KEY_A, 'recovered', () => worker('recovered'))
+      expect((await store.listWorkers(KEY_A)).map((item) => item.worker_id)).toEqual(['recovered'])
+
+      await fs.writeFile(join(dir, '.tmp-not-ours.json'), '{}')
+      await expect(new LedgerStore(dir).init()).rejects.toThrow(/invalid.*ledger filename/)
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true })
+    }
+  })
+
   it('fails loud for malformed manager keys and non-canonical ledger filenames', async () => {
     const dir = await fs.mkdtemp(join(tmpdir(), 'manager-ledger-filenames-'))
     try {

--- a/crabot-agent/tests/workers/harness/manager-key-ledger.test.ts
+++ b/crabot-agent/tests/workers/harness/manager-key-ledger.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+import { promises as fs } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { LedgerStore, managerKeyToFilename, isManagerKey } from '../../../src/workers/harness/ledger-store.js'
+import type { LedgerWorker, ManagerKey } from '../../../src/workers/harness/ledger-types.js'
+
+const KEY_A = 'wechat::session-a' as ManagerKey
+const KEY_B = 'telegram::session-b' as ManagerKey
+
+function worker(workerId: string, managerKey: ManagerKey = KEY_A): LedgerWorker {
+  const now = '2026-08-10T00:00:00.000Z'
+  return {
+    worker_id: workerId,
+    manager_key: managerKey,
+    task: { id: workerId, title: workerId, status: 'running', created_at: now },
+    origin: { trigger_type: 'message' },
+    report_to: { channel_id: 'wechat', session_id: 'session-a' },
+    incarnations: [],
+    updated_at: now,
+  }
+}
+
+describe('ManagerKey ledger contract', () => {
+  it('stores separate ledgers by manager key and ignores a sibling legacy ledgers directory', async () => {
+    const root = await fs.mkdtemp(join(tmpdir(), 'manager-ledger-red-'))
+    try {
+      const dir = join(root, 'worker-ledgers')
+      await fs.mkdir(join(root, 'ledgers'), { recursive: true })
+      await fs.writeFile(join(root, 'ledgers', 'friend%3Alegacy.json'), JSON.stringify({ workers: [worker('legacy')] }))
+      const store = new LedgerStore(dir)
+      await store.upsertWorker(KEY_A, 'a', () => worker('a'))
+      await store.upsertWorker(KEY_B, 'b', () => worker('b', KEY_B))
+      expect((await store.listWorkers(KEY_A)).map(w => w.worker_id)).toEqual(['a'])
+      expect((await store.listWorkers(KEY_B)).map(w => w.worker_id)).toEqual(['b'])
+      expect((await store.listAllWorkers()).map(entry => entry.worker.worker_id).sort()).toEqual(['a', 'b'])
+      expect(managerKeyToFilename(KEY_A)).toContain('wechat%3A%3Asession-a')
+    } finally {
+      await fs.rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects file/worker owner mismatch, immutable-owner mutation, and duplicate IDs across files', async () => {
+    const dir = await fs.mkdtemp(join(tmpdir(), 'manager-ledger-red-'))
+    try {
+      const store = new LedgerStore(dir)
+      await expect(store.upsertWorker(KEY_A, 'wrong', () => worker('wrong', KEY_B))).rejects.toThrow(/manager_key/)
+      await store.upsertWorker(KEY_A, 'same', () => worker('same'))
+      await expect(store.upsertWorker(KEY_A, 'same', () => worker('same', KEY_B))).rejects.toThrow(/manager_key/)
+      await fs.writeFile(join(dir, managerKeyToFilename(KEY_B)), JSON.stringify({ manager_key: KEY_B, workers: [worker('same', KEY_B)] }))
+      await expect(new LedgerStore(dir).init()).rejects.toThrow(/duplicate worker_id/i)
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true })
+    }
+  })
+  it('serializes concurrent same-worker upserts across ManagerKeys and validates the returned worker id', async () => {
+    const dir = await fs.mkdtemp(join(tmpdir(), 'manager-ledger-race-'))
+    try {
+      const store = new LedgerStore(dir)
+      const results = await Promise.allSettled([
+        store.upsertWorker(KEY_A, 'shared', () => worker('shared')),
+        store.upsertWorker(KEY_B, 'shared', () => worker('shared', KEY_B)),
+      ])
+      expect(results.filter(result => result.status === 'fulfilled')).toHaveLength(1)
+      expect(results.filter(result => result.status === 'rejected')).toHaveLength(1)
+      expect((await store.listAllWorkers()).filter(entry => entry.worker.worker_id === 'shared')).toHaveLength(1)
+      await expect(store.upsertWorker(KEY_A, 'requested', () => worker('returned'))).rejects.toThrow(/worker_id mismatch/)
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('fails loud for malformed manager keys and non-canonical ledger filenames', async () => {
+    const dir = await fs.mkdtemp(join(tmpdir(), 'manager-ledger-filenames-'))
+    try {
+      expect(isManagerKey('channel::session::nested')).toBe(true)
+      expect(isManagerKey('::session')).toBe(false)
+      expect(isManagerKey('channel::')).toBe(false)
+
+      const store = new LedgerStore(dir)
+      await expect(
+        store.upsertWorker('bad' as ManagerKey, 'bad-worker', () => worker('bad-worker', 'bad' as ManagerKey)),
+      ).rejects.toThrow(/invalid manager_key/)
+      expect(await fs.readdir(dir)).toEqual([])
+
+      await fs.writeFile(join(dir, 'channel::session.json'), '{}')
+      await expect(new LedgerStore(dir).init()).rejects.toThrow(/non-canonical ledger filename/)
+      await fs.rm(join(dir, 'channel::session.json'))
+      await fs.writeFile(join(dir, 'channel%3A%3A.json'), '{}')
+      await expect(new LedgerStore(dir).init()).rejects.toThrow(/invalid.*ledger filename/)
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/crabot-agent/tests/workers/legacy-importer.test.ts
+++ b/crabot-agent/tests/workers/legacy-importer.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it, afterEach } from 'vitest'
+import { promises as fs } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { createHash } from 'node:crypto'
+import { LedgerStore } from '../../src/workers/harness/ledger-store.js'
+import { WorkspaceManager } from '../../src/workers/harness/workspace-manager.js'
+import { importV2LegacyTasks } from '../../src/workers/legacy-importer.js'
+import { readLegacyTraces } from '../../src/workers/legacy-source-reader.js'
+import { WorkerEventLog } from '../../src/workers/harness/worker-events.js'
+
+const dirs: string[] = []
+async function fixture(tasks?: unknown): Promise<{ root: string; admin: string; agent: string; traces: string }> {
+  const root = await fs.mkdtemp(join(tmpdir(), 'legacy-import-')); dirs.push(root)
+  const admin = join(root, 'admin'); const agent = join(root, 'agent'); const traces = join(agent, 'traces')
+  await fs.mkdir(admin, { recursive: true }); await fs.mkdir(traces, { recursive: true })
+  if (tasks !== undefined) await fs.writeFile(join(admin, 'tasks.json'), JSON.stringify(tasks))
+  return { root, admin, agent, traces }
+}
+function task(id: string, overrides: Record<string, unknown> = {}) { return { id, title: `title ${id}`, status: 'completed', created_at: '2026-01-01T00:00:00.000Z', priority: 'high', source: { channel_id: 'wechat', session_id: 's', friend_id: 'f', trigger_type: 'message' }, result: { outcome_brief: 'done', finished_at: '2026-01-01T01:00:00.000Z' }, ...overrides } }
+function deps(f: Awaited<ReturnType<typeof fixture>>) { return { adminDataDir: f.admin, traceDir: f.traces, agentDataDir: f.agent, ledger: new LedgerStore(join(f.agent, 'worker-ledgers')), workspaces: new WorkspaceManager(join(f.root, 'workspaces')), now: () => '2026-08-10T00:00:00.000Z' } }
+afterEach(async () => { await Promise.all(dirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true }))) })
+
+describe('v2 legacy importer', () => {
+  it('fails closed when Admin root is absent, but absent tasks and empty tasks complete zero imports', async () => {
+    const missingRoot = await fixture()
+    await fs.rm(missingRoot.admin, { recursive: true })
+    await expect(importV2LegacyTasks(deps(missingRoot))).rejects.toThrow('Admin data directory')
+
+    const absent = await fixture()
+    expect(await importV2LegacyTasks(deps(absent))).toMatchObject({ imported: 0 })
+    const empty = await fixture([])
+    expect(await importV2LegacyTasks(deps(empty))).toMatchObject({ imported: 0 })
+  })
+
+  it('imports task authority only, maps source/statuses, writes one local event and never mutates sources', async () => {
+    const f = await fixture([
+      task('complete', { type: 'analysis', input: { q: 1 }, tags: ['legacy'], goal: { objective: 'finish' } }),
+      task('failed', { status: 'failed' }), task('cancel', { status: 'cancelled' }),
+      task('old', { status: 'executing', source: { trigger_type: 'auto' } }),
+      task('pending', { status: 'pending' }), task('planning', { status: 'planning' }),
+      task('waiting-human', { status: 'waiting_human' }), task('waiting', { status: 'waiting' }),
+      task('scheduled', { source: { channel_id: 'x', session_id: 'y', trigger_type: 'scheduled' } }),
+      task('manual', { source: { channel_id: 'x', session_id: 'manual', trigger_type: 'manual' } }),
+      task('unknown-trigger', { source: { trigger_type: 'unknown' } }),
+      task('chat', { source: { origin: 'admin_chat', trigger_type: 'event' } }),
+    ])
+    const sourceBefore = await fs.readFile(join(f.admin, 'tasks.json'), 'utf8')
+    await fs.writeFile(join(f.traces, 'traces-2026-01-01.jsonl'), JSON.stringify({ trace_id: 't1', related_task_id: 'complete', started_at: '2026-01-01T00:01:00.000Z', ended_at: '2026-01-01T00:02:00.000Z', resume_checkpoint: { worker_state: { cwd: '/does/not/exist' } } }) + '\n' + JSON.stringify({ trace_id: 'orphan', related_task_id: 'none' }) + '\n')
+    const traceBefore = await fs.readFile(join(f.traces, 'traces-2026-01-01.jsonl'), 'utf8')
+    const oldRunningPath = join(f.traces, 'traces-running.jsonl'); await fs.writeFile(oldRunningPath, JSON.stringify({ trace_id: 'old-running', related_task_id: 'complete' }) + '\n')
+    const oldRunningHash = createHash('sha256').update(await fs.readFile(oldRunningPath)).digest('hex')
+    const d = deps(f); const result = await importV2LegacyTasks(d)
+    expect(result.imported).toBe(12)
+    const id = `w-legacy-${createHash('sha256').update('complete').digest('hex').slice(0, 32)}`
+    const complete = await d.ledger.findWorker(id)
+    expect(complete?.worker.task).toMatchObject({
+      status: 'completed', type: 'analysis', input: { q: 1 }, tags: ['legacy'], goal: 'finish',
+      priority: 'high', outcome: 'done',
+    })
+    expect(complete?.worker.legacy_source?.trace_ids).toEqual(['t1', 'old-running'])
+    expect(complete?.worker.incarnations[0]).not.toHaveProperty('session_ref')
+    const old = await d.ledger.findWorker(`w-legacy-${createHash('sha256').update('old').digest('hex').slice(0, 32)}`); expect(old?.worker.task).toMatchObject({ status: 'failed', error: expect.stringContaining('v3') })
+    for (const legacyStatus of ['pending', 'planning', 'waiting-human', 'waiting']) {
+      const imported = await d.ledger.findWorker(`w-legacy-${createHash('sha256').update(legacyStatus).digest('hex').slice(0, 32)}`)
+      expect(imported?.worker.task.status).toBe('failed')
+      expect(imported?.worker.incarnations[0]?.ended_reason).toBe('pre_migration')
+    }
+    const manual = await d.ledger.findWorker(`w-legacy-${createHash('sha256').update('manual').digest('hex').slice(0, 32)}`)
+    expect(manual?.worker.origin.trigger_type).toBe('message')
+    const unknownTrigger = await d.ledger.findWorker(`w-legacy-${createHash('sha256').update('unknown-trigger').digest('hex').slice(0, 32)}`)
+    expect(unknownTrigger?.worker.origin.trigger_type).toBe('system')
+    const chat = await d.ledger.findWorker(`w-legacy-${createHash('sha256').update('chat').digest('hex').slice(0, 32)}`); expect(chat?.worker.manager_key).toBe('admin-web::system-tasks'); expect(chat?.worker.origin.trigger_type).toBe('message')
+    const importedWorkers = await d.ledger.listAllWorkers()
+    expect(importedWorkers).toHaveLength(12)
+    expect(await d.ledger.findWorker(`w-legacy-${createHash('sha256').update('none').digest('hex').slice(0, 32)}`)).toBeUndefined()
+    let importEventCount = 0
+    for (const { worker } of importedWorkers) {
+      const events = await new WorkerEventLog(join(f.agent, 'workers', worker.worker_id)).readAll()
+      importEventCount += events.filter((event) => event.kind === 'legacy_imported').length
+    }
+    expect(importEventCount).toBe(12)
+    expect(await fs.readFile(join(f.admin, 'tasks.json'), 'utf8')).toBe(sourceBefore); expect(await fs.readFile(join(f.traces, 'traces-2026-01-01.jsonl'), 'utf8')).toBe(traceBefore)
+    expect(createHash('sha256').update(await fs.readFile(oldRunningPath)).digest('hex')).toBe(oldRunningHash)
+  })
+
+  it('in_progress detects task and selected trace changes; completed does zero source scans or writes', async () => {
+    const f = await fixture([task('one')]); const d = deps(f)
+    await importV2LegacyTasks(d)
+    const marker = join(f.agent, 'migrations', 'v2-legacy-import-v1.json'); const completed = await fs.readFile(marker, 'utf8')
+    await fs.rm(f.admin, { recursive: true })
+    await fs.rm(f.traces, { recursive: true })
+    expect(await importV2LegacyTasks(d)).toEqual({ skipped: true, imported: 0 })
+    expect(await fs.readFile(marker, 'utf8')).toBe(completed)
+    const second = await fixture([task('two')]); const secondDeps = deps(second)
+    const markerPath = join(second.agent, 'migrations', 'v2-legacy-import-v1.json'); await fs.mkdir(join(second.agent, 'migrations'), { recursive: true })
+    await fs.writeFile(markerPath, JSON.stringify({ version: 1, state: 'in_progress', imported_at: '2026-08-10T00:00:00.000Z', fingerprint: 'absent', manifest: [] }))
+    await expect(importV2LegacyTasks(secondDeps)).rejects.toThrow('source changed')
+  })
+
+  it('rejects duplicate task IDs, unknown statuses, invalid created_at and corrupt completed markers', async () => {
+    const duplicate = await fixture([task('same'), task('same')])
+    await expect(importV2LegacyTasks(deps(duplicate))).rejects.toThrow('duplicate task id')
+    const unknown = await fixture([task('unknown', { status: 'mystery' })])
+    await expect(importV2LegacyTasks(deps(unknown))).rejects.toThrow('invalid required task fields')
+    const badTime = await fixture([task('bad-time', { created_at: '2026-01-01' })])
+    await expect(importV2LegacyTasks(deps(badTime))).rejects.toThrow('invalid required task fields')
+    const corrupt = await fixture([task('one')]); const marker = join(corrupt.agent, 'migrations', 'v2-legacy-import-v1.json')
+    await fs.mkdir(join(corrupt.agent, 'migrations'), { recursive: true })
+    await fs.writeFile(marker, JSON.stringify({ version: 1, state: 'completed', imported_at: '2026-08-10T00:00:00.000Z', fingerprint: 'absent', manifest: [], source_task_count: 1, imported_count: 1, by_manager_key: { 'admin-web::system-tasks': 1 } }))
+    await expect(importV2LegacyTasks(deps(corrupt))).rejects.toThrow('invalid migration marker')
+  })
+
+  it('retries after a crash without duplicate events and preserves cancelled completion time', async () => {
+    const f = await fixture([task('cancel', { status: 'cancelled', completed_at: '2026-01-01T02:00:00.000Z' })])
+    let crashed = false
+    await expect(importV2LegacyTasks({ ...deps(f), afterWorkerImported: () => { if (!crashed) { crashed = true; throw new Error('crash') } } })).rejects.toThrow('crash')
+    const secondPass = {
+      ...deps(f),
+      now: () => '2026-08-11T00:00:00.000Z',
+    }
+    await expect(importV2LegacyTasks(secondPass)).resolves.toMatchObject({ imported: 0 })
+    const id = `w-legacy-${createHash('sha256').update('cancel').digest('hex').slice(0, 32)}`
+    const worker = await deps(f).ledger.findWorker(id)
+    expect(worker?.worker.task).toMatchObject({ status: 'cancelled', completed_at: '2026-01-01T02:00:00.000Z' })
+    const events = (await new WorkerEventLog(join(f.agent, 'workers', id)).readAll()).filter(event => event.kind === 'legacy_imported')
+    expect(events).toEqual([expect.objectContaining({ ts: '2026-08-10T00:00:00.000Z', detail: { admin_task_id: 'cancel', trace_count: 0, imported_at: '2026-08-10T00:00:00.000Z' } })])
+  })
+
+  it('in_progress rejects task changes and selected trace content, removal, or corruption', async () => {
+    async function interruptedFixture(): Promise<{
+      f: Awaited<ReturnType<typeof fixture>>
+      tracePath: string
+      originalTrace: Record<string, unknown>
+    }> {
+      const f = await fixture([task('source')])
+      const tracePath = join(f.traces, 'traces-2026-01-01.jsonl')
+      const originalTrace = {
+        trace_id: 'selected',
+        related_task_id: 'source',
+        started_at: '2026-01-01T00:00:00.000Z',
+        outcome: { summary: 'original' },
+      }
+      await fs.writeFile(tracePath, `${JSON.stringify(originalTrace)}\n`)
+      await expect(importV2LegacyTasks({
+        ...deps(f),
+        afterWorkerImported: () => { throw new Error('interrupt') },
+      })).rejects.toThrow('interrupt')
+      return { f, tracePath, originalTrace }
+    }
+
+    const changedTask = await interruptedFixture()
+    await fs.writeFile(join(changedTask.f.admin, 'tasks.json'), JSON.stringify([
+      task('source', { title: 'changed title' }),
+    ]))
+    await expect(importV2LegacyTasks(deps(changedTask.f))).rejects.toThrow('source changed')
+
+    const changedTrace = await interruptedFixture()
+    await fs.writeFile(changedTrace.tracePath, `${JSON.stringify({
+      ...changedTrace.originalTrace,
+      outcome: { summary: 'changed' },
+    })}\n`)
+    await expect(importV2LegacyTasks(deps(changedTrace.f))).rejects.toThrow('source changed')
+
+    const missingTrace = await interruptedFixture()
+    await fs.rm(missingTrace.tracePath)
+    await expect(importV2LegacyTasks(deps(missingTrace.f))).rejects.toThrow('source changed')
+
+    const corruptTrace = await interruptedFixture()
+    await fs.writeFile(corruptTrace.tracePath, 'not-json\n')
+    await expect(importV2LegacyTasks(deps(corruptTrace.f))).rejects.toThrow('source changed')
+  })
+
+  it('chooses the earliest trace start and the independently latest trace end', async () => {
+    const f = await fixture([task('timeline', { result: { outcome_brief: 'done' } })])
+    const traces = [
+      {
+        trace_id: 'early-start-late-end', related_task_id: 'timeline',
+        started_at: '2026-01-01T00:00:00.000Z', ended_at: '2026-01-01T04:00:00.000Z',
+      },
+      {
+        trace_id: 'late-start-early-end', related_task_id: 'timeline',
+        started_at: '2026-01-01T01:00:00.000Z', ended_at: '2026-01-01T02:00:00.000Z',
+      },
+    ]
+    await fs.writeFile(
+      join(f.traces, 'traces-2026-01-01.jsonl'),
+      traces.map((trace) => JSON.stringify(trace)).join('\n') + '\n',
+    )
+
+    const d = deps(f)
+    await importV2LegacyTasks(d)
+    const workerId = `w-legacy-${createHash('sha256').update('timeline').digest('hex').slice(0, 32)}`
+    const worker = (await d.ledger.findWorker(workerId))!.worker
+    expect(worker.incarnations[0]).toMatchObject({
+      started_at: '2026-01-01T00:00:00.000Z',
+      ended_at: '2026-01-01T04:00:00.000Z',
+    })
+    expect(worker.task.completed_at).toBe('2026-01-01T04:00:00.000Z')
+  })
+
+  it('uses the latest same-task trace, skips v3/malformed input, and rejects cross-task trace IDs', async () => {
+    const f = await fixture()
+    const old = { trace_id: 'same', related_task_id: 'one', started_at: '2026-01-01T00:00:00.000Z', outcome: { summary: 'old' } }
+    const latest = { ...old, outcome: { summary: 'latest' } }
+    await fs.writeFile(join(f.traces, 'traces-2026-01-01.jsonl'), `${JSON.stringify(old)}\nnot-json\n${JSON.stringify(latest)}\n`)
+    await fs.writeFile(join(f.traces, 'traces-running.jsonl'), JSON.stringify({ ...old, outcome: { summary: 'global' } }) + '\n')
+    await fs.writeFile(join(f.traces, 'traces-running-one.jsonl'), JSON.stringify({ ...old, outcome: { summary: 'checkpoint' } }) + '\n')
+    await fs.writeFile(join(f.traces, 'traces-running-v3.jsonl'), JSON.stringify({ trace_id: 'v3', related_task_id: 'one' }) + '\n')
+    const traces = await readLegacyTraces(f.traces)
+    expect(traces.get('one')?.map(trace => trace.trace_id)).toEqual(['same'])
+    expect(traces.get('one')?.[0].outcome?.summary).toBe('checkpoint')
+    await fs.writeFile(join(f.traces, 'traces-running-other.jsonl'), JSON.stringify({ trace_id: 'same', related_task_id: 'two' }) + '\n')
+    await expect(readLegacyTraces(f.traces)).rejects.toThrow('belongs to both')
+  })
+})

--- a/crabot-agent/tests/workers/legacy-importer.test.ts
+++ b/crabot-agent/tests/workers/legacy-importer.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, afterEach } from 'vitest'
+import { describe, expect, it, afterEach, vi } from 'vitest'
 import { promises as fs } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
@@ -31,6 +31,17 @@ describe('v2 legacy importer', () => {
     expect(await importV2LegacyTasks(deps(absent))).toMatchObject({ imported: 0 })
     const empty = await fixture([])
     expect(await importV2LegacyTasks(deps(empty))).toMatchObject({ imported: 0 })
+  })
+
+  it('builds the ledger index once and does not rescan it for every new imported worker', async () => {
+    const f = await fixture([task('one'), task('two'), task('three')])
+    const d = deps(f)
+    const fullLookup = vi.spyOn(d.ledger, 'findWorker')
+
+    await expect(importV2LegacyTasks(d)).resolves.toMatchObject({ imported: 3 })
+
+    expect(fullLookup).not.toHaveBeenCalled()
+    expect(await d.ledger.listAllWorkers()).toHaveLength(3)
   })
 
   it('imports task authority only, maps source/statuses, writes one local event and never mutates sources', async () => {

--- a/crabot-agent/tests/workers/legacy-read-model.test.ts
+++ b/crabot-agent/tests/workers/legacy-read-model.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { promises as fs } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { readLegacyTraceEvents } from '../../src/workers/legacy-source-reader.js'
+
+const directories: string[] = []
+
+async function traceDir(): Promise<string> {
+  const root = await fs.mkdtemp(join(tmpdir(), 'legacy-read-model-'))
+  directories.push(root)
+  return root
+}
+
+afterEach(async () => {
+  await Promise.all(directories.splice(0).map((directory) => fs.rm(directory, { recursive: true, force: true })))
+})
+
+describe('legacy trace read model', () => {
+  it('merges selected traces in stable time order and reports missing references without failing detail', async () => {
+    const directory = await traceDir()
+    await fs.writeFile(join(directory, 'traces-2026-01-01.jsonl'), [
+      JSON.stringify({ trace_id: 'late', related_task_id: 'old', started_at: '2026-01-01T02:00:00.000Z', outcome: { summary: 'late summary' } }),
+      JSON.stringify({ trace_id: 'early', related_task_id: 'old', started_at: '2026-01-01T01:00:00.000Z', outcome: { summary: 'early summary' } }),
+      'broken-json',
+    ].join('\n'))
+
+    const result = await readLegacyTraceEvents(directory, ['late', 'missing', 'early'])
+
+    expect(result.entries.map((entry) => entry.event.summary)).toEqual(['early summary', 'late summary'])
+    expect(result.unavailable_reason).toBe(
+      '1 legacy trace reference(s) unavailable; 1 malformed or unreadable legacy trace record(s)',
+    )
+  })
+
+  it('reports unreadable source as unavailable rather than throwing', async () => {
+    const result = await readLegacyTraceEvents(join(tmpdir(), 'does-not-exist-legacy-traces'), ['gone'])
+    expect(result).toEqual({ entries: [], unavailable_reason: '1 legacy trace reference(s) unavailable' })
+  })
+})

--- a/crabot-shared/src/canonical-json.test.ts
+++ b/crabot-shared/src/canonical-json.test.ts
@@ -1,0 +1,22 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { canonicalizeJson, sha256CanonicalJson } from './canonical-json.js'
+
+test('canonicalizeJson uses RFC 8785 object key ordering and preserves arrays', () => {
+  assert.equal(canonicalizeJson({ z: [3, { b: true, a: 'x' }], a: null }), '{"a":null,"z":[3,{"a":"x","b":true}]}')
+  assert.equal(sha256CanonicalJson({ b: 2, a: 1 }), sha256CanonicalJson({ a: 1, b: 2 }))
+})
+
+test('canonicalizeJson orders object keys by UTF-16 code units', () => {
+  assert.equal(canonicalizeJson({ '\u{1f600}': 1, '\ufffd': 2 }), '{"😀":1,"�":2}')
+})
+
+test('canonicalizeJson uses ECMAScript JSON number and string escaping rules', () => {
+  assert.equal(canonicalizeJson({ n: 1e-7, zero: -0, text: 'line\n\t"\\\u0000' }), '{"n":1e-7,"text":"line\\n\\t\\\"\\\\\\u0000","zero":0}')
+})
+
+test('canonicalizeJson rejects non-I-JSON values, sparse arrays, and unpaired surrogates', () => {
+  for (const value of [NaN, Infinity, -Infinity, undefined, BigInt(1), [undefined], [, 1], { x: undefined }, '\ud800', { '\udc00': 1 }]) {
+    assert.throws(() => canonicalizeJson(value), /canonical JSON/i)
+  }
+})

--- a/crabot-shared/src/canonical-json.ts
+++ b/crabot-shared/src/canonical-json.ts
@@ -1,0 +1,57 @@
+import { createHash } from 'node:crypto'
+
+/** RFC 8785 JSON Canonicalization Scheme for I-JSON values. */
+export function canonicalizeJson(value: unknown): string {
+  return canonicalize(value)
+}
+
+export function sha256CanonicalJson(value: unknown): string {
+  return createHash('sha256').update(canonicalizeJson(value), 'utf8').digest('hex')
+}
+
+function canonicalize(value: unknown): string {
+  if (value === null) return 'null'
+  switch (typeof value) {
+    case 'string':
+      assertWellFormedUnicode(value, 'string')
+      return JSON.stringify(value)
+    case 'boolean':
+      return value ? 'true' : 'false'
+    case 'number':
+      if (!Number.isFinite(value)) throw new TypeError('canonical JSON rejects non-finite numbers')
+      return JSON.stringify(value)
+    case 'object':
+      if (Array.isArray(value)) {
+        for (let index = 0; index < value.length; index++) {
+          if (!(index in value)) throw new TypeError('canonical JSON rejects sparse arrays')
+        }
+        return `[${value.map(canonicalize).join(',')}]`
+      }
+      if (Object.getPrototypeOf(value) !== Object.prototype && Object.getPrototypeOf(value) !== null) {
+        throw new TypeError('canonical JSON only accepts plain objects')
+      }
+      return `{${Object.keys(value as Record<string, unknown>)
+        .map((key) => {
+          assertWellFormedUnicode(key, 'object key')
+          return key
+        })
+        .sort()
+        .map((key) => `${JSON.stringify(key)}:${canonicalize((value as Record<string, unknown>)[key])}`)
+        .join(',')}}`
+    default:
+      throw new TypeError('canonical JSON only accepts JSON values')
+  }
+}
+
+function assertWellFormedUnicode(value: string, kind: string): void {
+  for (let index = 0; index < value.length; index++) {
+    const unit = value.charCodeAt(index)
+    if (unit >= 0xd800 && unit <= 0xdbff) {
+      const next = value.charCodeAt(index + 1)
+      if (!(next >= 0xdc00 && next <= 0xdfff)) throw new TypeError(`canonical JSON rejects unpaired surrogate in ${kind}`)
+      index++
+    } else if (unit >= 0xdc00 && unit <= 0xdfff) {
+      throw new TypeError(`canonical JSON rejects unpaired surrogate in ${kind}`)
+    }
+  }
+}

--- a/crabot-shared/src/index.ts
+++ b/crabot-shared/src/index.ts
@@ -38,6 +38,8 @@ export {
   createEvent,
 } from './base-protocol.js'
 
+export { canonicalizeJson, sha256CanonicalJson } from './canonical-json.js'
+
 export {
   ModuleBase,
   RpcClient,


### PR DESCRIPTION
## Summary

- scope worker ledgers, discovery, known-ID operations, events, schedules, and Admin read models by immutable `ManagerKey`
- add explicit Master-only cross-session worker tools with execution-time authorization generation/revocation checks
- authorize both Admin Chat transports with short-lived, one-time, persisted anti-replay assertions consumed through the official `admin-web` RPC
- stabilize Manager system prompts and carry ingress-captured event time through mailbox, retry, overflow, and mid-episode injection
- import v2 Admin tasks/TraceStore as immutable legacy history and support authorized fresh-v3 continuation without restoring retired loops, RPCs, checkpoints, or a fake legacy adapter
- isolate new runtime traces under `traces-running-v3.jsonl` / `traces-v3-<date>.jsonl` while retaining read-only access to legacy archives

## Design and protocol

Confirmed documentation is in the independent `crabot-docs` repository:

- spec: `2026-08-10-manager-session-worker-ledger-and-event-time-design.md` (`bfce50f`)
- protocol updates: `protocol-agent-v3.md` v3.0.9 and `protocol-admin.md` v0.1.1 (`3e9fedb`)
- implementation plan: `2026-08-10-manager-session-worker-ledger-and-event-time-plan.md` (`313419b`)

## Validation

- Shared: **100 passed**, build passed
- Agent focused legacy/auth/read-model/continuation: **15 files / 285 passed**
- Agent full: **2662 passed / 4 failed / 2 skipped**
  - existing macOS baselines only: one tmux foreground-command mismatch and three `/var` → `/private/var` realpath mismatches
- Admin focused: **81 passed**, `build:all` passed
- Admin full: **1075 passed / 1 failed**
  - existing `v1-cleanup.test.ts` repository-scan failure; the referenced test string is present unchanged on `origin/main`
- `CI=true ./dev.sh build` passed
- `git diff --check` passed
- prohibited-regression searches found no worker `dialog_object_id`, `spawned_by_session`, fake legacy adapter, or retired resume RPC registration
- independent security/correctness reviews cover assertion/replay, known-ID authorization, generation revocation, Manager time semantics, importer crash consistency, read-model ordering, and no-adapter continuation; current head has no unresolved blocker/important findings

## Isolated upgrade evidence

A copy of the current production v2 snapshot was imported under `/tmp/crabot-v2-upgrade-e2e-uF3u3v`:

- 2696 source tasks → 2696 legacy workers
- exactly 2696 `legacy_imported` events
- marker reached `completed`
- second run skipped
- completed fast-path still skipped after source directories were hidden
- copied task/trace source hash remained unchanged

## Accepted residual

`IncarnationHandle.seq` remains adapter-local as documented in `protocol-agent-v3.md` §5.6. A legacy `seq=1` followed by a fresh adapter `seq=1` can therefore collide; fixing this requires a separately confirmed public contract change (harness-global sequence or an additional incarnation discriminator) and is intentionally outside this PR.

## Deployment gate

Before production cutover, retire active old worker/bg owners and back up the old `data/agent/ledgers/` directory. Do not migrate local test-era `friend:*` / `group:*` v3 ledgers. This PR must merge through the configured review/check automation; do not merge manually.
