### PR TITLE
fix/windows-release-install

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -121,6 +121,41 @@ function Ensure-Pnpm {
     Write-Info "pnpm $pnpmVer ready"
 }
 
+function Assert-CrabotStopped($targetInstallDir) {
+    $dataDir = Join-Path $targetInstallDir 'data'
+    $portOffset = 0
+    $instancePath = Join-Path $targetInstallDir 'instance.json'
+    if (Test-Path -LiteralPath $instancePath -PathType Leaf) {
+        $instance = Get-Content -LiteralPath $instancePath -Raw | ConvertFrom-Json
+        if ($instance.data_dir) {
+            $dataDir = $instance.data_dir
+        }
+        if ($null -ne $instance.port_offset) {
+            $portOffset = [int]$instance.port_offset
+        }
+    }
+
+    $pidPath = Join-Path $dataDir 'mm.pid'
+    if (Test-Path -LiteralPath $pidPath -PathType Leaf) {
+        $crabotPid = 0
+        $pidText = (Get-Content -LiteralPath $pidPath -Raw).Trim()
+        if ([int]::TryParse($pidText, [ref]$crabotPid) -and (Get-Process -Id $crabotPid -ErrorAction SilentlyContinue)) {
+            Write-Err "Crabot is running (PID $crabotPid). Run 'crabot stop', then run the installer again."
+            exit 1
+        }
+    }
+
+    try {
+        $health = Invoke-RestMethod -Uri "http://localhost:$((19000 + $portOffset))/health" -Method Post -ContentType 'application/json' -Body '{}' -TimeoutSec 2
+        if ($health.data.status -eq 'healthy') {
+            Write-Err "Crabot is running. Run 'crabot stop', then run the installer again."
+            exit 1
+        }
+    } catch {
+        # The management service is not running or is not a Crabot instance.
+    }
+}
+
 # --- Main ---
 Write-Host "`n== Crabot Installer ==`n" -ForegroundColor Cyan
 
@@ -172,6 +207,8 @@ if ($FromSource) {
         }
         Write-Info "Latest version: $Version"
     }
+    Assert-CrabotStopped $InstallDir
+
     $filename = "crabot-$Version-windows-x64.zip"
     $url = "https://github.com/smilefufu/crabot/releases/download/$Version/$filename"
     New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
@@ -220,6 +257,11 @@ if ($FromSource) {
             -not (Test-Path -LiteralPath (Join-Path $stageMemoryDir 'uv.lock') -PathType Leaf)) {
             Write-Err "Memory dependency manifest missing at $stageMemoryDir"
             exit 1
+        }
+
+        $versionPath = Join-Path $InstallDir 'VERSION'
+        if (Test-Path -LiteralPath $versionPath -PathType Leaf) {
+            Remove-Item -LiteralPath $versionPath -Force
         }
 
         $retainedEntries = @('PortableGit', 'data', 'instance.json', 'crabot.cmd')

--- a/install.ps1
+++ b/install.ps1
@@ -174,7 +174,8 @@ if ($FromSource) {
     }
     $filename = "crabot-$Version-windows-x64.zip"
     $url = "https://github.com/smilefufu/crabot/releases/download/$Version/$filename"
-    $stageParent = Join-Path $env:TEMP ("crabot-install-{0}-{1}" -f $PID, [guid]::NewGuid().ToString('N'))
+    New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+    $stageParent = Join-Path (Split-Path $InstallDir -Parent) (".crabot-i-{0}" -f [guid]::NewGuid().ToString('N').Substring(0, 8))
     $stageRelease = Join-Path $stageParent "crabot-$Version-windows-x64"
     $archivePath = Join-Path $stageParent $filename
 
@@ -221,7 +222,6 @@ if ($FromSource) {
             exit 1
         }
 
