### PR TITLE
fix(ci): aggregate paginated Claude reviews

### DIFF
--- a/.github/scripts/claude-review-verify.sh
+++ b/.github/scripts/claude-review-verify.sh
@@ -5,8 +5,11 @@
 # FINAL=true 时仍无有效 review 则退出非零，把整个 job 置红（fail-closed，merge-gate 不会放行）。
 set -euo pipefail
 
+# --paginate 会逐页执行 --jq；输出匹配 review 的 ID 后统一数行，避免把多页计数（如 "0\n3"）
+# 当成单个整数，误触发 attempt 2/3。
 count=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews" --paginate --jq \
-  "[.[] | select(.user.login==\"claude[bot]\" and .commit_id==\"${HEAD_SHA}\" and (.state==\"APPROVED\" or ((.body // \"\") | length > 0)))] | length")
+  ".[] | select(.user.login==\"claude[bot]\" and .commit_id==\"${HEAD_SHA}\" and (.state==\"APPROVED\" or ((.body // \"\") | length > 0))) | .id" \
+  | awk 'END { print NR + 0 }')
 
 echo "claude[bot] 对 head ${HEAD_SHA} 的有效 review 数：${count}"
 if [ "${count}" -gt 0 ]; then

--- a/.github/scripts/claude-review-verify.test.sh
+++ b/.github/scripts/claude-review-verify.test.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# claude-review-verify.sh 回归测试：第二页命中的 review 必须被计入。
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+mkdir -p "$tmp_dir/bin"
+
+cat > "$tmp_dir/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+# 旧查询逐页返回 0 和 1；修复后的查询跨页输出唯一一条匹配 review 的 ID。
+query=${!#}
+if [[ "$query" == *'] | length'* ]]; then
+  printf '0\n1\n'
+else
+  printf '4933087302\n'
+fi
+EOF
+chmod +x "$tmp_dir/bin/gh"
+
+output_file="$tmp_dir/github-output"
+PATH="$tmp_dir/bin:$PATH" \
+  GITHUB_REPOSITORY='smilefufu/crabot' PR_NUMBER='92' HEAD_SHA='test-head' \
+  GITHUB_OUTPUT="$output_file" \
+  bash "$repo_root/.github/scripts/claude-review-verify.sh" >/dev/null 2>&1
+
+grep -qx 'ok=true' "$output_file"
+echo 'claude-review-verify pagination test passed'


### PR DESCRIPTION
## 问题

`claude-review-verify.sh` 对 `gh api --paginate --jq '... | length'` 的逐页结果直接做整数比较。review records 超过 100 条后会得到类似 `0\n3` 的多行值，导致 `integer expression expected`，误触发 attempt 2/3 并最终把已有有效 review 的 job 标红。

## 修复

- 分页查询改为输出每条匹配 review 的 ID，再跨页统一计数。
- 新增 shell 回归测试，覆盖“第一页无匹配、第二页有匹配”的场景。

## 验证

- `.github/scripts/claude-review-verify.test.sh`
- `bash -n .github/scripts/claude-review-verify.sh .github/scripts/claude-review-verify.test.sh`
- 使用 PR #92 真实多页数据验证：head `a1a662a2` 正确得到 3 条有效 review 并输出 `ok=true`
- `git diff --check origin/main...HEAD`
