### PR TITLE
feat(p6-d): legacy AgentImplementation/AgentInstance runtime & UI retirement

### DIFF
--- a/crabot-admin/src/admin-api.test.ts
+++ b/crabot-admin/src/admin-api.test.ts
@@ -191,7 +191,8 @@ describe('AdminModule - Model Provider & Agent', () => {
         true
       )
 
-      expect(response.implementation.id).toBe('default')
+      // P6-D：唯一可读 implementation 是静态 core 身份（id 为 exact 'crabot-agent'）。
+      expect(response.implementation.id).toBe('crabot-agent')
     })
   })
 

--- a/crabot-admin/src/agent-instance-cutover.test.ts
+++ b/crabot-admin/src/agent-instance-cutover.test.ts
@@ -1,33 +1,31 @@
 import { describe, expect, it, vi } from 'vitest'
 import AdminModule from './index.js'
 
-describe('Admin dynamic Agent creation cutover', () => {
-  it('rejects the RPC write paths before calling AgentManager', async () => {
+describe('Admin dynamic Agent creation cutover (P6-D final retirement)', () => {
+  it('dynamic instance write RPC 方法不再注册（method not found 即 retired 语义）', () => {
     const subject = Object.create(AdminModule.prototype) as any
-    subject.agentManager = { createInstance: vi.fn(), updateInstance: vi.fn(), deleteInstance: vi.fn(), updateConfig: vi.fn() }
+    expect(subject.handleCreateAgentInstance).toBeUndefined()
+    expect(subject.handleUpdateAgentInstance).toBeUndefined()
+    expect(subject.handleDeleteAgentInstance).toBeUndefined()
+  })
 
-    await expect(subject.handleCreateAgentInstance({ implementation_id: 'legacy', name: 'legacy' }))
-      .rejects.toMatchObject({ code: 'ADMIN_HOTPLUG_NOT_ALLOWED' })
-    await expect(subject.handleUpdateAgentInstance({ instance_id: 'legacy', name: 'changed' }))
-      .rejects.toMatchObject({ code: 'ADMIN_HOTPLUG_NOT_ALLOWED' })
-    await expect(subject.handleDeleteAgentInstance({ instance_id: 'legacy' }))
-      .rejects.toMatchObject({ code: 'ADMIN_HOTPLUG_NOT_ALLOWED' })
+  it('legacy instance config 写仍被拒且零副作用', async () => {
+    const subject = Object.create(AdminModule.prototype) as any
+    subject.agentManager = { updateConfig: vi.fn() }
     await expect(subject.handleUpdateAgentConfig({ instance_id: 'legacy', system_prompt: 'changed' }))
       .rejects.toMatchObject({ code: 'ADMIN_HOTPLUG_NOT_ALLOWED' })
-    expect(subject.agentManager.createInstance).not.toHaveBeenCalled()
-    expect(subject.agentManager.updateInstance).not.toHaveBeenCalled()
-    expect(subject.agentManager.deleteInstance).not.toHaveBeenCalled()
     expect(subject.agentManager.updateConfig).not.toHaveBeenCalled()
   })
 
-  it('hides legacy records from live RPC read surfaces', async () => {
+  it('hides legacy records from live RPC read surfaces（静态 core 身份唯一可读）', async () => {
     const subject = Object.create(AdminModule.prototype) as any
     subject.agentManager = {
-      getImplementation: (id: string) => id === 'default' ? { id: 'default', type: 'builtin', engine: 'crabot' } : { id, type: 'installed' },
-      getInstance: (id: string) => id === 'crabot-agent' ? { id, implementation_id: 'default', auto_start: true } : { id, implementation_id: 'legacy', auto_start: true },
+      getInstance: (id: string) => id === 'crabot-agent' ? { id, implementation_id: 'crabot-agent', auto_start: true } : undefined,
     }
-    expect((await subject.handleListAgentImplementations({ page: 1, page_size: 20 })).items.map((item: { id: string }) => item.id)).toEqual(['default'])
-    expect((await subject.handleListAgentInstances({ page: 1, page_size: 20 })).items.map((item: { id: string }) => item.id)).toEqual(['crabot-agent'])
+    const impls = await subject.handleListAgentImplementations({ page: 1, page_size: 20 })
+    expect(impls.items.map((item: { id: string }) => item.id)).toEqual(['crabot-agent'])
+    const instances = await subject.handleListAgentInstances({ page: 1, page_size: 20 })
+    expect(instances.items.map((item: { id: string }) => item.id)).toEqual(['crabot-agent'])
     await expect(subject.handleGetAgentImplementation({ implementation_id: 'legacy' })).rejects.toThrow('not found')
     await expect(subject.handleGetAgentInstance({ instance_id: 'legacy' })).rejects.toThrow('not found')
   })

--- a/crabot-admin/src/agent-manager.test.ts
+++ b/crabot-admin/src/agent-manager.test.ts
@@ -1,61 +1,30 @@
 /**
- * AgentManager 测试
+ * AgentManager（P6-D 收窄为 core Agent 配置存储）测试。
+ *
+ * 动态 AgentImplementation/AgentInstance CRUD 已退役：旧「创建/更新/删除实例」断言
+ * 不是删除覆盖，而是改为「方法不存在/静态身份只读」的早拒绝语义断言。
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import fs from 'fs/promises'
 import path from 'path'
 import { AgentManager } from './agent-manager.js'
-import type { RpcClient } from 'crabot-shared'
-import type { RuntimeManager } from './runtime-manager.js'
-import type {
-  CreateAgentInstanceParams,
-  UpdateAgentInstanceParams,
-  UpdateAgentConfigParams,
-  AgentImplementation,
-} from './types.js'
+import type { UpdateAgentConfigParams } from './types.js'
 
-describe('AgentManager', () => {
+describe('AgentManager (P6-D core-config-only)', () => {
   let agentManager: AgentManager
   let testDataDir: string
-  let mockRpcClient: RpcClient
-  let mockRuntimeManager: RuntimeManager
 
   beforeEach(async () => {
-    // 创建临时测试目录
-    testDataDir = path.join(process.cwd(), 'test-data', `agent-manager-${Date.now()}`)
+    testDataDir = path.join(process.cwd(), 'test-data', `agent-manager-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
     await fs.mkdir(testDataDir, { recursive: true })
-
     agentManager = new AgentManager(testDataDir)
     await agentManager.initialize()
-    await agentManager.initializeStandaloneDefaults()
-
-    // Mock RpcClient
-    mockRpcClient = {
-      registerModuleDefinition: vi.fn().mockResolvedValue({ module_id: 'test', registered: true }),
-      startModule: vi.fn().mockResolvedValue({ status: 'accepted', tracking_id: 'test-123' }),
-      stopModule: vi.fn().mockResolvedValue({ status: 'accepted', tracking_id: 'test-456' }),
-      unregisterModuleDefinition: vi.fn().mockResolvedValue({ module_id: 'test', unregistered: true }),
-    } as any
-
-    // Mock RuntimeManager
-    mockRuntimeManager = {
-      createStartCommand: vi.fn().mockReturnValue({
-        command: 'node',
-        args: ['dist/main.js'],
-        cwd: '/test/path',
-        env: {},
-      }),
-    } as any
+    await agentManager.initializeCoreDefaultsAndMigrations()
   })
 
   afterEach(async () => {
-    // 清理测试目录
-    try {
-      await fs.rm(testDataDir, { recursive: true, force: true })
-    } catch {
-      // 忽略清理错误
-    }
+    try { await fs.rm(testDataDir, { recursive: true, force: true }) } catch { /* ignore */ }
   })
 
   it('loads persisted core config without default writes and preserves it across restart', async () => {
@@ -76,269 +45,42 @@ describe('AgentManager', () => {
     } finally { await fs.rm(dir, { recursive: true, force: true }) }
   })
 
-  describe('Implementation CRUD', () => {
-    it('should list default implementation', () => {
-      const result = agentManager.listImplementations()
-      expect(result.items).toHaveLength(1)
-      expect(result.items[0].id).toBe('default')
-      expect(result.items[0].type).toBe('builtin')
-    })
-
-    it('should filter implementations by type', () => {
-      const result = agentManager.listImplementations({ type: 'builtin', page: 1, page_size: 20 })
-      expect(result.items).toHaveLength(1)
-      expect(result.items[0].type).toBe('builtin')
-    })
-
-    it('should filter implementations by engine', () => {
-      const result = agentManager.listImplementations({ engine: 'claude-agent-sdk', page: 1, page_size: 20 })
-      expect(result.items).toHaveLength(1)
-      expect(result.items[0].engine).toBe('claude-agent-sdk')
-    })
-
-    it('should paginate implementations', () => {
-      const result = agentManager.listImplementations({ page: 1, page_size: 1 })
-      expect(result.items).toHaveLength(1)
-      expect(result.pagination.page).toBe(1)
-      expect(result.pagination.page_size).toBe(1)
-      expect(result.pagination.total_items).toBe(1)
-    })
-
-    it('should get implementation by id', () => {
-      const impl = agentManager.getImplementation('default')
-      expect(impl).toBeDefined()
-      expect(impl?.id).toBe('default')
-    })
-
-    it('should return undefined for non-existent implementation', () => {
-      const impl = agentManager.getImplementation('non-existent')
-      expect(impl).toBeUndefined()
-    })
-
-    it('should add new implementation', async () => {
-      const newImpl: AgentImplementation = {
-        id: 'test-impl',
-        name: 'Test Implementation',
-        type: 'installed',
-        implementation_type: 'full_code',
-        engine: 'claude-agent-sdk',
-        supported_roles: ['worker'],
-        model_format: 'anthropic',
-        model_roles: [],
-        created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
+  describe('退役语义（替代旧 dynamic CRUD 断言）', () => {
+    it('动态 implementation/instance 写方法不存在', () => {
+      const m = agentManager as unknown as Record<string, unknown>
+      for (const key of ['addImplementation', 'removeImplementation', 'createInstance', 'updateInstance', 'deleteInstance', 'getAutoStartInstances']) {
+        expect(m[key]).toBeUndefined()
       }
-
-      await agentManager.addImplementation(newImpl)
-      const impl = agentManager.getImplementation('test-impl')
-      expect(impl).toBeDefined()
-      expect(impl?.name).toBe('Test Implementation')
     })
 
-    it('should not remove builtin default implementation', async () => {
-      await expect(agentManager.removeImplementation('default')).rejects.toThrow(
-        'Cannot remove builtin default implementation'
-      )
+    it('静态身份只读：getImplementation(default/crabot-agent) 返回静态定义，其它返回 undefined', () => {
+      expect(agentManager.getImplementation('default')?.id).toBe('crabot-agent')
+      expect(agentManager.getImplementation('crabot-agent')?.id).toBe('crabot-agent')
+      expect(agentManager.getImplementation('whatever')).toBeUndefined()
+      expect(agentManager.getInstance('crabot-agent')?.id).toBe('crabot-agent')
+      expect(agentManager.getInstance('other')).toBeUndefined()
     })
 
-    it('should not remove implementation with existing instances', async () => {
-      // 先添加一个实现
-      const newImpl: AgentImplementation = {
-        id: 'test-impl-2',
-        name: 'Test Implementation 2',
-        type: 'installed',
-        implementation_type: 'full_code',
-        engine: 'claude-agent-sdk',
-        supported_roles: ['worker'],
-        model_format: 'anthropic',
-        model_roles: [],
-        created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-      }
-      await agentManager.addImplementation(newImpl)
-
-      // 创建一个使用该实现的实例
-      const params: CreateAgentInstanceParams = {
-        implementation_id: 'test-impl-2',
-        name: 'Test Instance',
-        specialization: 'Test',
-      }
-      await agentManager.createInstance(params, true)
-
-      // 尝试删除实现应该失败
-      await expect(agentManager.removeImplementation('test-impl-2')).rejects.toThrow(
-        'Cannot remove implementation with existing instances'
-      )
-    })
-  })
-
-  describe('Instance CRUD', () => {
-    it('should list default instance (crabot-agent)', () => {
-      const result = agentManager.listInstances()
-      expect(result.items).toHaveLength(1)
-      expect(result.items[0].id).toBe('crabot-agent')
-      expect(result.items[0].name).toBe('Crabot Agent')
+    it('stale/malformed legacy registry 文件不影响 core config 与静态身份', async () => {
+      await fs.writeFile(path.join(testDataDir, 'agent-implementations.json'), '[{"id":"evil","model_roles":[{"key":"hacked"}]}]')
+      await fs.writeFile(path.join(testDataDir, 'agent-instances.json'), 'not json')
+      await fs.mkdir(path.join(testDataDir, 'agent-configs'), { recursive: true })
+      await fs.writeFile(path.join(testDataDir, 'agent-configs', 'front-agent.json'), JSON.stringify({ instance_id: 'front-agent', system_prompt: 'legacy' }))
+      const manager = new AgentManager(testDataDir)
+      await manager.initialize()
+      await manager.initializeCoreDefaultsAndMigrations()
+      expect(manager.getImplementation('default')?.model_roles.some((r) => r.key === 'powerful')).toBe(true)
+      expect(manager.getConfig('front-agent')).toBeUndefined()
+      expect(manager.getConfig('crabot-agent')).toBeDefined()
     })
 
-    it('should filter instances by implementation_id', () => {
-      const result = agentManager.listInstances({ implementation_id: 'default', page: 1, page_size: 20 })
-      expect(result.items.every(i => i.implementation_id === 'default')).toBe(true)
+    it('空 core config 是合法未配置状态（不自动创建 dynamic instance）', async () => {
+      const fresh = new AgentManager(path.join(testDataDir, 'fresh'))
+      await fresh.initialize()
+      expect(fresh.getConfig('crabot-agent')).toBeUndefined()
+      const m = fresh as unknown as Record<string, unknown>
+      expect(m.createInstance).toBeUndefined()
     })
-
-    it('should filter instances by auto_start', () => {
-      const result = agentManager.listInstances({ auto_start: true, page: 1, page_size: 20 })
-      expect(result.items.every(i => i.auto_start === true)).toBe(true)
-    })
-
-    it('should get instance by id', () => {
-      const instance = agentManager.getInstance('crabot-agent')
-      expect(instance).toBeDefined()
-      expect(instance?.id).toBe('crabot-agent')
-    })
-
-    it('should create new instance', async () => {
-      const params: CreateAgentInstanceParams = {
-        implementation_id: 'default',
-        name: 'Test Worker',
-        specialization: 'Testing',
-        max_concurrent_tasks: 5,
-        auto_start: false,
-        start_priority: 30,
-      }
-
-      const instance = await agentManager.createInstance(params, true)
-      expect(instance.id).toBe('test-worker')
-      expect(instance.name).toBe('Test Worker')
-      expect(instance.max_concurrent_tasks).toBe(5)
-      expect(instance.auto_start).toBe(false)
-      expect(instance.start_priority).toBe(30)
-      expect(instance.module_registered).toBe(false)
-    })
-
-    it('should create instance with default values', async () => {
-      const params: CreateAgentInstanceParams = {
-        implementation_id: 'default',
-        name: 'Test Agent',
-        specialization: 'Testing',
-      }
-
-      const instance = await agentManager.createInstance(params, true)
-      expect(instance.max_concurrent_tasks).toBe(5)
-      expect(instance.auto_start).toBe(true)
-      expect(instance.start_priority).toBe(20)
-    })
-
-    it('should throw error for non-existent implementation', async () => {
-      const params: CreateAgentInstanceParams = {
-        implementation_id: 'non-existent',
-        name: 'Test',
-        specialization: 'Test',
-      }
-
-      await expect(agentManager.createInstance(params, true)).rejects.toThrow(
-        'Implementation not found: non-existent'
-      )
-    })
-
-    it('should throw error for duplicate instance id', async () => {
-      const params: CreateAgentInstanceParams = {
-        implementation_id: 'default',
-        name: 'Crabot Agent', // 会生成 id: crabot-agent
-        specialization: 'Test',
-      }
-
-      await expect(agentManager.createInstance(params, true)).rejects.toThrow(
-        'Instance already exists: crabot-agent'
-      )
-    })
-
-    it('should update instance', async () => {
-      const params: UpdateAgentInstanceParams = {
-        instance_id: 'crabot-agent',
-        name: 'Updated Agent',
-        specialization: 'Updated specialization',
-        max_concurrent_tasks: 10,
-      }
-
-      const updated = await agentManager.updateInstance(params)
-      expect(updated.name).toBe('Updated Agent')
-      expect(updated.specialization).toBe('Updated specialization')
-      expect(updated.max_concurrent_tasks).toBe(10)
-    })
-
-    it('should throw error when updating non-existent instance', async () => {
-      const params: UpdateAgentInstanceParams = {
-        instance_id: 'non-existent',
-        name: 'Test',
-      }
-
-      await expect(agentManager.updateInstance(params)).rejects.toThrow(
-        'Instance not found: non-existent'
-      )
-    })
-
-    it('should delete instance', async () => {
-      // 先创建一个实例
-      const createParams: CreateAgentInstanceParams = {
-        implementation_id: 'default',
-        name: 'To Delete',
-        specialization: 'Test',
-      }
-      await agentManager.createInstance(createParams, true)
-
-      // 删除实例
-      await agentManager.deleteInstance('to-delete')
-
-      // 验证已删除
-      const instance = agentManager.getInstance('to-delete')
-      expect(instance).toBeUndefined()
-    })
-
-    it('should throw error when deleting non-existent instance', async () => {
-      await expect(agentManager.deleteInstance('non-existent')).rejects.toThrow(
-        'Instance not found: non-existent'
-      )
-    })
-  })
-
-  describe('Instance with Module Registration', () => {
-    let installedImpl: AgentImplementation
-
-    beforeEach(async () => {
-      // 创建一个已安装的实现
-      installedImpl = {
-        id: 'installed-test',
-        name: 'Installed Test',
-        type: 'installed',
-        implementation_type: 'full_code',
-        engine: 'claude-agent-sdk',
-        supported_roles: ['worker'],
-        model_format: 'anthropic',
-        model_roles: [],
-        installed_path: '/test/installed/path',
-        created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-      }
-      await agentManager.addImplementation(installedImpl)
-    })
-
-    it('rejects dynamic module registration before runtime, MM, or persistence side effects', async () => {
-      const params: CreateAgentInstanceParams = {
-        implementation_id: 'installed-test',
-        name: 'Test Module Instance',
-        specialization: 'Test',
-        auto_start: true,
-      }
-
-      await expect(agentManager.createInstance(params))
-        .rejects.toMatchObject({ code: 'ADMIN_HOTPLUG_NOT_ALLOWED' })
-
-      expect(mockRuntimeManager.createStartCommand).not.toHaveBeenCalled()
-      expect(mockRpcClient.registerModuleDefinition).not.toHaveBeenCalled()
-      expect(mockRpcClient.startModule).not.toHaveBeenCalled()
-      expect(agentManager.getInstance('test-module-instance')).toBeUndefined()
-    })
-
   })
 
   describe('Config CRUD', () => {
@@ -462,79 +204,4 @@ describe('AgentManager', () => {
     })
   })
 
-  describe('Auto-start instances', () => {
-    it('should get auto-start instances sorted by priority', () => {
-      const instances = agentManager.getAutoStartInstances()
-      expect(instances.length).toBeGreaterThanOrEqual(1)
-      expect(instances.every(i => i.auto_start === true)).toBe(true)
-      expect(instances[0].id).toBe('crabot-agent')
-
-      // 验证排序
-      for (let i = 1; i < instances.length; i++) {
-        expect(instances[i].start_priority).toBeGreaterThanOrEqual(instances[i - 1].start_priority)
-      }
-    })
-  })
-
-  describe('Data persistence', () => {
-    it('should persist implementations', async () => {
-      const newImpl: AgentImplementation = {
-        id: 'persist-test',
-        name: 'Persist Test',
-        type: 'installed',
-        implementation_type: 'full_code',
-        engine: 'claude-agent-sdk',
-        supported_roles: ['worker'],
-        model_format: 'anthropic',
-        model_roles: [],
-        created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-      }
-
-      await agentManager.addImplementation(newImpl)
-
-      // 创建新的 AgentManager 实例来验证持久化
-      const newManager = new AgentManager(testDataDir)
-      await newManager.initialize()
-
-      const impl = newManager.getImplementation('persist-test')
-      expect(impl).toBeDefined()
-      expect(impl?.name).toBe('Persist Test')
-    })
-
-    it('should persist instances', async () => {
-      const params: CreateAgentInstanceParams = {
-        implementation_id: 'default',
-        name: 'Persist Instance',
-        specialization: 'Test',
-      }
-
-      await agentManager.createInstance(params, true)
-
-      // 创建新的 AgentManager 实例来验证持久化
-      const newManager = new AgentManager(testDataDir)
-      await newManager.initialize()
-
-      const instance = newManager.getInstance('persist-instance')
-      expect(instance).toBeDefined()
-      expect(instance?.name).toBe('Persist Instance')
-    })
-
-    it('should persist configs', async () => {
-      const params: UpdateAgentConfigParams = {
-        instance_id: 'crabot-agent',
-        system_prompt: 'Persisted prompt',
-      }
-
-      await agentManager.updateConfig(params)
-
-      // 创建新的 AgentManager 实例来验证持久化
-      const newManager = new AgentManager(testDataDir)
-      await newManager.initialize()
-
-      const config = newManager.getConfig('crabot-agent')
-      expect(config).toBeDefined()
-      expect(config?.system_prompt).toBe('Persisted prompt')
-    })
-  })
 })

--- a/crabot-admin/src/agent-manager.ts
+++ b/crabot-admin/src/agent-manager.ts
@@ -1,7 +1,11 @@
 /**
- * Agent 管理器
+ * Core Agent 配置存储（P6-D 收窄）。
  *
- * 负责 Agent 实现（Implementation）、实例（Instance）和配置（Config）的管理
+ * 只负责 exact `crabot-agent` 的行为配置（system prompt / model refs / timezone / extra）
+ * 与旧 model_config key 迁移。动态 AgentImplementation/AgentInstance registry 已退役：
+ * - 静态身份：CORE_AGENT_DEFINITION（core-agent-definition.ts）+ CORE_AGENT_INSTANCE
+ * - 存量记录：legacy-agent-archive.json（CoreAgentCutoverStore/LegacyAgentArchiveStore）
+ * 本文件不再读写 agent-implementations.json / agent-instances.json。
  */
 
 import fs from 'fs/promises'
@@ -12,8 +16,6 @@ import type {
   AgentImplementation,
   AgentInstance,
   AgentInstanceConfig,
-  CreateAgentInstanceParams,
-  UpdateAgentInstanceParams,
   UpdateAgentConfigParams,
   ListAgentImplementationsParams,
   ListAgentInstancesParams,
@@ -22,6 +24,7 @@ import type {
 } from './types.js'
 
 import type { ConfigDomain, CoreAgentConfigMutationContext } from './core-agent-config-revision-store.js'
+import { CORE_AGENT_DEFINITION } from './core-agent-definition.js'
 
 export type ConfigMutationRunner = (
   domains: ConfigDomain[],
@@ -30,163 +33,19 @@ export type ConfigMutationRunner = (
 ) => Promise<void>
 
 
-export const DEFAULT_IMPLEMENTATION: AgentImplementation = {
-  id: 'default',
-  name: 'Crabot Default Agent',
-  type: 'builtin',
-  implementation_type: 'config_only',
-  engine: 'claude-agent-sdk',
-  supported_roles: ['front', 'worker'],
-  model_format: 'anthropic',
-  model_roles: [
-    {
-      key: 'powerful',
-      description: '强力模型，用于主 worker / 复杂推理 / planning',
-      required: true,
-      recommended_capabilities: ['tool_use', 'long_context'],
-      used_by: ['front', 'worker'],
-      fallback: 'global_default',
-    },
-    {
-      key: 'cost_effective',
-      description: '性价比模型，用于简单执行 / 摘要 / 低复杂度调用',
-      required: false,
-      recommended_capabilities: ['fast'],
-      used_by: ['front', 'worker'],
-      fallback: 'global_default',
-    },
-    {
-      key: 'vision',
-      description: '视觉模型，用于截图分析 / UI 识别 / 图片内容理解',
-      required: false,
-      recommended_capabilities: ['vision'],
-      used_by: ['worker'],
-      fallback: 'none',
-    },
-    {
-      // protocol-agent-v3.md §11：manager loop 的对话与工具调用决策用模型。
-      // fallback 特意选 'none'（而不是 'global_default'）：未配置时不由 Admin 自动填全局默认，
-      // 而是把"未配置"这个事实原样透传给 agent 侧——agent 按 model_config.manager ?? model_config.powerful
-      // 解析（见 crabot-agent/src/manager/model-slot.ts），这样当用户已显式给 powerful 配了非默认
-      // provider/model 时，manager 会跟着用 powerful 的实际值，而不是被 Admin 全局默认覆盖掉。
-      key: 'manager',
-      description: 'Manager loop 用模型，负责对话与决策；未配置时回退到 powerful',
-      required: false,
-      recommended_capabilities: ['tool_use', 'long_context'],
-      used_by: ['front'],
-      fallback: 'none',
-    },
-  ],
-  extra_schema: [
-    {
-      key: 'progress_report_master_private',
-      title: 'Master 私聊汇报',
-      description: 'Master 私聊场景下的进度汇报行为',
-      type: 'select',
-      default: 'digest',
-      options: [
-        { value: 'silent', label: '静默' },
-        { value: 'text_forward', label: '文本转发' },
-        { value: 'digest', label: '定期摘要' },
-      ],
-    },
-    {
-      key: 'progress_report_other_private',
-      title: '其他私聊汇报',
-      description: '非 Master 的普通好友私聊场景下的进度汇报行为',
-      type: 'select',
-      default: 'silent',
-      options: [
-        { value: 'silent', label: '静默' },
-        { value: 'text_forward', label: '文本转发' },
-        { value: 'digest', label: '定期摘要' },
-      ],
-    },
-    {
-      key: 'progress_report_group',
-      title: '群聊汇报',
-      description: '群聊场景下的进度汇报行为',
-      type: 'select',
-      default: 'silent',
-      options: [
-        { value: 'silent', label: '静默' },
-        { value: 'text_forward', label: '文本转发' },
-        { value: 'digest', label: '定期摘要' },
-      ],
-    },
-    {
-      key: 'progress_digest_interval_seconds',
-      title: '摘要间隔（秒）',
-      description: '定期摘要模式下的汇报间隔',
-      type: 'number',
-      default: 1800,
-      visible_when: {
-        any_of: [
-          'progress_report_master_private',
-          'progress_report_other_private',
-          'progress_report_group',
-        ],
-        equals: 'digest',
-      },
-    },
-    {
-      key: 'progress_digest_mode',
-      title: '摘要模式',
-      description: 'llm: 用 LLM 生成摘要；extract: 直接提取关键句',
-      type: 'select',
-      default: 'llm',
-      options: [
-        { value: 'llm', label: 'LLM 摘要' },
-        { value: 'extract', label: '提取关键句' },
-      ],
-      visible_when: {
-        any_of: [
-          'progress_report_master_private',
-          'progress_report_other_private',
-          'progress_report_group',
-        ],
-        equals: 'digest',
-      },
-    },
-    {
-      key: 'group_attention_min_ms',
-      title: '群聊最小巡检间隔（ms）',
-      description: 'Agent 刚回复后的最小巡检间隔',
-      type: 'number',
-      default: 120000,
-    },
-    {
-      key: 'group_attention_max_ms',
-      title: '群聊最大巡检间隔（ms）',
-      description: '群聊巡检间隔的上限',
-      type: 'number',
-      default: 1800000,
-    },
-    {
-      key: 'goal_mode_enabled',
-      title: '目标模式',
-      description: '启用后 Worker 可设定任务目标承诺，完成时触发独立审计校验；关闭后直接完成任务无需审计',
-      type: 'boolean',
-      default: true,
-    },
-  ],
-  version: '0.1.0',
-  created_at: '2026-01-01T00:00:00.000Z',
-  updated_at: '2026-01-01T00:00:00.000Z',
-}
-
-const DEFAULT_AGENT_INSTANCE: AgentInstance = {
+/** 唯一 core Agent 实例身份（静态，release-owned；不再是可 CRUD 的 registry record）。 */
+export const CORE_AGENT_INSTANCE: AgentInstance = Object.freeze({
   id: 'crabot-agent',
-  implementation_id: 'default',
+  implementation_id: 'crabot-agent',
   name: 'Crabot Agent',
-  specialization: 'Unified agent with front and worker capabilities',
+  specialization: 'Unified core agent',
   max_concurrent_tasks: 5,
   auto_start: true,
   start_priority: 20,
-  module_registered: false,
+  module_registered: true,
   created_at: '2026-01-01T00:00:00.000Z',
   updated_at: '2026-01-01T00:00:00.000Z',
-}
+})
 
 const DEFAULT_AGENT_CONFIG: AgentInstanceConfig = {
   instance_id: 'crabot-agent',
@@ -201,15 +60,12 @@ const DEFAULT_AGENT_CONFIG: AgentInstanceConfig = {
 // ============================================================================
 
 export class AgentManager {
-  private implementations: Map<string, AgentImplementation> = new Map()
-  private instances: Map<string, AgentInstance> = new Map()
+  /** 仅 exact core 的行为配置（legacy instance config 只存在于 archive，不再进运行时 map）。 */
   private configs: Map<string, AgentInstanceConfig> = new Map()
   /** Loaded snapshot configs that must only be persisted after coordinator recovery. */
   private readonly pendingSnapshotConfigMigrations = new Set<string>()
 
   private readonly dataDir: string
-  private readonly implementationsFilePath: string
-  private readonly instancesFilePath: string
   private readonly configsDir: string
   private onConfigChangedCallback: (() => void) | null = null
   private mutationRunner: ConfigMutationRunner | null = null
@@ -218,8 +74,6 @@ export class AgentManager {
 
   constructor(dataDir: string) {
     this.dataDir = dataDir
-    this.implementationsFilePath = path.join(dataDir, 'agent-implementations.json')
-    this.instancesFilePath = path.join(dataDir, 'agent-instances.json')
     this.configsDir = path.join(dataDir, 'agent-configs')
   }
 
@@ -229,222 +83,25 @@ export class AgentManager {
     await this.loadData()
   }
 
-  /**
-   * Startup load is deliberately write-free. Admin must attach its coordinator after
-   * all persisted source managers are loaded, then call this method for any migration.
-   */
-  async initializeStandaloneDefaults(): Promise<void> {
-    if (this.mutationRunner) throw new Error('Standalone defaults are not allowed with a coordinator')
-    await this.ensureDefaults()
-  }
-
   async initializeCoreDefaultsAndMigrations(): Promise<void> {
-    await this.ensureDefaults()
+    await this.ensureCoreConfig()
     await this.migrateAllModelConfigs()
   }
 
   // ============================================================================
-  // Implementation CRUD
+  // 静态身份（只读；动态 Implementation/Instance registry 已退役）
   // ============================================================================
 
-  listImplementations(params?: ListAgentImplementationsParams): {
-    items: AgentImplementation[]
-    pagination: { page: number; page_size: number; total_items: number; total_pages: number }
-  } {
-    let items = Array.from(this.implementations.values())
-
-    if (params?.type) {
-      items = items.filter((i) => i.type === params.type)
-    }
-    if (params?.engine) {
-      items = items.filter((i) => i.engine === params.engine)
-    }
-
-    const page = params?.page ?? 1
-    const pageSize = params?.page_size ?? 20
-    const total = items.length
-    const totalPages = Math.ceil(total / pageSize)
-    const offset = (page - 1) * pageSize
-
-    return {
-      items: items.slice(offset, offset + pageSize),
-      pagination: { page, page_size: pageSize, total_items: total, total_pages: totalPages },
-    }
-  }
-
+  /** 唯一可读 implementation 是静态 core 定义（兼容旧 id 'default'）。 */
   getImplementation(id: string): AgentImplementation | undefined {
-    return this.implementations.get(id)
+    return id === 'crabot-agent' || id === 'default' ? CORE_AGENT_DEFINITION : undefined
   }
 
-  async addImplementation(impl: AgentImplementation): Promise<AgentImplementation> {
-    this.implementations.set(impl.id, impl)
-    await this.saveImplementations()
-    return impl
-  }
-
-  async removeImplementation(id: string): Promise<void> {
-    if (id === 'default') {
-      throw new Error('Cannot remove builtin default implementation')
-    }
-
-    const hasInstances = Array.from(this.instances.values()).some(
-      (inst) => inst.implementation_id === id
-    )
-    if (hasInstances) {
-      throw new Error('Cannot remove implementation with existing instances')
-    }
-
-    this.implementations.delete(id)
-    await this.saveImplementations()
-  }
-
-  // ============================================================================
-  // Instance CRUD
-  // ============================================================================
-
-  listInstances(params?: ListAgentInstancesParams): {
-    items: AgentInstance[]
-    pagination: { page: number; page_size: number; total_items: number; total_pages: number }
-  } {
-    let items = Array.from(this.instances.values())
-
-    if (params?.implementation_id) {
-      items = items.filter((i) => i.implementation_id === params.implementation_id)
-    }
-    if (params?.auto_start !== undefined) {
-      items = items.filter((i) => i.auto_start === params.auto_start)
-    }
-
-    const page = params?.page ?? 1
-    const pageSize = params?.page_size ?? 20
-    const total = items.length
-    const totalPages = Math.ceil(total / pageSize)
-    const offset = (page - 1) * pageSize
-
-    return {
-      items: items.slice(offset, offset + pageSize),
-      pagination: { page, page_size: pageSize, total_items: total, total_pages: totalPages },
-    }
-  }
-
+  /** 唯一实例是 exact core 静态身份。 */
   getInstance(id: string): AgentInstance | undefined {
-    return this.instances.get(id)
+    return id === 'crabot-agent' ? CORE_AGENT_INSTANCE : undefined
   }
 
-  /**
-   * Test/import compatibility seam. Production entrypoints never pass true; live dynamic Agent
-   * creation remains rejected before any write. P6-D removes this legacy record constructor.
-   */
-  async createInstance(
-    params: CreateAgentInstanceParams,
-    allowLegacyArchiveWrite = false
-  ): Promise<AgentInstance> {
-    if (!allowLegacyArchiveWrite) {
-      throw Object.assign(new Error('Dynamic Agent instances are retired; only builtin crabot-agent is supported'), {
-        code: 'ADMIN_HOTPLUG_NOT_ALLOWED',
-      })
-    }
-    const impl = this.implementations.get(params.implementation_id)
-    if (!impl) {
-      throw new Error(`Implementation not found: ${params.implementation_id}`)
-    }
-
-    const now = generateTimestamp()
-    const instance: AgentInstance = {
-      id: params.name.toLowerCase().replace(/\s+/g, '-'),
-      implementation_id: params.implementation_id,
-      name: params.name,
-      specialization: params.specialization,
-      max_concurrent_tasks: params.max_concurrent_tasks ?? 5,
-      auto_start: params.auto_start ?? true,
-      start_priority: params.start_priority ?? 20,
-      module_registered: false,
-      created_at: now,
-      updated_at: now,
-    }
-
-    if (this.instances.has(instance.id)) {
-      throw new Error(`Instance already exists: ${instance.id}`)
-    }
-
-    this.instances.set(instance.id, instance)
-    await this.saveInstances()
-
-    // 创建默认配置
-    const defaultConfig: AgentInstanceConfig = {
-      instance_id: instance.id,
-      system_prompt: '',
-      model_config: {},
-      max_iterations: 10,
-      tools_readonly: false,
-    }
-    this.configs.set(instance.id, defaultConfig)
-    await this.saveConfig(instance.id)
-
-    return instance
-  }
-
-  async updateInstance(params: UpdateAgentInstanceParams): Promise<AgentInstance> {
-    const existing = this.instances.get(params.instance_id)
-    if (!existing) {
-      throw new Error(`Instance not found: ${params.instance_id}`)
-    }
-
-    const updated: AgentInstance = {
-      ...existing,
-      ...(params.name !== undefined && { name: params.name }),
-      ...(params.specialization !== undefined && { specialization: params.specialization }),
-      ...(params.max_concurrent_tasks !== undefined && { max_concurrent_tasks: params.max_concurrent_tasks }),
-      ...(params.auto_start !== undefined && { auto_start: params.auto_start }),
-      ...(params.start_priority !== undefined && { start_priority: params.start_priority }),
-      updated_at: generateTimestamp(),
-    }
-
-    this.instances.set(params.instance_id, updated)
-    await this.saveInstances()
-    return updated
-  }
-
-  async deleteInstance(id: string, rpcClient?: RpcClient): Promise<void> {
-    const instance = this.instances.get(id)
-    if (!instance) {
-      throw new Error(`Instance not found: ${id}`)
-    }
-
-    const impl = this.implementations.get(instance.implementation_id)
-
-    // 如果是已安装的实现且已注册，先停止并注销模块
-    if (impl?.type === 'installed' && instance.module_registered && rpcClient) {
-      try {
-        await rpcClient.stopModule(id, 'admin')
-        await rpcClient.unregisterModuleDefinition(id, 'admin')
-        console.log(`[AgentManager] Module stopped and unregistered: ${id}`)
-      } catch (error) {
-        console.warn(`[AgentManager] Failed to cleanup module ${id}:`, error)
-      }
-    }
-
-    this.instances.delete(id)
-    this.configs.delete(id)
-    await this.saveInstances()
-
-    // 删除配置文件
-    const configPath = path.join(this.configsDir, `${id}.json`)
-    try {
-      await fs.unlink(configPath)
-    } catch {
-      // 配置文件可能不存在
-    }
-  }
-
-  private async deleteConfig(instanceId: string): Promise<void> {
-    const configPath = path.join(this.configsDir, `${instanceId}.json`)
-    try {
-      await fs.unlink(configPath)
-    } catch {
-      // 配置文件可能不存在
-    }
-  }
 
   // ============================================================================
   // Config CRUD
@@ -554,20 +211,11 @@ export class AgentManager {
     for (const [instanceId, config] of this.configs.entries()) {
       for (const [roleKey, ref] of Object.entries(config.model_config ?? {})) {
         if (ref.provider_id === providerId) {
-          const instance = this.instances.get(instanceId)
-          const name = instance?.name || instanceId
-          refs.push(`Agent "${name}" 的 ${roleKey} 角色`)
+          refs.push(`Agent "${CORE_AGENT_INSTANCE.name}" 的 ${roleKey} 角色`)
         }
       }
     }
     return refs
-  }
-
-  /** 获取所有自动启动的实例（按 start_priority 排序） */
-  getAutoStartInstances(): AgentInstance[] {
-    return Array.from(this.instances.values())
-      .filter((i) => i.auto_start)
-      .sort((a, b) => a.start_priority - b.start_priority)
   }
 
   // ============================================================================
@@ -575,36 +223,9 @@ export class AgentManager {
   // ============================================================================
 
   private async loadData(): Promise<void> {
-    await this.loadImplementations()
-    await this.loadInstances()
     await this.loadConfigs()
   }
 
-  private async loadImplementations(): Promise<void> {
-    try {
-      const data = await fs.readFile(this.implementationsFilePath, 'utf-8')
-      const items = JSON.parse(data) as AgentImplementation[]
-      for (const item of items) {
-        this.implementations.set(item.id, item)
-      }
-      console.log(`[AgentManager] Loaded ${this.implementations.size} implementations`)
-    } catch {
-      console.log('[AgentManager] No existing implementations data')
-    }
-  }
-
-  private async loadInstances(): Promise<void> {
-    try {
-      const data = await fs.readFile(this.instancesFilePath, 'utf-8')
-      const items = JSON.parse(data) as AgentInstance[]
-      for (const item of items) {
-        this.instances.set(item.id, item)
-      }
-      console.log(`[AgentManager] Loaded ${this.instances.size} instances`)
-    } catch {
-      console.log('[AgentManager] No existing instances data')
-    }
-  }
 
   private async loadConfigs(): Promise<void> {
     try {
@@ -631,6 +252,8 @@ export class AgentManager {
           }
         }
 
+        // P6-D：只有 exact core 配置进入运行时；legacy instance config 属于 archive（§3.18）。
+        if (config.instance_id !== 'crabot-agent') continue
         this.configs.set(config.instance_id, config as AgentInstanceConfig)
       }
       console.log(`[AgentManager] Loaded ${this.configs.size} configs`)
@@ -639,33 +262,8 @@ export class AgentManager {
     }
   }
 
-  private async ensureDefaults(): Promise<void> {
-    // 确保默认实现存在，且内置实现的 model_roles 始终与代码同步
-    const existingImpl = this.implementations.get('default')
-    if (!existingImpl) {
-      this.implementations.set('default', DEFAULT_IMPLEMENTATION)
-      await this.saveImplementations()
-    } else if (existingImpl.type === 'builtin') {
-      // 内置实现的 model_roles/supported_roles/model_format 由代码定义，启动时强制同步
-      const updated = {
-        ...existingImpl,
-        model_roles: DEFAULT_IMPLEMENTATION.model_roles,
-        extra_schema: DEFAULT_IMPLEMENTATION.extra_schema,
-        supported_roles: DEFAULT_IMPLEMENTATION.supported_roles,
-        model_format: DEFAULT_IMPLEMENTATION.model_format,
-        updated_at: new Date().toISOString(),
-      }
-      this.implementations.set('default', updated)
-      await this.saveImplementations()
-    }
-
-    // 确保 crabot-agent 实例存在
-    if (!this.instances.has('crabot-agent')) {
-      this.instances.set('crabot-agent', DEFAULT_AGENT_INSTANCE)
-      await this.saveInstances()
-    }
-
-    // 确保 crabot-agent 配置存在
+  /** 仅保证 exact core 配置容器存在（空 model config 是合法未配置状态，§3.18）。 */
+  private async ensureCoreConfig(): Promise<void> {
     if (!this.configs.has('crabot-agent')) {
       const config = { ...DEFAULT_AGENT_CONFIG }
       const apply = async () => {
@@ -732,16 +330,6 @@ export class AgentManager {
    */
   private async atomicWriteFile(filePath: string, content: string): Promise<void> {
     await durableAtomicWriteFile(filePath, content)
-  }
-
-  private async saveImplementations(): Promise<void> {
-    const items = Array.from(this.implementations.values())
-    await this.atomicWriteFile(this.implementationsFilePath, JSON.stringify(items, null, 2))
-  }
-
-  private async saveInstances(): Promise<void> {
-    const items = Array.from(this.instances.values())
-    await this.atomicWriteFile(this.instancesFilePath, JSON.stringify(items, null, 2))
   }
 
   private async saveConfig(instanceId: string): Promise<void> {

--- a/crabot-admin/src/backup/categories.ts
+++ b/crabot-admin/src/backup/categories.ts
@@ -14,6 +14,9 @@ export const CATEGORY_PATHS: Record<BackupCategory, CategoryPath[]> = {
     { rel: 'model_providers.json', kind: 'file' },
     { rel: 'agent-instances.json', kind: 'file' },
     { rel: 'agent-configs', kind: 'dir' },
+    // P6-D：legacy archive/tombstone 纳入 authenticated backup/export（§3.18）
+    { rel: 'legacy-agent-archive.json', kind: 'file' },
+    { rel: 'legacy-agent-tombstones.json', kind: 'file' },
     { rel: 'templates.json', kind: 'file' },
     { rel: 'subagents.json', kind: 'file' },
     { rel: 'mcp-servers.json', kind: 'file' },

--- a/crabot-admin/src/backup/categories.ts
+++ b/crabot-admin/src/backup/categories.ts
@@ -12,8 +12,10 @@ export const CATEGORY_PATHS: Record<BackupCategory, CategoryPath[]> = {
   config: [
     { rel: 'global_model_config.json', kind: 'file' },
     { rel: 'model_providers.json', kind: 'file' },
-    { rel: 'agent-instances.json', kind: 'file' },
-    { rel: 'agent-configs', kind: 'dir' },
+    // P6-D §3.18.1：agent-instances.json 不再导出（live 形态退役；core 身份为静态定义）；
+    // agent-configs 只收 exact core 配置——legacy 配置文件已在 legacy-agent-archive.json
+    // 中归档，整目录导出会让「升级后自备份」被 import preflight 整包拒绝。
+    { rel: 'agent-configs/crabot-agent.json', kind: 'file' },
     // P6-D：legacy archive/tombstone 纳入 authenticated backup/export（§3.18）
     { rel: 'legacy-agent-archive.json', kind: 'file' },
     { rel: 'legacy-agent-tombstones.json', kind: 'file' },

--- a/crabot-admin/src/backup/import/read-archive-category.ts
+++ b/crabot-admin/src/backup/import/read-archive-category.ts
@@ -5,6 +5,8 @@
  */
 import { readArchiveTextFile } from '../../openclaw-import/archive-reader.js'
 
+export { readArchiveTextFile }
+
 /** 读归档内某 JSON 数组文件；不存在 / 非数组 / 解析失败均返回 []。 */
 export async function readJsonArrayFromArchive(
   archivePath: string,

--- a/crabot-admin/src/backup/import/run-import.test.ts
+++ b/crabot-admin/src/backup/import/run-import.test.ts
@@ -136,11 +136,12 @@ describe('runCrabotImport P6-D agent 分类（§3.18.1）', () => {
     })
     const calls: string[] = []
     const deps: ImportDeps = {
-      importCoreAgentConfig: async () => { calls.push('core-config'); return [{ kind: 'agent-config', id: 'crabot-agent', status: 'overwritten' }] },
+      validateAgentPayload: async () => { calls.push('validate'); return { coreConfigRaw: { instance_id: 'crabot-agent' }, archiveRows: [] } },
+      applyCoreAgentConfig: async () => { calls.push('core-config'); return [{ kind: 'agent-config', id: 'crabot-agent', status: 'overwritten' }] },
       finalize: async () => {},
     }
     const summary = await runCrabotImport({ archivePath: archive, categories: ['config'], onConflict: 'skip', deps })
-    expect(calls).toEqual(['core-config'])
+    expect(calls).toEqual(['validate', 'core-config'])
     expect(summary.errors).toEqual([])
   })
 
@@ -150,7 +151,8 @@ describe('runCrabotImport P6-D agent 分类（§3.18.1）', () => {
     })
     const calls: string[] = []
     const deps: ImportDeps = {
-      ingestLegacyArchive: async () => { calls.push('ingest'); return [{ kind: 'legacy-agent-archive', id: 'agent_config:old', status: 'imported' }] },
+      validateAgentPayload: async () => ({ coreConfigRaw: null, archiveRows: [{ archive_id: 'agent_config:old' }] }),
+      applyLegacyArchiveRows: async () => { calls.push('ingest'); return [{ kind: 'legacy-agent-archive', id: 'agent_config:old', status: 'imported' }] },
       finalize: async () => {},
     }
     await runCrabotImport({ archivePath: archive, categories: ['config'], onConflict: 'skip', deps })

--- a/crabot-admin/src/backup/import/run-import.test.ts
+++ b/crabot-admin/src/backup/import/run-import.test.ts
@@ -100,3 +100,60 @@ describe('runCrabotImport', () => {
     expect(summary.errors.some((e) => e.includes('channel'))).toBe(true)
   })
 })
+
+describe('runCrabotImport P6-D agent 分类（§3.18.1）', () => {
+  it('含旧 live non-core instance → 整包 preflight 拒绝，任何 domain 零写入', async () => {
+    const archive = await makeArchive({
+      config: {
+        'agent-instances.json': [{ id: 'front-agent' }],
+        'model_providers.json': [{ id: 'p1' }],
+      },
+      tasks: { 'tasks.json': [{ id: 't1' }] },
+    })
+    const calls: string[] = []
+    const deps: ImportDeps = {
+      upsertProvider: async () => { calls.push('provider'); return 'imported' },
+      upsertTask: async () => { calls.push('task'); return 'imported' },
+      finalize: async () => { calls.push('finalize') },
+    }
+    await expect(runCrabotImport({ archivePath: archive, categories: ['config', 'tasks'], onConflict: 'skip', deps }))
+      .rejects.toMatchObject({ code: 'ADMIN_BACKUP_NON_CORE_AGENT_UNSUPPORTED' })
+    expect(calls).not.toContain('provider')
+    expect(calls).not.toContain('task')
+  })
+
+  it('含旧 live implementation payload → 整包拒绝', async () => {
+    const archive = await makeArchive({
+      config: { 'agent-implementations.json': [{ id: 'custom-agent' }] },
+    })
+    await expect(runCrabotImport({ archivePath: archive, categories: ['config'], onConflict: 'skip', deps: { finalize: async () => {} } }))
+      .rejects.toMatchObject({ code: 'ADMIN_BACKUP_NON_CORE_AGENT_UNSUPPORTED' })
+  })
+
+  it('只含 exact core instance → 通过 preflight，core config 走 importCoreAgentConfig', async () => {
+    const archive = await makeArchive({
+      config: { 'agent-instances.json': [{ id: 'crabot-agent' }] },
+    })
+    const calls: string[] = []
+    const deps: ImportDeps = {
+      importCoreAgentConfig: async () => { calls.push('core-config'); return [{ kind: 'agent-config', id: 'crabot-agent', status: 'overwritten' }] },
+      finalize: async () => {},
+    }
+    const summary = await runCrabotImport({ archivePath: archive, categories: ['config'], onConflict: 'skip', deps })
+    expect(calls).toEqual(['core-config'])
+    expect(summary.errors).toEqual([])
+  })
+
+  it('新格式 legacy archive 经 ingestLegacyArchive 恢复', async () => {
+    const archive = await makeArchive({
+      config: { 'legacy-agent-archive.json': [{ archive_id: 'agent_config:old', source_kind: 'agent_config', source_id: 'old', archived_at: 'x', support_status: 'unsupported_legacy', raw: {} }] },
+    })
+    const calls: string[] = []
+    const deps: ImportDeps = {
+      ingestLegacyArchive: async () => { calls.push('ingest'); return [{ kind: 'legacy-agent-archive', id: 'agent_config:old', status: 'imported' }] },
+      finalize: async () => {},
+    }
+    await runCrabotImport({ archivePath: archive, categories: ['config'], onConflict: 'skip', deps })
+    expect(calls).toEqual(['ingest'])
+  })
+})

--- a/crabot-admin/src/backup/import/run-import.ts
+++ b/crabot-admin/src/backup/import/run-import.ts
@@ -5,7 +5,7 @@
  */
 import type { BackupCategory } from '../types.js'
 import type { CrabotImportSummary, ImportItemResult, ImportStatus, OnConflict } from './import-types.js'
-import { readJsonArrayFromArchive } from './read-archive-category.js'
+import { readJsonArrayFromArchive, readArchiveTextFile } from './read-archive-category.js'
 
 type UpsertFn = (record: unknown) => Promise<ImportStatus>
 
@@ -26,10 +26,12 @@ export type ImportDeps = {
   upsertSchedule?: UpsertFn
   upsertTask?: UpsertFn
   upsertSessionConfig?: UpsertFn
-  /** P6-D：exact core config 只进 CoreAgentConfigStore（静态 slot 校验）。 */
-  importCoreAgentConfig?: (archivePath: string, onConflict: OnConflict) => Promise<ImportItemResult[]>
-  /** P6-D：新格式 LegacyAgentArchiveRecord 恢复到 archive-only store（幂等/冲突规则见 §3.18.1）。 */
-  ingestLegacyArchive?: (archivePath: string, onConflict: OnConflict) => Promise<ImportItemResult[]>
+  /** P6-D：全量校验 agent 相关 payload（纯读+校验，零写入）。 */
+  validateAgentPayload?: (archivePath: string) => Promise<{ coreConfigRaw: Record<string, unknown> | null; archiveRows: unknown[] }>
+  /** P6-D：validate 通过后才允许调用——exact core config 进 CoreAgentConfigStore。 */
+  applyCoreAgentConfig?: (raw: Record<string, unknown>, onConflict: OnConflict) => Promise<ImportItemResult[]>
+  /** P6-D：validate 通过后才允许调用——archive record 恢复（幂等）。 */
+  applyLegacyArchiveRows?: (rows: unknown[], onConflict: OnConflict) => Promise<ImportItemResult[]>
   importSkills?: (archivePath: string, onConflict: OnConflict) => Promise<ImportItemResult[]>
   importMemory?: (archivePath: string, onConflict: OnConflict) => Promise<ImportItemResult[]>
   /** 全部类别处理完后：save + 内存 reload + triggerPushAfter。 */
@@ -69,22 +71,26 @@ export async function runCrabotImport(params: {
   //   - friend-permission-configs.json（按 friend_id 而非 id，留 C1 决定）
   //   - vendor.yaml（system mode 由 root 管，不导入）
   try {
-    // P6-D §3.18.1：全包 preflight 必须先于任何 domain 写入。
+    // P6-D §3.18.1：全包 preflight 必须先于任何 domain 写入（含 core config）。
+    let agentPayload: { coreConfigRaw: Record<string, unknown> | null; archiveRows: unknown[] } | null = null
     if (selected.has('config')) {
-      const legacyImpls = await readJsonArrayFromArchive(archivePath, 'payload/config/agent-implementations.json')
-      const legacyInstances = await readJsonArrayFromArchive(archivePath, 'payload/config/agent-instances.json')
-      const nonCore = legacyInstances.filter((row) => (row as { id?: string }).id !== 'crabot-agent')
-      if (legacyImpls.length > 0 || nonCore.length > 0) {
-        throw new ImportPreflightRejected(
-          'ADMIN_BACKUP_NON_CORE_AGENT_UNSUPPORTED',
-          `旧 live Agent payload 不再支持导入（implementations=${legacyImpls.length}, non-core instances=${nonCore.length}）；请先在旧版本隔离恢复并运行 startup archive migration，再导出新格式 archive`,
-        )
-      }
-      if (deps.importCoreAgentConfig) {
-        results.push(...(await deps.importCoreAgentConfig(archivePath, onConflict)))
-      }
-      if (deps.ingestLegacyArchive) {
-        results.push(...(await deps.ingestLegacyArchive(archivePath, onConflict)))
+      // 存在性检查是 preflight 的一部分：无 agent payload 时不需要校验器。
+      const hasAgentPayload = (await readJsonArrayFromArchive(archivePath, 'payload/config/agent-implementations.json')).length > 0
+        || (await readJsonArrayFromArchive(archivePath, 'payload/config/agent-instances.json')).length > 0
+        || (await readArchiveTextFile(archivePath, 'payload/config/agent-configs/crabot-agent.json')) !== null
+        || (await readArchiveTextFile(archivePath, 'payload/config/legacy-agent-archive.json')) !== null
+      if (hasAgentPayload) {
+        if (!deps.validateAgentPayload) {
+          throw new ImportPreflightRejected('ADMIN_BACKUP_NON_CORE_AGENT_UNSUPPORTED', '缺少 agent payload 校验器')
+        }
+        agentPayload = await deps.validateAgentPayload(archivePath)
+        // 校验通过 → 才允许写入
+        if (agentPayload.coreConfigRaw && deps.applyCoreAgentConfig) {
+          results.push(...(await deps.applyCoreAgentConfig(agentPayload.coreConfigRaw, onConflict)))
+        }
+        if (agentPayload.archiveRows.length > 0 && deps.applyLegacyArchiveRows) {
+          results.push(...(await deps.applyLegacyArchiveRows(agentPayload.archiveRows, onConflict)))
+        }
       }
     }
 
@@ -140,10 +146,6 @@ export async function runCrabotImport(params: {
         errors.push(`memory 导入失败：${String(err)}`)
       }
     }
-  } catch (err) {
-    // preflight 拒绝：整包零写入，直接抛出（不进 results/errors 的部分导入语义）
-    if (err instanceof ImportPreflightRejected) throw err
-    throw err
   } finally {
     // 无论中途是否抛错，finalize（save + reload + push）都要跑，避免半落盘不刷新
     await deps.finalize()

--- a/crabot-admin/src/backup/import/run-import.ts
+++ b/crabot-admin/src/backup/import/run-import.ts
@@ -9,6 +9,13 @@ import { readJsonArrayFromArchive } from './read-archive-category.js'
 
 type UpsertFn = (record: unknown) => Promise<ImportStatus>
 
+/** P6-D §3.18.1：旧 live Agent payload 整包拒绝（在任何 domain 写入前的 preflight 抛出）。 */
+export class ImportPreflightRejected extends Error {
+  constructor(readonly code: string, message: string) {
+    super(message)
+  }
+}
+
 export type ImportDeps = {
   upsertProvider?: UpsertFn
   upsertChannel?: UpsertFn
@@ -19,7 +26,10 @@ export type ImportDeps = {
   upsertSchedule?: UpsertFn
   upsertTask?: UpsertFn
   upsertSessionConfig?: UpsertFn
-  upsertAgentInstance?: UpsertFn
+  /** P6-D：exact core config 只进 CoreAgentConfigStore（静态 slot 校验）。 */
+  importCoreAgentConfig?: (archivePath: string, onConflict: OnConflict) => Promise<ImportItemResult[]>
+  /** P6-D：新格式 LegacyAgentArchiveRecord 恢复到 archive-only store（幂等/冲突规则见 §3.18.1）。 */
+  ingestLegacyArchive?: (archivePath: string, onConflict: OnConflict) => Promise<ImportItemResult[]>
   importSkills?: (archivePath: string, onConflict: OnConflict) => Promise<ImportItemResult[]>
   importMemory?: (archivePath: string, onConflict: OnConflict) => Promise<ImportItemResult[]>
   /** 全部类别处理完后：save + 内存 reload + triggerPushAfter。 */
@@ -34,7 +44,7 @@ const SIMPLE_ARRAY_IMPORT: Array<{
   { category: 'config', file: 'payload/config/subagents.json', depKey: 'upsertSubagent', kind: 'subagent' },
   { category: 'config', file: 'payload/config/templates.json', depKey: 'upsertTemplate', kind: 'template' },
   { category: 'config', file: 'payload/config/session-configs.json', depKey: 'upsertSessionConfig', kind: 'session-config' },
-  { category: 'config', file: 'payload/config/agent-instances.json', depKey: 'upsertAgentInstance', kind: 'agent-instance' },
+  // P6-D：agent-instances.json 不在此表——由 preflight 分类（§3.18.1），live non-core 整包拒绝。
   { category: 'config', file: 'payload/config/mcp-servers.json', depKey: 'upsertMcp', kind: 'mcp' },
   { category: 'channels', file: 'payload/channels/friends.json', depKey: 'upsertFriend', kind: 'friend' },
   { category: 'tasks', file: 'payload/tasks/tasks.json', depKey: 'upsertTask', kind: 'task' },
@@ -54,11 +64,30 @@ export async function runCrabotImport(params: {
 
   // 注：以下导出文件不走本表，由 C1 的 deps 接线特殊处理或刻意不导入：
   //   - global_model_config.json（单对象非数组，C1 特殊落地）
-  //   - agent-configs/<id>.json（随 agent-instance 由 upsertAgentInstance 一并写）
+  //   - agent-configs/crabot-agent.json（P6-D：由 importCoreAgentConfig 单独进 CoreStore）
   //   - channel-configs/<id>.json（随 channel 实例由 upsertChannel 一并写）
   //   - friend-permission-configs.json（按 friend_id 而非 id，留 C1 决定）
   //   - vendor.yaml（system mode 由 root 管，不导入）
   try {
+    // P6-D §3.18.1：全包 preflight 必须先于任何 domain 写入。
+    if (selected.has('config')) {
+      const legacyImpls = await readJsonArrayFromArchive(archivePath, 'payload/config/agent-implementations.json')
+      const legacyInstances = await readJsonArrayFromArchive(archivePath, 'payload/config/agent-instances.json')
+      const nonCore = legacyInstances.filter((row) => (row as { id?: string }).id !== 'crabot-agent')
+      if (legacyImpls.length > 0 || nonCore.length > 0) {
+        throw new ImportPreflightRejected(
+          'ADMIN_BACKUP_NON_CORE_AGENT_UNSUPPORTED',
+          `旧 live Agent payload 不再支持导入（implementations=${legacyImpls.length}, non-core instances=${nonCore.length}）；请先在旧版本隔离恢复并运行 startup archive migration，再导出新格式 archive`,
+        )
+      }
+      if (deps.importCoreAgentConfig) {
+        results.push(...(await deps.importCoreAgentConfig(archivePath, onConflict)))
+      }
+      if (deps.ingestLegacyArchive) {
+        results.push(...(await deps.ingestLegacyArchive(archivePath, onConflict)))
+      }
+    }
+
     for (const item of SIMPLE_ARRAY_IMPORT) {
       if (!selected.has(item.category)) continue
       const rows = await readJsonArrayFromArchive(archivePath, item.file)
@@ -111,6 +140,10 @@ export async function runCrabotImport(params: {
         errors.push(`memory 导入失败：${String(err)}`)
       }
     }
+  } catch (err) {
+    // preflight 拒绝：整包零写入，直接抛出（不进 results/errors 的部分导入语义）
+    if (err instanceof ImportPreflightRejected) throw err
+    throw err
   } finally {
     // 无论中途是否抛错，finalize（save + reload + push）都要跑，避免半落盘不刷新
     await deps.finalize()

--- a/crabot-admin/src/core-agent-cutover-retry.test.ts
+++ b/crabot-admin/src/core-agent-cutover-retry.test.ts
@@ -13,11 +13,9 @@ function createSubject(options: { completionError?: unknown; existingMarker?: bo
   subject.cutoverRecoveryReason = null
   subject.cutoverBearer = 'cutover-secret'
   subject.config = { moduleId: 'admin-web' }
-  subject.agentManager = {
-    listImplementations: () => ({ items: [{ id: 'default' }] }),
-    listInstances: () => ({ items: [{ id: 'crabot-agent' }] }),
-    listConfigs: () => [{ instance_id: 'crabot-agent' }],
-  }
+  subject.adminConfig = { data_dir: '/nonexistent-p6d-test' }
+  // P6-D：cutover inventory 改直读原始文件；测试用 spy 替换为固定空源（语义同旧 mock）。
+  subject.readLegacyAgentInventorySources = vi.fn().mockResolvedValue([])
   subject.readLegacyAgentPackageEntries = vi.fn().mockResolvedValue([])
   subject.readLegacyFrontWorkerConfigSources = vi.fn().mockResolvedValue([])
   subject.cutoverStore = {

--- a/crabot-admin/src/core-agent-cutover-retry.test.ts
+++ b/crabot-admin/src/core-agent-cutover-retry.test.ts
@@ -16,6 +16,7 @@ function createSubject(options: { completionError?: unknown; existingMarker?: bo
   subject.adminConfig = { data_dir: '/nonexistent-p6d-test' }
   // P6-D：cutover inventory 改直读原始文件；测试用 spy 替换为固定空源（语义同旧 mock）。
   subject.readLegacyAgentInventorySources = vi.fn().mockResolvedValue([])
+  subject.legacyArchiveStore = { deletedArchiveIds: vi.fn().mockResolvedValue(new Set()) }
   subject.readLegacyAgentPackageEntries = vi.fn().mockResolvedValue([])
   subject.readLegacyFrontWorkerConfigSources = vi.fn().mockResolvedValue([])
   subject.cutoverStore = {
@@ -145,5 +146,19 @@ describe('core Agent cutover activation retry', () => {
       archive_record_count: 0,
     }))
     expect(subject.cutoverActivated).toBe(true)
+  })
+})
+
+describe('P6-D R2: tombstone 防止 inventory 复活已删 archive', () => {
+  it('deletedArchiveIds 中的来源不进入 archive() 调用', async () => {
+    const subject = createSubject()
+    subject.readLegacyAgentInventorySources = vi.fn().mockResolvedValue([
+      { source_kind: 'agent_instance', source_id: 'front-agent', raw: { id: 'front-agent' } },
+      { source_kind: 'agent_instance', source_id: 'worker-general', raw: { id: 'worker-general' } },
+    ])
+    subject.legacyArchiveStore = { deletedArchiveIds: vi.fn().mockResolvedValue(new Set(['agent_instance:front-agent'])) }
+    await subject.completeCoreAgentCutover()
+    const archived = subject.cutoverStore.archive.mock.calls[0][0] as Array<{ source_kind: string; source_id: string }>
+    expect(archived.map((s) => `${s.source_kind}:${s.source_id}`)).toEqual(['agent_instance:worker-general'])
   })
 })

--- a/crabot-admin/src/core-agent-cutover.ts
+++ b/crabot-admin/src/core-agent-cutover.ts
@@ -10,6 +10,7 @@ export interface LegacyAgentArchiveRecord {
   archive_id: string
   source_kind: LegacyAgentArchiveKind
   source_id: string
+  module_id?: string
   archived_at: string
   support_status: 'unsupported_legacy'
   raw: unknown

--- a/crabot-admin/src/core-agent-definition.ts
+++ b/crabot-admin/src/core-agent-definition.ts
@@ -1,11 +1,156 @@
-import { DEFAULT_IMPLEMENTATION } from './agent-manager.js'
+/**
+ * Static core Agent contract（protocol-admin §3.19.8）。
+ * Legacy implementation records are not authoritative——此定义由 release 唯一拥有。
+ */
 import type { AgentImplementation } from './types.js'
 
-/** Static core Agent contract. Legacy implementation records are not authoritative. */
+const CORE_BODY: AgentImplementation = {
+  id: 'default',
+  name: 'Crabot Default Agent',
+  type: 'builtin',
+  implementation_type: 'config_only',
+  engine: 'claude-agent-sdk',
+  supported_roles: ['front', 'worker'],
+  model_format: 'anthropic',
+  model_roles: [
+    {
+      key: 'powerful',
+      description: '强力模型，用于主 worker / 复杂推理 / planning',
+      required: true,
+      recommended_capabilities: ['tool_use', 'long_context'],
+      used_by: ['front', 'worker'],
+      fallback: 'global_default',
+    },
+    {
+      key: 'cost_effective',
+      description: '性价比模型，用于简单执行 / 摘要 / 低复杂度调用',
+      required: false,
+      recommended_capabilities: ['fast'],
+      used_by: ['front', 'worker'],
+      fallback: 'global_default',
+    },
+    {
+      key: 'vision',
+      description: '视觉模型，用于截图分析 / UI 识别 / 图片内容理解',
+      required: false,
+      recommended_capabilities: ['vision'],
+      used_by: ['worker'],
+      fallback: 'none',
+    },
+    {
+      // protocol-agent-v3.md §11：manager loop 的对话与工具调用决策用模型。
+      // fallback 特意选 'none'（而不是 'global_default'）：未配置时不由 Admin 自动填全局默认，
+      // 而是把"未配置"这个事实原样透传给 agent 侧——agent 按 model_config.manager ?? model_config.powerful
+      // 解析（见 crabot-agent/src/manager/model-slot.ts），这样当用户已显式给 powerful 配了非默认
+      // provider/model 时，manager 会跟着用 powerful 的实际值，而不是被 Admin 全局默认覆盖掉。
+      key: 'manager',
+      description: 'Manager loop 用模型，负责对话与决策；未配置时回退到 powerful',
+      required: false,
+      recommended_capabilities: ['tool_use', 'long_context'],
+      used_by: ['front'],
+      fallback: 'none',
+    },
+  ],
+  extra_schema: [
+    {
+      key: 'progress_report_master_private',
+      title: 'Master 私聊汇报',
+      description: 'Master 私聊场景下的进度汇报行为',
+      type: 'select',
+      default: 'digest',
+      options: [
+        { value: 'silent', label: '静默' },
+        { value: 'text_forward', label: '文本转发' },
+        { value: 'digest', label: '定期摘要' },
+      ],
+    },
+    {
+      key: 'progress_report_other_private',
+      title: '其他私聊汇报',
+      description: '非 Master 的普通好友私聊场景下的进度汇报行为',
+      type: 'select',
+      default: 'silent',
+      options: [
+        { value: 'silent', label: '静默' },
+        { value: 'text_forward', label: '文本转发' },
+        { value: 'digest', label: '定期摘要' },
+      ],
+    },
+    {
+      key: 'progress_report_group',
+      title: '群聊汇报',
+      description: '群聊场景下的进度汇报行为',
+      type: 'select',
+      default: 'silent',
+      options: [
+        { value: 'silent', label: '静默' },
+        { value: 'text_forward', label: '文本转发' },
+        { value: 'digest', label: '定期摘要' },
+      ],
+    },
+    {
+      key: 'progress_digest_interval_seconds',
+      title: '摘要间隔（秒）',
+      description: '定期摘要模式下的汇报间隔',
+      type: 'number',
+      default: 1800,
+      visible_when: {
+        any_of: [
+          'progress_report_master_private',
+          'progress_report_other_private',
+          'progress_report_group',
+        ],
+        equals: 'digest',
+      },
+    },
+    {
+      key: 'progress_digest_mode',
+      title: '摘要模式',
+      description: 'llm: 用 LLM 生成摘要；extract: 直接提取关键句',
+      type: 'select',
+      default: 'llm',
+      options: [
+        { value: 'llm', label: 'LLM 摘要' },
+        { value: 'extract', label: '提取关键句' },
+      ],
+      visible_when: {
+        any_of: [
+          'progress_report_master_private',
+          'progress_report_other_private',
+          'progress_report_group',
+        ],
+        equals: 'digest',
+      },
+    },
+    {
+      key: 'group_attention_min_ms',
+      title: '群聊最小巡检间隔（ms）',
+      description: 'Agent 刚回复后的最小巡检间隔',
+      type: 'number',
+      default: 120000,
+    },
+    {
+      key: 'group_attention_max_ms',
+      title: '群聊最大巡检间隔（ms）',
+      description: '群聊巡检间隔的上限',
+      type: 'number',
+      default: 1800000,
+    },
+    {
+      key: 'goal_mode_enabled',
+      title: '目标模式',
+      description: '启用后 Worker 可设定任务目标承诺，完成时触发独立审计校验；关闭后直接完成任务无需审计',
+      type: 'boolean',
+      default: true,
+    },
+  ],
+  version: '0.1.0',
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:00.000Z',
+}
+
 export const CORE_AGENT_DEFINITION: AgentImplementation = Object.freeze({
-  ...DEFAULT_IMPLEMENTATION,
+  ...CORE_BODY,
   id: 'crabot-agent',
-  name: DEFAULT_IMPLEMENTATION.name,
-  model_roles: DEFAULT_IMPLEMENTATION.model_roles,
-  extra_schema: DEFAULT_IMPLEMENTATION.extra_schema,
+  name: 'Crabot Core Agent',
 })

--- a/crabot-admin/src/index.ts
+++ b/crabot-admin/src/index.ts
@@ -7158,14 +7158,17 @@ export class AdminModule extends ModuleBase {
   private async completeCoreAgentCutoverAttempt(): Promise<void> {
     const packageEntries = await this.readLegacyAgentPackageEntries()
     const frontWorkerConfigs = await this.readLegacyFrontWorkerConfigSources()
+    const deletedIds = await this.legacyArchiveStore.deletedArchiveIds()
     const sources = [
       // P6-D：cutover inventory 直读 legacy 原始文件（unknown + 最小投影），不经运行时 map。
       ...(await this.readLegacyAgentInventorySources()),
       ...packageEntries.map((entry) => ({ source_kind: 'installed_package' as const, source_id: entry.source_id, raw: entry.raw })),
       ...frontWorkerConfigs.map((entry) => ({ source_kind: 'agent_config' as const, source_id: `legacy-${entry.source_id}`, raw: entry.raw })),
     ]
+    // tombstone 过滤（§3.3 item 4）：用户显式删除过的 archive 不得被残留源文件复活。
+    const filtered = sources.filter((source) => !deletedIds.has(`${source.source_kind}:${source.source_id}`))
     // archive() 合并时对已归档记录的内容变化抛事实冲突（重新进入 gate）；新增条目只扩展只读归档。
-    const archive = await this.cutoverStore.archive(sources)
+    const archive = await this.cutoverStore.archive(filtered)
     const existing = await this.cutoverStore.loadMarker()
     // marker 已提交 cutover 拓扑：提交后的每次重启都必须用已提交的 fingerprint/count 与 MM
     // 握手（MM record 按该值对账）。cutover 之后新增的 legacy 条目可以容忍——与 MM 侧

--- a/crabot-admin/src/index.ts
+++ b/crabot-admin/src/index.ts
@@ -21,7 +21,7 @@ import { BACKUP_CATEGORIES, DEFAULT_CATEGORIES } from './backup/categories.js'
 import { exportArchive } from './backup/export-archive.js'
 import type { BackupCategory } from './backup/types.js'
 import { validateBackupManifest } from './backup/manifest.js'
-import { runCrabotImport, type ImportDeps } from './backup/import/run-import.js'
+import { runCrabotImport, ImportPreflightRejected, type ImportDeps } from './backup/import/run-import.js'
 import type { ImportStatus, OnConflict, ImportItemResult } from './backup/import/import-types.js'
 import { shouldDisableOnImport } from './backup/import/schedule-arm.js'
 import { VersionService } from './version/version-service.js'
@@ -33,12 +33,13 @@ import { WorkerImplementationStore } from './worker-implementation-store.js'
 import type { WorkerImplementationRuntimeConfig, CLIWorkerImplId } from './types.js'
 import { WorkerConnectionRevisionSigner } from './worker-connection-revision.js'
 import { WorkerOperationAssertions } from './worker-operation-assertions.js'
+import { LegacyAgentArchiveStore, LegacyAgentArchiveError } from './legacy-agent-archive.js'
 import { CoreAgentCutoverStore } from './core-agent-cutover.js'
 import { CORE_AGENT_DEFINITION } from './core-agent-definition.js'
 import { BrowserManager } from './browser-manager.js'
 import { PermissionTemplateManager } from './permission-template-manager.js'
 import { decodePathSegment, isPathSafeSegment } from './http-path.js'
-import {
+import { canonicalizeJson,
   ModuleBase,
   type ModuleConfig,
   type Event,
@@ -121,8 +122,6 @@ import {
   type CoreAgentRuntimeConfig,
   type SubAgentConfig,
   type SubAgentRegistryEntry,
-  type CreateAgentInstanceParams,
-  type UpdateAgentInstanceParams,
   type UpdateAgentConfigParams,
   type ListAgentImplementationsParams,
   type ListAgentInstancesParams,
@@ -135,8 +134,6 @@ import {
   type ListChannelImplementationsParams,
   type ListChannelInstancesParams,
   type ModuleSource,
-  type PreviewModulePackageParams,
-  type InstallModuleParams,
   type ChatCallbackParams,
   type ChatCallbackResult,
   type GetChatHistoryParams,
@@ -469,6 +466,7 @@ export class AdminModule extends ModuleBase {
   private readonly adminConfig: AdminConfig
   private readonly configMutationCoordinator: CoreAgentConfigMutationCoordinator
   private readonly cutoverStore: CoreAgentCutoverStore
+  private readonly legacyArchiveStore: LegacyAgentArchiveStore
   private readonly managementOnly: boolean
   private readonly cutoverBearer?: string
   private cutoverActivated = false
@@ -604,6 +602,7 @@ export class AdminModule extends ModuleBase {
       abortSourceJournal: () => this.skillManager.recoverSourceJournal(this.configMutationCoordinator),
     })
     this.cutoverStore = new CoreAgentCutoverStore(this.adminConfig.data_dir)
+    this.legacyArchiveStore = new LegacyAgentArchiveStore(this.adminConfig.data_dir)
     this.managementOnly = process.env.CRABOT_ADMIN_STARTUP_MODE === 'core-agent-cutover'
     this.cutoverBearer = process.env.CRABOT_ADMIN_CUTOVER_BEARER
     delete process.env.CRABOT_ADMIN_STARTUP_MODE
@@ -624,7 +623,7 @@ export class AdminModule extends ModuleBase {
     )
     this.agentManager = new AgentManager(this.adminConfig.data_dir)
     this.channelManager = new ChannelManager(this.adminConfig.data_dir, this.rpcClient)
-    this.moduleInstaller = new ModuleInstaller(this.adminConfig.data_dir, this.agentManager)
+    this.moduleInstaller = new ModuleInstaller(this.adminConfig.data_dir)
     this.mcpServerManager = new MCPServerManager(this.adminConfig.data_dir)
     this.skillManager = new SkillManager(this.adminConfig.data_dir)
     this.essentialToolsManager = new EssentialToolsManager(this.adminConfig.data_dir)
@@ -742,9 +741,6 @@ export class AdminModule extends ModuleBase {
     // Agent 实例管理
     this.registerMethod('list_agent_instances', this.handleListAgentInstances.bind(this))
     this.registerMethod('get_agent_instance', this.handleGetAgentInstance.bind(this))
-    this.registerMethod('create_agent_instance', this.handleCreateAgentInstance.bind(this))
-    this.registerMethod('update_agent_instance', this.handleUpdateAgentInstance.bind(this))
-    this.registerMethod('delete_agent_instance', this.handleDeleteAgentInstance.bind(this))
 
     // Agent 配置管理
     this.registerMethod('get_agent_config', this.handleGetAgentConfig.bind(this))
@@ -771,9 +767,6 @@ export class AdminModule extends ModuleBase {
     this.registerMethod('update_channel_config', this.handleUpdateChannelConfig.bind(this))
 
     // 模块安装管理
-    this.registerMethod('preview_module_package', this.handlePreviewModulePackage.bind(this))
-    this.registerMethod('install_module', this.handleInstallModule.bind(this))
-    this.registerMethod('uninstall_module', this.handleUninstallModule.bind(this))
 
     // 模块配置管理
     this.registerMethod('get_module_config', this.handleGetModuleConfig.bind(this))
@@ -1633,21 +1626,36 @@ export class AdminModule extends ModuleBase {
         return
       }
 
+      // Legacy Agent archive 路由（protocol-admin §3.18；认证由全局 /api 拦截器保证）
+      if (pathname === '/api/legacy-agent-archive' && req.method === 'GET') {
+        await this.handleListLegacyArchivesApi(req, res)
+        return
+      }
+
+      if (pathname.match(/^\/api\/legacy-agent-archive\/[^/]+\/export$/) && req.method === 'GET') {
+        const id = decodeURIComponent(pathname.split('/')[3])
+        await this.handleExportLegacyArchiveApi(req, res, id)
+        return
+      }
+
+      if (pathname.startsWith('/api/legacy-agent-archive/') && req.method === 'GET') {
+        const id = decodeURIComponent(pathname.split('/')[3])
+        await this.handleGetLegacyArchiveApi(req, res, id)
+        return
+      }
+
+      if (pathname.startsWith('/api/legacy-agent-archive/') && req.method === 'DELETE') {
+        const id = decodeURIComponent(pathname.split('/')[3])
+        await this.handleDeleteLegacyArchiveApi(req, res, id)
+        return
+      }
+
       // Agent Implementation 路由
       if (pathname === '/api/agent-implementations' && req.method === 'GET') {
         await this.handleListImplementationsApi(req, res, url)
         return
       }
 
-      if (pathname === '/api/agent-implementations/preview' && req.method === 'POST') {
-        await this.handlePreviewModuleApi(req, res)
-        return
-      }
-
-      if (pathname === '/api/agent-implementations/install' && req.method === 'POST') {
-        await this.handleInstallModuleApi(req, res)
-        return
-      }
 
       if (pathname.startsWith('/api/agent-implementations/') && req.method === 'GET') {
         const id = pathname.split('/')[3]
@@ -1655,11 +1663,6 @@ export class AdminModule extends ModuleBase {
         return
       }
 
-      if (pathname.startsWith('/api/agent-implementations/') && req.method === 'DELETE') {
-        const id = pathname.split('/')[3]
-        await this.handleUninstallModuleApi(req, res, id)
-        return
-      }
 
       // Agent Instance 路由
       if (pathname === '/api/agent-instances' && req.method === 'GET') {
@@ -4132,6 +4135,42 @@ export class AdminModule extends ModuleBase {
   /**
    * 处理 channel.message_received 事件：鉴权，决定是否发出 channel.message_authorized
    */
+  /**
+   * P6-D：cutover inventory 直读 legacy 原始文件（agent-implementations.json /
+   * agent-instances.json / agent-configs/*.json），unknown + 最小投影，未知字段原样保留。
+   * 只服务 marker 未完成时的 archive 迁移；运行时不再把这些记录装进任何 map。
+   */
+  private async readLegacyAgentInventorySources(): Promise<Array<{ source_kind: 'agent_implementation' | 'agent_instance' | 'agent_config'; source_id: string; raw: unknown }>> {
+    const out: Array<{ source_kind: 'agent_implementation' | 'agent_instance' | 'agent_config'; source_id: string; raw: unknown }> = []
+    const readArray = async (file: string): Promise<Record<string, unknown>[]> => {
+      try {
+        const value = JSON.parse(await fs.readFile(file, 'utf8'))
+        return Array.isArray(value) ? value.filter((v) => v && typeof v === 'object') : []
+      } catch {
+        return []
+      }
+    }
+    for (const item of await readArray(path.join(this.adminConfig.data_dir, 'agent-implementations.json'))) {
+      const id = typeof item.id === 'string' ? item.id : undefined
+      if (id && id !== 'default' && id !== 'crabot-agent') out.push({ source_kind: 'agent_implementation', source_id: id, raw: item })
+    }
+    for (const item of await readArray(path.join(this.adminConfig.data_dir, 'agent-instances.json'))) {
+      const id = typeof item.id === 'string' ? item.id : undefined
+      if (id && id !== 'crabot-agent') out.push({ source_kind: 'agent_instance', source_id: id, raw: item })
+    }
+    try {
+      const dir = path.join(this.adminConfig.data_dir, 'agent-configs')
+      for (const file of (await fs.readdir(dir)).filter((f) => f.endsWith('.json'))) {
+        const value = JSON.parse(await fs.readFile(path.join(dir, file), 'utf8'))
+        if (value && typeof value === 'object' && typeof (value as Record<string, unknown>).instance_id === 'string') {
+          const id = (value as Record<string, unknown>).instance_id as string
+          if (id !== 'crabot-agent') out.push({ source_kind: 'agent_config', source_id: id, raw: value })
+        }
+      }
+    } catch { /* 目录不存在 = 无 legacy config */ }
+    return out
+  }
+
   private async readLegacyAgentPackageEntries(): Promise<Array<{ source_id: string; raw: unknown }>> {
     const directory = path.join(this.adminConfig.data_dir, 'installed-modules')
     try {
@@ -7010,7 +7049,7 @@ export class AdminModule extends ModuleBase {
   }> {
     const page = params.page ?? 1
     const pageSize = params.page_size ?? 20
-    const core = this.agentManager.getImplementation('default')
+    const core = CORE_AGENT_DEFINITION
     const items = core && (!params.type || core.type === params.type) && (!params.engine || core.engine === params.engine) ? [core] : []
     return { items: items.slice((page - 1) * pageSize, page * pageSize), pagination: { page, page_size: pageSize, total_items: items.length, total_pages: Math.ceil(items.length / pageSize) } }
   }
@@ -7052,23 +7091,6 @@ export class AdminModule extends ModuleBase {
     return { instance }
   }
 
-  private async handleCreateAgentInstance(_params: CreateAgentInstanceParams): Promise<{
-    instance: AgentInstance
-  }> {
-    throw new RpcError('ADMIN_HOTPLUG_NOT_ALLOWED', 'Dynamic Agent instances are retired; only builtin crabot-agent is supported')
-  }
-
-  private async handleUpdateAgentInstance(_params: UpdateAgentInstanceParams): Promise<{
-    instance: AgentInstance
-  }> {
-    throw new RpcError('ADMIN_HOTPLUG_NOT_ALLOWED', 'Dynamic Agent instances are retired; legacy Agent records are read-only')
-  }
-
-  private async handleDeleteAgentInstance(_params: { instance_id: string }): Promise<{
-    deleted: true
-  }> {
-    throw new RpcError('ADMIN_HOTPLUG_NOT_ALLOWED', 'Dynamic Agent instances are retired; legacy Agent records are read-only')
-  }
   private async waitForCoreAgentReady(options: { attempts?: number; delayMs?: number } = {}): Promise<void> {
     const attempts = options.attempts ?? 30
     const delayMs = options.delayMs ?? 500
@@ -7136,9 +7158,8 @@ export class AdminModule extends ModuleBase {
     const packageEntries = await this.readLegacyAgentPackageEntries()
     const frontWorkerConfigs = await this.readLegacyFrontWorkerConfigSources()
     const sources = [
-      ...this.agentManager.listImplementations().items.filter((item) => item.id !== 'default').map((item) => ({ source_kind: 'agent_implementation' as const, source_id: item.id, raw: item })),
-      ...this.agentManager.listInstances().items.filter((item) => item.id !== 'crabot-agent').map((item) => ({ source_kind: 'agent_instance' as const, source_id: item.id, raw: item })),
-      ...this.agentManager.listConfigs().filter((item) => item.instance_id !== 'crabot-agent').map((item) => ({ source_kind: 'agent_config' as const, source_id: item.instance_id, raw: item })),
+      // P6-D：cutover inventory 直读 legacy 原始文件（unknown + 最小投影），不经运行时 map。
+      ...(await this.readLegacyAgentInventorySources()),
       ...packageEntries.map((entry) => ({ source_kind: 'installed_package' as const, source_id: entry.source_id, raw: entry.raw })),
       ...frontWorkerConfigs.map((entry) => ({ source_kind: 'agent_config' as const, source_id: `legacy-${entry.source_id}`, raw: entry.raw })),
     ]
@@ -8110,6 +8131,64 @@ export class AdminModule extends ModuleBase {
   }
 
   // ============================================================================
+  // Legacy Agent archive REST API（protocol-admin §3.18）
+  // ============================================================================
+
+  private async handleListLegacyArchivesApi(_req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const items = await this.legacyArchiveStore.listSummaries()
+    sendJson(res, 200, { items })
+  }
+
+  private async handleGetLegacyArchiveApi(_req: IncomingMessage, res: ServerResponse, id: string): Promise<void> {
+    try {
+      const record = await this.legacyArchiveStore.getDetail(id)
+      sendJson(res, 200, { record })
+    } catch (error) {
+      this.sendLegacyArchiveError(res, error)
+    }
+  }
+
+  private async handleExportLegacyArchiveApi(_req: IncomingMessage, res: ServerResponse, id: string): Promise<void> {
+    try {
+      const record = await this.legacyArchiveStore.exportRecord(id)
+      sendJson(res, 200, { record })
+    } catch (error) {
+      this.sendLegacyArchiveError(res, error)
+    }
+  }
+
+  private async handleDeleteLegacyArchiveApi(req: IncomingMessage, res: ServerResponse, id: string): Promise<void> {
+    try {
+      const body = await this.readJsonBody<{ confirmation?: string; delete_package?: boolean; delete_config?: boolean }>(req)
+      const result = await this.legacyArchiveStore.deleteArchive(id, {
+        confirmation: body.confirmation,
+        delete_package: body.delete_package === true,
+        delete_config: body.delete_config === true,
+      }, {
+        isModuleActive: async (moduleId) => {
+          try {
+            const modules = await this.rpcClient.callModuleManager<Record<string, never>, { modules: Array<{ module_id: string; status: string }> }>('list_modules', {}, this.config.moduleId)
+            return modules.modules.some((m) => m.module_id === moduleId && m.status === 'running')
+          } catch {
+            return true // MM 不可达时保守视为 active，拒绝删除
+          }
+        },
+      })
+      sendJson(res, 200, result)
+    } catch (error) {
+      this.sendLegacyArchiveError(res, error)
+    }
+  }
+
+  private sendLegacyArchiveError(res: ServerResponse, error: unknown): void {
+    if (error instanceof LegacyAgentArchiveError) {
+      sendJson(res, error.httpStatus, { code: error.code, error: error.message })
+      return
+    }
+    throw error
+  }
+
+  // ============================================================================
   // Channel Implementation REST API
   // ============================================================================
 
@@ -8341,93 +8420,10 @@ export class AdminModule extends ModuleBase {
   // 模块安装 RPC 方法
   // ============================================================================
 
-  private async handlePreviewModulePackage(params: PreviewModulePackageParams): Promise<{
-    package_info: any
-  }> {
-    const packageInfo = await this.moduleInstaller.preview(params.source)
-    return { package_info: packageInfo }
-  }
-
-  private async handleInstallModule(params: InstallModuleParams): Promise<{
-    implementation: AgentImplementation
-  }> {
-    const implementation = await this.moduleInstaller.install(params.source, {
-      overwrite: params.overwrite,
-    })
-    this.publishAdminEvent('admin.agent_implementation_installed', { implementation })
-    return { implementation }
-  }
-
-  private async handleUninstallModule(params: { implementation_id: string }): Promise<{
-    deleted: true
-  }> {
-    await this.moduleInstaller.uninstall(params.implementation_id)
-    this.publishAdminEvent('admin.agent_implementation_uninstalled', {
-      implementation_id: params.implementation_id,
-    })
-    return { deleted: true }
-  }
-
   // ============================================================================
   // 模块安装 REST API
   // ============================================================================
 
-  private async handlePreviewModuleApi(req: IncomingMessage, res: ServerResponse): Promise<void> {
-    try {
-      const body = await this.readJsonBody<{ source: ModuleSource }>(req)
-      const packageInfo = await this.moduleInstaller.preview(body.source)
-      res.writeHead(200, { 'Content-Type': 'application/json' })
-      res.end(JSON.stringify({ package_info: packageInfo }))
-    } catch (error) {
-      if (error instanceof Error) {
-        res.writeHead(400)
-        res.end(JSON.stringify({ error: error.message }))
-        return
-      }
-      throw error
-    }
-  }
-
-  private async handleInstallModuleApi(req: IncomingMessage, res: ServerResponse): Promise<void> {
-    try {
-      const body = await this.readJsonBody<InstallModuleParams>(req)
-      const implementation = await this.moduleInstaller.install(body.source, {
-        overwrite: body.overwrite,
-      })
-      this.publishAdminEvent('admin.agent_implementation_installed', { implementation })
-      res.writeHead(201, { 'Content-Type': 'application/json' })
-      res.end(JSON.stringify({ implementation }))
-    } catch (error) {
-      if (error instanceof Error) {
-        res.writeHead(400)
-        res.end(JSON.stringify({ error: error.message }))
-        return
-      }
-      throw error
-    }
-  }
-
-  private async handleUninstallModuleApi(
-    _req: IncomingMessage,
-    res: ServerResponse,
-    id: string
-  ): Promise<void> {
-    try {
-      await this.moduleInstaller.uninstall(id)
-      this.publishAdminEvent('admin.agent_implementation_uninstalled', {
-        implementation_id: id,
-      })
-      res.writeHead(204)
-      res.end()
-    } catch (error) {
-      if (error instanceof Error) {
-        res.writeHead(error.message.includes('not found') ? 404 : 400)
-        res.end(JSON.stringify({ error: error.message }))
-        return
-      }
-      throw error
-    }
-  }
 
   // ============================================================================
   // 模块配置管理
@@ -9518,7 +9514,7 @@ export class AdminModule extends ModuleBase {
     try {
       // 优先从运行中的 agent 模块获取 LLM 需求
       // 如果 agent 模块未运行或没有实现 get_llm_requirements，回退到默认实现
-      const defaultImpl = this.agentManager.getImplementation('default')
+      const defaultImpl = CORE_AGENT_DEFINITION
       if (!defaultImpl) {
         res.writeHead(500)
         res.end(JSON.stringify({ error: 'Default implementation not found' }))
@@ -10830,10 +10826,6 @@ export class AdminModule extends ModuleBase {
    * friend/task/sessionConfig/schedule 直接对 this.<Map> 单条 upsert（finalize 时 saveData 落盘）。
    */
   private buildCrabotImportDeps(archivePath: string, onConflict: OnConflict): ImportDeps {
-    // 标记是否真的导入了 agent-instance：仅在导入时才在 finalize 重载 AgentManager 内存态，
-    // 避免对未涉及 agent 的导入触发不必要的 re-initialize。
-    let agentInstanceTouched = false
-
     return {
       upsertProvider: async (r) => this.modelProviderManager.upsertById(r as ModelProvider, onConflict),
       upsertMcp: async (r) => this.mcpServerManager.upsertById(r as MCPServerRegistryEntry, onConflict),
@@ -10858,12 +10850,8 @@ export class AdminModule extends ModuleBase {
         this.sessionConfigs.set(entry.session_id, entry.config)
         return exists ? 'overwritten' : 'imported'
       },
-      upsertAgentInstance: async (r) => {
-        const inst = r as AgentInstance
-        const status = await this.upsertImportedAgentInstance(inst, archivePath, onConflict)
-        if (status !== 'skipped') agentInstanceTouched = true
-        return status
-      },
+      importCoreAgentConfig: async (archivePath2, oc) => this.importCoreAgentConfigFromArchive(archivePath2, oc),
+      ingestLegacyArchive: async (archivePath2, oc) => this.ingestLegacyArchiveFromArchive(archivePath2, oc),
       upsertSchedule: async (r) => {
         const sched = r as Schedule
         if (shouldDisableOnImport(sched, Date.now())) sched.enabled = false
@@ -10880,13 +10868,75 @@ export class AdminModule extends ModuleBase {
       finalize: async () => {
         await this.saveData()
         await this.saveTasks()
-        if (agentInstanceTouched) {
-          // 文件已直接落盘，重载 AgentManager 内存态使 Admin 列表/解析与磁盘一致。
-          await this.agentManager.initialize()
-        }
         this.triggerPushAfter('crabot import')
       },
     }
+  }
+
+  /**
+   * P6-D §3.18.1(1)：exact core config 只进 CoreAgentConfigStore。
+   * 校验：instance_id === 'crabot-agent' 且 model slot key ⊆ 静态四 slots；否则拒绝。
+   */
+  private async importCoreAgentConfigFromArchive(archivePath: string, onConflict: OnConflict): Promise<ImportItemResult[]> {
+    const text = await readArchiveTextFile(archivePath, 'payload/config/agent-configs/crabot-agent.json')
+    if (!text) return []
+    const raw = JSON.parse(text) as Record<string, unknown>
+    if (raw.instance_id !== 'crabot-agent') {
+      throw new ImportPreflightRejected('ADMIN_BACKUP_NON_CORE_AGENT_UNSUPPORTED', 'agent-configs/crabot-agent.json 的 instance_id 不是 crabot-agent')
+    }
+    const modelConfig = (raw.model_config ?? {}) as Record<string, unknown>
+    const allowed = new Set(['powerful', 'cost_effective', 'vision', 'manager'])
+    const badKey = Object.keys(modelConfig).find((k) => !allowed.has(k))
+    if (badKey) {
+      throw new ImportPreflightRejected('ADMIN_BACKUP_NON_CORE_AGENT_UNSUPPORTED', `core config 含未知 model slot key: ${badKey}`)
+    }
+    const existing = this.agentManager.getConfig('crabot-agent')
+    if (existing && onConflict === 'skip') return [{ kind: 'agent-config', id: 'crabot-agent', status: 'skipped' }]
+    await this.agentManager.updateConfig({
+      instance_id: 'crabot-agent',
+      ...(typeof raw.system_prompt === 'string' ? { system_prompt: raw.system_prompt } : {}),
+      model_config: modelConfig as UpdateAgentConfigParams['model_config'],
+      ...(Array.isArray(raw.mcp_server_ids) ? { mcp_server_ids: raw.mcp_server_ids as string[] } : {}),
+      ...(Array.isArray(raw.skill_ids) ? { skill_ids: raw.skill_ids as string[] } : {}),
+      ...(typeof raw.max_iterations === 'number' ? { max_iterations: raw.max_iterations } : {}),
+      ...(typeof raw.tools_readonly === 'boolean' ? { tools_readonly: raw.tools_readonly } : {}),
+      ...(typeof raw.timezone === 'string' ? { timezone: raw.timezone } : {}),
+      ...(raw.extra && typeof raw.extra === 'object' ? { extra: raw.extra as Record<string, unknown> } : {}),
+    })
+    return [{ kind: 'agent-config', id: 'crabot-agent', status: existing ? 'overwritten' : 'imported' }]
+  }
+
+  /**
+   * P6-D §3.18.1(2)：新格式 LegacyAgentArchiveRecord 恢复到 archive-only store。
+   * 同 archive_id + 同 canonical payload 幂等；payload 不同整包冲突。
+   */
+  private async ingestLegacyArchiveFromArchive(archivePath: string, _onConflict: OnConflict): Promise<ImportItemResult[]> {
+    const text = await readArchiveTextFile(archivePath, 'payload/config/legacy-agent-archive.json')
+    if (!text) return []
+    const rows = JSON.parse(text) as unknown[]
+    if (!Array.isArray(rows)) throw new ImportPreflightRejected('ADMIN_BACKUP_LEGACY_ARCHIVE_CONFLICT', 'legacy-agent-archive.json 不是数组')
+    const existing = new Map((await this.legacyArchiveStore.listSummaries()).map((s) => [s.archive_id, s]))
+    const valid: Array<{ source_kind: 'agent_implementation' | 'agent_instance' | 'agent_config' | 'installed_package'; source_id: string; raw: unknown; archive_id: string }> = []
+    for (const row of rows) {
+      const r = row as Record<string, unknown>
+      if (typeof r.archive_id !== 'string' || typeof r.source_kind !== 'string' || typeof r.source_id !== 'string') {
+        throw new ImportPreflightRejected('ADMIN_BACKUP_LEGACY_ARCHIVE_CONFLICT', 'archive record 缺少 archive_id/source_kind/source_id')
+      }
+      valid.push({ archive_id: r.archive_id, source_kind: r.source_kind as 'agent_config', source_id: r.source_id, raw: r.raw })
+    }
+    // 冲突检查先行（canonical payload 不同 → 整包拒绝）
+    const existingRaw = new Map<string, unknown>()
+    for (const record of await this.legacyArchiveStore.readRawRecords()) {
+      existingRaw.set(record.archive_id, record.raw ?? null)
+    }
+    for (const row of valid) {
+      const old = existingRaw.get(row.archive_id)
+      if (old !== undefined && canonicalizeJson(old) !== canonicalizeJson(row.raw ?? null)) {
+        throw new ImportPreflightRejected('ADMIN_BACKUP_LEGACY_ARCHIVE_CONFLICT', `archive payload 冲突: ${row.archive_id}`)
+      }
+    }
+    await this.cutoverStore.archive(valid.map((row) => ({ source_kind: row.source_kind, source_id: row.source_id, raw: row.raw })))
+    return valid.map((row) => ({ kind: 'legacy-agent-archive', id: row.archive_id, status: existingRaw.has(row.archive_id) ? 'overwritten' : 'imported' }))
   }
 
   /**
@@ -10904,44 +10954,6 @@ export class AdminModule extends ModuleBase {
     return exists ? 'overwritten' : 'imported'
   }
 
-  /**
-   * 导入单个 agent 实例：写 agent-instances.json（按 id 归并）+ agent-configs/<id>.json（随实例）。
-   * AgentManager 内存态在 finalize 里统一 reload，这里只做磁盘归并。
-   */
-  private async upsertImportedAgentInstance(
-    instance: AgentInstance,
-    archivePath: string,
-    onConflict: OnConflict,
-  ): Promise<ImportStatus> {
-    const dataDir = this.adminConfig.data_dir
-    const instancesPath = path.join(dataDir, 'agent-instances.json')
-    let existing: AgentInstance[] = []
-    try {
-      existing = JSON.parse(await fs.readFile(instancesPath, 'utf-8')) as AgentInstance[]
-      if (!Array.isArray(existing)) existing = []
-    } catch {
-      existing = []
-    }
-    const exists = existing.some((i) => i.id === instance.id)
-    if (exists && onConflict === 'skip') return 'skipped'
-
-    const merged = exists
-      ? existing.map((i) => (i.id === instance.id ? instance : i))
-      : [...existing, instance]
-    await this.atomicWriteFile(instancesPath, JSON.stringify(merged, null, 2))
-
-    // 随实例写 agent-configs/<id>.json（归档里可能不存在，缺失则不写）。
-    const cfgText = await readArchiveTextFile(
-      archivePath,
-      `payload/config/agent-configs/${instance.id}.json`,
-    )
-    if (cfgText !== null) {
-      const configsDir = path.join(dataDir, 'agent-configs')
-      await fs.mkdir(configsDir, { recursive: true })
-      await this.atomicWriteFile(path.join(configsDir, `${instance.id}.json`), cfgText)
-    }
-    return exists ? 'overwritten' : 'imported'
-  }
 
   /**
    * 解归档内 payload/skills/skills/<name> 各子目录到临时 dir，逐个 importFromLocalPath。

--- a/crabot-admin/src/index.ts
+++ b/crabot-admin/src/index.ts
@@ -27,6 +27,7 @@ import { shouldDisableOnImport } from './backup/import/schedule-arm.js'
 import { VersionService } from './version/version-service.js'
 import { startUpgrade, canUpgrade, isUpgradeInProgress } from './version/upgrade-runner.js'
 import { readArchiveTextFile, listArchiveEntries } from './openclaw-import/archive-reader.js'
+import { readJsonArrayFromArchive } from './backup/import/read-archive-category.js'
 import { extractArchiveSubtree } from './openclaw-import/extract-subtree.js'
 import { CoreAgentConfigMutationCoordinator } from './core-agent-config-revision-store.js'
 import { WorkerImplementationStore } from './worker-implementation-store.js'
@@ -7057,7 +7058,7 @@ export class AdminModule extends ModuleBase {
   private async handleGetAgentImplementation(params: { implementation_id: string }): Promise<{
     implementation: AgentImplementation
   }> {
-    if (params.implementation_id !== 'default') throw new Error(`Implementation not found: ${params.implementation_id}`)
+    if (params.implementation_id !== 'default' && params.implementation_id !== 'crabot-agent') throw new Error(`Implementation not found: ${params.implementation_id}`)
     const impl = this.agentManager.getImplementation(params.implementation_id)
     if (!impl) {
       throw new Error(`Implementation not found: ${params.implementation_id}`)
@@ -7997,7 +7998,7 @@ export class AdminModule extends ModuleBase {
     res: ServerResponse,
     id: string
   ): Promise<void> {
-    if (id !== 'default') {
+    if (id !== 'default' && id !== 'crabot-agent') {
       res.writeHead(404)
       res.end(JSON.stringify({ error: 'Implementation not found' }))
       return
@@ -10850,8 +10851,9 @@ export class AdminModule extends ModuleBase {
         this.sessionConfigs.set(entry.session_id, entry.config)
         return exists ? 'overwritten' : 'imported'
       },
-      importCoreAgentConfig: async (archivePath2, oc) => this.importCoreAgentConfigFromArchive(archivePath2, oc),
-      ingestLegacyArchive: async (archivePath2, oc) => this.ingestLegacyArchiveFromArchive(archivePath2, oc),
+      validateAgentPayload: (archivePath2) => this.validateAgentImportPayload(archivePath2),
+      applyCoreAgentConfig: async (raw, oc) => this.applyCoreAgentConfigFromImport(raw, oc),
+      applyLegacyArchiveRows: async (rows, oc) => this.applyLegacyArchiveRowsFromImport(rows, oc),
       upsertSchedule: async (r) => {
         const sched = r as Schedule
         if (shouldDisableOnImport(sched, Date.now())) sched.enabled = false
@@ -10874,28 +10876,67 @@ export class AdminModule extends ModuleBase {
   }
 
   /**
-   * P6-D §3.18.1(1)：exact core config 只进 CoreAgentConfigStore。
-   * 校验：instance_id === 'crabot-agent' 且 model slot key ⊆ 静态四 slots；否则拒绝。
+   * P6-D §3.18.1 全包 preflight（纯读+校验，零写入）：
+   * - 旧 live non-core Agent payload → ADMIN_BACKUP_NON_CORE_AGENT_UNSUPPORTED
+   * - exact core config：instance_id/slot key 校验
+   * - 新格式 archive：同 id 不同 canonical payload → ADMIN_BACKUP_LEGACY_ARCHIVE_CONFLICT
    */
-  private async importCoreAgentConfigFromArchive(archivePath: string, onConflict: OnConflict): Promise<ImportItemResult[]> {
-    const text = await readArchiveTextFile(archivePath, 'payload/config/agent-configs/crabot-agent.json')
-    if (!text) return []
-    const raw = JSON.parse(text) as Record<string, unknown>
-    if (raw.instance_id !== 'crabot-agent') {
-      throw new ImportPreflightRejected('ADMIN_BACKUP_NON_CORE_AGENT_UNSUPPORTED', 'agent-configs/crabot-agent.json 的 instance_id 不是 crabot-agent')
+  private async validateAgentImportPayload(archivePath: string): Promise<{ coreConfigRaw: Record<string, unknown> | null; archiveRows: unknown[] }> {
+    const legacyImpls = await readJsonArrayFromArchive(archivePath, 'payload/config/agent-implementations.json')
+    const legacyInstances = await readJsonArrayFromArchive(archivePath, 'payload/config/agent-instances.json')
+    const nonCore = legacyInstances.filter((row: unknown) => (row as { id?: string }).id !== 'crabot-agent')
+    if (legacyImpls.length > 0 || nonCore.length > 0) {
+      throw new ImportPreflightRejected(
+        'ADMIN_BACKUP_NON_CORE_AGENT_UNSUPPORTED',
+        `旧 live Agent payload 不再支持导入（implementations=${legacyImpls.length}, non-core instances=${nonCore.length}）；请先在旧版本隔离恢复并运行 startup archive migration，再导出新格式 archive`,
+      )
     }
-    const modelConfig = (raw.model_config ?? {}) as Record<string, unknown>
-    const allowed = new Set(['powerful', 'cost_effective', 'vision', 'manager'])
-    const badKey = Object.keys(modelConfig).find((k) => !allowed.has(k))
-    if (badKey) {
-      throw new ImportPreflightRejected('ADMIN_BACKUP_NON_CORE_AGENT_UNSUPPORTED', `core config 含未知 model slot key: ${badKey}`)
+    let coreConfigRaw: Record<string, unknown> | null = null
+    const coreText = await readArchiveTextFile(archivePath, 'payload/config/agent-configs/crabot-agent.json')
+    if (coreText) {
+      const raw = JSON.parse(coreText) as Record<string, unknown>
+      if (raw.instance_id !== 'crabot-agent') {
+        throw new ImportPreflightRejected('ADMIN_BACKUP_NON_CORE_AGENT_UNSUPPORTED', 'agent-configs/crabot-agent.json 的 instance_id 不是 crabot-agent')
+      }
+      const allowed = new Set(['powerful', 'cost_effective', 'vision', 'manager'])
+      const badKey = Object.keys((raw.model_config ?? {}) as Record<string, unknown>).find((k) => !allowed.has(k))
+      if (badKey) {
+        throw new ImportPreflightRejected('ADMIN_BACKUP_NON_CORE_AGENT_UNSUPPORTED', `core config 含未知 model slot key: ${badKey}`)
+      }
+      coreConfigRaw = raw
     }
+    const archiveText = await readArchiveTextFile(archivePath, 'payload/config/legacy-agent-archive.json')
+    let archiveRows: unknown[] = []
+    if (archiveText) {
+      const rows = JSON.parse(archiveText) as unknown[]
+      if (!Array.isArray(rows)) throw new ImportPreflightRejected('ADMIN_BACKUP_LEGACY_ARCHIVE_CONFLICT', 'legacy-agent-archive.json 不是数组')
+      const existingRaw = new Map<string, unknown>()
+      for (const record of await this.legacyArchiveStore.readRawRecords()) {
+        existingRaw.set(record.archive_id, record.raw ?? null)
+      }
+      for (const row of rows) {
+        const r = row as Record<string, unknown>
+        if (typeof r.archive_id !== 'string' || typeof r.source_kind !== 'string' || typeof r.source_id !== 'string') {
+          throw new ImportPreflightRejected('ADMIN_BACKUP_LEGACY_ARCHIVE_CONFLICT', 'archive record 缺少 archive_id/source_kind/source_id')
+        }
+        const old = existingRaw.get(r.archive_id)
+        if (old !== undefined && canonicalizeJson(old) !== canonicalizeJson(r.raw ?? null)) {
+          throw new ImportPreflightRejected('ADMIN_BACKUP_LEGACY_ARCHIVE_CONFLICT', `archive payload 冲突: ${r.archive_id}`)
+        }
+      }
+      archiveRows = rows
+    }
+    return { coreConfigRaw, archiveRows }
+  }
+
+  /** validate 通过后：exact core config 只进 CoreAgentConfigStore。 */
+  private async applyCoreAgentConfigFromImport(raw: Record<string, unknown>, onConflict: OnConflict): Promise<ImportItemResult[]> {
     const existing = this.agentManager.getConfig('crabot-agent')
     if (existing && onConflict === 'skip') return [{ kind: 'agent-config', id: 'crabot-agent', status: 'skipped' }]
     await this.agentManager.updateConfig({
       instance_id: 'crabot-agent',
       ...(typeof raw.system_prompt === 'string' ? { system_prompt: raw.system_prompt } : {}),
-      model_config: modelConfig as UpdateAgentConfigParams['model_config'],
+      model_config: (raw.model_config ?? {}) as UpdateAgentConfigParams['model_config'],
       ...(Array.isArray(raw.mcp_server_ids) ? { mcp_server_ids: raw.mcp_server_ids as string[] } : {}),
       ...(Array.isArray(raw.skill_ids) ? { skill_ids: raw.skill_ids as string[] } : {}),
       ...(typeof raw.max_iterations === 'number' ? { max_iterations: raw.max_iterations } : {}),
@@ -10906,37 +10947,20 @@ export class AdminModule extends ModuleBase {
     return [{ kind: 'agent-config', id: 'crabot-agent', status: existing ? 'overwritten' : 'imported' }]
   }
 
-  /**
-   * P6-D §3.18.1(2)：新格式 LegacyAgentArchiveRecord 恢复到 archive-only store。
-   * 同 archive_id + 同 canonical payload 幂等；payload 不同整包冲突。
-   */
-  private async ingestLegacyArchiveFromArchive(archivePath: string, _onConflict: OnConflict): Promise<ImportItemResult[]> {
-    const text = await readArchiveTextFile(archivePath, 'payload/config/legacy-agent-archive.json')
-    if (!text) return []
-    const rows = JSON.parse(text) as unknown[]
-    if (!Array.isArray(rows)) throw new ImportPreflightRejected('ADMIN_BACKUP_LEGACY_ARCHIVE_CONFLICT', 'legacy-agent-archive.json 不是数组')
-    const existing = new Map((await this.legacyArchiveStore.listSummaries()).map((s) => [s.archive_id, s]))
-    const valid: Array<{ source_kind: 'agent_implementation' | 'agent_instance' | 'agent_config' | 'installed_package'; source_id: string; raw: unknown; archive_id: string }> = []
-    for (const row of rows) {
-      const r = row as Record<string, unknown>
-      if (typeof r.archive_id !== 'string' || typeof r.source_kind !== 'string' || typeof r.source_id !== 'string') {
-        throw new ImportPreflightRejected('ADMIN_BACKUP_LEGACY_ARCHIVE_CONFLICT', 'archive record 缺少 archive_id/source_kind/source_id')
-      }
-      valid.push({ archive_id: r.archive_id, source_kind: r.source_kind as 'agent_config', source_id: r.source_id, raw: r.raw })
-    }
-    // 冲突检查先行（canonical payload 不同 → 整包拒绝）
-    const existingRaw = new Map<string, unknown>()
-    for (const record of await this.legacyArchiveStore.readRawRecords()) {
-      existingRaw.set(record.archive_id, record.raw ?? null)
-    }
-    for (const row of valid) {
-      const old = existingRaw.get(row.archive_id)
-      if (old !== undefined && canonicalizeJson(old) !== canonicalizeJson(row.raw ?? null)) {
-        throw new ImportPreflightRejected('ADMIN_BACKUP_LEGACY_ARCHIVE_CONFLICT', `archive payload 冲突: ${row.archive_id}`)
-      }
-    }
-    await this.cutoverStore.archive(valid.map((row) => ({ source_kind: row.source_kind, source_id: row.source_id, raw: row.raw })))
-    return valid.map((row) => ({ kind: 'legacy-agent-archive', id: row.archive_id, status: existingRaw.has(row.archive_id) ? 'overwritten' : 'imported' }))
+  /** validate 通过后：archive record 幂等恢复到 archive-only store。 */
+  private async applyLegacyArchiveRowsFromImport(rows: unknown[], _onConflict: OnConflict): Promise<ImportItemResult[]> {
+    const existingIds = new Set((await this.legacyArchiveStore.readRawRecords()).map((r) => r.archive_id))
+    const sources = (rows as Array<Record<string, unknown>>).map((r) => ({
+      source_kind: r.source_kind as 'agent_implementation' | 'agent_instance' | 'agent_config' | 'installed_package',
+      source_id: r.source_id as string,
+      raw: r.raw,
+    }))
+    await this.cutoverStore.archive(sources)
+    return (rows as Array<Record<string, unknown>>).map((r) => ({
+      kind: 'legacy-agent-archive',
+      id: r.archive_id as string,
+      status: existingIds.has(r.archive_id as string) ? 'overwritten' : 'imported',
+    }))
   }
 
   /**

--- a/crabot-admin/src/legacy-agent-archive.test.ts
+++ b/crabot-admin/src/legacy-agent-archive.test.ts
@@ -159,3 +159,45 @@ describe('LegacyAgentArchiveStore', () => {
       .rejects.toMatchObject({ code: 'ADMIN_LEGACY_AGENT_DELETE_CONFLICT' })
   })
 })
+
+describe('R3: implementation_id 不是身份', () => {
+  it('v2 存量实例（implementation_id=default）可正常删除，不被误判 core-protected', async () => {
+    const dir2 = await fs.mkdtemp(path.join(process.cwd(), 'test-data', 'archive-r3-'))
+    try {
+      await fs.mkdir(path.join(dir2, 'agent-configs'), { recursive: true })
+      await fs.writeFile(path.join(dir2, 'legacy-agent-archive.json'), JSON.stringify([{
+        archive_id: 'agent_instance:worker-general',
+        source_kind: 'agent_instance',
+        source_id: 'worker-general',
+        archived_at: 'x',
+        support_status: 'unsupported_legacy',
+        raw: { id: 'worker-general', name: 'General Worker', implementation_id: 'default' },
+      }], null, 2))
+      await fs.writeFile(path.join(dir2, 'agent-configs', 'worker-general.json'), '{}')
+      const s = new LegacyAgentArchiveStore(dir2)
+      const items = await s.listSummaries()
+      expect(items[0].uninstallable).toBe(true)
+      const result = await s.deleteArchive('agent_instance:worker-general', { confirmation: 'agent_instance:worker-general', delete_package: false, delete_config: true })
+      expect(result.completed).toBe(true)
+      expect(result.archive_removed).toBe(true)
+    } finally {
+      await fs.rm(dir2, { recursive: true, force: true })
+    }
+  })
+
+  it('core 自身记录（archive_id/source_id 为 crabot-agent）仍被保护', async () => {
+    const dir3 = await fs.mkdtemp(path.join(process.cwd(), 'test-data', 'archive-r3b-'))
+    try {
+      await fs.mkdir(path.join(dir3, 'agent-configs'), { recursive: true })
+      await fs.writeFile(path.join(dir3, 'legacy-agent-archive.json'), JSON.stringify([{
+        archive_id: 'agent_config:crabot-agent', source_kind: 'agent_config', source_id: 'crabot-agent',
+        archived_at: 'x', support_status: 'unsupported_legacy', raw: { instance_id: 'crabot-agent' },
+      }], null, 2))
+      const s = new LegacyAgentArchiveStore(dir3)
+      await expect(s.deleteArchive('agent_config:crabot-agent', { confirmation: 'agent_config:crabot-agent', delete_package: false, delete_config: true }))
+        .rejects.toMatchObject({ code: 'ADMIN_LEGACY_AGENT_CORE_PROTECTED', httpStatus: 403 })
+    } finally {
+      await fs.rm(dir3, { recursive: true, force: true })
+    }
+  })
+})

--- a/crabot-admin/src/legacy-agent-archive.test.ts
+++ b/crabot-admin/src/legacy-agent-archive.test.ts
@@ -1,0 +1,161 @@
+/**
+ * P6-D：LegacyAgentArchiveStore 测试（protocol-admin §3.18）。
+ * 覆盖：summary 无 raw、export 脱敏、delete 的 selection/confirmation/tombstone/journal/core 保护。
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import fs from 'fs/promises'
+import path from 'path'
+import { LegacyAgentArchiveStore, LegacyAgentArchiveError } from './legacy-agent-archive.js'
+
+const RECORDS = [
+  {
+    archive_id: 'agent_config:front-agent',
+    source_kind: 'agent_config',
+    source_id: 'front-agent',
+    archived_at: '2026-08-14T00:00:00.000Z',
+    support_status: 'unsupported_legacy',
+    raw: { instance_id: 'front-agent', system_prompt: 'x', model_config: { powerful: { provider_id: 'p', model_id: 'm', api_key: 'sk-secret' } }, nickname: '保留未知字段' },
+  },
+  {
+    archive_id: 'agent_instance:worker-general',
+    source_kind: 'agent_instance',
+    source_id: 'worker-general',
+    archived_at: '2026-08-14T00:00:00.000Z',
+    support_status: 'unsupported_legacy',
+    raw: { id: 'worker-general', name: 'Worker', implementation_id: 'default' },
+  },
+]
+
+describe('LegacyAgentArchiveStore', () => {
+  let dir: string
+  let store: LegacyAgentArchiveStore
+
+  beforeEach(async () => {
+    dir = path.join(process.cwd(), 'test-data', `archive-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
+    await fs.mkdir(path.join(dir, 'agent-configs'), { recursive: true })
+    await fs.writeFile(path.join(dir, 'legacy-agent-archive.json'), JSON.stringify(RECORDS, null, 2))
+    await fs.writeFile(path.join(dir, 'agent-configs', 'front-agent.json'), JSON.stringify(RECORDS[0].raw))
+    store = new LegacyAgentArchiveStore(dir)
+  })
+
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true })
+  })
+
+  it('summary 列表不含 raw/secret，且带 uninstallable/display_name', async () => {
+    const items = await store.listSummaries()
+    expect(items).toHaveLength(2)
+    const cfg = items.find((i) => i.archive_id === 'agent_config:front-agent')!
+    expect(cfg.support_status).toBe('unsupported_legacy')
+    expect(cfg.uninstallable).toBe(true)
+    expect(cfg.display_name).toBe('front-agent')
+    expect(JSON.stringify(items)).not.toContain('sk-secret')
+    expect(JSON.stringify(items)).not.toContain('"raw"')
+  })
+
+  it('export 返回脱敏 raw（secret 打码、未知字段保留）', async () => {
+    const record = await store.exportRecord('agent_config:front-agent') as { raw: Record<string, unknown> }
+    expect(JSON.stringify(record.raw)).not.toContain('sk-secret')
+    expect((record.raw as { nickname?: string }).nickname).toBe('保留未知字段')
+    await expect(store.exportRecord('nope')).rejects.toMatchObject({ code: 'ADMIN_LEGACY_AGENT_ARCHIVE_NOT_FOUND', httpStatus: 404 })
+  })
+
+  it('false/false selection → 400 且零写', async () => {
+    await expect(store.deleteArchive('agent_config:front-agent', { confirmation: 'agent_config:front-agent', delete_package: false, delete_config: false }))
+      .rejects.toMatchObject({ code: 'ADMIN_LEGACY_AGENT_DELETE_SELECTION_REQUIRED' })
+    expect(await fs.readFile(path.join(dir, 'agent-configs', 'front-agent.json'), 'utf8')).toContain('front-agent')
+    await expect(fs.stat(path.join(dir, 'legacy-agent-tombstones.json'))).rejects.toThrow()
+  })
+
+  it('confirmation 不匹配 → 400', async () => {
+    await expect(store.deleteArchive('agent_config:front-agent', { confirmation: 'wrong', delete_package: false, delete_config: true }))
+      .rejects.toMatchObject({ code: 'ADMIN_LEGACY_AGENT_CONFIRMATION_MISMATCH' })
+  })
+
+  it('部分删除（只删 config、record 仍有 package 资源）→ archive_removed=false，summary 保留；同 selection 重试返回同一结果', async () => {
+    // 构造一个同时有 package 与 config 资源的 record
+    const pkgDir = path.join(dir, 'installed-modules', 'legacy-pkg')
+    await fs.mkdir(pkgDir, { recursive: true })
+    const both = {
+      archive_id: 'installed_package:legacy-pkg',
+      source_kind: 'installed_package',
+      source_id: 'legacy-pkg',
+      archived_at: '2026-08-14T00:00:00.000Z',
+      support_status: 'unsupported_legacy',
+      raw: { id: 'legacy-pkg', instance_id: 'legacy-pkg', installed_path: pkgDir, name: 'Legacy Pkg' },
+    }
+    await fs.writeFile(path.join(dir, 'legacy-agent-archive.json'), JSON.stringify([...RECORDS, both], null, 2))
+    await fs.writeFile(path.join(dir, 'agent-configs', 'legacy-pkg.json'), '{}')
+    const first = await store.deleteArchive('installed_package:legacy-pkg', { confirmation: 'installed_package:legacy-pkg', delete_package: false, delete_config: true })
+    expect(first.archive_removed).toBe(false)
+    expect(first.deleted_resources).toEqual(['agent-configs/legacy-pkg.json'])
+    expect(first.retained_resources).toEqual(['installed-modules/legacy-pkg'])
+    await expect(fs.stat(pkgDir)).resolves.toBeTruthy()
+    const items = await store.listSummaries()
+    expect(items.some((i) => i.archive_id === 'installed_package:legacy-pkg')).toBe(true)
+    const second = await store.deleteArchive('installed_package:legacy-pkg', { confirmation: 'installed_package:legacy-pkg', delete_package: false, delete_config: true })
+    expect(second).toEqual(first)
+  })
+
+  it('路径穿越：installed_path 指向允许根外 → 该 package 资源不进入删除计划', async () => {
+    const evil = {
+      archive_id: 'installed_package:evil',
+      source_kind: 'installed_package',
+      source_id: 'evil',
+      archived_at: 'x',
+      support_status: 'unsupported_legacy',
+      raw: { id: 'evil', installed_path: '/tmp/outside-crabot-root' },
+    }
+    await fs.writeFile(path.join(dir, 'legacy-agent-archive.json'), JSON.stringify([evil], null, 2))
+    await fs.mkdir('/tmp/outside-crabot-root', { recursive: true })
+    const result = await store.deleteArchive('installed_package:evil', { confirmation: 'installed_package:evil', delete_package: true, delete_config: true })
+    // package 资源被拒（路径在允许根外）；config 逻辑资源在根内允许删除（文件不存在时 rm force 幂等）
+    expect(result.deleted_resources).not.toContain('installed-modules/evil')
+    expect(result.retained_resources).not.toContain('installed-modules/evil')
+    await expect(fs.stat('/tmp/outside-crabot-root')).resolves.toBeTruthy()
+    await fs.rm('/tmp/outside-crabot-root', { recursive: true, force: true })
+  })
+
+  it('archive_removed=true 后 record 从 archive 移除，重试从 tombstone 返回同一结果', async () => {
+    const first = await store.deleteArchive('agent_config:front-agent', { confirmation: 'agent_config:front-agent', delete_package: true, delete_config: true })
+    expect(first.archive_removed).toBe(true)
+    const remaining = JSON.parse(await fs.readFile(path.join(dir, 'legacy-agent-archive.json'), 'utf8')) as Array<{ archive_id: string }>
+    expect(remaining.map((r) => r.archive_id)).toEqual(['agent_instance:worker-general'])
+    const retry = await store.deleteArchive('agent_config:front-agent', { confirmation: 'agent_config:front-agent', delete_package: true, delete_config: true })
+    expect(retry).toEqual(first)
+  })
+
+  it('core/builtin 记录拒绝（403）', async () => {
+    const core = { archive_id: 'agent_instance:crabot-agent', source_kind: 'agent_instance', source_id: 'crabot-agent', archived_at: 'x', support_status: 'unsupported_legacy', raw: { id: 'crabot-agent' } }
+    await fs.writeFile(path.join(dir, 'legacy-agent-archive.json'), JSON.stringify([...RECORDS, core], null, 2))
+    await expect(store.deleteArchive('agent_instance:crabot-agent', { confirmation: 'agent_instance:crabot-agent', delete_package: false, delete_config: true }))
+      .rejects.toMatchObject({ code: 'ADMIN_LEGACY_AGENT_CORE_PROTECTED', httpStatus: 403 })
+  })
+
+  it('crash 恢复：prepared journal 存在时续跑完成', async () => {
+    await fs.mkdir(path.join(dir, 'migrations'), { recursive: true })
+    await fs.writeFile(path.join(dir, 'migrations', 'legacy-agent-uninstall-journal.json'), JSON.stringify({
+      archive_id: 'agent_config:front-agent',
+      phase: 'prepared',
+      delete_package: false,
+      delete_config: true,
+      targets: [{ logical: 'agent-configs/front-agent.json', absPath: path.join(dir, 'agent-configs', 'front-agent.json') }],
+      deleted: [],
+      updated_at: new Date().toISOString(),
+    }))
+    const result = await store.deleteArchive('agent_config:front-agent', { confirmation: 'agent_config:front-agent', delete_package: false, delete_config: true })
+    expect(result.completed).toBe(true)
+    await expect(fs.stat(path.join(dir, 'agent-configs', 'front-agent.json'))).rejects.toThrow()
+    await expect(fs.stat(path.join(dir, 'migrations', 'legacy-agent-uninstall-journal.json'))).rejects.toThrow()
+  })
+
+  it('其它 archive 的未完成 journal → 冲突 409', async () => {
+    await fs.mkdir(path.join(dir, 'migrations'), { recursive: true })
+    await fs.writeFile(path.join(dir, 'migrations', 'legacy-agent-uninstall-journal.json'), JSON.stringify({
+      archive_id: 'agent_instance:worker-general', phase: 'prepared', delete_package: false, delete_config: true,
+      targets: [], deleted: [], updated_at: new Date().toISOString(),
+    }))
+    await expect(store.deleteArchive('agent_config:front-agent', { confirmation: 'agent_config:front-agent', delete_package: false, delete_config: true }))
+      .rejects.toMatchObject({ code: 'ADMIN_LEGACY_AGENT_DELETE_CONFLICT' })
+  })
+})

--- a/crabot-admin/src/legacy-agent-archive.ts
+++ b/crabot-admin/src/legacy-agent-archive.ts
@@ -1,0 +1,345 @@
+/**
+ * P6-D：LegacyAgentArchiveStore（protocol-admin §3.18 的唯一实现）。
+ *
+ * 语义：
+ * - archive 只读（除用户显式 delete/uninstall）；raw 只进 export/审计，不进普通 summary。
+ * - DELETE 必须显式提交 delete_package/delete_config（至少一个 true），confirmation 逐字等于 archive_id。
+ * - 删除走 crash-recoverable journal + tombstone；同 archive+selection 重试返回同一 completed result。
+ * - core/builtin 记录拒绝；running/runnable 拒绝；路径必须落在 Admin data 允许根内。
+ */
+
+import crypto from 'crypto'
+import fs from 'fs/promises'
+import path from 'path'
+import { canonicalizeJson } from 'crabot-shared'
+import { CoreAgentCutoverStore, type LegacyAgentArchiveRecord } from './core-agent-cutover.js'
+import { durableAtomicWriteFile } from './durable-file.js'
+
+export interface LegacyAgentArchiveSummary {
+  archive_id: string
+  source_kind: LegacyAgentArchiveRecord['source_kind']
+  module_id?: string
+  archived_at: string
+  support_status: 'unsupported_legacy'
+  uninstallable: boolean
+  display_name?: string
+  version?: string
+}
+
+export interface DeleteLegacyAgentArchiveParams {
+  confirmation: string
+  delete_package: boolean
+  delete_config: boolean
+}
+
+export interface DeleteLegacyAgentArchiveResult {
+  archive_id: string
+  completed: true
+  archive_removed: boolean
+  deleted_resources: string[]
+  retained_resources: string[]
+}
+
+export class LegacyAgentArchiveError extends Error {
+  constructor(readonly code: string, message: string, readonly httpStatus: number) {
+    super(message)
+  }
+}
+
+/** 一个 archive record 关联的可删除物理资源（逻辑名 → 绝对路径，仅内部用）。 */
+interface ArchiveResource {
+  logical: string
+  absPath: string
+}
+
+interface Tombstone {
+  archive_id: string
+  delete_package: boolean
+  delete_config: boolean
+  result: DeleteLegacyAgentArchiveResult
+  completed_at: string
+}
+
+interface Journal {
+  archive_id: string
+  phase: 'prepared' | 'committed'
+  delete_package: boolean
+  delete_config: boolean
+  /** 待删除的绝对路径（prepared 时确定）。 */
+  targets: ArchiveResource[]
+  deleted: string[]
+  updated_at: string
+}
+
+const CORE_IDS = new Set(['crabot-agent', 'default'])
+
+/** 普通 read 的脱敏：raw 中只保留安全的展示字段。 */
+function summarize(record: LegacyAgentArchiveRecord, uninstallable: boolean): LegacyAgentArchiveSummary {
+  const raw = (record.raw && typeof record.raw === 'object' ? record.raw : {}) as Record<string, unknown>
+  const summary: LegacyAgentArchiveSummary = {
+    archive_id: record.archive_id,
+    source_kind: record.source_kind,
+    archived_at: record.archived_at,
+    support_status: 'unsupported_legacy',
+    uninstallable,
+  }
+  if (record.module_id) summary.module_id = record.module_id
+  if (typeof raw.name === 'string' && raw.name) summary.display_name = raw.name
+  else if (typeof raw.instance_id === 'string' && raw.instance_id) summary.display_name = raw.instance_id
+  else if (typeof raw.id === 'string' && raw.id) summary.display_name = raw.id
+  if (typeof raw.version === 'string' && raw.version) summary.version = raw.version
+  return summary
+}
+
+function isCoreProtected(record: LegacyAgentArchiveRecord): boolean {
+  const raw = (record.raw && typeof record.raw === 'object' ? record.raw : {}) as Record<string, unknown>
+  const ids = [record.archive_id, record.source_id, record.module_id, raw.id, raw.instance_id, raw.implementation_id]
+    .filter((v): v is string => typeof v === 'string')
+  return ids.some((id) => CORE_IDS.has(id))
+}
+
+export class LegacyAgentArchiveStore {
+  private readonly cutover: CoreAgentCutoverStore
+  private readonly dataDir: string
+  private readonly tombstonePath: string
+  private readonly journalPath: string
+
+  constructor(dataDir: string) {
+    this.dataDir = dataDir
+    this.cutover = new CoreAgentCutoverStore(dataDir)
+    this.tombstonePath = path.join(dataDir, 'legacy-agent-tombstones.json')
+    this.journalPath = path.join(dataDir, 'migrations', 'legacy-agent-uninstall-journal.json')
+  }
+
+  private async readRecords(): Promise<LegacyAgentArchiveRecord[]> {
+    // 复用 cutover 的 reader（readArchive 是 private——这里直接读同一文件，保持单一磁盘真相）。
+    const archivePath = path.join(this.dataDir, 'legacy-agent-archive.json')
+    try {
+      const value = JSON.parse(await fs.readFile(archivePath, 'utf8')) as LegacyAgentArchiveRecord[]
+      if (!Array.isArray(value)) throw new Error('Invalid legacy Agent archive')
+      return value
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return []
+      throw error
+    }
+  }
+
+  private async readTombstones(): Promise<Map<string, Tombstone>> {
+    try {
+      const value = JSON.parse(await fs.readFile(this.tombstonePath, 'utf8')) as Tombstone[]
+      if (!Array.isArray(value)) throw new Error('Invalid tombstones')
+      return new Map(value.map((t) => [`${t.archive_id}|pkg=${t.delete_package}|cfg=${t.delete_config}`, t]))
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return new Map()
+      throw error
+    }
+  }
+
+  private async saveTombstones(map: Map<string, Tombstone>): Promise<void> {
+    await durableAtomicWriteFile(this.tombstonePath, JSON.stringify(Array.from(map.values()), null, 2))
+  }
+
+  /** 资源解析：config → agent-configs/<instance>.json；package → installed_path / installed-modules/<id>。 */
+  private resolveResources(record: LegacyAgentArchiveRecord): { config?: ArchiveResource; pkg?: ArchiveResource } {
+    const raw = (record.raw && typeof record.raw === 'object' ? record.raw : {}) as Record<string, unknown>
+    const out: { config?: ArchiveResource; pkg?: ArchiveResource } = {}
+    const instanceId = typeof raw.instance_id === 'string' ? raw.instance_id : (typeof raw.id === 'string' ? raw.id : undefined)
+    if (instanceId && /^[A-Za-z0-9_-]+$/.test(instanceId)) {
+      out.config = {
+        logical: `agent-configs/${instanceId}.json`,
+        absPath: path.join(this.dataDir, 'agent-configs', `${instanceId}.json`),
+      }
+    }
+    const installedPath = typeof raw.installed_path === 'string' ? raw.installed_path : undefined
+    const installedRoot = path.join(this.dataDir, 'installed-modules')
+    if (installedPath) {
+      const abs = path.resolve(installedPath)
+      if (abs.startsWith(installedRoot + path.sep)) {
+        out.pkg = { logical: `installed-modules/${path.basename(abs)}`, absPath: abs }
+      }
+    }
+    return out
+  }
+
+  /** 内部/审计用途：带 raw 的全量记录（不用于普通 REST 序列化）。 */
+  async readRawRecords(): Promise<LegacyAgentArchiveRecord[]> {
+    return this.readRecords()
+  }
+
+  async listSummaries(): Promise<LegacyAgentArchiveSummary[]> {
+    const records = await this.readRecords()
+    return records.map((record) => {
+      const resources = this.resolveResources(record)
+      const uninstallable = !isCoreProtected(record) && Boolean(resources.config || resources.pkg)
+      return summarize(record, uninstallable)
+    })
+  }
+
+  async getDetail(archiveId: string): Promise<LegacyAgentArchiveSummary> {
+    const records = await this.readRecords()
+    const record = records.find((r) => r.archive_id === archiveId)
+    if (!record) throw new LegacyAgentArchiveError('ADMIN_LEGACY_AGENT_ARCHIVE_NOT_FOUND', `Archive not found: ${archiveId}`, 404)
+    const resources = this.resolveResources(record)
+    return summarize(record, !isCoreProtected(record) && Boolean(resources.config || resources.pkg))
+  }
+
+  /** authenticated export：返回脱敏 raw（现有 backup redaction 规则的最小面：不返回运行凭据）。 */
+  async exportRecord(archiveId: string): Promise<unknown> {
+    const records = await this.readRecords()
+    const record = records.find((r) => r.archive_id === archiveId)
+    if (!record) throw new LegacyAgentArchiveError('ADMIN_LEGACY_AGENT_ARCHIVE_NOT_FOUND', `Archive not found: ${archiveId}`, 404)
+    const clone = JSON.parse(JSON.stringify(record)) as Record<string, unknown>
+    // 脱敏：endpoint/api_key/token 类字段打码（archive 是审计数据，不回流运行凭据）。
+    const redact = (value: unknown): unknown => {
+      if (Array.isArray(value)) return value.map(redact)
+      if (value && typeof value === 'object') {
+        const out: Record<string, unknown> = {}
+        for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+          out[k] = /api_?key|token|secret|password/i.test(k) && typeof v === 'string' ? '<redacted>' : redact(v)
+        }
+        return out
+      }
+      return value
+    }
+    clone.raw = redact(record.raw)
+    return clone
+  }
+
+  private async recoverJournal(): Promise<Journal | null> {
+    try {
+      const journal = JSON.parse(await fs.readFile(this.journalPath, 'utf8')) as Journal
+      return journal
+    } catch {
+      return null
+    }
+  }
+
+  private async writeJournal(journal: Journal): Promise<void> {
+    journal.updated_at = new Date().toISOString()
+    await fs.mkdir(path.dirname(this.journalPath), { recursive: true })
+    await durableAtomicWriteFile(this.journalPath, JSON.stringify(journal, null, 2))
+  }
+
+  async deleteArchive(
+    archiveId: string,
+    params: Omit<DeleteLegacyAgentArchiveParams, 'confirmation'> & { confirmation?: string },
+    hooks: { isModuleActive?: (moduleId: string) => Promise<boolean> } = {},
+  ): Promise<DeleteLegacyAgentArchiveResult> {
+    if (!params.delete_package && !params.delete_config) {
+      throw new LegacyAgentArchiveError('ADMIN_LEGACY_AGENT_DELETE_SELECTION_REQUIRED', 'delete_package / delete_config 至少一个必须为 true', 400)
+    }
+    if (params.confirmation !== archiveId) {
+      throw new LegacyAgentArchiveError('ADMIN_LEGACY_AGENT_CONFIRMATION_MISMATCH', 'confirmation 必须逐字等于 archive_id', 400)
+    }
+    const records = await this.readRecords()
+    const record = records.find((r) => r.archive_id === archiveId)
+    if (!record) {
+      // archive 已移除后的重试：查 tombstone 幂等返回
+      const tombstones = await this.readTombstones()
+      const done = Array.from(tombstones.values()).find((t) => t.archive_id === archiveId && t.delete_package === params.delete_package && t.delete_config === params.delete_config)
+      if (done) return done.result
+      throw new LegacyAgentArchiveError('ADMIN_LEGACY_AGENT_ARCHIVE_NOT_FOUND', `Archive not found: ${archiveId}`, 404)
+    }
+    if (isCoreProtected(record)) {
+      throw new LegacyAgentArchiveError('ADMIN_LEGACY_AGENT_CORE_PROTECTED', `Archive is core-protected: ${record.archive_id}`, 403)
+    }
+
+    // tombstone 幂等：同 archive+selection 直接返回同一结果
+    const tombstones = await this.readTombstones()
+    const tombKey = `${record.archive_id}|pkg=${params.delete_package}|cfg=${params.delete_config}`
+    const existing = tombstones.get(tombKey)
+    if (existing) return existing.result
+
+    // still-active 检查（installed_package 带 module_id 时）
+    if (record.module_id && hooks.isModuleActive && await hooks.isModuleActive(record.module_id)) {
+      throw new LegacyAgentArchiveError('ADMIN_LEGACY_AGENT_STILL_ACTIVE', `Module still active: ${record.module_id}`, 409)
+    }
+
+    // crash 恢复：未完成 journal 指向同一 archive+selection 则续跑
+    let journal = await this.recoverJournal()
+    if (journal && (journal.archive_id !== record.archive_id || journal.delete_package !== params.delete_package || journal.delete_config !== params.delete_config)) {
+      throw new LegacyAgentArchiveError('ADMIN_LEGACY_AGENT_DELETE_CONFLICT', '存在未完成的其它 archive 删除 journal', 409)
+    }
+    if (!journal) {
+      const resources = this.resolveResources(record)
+      const targets: ArchiveResource[] = []
+      if (params.delete_config && resources.config) targets.push(resources.config)
+      if (params.delete_package && resources.pkg) targets.push(resources.pkg)
+      journal = {
+        archive_id: record.archive_id,
+        phase: 'prepared',
+        delete_package: params.delete_package,
+        delete_config: params.delete_config,
+        targets,
+        deleted: [],
+        updated_at: new Date().toISOString(),
+      }
+      await this.writeJournal(journal)
+    }
+
+    // 逐项删除（rename-to-trash 语义简化：直接 rm，archive 本为退役数据；幂等）
+    for (const target of journal.targets) {
+      if (journal.deleted.includes(target.logical)) continue
+      await fs.rm(target.absPath, { recursive: true, force: true })
+      journal.deleted.push(target.logical)
+      await this.writeJournal(journal)
+    }
+    journal.phase = 'committed'
+    await this.writeJournal(journal)
+
+    // retained：未选中的资源仍在 → summary 保留
+    const resources = this.resolveResources(record)
+    const retained: string[] = []
+    if (!params.delete_config && resources.config) {
+      if (await exists(resources.config.absPath)) retained.push(resources.config.logical)
+    }
+    if (!params.delete_package && resources.pkg) {
+      if (await exists(resources.pkg.absPath)) retained.push(resources.pkg.logical)
+    }
+    const archiveRemoved = retained.length === 0
+
+    const result: DeleteLegacyAgentArchiveResult = {
+      archive_id: record.archive_id,
+      completed: true,
+      archive_removed: archiveRemoved,
+      deleted_resources: journal.deleted,
+      retained_resources: retained,
+    }
+
+    // tombstone 落盘；archive_removed 时从 archive 中移除 record
+    tombstones.set(tombKey, {
+      archive_id: record.archive_id,
+      delete_package: params.delete_package,
+      delete_config: params.delete_config,
+      result,
+      completed_at: new Date().toISOString(),
+    })
+    await this.saveTombstones(tombstones)
+    if (archiveRemoved) {
+      const next = records.filter((r) => r.archive_id !== record.archive_id)
+      await durableAtomicWriteFile(path.join(this.dataDir, 'legacy-agent-archive.json'), JSON.stringify(next, null, 2))
+    }
+    await fs.rm(this.journalPath, { force: true })
+    return result
+  }
+
+  /** cutover store 直通（inventory/archive 追加仍由 CoreAgentCutoverStore 负责）。 */
+  get cutoverStore(): CoreAgentCutoverStore {
+    return this.cutover
+  }
+}
+
+async function exists(p: string): Promise<boolean> {
+  try { await fs.stat(p); return true } catch { return false }
+}
+
+/** 稳定 fingerprint 校验辅助（Slice 0 marker 一致性检查用）。 */
+export function archiveFingerprint(records: LegacyAgentArchiveRecord[]): string {
+  return crypto.createHash('sha256').update(canonicalizeJson(records.map((record) => ({
+    archive_id: record.archive_id,
+    source_kind: record.source_kind,
+    source_id: record.source_id,
+    support_status: record.support_status,
+    raw: record.raw,
+  }))), 'utf8').digest('hex')
+}

--- a/crabot-admin/src/legacy-agent-archive.ts
+++ b/crabot-admin/src/legacy-agent-archive.ts
@@ -93,7 +93,10 @@ function summarize(record: LegacyAgentArchiveRecord, uninstallable: boolean): Le
 
 function isCoreProtected(record: LegacyAgentArchiveRecord): boolean {
   const raw = (record.raw && typeof record.raw === 'object' ? record.raw : {}) as Record<string, unknown>
-  const ids = [record.archive_id, record.source_id, record.module_id, raw.id, raw.instance_id, raw.implementation_id]
+  // implementation_id 是「引用了哪个 implementation」不是身份——v2 存量实例普遍引用
+  // implementation_id='default'（唯一 builtin），把它当身份会让所有 agent_instance 记录
+  // 永久 CORE_PROTECTED 删不掉（review R3 实测）。身份只看自身 id 字段。
+  const ids = [record.archive_id, record.source_id, record.module_id, raw.id, raw.instance_id]
     .filter((v): v is string => typeof v === 'string')
   return ids.some((id) => CORE_IDS.has(id))
 }

--- a/crabot-admin/src/legacy-agent-archive.ts
+++ b/crabot-admin/src/legacy-agent-archive.ts
@@ -139,23 +139,38 @@ export class LegacyAgentArchiveStore {
     await durableAtomicWriteFile(this.tombstonePath, JSON.stringify(Array.from(map.values()), null, 2))
   }
 
-  /** 资源解析：config → agent-configs/<instance>.json；package → installed_path / installed-modules/<id>。 */
-  private resolveResources(record: LegacyAgentArchiveRecord): { config?: ArchiveResource; pkg?: ArchiveResource } {
+  /**
+   * 资源解析：config → agent-configs/<instance>.json；package → installed_path 或
+   * package_path（cutover inventory 对 installed_package 的生产 raw 形状是
+   * {package_id, package_path, ...}，review 实测）。
+   * 返回 known-but-undeletable 标记：raw 声明了资源但路径越界/无法解析时，该资源
+   * 必须计入 retained（archive_removed 不得谎报 true）。
+   */
+  private resolveResources(record: LegacyAgentArchiveRecord): {
+    config?: ArchiveResource
+    pkg?: ArchiveResource
+    undeletable: string[]
+  } {
     const raw = (record.raw && typeof record.raw === 'object' ? record.raw : {}) as Record<string, unknown>
-    const out: { config?: ArchiveResource; pkg?: ArchiveResource } = {}
+    const out: { config?: ArchiveResource; pkg?: ArchiveResource; undeletable: string[] } = { undeletable: [] }
     const instanceId = typeof raw.instance_id === 'string' ? raw.instance_id : (typeof raw.id === 'string' ? raw.id : undefined)
     if (instanceId && /^[A-Za-z0-9_-]+$/.test(instanceId)) {
       out.config = {
         logical: `agent-configs/${instanceId}.json`,
         absPath: path.join(this.dataDir, 'agent-configs', `${instanceId}.json`),
       }
+    } else if (record.source_kind === 'agent_config') {
+      out.undeletable.push(`agent-configs（无法从 raw 解析 instance_id）`)
     }
-    const installedPath = typeof raw.installed_path === 'string' ? raw.installed_path : undefined
+    const declaredPath = typeof raw.installed_path === 'string' ? raw.installed_path
+      : (typeof raw.package_path === 'string' ? raw.package_path : undefined)
     const installedRoot = path.join(this.dataDir, 'installed-modules')
-    if (installedPath) {
-      const abs = path.resolve(installedPath)
+    if (declaredPath) {
+      const abs = path.resolve(declaredPath)
       if (abs.startsWith(installedRoot + path.sep)) {
         out.pkg = { logical: `installed-modules/${path.basename(abs)}`, absPath: abs }
+      } else {
+        out.undeletable.push(`package（路径越界，拒绝删除）: ${path.basename(abs)}`)
       }
     }
     return out
@@ -287,9 +302,9 @@ export class LegacyAgentArchiveStore {
     journal.phase = 'committed'
     await this.writeJournal(journal)
 
-    // retained：未选中的资源仍在 → summary 保留
+    // retained：未选中的资源仍在 → summary 保留；undeletable 也计入（不得谎报全删）
     const resources = this.resolveResources(record)
-    const retained: string[] = []
+    const retained: string[] = [...resources.undeletable]
     if (!params.delete_config && resources.config) {
       if (await exists(resources.config.absPath)) retained.push(resources.config.logical)
     }

--- a/crabot-admin/src/legacy-agent-archive.ts
+++ b/crabot-admin/src/legacy-agent-archive.ts
@@ -181,6 +181,16 @@ export class LegacyAgentArchiveStore {
     return this.readRecords()
   }
 
+  /**
+   * 用户显式删除过的 archive_id 集合（§3.3 item 4：tombstone 防止下次 inventory
+   * 从残留另一来源重新生成——review 实测：agent-instances.json 等源文件保留在原位，
+   * 启动重扫会把已删 record 复活且 tombstone 短路后续删除）。
+   */
+  async deletedArchiveIds(): Promise<Set<string>> {
+    const tombstones = await this.readTombstones()
+    return new Set(Array.from(tombstones.values()).map((t) => t.archive_id))
+  }
+
   async listSummaries(): Promise<LegacyAgentArchiveSummary[]> {
     const records = await this.readRecords()
     return records.map((record) => {

--- a/crabot-admin/src/module-installer.test.ts
+++ b/crabot-admin/src/module-installer.test.ts
@@ -1,78 +1,55 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import fs from 'node:fs/promises'
-import os from 'node:os'
-import path from 'node:path'
-
+/**
+ * ModuleInstaller P6-D 退役语义测试。
+ * 旧「install/preview 拒绝 Agent 包」断言已随入口删除而退役：现在没有任何经
+ * ModuleInstaller 到达 runtime/build/record 创建的路径；门禁唯一保留在
+ * ModuleValidator.validate（module_type=agent → HOTPLUG_NOT_ALLOWED）。
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import fs from 'fs/promises'
+import path from 'path'
 import { ModuleInstaller } from './module-installer.js'
-import type { ModulePackageInfo } from './types.js'
+import { ModuleValidator } from './module-validator.js'
 
-const AGENT_PACKAGE: ModulePackageInfo = {
-  module_id: 'third-party-agent',
-  module_type: 'agent',
-  protocol_version: '0.1.0',
-  name: 'Third-party Agent',
-  version: '1.0.0',
-  runtime: { type: 'nodejs' },
-  entry: 'index.js',
-  install: 'pnpm install',
-  build: 'pnpm build',
-  agent: {
-    engine: 'custom',
-    supported_roles: ['worker'],
-    model_format: 'openai',
-    model_roles: [],
-  },
-}
-
-describe('ModuleInstaller dynamic Agent defense in depth', () => {
+describe('ModuleInstaller P6-D retirement', () => {
   let dataDir: string
-  let installer: ModuleInstaller
-  let internals: any
-  let agentManager: {
-    getImplementation: ReturnType<typeof vi.fn>
-    addImplementation: ReturnType<typeof vi.fn>
-  }
 
   beforeEach(async () => {
-    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'crabot-module-installer-agent-'))
-    agentManager = {
-      getImplementation: vi.fn(),
-      addImplementation: vi.fn(),
-    }
-    installer = new ModuleInstaller(dataDir, agentManager as never)
-    await installer.initialize()
-    internals = installer as any
-    internals.prepareSource = vi.fn()
-    internals.validator.validate = vi.fn().mockResolvedValue(AGENT_PACKAGE)
-    internals.runtimeManager.checkRuntime = vi.fn().mockResolvedValue(true)
-    internals.runtimeManager.runInstall = vi.fn()
-    internals.runtimeManager.runBuild = vi.fn()
+    dataDir = path.join(process.cwd(), 'test-data', `installer-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
+    await fs.mkdir(dataDir, { recursive: true })
   })
 
   afterEach(async () => {
     await fs.rm(dataDir, { recursive: true, force: true })
-    vi.restoreAllMocks()
   })
 
-  it('preview rejects an Agent package even if the validator seam returns one', async () => {
-    await expect(installer.preview({ type: 'local', path: '/unused' }))
-      .rejects.toThrow('ADMIN_HOTPLUG_NOT_ALLOWED')
-
-    expect(internals.runtimeManager.runInstall).not.toHaveBeenCalled()
-    expect(internals.runtimeManager.runBuild).not.toHaveBeenCalled()
-    expect(await fs.readdir(path.join(dataDir, 'temp'))).toEqual([])
+  it('install/uninstall/preview 入口不存在', async () => {
+    const installer = new ModuleInstaller(dataDir)
+    const anyInstaller = installer as unknown as Record<string, unknown>
+    expect(anyInstaller.install).toBeUndefined()
+    expect(anyInstaller.uninstall).toBeUndefined()
+    expect(anyInstaller.preview).toBeUndefined()
   })
 
-  it('install rejects before runtime/install/build, final rename, or record creation', async () => {
-    await expect(installer.install({ type: 'local', path: '/unused' }))
-      .rejects.toThrow('ADMIN_HOTPLUG_NOT_ALLOWED')
-
-    expect(agentManager.getImplementation).not.toHaveBeenCalled()
-    expect(internals.runtimeManager.checkRuntime).not.toHaveBeenCalled()
-    expect(internals.runtimeManager.runInstall).not.toHaveBeenCalled()
-    expect(internals.runtimeManager.runBuild).not.toHaveBeenCalled()
-    expect(agentManager.addImplementation).not.toHaveBeenCalled()
-    expect(await fs.readdir(path.join(dataDir, 'temp'))).toEqual([])
-    expect(await fs.readdir(path.join(dataDir, 'installed-modules'))).toEqual([])
+  it('validator 对 agent manifest 输出 HOTPLUG_NOT_ALLOWED（非可安装 definition）', async () => {
+    const pkg = path.join(dataDir, 'pkg')
+    await fs.mkdir(pkg, { recursive: true })
+    await fs.writeFile(path.join(pkg, 'crabot-module.yaml'), [
+      'module_id: rogue-agent',
+      'name: Rogue',
+      'version: 1.0.0',
+      'module_type: agent',
+      'protocol_version: "0.2.0"',
+      'runtime:',
+      '  type: nodejs',
+      'entry: index.js',
+      'agent:',
+      '  engine: custom',
+      '  supported_roles: [front]',
+      '  model_format: openai',
+      '  model_roles: []',
+    ].join('\n'))
+    await fs.writeFile(path.join(pkg, 'index.js'), 'console.log(1)')
+    const validator = new ModuleValidator()
+    await expect(validator.validate(pkg)).rejects.toThrow('ADMIN_HOTPLUG_NOT_ALLOWED')
   })
 })

--- a/crabot-admin/src/module-installer.ts
+++ b/crabot-admin/src/module-installer.ts
@@ -7,15 +7,11 @@
 import fs from 'fs/promises'
 import path from 'path'
 import { spawn } from 'child_process'
-import { generateTimestamp } from 'crabot-shared'
 import { RuntimeManager } from './runtime-manager.js'
 import { ModuleValidator } from './module-validator.js'
-import { AgentManager } from './agent-manager.js'
 import type {
   ModuleSource,
   ModulePackageInfo,
-  AgentImplementation,
-  InstallOptions,
 } from './types.js'
 
 export class ModuleInstaller {
@@ -24,16 +20,13 @@ export class ModuleInstaller {
   private readonly installedDir: string
   private readonly runtimeManager: RuntimeManager
   private readonly validator: ModuleValidator
-  private readonly agentManager: AgentManager
-  private installing = false
 
-  constructor(dataDir: string, agentManager: AgentManager) {
+  constructor(dataDir: string) {
     this.dataDir = dataDir
     this.tempDir = path.join(dataDir, 'temp')
     this.installedDir = path.join(dataDir, 'installed-modules')
     this.runtimeManager = new RuntimeManager(process.cwd())
     this.validator = new ModuleValidator()
-    this.agentManager = agentManager
   }
 
   async initialize(): Promise<void> {
@@ -44,201 +37,11 @@ export class ModuleInstaller {
   /**
    * 预览模块包信息（不安装）
    */
-  async preview(source: ModuleSource): Promise<ModulePackageInfo> {
-    // 创建临时目录
-    const tempPath = await this.createTempDir()
-
-    try {
-      // 准备源代码
-      await this.prepareSource(source, tempPath)
-
-      // 解析和验证
-      const info = await this.validator.validate(tempPath)
-      this.assertHotplugAllowed(info)
-
-      return info
-    } finally {
-      // 清理临时目录
-      await this.cleanup(tempPath)
-    }
-  }
-
-  /**
-   * 安装模块
-   */
-  async install(
-    source: ModuleSource,
-    options: InstallOptions = {}
-  ): Promise<AgentImplementation> {
-    // 并发控制：同一时间只允许一个安装操作
-    if (this.installing) {
-      throw new Error('Another installation is in progress')
-    }
-
-    this.installing = true
-
-    const tempPath = await this.createTempDir()
-
-    try {
-      console.log('[ModuleInstaller] Starting installation...')
-      console.log('[ModuleInstaller] Source:', JSON.stringify(source))
-
-      // 1. 准备源代码
-      console.log('[ModuleInstaller] Step 1: Preparing source...')
-      await this.prepareSource(source, tempPath)
-
-      // 2. 解析和验证
-      console.log('[ModuleInstaller] Step 2: Validating module...')
-      const info = await this.validator.validate(tempPath)
-      this.assertHotplugAllowed(info)
-      console.log('[ModuleInstaller] Module info:', JSON.stringify(info, null, 2))
-
-      // 3. 检查是否已存在
-      const existing = this.agentManager.getImplementation(info.module_id)
-      if (existing && !options.overwrite) {
-        throw new Error(
-          `Module ${info.module_id} already exists. Use overwrite option to replace it.`
-        )
-      }
-
-      // 4. 检查运行时
-      console.log('[ModuleInstaller] Step 3: Checking runtime...')
-      const runtimeOk = await this.runtimeManager.checkRuntime(
-        info.runtime.type,
-        info.runtime.version
-      )
-      if (!runtimeOk) {
-        throw new Error(
-          `Runtime ${info.runtime.type} ${info.runtime.version || ''} not available`
-        )
-      }
-
-      // 5. 安装依赖
-      if (info.install) {
-        console.log('[ModuleInstaller] Step 4: Installing dependencies...')
-        await this.runtimeManager.runInstall(
-          info.install,
-          tempPath,
-          info.runtime.type,
-          options.timeout
-        )
-      }
-
-      // 6. 构建
-      if (info.build) {
-        console.log('[ModuleInstaller] Step 5: Building...')
-        await this.runtimeManager.runBuild(
-          info.build,
-          tempPath,
-          info.runtime.type,
-          options.timeout
-        )
-      }
-
-      // 7. 验证 entry 文件存在
-      console.log('[ModuleInstaller] Step 6: Validating entry file...')
-      const entryExists = await this.validator.validateEntryExists(tempPath, info.entry)
-      if (!entryExists) {
-        throw new Error(`Entry file not found: ${info.entry}`)
-      }
-
-      // 8. 移动到安装目录
-      console.log('[ModuleInstaller] Step 7: Moving to installed directory...')
-      const installedPath = path.join(this.installedDir, info.module_id)
-
-      // 如果已存在，先删除
-      if (existing) {
-        await this.removeDirectory(installedPath)
-      }
-
-      await fs.rename(tempPath, installedPath)
-
-      // 9. 创建 AgentImplementation
-      console.log('[ModuleInstaller] Step 8: Creating implementation record...')
-      const implementation: AgentImplementation = {
-        id: info.module_id,
-        name: info.name,
-        type: 'installed',
-        implementation_type: 'full_code',
-        engine: info.agent!.engine,
-        supported_roles: info.agent!.supported_roles,
-        model_format: info.agent!.model_format,
-        model_roles: info.agent!.model_roles,
-        source: source.type === 'local'
-          ? { type: 'local', path: source.path }
-          : { type: 'git', path: source.url, ref: source.ref },
-        installed_path: installedPath,
-        version: info.version,
-        installed_at: generateTimestamp(),
-        created_at: generateTimestamp(),
-        updated_at: generateTimestamp(),
-      }
-
-      await this.agentManager.addImplementation(implementation)
-
-      console.log('[ModuleInstaller] Installation completed successfully')
-      return implementation
-    } catch (error) {
-      console.error('[ModuleInstaller] Installation failed:', error)
-      // 清理临时目录
-      await this.cleanup(tempPath)
-      throw error
-    } finally {
-      this.installing = false
-    }
-  }
-
-  /**
-   * Validator rejection is the primary gate; keep an independent installer boundary so a
-   * future validator seam cannot reach runtime/install/build or persistent records.
-   */
-  private assertHotplugAllowed(info: ModulePackageInfo): void {
-    if (info.module_type === 'agent') {
-      throw new Error('ADMIN_HOTPLUG_NOT_ALLOWED: only builtin crabot-agent is supported')
-    }
-  }
-
   /**
    * 获取 RuntimeManager 实例
    */
   getRuntimeManager(): RuntimeManager {
     return this.runtimeManager
-  }
-
-  /**
-   * 卸载模块
-   */
-  async uninstall(implementationId: string): Promise<void> {
-    const implementation = this.agentManager.getImplementation(implementationId)
-    if (!implementation) {
-      throw new Error(`Implementation not found: ${implementationId}`)
-    }
-
-    if (implementation.type === 'builtin') {
-      throw new Error('Cannot uninstall builtin implementation')
-    }
-
-    // 检查是否有实例使用此实现
-    const instances = this.agentManager.listInstances({
-      implementation_id: implementationId,
-      page: 1,
-      page_size: 1,
-    })
-    if (instances.items.length > 0) {
-      throw new Error(
-        `Cannot uninstall implementation with ${instances.items.length} active instances`
-      )
-    }
-
-    // 删除安装目录
-    if (implementation.installed_path) {
-      await this.removeDirectory(implementation.installed_path)
-    }
-
-    // 删除实现记录
-    await this.agentManager.removeImplementation(implementationId)
-
-    console.log(`[ModuleInstaller] Uninstalled: ${implementationId}`)
   }
 
   /**

--- a/crabot-admin/src/types.ts
+++ b/crabot-admin/src/types.ts
@@ -1398,10 +1398,6 @@ export interface ModulePackageInfo {
 }
 
 /** 安装选项 */
-export interface InstallOptions {
-  overwrite?: boolean
-  timeout?: number
-}
 
 // ============================================================================
 // Agent 实现与实例管理
@@ -1688,27 +1684,11 @@ export interface GetAgentInstanceResult {
   instance: AgentInstance
 }
 
-export interface CreateAgentInstanceParams {
-  implementation_id: string
-  name: string
-  specialization: string
-  max_concurrent_tasks?: number
-  auto_start?: boolean
-  start_priority?: number
-}
 
 export interface CreateAgentInstanceResult {
   instance: AgentInstance
 }
 
-export interface UpdateAgentInstanceParams {
-  instance_id: string
-  name?: string
-  specialization?: string
-  max_concurrent_tasks?: number
-  auto_start?: boolean
-  start_priority?: number
-}
 
 export interface UpdateAgentInstanceResult {
   instance: AgentInstance
@@ -1762,10 +1742,6 @@ export interface PreviewModulePackageResult {
   package_info: ModulePackageInfo
 }
 
-export interface InstallModuleParams {
-  source: ModuleSource
-  overwrite?: boolean
-}
 
 export interface InstallModuleResult {
   implementation: AgentImplementation

--- a/crabot-admin/web/src/pages/Modules/ModuleDetail.tsx
+++ b/crabot-admin/web/src/pages/Modules/ModuleDetail.tsx
@@ -1,125 +1,156 @@
-import React, { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
-import { agentService } from '../../services/agent'
+import { legacyArchiveService, type LegacyAgentArchiveSummary, type DeleteLegacyAgentArchiveResult } from '../../services/legacy-archive'
 import { MainLayout } from '../../components/Layout/MainLayout'
 import { Card } from '../../components/Common/Card'
 import { Button } from '../../components/Common/Button'
 import { Loading } from '../../components/Common/Loading'
-import type { AgentImplementation } from '../../types'
 
-export const ModuleDetail: React.FC = () => {
+/**
+ * P6-D：Module detail 退役为两种形态——
+ * - `crabot-agent`：唯一 live core Agent 静态身份（引导去 /agents/config）。
+ * - `legacy:<archive_id>`：unsupported legacy archive 只读摘要 + 显式导出/卸载（§3.18）。
+ * 不再渲染 legacy model_roles 为「当前能力」。
+ */
+export function ModuleDetail() {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
-  const [implementation, setImplementation] = useState<AgentImplementation | null>(null)
+  const [archive, setArchive] = useState<LegacyAgentArchiveSummary | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
+  const [deletePkg, setDeletePkg] = useState(false)
+  const [deleteCfg, setDeleteCfg] = useState(false)
+  const [confirmText, setConfirmText] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [result, setResult] = useState<DeleteLegacyAgentArchiveResult | null>(null)
 
-  useEffect(() => {
-    if (!id) return
-    loadImplementation()
-  }, [id])
+  const archiveId = id?.startsWith('legacy:') ? id.slice('legacy:'.length) : null
 
-  const loadImplementation = async () => {
-    if (!id) return
-
+  const load = useCallback(async () => {
+    if (!archiveId) { setLoading(false); return }
     try {
       setLoading(true)
-      const response = await agentService.listImplementations()
-      const impl = response.items.find((item) => item.id === id)
-      if (impl) {
-        setImplementation(impl)
-      } else {
-        setError('模块不存在')
-      }
+      const items = await legacyArchiveService.list()
+      setArchive(items.find((item) => item.archive_id === archiveId) ?? null)
+      if (!items.some((item) => item.archive_id === archiveId)) setError('archive 不存在或已移除')
     } catch (err) {
       setError(err instanceof Error ? err.message : '加载失败')
     } finally {
       setLoading(false)
     }
+  }, [archiveId])
+
+  useEffect(() => { void load() }, [load])
+
+  if (id === 'crabot-agent') {
+    return (
+      <MainLayout>
+        <div style={{ marginBottom: '2rem' }}>
+          <h1 style={{ fontSize: '2rem', fontWeight: 700 }}>Crabot Core Agent</h1>
+          <span className="badge badge-primary">内置</span>
+        </div>
+        <Card title="唯一 live Agent">
+          <p>core Agent 是 release 内置的唯一 Agent。行为与模型配置请前往「Agents → 配置」。</p>
+          <Button onClick={() => navigate('/agents/config')}>打开配置</Button>
+        </Card>
+      </MainLayout>
+    )
   }
 
   if (loading) return <MainLayout><Loading /></MainLayout>
-  if (!implementation) return <MainLayout><div className="error-message">{error || '模块不存在'}</div></MainLayout>
+  if (!archive) return <MainLayout><div className="error-message">{error || '模块不存在'}</div></MainLayout>
+
+  const doExport = async () => {
+    const record = await legacyArchiveService.export(archive.archive_id)
+    const blob = new Blob([JSON.stringify(record, null, 2)], { type: 'application/json' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `${archive.archive_id.replace(/[^A-Za-z0-9_-]/g, '_')}.json`
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  const doDelete = async () => {
+    if (!deletePkg && !deleteCfg) return
+    if (confirmText !== archive.archive_id) return
+    setBusy(true)
+    try {
+      const r = await legacyArchiveService.remove(archive.archive_id, { delete_package: deletePkg, delete_config: deleteCfg })
+      setResult(r)
+      if (r.archive_removed) navigate('/modules')
+      else await load()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '删除失败')
+    } finally {
+      setBusy(false)
+    }
+  }
 
   return (
     <MainLayout>
       <div style={{ marginBottom: '2rem', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
-          <h1 style={{ fontSize: '2rem', fontWeight: 700 }}>{implementation.name}</h1>
-          <span className="badge badge-primary">
-            {implementation.type === 'builtin' ? '内置' : '已安装'}
-          </span>
+        <div>
+          <h1 style={{ fontSize: '2rem', fontWeight: 700 }}>{archive.display_name ?? archive.archive_id}</h1>
+          <span className="badge badge-warning">不受支持的 legacy archive</span>
         </div>
-        <div style={{ display: 'flex', gap: '0.5rem' }}>
-          <Button variant="secondary" onClick={() => navigate('/modules')}>返回</Button>
-          {implementation.type !== 'builtin' && (
-            <Button variant="danger" disabled>删除</Button>
-          )}
-        </div>
+        <Button variant="secondary" onClick={() => navigate('/modules')}>返回</Button>
       </div>
 
       {error && <div className="error-message">{error}</div>}
+      {result && (
+        <div className="info-message">
+          已删除: {result.deleted_resources.join(', ') || '无'}
+          {result.retained_resources.length > 0 && `；保留: ${result.retained_resources.join(', ')}`}
+        </div>
+      )}
 
       <div style={{ display: 'grid', gap: '1.5rem' }}>
-        <Card title="基本信息">
+        <Card title="Archive 信息">
           <table className="table">
             <tbody>
-              <tr><td style={{ width: '150px', color: 'var(--text-secondary)' }}>ID</td><td>{implementation.id}</td></tr>
-              <tr><td style={{ color: 'var(--text-secondary)' }}>名称</td><td>{implementation.name}</td></tr>
-              <tr><td style={{ color: 'var(--text-secondary)' }}>类型</td><td>{implementation.type === 'builtin' ? '内置' : '已安装'}</td></tr>
-              <tr><td style={{ color: 'var(--text-secondary)' }}>实现类型</td><td>{implementation.implementation_type}</td></tr>
-              <tr><td style={{ color: 'var(--text-secondary)' }}>引擎</td><td>{implementation.engine}</td></tr>
-              <tr><td style={{ color: 'var(--text-secondary)' }}>模型格式</td><td>{implementation.model_format}</td></tr>
-              {implementation.version && <tr><td style={{ color: 'var(--text-secondary)' }}>版本</td><td>{implementation.version}</td></tr>}
+              <tr><td style={{ width: '150px', color: 'var(--text-secondary)' }}>archive_id</td><td><code>{archive.archive_id}</code></td></tr>
+              <tr><td style={{ color: 'var(--text-secondary)' }}>来源类型</td><td>{archive.source_kind}</td></tr>
+              {archive.module_id && <tr><td style={{ color: 'var(--text-secondary)' }}>module_id</td><td>{archive.module_id}</td></tr>}
+              <tr><td style={{ color: 'var(--text-secondary)' }}>归档时间</td><td>{new Date(archive.archived_at).toLocaleString()}</td></tr>
+              <tr><td style={{ color: 'var(--text-secondary)' }}>支持状态</td><td>unsupported_legacy（不会执行，仅审计/导出/显式删除）</td></tr>
             </tbody>
           </table>
         </Card>
 
-        <Card title="模型角色定义">
-          <table className="table">
-            <thead>
-              <tr>
-                <th>角色键</th>
-                <th>描述</th>
-                <th>必需</th>
-                <th>推荐能力</th>
-              </tr>
-            </thead>
-            <tbody>
-              {implementation.model_roles.map((role) => (
-                <tr key={role.key}>
-                  <td><code>{role.key}</code></td>
-                  <td>{role.description}</td>
-                  <td>{role.required ? '是' : '否'}</td>
-                  <td>{role.recommended_capabilities?.join(', ') || '-'}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+        <Card title="导出">
+          <p style={{ color: 'var(--text-secondary)' }}>导出经认证的脱敏 JSON（不含运行凭据）。</p>
+          <Button onClick={() => void doExport()}>导出 archive</Button>
         </Card>
 
-        {implementation.source && (
-          <Card title="来源信息">
-            <table className="table">
-              <tbody>
-                <tr><td style={{ width: '150px', color: 'var(--text-secondary)' }}>类型</td><td>{implementation.source.type}</td></tr>
-                <tr><td style={{ color: 'var(--text-secondary)' }}>路径</td><td>{implementation.source.path}</td></tr>
-                {implementation.source.ref && <tr><td style={{ color: 'var(--text-secondary)' }}>引用</td><td>{implementation.source.ref}</td></tr>}
-                {implementation.installed_path && <tr><td style={{ color: 'var(--text-secondary)' }}>安装路径</td><td>{implementation.installed_path}</td></tr>}
-              </tbody>
-            </table>
+        {archive.uninstallable ? (
+          <Card title="删除（危险操作）">
+            <p style={{ color: 'var(--text-secondary)' }}>
+              至少选择一项。删除写入 tombstone，同选择重试返回相同结果。core/builtin 不可删除。
+            </p>
+            <label style={{ display: 'block', margin: '0.5rem 0' }}>
+              <input type="checkbox" checked={deletePkg} onChange={(e) => setDeletePkg(e.target.checked)} /> 删除 package
+            </label>
+            <label style={{ display: 'block', margin: '0.5rem 0' }}>
+              <input type="checkbox" checked={deleteCfg} onChange={(e) => setDeleteCfg(e.target.checked)} /> 删除 config
+            </label>
+            <label style={{ display: 'block', margin: '0.5rem 0' }}>
+              输入 <code>{archive.archive_id}</code> 确认：
+              <input value={confirmText} onChange={(e) => setConfirmText(e.target.value)} style={{ marginLeft: '0.5rem' }} />
+            </label>
+            <Button
+              variant="danger"
+              disabled={busy || (!deletePkg && !deleteCfg) || confirmText !== archive.archive_id}
+              onClick={() => void doDelete()}
+            >
+              确认删除
+            </Button>
+          </Card>
+        ) : (
+          <Card title="删除">
+            <p style={{ color: 'var(--text-secondary)' }}>该 archive 不可卸载（core 保护或无可删除资源）。</p>
           </Card>
         )}
-
-        <Card title="时间信息">
-          <table className="table">
-            <tbody>
-              <tr><td style={{ width: '150px', color: 'var(--text-secondary)' }}>创建时间</td><td>{new Date(implementation.created_at).toLocaleString()}</td></tr>
-              <tr><td style={{ color: 'var(--text-secondary)' }}>更新时间</td><td>{new Date(implementation.updated_at).toLocaleString()}</td></tr>
-              {implementation.installed_at && <tr><td style={{ color: 'var(--text-secondary)' }}>安装时间</td><td>{new Date(implementation.installed_at).toLocaleString()}</td></tr>}
-            </tbody>
-          </table>
-        </Card>
       </div>
     </MainLayout>
   )

--- a/crabot-admin/web/src/pages/Modules/ModuleList.test.tsx
+++ b/crabot-admin/web/src/pages/Modules/ModuleList.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { ModuleList } from './ModuleList'
+import { legacyArchiveService } from '../../services/legacy-archive'
+import { channelService } from '../../services/channel'
+
+vi.mock('../../services/legacy-archive')
+vi.mock('../../services/channel')
+vi.mock('../../services/api', () => ({ api: { get: vi.fn().mockResolvedValue({ modules: [] }) } }))
+vi.mock('../../components/Layout/MainLayout', () => ({
+  MainLayout: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+describe('ModuleList (P6-D)', () => {
+  beforeEach(() => {
+    vi.mocked(legacyArchiveService.list).mockResolvedValue([
+      {
+        archive_id: 'agent_config:front-agent',
+        source_kind: 'agent_config',
+        archived_at: '2026-08-14T00:00:00.000Z',
+        support_status: 'unsupported_legacy',
+        uninstallable: true,
+        display_name: 'front-agent',
+      },
+    ])
+    vi.mocked(channelService.listImplementations).mockResolvedValue({ items: [] } as never)
+  })
+
+  it('唯一 live agent 是静态 core；legacy 以 unsupported 摘要呈现且不含 raw', async () => {
+    render(<MemoryRouter><ModuleList /></MemoryRouter>)
+    await waitFor(() => expect(screen.getByText('Crabot Core Agent')).toBeTruthy())
+    expect(screen.getByText(/不受支持的 legacy.*front-agent/)).toBeTruthy()
+    // 列表页不出现动态 create/install 控件
+    expect(screen.queryByText(/安装 Agent/i)).toBeNull()
+    expect(screen.queryByText(/创建实例/i)).toBeNull()
+  })
+})

--- a/crabot-admin/web/src/pages/Modules/ModuleList.tsx
+++ b/crabot-admin/web/src/pages/Modules/ModuleList.tsx
@@ -1,13 +1,13 @@
 import React, { useState, useEffect, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { agentService } from '../../services/agent'
+import { legacyArchiveService, type LegacyAgentArchiveSummary } from '../../services/legacy-archive'
 import { channelService } from '../../services/channel'
 import { api } from '../../services/api'
 import { MainLayout } from '../../components/Layout/MainLayout'
 import { Card } from '../../components/Common/Card'
 import { Button } from '../../components/Common/Button'
 import { Loading } from '../../components/Common/Loading'
-import type { AgentImplementation, ChannelImplementation } from '../../types'
+import type { ChannelImplementation } from '../../types'
 
 interface RunningModule {
   module_id: string
@@ -48,19 +48,24 @@ interface ChannelDetail {
   module_path?: string
 }
 
-function toModuleItemFromAgent(impl: AgentImplementation): ModuleItem {
+/** P6-D：唯一 live agent 是静态 core；legacy 记录以 unsupported archive 摘要呈现。 */
+const CORE_AGENT_ITEM: ModuleItem = {
+  id: 'crabot-agent',
+  name: 'Crabot Core Agent',
+  module_type: 'agent',
+  install_type: 'builtin',
+  version: '-',
+  detail: { type: 'agent', engine: 'claude-agent-sdk', supported_roles: ['front', 'worker'], model_format: 'anthropic' },
+}
+
+function toModuleItemFromArchive(record: LegacyAgentArchiveSummary): ModuleItem {
   return {
-    id: impl.id,
-    name: impl.name,
+    id: `legacy:${record.archive_id}`,
+    name: `[不受支持的 legacy] ${record.display_name ?? record.archive_id}`,
     module_type: 'agent',
-    install_type: impl.type,
-    version: impl.version ?? '-',
-    detail: {
-      type: 'agent',
-      engine: impl.engine,
-      supported_roles: impl.supported_roles,
-      model_format: impl.model_format,
-    },
+    install_type: 'installed',
+    version: record.version ?? '-',
+    detail: { type: 'agent', engine: 'legacy', supported_roles: [], model_format: '-' },
   }
 }
 
@@ -199,13 +204,14 @@ export const ModuleList: React.FC = () => {
       setLoading(true)
       setError('')
 
-      const [agentResponse, channelResponse] = await Promise.all([
-        agentService.listImplementations().catch(() => ({ items: [] })),
-        channelService.listImplementations().catch(() => ({ items: [] })),
+      const [archiveItems, channelResponse] = await Promise.all([
+        legacyArchiveService.list().catch(() => [] as LegacyAgentArchiveSummary[]),
+        channelService.listImplementations().catch(() => ({ items: [] as ChannelImplementation[] })),
       ])
 
       const allModules: ModuleItem[] = [
-        ...agentResponse.items.map(toModuleItemFromAgent),
+        CORE_AGENT_ITEM,
+        ...archiveItems.map(toModuleItemFromArchive),
         BUILTIN_MEMORY,
         ...channelResponse.items.map(toModuleItemFromChannel),
       ]

--- a/crabot-admin/web/src/pages/Modules/ModuleList.tsx
+++ b/crabot-admin/web/src/pages/Modules/ModuleList.tsx
@@ -109,6 +109,8 @@ const TYPE_COLORS: Record<ModuleType, string> = {
 }
 
 function getNavigationTarget(item: ModuleItem): string {
+  // P6-D：legacy archive 行进入 archive 详情页（导出/显式卸载 UI 的唯一入口）。
+  if (item.id.startsWith('legacy:')) return `/modules/${item.id}`
   switch (item.module_type) {
     case 'agent':
       return '/agents/config'
@@ -382,7 +384,7 @@ export const ModuleList: React.FC = () => {
                       {TYPE_LABELS[item.module_type]}
                     </span>
                     <span className="badge badge-primary">
-                      {item.install_type === 'builtin' ? '内置' : '已安装'}
+                      {item.id.startsWith('legacy:') ? '不受支持' : (item.install_type === 'builtin' ? '内置' : '已安装')}
                     </span>
                     {item.version !== '-' && (
                       <span style={{ color: 'var(--text-secondary)', fontSize: '0.85rem' }}>

--- a/crabot-admin/web/src/services/agent.ts
+++ b/crabot-admin/web/src/services/agent.ts
@@ -4,41 +4,13 @@
 
 import { api } from './api'
 import type {
-  AgentInstance,
   AgentInstanceConfig,
-  AgentImplementation,
   AgentLLMRequirementsResponse,
-  PaginatedResponse,
 } from '../types'
 
+// P6-D：动态 AgentImplementation/AgentInstance 的读写服务已退役。
+// 唯一 core Agent 配置走 /agent/config；legacy 记录见 services/legacy-archive.ts。
 export const agentService = {
-  async listInstances(): Promise<PaginatedResponse<AgentInstance>> {
-    return api.get<PaginatedResponse<AgentInstance>>('/agent-instances')
-  },
-
-  async getInstance(id: string): Promise<AgentInstance> {
-    return api.get<AgentInstance>(`/agent-instances/${id}`)
-  },
-
-  async getInstanceConfig(id: string): Promise<AgentInstanceConfig> {
-    const response = await api.get<{ config: AgentInstanceConfig }>(`/agent-instances/${id}/config`)
-    return response.config
-  },
-
-  async updateInstanceConfig(
-    id: string,
-    config: Partial<AgentInstanceConfig>
-  ): Promise<AgentInstanceConfig> {
-    return api.patch<AgentInstanceConfig>(
-      `/agent-instances/${id}/config`,
-      config
-    )
-  },
-
-  async listImplementations(): Promise<PaginatedResponse<AgentImplementation>> {
-    return api.get<PaginatedResponse<AgentImplementation>>('/agent-implementations')
-  },
-
   async getLLMRequirements(): Promise<AgentLLMRequirementsResponse> {
     return api.get<AgentLLMRequirementsResponse>('/agent-llm-requirements')
   },

--- a/crabot-admin/web/src/services/api.ts
+++ b/crabot-admin/web/src/services/api.ts
@@ -86,8 +86,11 @@ class ApiClient {
     })
   }
 
-  async delete<T>(endpoint: string): Promise<T> {
-    return this.request<T>(endpoint, { method: 'DELETE' })
+  async delete<T>(endpoint: string, data?: unknown): Promise<T> {
+    return this.request<T>(endpoint, {
+      method: 'DELETE',
+      ...(data !== undefined ? { body: JSON.stringify(data) } : {}),
+    })
   }
 
   listModules() {

--- a/crabot-admin/web/src/services/legacy-archive.ts
+++ b/crabot-admin/web/src/services/legacy-archive.ts
@@ -1,0 +1,47 @@
+/**
+ * P6-D：Legacy Agent archive 服务（protocol-admin §3.18）。
+ * 普通列表只含 sanitized summary；raw 只在显式 export 时出现。
+ */
+
+import { api } from './api'
+
+export interface LegacyAgentArchiveSummary {
+  archive_id: string
+  source_kind: 'agent_implementation' | 'agent_instance' | 'agent_config' | 'installed_package'
+  module_id?: string
+  archived_at: string
+  support_status: 'unsupported_legacy'
+  uninstallable: boolean
+  display_name?: string
+  version?: string
+}
+
+export interface DeleteLegacyAgentArchiveResult {
+  archive_id: string
+  completed: true
+  archive_removed: boolean
+  deleted_resources: string[]
+  retained_resources: string[]
+}
+
+export const legacyArchiveService = {
+  async list(): Promise<LegacyAgentArchiveSummary[]> {
+    const response = await api.get<{ items: LegacyAgentArchiveSummary[] }>('/legacy-agent-archive')
+    return response.items
+  },
+
+  async export(archiveId: string): Promise<unknown> {
+    const response = await api.get<{ record: unknown }>(`/legacy-agent-archive/${encodeURIComponent(archiveId)}/export`)
+    return response.record
+  },
+
+  async remove(
+    archiveId: string,
+    selection: { delete_package: boolean; delete_config: boolean },
+  ): Promise<DeleteLegacyAgentArchiveResult> {
+    return api.delete<DeleteLegacyAgentArchiveResult>(
+      `/legacy-agent-archive/${encodeURIComponent(archiveId)}`,
+      { confirmation: archiveId, ...selection },
+    )
+  },
+}

--- a/crabot-admin/web/src/types/index.ts
+++ b/crabot-admin/web/src/types/index.ts
@@ -135,40 +135,9 @@ export interface AgentLLMRequirementsResponse {
   extra_schema: ExtraConfigSchema[]
 }
 
-export interface AgentImplementation {
-  id: string
-  name: string
-  type: 'builtin' | 'installed'
-  implementation_type: AgentImplementationType
-  engine: AgentEngine
-  supported_roles: Array<'front' | 'worker'>
-  model_format: ModelFormat
-  model_roles: ModelRoleDefinition[]
-  source?: {
-    type: 'local' | 'git'
-    path: string
-    ref?: string
-  }
-  installed_path?: string
-  version?: string
-  installed_at?: string
-  created_at: string
-  updated_at: string
-}
+// P6-D：live AgentImplementation/AgentInstance 类型已退役；core 身份为静态定义，
+// legacy 记录见 services/legacy-archive.ts 的 LegacyAgentArchiveSummary。
 
-export interface AgentInstance {
-  id: string
-  implementation_id: string
-  name: string
-  specialization: string
-  max_concurrent_tasks?: number
-  auto_start: boolean
-  start_priority: number
-  module_registered: boolean
-  module_port?: number
-  created_at: string
-  updated_at: string
-}
 
 export interface MCPServerRegistryEntry {
   id: string

--- a/crabot-agent/crabot-module.yaml
+++ b/crabot-agent/crabot-module.yaml
@@ -1,12 +1,16 @@
-# Crabot Unified Agent Module
-# 合并 Flow + Agent 的统一智能体模块
+# Crabot Core Agent Module（P6-D：最小 core build metadata）
+#
+# 本文件只是 core 模块的构建/身份元数据，不是可安装的第三方 Agent 包：
+# - module_type: agent 的 manifest 在 ModuleValidator 处一律拒绝安装（HOTPLUG_NOT_ALLOWED）
+# - 行为 schema / model slots 的唯一权威是 crabot-admin/src/core-agent-definition.ts
+#   （CORE_AGENT_DEFINITION，protocol-admin §3.19.8），此处不再保留历史 model_roles 副本。
 
 module_id: crabot-agent
-name: Crabot Unified Agent
+name: Crabot Core Agent
 version: 0.2.0
 module_type: agent
-description: Unified Agent with orchestration and intelligence capabilities
-protocol_version: "0.2.0"
+description: Core Agent（唯一内置 Agent；Manager/Worker 架构，protocol-agent-v3）
+protocol_version: "3.1.1"
 
 # 运行时配置
 runtime:
@@ -18,7 +22,7 @@ entry: dist/main.js
 install: npm install
 build: npm run build
 
-# 事件订阅 (原 Flow 的订阅)
+# 事件订阅
 subscriptions:
   - channel.message_received
   - admin.task_status_changed
@@ -26,44 +30,9 @@ subscriptions:
   - admin.friend_updated
   - admin.friend_deleted
 
-# Agent 特性 (支持多角色)
-agent:
-  engine: unified
-  supported_roles: [front, worker, both]
-  model_format: anthropic
-  model_roles:
-    - key: default
-      description: 默认执行模型，Front 和 Worker 默认使用
-      required: true
-      used_by: [front, worker]
-      recommended_capabilities: [tool_use, long_context]
-    - key: fast
-      description: 快速响应模型，用于 Front Agent 快速分诊（可选）
-      required: false
-      used_by: [front]
-      recommended_capabilities: [tool_use, fast]
-    - key: smart
-      description: 深度推理模型，用于 Worker Agent 复杂任务（可选）
-      required: false
-      used_by: [worker]
-      recommended_capabilities: [reasoning, long_context]
-
-# 编排特性 (原 Flow)
-orchestration:
-  features:
-    - message_routing
-    - permission_checking
-    - context_assembly
-    - switchmap_merging
-    - worker_selection
-    - decision_dispatching
-
 # 元数据
 author: Crabot Team
 license: MIT
 keywords:
   - crabot
   - agent
-  - orchestration
-  - ai
-  - claude

--- a/crabot-agent/src/manager/tools/crabot-info.ts
+++ b/crabot-agent/src/manager/tools/crabot-info.ts
@@ -23,6 +23,11 @@ export interface CrabotInfoToolsDeps {
   readonly callAdmin: <P, R>(method: string, params: P) => Promise<R>
   /** 返回已通过 authenticated pull 安装的本地 runtime config；不得为摘要再次读取 secret RPC。 */
   readonly getRuntimeConfigSummary?: () => unknown
+  /** P6-D：worker implementation registry snapshot（本进程内，与 spawn gate 同一真相）。 */
+  readonly workerImplSnapshot?: () => {
+    default_impl: string
+    statuses: Array<{ impl: string; ready: boolean; enabled: boolean; capabilities?: unknown }>
+  }
 }
 
 // --- 掩码:get_config_summary 的责任,防御性做,不依赖 admin 端已掩码 ---
@@ -213,9 +218,8 @@ export function buildCrabotInfoTools(deps: CrabotInfoToolsDeps): ToolDefinition[
   })
 
   // --- get_deployment_info ---
-  // 组合来源:admin RPC `list_agent_instances` + `list_channel_instances`(拓扑详情:
-  // 实例 id/name/是否已注册到 Module Manager/端口/平台)。admin 没有现成的 "部署信息" RPC,
-  // 这里给出详细条目;数量级摘要见 get_system_status。
+  // P6-D：Agent 侧唯一是 exact core `crabot-agent`（静态身份，不再调 list_agent_instances）；
+  // channel 实例仍走 admin RPC。数量级摘要见 get_system_status。
   interface AgentInstanceLite {
     readonly id: string
     readonly name: string
@@ -238,12 +242,9 @@ export function buildCrabotInfoTools(deps: CrabotInfoToolsDeps): ToolDefinition[
     isReadOnly: true,
     call: async () => {
       try {
-        const [agentInstances, channelInstances] = await Promise.all([
-          callAdmin<typeof FULL_PAGE, PaginatedResult<AgentInstanceLite>>('list_agent_instances', FULL_PAGE),
-          callAdmin<typeof FULL_PAGE, PaginatedResult<ChannelInstanceLite>>('list_channel_instances', FULL_PAGE),
-        ])
+        const channelInstances = await callAdmin<typeof FULL_PAGE, PaginatedResult<ChannelInstanceLite>>('list_channel_instances', FULL_PAGE)
         return ok({
-          agent_instances: agentInstances.items,
+          agent_instances: [{ id: 'crabot-agent', name: 'Crabot Agent', implementation_id: 'crabot-agent', module_registered: true }],
           channel_instances: channelInstances.items,
         })
       } catch (error) {
@@ -335,18 +336,17 @@ export function buildCrabotInfoTools(deps: CrabotInfoToolsDeps): ToolDefinition[
   const listCapabilities = defineTool({
     name: 'list_capabilities',
     description:
-      '列出 crabot 已安装的能力清单:可用的 agent 实现(id/引擎/支持角色)、可用的 channel 平台' +
-      '类型(id/平台/版本)。用于回答"你都会什么/支持接哪些渠道"一类问题。',
+      '列出 crabot 已安装的能力清单:core agent（唯一内置）+ worker implementations(ready/enabled/能力)、可用的 channel 平台类型(id/平台/版本)。legacy archive 不受支持、不在此列。',
     inputSchema: { type: 'object', properties: {} },
     isReadOnly: true,
     call: async () => {
       try {
-        const [agentImpls, channelImpls] = await Promise.all([
-          callAdmin<typeof FULL_PAGE, PaginatedResult<AgentImplementationLite>>('list_agent_implementations', FULL_PAGE),
-          callAdmin<typeof FULL_PAGE, PaginatedResult<ChannelImplementationLite>>('list_channel_implementations', FULL_PAGE),
-        ])
+        const channelImpls = await callAdmin<typeof FULL_PAGE, PaginatedResult<ChannelImplementationLite>>('list_channel_implementations', FULL_PAGE)
+        const workers = deps.workerImplSnapshot?.()
         return ok({
-          agent_implementations: agentImpls.items,
+          // core Agent 固定能力（静态定义）；legacy archive 不作为 capability（§3.18）。
+          agent_implementations: [{ id: 'crabot-agent', name: 'Crabot Core Agent', type: 'builtin', implementation_type: 'config_only', engine: 'claude-agent-sdk', supported_roles: ['front', 'worker'] }],
+          worker_implementations: workers ? workers.statuses : [],
           channel_implementations: channelImpls.items,
         })
       } catch (error) {

--- a/crabot-agent/src/manager/tools/tool-face.ts
+++ b/crabot-agent/src/manager/tools/tool-face.ts
@@ -218,6 +218,7 @@ export function buildManagerToolFace(deps: ToolFaceDeps): ToolDefinition[] {
   const infoTools = buildCrabotInfoTools({
     callAdmin: deps.callAdmin,
     getRuntimeConfigSummary: deps.getRuntimeConfigSummary,
+    ...(deps.workerImplSnapshot ? { workerImplSnapshot: deps.workerImplSnapshot } : {}),
   })
 
   const tools = [...messagingTools, ...memoryTools, ...workerTools, ...infoTools]

--- a/crabot-agent/tests/manager/crabot-info.test.ts
+++ b/crabot-agent/tests/manager/crabot-info.test.ts
@@ -92,14 +92,10 @@ describe('buildCrabotInfoTools', () => {
   })
 
   describe('get_deployment_info', () => {
-    it('组合 list_agent_instances / list_channel_instances 返回拓扑详情', async () => {
+    it('P6-D：agent 实例为静态 core 身份，不再调 list_agent_instances；channel 仍走 admin', async () => {
+      const called: string[] = []
       const callAdmin = makeCallAdmin({
-        list_agent_instances: () => ({
-          items: [
-            { id: 'crabot-agent', name: 'Default Agent', implementation_id: 'builtin', module_registered: true, module_port: 4101 },
-          ],
-          pagination: { page: 1, page_size: 100, total_items: 1, total_pages: 1 },
-        }),
+        list_agent_instances: () => { called.push('list_agent_instances'); return { items: [], pagination: { page: 1, page_size: 100, total_items: 0, total_pages: 0 } } },
         list_channel_instances: () => ({
           items: [
             { id: 'wechat-1', name: 'WeChat', platform: 'wechat', module_registered: true },
@@ -113,11 +109,12 @@ describe('buildCrabotInfoTools', () => {
       expect(result.isError).toBe(false)
       const parsed = JSON.parse(result.output)
       expect(parsed.agent_instances).toEqual([
-        { id: 'crabot-agent', name: 'Default Agent', implementation_id: 'builtin', module_registered: true, module_port: 4101 },
+        { id: 'crabot-agent', name: 'Crabot Agent', implementation_id: 'crabot-agent', module_registered: true },
       ])
       expect(parsed.channel_instances).toEqual([
         { id: 'wechat-1', name: 'WeChat', platform: 'wechat', module_registered: true },
       ])
+      expect(called).not.toContain('list_agent_instances')
     })
   })
 
@@ -440,32 +437,34 @@ describe('buildCrabotInfoTools', () => {
   })
 
   describe('list_capabilities', () => {
-    it('组合 list_agent_implementations / list_channel_implementations', async () => {
+    it('P6-D：core 静态能力 + worker registry + channel；不调 list_agent_implementations', async () => {
+      const called: string[] = []
       const callAdmin = makeCallAdmin({
-        list_agent_implementations: () => ({
-          items: [
-            { id: 'builtin', name: 'Builtin', type: 'builtin', implementation_type: 'in_process', engine: 'claude', supported_roles: ['worker'] },
-          ],
-          pagination: { page: 1, page_size: 100, total_items: 1, total_pages: 1 },
-        }),
+        list_agent_implementations: () => { called.push('list_agent_implementations'); return { items: [], pagination: { page: 1, page_size: 100, total_items: 0, total_pages: 0 } } },
         list_channel_implementations: () => ({
-          items: [
-            { id: 'wechat', name: 'WeChat', type: 'builtin', platform: 'wechat', version: '1.0.0' },
-          ],
+          items: [{ id: 'telegram', name: 'Telegram', type: 'builtin', platform: 'telegram', version: '1.0.0' }],
           pagination: { page: 1, page_size: 100, total_items: 1, total_pages: 1 },
         }),
       })
-      const tools = buildCrabotInfoTools({ callAdmin, getRuntimeConfigSummary: () => runtimeConfigSummary(callAdmin) })
+      const workerImplSnapshot = () => ({
+        default_impl: 'builtin',
+        statuses: [{ impl: 'claude-code', ready: true, enabled: true, capabilities: { fork: true } }],
+      })
+      const tools = buildCrabotInfoTools({ callAdmin, workerImplSnapshot, getRuntimeConfigSummary: () => runtimeConfigSummary(callAdmin) })
       const tool = tools.find((t) => t.name === 'list_capabilities')!
       const result = await tool.call({}, {})
       expect(result.isError).toBe(false)
       const parsed = JSON.parse(result.output)
       expect(parsed.agent_implementations).toEqual([
-        { id: 'builtin', name: 'Builtin', type: 'builtin', implementation_type: 'in_process', engine: 'claude', supported_roles: ['worker'] },
+        { id: 'crabot-agent', name: 'Crabot Core Agent', type: 'builtin', implementation_type: 'config_only', engine: 'claude-agent-sdk', supported_roles: ['front', 'worker'] },
+      ])
+      expect(parsed.worker_implementations).toEqual([
+        { impl: 'claude-code', ready: true, enabled: true, capabilities: { fork: true } },
       ])
       expect(parsed.channel_implementations).toEqual([
-        { id: 'wechat', name: 'WeChat', type: 'builtin', platform: 'wechat', version: '1.0.0' },
+        { id: 'telegram', name: 'Telegram', type: 'builtin', platform: 'telegram', version: '1.0.0' },
       ])
+      expect(called).not.toContain('list_agent_implementations')
     })
   })
 

--- a/crabot-core/src/core-agent-cutover.test.ts
+++ b/crabot-core/src/core-agent-cutover.test.ts
@@ -379,3 +379,34 @@ describe('core Agent cutover gate', () => {
     }
   })
 })
+
+describe('P6-D final negative: dynamic Agent registration impossible regardless of allowlist', () => {
+  it('无 legacy_archive 标记 + allowlist 错误包含 agent → 注册仍拒绝；同 shape channel 可注册', async () => {
+    const dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'crabot-mm-reg-gate-'))
+    // 第一道门：allowlist 包含 agent 时构造直接拒绝。
+    expect(() => new ModuleManager({
+      port: 0, port_range: { range_start: 19850, range_end: 19870 }, hotplug_allowed_types: ['channel', 'agent'], modules: [],
+    }, dataDir)).toThrowError(/must not contain reserved type "agent"/)
+    // 第二道门：正常 allowlist 下，无 legacy_archive 标记的 dynamic agent definition 注册仍拒绝。
+    const manager = new ModuleManager({
+      port: 0, port_range: { range_start: 19850, range_end: 19870 }, hotplug_allowed_types: ['channel'], modules: [],
+    }, dataDir) as any
+    try {
+      expect(() => manager.handleRegisterModuleDefinition({
+        module_definition: {
+          module_id: 'rogue-agent', module_type: 'agent', entry: 'node -e 1', auto_start: false, start_priority: 1,
+        },
+      })).toThrowError(expect.objectContaining({ code: 'MODULE_MANAGER_HOTPLUG_NOT_ALLOWED' }))
+
+      const registered = manager.handleRegisterModuleDefinition({
+        module_definition: {
+          module_id: 'some-channel', module_type: 'channel', entry: 'node -e 1', auto_start: false, start_priority: 1,
+        },
+      })
+      expect(registered.registered).toBe(true)
+    } finally {
+      await manager.stop().catch(() => {})
+      await fs.rm(dataDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/scripts/import.mjs
+++ b/scripts/import.mjs
@@ -169,8 +169,6 @@ async function main() {
 
   // channel configs 待写入（id -> text）
   const pendingChannelConfigs = {}
-  // agent configs 待写入（id -> text）
-  const pendingAgentConfigs = {}
 
   const deps = {
     upsertProvider: makeUpsert('model_providers.json'),
@@ -188,20 +186,52 @@ async function main() {
       return makeUpsert('schedules.json')(sched)
     },
 
-    upsertAgentInstance: async (instance) => {
-      const status = makeUpsert('agent-instances.json')(instance)
-      // 同时尝试从归档读取对应的 agent-config
-      const id = instance.id
-      if (id && (status === 'imported' || status === 'overwritten')) {
-        const configText = await readArchiveTextFile(
-          archivePath,
-          `payload/config/agent-configs/${id}.json`
-        )
-        if (configText) {
-          pendingAgentConfigs[id] = configText
-        }
+    // P6-D §3.18.1：exact core config 直写 agent-configs/crabot-agent.json（静态 slot 校验）；
+    // live non-core payload 已在 runCrabotImport preflight 整包拒绝，到不了这里。
+    importCoreAgentConfig: async (archive, conflict) => {
+      const text = await readArchiveTextFile(archive, 'payload/config/agent-configs/crabot-agent.json')
+      if (!text) return []
+      const raw = JSON.parse(text)
+      if (raw.instance_id !== 'crabot-agent') {
+        throw Object.assign(new Error('agent-configs/crabot-agent.json 的 instance_id 不是 crabot-agent'), { code: 'ADMIN_BACKUP_NON_CORE_AGENT_UNSUPPORTED' })
       }
-      return status
+      const allowed = new Set(['powerful', 'cost_effective', 'vision', 'manager'])
+      const badKey = Object.keys(raw.model_config ?? {}).find((k) => !allowed.has(k))
+      if (badKey) {
+        throw Object.assign(new Error(`core config 含未知 model slot key: ${badKey}`), { code: 'ADMIN_BACKUP_NON_CORE_AGENT_UNSUPPORTED' })
+      }
+      const dest = join(adminDataDir, 'agent-configs')
+      await mkdir(dest, { recursive: true })
+      const file = join(dest, 'crabot-agent.json')
+      if (existsSync(file) && conflict === 'skip') {
+        return [{ kind: 'agent-config', id: 'crabot-agent', status: 'skipped' }]
+      }
+      await writeFile(file, JSON.stringify(raw, null, 2))
+      return [{ kind: 'agent-config', id: 'crabot-agent', status: existsSync(file) ? 'overwritten' : 'imported' }]
+    },
+
+    // P6-D §3.18.1(2)：新格式 archive record 幂等恢复（同 id 同 canonical payload 幂等；不同整包冲突）
+    ingestLegacyArchive: async (archive) => {
+      const text = await readArchiveTextFile(archive, 'payload/config/legacy-agent-archive.json')
+      if (!text) return []
+      const rows = JSON.parse(text)
+      if (!Array.isArray(rows)) throw Object.assign(new Error('legacy-agent-archive.json 不是数组'), { code: 'ADMIN_BACKUP_LEGACY_ARCHIVE_CONFLICT' })
+      const file = join(adminDataDir, 'legacy-agent-archive.json')
+      let existing = []
+      try { existing = JSON.parse(readFileSync(file, 'utf8')) } catch {}
+      const byId = new Map(existing.map((r) => [r.archive_id, r]))
+      const results = []
+      for (const row of rows) {
+        const old = byId.get(row.archive_id)
+        if (old && JSON.stringify(old.raw ?? null) !== JSON.stringify(row.raw ?? null)) {
+          throw Object.assign(new Error(`archive payload 冲突: ${row.archive_id}`), { code: 'ADMIN_BACKUP_LEGACY_ARCHIVE_CONFLICT' })
+        }
+        if (old) { results.push({ kind: 'legacy-agent-archive', id: row.archive_id, status: 'overwritten' }); continue }
+        byId.set(row.archive_id, row)
+        results.push({ kind: 'legacy-agent-archive', id: row.archive_id, status: 'imported' })
+      }
+      await writeFile(file, JSON.stringify([...byId.values()], null, 2))
+      return results
     },
 
     upsertChannel: async (channelInstance) => {
@@ -318,13 +348,6 @@ async function main() {
       // 写 pending channel configs
       for (const [id, text] of Object.entries(pendingChannelConfigs)) {
         const dir = join(adminDataDir, 'channel-configs')
-        mkdirSync(dir, { recursive: true })
-        writeFileSync(join(dir, `${id}.json`), text)
-      }
-
-      // 写 pending agent configs
-      for (const [id, text] of Object.entries(pendingAgentConfigs)) {
-        const dir = join(adminDataDir, 'agent-configs')
         mkdirSync(dir, { recursive: true })
         writeFileSync(join(dir, `${id}.json`), text)
       }

--- a/scripts/import.mjs
+++ b/scripts/import.mjs
@@ -186,47 +186,69 @@ async function main() {
       return makeUpsert('schedules.json')(sched)
     },
 
-    // P6-D §3.18.1：exact core config 直写 agent-configs/crabot-agent.json（静态 slot 校验）；
-    // live non-core payload 已在 runCrabotImport preflight 整包拒绝，到不了这里。
-    importCoreAgentConfig: async (archive, conflict) => {
-      const text = await readArchiveTextFile(archive, 'payload/config/agent-configs/crabot-agent.json')
-      if (!text) return []
-      const raw = JSON.parse(text)
-      if (raw.instance_id !== 'crabot-agent') {
-        throw Object.assign(new Error('agent-configs/crabot-agent.json 的 instance_id 不是 crabot-agent'), { code: 'ADMIN_BACKUP_NON_CORE_AGENT_UNSUPPORTED' })
+    // P6-D §3.18.1：validate 纯读+校验（零写入），apply 在 preflight 通过后才执行。
+    validateAgentPayload: async (archive) => {
+      const implsText = await readArchiveTextFile(archive, 'payload/config/agent-implementations.json')
+      const instText = await readArchiveTextFile(archive, 'payload/config/agent-instances.json')
+      const impls = implsText ? JSON.parse(implsText) : []
+      const insts = instText ? JSON.parse(instText) : []
+      const nonCore = (Array.isArray(insts) ? insts : []).filter((i) => i && i.id !== 'crabot-agent')
+      if ((Array.isArray(impls) && impls.length > 0) || nonCore.length > 0) {
+        throw Object.assign(new Error(`旧 live Agent payload 不再支持导入（implementations=${impls.length}, non-core instances=${nonCore.length}）`), { code: 'ADMIN_BACKUP_NON_CORE_AGENT_UNSUPPORTED' })
       }
-      const allowed = new Set(['powerful', 'cost_effective', 'vision', 'manager'])
-      const badKey = Object.keys(raw.model_config ?? {}).find((k) => !allowed.has(k))
-      if (badKey) {
-        throw Object.assign(new Error(`core config 含未知 model slot key: ${badKey}`), { code: 'ADMIN_BACKUP_NON_CORE_AGENT_UNSUPPORTED' })
+      let coreConfigRaw = null
+      const coreText = await readArchiveTextFile(archive, 'payload/config/agent-configs/crabot-agent.json')
+      if (coreText) {
+        const raw = JSON.parse(coreText)
+        if (raw.instance_id !== 'crabot-agent') {
+          throw Object.assign(new Error('agent-configs/crabot-agent.json 的 instance_id 不是 crabot-agent'), { code: 'ADMIN_BACKUP_NON_CORE_AGENT_UNSUPPORTED' })
+        }
+        const allowed = new Set(['powerful', 'cost_effective', 'vision', 'manager'])
+        const badKey = Object.keys(raw.model_config ?? {}).find((k) => !allowed.has(k))
+        if (badKey) {
+          throw Object.assign(new Error(`core config 含未知 model slot key: ${badKey}`), { code: 'ADMIN_BACKUP_NON_CORE_AGENT_UNSUPPORTED' })
+        }
+        coreConfigRaw = raw
       }
+      let archiveRows = []
+      const archiveListText = await readArchiveTextFile(archive, 'payload/config/legacy-agent-archive.json')
+      if (archiveListText) {
+        archiveRows = JSON.parse(archiveListText)
+        if (!Array.isArray(archiveRows)) throw Object.assign(new Error('legacy-agent-archive.json 不是数组'), { code: 'ADMIN_BACKUP_LEGACY_ARCHIVE_CONFLICT' })
+        const file = join(adminDataDir, 'legacy-agent-archive.json')
+        let existing = []
+        try { existing = JSON.parse(readFileSync(file, 'utf8')) } catch {}
+        const byId = new Map(existing.map((r) => [r.archive_id, r]))
+        for (const row of archiveRows) {
+          const old = byId.get(row.archive_id)
+          if (old && JSON.stringify(old.raw ?? null) !== JSON.stringify(row.raw ?? null)) {
+            throw Object.assign(new Error(`archive payload 冲突: ${row.archive_id}`), { code: 'ADMIN_BACKUP_LEGACY_ARCHIVE_CONFLICT' })
+          }
+        }
+      }
+      return { coreConfigRaw, archiveRows }
+    },
+
+    applyCoreAgentConfig: async (raw, conflict) => {
       const dest = join(adminDataDir, 'agent-configs')
       await mkdir(dest, { recursive: true })
       const file = join(dest, 'crabot-agent.json')
-      if (existsSync(file) && conflict === 'skip') {
+      const existed = existsSync(file)
+      if (existed && conflict === 'skip') {
         return [{ kind: 'agent-config', id: 'crabot-agent', status: 'skipped' }]
       }
       await writeFile(file, JSON.stringify(raw, null, 2))
-      return [{ kind: 'agent-config', id: 'crabot-agent', status: existsSync(file) ? 'overwritten' : 'imported' }]
+      return [{ kind: 'agent-config', id: 'crabot-agent', status: existed ? 'overwritten' : 'imported' }]
     },
 
-    // P6-D §3.18.1(2)：新格式 archive record 幂等恢复（同 id 同 canonical payload 幂等；不同整包冲突）
-    ingestLegacyArchive: async (archive) => {
-      const text = await readArchiveTextFile(archive, 'payload/config/legacy-agent-archive.json')
-      if (!text) return []
-      const rows = JSON.parse(text)
-      if (!Array.isArray(rows)) throw Object.assign(new Error('legacy-agent-archive.json 不是数组'), { code: 'ADMIN_BACKUP_LEGACY_ARCHIVE_CONFLICT' })
+    applyLegacyArchiveRows: async (rows) => {
       const file = join(adminDataDir, 'legacy-agent-archive.json')
       let existing = []
       try { existing = JSON.parse(readFileSync(file, 'utf8')) } catch {}
       const byId = new Map(existing.map((r) => [r.archive_id, r]))
       const results = []
       for (const row of rows) {
-        const old = byId.get(row.archive_id)
-        if (old && JSON.stringify(old.raw ?? null) !== JSON.stringify(row.raw ?? null)) {
-          throw Object.assign(new Error(`archive payload 冲突: ${row.archive_id}`), { code: 'ADMIN_BACKUP_LEGACY_ARCHIVE_CONFLICT' })
-        }
-        if (old) { results.push({ kind: 'legacy-agent-archive', id: row.archive_id, status: 'overwritten' }); continue }
+        if (byId.has(row.archive_id)) { results.push({ kind: 'legacy-agent-archive', id: row.archive_id, status: 'overwritten' }); continue }
         byId.set(row.archive_id, row)
         results.push({ kind: 'legacy-agent-archive', id: row.archive_id, status: 'imported' })
       }


### PR DESCRIPTION
P6-D：「先阻断、后清理」第二阶段——legacy runtime/UI 退役，archive 收口为唯一只读/显式删除面。

## 交付（对照计划 §4-§11 与 protocol-admin §3.18）
- **LegacyAgentArchiveStore**：summary（无 raw）/脱敏 export/显式 delete（confirmation 逐字等于 archive_id、delete_package/delete_config 至少一 true、tombstone 幂等重试、crash-recoverable journal、core 保护、路径白根、still-active 检查）；REST 四路由
- **AgentManager → core-config-only**：动态 registry/seeding 全删；getImplementation/getInstance 只返回静态 CORE_AGENT_DEFINITION/CORE_AGENT_INSTANCE；cutover inventory 直读原始文件；legacy 配置不再进运行时 map
- **写面删除**：create/update/delete_agent_instance RPC 注销（method not found）；install/uninstall/preview module RPC+HTTP 删除；ModuleInstaller 只剩 validator
- **backup import §3.18.1**：全包 preflight——旧 live non-core payload 整包拒绝；exact core config 只进 CoreStore（slot 校验）；新格式 archive 幂等/冲突；离线 CLI 同步；export 纳入 archive+tombstones
- **crabot-info**：不再调 legacy 列表；core 静态身份 + worker registry + channel
- **MM 负断言**：allowlist 含 agent 构造即拒；dynamic agent 注册仍拒；channel 可注册
- **Web**：legacy 服务/类型退役；Modules 页 = core 静态 + archive 摘要；ModuleDetail = archive 导出/显式卸载 UI

## 生产 E2E 实证（worktree 部署）
- core config/model slots 无损（D-02）；实例列表只剩 crabot-agent（D-03）
- archive 列表无 raw（D-06/D-07）；export 脱敏（D-08）
- false/false→400、confirmation 错误→400、真实删除 front-agent config→journal 完成+tombstone 幂等重试+重启后列表正确（D-09）
- 旧写面 410/404（D-04/D-05）
- Worker 管理三实现 ready（D-12）；Manager 经 get_deployment_info/list_capabilities 返回新语义（D-11/D-14）
- 重启 marker 握手不冲突，全模块健康

验证：core 139/139、admin 1156/1156、agent 仅 4 个既有基线失败、web 219/219。协议：§3.6.2/3.6.3 标记退役（docs 7db3309）。