-        New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
         $retainedEntries = @('PortableGit', 'data', 'instance.json', 'crabot.cmd')
         foreach ($entry in Get-ChildItem -LiteralPath $stageRelease -Force) {
             if ($retainedEntries -contains $entry.Name) {
@@ -242,6 +242,11 @@ if ($FromSource) {
         # 根 package 的 commander、js-yaml、rotating-file-stream 保留发布包自带版本，不能在这里再次解析版本。
         foreach ($mod in $runtimeModules) {
             $moduleDir = Join-Path $InstallDir $mod
+            $nodeModulesDir = Join-Path $moduleDir 'node_modules'
+            if (Test-Path -LiteralPath $nodeModulesDir -PathType Container) {
+                Remove-Item -LiteralPath $nodeModulesDir -Recurse -Force
+            }
+
             Write-Info "Restoring dependencies: $mod"
             Push-Location $moduleDir
             try {

--- a/install.ps1
+++ b/install.ps1
@@ -79,7 +79,7 @@ function Ensure-Bash {
     try {
         Invoke-WebRequest -Uri $url -OutFile $exe -UseBasicParsing
     } catch {
-        Write-Err "Failed to download PortableGit from ${url}                                                                       : $_"
+        Write-Err "Failed to download PortableGit from ${url}: $_"
         Write-Err "Install Git for Windows manually: https://git-scm.com/downloads/win"
         exit 1
     }
@@ -178,13 +178,50 @@ if ($FromSource) {
     Expand-Archive -Path "$env:TEMP\$filename" -DestinationPath $InstallDir -Force
     Remove-Item "$env:TEMP\$filename"
 
-    Set-Location "$InstallDir\crabot-memory"
-    uv sync
-    Set-Location $InstallDir
+    $crabotDir = Join-Path $InstallDir "crabot-$Version-windows-x64"
+    if (-not (Test-Path (Join-Path $crabotDir "cli.mjs"))) {
+        Write-Err "Extracted release directory not found at $crabotDir"
+        exit 1
+    }
+
+    Ensure-Pnpm
+    foreach ($mod in @('crabot-shared','scripts/lib','crabot-core','crabot-admin','crabot-agent','crabot-channel-dingtalk','crabot-channel-feishu','crabot-channel-telegram','crabot-channel-wechat','crabot-mcp-tools')) {
+        $moduleDir = Join-Path $crabotDir $mod
+        if (-not (Test-Path (Join-Path $moduleDir 'package.json')) -or -not (Test-Path (Join-Path $moduleDir 'pnpm-lock.yaml'))) {
+            Write-Err "Release dependency manifest missing for $mod"
+            exit 1
+        }
+        Write-Info "Restoring dependencies: $mod"
+        Push-Location $moduleDir
+        try {
+            corepack pnpm install --prod --frozen-lockfile
+            if ($LASTEXITCODE -ne 0) {
+                exit $LASTEXITCODE
+            }
+        } finally {
+            Pop-Location
+        }
+    }
+
+    $memoryDir = Join-Path $crabotDir "crabot-memory"
+    if (-not (Test-Path (Join-Path $memoryDir 'pyproject.toml')) -or -not (Test-Path (Join-Path $memoryDir 'uv.lock'))) {
+        Write-Err "Memory dependency manifest missing at $memoryDir"
+        exit 1
+    }
+    Write-Info "Syncing Memory dependencies..."
+    Push-Location $memoryDir
+    try {
+        uv sync --frozen --no-dev
+        if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+        }
+    } finally {
+        Pop-Location
+    }
 }
 
 # PATH
-$crabotDir = if ($FromSource) { (Get-Location).Path } else { $InstallDir }
+$crabotDir = if ($FromSource) { (Get-Location).Path } elseif (-not $crabotDir) { $InstallDir } else { $crabotDir }
 $currentPath = [Environment]::GetEnvironmentVariable("Path", "User")
 if ($currentPath -notlike "*$crabotDir*") {
     [Environment]::SetEnvironmentVariable("Path", "$crabotDir;$currentPath", "User")

--- a/install.ps1
+++ b/install.ps1
@@ -102,7 +102,7 @@ function Ensure-Bash {
     Write-Info "PortableGit installed. CRABOT_BASH_PATH set to $bashPath"
 }
 
-# --- pnpm（仅源码安装路径需要） ---
+# --- pnpm ---
 function Ensure-Pnpm {
     $corepackCmd = Get-Command corepack -ErrorAction SilentlyContinue
     if (-not $corepackCmd) {
@@ -113,6 +113,10 @@ function Ensure-Pnpm {
     # 系统 shim，非管理员 cmd 必然 EPERM。后续所有 `corepack pnpm ...` 调用会按
     # packageManager 字段按需下载到用户 cache 执行，不需要 enable。
     $pnpmVer = (corepack pnpm --version)
+    if ($LASTEXITCODE -ne 0) {
+        Write-Err "corepack could not run pnpm. Reinstall Node.js."
+        exit $LASTEXITCODE
+    }
     Write-Info "pnpm $pnpmVer ready"
 }
 
@@ -122,9 +126,9 @@ Write-Host "`n== Crabot Installer ==`n" -ForegroundColor Cyan
 Ensure-Node
 Ensure-Uv
 Ensure-Bash
+Ensure-Pnpm
 
 if ($FromSource) {
-    Ensure-Pnpm
     Write-Info "Source install..."
     corepack pnpm install
     # shared 必须先编译
@@ -180,17 +184,33 @@ if ($FromSource) {
 
         Write-Info "Extracting..."
         Expand-Archive -Path $archivePath -DestinationPath $stageParent -Force
-        if (-not (Test-Path (Join-Path $stageRelease "cli.mjs")) -or
-            -not (Test-Path (Join-Path $stageRelease "package.json")) -or
-            -not (Test-Path (Join-Path $stageRelease "scripts")) -or
-            -not (Test-Path (Join-Path $stageRelease "crabot-memory"))) {
+        if (-not (Test-Path -LiteralPath (Join-Path $stageRelease "cli.mjs") -PathType Leaf) -or
+            -not (Test-Path -LiteralPath (Join-Path $stageRelease "package.json") -PathType Leaf) -or
+            -not (Test-Path -LiteralPath (Join-Path $stageRelease "scripts") -PathType Container) -or
+            -not (Test-Path -LiteralPath (Join-Path $stageRelease "crabot-memory") -PathType Container) -or
+            -not (Test-Path -LiteralPath (Join-Path $stageRelease "dist") -PathType Container)) {
             Write-Err "Invalid release archive: expected files are missing from $stageRelease"
             exit 1
         }
 
+        $runtimeModules = @('crabot-shared','scripts/lib','crabot-core','crabot-admin','crabot-agent','crabot-channel-dingtalk','crabot-channel-feishu','crabot-channel-telegram','crabot-channel-wechat','crabot-mcp-tools')
+        foreach ($mod in $runtimeModules) {
+            $moduleDir = Join-Path $stageRelease $mod
+            if (-not (Test-Path -LiteralPath (Join-Path $moduleDir 'package.json') -PathType Leaf) -or
+                -not (Test-Path -LiteralPath (Join-Path $moduleDir 'pnpm-lock.yaml') -PathType Leaf)) {
+                Write-Err "Release dependency manifest missing for $mod"
+                exit 1
+            }
+        }
+        $stageMemoryDir = Join-Path $stageRelease 'crabot-memory'
+        if (-not (Test-Path -LiteralPath (Join-Path $stageMemoryDir 'pyproject.toml') -PathType Leaf) -or
+            -not (Test-Path -LiteralPath (Join-Path $stageMemoryDir 'uv.lock') -PathType Leaf)) {
+            Write-Err "Memory dependency manifest missing at $stageMemoryDir"
+            exit 1
+        }
+
         New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
-        $retainedEntries = @('PortableGit', 'data', 'instance.json')
-        Remove-Item (Join-Path $stageRelease 'data') -Recurse -Force -ErrorAction SilentlyContinue
+        $retainedEntries = @('PortableGit', 'data', 'instance.json', 'crabot.cmd')
         foreach ($entry in Get-ChildItem -LiteralPath $stageRelease -Force) {
             if ($retainedEntries -contains $entry.Name) {
                 continue
@@ -206,16 +226,10 @@ if ($FromSource) {
             Remove-Item $legacyDir.FullName -Recurse -Force
         }
 
-        Ensure-Pnpm
         # 根 package 没有随发布包提供 pnpm-lock.yaml，不能用非冻结安装恢复不固定的生产依赖。
         # 根 package 的 commander、js-yaml、rotating-file-stream 保留发布包自带版本，不能在这里再次解析版本。
-        $runtimeModules = @('crabot-shared','scripts/lib','crabot-core','crabot-admin','crabot-agent','crabot-channel-dingtalk','crabot-channel-feishu','crabot-channel-telegram','crabot-channel-wechat','crabot-mcp-tools')
         foreach ($mod in $runtimeModules) {
             $moduleDir = Join-Path $InstallDir $mod
-            if (-not (Test-Path (Join-Path $moduleDir 'package.json')) -or -not (Test-Path (Join-Path $moduleDir 'pnpm-lock.yaml'))) {
-                Write-Err "Release dependency manifest missing for $mod"
-                exit 1
-            }
             Write-Info "Restoring dependencies: $mod"
             Push-Location $moduleDir
             try {
@@ -229,10 +243,6 @@ if ($FromSource) {
         }
 
         $memoryDir = Join-Path $InstallDir "crabot-memory"
-        if (-not (Test-Path (Join-Path $memoryDir 'pyproject.toml')) -or -not (Test-Path (Join-Path $memoryDir 'uv.lock'))) {
-            Write-Err "Memory dependency manifest missing at $memoryDir"
-            exit 1
-        }
         Write-Info "Syncing Memory dependencies..."
         Push-Location $memoryDir
         try {
@@ -244,8 +254,7 @@ if ($FromSource) {
             Pop-Location
         }
 
-        Set-Content -Path (Join-Path $InstallDir 'VERSION') -Value "$Version`n" -Encoding ASCII
-        $crabotDir = $InstallDir
+        Set-Content -Path (Join-Path $InstallDir 'VERSION') -Value $Version -Encoding ASCII
     } finally {
         Remove-Item $stageParent -Recurse -Force -ErrorAction SilentlyContinue
     }
@@ -253,22 +262,34 @@ if ($FromSource) {
 
 # PATH
 $crabotDir = if ($FromSource) { (Get-Location).Path } else { $InstallDir }
+$legacyReleasePattern = ('^{0}\\crabot-[^\\]+-windows-x64\\?$' -f [regex]::Escape($crabotDir.TrimEnd('\')))
+function Update-CrabotPath($pathValue) {
+    $entries = @($pathValue -split ';' | Where-Object { $_ })
+    $filtered = @($entries | Where-Object {
+        $normalized = $_.Trim().TrimEnd('\')
+        $normalized -notmatch $legacyReleasePattern -and $normalized -ine $crabotDir.TrimEnd('\')
+    })
+    return ((@($crabotDir) + $filtered) -join ';')
+}
+
 $currentPath = [Environment]::GetEnvironmentVariable("Path", "User")
-$userPathEntries = @($currentPath -split ';' | Where-Object { $_ })
-if (-not ($userPathEntries | Where-Object { $_.TrimEnd('\') -ieq $crabotDir.TrimEnd('\') })) {
-    [Environment]::SetEnvironmentVariable("Path", "$crabotDir;$currentPath", "User")
-    Write-Info "Added $crabotDir to user PATH"
+$newUserPath = Update-CrabotPath $currentPath
+if ($newUserPath -cne $currentPath) {
+    [Environment]::SetEnvironmentVariable("Path", $newUserPath, "User")
+    Write-Info "Updated user PATH for $crabotDir"
 }
 # 同步更新当前 session 的 $env:Path——SetEnvironmentVariable 只写注册表，
 # 当前进程的 PATH 不会自动刷新。同 session 后续操作（如 crabot start）能立即用。
-$sessionPathEntries = @($env:Path -split ';' | Where-Object { $_ })
-if (-not ($sessionPathEntries | Where-Object { $_.TrimEnd('\') -ieq $crabotDir.TrimEnd('\') })) {
-    $env:Path = "$crabotDir;$env:Path"
+$newSessionPath = Update-CrabotPath $env:Path
+if ($newSessionPath -cne $env:Path) {
+    $env:Path = $newSessionPath
 }
 
-# 始终重写固定根目录的启动器，修复旧版本化目录安装留下的错误路径。
+# 创建 crabot.cmd 如果不存在，避免覆盖用户自定义的启动器。
 $cmdPath = Join-Path $crabotDir "crabot.cmd"
-@('@echo off', 'node "%~dp0cli.mjs" %*') | Set-Content -Path $cmdPath -Encoding ASCII
+if (-not (Test-Path -LiteralPath $cmdPath -PathType Leaf)) {
+    @('@echo off', 'node "%~dp0cli.mjs" %*') | Set-Content -Path $cmdPath -Encoding ASCII
+}
 
 Write-Host "`n== Done! ==`n" -ForegroundColor Cyan
 Write-Info "Run 'crabot start' to start Crabot (will prompt for admin password on first run)."

--- a/install.ps1
+++ b/install.ps1
@@ -169,77 +169,106 @@ if ($FromSource) {
     }
     $filename = "crabot-$Version-windows-x64.zip"
     $url = "https://github.com/smilefufu/crabot/releases/download/$Version/$filename"
+    $stageParent = Join-Path $env:TEMP ("crabot-install-{0}-{1}" -f $PID, [guid]::NewGuid().ToString('N'))
+    $stageRelease = Join-Path $stageParent "crabot-$Version-windows-x64"
+    $archivePath = Join-Path $stageParent $filename
 
-    New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
-    Write-Info "Downloading $filename..."
-    Invoke-WebRequest -Uri $url -OutFile "$env:TEMP\$filename"
+    New-Item -ItemType Directory -Force -Path $stageParent | Out-Null
+    try {
+        Write-Info "Downloading $filename..."
+        Invoke-WebRequest -Uri $url -OutFile $archivePath
 
-    Write-Info "Extracting..."
-    Expand-Archive -Path "$env:TEMP\$filename" -DestinationPath $InstallDir -Force
-    Remove-Item "$env:TEMP\$filename"
-
-    $crabotDir = Join-Path $InstallDir "crabot-$Version-windows-x64"
-    if (-not (Test-Path (Join-Path $crabotDir "cli.mjs"))) {
-        Write-Err "Extracted release directory not found at $crabotDir"
-        exit 1
-    }
-
-    Ensure-Pnpm
-    foreach ($mod in @('crabot-shared','scripts/lib','crabot-core','crabot-admin','crabot-agent','crabot-channel-dingtalk','crabot-channel-feishu','crabot-channel-telegram','crabot-channel-wechat','crabot-mcp-tools')) {
-        $moduleDir = Join-Path $crabotDir $mod
-        if (-not (Test-Path (Join-Path $moduleDir 'package.json')) -or -not (Test-Path (Join-Path $moduleDir 'pnpm-lock.yaml'))) {
-            Write-Err "Release dependency manifest missing for $mod"
+        Write-Info "Extracting..."
+        Expand-Archive -Path $archivePath -DestinationPath $stageParent -Force
+        if (-not (Test-Path (Join-Path $stageRelease "cli.mjs")) -or
+            -not (Test-Path (Join-Path $stageRelease "package.json")) -or
+            -not (Test-Path (Join-Path $stageRelease "scripts")) -or
+            -not (Test-Path (Join-Path $stageRelease "crabot-memory"))) {
+            Write-Err "Invalid release archive: expected files are missing from $stageRelease"
             exit 1
         }
-        Write-Info "Restoring dependencies: $mod"
-        Push-Location $moduleDir
+
+        New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+        $retainedEntries = @('PortableGit', 'data', 'instance.json')
+        Remove-Item (Join-Path $stageRelease 'data') -Recurse -Force -ErrorAction SilentlyContinue
+        foreach ($entry in Get-ChildItem -LiteralPath $stageRelease -Force) {
+            if ($retainedEntries -contains $entry.Name) {
+                continue
+            }
+            $target = Join-Path $InstallDir $entry.Name
+            if (Test-Path $target) {
+                Remove-Item $target -Recurse -Force
+            }
+            Move-Item -LiteralPath $entry.FullName -Destination $target
+        }
+
+        foreach ($legacyDir in Get-ChildItem -LiteralPath $InstallDir -Directory -Filter 'crabot-*-windows-x64' -ErrorAction SilentlyContinue) {
+            Remove-Item $legacyDir.FullName -Recurse -Force
+        }
+
+        Ensure-Pnpm
+        # 根 package 没有随发布包提供 pnpm-lock.yaml，不能用非冻结安装恢复不固定的生产依赖。
+        # 根 package 的 commander、js-yaml、rotating-file-stream 保留发布包自带版本，不能在这里再次解析版本。
+        $runtimeModules = @('crabot-shared','scripts/lib','crabot-core','crabot-admin','crabot-agent','crabot-channel-dingtalk','crabot-channel-feishu','crabot-channel-telegram','crabot-channel-wechat','crabot-mcp-tools')
+        foreach ($mod in $runtimeModules) {
+            $moduleDir = Join-Path $InstallDir $mod
+            if (-not (Test-Path (Join-Path $moduleDir 'package.json')) -or -not (Test-Path (Join-Path $moduleDir 'pnpm-lock.yaml'))) {
+                Write-Err "Release dependency manifest missing for $mod"
+                exit 1
+            }
+            Write-Info "Restoring dependencies: $mod"
+            Push-Location $moduleDir
+            try {
+                corepack pnpm install --prod --frozen-lockfile
+                if ($LASTEXITCODE -ne 0) {
+                    exit $LASTEXITCODE
+                }
+            } finally {
+                Pop-Location
+            }
+        }
+
+        $memoryDir = Join-Path $InstallDir "crabot-memory"
+        if (-not (Test-Path (Join-Path $memoryDir 'pyproject.toml')) -or -not (Test-Path (Join-Path $memoryDir 'uv.lock'))) {
+            Write-Err "Memory dependency manifest missing at $memoryDir"
+            exit 1
+        }
+        Write-Info "Syncing Memory dependencies..."
+        Push-Location $memoryDir
         try {
-            corepack pnpm install --prod --frozen-lockfile
+            uv sync --frozen --no-dev
             if ($LASTEXITCODE -ne 0) {
                 exit $LASTEXITCODE
             }
         } finally {
             Pop-Location
         }
-    }
 
-    $memoryDir = Join-Path $crabotDir "crabot-memory"
-    if (-not (Test-Path (Join-Path $memoryDir 'pyproject.toml')) -or -not (Test-Path (Join-Path $memoryDir 'uv.lock'))) {
-        Write-Err "Memory dependency manifest missing at $memoryDir"
-        exit 1
-    }
-    Write-Info "Syncing Memory dependencies..."
-    Push-Location $memoryDir
-    try {
-        uv sync --frozen --no-dev
-        if ($LASTEXITCODE -ne 0) {
-            exit $LASTEXITCODE
-        }
+        Set-Content -Path (Join-Path $InstallDir 'VERSION') -Value "$Version`n" -Encoding ASCII
+        $crabotDir = $InstallDir
     } finally {
-        Pop-Location
+        Remove-Item $stageParent -Recurse -Force -ErrorAction SilentlyContinue
     }
 }
 
 # PATH
-$crabotDir = if ($FromSource) { (Get-Location).Path } elseif (-not $crabotDir) { $InstallDir } else { $crabotDir }
+$crabotDir = if ($FromSource) { (Get-Location).Path } else { $InstallDir }
 $currentPath = [Environment]::GetEnvironmentVariable("Path", "User")
-if ($currentPath -notlike "*$crabotDir*") {
+$userPathEntries = @($currentPath -split ';' | Where-Object { $_ })
+if (-not ($userPathEntries | Where-Object { $_.TrimEnd('\') -ieq $crabotDir.TrimEnd('\') })) {
     [Environment]::SetEnvironmentVariable("Path", "$crabotDir;$currentPath", "User")
     Write-Info "Added $crabotDir to user PATH"
 }
 # 同步更新当前 session 的 $env:Path——SetEnvironmentVariable 只写注册表，
 # 当前进程的 PATH 不会自动刷新。同 session 后续操作（如 crabot start）能立即用。
-if ($env:Path -notlike "*$crabotDir*") {
+$sessionPathEntries = @($env:Path -split ';' | Where-Object { $_ })
+if (-not ($sessionPathEntries | Where-Object { $_.TrimEnd('\') -ieq $crabotDir.TrimEnd('\') })) {
     $env:Path = "$crabotDir;$env:Path"
 }
 
-# 创建 crabot.cmd 如果不存在
+# 始终重写固定根目录的启动器，修复旧版本化目录安装留下的错误路径。
 $cmdPath = Join-Path $crabotDir "crabot.cmd"
-if (-not (Test-Path $cmdPath)) {
-    # 注意：PowerShell 单引号字符串不转义 `n（会写出字面 `n 而非换行），必须用
-    # 数组 + Set-Content 保证 Windows CRLF 行尾正确写两行。
-    @('@echo off', 'node "%~dp0cli.mjs" %*') | Set-Content -Path $cmdPath -Encoding ASCII
-}
+@('@echo off', 'node "%~dp0cli.mjs" %*') | Set-Content -Path $cmdPath -Encoding ASCII
 
 Write-Host "`n== Done! ==`n" -ForegroundColor Cyan
 Write-Info "Run 'crabot start' to start Crabot (will prompt for admin password on first run)."

--- a/install.ps1
+++ b/install.ps1
@@ -79,7 +79,7 @@ function Ensure-Bash {
     try {
         Invoke-WebRequest -Uri $url -OutFile $exe -UseBasicParsing
     } catch {
-        Write-Err "Failed to download PortableGit from $url: $_"
+        Write-Err "Failed to download PortableGit from ${url}                                                                       : $_"
         Write-Err "Install Git for Windows manually: https://git-scm.com/downloads/win"
         exit 1
     }

--- a/install.ps1
+++ b/install.ps1
@@ -8,6 +8,7 @@ param(
 )
 
 $RequiredNodeVersion = "22.14.0"
+$ErrorActionPreference = 'Stop'
 
 function Write-Info($msg)  { Write-Host "[crabot] $msg" -ForegroundColor Green }
 function Write-Warn($msg)  { Write-Host "[crabot] $msg" -ForegroundColor Yellow }
@@ -181,6 +182,17 @@ if ($FromSource) {
     try {
         Write-Info "Downloading $filename..."
         Invoke-WebRequest -Uri $url -OutFile $archivePath
+
+        $checksumUrl = "$url.sha256"
+        $checksumPath = "$archivePath.sha256"
+        Write-Info "Verifying release checksum..."
+        Invoke-WebRequest -Uri $checksumUrl -OutFile $checksumPath
+        $expectedHash = (Get-Content -LiteralPath $checksumPath -Raw).Trim()
+        $actualHash = (Get-FileHash -LiteralPath $archivePath -Algorithm SHA256).Hash
+        if ($actualHash -ine $expectedHash) {
+            Write-Err "Release archive checksum verification failed."
+            exit 1
+        }
 
         Write-Info "Extracting..."
         Expand-Archive -Path $archivePath -DestinationPath $stageParent -Force


### PR DESCRIPTION
正 Windows 安装脚本中 PortableGit 下载失败提示的 PowerShell 变量插值。

原写法 `$url:` 可能被 PowerShell 作为变量名解析，导致错误信息无法正确显示下载地址；改为 `${url}:` 以明确变量边界。