### PR TITLE
[codex] Manager -> Worker 输入与侧问端到端可靠交付

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,13 +1,13 @@
 # Crabot 项目进度
 
-> 最后整理：2026-08-17
+> 最后整理：2026-08-18
 > 本文件只保留当前状态、明确 follow-up 和阶段性里程碑；详细实施流水、逐轮 review 与历史测试输出见 Git 历史。压缩前完整版本可用 `git show 49b9cb4:PROGRESS.md` 查看。
 
 ## 当前状态
 
-### P6 已完成；Traces 人话视图已合并，统一 retention（PR B）待执行
+### P6 已完成；Manager -> Worker 输入与侧问可靠交付待 PR review
 
-### 模块关闭与孤儿模块回收：PR #99 已获 approve
+### 模块关闭与孤儿模块回收：已合并（PR #99 → `bf989ec`）
 
 - 已确认设计：`crabot-docs/superpowers/specs/2026-08-16-module-shutdown-orphan-fencing-design.md`；实施计划：`crabot-docs/superpowers/plans/2026-08-17-module-shutdown-orphan-fencing.md`。
 - Agent shutdown 统一释放 builtin/Claude Code/Codex adapter 资源，关闭后不重建 CLI watcher，也不终止独立 tmux Worker。
@@ -20,11 +20,19 @@
   - Wire 契约：authenticated pull 返回正式 `CoreAgentRuntimeConfig`（protocol-agent-v3 §11，当前 `protocol_version: '3.2.0'`）；实例配置为 slot 制（`powerful` 必填），legacy `roles` 不是 wire 字段。
   - **降级启动自愈**：全新安装未配置 LLM 时 Agent 不再退出，进程存活照常注册，所有执行入口 fail closed，靠退避 pull 自愈；首次安装补建 worker 层（roles/LSP），无需手动重启。
   - Management-only cutover + durable config revision（seqlock 一致性读、HMAC fingerprint、Skill journal binding、publish 失败退避 drain 自愈）。
-### 最近验证基线（2026-08-13，PR #90 最新 push）
+- **部署约束**：pre-P6 存量生产不得部署 Slice 0/A/B 中间态；首次 rollout 至少包含 Slice 0 + P6-B grandfather bootstrap + P6-C 最终选择语义。
 
-- Shared 107、Core 138、**Admin 1152/1152**、Web build+269（web 此后未再改动）。
-- Agent 全量 2683 passed / 4 failed / 2 skipped，4 个失败均为既有 macOS 环境基线（`/var` realpath 3、tmux 探测 1），文件不在分支 diff 内。
-- 顺带修复的既有缺陷：`admin-chat-assertions` 签名篡改用例约 6% no-op flake（base64 末尾填充位）；Admin startup seeding 依赖 MM 事件扇出导致的全量 suite 崩溃；MM cutover 后对已运行 admin-web 重复 auto-start 的日志噪音。
+### Manager -> Worker 输入与侧问可靠交付（实现完成，待 PR review）
+
+- 已确认并发布设计、计划和 `protocol-agent-v3` 3.2.1 契约（crabot-docs `d4b4e50`）：`send_to_worker` 使用持久 receipt 返回 `delivered / pending / failed`，5 分钟内有限收口；失败及 pending 后终态只有被原 Manager episode 以 `consumedEvents=true` 消费后才确认完成，Agent 重启不自动重发输入。
+- `query_worker` 改为同步建立 fork 和提交首问、异步生成回答，不进入主 TUI 排队；builtin、Claude Code、Codex 统一“fork + 首问接受后返回”契约，Codex 使用 app-server `thread/fork + turn/start`。
+- 实现分支 `feat/manager-worker-operation-reliability` 已 rebase 到包含 #99/#100 的主线；adapter 关闭保护与可靠投递契约均保留，待 PR review。
+
+### 最近验证基线（2026-08-18，可靠交付实现分支）
+
+- Agent 可靠交付核心定向测试 17 文件 `468/468`；Manager 定向 `113/113`；Harness 定向 `104/104`；Codex runtime 清理与 Claude streaming fork 精确回归均通过。
+- Agent 全量 `2781 passed / 4 failed / 2 skipped`：其中 3 条是干净 main 同样复现的 macOS `/var` realpath 基线失败，1 条 tmux 探测超时单独重跑通过。
+- Agent TypeScript build 与 `git diff --check` 通过。
 
 ### Manager / Worker v3（已生产运行，背景）
 

--- a/crabot-agent/src/manager/bootstrap.ts
+++ b/crabot-agent/src/manager/bootstrap.ts
@@ -176,6 +176,8 @@ export interface BootstrapDeps {
   readonly publishEvent?: AgentEventPublisher
   /** P6-A：Manager episode trace writer（窄接口）；缺省时整个 trace 面静默关闭。 */
   readonly traceWriter?: import('./trace-types.js').ManagerTraceWriter
+  /** Redacts runtime credentials before durable Manager/Worker operation failures are recorded. */
+  readonly redactFailureReason?: (text: string) => string
   /** P6-A §8.4：builtin worker 结构化 trace 写钩子/读入口（TraceStore 窄口）。 */
   readonly builtinTraceHooks?: import('../workers/builtin/adapter.js').BuiltinTraceHooks
   /** P6-B §6：activation registry gate（unified-agent 注入）。 */
@@ -387,6 +389,18 @@ export function buildManagerStack(deps: BootstrapDeps): ManagerStack {
         },
       )
     },
+    onOperationNotification: (managerKey, event) => {
+      if (!registry) return { consumed: false }
+      return registry.routeOperationNotification(managerKey, event).catch((err) => {
+        console.error(
+          `[manager-bootstrap] routeOperationNotification failed ` +
+            `(manager=${managerKey}, worker=${event.worker_id}, kind=${event.kind}):`,
+          err,
+        )
+        return { consumed: false }
+      })
+    },
+    redactFailureReason: deps.redactFailureReason,
     builtinSpawnDefaults: deps.builtinSpawnDefaults,
     assertExecutionAdmission: deps.assertExecutionAdmission,
     capabilityBundle: deps.capabilityBundle,
@@ -475,7 +489,7 @@ export function buildManagerStack(deps: BootstrapDeps): ManagerStack {
         sessionId,
       )
     },
-    toolFace: (key, isSystemThread, onAsyncError, scheduleIdentity, humanPrincipal, principalPermissions, traceHooks) => {
+    toolFace: (key, isSystemThread, scheduleIdentity, humanPrincipal, principalPermissions, traceHooks) => {
       // Capture at tool-face construction. Calling the resulting factory later must not
       // pick up a regrant/new generation from a subsequent wake.
       const legacyAuthTemplate = principals.captureLegacyContinuationAuth(key)
@@ -527,7 +541,6 @@ export function buildManagerStack(deps: BootstrapDeps): ManagerStack {
         isSystemThread,
         authorization: () => principals.currentMasterAuthorization(key),
         validateMasterAuthorization: (auth) => principals.validateMasterAuthorization(auth),
-        onAsyncError,
       })
     },
     // system prompt 的「对话对象档案」段(§4.2 5b/5d):场景画像 + crab 在该渠道的
@@ -572,5 +585,8 @@ export function buildManagerStack(deps: BootstrapDeps): ManagerStack {
 export async function reconcileManagerStack(stack: ManagerStack): Promise<ReconcileReport> {
   await stack.principals.init()
   await BuiltinWorkerAdapter.scanOrphans(stack.builtinDataDir)
-  return stack.harness.reconcileOnStartup()
+  const report = await stack.harness.reconcileOnStartup()
+  await stack.harness.reconcileInputDeliveriesOnStartup()
+  await stack.harness.reconcileQueryReceiptsOnStartup()
+  return report
 }

--- a/crabot-agent/src/manager/registry.ts
+++ b/crabot-agent/src/manager/registry.ts
@@ -25,27 +25,6 @@
  * 内部按 `key === SYSTEM_TASKS_MANAGER_KEY` 判定 `ManagerLoopDeps.isSystemThread`,不需要
  * 调用方在路由时额外传一个"是不是系统线程"的标志——key 本身就是唯一判据。
  *
- * ## `onAsyncError` 出口(Task 4 遗留接线点)
- *
- * `worker-tools.ts` 的 `query_worker` 是字面 fire-and-forget:发起 `adapter.fork` 后不
- * `await`,失败时唯一的"通知调用方"手段是 `WorkerToolsDeps.onAsyncError` 这个可选回调
- * (Task 4 只留出口、不接线)。`getOrCreate` 为每个 key 构造一个绑定该 key 的
- * `OnAsyncError` 实现并通过 `deps.toolFace(key, isSystemThread, onAsyncError)` 交给调用方
- * ——调用方(真正装配 `buildManagerToolFace`/`buildWorkerTools` 的那一层,不在本任务范围)
- * 负责把它接进 `WorkerToolsDeps.onAsyncError`。本文件只负责这个回调"接住错误之后做什么":
- * 按"当前这个 manager 是否正有 episode 在跑"(`activeEpisodes`)二选一——
- *   - 有 episode 在跑:`enqueueDuringEpisode`,错误作为 mid-episode 注入随下一轮 turn 一起
- *     喂给 LLM,不用等这个 episode 结束再唤醒一次;
- *   - 没有 episode 在跑(该 episode 已经结束/loop 甚至被 evictIdle 回收过):`getOrCreate`
- *     惰性重建后直接 `wakeUp`,开一个新 episode 处理这条错误。
- * 错误信息包成 `WakeEvent`:复用既有 `worker_event` kind(不新增 `WakeEvent` 变体,因为
- * `loop.ts` 是 Task 7 的既有产物,本任务的"零现网影响"约束不允许改动),用既有的
- * `HarnessEventKind.query_failed`(worker-events.ts 已经为 `query_worker` 失败预留了这个
- * kind)承载,`seq` 填 `0` 作 sentinel——真实 seq 从 1 起分配(与 harness.ts `queryWorker`
- * 对"worker 不存在"场景同一套 sentinel 约定),`0` 标记"这不对应任何真实化身事件,只是一次
- * 唤醒信号"(真正的失败留痕已经由 `harness.queryWorker` 自己 `appendEvent('query_failed')`
- * 完成,这里不重复写事件流,只借用同一个 kind 语义)。
- *
  * @see crabot-docs/protocols/protocol-agent-v3.md §4.4
  */
 
@@ -56,7 +35,7 @@ import type { ManagerKey } from './types.js'
 import type { EngineMessage, LLMAdapter, ToolDefinition } from '../engine/index.js'
 import type { WorkerHarness } from '../workers/harness/harness'
 import type { LedgerStore } from '../workers/harness/ledger-store'
-import type { HarnessEvent, HarnessEventKind } from '../workers/harness/worker-events'
+import type { HarnessEvent, HarnessEventDelivery } from '../workers/harness/worker-events'
 import type { ChannelMessage, Friend, ResolvedPermissions } from '../types'
 import type { HumanPrincipal } from './principal.js'
 import { resolveTimezone } from '../utils/time.js'
@@ -67,23 +46,13 @@ export const SYSTEM_TASKS_MANAGER_KEY = 'admin-web::system-tasks' as ManagerKey
 /**
  * 连锁自唤醒的上限(见 `ManagerRegistry.maybeSelfWake`)。
  *
- * 自唤醒本身可能再产生新的 mailbox 内容(自唤醒 episode 期间又有注入到达),不设上限就是
- * 一条"episode → 注入 → episode"的无限链:注入源若是稳定复发的故障(如某 worker 上
- * `query_worker` 恒失败,每个 episode 都触发一次 onAsyncError),链条永不收敛,烧的是真钱。
+ * 自唤醒本身可能再产生新的 mailbox 内容(自唤醒 episode 期间又有普通事件到达),不设上限
+ * 就是一条"episode → 注入 → episode"的无限链:注入源若稳定复发,链条永不收敛,烧的是真钱。
  * 取 3:够把"收口瞬间才到达"这类一次性尾巴处理干净,又不至于替一个稳定故障源无限重开
  * episode。到顶后残留**不丢**——它留在 mailbox 里,受 `evictIdle` 的非空保护,由下一次
  * 真实唤醒(人类消息 / worker 事件 / schedule)顺带 drain 走,仍满足 §4.1 至少一次投递。
  */
 export const MAX_SELF_WAKE_CHAIN = 3
-
-/** `query_worker` 异步失败(Task 4 `WorkerToolsDeps.onAsyncError`)的信息形状,逐字对齐该接口。 */
-export interface AsyncToolErrorInfo {
-  readonly tool: string
-  readonly worker_id: string
-  readonly error: string
-}
-
-export type OnAsyncError = (info: AsyncToolErrorInfo) => void
 
 /**
  * scheduled 唤醒随行的**权限身份**(protocol-agent-v3 §8.2 的 `creator_friend_id` /
@@ -168,8 +137,7 @@ export interface ManagerRegistryDeps {
   }) => Promise<ResolvedPermissions | null>
   /**
    * 工具面工厂:调用方据 key/isSystemThread 装配 `buildManagerToolFace` 的完整依赖并返回
-   * 工具面数组;`onAsyncError` 由本 registry 按 key 绑定好传入,调用方负责把它接进
-   * `WorkerToolsDeps.onAsyncError`(见文件头说明)。
+   * 工具面数组。
    *
    * P5 Task 4 additive:第四个参数是**本 episode 若由 scheduled 触发**时随行的权限身份
    * (非 schedule 唤醒为 undefined),调用方据它填 `WorkerToolsContext.creatorFriendId` /
@@ -187,7 +155,6 @@ export interface ManagerRegistryDeps {
   readonly toolFace: (
     key: ManagerKey,
     isSystemThread: boolean,
-    onAsyncError: OnAsyncError,
     scheduleIdentity?: ScheduleIdentity,
     humanPrincipal?: HumanPrincipal,
     principalPermissions?: ResolvedPermissions,
@@ -205,8 +172,8 @@ export interface ManagerRegistryDeps {
 export class ManagerRegistry {
   private readonly loops = new Map<ManagerKey, ManagerLoop>()
   /**
-   * 每个 key 当前"在途" episode 的引用计数——决定 evictIdle 是否可回收、onAsyncError 走
-   * wakeUp 还是 enqueueDuringEpisode。**必须是计数,不能是布尔/Set 的有无标记**:同一 key 可能
+   * 每个 key 当前"在途" episode 的引用计数——决定 evictIdle 是否可回收，以及持久操作通知
+   * 是否需要 deferred。**必须是计数,不能是布尔/Set 的有无标记**:同一 key 可能
    * 有多个并发唤醒同时在途(人类消息与该 session 监护的 worker 事件几乎必然撞上)——第二个
    * 已经进了 `runWake`,可能仍在 `ManagerLoop` 内部 mutex 排队或执行,第一个却先 resolve。
    * 若只用 Set,第一个 resolve 时 `finally` 会直接 `delete(key)`,把仍在途的第二个也一并
@@ -233,7 +200,6 @@ export class ManagerRegistry {
     if (existing) return existing
 
     const isSystemThread = key === SYSTEM_TASKS_MANAGER_KEY
-    const onAsyncError: OnAsyncError = (info) => this.handleAsyncToolError(key, info)
 
     const loopDeps: ManagerLoopDeps = {
       key,
@@ -254,7 +220,6 @@ export class ManagerRegistry {
         this.deps.toolFace(
           key,
           isSystemThread,
-          onAsyncError,
           scheduleIdentityOf(wakeEvent),
           humanPrincipalOf(wakeEvent),
           principalPermissionsOf(wakeEvent),
@@ -377,6 +342,18 @@ export class ManagerRegistry {
     return this.runWake(key, envelope)
   }
 
+  /** Durable operation notifications never join an already-running episode's in-memory mailbox. */
+  async routeOperationNotification(
+    key: ManagerKey,
+    event: HarnessEvent,
+  ): Promise<HarnessEventDelivery> {
+    if (this.isEpisodeActive(key)) return { consumed: false }
+    const capture = this.captureIngress()
+    const envelope = this.makeEnvelope(capture, { kind: 'worker_event', event }, event.ts)
+    const result = await this.runWake(key, envelope)
+    return { consumed: result.consumedEvents === true }
+  }
+
   async routeMediaNotification(p: {
     channelId: string
     sessionId: string
@@ -484,24 +461,6 @@ export class ManagerRegistry {
     return evicted
   }
 
-  /** query_worker 异步失败 → 唤醒信号(见文件头"onAsyncError 出口"一节)。 */
-  private handleAsyncToolError(key: ManagerKey, info: AsyncToolErrorInfo): void {
-    if (this.deps.isClosing?.()) return
-    const capture = this.captureIngress()
-    const envelope = this.makeEnvelope(
-      capture,
-      buildAsyncErrorWakeEvent(info, capture.now),
-      capture.now.toISOString(),
-    )
-    if (this.isEpisodeActive(key)) {
-      this.getOrCreate(key).enqueueDuringEpisode(envelope)
-      return
-    }
-    void this.runWake(key, envelope).catch((err) => {
-      console.error(`[ManagerRegistry] onAsyncError 唤醒 manager '${key}' 失败:`, err)
-    })
-  }
-
   private captureIngress(): IngressCapture {
     this.assertWakeAdmission()
     const now = this.deps.now()
@@ -548,7 +507,7 @@ export class ManagerRegistry {
   }
 
   /**
-   * getOrCreate + 维护 activeEpisodes 引用计数的公共路径,所有 routeXxx / onAsyncError /
+   * getOrCreate + 维护 activeEpisodes 引用计数的公共路径,所有 routeXxx /
    * 自唤醒都走这里。`event === undefined` ⇒ 自唤醒(只处理 mailbox 残留,见
    * `ManagerLoop.drainMailbox`);`selfWakeChain` 是当前连锁自唤醒的深度,真实唤醒恒为 0。
    */
@@ -653,19 +612,6 @@ function principalPermissionsOf(wakeEvent: WakeEvent | undefined): ResolvedPermi
     return undefined
   }
   return wakeEvent.principalPermissions
-}
-
-/** query_worker 异步失败 → 借用既有 `worker_event`/`query_failed` kind 包装成 WakeEvent(见文件头)。 */
-function buildAsyncErrorWakeEvent(info: AsyncToolErrorInfo, now: Date): WakeEvent {
-  const kind: HarnessEventKind = 'query_failed'
-  const event: HarnessEvent = {
-    ts: now.toISOString(),
-    kind,
-    worker_id: info.worker_id,
-    seq: 0, // sentinel:不对应任何真实化身事件,只是一次唤醒信号(见文件头)
-    detail: { tool: info.tool, error: info.error, synthetic: true },
-  }
-  return { kind: 'worker_event', event }
 }
 
 interface IngressCapture {

--- a/crabot-agent/src/manager/tools/tool-face.ts
+++ b/crabot-agent/src/manager/tools/tool-face.ts
@@ -41,13 +41,6 @@ export interface ToolFaceDeps {
   /** Opaque control-plane authorization, never represented in any tool schema. */
   readonly authorization?: () => MasterAuthorization | undefined
   readonly validateMasterAuthorization?: (auth: MasterAuthorization) => Promise<boolean>
-  /**
-   * query_worker 异步失败出口（Task 4 留口、Task 8 接线）：原样透传给 `buildWorkerTools` 的
-   * `WorkerToolsDeps.onAsyncError`——真正的绑定逻辑（按 key 决定 enqueueDuringEpisode 还是
-   * 重新 wakeUp）在 `ManagerRegistry.handleAsyncToolError`，本层只负责不掉链子地转发。
-   * 缺省不传时行为与之前完全一致（query_worker 失败仅 console.error）。
-   */
-  readonly onAsyncError?: Parameters<typeof buildWorkerTools>[0]['onAsyncError']
 }
 
 // ============================================================================
@@ -212,7 +205,6 @@ export function buildManagerToolFace(deps: ToolFaceDeps): ToolDefinition[] {
     context: deps.workerContext,
     authorization: deps.authorization,
     validateMasterAuthorization: deps.validateMasterAuthorization,
-    onAsyncError: deps.onAsyncError,
     ...(deps.workerImplSnapshot ? { workerImplSnapshot: deps.workerImplSnapshot } : {}),
   })
   const infoTools = buildCrabotInfoTools({

--- a/crabot-agent/src/manager/tools/worker-tools.ts
+++ b/crabot-agent/src/manager/tools/worker-tools.ts
@@ -4,45 +4,25 @@
  * 七个工具全部是 `WorkerHarness`(P3 已合并,本模块只调用、不修改,唯一的 additive 例外见
  * `harness.readWorkerOutput` 的 `opts.seq` 参数)既有方法的薄封装:只负责
  * 1) 组装 harness 方法的入参(`spawn_worker` 据 `deps.context()` 填 `origin`/`report_to`);
- * 2) 把 harness 的返回值/异常转成 engine `ToolCallResult`——除 `query_worker`(见下)外,
- *    异常永不穿透成 engine 层错误,统一转成 `isError: true` 的可读文本,manager 能读到失败
+ * 2) 把 harness 的返回值/异常转成 engine `ToolCallResult`——异常永不穿透成 engine 层错误,
+ *    统一转成 `isError: true` 的可读文本,manager 能读到失败
  *    原因并自行决策(如 worker 不存在就换个 id 或重新 spawn,protocol-agent-v3 §4.3)。
  *
  * ---
  *
  * ## 同步性语义的实现取舍(protocol §4.1"等待 = end_turn")
  *
- * 协议表(§4.3)把 `spawn_worker`/`send_to_worker`/`query_worker` 标"异步",
- * `read_worker_output`/`list_workers`/`kill_worker` 标"同步"。`spawn_worker`/`send_to_worker`
- * 与 `read_worker_output`/`list_workers`/`kill_worker` 这五个工具都完整 `await` 对应的
+ * `spawn_worker`、`send_to_worker` 和 `query_worker` 都完整 `await` 对应的
  * harness 方法——`spawnWorker` 顺序 await workspace 解析、台账初始写入、`adapter.provision`、
  * `adapter.spawn`;`sendToWorker` 顺序 await 入信箱与 `inbox.flush`(经 `adapter.sendInput`,
- * 命中终态化身时还会走一整套 kill+provision+spawn 的透明接续)——这些都是"编排动作完整
- * 落地"才 resolve 的有限时长调用,不会进一步阻塞等待 worker 自己执行任务、产出真正的回复
- * (那部分永远经由 harness 的 `onEvent`/`onStateChange` 异步发生),完整 await 并不违反
- * "manager 的 loop 内不存在阻塞等待原语"这条约束。这五个工具若不 await,会丢失两样东西:
+ * 命中终态化身时还会走一整套 kill+provision+spawn 的透明接续);`queryWorker` 只 await
+ * fork 建立、首问接受与 ledger/receipt 提交，不等待侧问回答生成——这些都是"编排动作完整
+ * 落地"才 resolve 的有限时长调用。Worker 执行、输入异步终态与侧问回答终态仍通过事件
+ * 唤醒 manager，完整 await 不违反"manager 的 loop 内不存在等待 Worker 执行完成的阻塞原语"
+ * 这条约束。若不 await,会丢失两样东西:
  * 1. `spawn_worker` 依赖 harness 内部生成的 `worker_id` 供 LLM 后续引用——不 await 就拿不到;
- * 2. `WorkerNotFoundError`/`TaskCancelledError`/`ImplAlreadyUsedError` 一类的失败原因就没有
+ * 2. `WorkerNotFoundError`/`TaskCancelledError`/`QueryEstablishmentError` 一类的失败原因就没有
  *    办法在这次调用内回传给 LLM,违反"manager 应能读到失败原因并自行决策"这条要求。
- *
- * `query_worker` 是唯一的例外,采用字面意义的 JS fire-and-forget(调用 `harness.queryWorker`
- * 后不 `await`、立即返回,游离 promise 用 `.catch()` 兜住)。原因:`harness.queryWorker` 顺序
- * await `adapter.fork`,而 `claude-code/adapter.ts` 的 `fork()` 实现是
- * `await execFileAsync('/bin/sh', ['-c', shellCommand], ...)`——等的是整个无头 `claude -p`
- * 子进程跑完(一次完整 LLM 调用,几十秒到数分钟),不是"发起"这一有限时长的编排动作。完整
- * await 会把 manager 的这一整个 turn 阻塞住,违反 protocol-agent-v3 §4.1/§4.3"慢工具异步
- * 发起即返回,结果作为事件唤醒"。代价:`forkSeq` 拿不到(它在 `adapter.fork` 落地之后才由
- * harness 生成),`WorkerNotFoundError`/`CapabilityNotSupportedError` 等失败原因也不再能在
- * 这次调用内回传给 LLM,只记诊断日志——不打破"manager 应能读到失败原因"这条要求的字面表述
- * 的场景是:manager 观察不到进展(既无 fork 化身出现,也没有对应事件)时,应主动用
- * `list_workers` 核实,不是假定这条要求覆盖 `query_worker` 这一条异步发起路径(controller
- * 决定,理由见上,记录于 task-4-report.md 追加内容)。
- *
- * 三个"异步"工具的输出因此刻意写得简短(确认式:status + 关键标识符,`query_worker` 甚至
- * 只有 status + worker_id),提示 LLM 后续进展会由事件唤醒。
- *
- * 若未来 harness 提供了"仅等 fork 发起、不等 `claude -p` 子进程落地"的拆分入口,`query_worker`
- * 应优先切换回完整 await 的实现,与其余五个工具的语义保持一致。
  *
  * ## isReadOnly
  *
@@ -61,6 +41,7 @@ import type { MasterAuthorization } from '../principal.js'
 import type { WorkerImplId } from '../../workers/types'
 import type { ResolvedPermissions } from '../../types'
 import type { LegacyContinuationAuth } from '../../workers/harness/legacy-continuation-auth.js'
+import { QueryEstablishmentError } from '../../workers/errors.js'
 
 export interface WorkerToolsContext {
   /** Current manager session: worker owner and list_workers scope. */
@@ -121,16 +102,6 @@ export interface WorkerToolsDeps {
   /** Opaque authorization is captured by the control plane, never exposed in a tool schema/history. */
   readonly authorization?: () => MasterAuthorization | undefined
   readonly validateMasterAuthorization?: (auth: MasterAuthorization) => Promise<boolean>
-  /**
-   * P4 Task 4 additive 扩展点:`query_worker` 的游离 promise reject 时,除了
-   * `console.error` 诊断日志外还调用这个可选回调。本任务只提供出口、不接线——`harness.
-   * queryWorker` 本身已经把同一失败 appendEvent('query_failed')(见 harness.ts 注释),
-   * 这里的 `onAsyncError` 面向的是"当前这个 manager 实例要不要因为这次失败立刻醒来"这层
-   * 决策,不是失败留痕本身。Task 7/8 的契约:接上后用它"把这条错误接成唤醒本 manager 的
-   * 信号"(如推一条系统消息触发下一轮 loop),不在这里预判具体唤醒机制。缺省不传时行为
-   * 与之前完全一致(仅 console.error)。
-   */
-  readonly onAsyncError?: (info: { tool: string; worker_id: string; error: string }) => void
 }
 
 // --- tool_result 构造辅助 ---
@@ -154,6 +125,17 @@ function invalid(message: string): ToolCallResult {
 function mapError(prefix: string, error: unknown): ToolCallResult {
   const message = error instanceof Error ? error.message : String(error)
   console.error(`[worker-tools] ${prefix} failed:`, error)
+  if (error instanceof QueryEstablishmentError) {
+    return {
+      output: JSON.stringify({
+        query_id: error.query_id,
+        reason_code: error.reason_code,
+        reason: error.reason,
+        certainty: error.certainty,
+      }),
+      isError: true,
+    }
+  }
   // P6-C：结构化 NOT_READY 的 ready_impls/reasons 必须到 Manager（C-02/C-05 的观测点）。
   const details = (error as { code?: string; details?: { ready_impls?: string[]; reasons?: Record<string, string> } })
   if (details.code === 'WORKER_IMPLEMENTATION_NOT_READY' && details.details) {
@@ -195,7 +177,7 @@ function normalizePagination(page: unknown, pageSize: unknown): { page: number; 
 const ACCESS_DENIED = 'worker 不存在或当前会话无权访问'
 
 export function buildWorkerTools(deps: WorkerToolsDeps): ToolDefinition[] {
-  const { harness, context, authorization, validateMasterAuthorization, onAsyncError } = deps
+  const { harness, context, authorization, validateMasterAuthorization } = deps
   // Capture exactly once: a tool definition belongs to one model turn. A later
   // regrant must not make an already-issued privileged closure usable again.
   const capturedAuthorization = authorization?.()
@@ -287,10 +269,12 @@ export function buildWorkerTools(deps: WorkerToolsDeps): ToolDefinition[] {
   const sendToWorker = defineTool({
     name: 'send_to_worker',
     description:
-      '向指定 worker 的信箱投递一条输入,worker 处于什么状态都能投:在跑/空闲的排进信箱,' +
+      '向指定 worker 投递一条输入。返回 delivered 才表示 worker adapter 已确认接受；pending ' +
+      '表示尚未送达，系统会在 5 分钟内结算并用事件通知你；failed 会给出原因与送达确定性。' +
+      'worker 处于什么状态都能投:在跑/空闲的排进信箱,' +
       '已结束(completed/failed)的会自动复活它原来的会话接着干、上下文完整保留——所以延续、' +
       '补充、返工一个老任务都走这里,不必先判断它死活,也不必为此新开 worker。异步语义:本工具' +
-      '在投递落地(或复活发起)后即返回,不等 worker 处理完这条消息;worker 每跑完一轮或结束时' +
+      '不等 worker 处理完这条消息;worker 每跑完一轮或结束时' +
       '会作为事件唤醒你,事件里带着它这一轮最后说的那段话。命中已 cancelled 的任务会被拒绝。' +
       'raw=true 用于向卡住的交互式界面原样敲键,不是普通对话消息。',
     inputSchema: {
@@ -311,38 +295,26 @@ export function buildWorkerTools(deps: WorkerToolsDeps): ToolDefinition[] {
       try {
         const worker = await authorizeWorker(worker_id)
         const legacyContinuationAuth = capturedLegacyContinuationAuth?.(worker.manager_key)
-        await harness.sendToWorker(worker_id, text, {
+        const result = await harness.sendToWorker(worker_id, text, {
+          managerKey: context().managerKey,
           ...(raw !== undefined ? { raw } : {}),
           ...(legacyContinuationAuth ? { legacyContinuationAuth } : {}),
         })
-        return ok({ status: 'sent', worker_id })
+        return ok(result)
       } catch (error) {
         return mapError(`send_to_worker(${worker_id})`, error)
       }
     },
   })
 
-  // --- query_worker(字面 fire-and-forget:发起后不 await,立即返回;答案由事件唤醒) ---
-  //
-  // 与其余五个工具不同的实现取舍:cc worker 的 harness.queryWorker → adapter.fork 会 await
-  // 一整个无头 `claude -p` 子进程跑完(一次完整 LLM 调用,几十秒到数分钟)——完整 await 会把
-  // manager 的这一整个 turn 阻塞住,违反 protocol-agent-v3 §4.1/§4.3"慢工具异步发起即返回,
-  // 结果作为事件唤醒"。因此本工具字面意义地不等 harness.queryWorker 落地:调用后立即返回
-  // 简短确认,游离 promise 用 .catch() 兜住(不得产生 unhandledRejection,P1/P3 反复踩过的
-  // 坑),失败只记诊断日志——这意味着 WorkerNotFoundError/CapabilityNotSupportedError 等
-  // 已知错误不再能在这次调用内回传给 LLM(相对其余五个工具"异常永不穿透,统一转 isError"
-  // 这条约定的一处刻意偏离,controller 决定,见 task-4-report.md 追加记录)。forkSeq 同理
-  // 拿不到(它在 adapter.fork 落地之后才由 harness 生成),不写进返回文本。
-  // P4 Task 4 additive:失败除 console.error 外还调 deps.onAsyncError?.(见 WorkerToolsDeps
-  // 注释)——本任务只开这个口子,不接线;harness.queryWorker 自己也会把同一失败
-  // appendEvent('query_failed'),二者互补(留痕 vs. 是否要唤醒当前 manager 两层决策)。
+  // --- query_worker（同步确认 fork + 首问建立；回答继续异步执行） ---
   const queryWorker = defineTool({
     name: 'query_worker',
     description:
-      '对正在跑的 worker 发起一次侧问(fork 语义),不打扰主线执行。fire-and-forget:本工具' +
-      '发起侧问后立即返回,不等侧问化身创建完成,拿不到 fork_seq;答案就绪(或发起失败)只' +
-      '会作为事件唤醒你,届时事件会带上该侧问化身的 seq,用 read_worker_output 传入该 seq ' +
-      '读取答案。目标实现需支持 fork 能力,不支持时的失败不会体现在这次调用的返回里。',
+      '对正在跑的 worker 建立一次独立侧问(fork 语义),不打扰主线执行。只有 fork 已创建、' +
+      '首问已接受且化身已落账后才返回 started + query_id + fork_seq；建立失败会在本次调用' +
+      '直接返回原因。答案生成仍异步，完成或失败后会可靠通知你；用 read_worker_output 传入' +
+      '返回的 fork_seq 可随时读取侧问输出。',
     inputSchema: {
       type: 'object',
       properties: {
@@ -358,16 +330,14 @@ export function buildWorkerTools(deps: WorkerToolsDeps): ToolDefinition[] {
       if (!question || typeof question !== 'string') return invalid('query_worker: question 必填且为字符串')
 
       try {
-        // Authorization must settle before this fire-and-forget action is started.
         await authorizeWorker(worker_id)
+        const result = await harness.queryWorker(worker_id, question, {
+          managerKey: context().managerKey,
+        })
+        return ok(result)
       } catch (error) {
         return mapError(`query_worker(${worker_id})`, error)
       }
-      harness.queryWorker(worker_id, question).catch((error) => {
-        console.error(`[worker-tools] query_worker(${worker_id}) 后台发起失败(fire-and-forget):`, error)
-        onAsyncError?.({ tool: 'query_worker', worker_id, error: error instanceof Error ? error.message : String(error) })
-      })
-      return ok({ status: 'queried', worker_id })
     },
   })
 

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -720,6 +720,7 @@ export class UnifiedAgent extends ModuleBase {
       now: () => new Date().toISOString(),
       // P6-A：Manager episode trace writer（窄接口 + 脱敏收口在 TraceStore.managerTraceWriter）。
       traceWriter: this.traceStore.managerTraceWriter((text) => redactSecrets(text, [...this.knownSecrets])),
+      redactFailureReason: (text) => redactSecrets(text, [...this.knownSecrets]),
       // P6-A §8.4：builtin worker 结构化 trace（写钩子 + 读入口，同一脱敏纪律）。
       builtinTraceHooks: this.builtinTraceHooks(),
       // P6-B §6：显式 impl spawn/resume/handoff 的 registry gate。
@@ -2959,6 +2960,7 @@ export class UnifiedAgent extends ModuleBase {
       this.config.moduleId,
       { authorizationBearer: ConfigLoader.getRuntimeBearer() },
     )
+    if (result.connection.apikey) this.registerSecret(result.connection.apikey)
     return result
   }
 

--- a/crabot-agent/src/workers/activation-registry.ts
+++ b/crabot-agent/src/workers/activation-registry.ts
@@ -325,6 +325,7 @@ export class ActivationRegistry {
     const capabilities = adapter.connectionCapabilities?.() ?? []
     const status: WorkerImplementationStatus = {
       ...base,
+      capabilities: adapter.capabilities(),
       installed: detect.installed,
       version: detect.version,
       install_source: detect.install_source,

--- a/crabot-agent/src/workers/builtin/adapter.ts
+++ b/crabot-agent/src/workers/builtin/adapter.ts
@@ -48,6 +48,7 @@
  * 的磁盘状态。
  */
 import { promises as fs } from 'fs'
+import { assertInputDeliveryActive } from '../input-delivery-control.js'
 import { join } from 'path'
 import { randomUUID } from 'crypto'
 import { runEngine, defineTool, createUserMessage } from '../../engine/index.js'
@@ -57,7 +58,7 @@ import { SessionTree } from '../session-tree.js'
 import { OutputLog } from '../output-log.js'
 import { AsyncMutex } from '../async-mutex.js'
 import { latestModifiedMs } from '../meta-store.js'
-import { WorkerExitedError } from '../errors.js'
+import { WorkerExitedError, ForkEstablishmentError } from '../errors.js'
 import {
   BUILTIN_WORKER_PERMISSIONS,
   FORBIDDEN_WORKER_TOOLS,
@@ -73,10 +74,12 @@ import type {
   DetectResult,
   IncarnationHandle,
   IncarnationRef,
+  ForkOptions,
   IncarnationEndReason,
   StateChangeReport,
   OutputCursor,
   SpawnSpec,
+  SendInputOptions,
   WorkerAdapter,
   WorkerContractState,
   Workspace,
@@ -435,8 +438,14 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     return handle
   }
 
-  async fork(prev: IncarnationRef, forkInput: string): Promise<IncarnationHandle> {
+  async fork(prev: IncarnationRef, forkInput: string, opts: ForkOptions): Promise<IncarnationHandle> {
     this.assertActive()
+    const assertEstablishmentActive = () => {
+      if (Date.parse(opts.establishment_deadline_at) <= Date.now()) {
+        throw new ForkEstablishmentError('timeout', 'fork establishment deadline expired', 'not_started')
+      }
+    }
+    assertEstablishmentActive()
     // 同 resume：fork 也是起一个新化身，运行配置现取。
     const builtin = await this.runtimeFor(prev.worker_id, 'fork')
 
@@ -447,6 +456,7 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     // 不变量是它们各自场景下的语义，不适用于 fork）。
     const mutex = this.getMutex(prev.worker_id)
     const { instance, handle } = await mutex.run(async () => {
+      assertEstablishmentActive()
       const dir = join(this.deps.dataDir, prev.worker_id)
       let sessionTree = this.findSessionTreeForWorker(prev.worker_id)
       if (!sessionTree) {
@@ -469,7 +479,13 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
         pendingInputs: [],
       }
 
-      const newHandle: IncarnationHandle = { worker_id: prev.worker_id, seq: newSeq, impl: 'builtin', session_ref: forkId }
+      const newHandle: IncarnationHandle = {
+        worker_id: prev.worker_id,
+        seq: newSeq,
+        impl: 'builtin',
+        session_ref: forkId,
+        query_id: opts.query_id,
+      }
       // writeMeta 成功之后才注册到 instances，和 resume 保持一致的提交次序：磁盘失败时
       // 不留孤儿实例。
       await this.writeMeta(newInstance)
@@ -483,7 +499,7 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     return handle
   }
 
-  async sendInput(h: IncarnationHandle, text: string, _opts?: { raw?: boolean }): Promise<void> {
+  async sendInput(h: IncarnationHandle, text: string, opts?: SendInputOptions): Promise<void> {
     this.assertActive()
     // 状态检查 + 相应动作（入队 / append+转running）整体在该 worker 的互斥锁内完成，消除
     // "两次背靠背 sendInput 都读到 idle、拿同一 tip"的 check-then-act 竞态（跨 await 边界）。
@@ -498,6 +514,8 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
         // 带上 ended_reason:harness 的透明接续要用它给"台账还没追上"的源化身补终态。
         throw new WorkerExitedError(h.worker_id, h.seq, instance.ended_reason)
       }
+
+      assertInputDeliveryActive(opts, 'not_delivered')
 
       if (instance.state === 'running') {
         instance.pendingInputs.push(text)

--- a/crabot-agent/src/workers/claude-code/adapter.ts
+++ b/crabot-agent/src/workers/claude-code/adapter.ts
@@ -28,7 +28,7 @@ import { promises as fs } from 'fs'
 import { join, dirname } from 'path'
 import { randomUUID } from 'crypto'
 import { homedir } from 'os'
-import { execFile } from 'child_process'
+import { execFile, spawn, type ChildProcess } from 'child_process'
 import { promisify } from 'util'
 import { TmuxDriver, type PaneSnapshot } from '../tmux/driver.js'
 import { commitInput, waitForPaneChange, type InputMode } from '../tmux/input-commit.js'
@@ -41,8 +41,9 @@ import { writeMetaAtomic, maxSeqOnDisk, latestModifiedMs } from '../meta-store.j
 import { buildChildEnv } from '../../core/runtime-env.js'
 import { buildScrubbedChildEnv } from '../connections/secret-env.js'
 import { connectionCapabilitiesFor } from '../connections/registry.js'
-import { WorkerExitedError, CliInputStallError, WorkerImplUnavailableError } from '../errors.js'
+import { WorkerExitedError, CliInputStallError, WorkerImplUnavailableError, ForkEstablishmentError } from '../errors.js'
 import { probeClaudeInput, acceptedClaudeInput, hasClaudeInteraction } from './input-surface.js'
+import { assertInputDeliveryActive } from '../input-delivery-control.js'
 import { assertWorkspaceFilesUntracked, materializeSkills, renderMcpJson, renderContextMd, writeSensitiveFileAtomic, type ProvisionSources } from '../provision/materialize.js'
 import type {
   AdapterCapabilities,
@@ -54,9 +55,11 @@ import type {
   StateChangeReport,
   IncarnationHandle,
   IncarnationRef,
+  ForkOptions,
   NormalizedTraceEvent,
   OutputCursor,
   SpawnSpec,
+  SendInputOptions,
   TraceCursor,
   WorkerAdapter,
   WorkerContractState,
@@ -68,6 +71,49 @@ const execFileAsync = promisify(execFile)
 /** POSIX shell 单引号转义,与 tmux/driver.ts 的私有 shQuote 同款用法(独立复制一份)。 */
 function shQuote(s: string): string {
   return `'${s.replace(/'/g, `'\\''`)}'`
+}
+
+function safeProcessError(error: unknown): string {
+  return (error instanceof Error ? error.message : String(error)).replace(/\s+/g, ' ').trim().slice(0, 1000)
+}
+
+function killProcessTree(child: ChildProcess, signal: NodeJS.Signals): boolean {
+  if (child.pid === undefined) return false
+  try {
+    process.kill(-child.pid, signal)
+    return true
+  } catch {
+    try {
+      return child.kill(signal)
+    } catch {
+      return false
+    }
+  }
+}
+
+async function waitForProcessExit(child: ChildProcess, timeoutMs: number): Promise<boolean> {
+  if (child.exitCode !== null || child.signalCode !== null) return true
+  return new Promise((resolve) => {
+    const finish = (exited: boolean) => {
+      clearTimeout(timer)
+      child.off('exit', onExit)
+      child.off('error', onExit)
+      resolve(exited)
+    }
+    const onExit = () => finish(true)
+    const timer = setTimeout(() => finish(false), timeoutMs)
+    timer.unref?.()
+    child.once('exit', onExit)
+    child.once('error', onExit)
+  })
+}
+
+async function terminateProcessTree(child: ChildProcess): Promise<boolean> {
+  if (child.exitCode !== null || child.signalCode !== null) return true
+  killProcessTree(child, 'SIGTERM')
+  if (await waitForProcessExit(child, 1000)) return true
+  killProcessTree(child, 'SIGKILL')
+  return waitForProcessExit(child, 1000)
 }
 
 /**
@@ -144,7 +190,7 @@ interface Runtime {
   readonly workspaceRoot: string
   /** tmux 会话名;fork 化身不进 tmux,恒为空串。 */
   readonly sessionName: string
-  readonly sessionId: string
+  sessionId: string
   readonly outputLog: OutputLog
   readonly eventChannel: CliEventChannel
   controlState: CliControlState
@@ -164,6 +210,8 @@ interface Runtime {
   /** 是否已经被 resume 过一次。resume() 锁内检测"对同一 prev 的重复 resume"(先到先得,
    * 后来者报错),对齐 builtin 同款语义(P2 review #2)。fork 不受此限制。 */
   resumed?: boolean
+  /** Present only for a headless query fork; mainline incarnations are owned by tmux. */
+  headlessChild?: ChildProcess
 }
 
 function instanceKey(h: { worker_id: string; seq: number }): string {
@@ -519,6 +567,7 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
     mode: InputMode,
     notify: boolean,
     foldStop: boolean,
+    delivery?: SendInputOptions,
   ): Promise<InitialInputResult> {
     let baseline = ''
     let pasted = false
@@ -537,6 +586,10 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
         (snapshot, phase) => probeClaudeInput(snapshot, mode, phase === 'after_paste' ? text : undefined, phase === 'before_paste'),
         (snapshot) => acceptedClaudeInput(snapshot, mode, text),
         text,
+        {
+          beforeSideEffect: (phase) =>
+            assertInputDeliveryActive(delivery, phase === 'paste' ? 'not_delivered' : 'unknown'),
+        },
       )
     } catch (err) {
       if (!(await this.tmux.isAlive(runtime.sessionName))) {
@@ -772,46 +825,36 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
     return { ...handle, initial_input }
   }
 
-  async fork(prev: IncarnationRef, forkInput: string, opts?: { connection_env?: Record<string, string> }): Promise<IncarnationHandle> {
+  async fork(prev: IncarnationRef, forkInput: string, opts: ForkOptions): Promise<IncarnationHandle> {
     this.assertActive()
     // API 边界校验:session_ref 必须是有效 UUID 格式,防止 shell 注入
     validateSessionRef(prev.session_ref)
-
-    // fork 不检查 prevRuntime 是否存活(cc 的 --fork-session 无头一击直接靠 --resume 打给
-    // cc 自己的会话文件,不依赖任何 tmux pane 还在跑)——ensureRuntime 因此对 fork 同样适用:
-    // 只要 meta 还在,不管 tmux 会话死活都能重建出这里需要的 dir/workspaceRoot。
+    const remainingMs = Date.parse(opts.establishment_deadline_at) - Date.now()
+    if (remainingMs <= 0) {
+      throw new ForkEstablishmentError('timeout', 'fork establishment deadline already expired', 'not_started')
+    }
     const prevRuntime = await this.ensureRuntime(prev)
     if (!prevRuntime) {
-      throw new Error(`ClaudeCodeAdapter.fork: no such incarnation ${prev.worker_id}#${prev.seq} resident in this process`)
+      throw new ForkEstablishmentError(
+        'fork_create',
+        `ClaudeCodeAdapter.fork: no such incarnation ${prev.worker_id}#${prev.seq}`,
+        'not_started',
+      )
     }
     if (!prevRuntime.workspaceRoot) {
-      // 重建自缺 workspace_root 的老 meta(已知限制,见 ensureRuntime 注释)——fork 的子进程
-      // cwd 依赖它,不能悄悄传空串。
-      throw new Error(
+      throw new ForkEstablishmentError(
+        'fork_create',
         `ClaudeCodeAdapter.fork: cannot rebuild workspace for ${prev.worker_id}#${prev.seq} ` +
           `(meta.json predates workspace_root persistence; this incarnation cannot be forked after an adapter restart)`,
+        'not_started',
       )
     }
 
     const dir = prevRuntime.dir
-    // cc 的 --fork-session 在其内部生成一个新会话 id,--output-format text 的 stdout 不
-    // 携带它,拿不到就拿不到:这里落一个本地占位 uuid,不对应真实 cc 会话文件(已知限制)。
-    const sessionId = randomUUID()
-
-    // seq 分配(nextSeq(),该 worker 现存所有化身 max seq + 1)+ 提交一段 meta(running)+
-    // 注册 runtime 整体在 per-worker 互斥锁内完成——不能再用 prev.seq+1 这种固定公式:fork
-    // 化身常驻 runtimes 不删,对同一个 prev 连续 fork 两次,prev.seq+1 算出来的号位第二次会
-    // 撞上第一次已经占用的那个,而不是真正分配到空位(见文件头注释、P2 review #1)。nextSeq()
-    // 与锁内的注册在同一次 mutex.run 内完成,保证分配即生效,不会被并发的另一次
-    // fork/resume 抢到同一个号位。
-    let handle!: IncarnationHandle
     let runtime!: Runtime
-    // 侧问收尾的 stop 事件必须落到 fork 化身自己的事件文件,不能进 workspace 共享的那份
-    // (见下方 execFileAsync 的 env 注释)。
     let forkEventsFile!: string
     await this.getMutex(prev.worker_id).run(async () => {
       const seq = await this.nextSeq(prev.worker_id)
-      handle = { worker_id: prev.worker_id, seq, impl: 'claude-code', session_ref: sessionId }
       const outputFile = join(dir, `output-${seq}.log`)
       forkEventsFile = join(dir, `fork-events-${seq}.jsonl`)
       runtime = {
@@ -820,71 +863,171 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
         dir,
         workspaceRoot: prevRuntime.workspaceRoot,
         sessionName: '',
-        sessionId,
+        sessionId: '',
         outputLog: new OutputLog(outputFile),
         eventChannel: new CliEventChannel(forkEventsFile),
         controlState: { kind: 'running' },
         stopBaseline: 0,
         killed: false,
       }
-      await writeMetaAtomic(dir, seq, { seq, state: 'running', session_id: sessionId, workspace_root: prevRuntime.workspaceRoot })
-      this.runtimes.set(instanceKey(handle), runtime)
+      this.runtimes.set(instanceKey(runtime), runtime)
     })
 
-    // 无头一击,不进 tmux:子进程在锁外跑(可能耗时较长),不阻塞同 worker_id 上其它操作
-    // (主线不受影响)。claudeBin 与 spawn/resume 同款语义——一段 shell 命令片段,经 sh -c
-    // 跑;forkInput 与其它参数逐个 shQuote 转义,防止内容里的 shell 元字符注入。
-    const args = [
-      '-p', forkInput,
-      '--resume', prev.session_ref,
-      '--fork-session',
-      '--output-format', 'text',
-      '--mcp-config', MCP_CONFIG_FILE,
-      '--strict-mcp-config',
-    ]
-    // P6-B：fork 与 spawn/resume 同一 binary 解析纪律（managed 优先）——否则 managed install
-    // 且宿主无 system claude 时主线正常、侧问 command not found（R8）。
-    const forkBin = await this.resolveBinForCommand()
-    if (!forkBin) throw new WorkerImplUnavailableError(`ClaudeCodeAdapter.fork: no user-level claude installation`)
-    const shellCommand = `${forkBin} ${args.map(shQuote).join(' ')}`
-
-    // 事件文件重定向:cc 的 hooks 在 print 模式同样执行,而 Stop hook 配在 **workspace 级**
-    // 的 .claude/settings.json 里、写的是 **workspace 级**共享的 events-cli.jsonl——不重定向
-    // 的话,侧问收尾会往主线正在用的那份事件文件追加一条 stop,污染主线的 stop 计数:主线
-    // 跑到一半被 watcher 判成 idle 推一条假唤醒,而它真正跑完这一轮时因为"状态没变"不再
-    // 产生迁移,真正的轮次边界唤醒被整条吞掉。侧问按设计就是在主线还在跑的时候发起的
-    // (queryWorker 把 fork 放在锁外、不阻塞主线),这不是罕见时序。
-    // 这里给子进程 env 塞一个 fork 化身私有的事件文件路径,cc 拉起 hook 子进程时原样继承
-    // 下去,hook 写私有文件(见 CliEventChannel.EVENTS_FILE_ENV)。交互态(tmux pane)不设
-    // 这个变量,照旧写共享文件,行为不变。
-    // P6-B：fork 与 tmux pane/verify/installer 同源——从 allowlist 重建（buildScrubbedChildEnv
-    // 打底），不是继承整个 process.env；否则宿主 export 的 ANTHROPIC_API_KEY 会随请求发往
-    // 第三方镜像（admin_provider 形态下尤其不能容忍）。连接注入叠在其上。
-    const inheritedConnectionEnv = opts?.connection_env ?? prevRuntime.connectionEnv ?? {}
-    const execOpts = { cwd: prevRuntime.workspaceRoot, env: { ...buildScrubbedChildEnv(), [EVENTS_FILE_ENV]: forkEventsFile, ...inheritedConnectionEnv } }
-
-    let stdout = ''
-    let endedReason: IncarnationEndReason
+    let child: ChildProcess
     try {
-      const result = await execFileAsync('/bin/sh', ['-c', shellCommand], execOpts)
-      stdout = result.stdout
-      endedReason = 'completed'
-    } catch (err) {
-      stdout = (err as { stdout?: string }).stdout ?? ''
-      endedReason = 'crashed'
+      const args = [
+        '-p', forkInput,
+        '--resume', prev.session_ref,
+        '--fork-session',
+        '--output-format', 'stream-json',
+        '--verbose',
+        '--include-partial-messages',
+        '--mcp-config', MCP_CONFIG_FILE,
+        '--strict-mcp-config',
+      ]
+      const forkBin = await this.resolveBinForCommand()
+      if (!forkBin) {
+        throw new ForkEstablishmentError(
+          'fork_create',
+          'ClaudeCodeAdapter.fork: no user-level claude installation',
+          'not_started',
+        )
+      }
+      const shellCommand = `${forkBin} ${args.map(shQuote).join(' ')}`
+      const inheritedConnectionEnv = opts.connection_env ?? prevRuntime.connectionEnv ?? {}
+      const execOpts = { cwd: prevRuntime.workspaceRoot, env: { ...buildScrubbedChildEnv(), [EVENTS_FILE_ENV]: forkEventsFile, ...inheritedConnectionEnv } }
+
+      child = spawn('/bin/sh', ['-c', shellCommand], {
+        ...execOpts,
+        detached: true,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      })
+      runtime.headlessChild = child
+    } catch (error) {
+      this.runtimes.delete(instanceKey(runtime))
+      if (error instanceof ForkEstablishmentError) throw error
+      throw new ForkEstablishmentError('fork_create', safeProcessError(error), 'not_started')
     }
-
-    if (stdout) await runtime.outputLog.append(stdout)
-
-    await this.getMutex(prev.worker_id).run(async () => {
-      if (runtime.controlState.kind === 'exited') return // 幂等兜底
-      await this.transitionExited(runtime, handle, endedReason)
+    let handle: IncarnationHandle | undefined
+    let established = false
+    let establishing: Promise<void> | undefined
+    let stdoutBuffer = ''
+    let stderr = ''
+    let outputWrites = Promise.resolve()
+    let sawTextDelta = false
+    let finished = false
+    let resolveEstablished!: (value: IncarnationHandle) => void
+    let rejectEstablished!: (reason: unknown) => void
+    const establishedPromise = new Promise<IncarnationHandle>((resolve, reject) => {
+      resolveEstablished = resolve
+      rejectEstablished = reject
     })
 
-    return handle
+    const appendOutput = (text: string) => {
+      if (!text) return
+      outputWrites = outputWrites.then(() => runtime.outputLog.append(text))
+    }
+    const establish = (sessionId: string): Promise<void> => {
+      if (establishing) return establishing
+      establishing = (async () => {
+        validateSessionRef(sessionId)
+        if (sessionId === prev.session_ref) {
+          throw new Error('Claude Code fork reused the parent session id')
+        }
+        runtime.sessionId = sessionId
+        handle = {
+          worker_id: prev.worker_id,
+          seq: runtime.seq,
+          impl: 'claude-code',
+          session_ref: sessionId,
+          query_id: opts.query_id,
+        }
+        await writeMetaAtomic(dir, runtime.seq, {
+          seq: runtime.seq,
+          state: 'running',
+          session_id: sessionId,
+          workspace_root: prevRuntime.workspaceRoot,
+        })
+        established = true
+        resolveEstablished(handle)
+      })().catch((error) => {
+        void terminateProcessTree(child)
+        rejectEstablished(new ForkEstablishmentError('fork_create', safeProcessError(error), 'unknown'))
+      })
+      return establishing
+    }
+    const consumeEvent = (line: string) => {
+      if (!line.trim()) return
+      let event: Record<string, unknown>
+      try {
+        event = JSON.parse(line) as Record<string, unknown>
+      } catch {
+        return
+      }
+      if (event.type === 'system' && event.subtype === 'init' && typeof event.session_id === 'string') {
+        void establish(event.session_id)
+        return
+      }
+      if (event.type === 'stream_event') {
+        const streamEvent = event.event as { type?: string; delta?: { type?: string; text?: string } } | undefined
+        if (streamEvent?.type === 'content_block_delta' && streamEvent.delta?.type === 'text_delta') {
+          sawTextDelta = true
+          appendOutput(streamEvent.delta.text ?? '')
+        }
+        return
+      }
+      if (!sawTextDelta && event.type === 'result' && typeof event.result === 'string') appendOutput(event.result)
+    }
+    child.stdout!.on('data', (chunk: Buffer) => {
+      stdoutBuffer += chunk.toString('utf-8')
+      const lines = stdoutBuffer.split('\n')
+      stdoutBuffer = lines.pop() ?? ''
+      for (const line of lines) consumeEvent(line)
+    })
+    child.stderr!.on('data', (chunk: Buffer) => {
+      stderr = `${stderr}${chunk.toString('utf-8')}`.slice(-4000)
+    })
+
+    let timedOut = false
+    const timeout = setTimeout(() => {
+      if (established) return
+      timedOut = true
+      void terminateProcessTree(child)
+    }, Math.max(1, remainingMs))
+    timeout.unref?.()
+
+    const finish = async (code: number | null, error?: Error) => {
+      if (finished) return
+      finished = true
+      clearTimeout(timeout)
+      if (stdoutBuffer) consumeEvent(stdoutBuffer)
+      if (establishing) await establishing.catch(() => undefined)
+      await outputWrites.catch((writeError) => {
+        console.error(`[ClaudeCodeAdapter] fork output write failed for ${prev.worker_id}#${runtime.seq}:`, writeError)
+      })
+      if (!established || !handle) {
+        this.runtimes.delete(instanceKey(runtime))
+        rejectEstablished(new ForkEstablishmentError(
+          timedOut ? 'timeout' : 'fork_create',
+          timedOut
+            ? 'Claude Code fork establishment timed out'
+            : safeProcessError(error ?? new Error(stderr || `Claude Code fork exited before initialization (code=${code})`)),
+          timedOut || error === undefined ? 'unknown' : 'not_started',
+        ))
+        return
+      }
+      await this.getMutex(prev.worker_id).run(async () => {
+        if (runtime.controlState.kind === 'exited') return
+        await this.transitionExited(runtime, handle!, code === 0 ? 'completed' : 'crashed')
+      })
+    }
+    child.once('error', (error) => { void finish(null, error) })
+    child.once('exit', (code) => { void finish(code) })
+
+    return establishedPromise
   }
 
-  async sendInput(h: IncarnationHandle, text: string, opts?: { raw?: boolean }): Promise<void> {
+  async sendInput(h: IncarnationHandle, text: string, opts?: SendInputOptions): Promise<void> {
     this.assertActive()
     const runtime = await this.ensureRuntime(h)
     if (!runtime) throw new WorkerExitedError(h.worker_id, h.seq)
@@ -895,7 +1038,10 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
     return this.getMutex(h.worker_id).run(async () => {
       if (runtime.controlState.kind === 'exited') throw new WorkerExitedError(h.worker_id, h.seq, runtime.ended_reason)
 
-      if (opts?.raw) return this.sendRawInput(runtime, h, text)
+      if (opts?.raw) {
+        assertInputDeliveryActive(opts, 'not_delivered')
+        return this.sendRawInput(runtime, h, text)
+      }
 
       if (runtime.controlState.kind === 'waiting_action') {
         const snapshot = await this.capture(runtime)
@@ -904,7 +1050,7 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
       }
 
       const mode: InputMode = runtime.controlState.kind === 'running' ? 'steering' : 'primary'
-      const result = await this.commitGuardedInput(runtime, h, text, mode, false, false)
+      const result = await this.commitGuardedInput(runtime, h, text, mode, false, false, opts)
       if (result.disposition !== 'accepted') {
         throw new CliInputStallError(result.disposition, result.control_state, result.report)
       }
@@ -961,6 +1107,7 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
   async state(h: IncarnationHandle): Promise<WorkerContractState> {
     const runtime = await this.ensureRuntime(h)
     if (!runtime) return 'exited'
+    if (runtime.headlessChild) return contractState(runtime.controlState)
     return (await this.syncState(runtime, h)).state
   }
 
@@ -1026,7 +1173,13 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
     await this.getMutex(h.worker_id).run(async () => {
       if (runtime.controlState.kind === 'exited') return // 幂等:不覆盖原 ended_reason
       runtime.killed = true
-      await this.tmux.killSession(runtime.sessionName)
+      if (runtime.headlessChild) {
+        if (!await terminateProcessTree(runtime.headlessChild)) {
+          throw new Error(`ClaudeCodeAdapter.kill: fork process did not exit for ${h.worker_id}#${h.seq}`)
+        }
+      } else {
+        await this.tmux.killSession(runtime.sessionName)
+      }
       await this.transitionExited(runtime, h, 'killed')
     })
   }

--- a/crabot-agent/src/workers/codex/adapter.ts
+++ b/crabot-agent/src/workers/codex/adapter.ts
@@ -16,12 +16,13 @@
  * reads native rollout metadata; a placeholder session can continue visually but cannot be
  * resumed. Native rollout data is trace/diagnostic evidence and never causes automatic re-paste.
  * Meta persists external state plus wait_mode/wait_reason and supports runtime reconstruction from
- * deterministic tmux names after an agent restart. Codex fork remains unsupported.
+ * deterministic tmux names after an agent restart. Query forks use a separate headless app-server
+ * process and never enter the interactive tmux session.
  */
 import { promises as fs, type Dirent } from 'fs'
 import { join, dirname } from 'path'
 import { randomUUID } from 'crypto'
-import { homedir } from 'os'
+import { homedir, tmpdir } from 'os'
 import { execFile } from 'child_process'
 import { buildChildEnv } from '../../core/runtime-env.js'
 import { connectionCapabilitiesFor } from '../connections/registry.js'
@@ -34,8 +35,17 @@ import { OutputLog } from '../output-log.js'
 import { decodeTerminalOutput } from '../terminal-output.js'
 import { AsyncMutex } from '../async-mutex.js'
 import { writeMetaAtomic, maxSeqOnDisk, latestModifiedMs } from '../meta-store.js'
-import { WorkerExitedError, CapabilityNotSupportedError, CliInputStallError, WorkerImplUnavailableError } from '../errors.js'
+import { WorkerExitedError, CapabilityNotSupportedError, CliInputStallError, WorkerImplUnavailableError, ForkEstablishmentError } from '../errors.js'
 import { probeCodexInput, acceptedCodexInput } from './input-surface.js'
+import { assertInputDeliveryActive } from '../input-delivery-control.js'
+import { buildScrubbedChildEnv } from '../connections/secret-env.js'
+import {
+  CodexAppServerClient,
+  CodexAppServerDeadlineError,
+  CodexAppServerRpcError,
+  probeCodexAppServerFork,
+  type AppServerNotification,
+} from './app-server-client.js'
 import { parse as parseToml, stringify as stringifyToml } from 'smol-toml'
 import { createHash } from 'node:crypto'
 import { assertWorkspaceFilesUntracked, materializeSkills, renderCodexMcpToml, renderContextMd, writeSensitiveFileAtomic, type ProvisionSources } from '../provision/materialize.js'
@@ -49,9 +59,11 @@ import type {
   StateChangeReport,
   IncarnationHandle,
   IncarnationRef,
+  ForkOptions,
   NormalizedTraceEvent,
   OutputCursor,
   SpawnSpec,
+  SendInputOptions,
   TraceCursor,
   WorkerAdapter,
   WorkerContractState,
@@ -69,6 +81,10 @@ const CODEX_CREDENTIAL_FILES = ['.codex/config.toml', '.codex/auth.json'] as con
 /** POSIX shell 单引号转义,与 cc adapter 的私有 shQuote 同款用法(独立复制一份)。 */
 function shQuote(s: string): string {
   return `'${s.replace(/'/g, `'\\''`)}'`
+}
+
+function safeProcessError(error: unknown): string {
+  return (error instanceof Error ? error.message : String(error)).replace(/\s+/g, ' ').trim().slice(0, 1000)
 }
 
 /** 取一个 TOML table 值当普通对象用;不是 table(缺失/标量/数组)就当空表。 */
@@ -185,6 +201,8 @@ interface Runtime {
   /** 是否已经被 resume 过一次。resume() 锁内检测"对同一 prev 的重复 resume"(先到先得,
    * 后来者报错),对齐 builtin/cc 同款语义(P2 review #2)。 */
   resumed?: boolean
+  /** Present only for a headless query fork; mainline incarnations are owned by tmux. */
+  headlessClient?: CodexAppServerClient
 }
 
 function instanceKey(h: { worker_id: string; seq: number }): string {
@@ -384,6 +402,8 @@ export class CodexWorkerAdapter implements WorkerAdapter {
   }
   private lastDetectedVersion?: string
   private lastGlobalDetected = false
+  private appServerForkSupported = false
+  private lastCapabilityProbeKey?: string
 
   /** 同 claude adapter：resolver 存在时只认其结论，无用户级绝不回落裸命令。
    *  返回 { cmd: shell 引用形态, raw: 原始绝对路径 }（raw 供 PATH 前置等目录推导，
@@ -543,6 +563,29 @@ export class CodexWorkerAdapter implements WorkerAdapter {
     // 'codex-cli 0.146.0' → '0.146.0'
     const version = /([0-9]+\.[0-9]+\.[0-9]+)/.exec(versionOutput)?.[1]
     this.lastDetectedVersion = version
+    if (!version) {
+      this.appServerForkSupported = false
+      this.lastCapabilityProbeKey = undefined
+    } else {
+      const capabilityProbeKey = `${effectiveBin}\n${version}`
+      if (this.lastCapabilityProbeKey !== capabilityProbeKey) {
+        const probeHome = await fs.mkdtemp(join(tmpdir(), 'crabot-codex-app-server-probe-'))
+        try {
+          this.appServerForkSupported = await probeCodexAppServerFork({
+            command: `${effectiveBin} app-server --stdio`,
+            cwd: probeHome,
+            env: {
+              ...buildScrubbedChildEnv(),
+              PATH: binDir ? `${binDir}:${process.env.PATH ?? ''}` : (process.env.PATH ?? ''),
+              CODEX_HOME: probeHome,
+            },
+          })
+          this.lastCapabilityProbeKey = capabilityProbeKey
+        } finally {
+          await fs.rm(probeHome, { recursive: true, force: true }).catch(() => {})
+        }
+      }
+    }
     return { installed: true, activated, version, install_source: 'user', credential_generation: credentialGeneration, global_detected: false, detail: versionOutput }
   }
 
@@ -772,6 +815,7 @@ export class CodexWorkerAdapter implements WorkerAdapter {
     mode: InputMode,
     notify: boolean,
     foldStop: boolean,
+    delivery?: SendInputOptions,
   ): Promise<InitialInputResult> {
     let baseline = ''
     let pasted = false
@@ -790,6 +834,10 @@ export class CodexWorkerAdapter implements WorkerAdapter {
         (snapshot, phase) => probeCodexInput(snapshot, mode, phase === 'after_paste' ? text : undefined, phase === 'before_paste'),
         (snapshot) => acceptedCodexInput(snapshot, mode, text, baseline),
         text,
+        {
+          beforeSideEffect: (phase) =>
+            assertInputDeliveryActive(delivery, phase === 'paste' ? 'not_delivered' : 'unknown'),
+        },
       )
     } catch (err) {
       if (!(await this.tmux.isAlive(runtime.sessionName))) {
@@ -1103,18 +1151,211 @@ export class CodexWorkerAdapter implements WorkerAdapter {
     return { ...handle, initial_input }
   }
 
-  async fork(_prev: IncarnationRef, _forkInput: string): Promise<IncarnationHandle> {
+  async fork(prev: IncarnationRef, forkInput: string, opts: ForkOptions): Promise<IncarnationHandle> {
     this.assertActive()
-    // codex-docs: codex exec 没有 cc `-p ... --fork-session --output-format text` 那种
-    // "一条命令完成侧问"的等价物——openai/codex#11750、#17568 两个 open feature request
-    // 明确指出 exec CLI 目前不支持 fork,唯一记录在案的变通方案是拉起交互式 TUI 塞进伪终端、
-    // 轮询文件系统等新 rollout 文件出现、杀掉 TUI、再用 `codex exec resume` 接力——这已经不是
-    // "无头一击",是要在这里重新实现一遍 tmux 交互流程,不是本 adapter 想提供的 fork 语义。
-    // capabilities().fork 如实定为 false,这里对应抛出同款语义的能力缺失错误。
-    throw new CapabilityNotSupportedError('codex', 'fork')
+    validateSessionRef(prev.session_ref)
+    if (!this.appServerForkSupported) {
+      throw new ForkEstablishmentError('fork_create', 'Codex app-server fork capability is unavailable', 'not_started')
+    }
+    if (Date.parse(opts.establishment_deadline_at) <= Date.now()) {
+      throw new ForkEstablishmentError('timeout', 'fork establishment deadline already expired', 'not_started')
+    }
+
+    const prevRuntime = await this.ensureRuntime(prev)
+    if (!prevRuntime) {
+      throw new ForkEstablishmentError(
+        'fork_create',
+        `CodexWorkerAdapter.fork: no such incarnation ${prev.worker_id}#${prev.seq}`,
+        'not_started',
+      )
+    }
+    if (!prevRuntime.workspaceRoot || !prevRuntime.codexHome) {
+      throw new ForkEstablishmentError(
+        'fork_create',
+        `CodexWorkerAdapter.fork: cannot rebuild workspace or CODEX_HOME for ${prev.worker_id}#${prev.seq}`,
+        'not_started',
+      )
+    }
+
+    const resolvedBin = await this.resolveBinForCommand()
+    if (!resolvedBin) {
+      throw new ForkEstablishmentError('fork_create', 'CodexWorkerAdapter.fork: no user-level codex installation', 'not_started')
+    }
+
+    const dir = prevRuntime.dir
+    let runtime!: Runtime
+    await this.getMutex(prev.worker_id).run(async () => {
+      const seq = await this.nextSeq(prev.worker_id)
+      runtime = {
+        worker_id: prev.worker_id,
+        seq,
+        dir,
+        workspaceRoot: prevRuntime.workspaceRoot,
+        codexHome: opts.connection_env?.CODEX_HOME ?? prevRuntime.codexHome,
+        sessionName: '',
+        sessionId: '',
+        rolloutPath: undefined,
+        outputLog: new OutputLog(join(dir, `output-${seq}.log`)),
+        eventChannel: new CliEventChannel(join(dir, `fork-events-${seq}.jsonl`)),
+        sessionDiscoveryStatus: 'placeholder',
+        discoveryStartedAt: Date.now(),
+        controlState: { kind: 'running' },
+        stopBaseline: 0,
+        killed: false,
+      }
+      this.runtimes.set(instanceKey(runtime), runtime)
+    })
+
+    let client: CodexAppServerClient
+    try {
+      const env = {
+        ...buildScrubbedChildEnv(),
+        ...(await this.buildEnv({
+          CODEX_HOME: opts.connection_env?.CODEX_HOME ?? prevRuntime.codexHome,
+          ...opts.connection_env,
+        })),
+      }
+      client = new CodexAppServerClient({
+        command: `${resolvedBin.cmd} app-server --stdio`,
+        cwd: prevRuntime.workspaceRoot,
+        env,
+      })
+      runtime.headlessClient = client
+    } catch (error) {
+      this.runtimes.delete(instanceKey(runtime))
+      await fs.rm(join(dir, `meta-${runtime.seq}.json`), { force: true }).catch(() => {})
+      throw new ForkEstablishmentError('fork_create', safeProcessError(error), 'not_started')
+    }
+
+    let forkThreadId: string | undefined
+    let turnId: string | undefined
+    let handle: IncarnationHandle | undefined
+    let established = false
+    let finished = false
+    let processExitBeforeEstablishment: Error | undefined
+    let pendingCompletion: { status: string; error?: unknown } | undefined
+    let outputWrites = Promise.resolve()
+
+    const appendOutput = (text: string) => {
+      if (!text) return
+      outputWrites = outputWrites.then(() => runtime.outputLog.append(text))
+    }
+    const finish = async (reason: IncarnationEndReason, error?: unknown) => {
+      if (finished || !handle) return
+      finished = true
+      if (error !== undefined) appendOutput(`\n[codex query failed: ${safeProcessError(error)}]\n`)
+      await outputWrites.catch((writeError) => {
+        console.error(`[CodexWorkerAdapter] fork output write failed for ${prev.worker_id}#${runtime.seq}:`, writeError)
+      })
+      await this.getMutex(prev.worker_id).run(async () => {
+        if (runtime.controlState.kind !== 'exited') await this.transitionExited(runtime, handle!, reason)
+      })
+      await client.terminate()
+    }
+    const consumeNotification = (notification: AppServerNotification) => {
+      const params = asTable(notification.params)
+      if (notification.method === 'item/agentMessage/delta') {
+        if (typeof params.threadId !== 'string' || params.threadId !== forkThreadId) return
+        if (turnId !== undefined && params.turnId !== turnId) return
+        if (typeof params.delta === 'string') appendOutput(params.delta)
+        return
+      }
+      if (notification.method !== 'turn/completed') return
+      if (typeof params.threadId !== 'string' || params.threadId !== forkThreadId) return
+      const turn = asTable(params.turn)
+      if (typeof turn.id !== 'string' || (turnId !== undefined && turn.id !== turnId)) return
+      const completion = {
+        status: typeof turn.status === 'string' ? turn.status : 'failed',
+        ...('error' in turn ? { error: turn.error } : {}),
+      }
+      if (!established) {
+        pendingCompletion = completion
+        return
+      }
+      void finish(completion.status === 'completed' ? 'completed' : 'failed', completion.error)
+    }
+    client.onNotification(consumeNotification)
+    client.onExit((error) => {
+      if (!established) {
+        processExitBeforeEstablishment = error ?? new Error('codex app-server exited during fork establishment')
+        return
+      }
+      void finish('crashed', error ?? new Error('codex app-server exited before turn/completed'))
+    })
+
+    let stage: 'fork_create' | 'query_submit' = 'fork_create'
+    let turnAccepted = false
+    try {
+      await client.initialize(opts.establishment_deadline_at)
+      const forkResult = asTable(await client.request('thread/fork', {
+        threadId: prev.session_ref,
+        ephemeral: true,
+        excludeTurns: true,
+      }, opts.establishment_deadline_at))
+      const thread = asTable(forkResult.thread)
+      if (typeof thread.id !== 'string') {
+        throw new Error('codex app-server thread/fork returned an incompatible response')
+      }
+      validateSessionRef(thread.id)
+      if (thread.id === prev.session_ref) throw new Error('codex app-server fork reused the parent thread id')
+      forkThreadId = thread.id
+      runtime.sessionId = thread.id
+
+      stage = 'query_submit'
+      const turnResult = asTable(await client.request('turn/start', {
+        threadId: thread.id,
+        input: [{ type: 'text', text: forkInput }],
+      }, opts.establishment_deadline_at))
+      const turn = asTable(turnResult.turn)
+      if (typeof turn.id !== 'string') {
+        throw new Error('codex app-server turn/start returned an incompatible response')
+      }
+      turnId = turn.id
+      turnAccepted = true
+      handle = {
+        worker_id: prev.worker_id,
+        seq: runtime.seq,
+        impl: 'codex',
+        session_ref: thread.id,
+        query_id: opts.query_id,
+      }
+      await writeMetaAtomic(dir, runtime.seq, {
+        seq: runtime.seq,
+        state: 'running',
+        session_id: thread.id,
+        session_discovery: 'placeholder',
+        workspace_root: prevRuntime.workspaceRoot,
+        codex_home: runtime.codexHome,
+      })
+      if (processExitBeforeEstablishment && !pendingCompletion) throw processExitBeforeEstablishment
+      established = true
+      if (pendingCompletion) {
+        void finish(
+          pendingCompletion.status === 'completed' ? 'completed' : 'failed',
+          pendingCompletion.error,
+        )
+      }
+      return handle
+    } catch (error) {
+      const stopped = await client.terminate()
+      this.runtimes.delete(instanceKey(runtime))
+      await fs.rm(join(dir, `meta-${runtime.seq}.json`), { force: true }).catch(() => {})
+      const isTimeout = error instanceof CodexAppServerDeadlineError
+      const rpcRejected = error instanceof CodexAppServerRpcError
+      let certainty: ForkEstablishmentError['certainty']
+      if (isTimeout) certainty = 'unknown'
+      else if (stage === 'fork_create' || rpcRejected) certainty = 'not_started'
+      else if (turnAccepted && stopped) certainty = 'failed'
+      else certainty = 'unknown'
+      throw new ForkEstablishmentError(
+        isTimeout ? 'timeout' : stage,
+        safeProcessError(error),
+        certainty,
+      )
+    }
   }
 
-  async sendInput(h: IncarnationHandle, text: string, opts?: { raw?: boolean }): Promise<void> {
+  async sendInput(h: IncarnationHandle, text: string, opts?: SendInputOptions): Promise<void> {
     this.assertActive()
     const runtime = await this.ensureRuntime(h)
     if (!runtime) throw new WorkerExitedError(h.worker_id, h.seq)
@@ -1124,7 +1365,10 @@ export class CodexWorkerAdapter implements WorkerAdapter {
     return this.getMutex(h.worker_id).run(async () => {
       if (runtime.controlState.kind === 'exited') throw new WorkerExitedError(h.worker_id, h.seq, runtime.ended_reason)
 
-      if (opts?.raw) return this.sendRawInput(runtime, h, text)
+      if (opts?.raw) {
+        assertInputDeliveryActive(opts, 'not_delivered')
+        return this.sendRawInput(runtime, h, text)
+      }
 
       if (runtime.controlState.kind === 'waiting_action') {
         const snapshot = await this.capture(runtime)
@@ -1132,7 +1376,7 @@ export class CodexWorkerAdapter implements WorkerAdapter {
         throw new CliInputStallError('not_pasted', 'waiting_action', report)
       }
       const mode: InputMode = runtime.controlState.kind === 'running' ? 'steering' : 'primary'
-      const result = await this.commitGuardedInput(runtime, h, text, mode, false, false)
+      const result = await this.commitGuardedInput(runtime, h, text, mode, false, false, opts)
       if (result.disposition !== 'accepted') throw new CliInputStallError(result.disposition, result.control_state, result.report)
       if (!runtime.sessionId) {
         const discoveredHandle = await this.discoverSpawnedSession(runtime, h)
@@ -1203,6 +1447,7 @@ export class CodexWorkerAdapter implements WorkerAdapter {
   async state(h: IncarnationHandle): Promise<WorkerContractState> {
     const runtime = await this.ensureRuntime(h)
     if (!runtime) return 'exited'
+    if (runtime.headlessClient) return contractState(runtime.controlState)
     return (await this.syncState(runtime, h)).state
   }
 
@@ -1260,7 +1505,8 @@ export class CodexWorkerAdapter implements WorkerAdapter {
     await this.getMutex(h.worker_id).run(async () => {
       if (runtime.controlState.kind === 'exited') return // 幂等:不覆盖原 ended_reason
       runtime.killed = true
-      await this.tmux.killSession(runtime.sessionName)
+      if (runtime.headlessClient) await runtime.headlessClient.terminate()
+      else await this.tmux.killSession(runtime.sessionName)
       await this.transitionExited(runtime, h, 'killed')
     })
   }
@@ -1275,7 +1521,7 @@ export class CodexWorkerAdapter implements WorkerAdapter {
   }
 
   capabilities(): AdapterCapabilities {
-    return { fork: false, revive: true, goalMode: false, subagent: false, structuredTrace: true }
+    return { fork: this.appServerForkSupported, revive: true, goalMode: false, subagent: false, structuredTrace: true }
   }
 
   // --- Internal ---
@@ -1417,9 +1663,8 @@ export class CodexWorkerAdapter implements WorkerAdapter {
   }
 
   /**
-   * worker_id 对应下一个可用的化身序号:该 worker 现存所有化身里最大 seq + 1。resume() 在
-   * mutex.run 内调用,保证不与并发的另一次 resume 撞号。与 cc adapter 的同名方法同一思路
-   * (codex 的 fork() 不支持,不参与这个分配)。
+   * worker_id 对应下一个可用的化身序号:该 worker 现存所有化身里最大 seq + 1。resume() 和
+   * fork() 都在 mutex.run 内分配,保证并发操作不会撞号。与 cc adapter 的同名方法同一思路。
    *
    * 五轮 review 修复:磁盘感知,理由与 cc adapter 的同名方法一致——重启后新 adapter 实例
    * 的 runtimes 只含 ensureRuntime 按需重建过的那几条,只扫内存会把磁盘上未被重建的旧化身

--- a/crabot-agent/src/workers/codex/app-server-client.ts
+++ b/crabot-agent/src/workers/codex/app-server-client.ts
@@ -1,0 +1,300 @@
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
+import { buildScrubbedChildEnv } from '../connections/secret-env.js'
+
+type JsonObject = Record<string, unknown>
+
+interface PendingRequest {
+  readonly method: string
+  readonly resolve: (result: unknown) => void
+  readonly reject: (error: unknown) => void
+  readonly timer: ReturnType<typeof setTimeout>
+}
+
+export interface AppServerNotification {
+  readonly method: string
+  readonly params?: unknown
+}
+
+export class CodexAppServerRpcError extends Error {
+  constructor(
+    readonly code: number,
+    message: string,
+    readonly data?: unknown,
+  ) {
+    super(message)
+    this.name = 'CodexAppServerRpcError'
+  }
+}
+
+export class CodexAppServerDeadlineError extends Error {
+  constructor(readonly method: string) {
+    super(`codex app-server request '${method}' exceeded its deadline`)
+    this.name = 'CodexAppServerDeadlineError'
+  }
+}
+
+function safeError(error: unknown): string {
+  return (error instanceof Error ? error.message : String(error)).replace(/\s+/g, ' ').trim().slice(0, 1000)
+}
+
+function killProcessTree(child: ChildProcessWithoutNullStreams, signal: NodeJS.Signals): boolean {
+  if (child.pid === undefined) return false
+  try {
+    process.kill(-child.pid, signal)
+    return true
+  } catch {
+    try {
+      return child.kill(signal)
+    } catch {
+      return false
+    }
+  }
+}
+
+/** Minimal JSONL client for the two RPCs used by query_worker. */
+export class CodexAppServerClient {
+  private readonly child: ChildProcessWithoutNullStreams
+  private readonly pending = new Map<number, PendingRequest>()
+  private readonly notificationHandlers = new Set<(notification: AppServerNotification) => void>()
+  private readonly exitHandlers = new Set<(error?: Error) => void>()
+  private readonly exitedPromise: Promise<void>
+  private resolveExited!: () => void
+  private nextRequestId = 1
+  private stdoutBuffer = ''
+  private stderrBuffer = ''
+  private exited = false
+  private processExited = false
+
+  constructor(opts: {
+    readonly command: string
+    readonly cwd: string
+    readonly env: Record<string, string>
+  }) {
+    this.exitedPromise = new Promise((resolve) => {
+      this.resolveExited = resolve
+    })
+    this.child = spawn('/bin/sh', ['-c', opts.command], {
+      cwd: opts.cwd,
+      env: { ...buildScrubbedChildEnv(), ...opts.env },
+      detached: true,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    })
+    this.child.stdout.on('data', (chunk: Buffer) => this.consumeStdout(chunk.toString('utf8')))
+    this.child.stderr.on('data', (chunk: Buffer) => {
+      this.stderrBuffer = `${this.stderrBuffer}${chunk.toString('utf8')}`.slice(-4000)
+    })
+    this.child.stdin.on('error', (error) => {
+      this.finish(error)
+      void this.terminate()
+    })
+    this.child.once('error', (error) => {
+      this.processExited = true
+      this.resolveExited()
+      this.finish(error)
+    })
+    this.child.once('exit', (code, signal) => {
+      this.processExited = true
+      this.resolveExited()
+      const error = code === 0 || this.exited
+        ? undefined
+        : new Error(`codex app-server exited (code=${code}, signal=${signal ?? 'none'})${this.stderrTail ? `: ${this.stderrTail}` : ''}`)
+      this.finish(error)
+    })
+  }
+
+  get stderrTail(): string {
+    return this.stderrBuffer.replace(/\s+/g, ' ').trim().slice(-1000)
+  }
+
+  onNotification(handler: (notification: AppServerNotification) => void): () => void {
+    this.notificationHandlers.add(handler)
+    return () => this.notificationHandlers.delete(handler)
+  }
+
+  onExit(handler: (error?: Error) => void): () => void {
+    this.exitHandlers.add(handler)
+    return () => this.exitHandlers.delete(handler)
+  }
+
+  async initialize(deadlineAt: string): Promise<void> {
+    const result = await this.request('initialize', {
+      clientInfo: { name: 'crabot', title: 'Crabot', version: '1' },
+      capabilities: { experimentalApi: true },
+    }, deadlineAt)
+    if (
+      !isObject(result) ||
+      typeof result.userAgent !== 'string' ||
+      typeof result.codexHome !== 'string'
+    ) {
+      throw new Error('codex app-server initialize returned an incompatible response')
+    }
+    this.notify('initialized', {})
+  }
+
+  request(method: string, params: JsonObject, deadlineAt: string): Promise<unknown> {
+    if (this.exited) return Promise.reject(new Error(`codex app-server exited before '${method}'`))
+    const remainingMs = Date.parse(deadlineAt) - Date.now()
+    if (!Number.isFinite(remainingMs) || remainingMs <= 0) {
+      return Promise.reject(new CodexAppServerDeadlineError(method))
+    }
+    const id = this.nextRequestId++
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id)
+        reject(new CodexAppServerDeadlineError(method))
+      }, remainingMs)
+      timer.unref?.()
+      this.pending.set(id, { method, resolve, reject, timer })
+      try {
+        this.write({ id, method, params })
+      } catch (error) {
+        clearTimeout(timer)
+        this.pending.delete(id)
+        reject(error)
+      }
+    })
+  }
+
+  notify(method: string, params: JsonObject): void {
+    this.write({ method, params })
+  }
+
+  async terminate(): Promise<boolean> {
+    if (this.processExited) return true
+    killProcessTree(this.child, 'SIGTERM')
+    if (await this.waitForExit(1000)) return true
+    killProcessTree(this.child, 'SIGKILL')
+    return this.waitForExit(1000)
+  }
+
+  private write(message: JsonObject): void {
+    if (this.exited || !this.child.stdin.writable) throw new Error('codex app-server stdin is closed')
+    this.child.stdin.write(`${JSON.stringify(message)}\n`)
+  }
+
+  private consumeStdout(chunk: string): void {
+    this.stdoutBuffer += chunk
+    const lines = this.stdoutBuffer.split('\n')
+    this.stdoutBuffer = lines.pop() ?? ''
+    for (const line of lines) this.consumeLine(line)
+  }
+
+  private consumeLine(line: string): void {
+    if (!line.trim()) return
+    let message: JsonObject
+    try {
+      const parsed = JSON.parse(line)
+      if (!isObject(parsed)) throw new Error('message is not an object')
+      message = parsed
+    } catch (error) {
+      this.finish(new Error(`invalid JSON from codex app-server: ${safeError(error)}`))
+      void this.terminate()
+      return
+    }
+
+    if (typeof message.id === 'number' && !('method' in message)) {
+      const request = this.pending.get(message.id)
+      if (!request) return
+      this.pending.delete(message.id)
+      clearTimeout(request.timer)
+      if (isObject(message.error)) {
+        request.reject(new CodexAppServerRpcError(
+          typeof message.error.code === 'number' ? message.error.code : -32000,
+          typeof message.error.message === 'string' ? message.error.message : `${request.method} failed`,
+          message.error.data,
+        ))
+      } else {
+        request.resolve(message.result)
+      }
+      return
+    }
+
+    if (typeof message.method !== 'string') return
+    if (typeof message.id === 'number') {
+      this.write({
+        id: message.id,
+        error: { code: -32601, message: `client method not supported: ${message.method}` },
+      })
+      return
+    }
+    const notification = { method: message.method, ...('params' in message ? { params: message.params } : {}) }
+    for (const handler of this.notificationHandlers) {
+      try {
+        handler(notification)
+      } catch {
+        // A consumer callback cannot corrupt the JSONL transport.
+      }
+    }
+  }
+
+  private finish(error?: Error): void {
+    if (this.exited) return
+    this.exited = true
+    for (const request of this.pending.values()) {
+      clearTimeout(request.timer)
+      request.reject(error ?? new Error(`codex app-server exited before '${request.method}' completed`))
+    }
+    this.pending.clear()
+    for (const handler of this.exitHandlers) {
+      try {
+        handler(error)
+      } catch {
+        // Exit observers are best effort; process settlement is already final.
+      }
+    }
+  }
+
+  private async waitForExit(timeoutMs: number): Promise<boolean> {
+    if (this.processExited) return true
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const timeout = new Promise<false>((resolve) => {
+      timer = setTimeout(() => resolve(false), timeoutMs)
+      timer.unref?.()
+    })
+    const exited = this.exitedPromise.then(() => true)
+    const result = await Promise.race([exited, timeout])
+    if (timer) clearTimeout(timer)
+    return result
+  }
+}
+
+function isObject(value: unknown): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function provesThreadLookup(error: unknown): boolean {
+  return error instanceof CodexAppServerRpcError &&
+    error.code !== -32601 &&
+    error.code !== -32602 &&
+    /(?:thread not found|no rollout found)/i.test(error.message)
+}
+
+export async function probeCodexAppServerFork(opts: {
+  readonly command: string
+  readonly cwd: string
+  readonly env: Record<string, string>
+  readonly timeoutMs?: number
+}): Promise<boolean> {
+  const deadlineAt = new Date(Date.now() + (opts.timeoutMs ?? 3000)).toISOString()
+  const client = new CodexAppServerClient(opts)
+  try {
+    await client.initialize(deadlineAt)
+    const [fork, turn] = await Promise.allSettled([
+      client.request('thread/fork', {
+        threadId: '00000000-0000-0000-0000-000000000001',
+        ephemeral: true,
+        excludeTurns: true,
+      }, deadlineAt),
+      client.request('turn/start', {
+        threadId: '00000000-0000-0000-0000-000000000002',
+        input: [{ type: 'text', text: 'capability probe' }],
+      }, deadlineAt),
+    ])
+    return fork.status === 'rejected' && provesThreadLookup(fork.reason) &&
+      turn.status === 'rejected' && provesThreadLookup(turn.reason)
+  } catch {
+    return false
+  } finally {
+    await client.terminate()
+  }
+}

--- a/crabot-agent/src/workers/errors.ts
+++ b/crabot-agent/src/workers/errors.ts
@@ -5,6 +5,7 @@
  */
 
 import type { IncarnationEndReason, InitialInputDisposition, CliControlState, StateChangeReport } from './types'
+import type { QueryFailureCode } from './harness/query-receipt-store'
 
 /** Raised when sendInput is called on an incarnation that has already exited. */
 export class WorkerExitedError extends Error {
@@ -60,5 +61,30 @@ export class WorkerImplUnavailableError extends Error {
   constructor(message: string) {
     super(message)
     this.name = 'WorkerImplUnavailableError'
+  }
+}
+
+/** A query receipt exists, but its synchronous fork establishment contract failed. */
+export class QueryEstablishmentError extends Error {
+  constructor(
+    readonly query_id: string,
+    readonly reason_code: QueryFailureCode,
+    readonly reason: string,
+    readonly certainty: 'not_started' | 'failed' | 'unknown',
+  ) {
+    super(reason)
+    this.name = 'QueryEstablishmentError'
+  }
+}
+
+/** Adapter-level classification used by the harness to preserve the failed establishment phase. */
+export class ForkEstablishmentError extends Error {
+  constructor(
+    readonly stage: 'fork_create' | 'query_submit' | 'timeout',
+    message: string,
+    readonly certainty: 'not_started' | 'failed' | 'unknown' = 'unknown',
+  ) {
+    super(message)
+    this.name = 'ForkEstablishmentError'
   }
 }

--- a/crabot-agent/src/workers/harness/harness.ts
+++ b/crabot-agent/src/workers/harness/harness.ts
@@ -78,10 +78,19 @@ import type {
   CapabilityBundle,
   WorkerCapabilityContext,
   Workspace,
+  SendInputOptions,
+  ForkOptions,
 } from '../types'
 import type { BuiltinRuntimeFactory } from '../builtin/runtime'
 import type { ResolvedPermissions } from '../../types'
-import { CapabilityNotSupportedError, WorkerExitedError, CliInputStallError, WorkerImplUnavailableError } from '../errors'
+import {
+  CapabilityNotSupportedError,
+  WorkerExitedError,
+  CliInputStallError,
+  WorkerImplUnavailableError,
+  ForkEstablishmentError,
+  QueryEstablishmentError,
+} from '../errors'
 import { AsyncMutex } from '../async-mutex'
 import {
   isExecutableIncarnation,
@@ -99,6 +108,7 @@ import {
   type InboxItem,
   type InboxDeliveryResult,
   type InboxSettlement,
+  type InboxSettledResult,
 } from './inbox'
 import { WorkerEventLog, type HarnessEvent, type HarnessEventDelivery, type HarnessEventKind } from './worker-events'
 import { WorkerContextStore, type WorkerContext } from './context-store'
@@ -106,6 +116,20 @@ import { readLegacyTraces } from '../legacy-source-reader.js'
 import { isLegacyContinuationAuth, type LegacyContinuationAuth } from './legacy-continuation-auth.js'
 import { applyStatusTransition, canTransition, isTerminalStatus, reviveTask, taskStatusFromIncarnation } from './task-status'
 import { join, dirname } from 'path'
+import {
+  InputDeliveryStore,
+  type InputDeliveryFailure,
+  type InputDeliveryFailureCode,
+  type SendToWorkerResult,
+  type WorkerInputDeliveryReceipt,
+} from './input-delivery-store'
+import {
+  QueryReceiptStore,
+  type QueryFailure,
+  type QueryFailureCode,
+  type QueryWorkerStartedResult,
+  type WorkerQueryReceipt,
+} from './query-receipt-store'
 
 /** 交接材料里"最近输出尾部"的上限(字符数,近似 4KB,见 protocol-agent-v3 §5.3)。 */
 const HANDOFF_TAIL_MAX_CHARS = 4096
@@ -128,6 +152,104 @@ const HANDOFF_TAIL_MAX_CHARS = 4096
  * 的措辞不同,因为两者读得回来的东西不同,见 processStateChange 里给出提示语的那一处。
  */
 const WAKE_TEXT_MAX_CHARS = 2000
+
+export const INPUT_DELIVERY_TIMEOUT_MS = 5 * 60_000
+export const QUERY_ESTABLISHMENT_TIMEOUT_MS = 30_000
+
+const INPUT_DELIVERY_FAILURE_CODES = new Set<InputDeliveryFailureCode>([
+  'target_unavailable',
+  'task_cancelled',
+  'continuation_failed',
+  'input_surface_timeout',
+  'submission_unconfirmed_timeout',
+  'delivery_attempt_failed',
+  'abandoned_by_control_input',
+  'confirmation_lost_after_restart',
+])
+
+function isInputDeliveryFailureCode(value: string | undefined): value is InputDeliveryFailureCode {
+  return value !== undefined && INPUT_DELIVERY_FAILURE_CODES.has(value as InputDeliveryFailureCode)
+}
+
+function describeInputDeliveryFailure(code: InputDeliveryFailureCode): string {
+  switch (code) {
+    case 'task_cancelled': return 'task was cancelled before this input could be delivered'
+    case 'continuation_failed': return 'worker continuation failed before accepting this input'
+    case 'abandoned_by_control_input': return 'a later control input abandoned the pending composer text'
+    default: return `input delivery failed: ${code}`
+  }
+}
+
+function renderInputDeliveryNotification(receipt: WorkerInputDeliveryReceipt): string {
+  if (receipt.state === 'delivered') {
+    return (
+      `[crabot] 输入 ${receipt.delivery_id} 已确认送达 worker ${receipt.worker_id}。` +
+      `内容预览：${receipt.text_preview || '(空)'}`
+    )
+  }
+  const failure = receipt.failure
+  if (!failure) return `[crabot] 输入 ${receipt.delivery_id} 投递失败，但缺少失败详情。`
+  const guidance = failure.certainty === 'unknown'
+    ? '送达结果未知，禁止盲目重发；请先检查 worker 当前输出和输入框现场。'
+    : '已确认未送达，可以根据任务当前状态决定是否重试。'
+  return (
+    `[crabot] 输入 ${receipt.delivery_id} 投递失败：${failure.reason} ` +
+    `(reason_code=${failure.reason_code}, certainty=${failure.certainty})。${guidance}` +
+    `内容预览：${receipt.text_preview || '(空)'}`
+  )
+}
+
+function renderQueryNotification(receipt: WorkerQueryReceipt): string {
+  if (receipt.state === 'completed') {
+    return (
+      `[crabot] 侧问 ${receipt.query_id} 已完成` +
+      `${receipt.fork_seq === undefined ? '' : `（worker ${receipt.worker_id}#${receipt.fork_seq}）`}。` +
+      `问题预览：${receipt.question_preview || '(空)'}`
+    )
+  }
+  const failure = receipt.failure
+  if (!failure) return `[crabot] 侧问 ${receipt.query_id} 失败，但缺少失败详情。`
+  return (
+    `[crabot] 侧问 ${receipt.query_id} 失败：${failure.reason} ` +
+    `(reason_code=${failure.reason_code}, certainty=${failure.certainty})。` +
+    `${failure.certainty === 'unknown' ? '执行结果未知，禁止自动重跑。' : ''}` +
+    `问题预览：${receipt.question_preview || '(空)'}`
+  )
+}
+
+function queryFailureCode(error: unknown): QueryFailureCode {
+  if (error instanceof ForkEstablishmentError) {
+    if (error.stage === 'query_submit') return 'query_submit_failed'
+    if (error.stage === 'timeout') return 'fork_establishment_timeout'
+  }
+  return 'fork_create_failed'
+}
+
+function queryFailureCertainty(error: unknown): QueryFailure['certainty'] {
+  return error instanceof ForkEstablishmentError ? error.certainty : 'unknown'
+}
+
+function sanitizeOperationFailureReason(
+  error: unknown,
+  redact: ((text: string) => string) | undefined,
+  sensitiveText: string | undefined,
+  fallback: string,
+): string {
+  let message = (error instanceof Error ? error.message : String(error)).replace(/\s+/g, ' ').trim()
+  const normalizedSensitive = sensitiveText?.replace(/\s+/g, ' ').trim()
+  if (normalizedSensitive) message = message.split(normalizedSensitive).join('<message>')
+  try {
+    if (redact) message = redact(message)
+  } catch {
+    return fallback
+  }
+  return message
+    .replace(/Bearer\s+\S+/gi, 'Bearer <redacted>')
+    .replace(/(?:[A-Za-z]:\\|\/)[^\s"'`]+/g, '<path>')
+    .replace(/\b(?:sk|rk|pk)-[A-Za-z0-9_-]{8,}\b/g, '<redacted>')
+    .replace(/\b[A-Za-z0-9_+/=-]{32,}\b/g, '<redacted>')
+    .slice(0, 1000) || fallback
+}
 
 /**
  * 唤醒事件 `detail.summary` 的上限(字符数)。比 `detail.text` 宽一倍,两条依据:
@@ -403,6 +525,13 @@ export interface HarnessDeps {
    * 在锁内等它就是自锁。返回 `void` 的实现(P3 桩、既有测试)行为逐字不变。
    */
   readonly onEvent?: (e: HarnessEvent) => void | HarnessEventDelivery | Promise<HarnessEventDelivery | void>
+  /** Durable input/query terminal notification routed to the receipt's fixed Manager owner. */
+  readonly onOperationNotification?: (
+    managerKey: ManagerKey,
+    event: HarnessEvent,
+  ) => void | HarnessEventDelivery | Promise<HarnessEventDelivery | void>
+  /** Removes runtime credentials before an operation failure reason is persisted or returned. */
+  readonly redactFailureReason?: (text: string) => string
   /** provision 素材(P3 可返回空集)，必须按 worker 固定的权限快照生成。 */
   readonly capabilityBundle?: (ctx: WorkerCapabilityContext) => Promise<CapabilityBundle>
   /**
@@ -468,6 +597,15 @@ export interface SpawnWorkerParams {
   readonly builtin?: SpawnSpec['builtin']
 }
 
+export interface HarnessSendToWorkerOptions {
+  readonly raw?: boolean
+  readonly managerKey?: ManagerKey
+  readonly onSettled?: InboxItem['onSettled']
+  readonly dedupeKey?: string
+  readonly onDeduplicated?: () => void
+  readonly legacyContinuationAuth?: LegacyContinuationAuth
+}
+
 /**
  * reconcileOnStartup 的巡检结果(protocol-agent-v3 §12,替代 admin 的一刀切自愈)。三个
  * 桶各装 worker_id,供 P4 manager 决定唤醒哪些 monitor:
@@ -512,7 +650,7 @@ type ContinuationRetry = {
   readonly endedReason?: IncarnationEndReason
 }
 
-type ContinuationDelivery = InboxSettlement | InboxDeliveryResult | ContinuationRetry
+type ContinuationDelivery = InboxSettlement | InboxDeliveryResult | InboxSettledResult | ContinuationRetry
 
 function isContinuationRetry(delivery: ContinuationDelivery): delivery is ContinuationRetry {
   return typeof delivery === 'object' && 'kind' in delivery && delivery.kind === 'retry_continuation'
@@ -557,6 +695,13 @@ function continuationDelivery(
 export class WorkerHarness {
   private readonly pendingBgNotifications = new Map<string, number>()
   private readonly contextStore: WorkerContextStore
+  private readonly inputDeliveryStore: InputDeliveryStore
+  private readonly queryReceiptStore: QueryReceiptStore
+  private readonly inputDeliveryControllers = new Map<string, AbortController>()
+  private readonly pendingQueryStateChanges = new Map<
+    string,
+    { h: IncarnationHandle; state: WorkerContractState; report?: StateChangeReport }
+  >()
 
   /**
    * Marks a shell-exit notification before its async rendering starts.  This
@@ -591,6 +736,8 @@ export class WorkerHarness {
 
   constructor(private readonly deps: HarnessDeps) {
     this.contextStore = new WorkerContextStore(deps.workersDir)
+    this.inputDeliveryStore = new InputDeliveryStore(deps.workersDir)
+    this.queryReceiptStore = new QueryReceiptStore(deps.workersDir)
   }
 
   private inputOwnershipRevision(workerId: string): number {
@@ -836,16 +983,17 @@ export class WorkerHarness {
   async sendToWorker(
     workerId: string,
     text: string,
-    opts?: {
-      raw?: boolean
-      onSettled?: InboxItem['onSettled']
-      dedupeKey?: string
-      onDeduplicated?: () => void
-      legacyContinuationAuth?: LegacyContinuationAuth
-    },
-  ): Promise<void> {
+    opts: HarnessSendToWorkerOptions & { readonly managerKey: ManagerKey },
+  ): Promise<SendToWorkerResult>
+  async sendToWorker(workerId: string, text: string, opts?: HarnessSendToWorkerOptions): Promise<void>
+  async sendToWorker(
+    workerId: string,
+    text: string,
+    opts?: HarnessSendToWorkerOptions,
+  ): Promise<SendToWorkerResult | void> {
     const inbox = this.getInbox(workerId)
     let enqueued = true
+    let receipt: WorkerInputDeliveryReceipt | undefined
 
     // "读台账状态 → 判断 cancelled/化身 → 入信箱"在同一临界区完成,不允许 check-then-act 跨 await。
     await this.withLock(workerId, async () => {
@@ -853,20 +1001,207 @@ export class WorkerHarness {
       if (!found) throw new WorkerNotFoundError(workerId)
       if (found.worker.task.status === 'cancelled') throw new TaskCancelledError(workerId)
       requireMainlineIncarnation(found.worker)
+
+      if (opts?.managerKey) {
+        const createdAt = this.deps.now()
+        const deliveryId = randomUUID()
+        try {
+          receipt = await this.inputDeliveryStore.create({
+            delivery_id: deliveryId,
+            worker_id: workerId,
+            manager_key: opts.managerKey,
+            raw: opts.raw ?? false,
+            text_preview: text,
+            created_at: createdAt,
+            updated_at: createdAt,
+            deadline_at: new Date(Date.parse(createdAt) + INPUT_DELIVERY_TIMEOUT_MS).toISOString(),
+            state: 'pending',
+            phase: 'queued',
+            manager_notification: { status: 'not_required' },
+          })
+        } catch (error) {
+          throw new Error(`delivery receipt unavailable: ${sanitizeOperationFailureReason(
+            error,
+            this.deps.redactFailureReason,
+            text,
+            'receipt store failed',
+          )}`)
+        }
+        this.inputDeliveryControllers.set(deliveryId, new AbortController())
+      }
+
+      const durableReceipt = receipt
       const item: InboxItem = {
         text,
         raw: opts?.raw ?? false,
         enqueued_at: this.deps.now(),
         allow_terminal_continuation: true,
-        ...(opts?.onSettled ? { onSettled: opts.onSettled } : {}),
+        ...(durableReceipt
+          ? {
+              delivery_id: durableReceipt.delivery_id,
+              onPending: (reason: InboxDeliveryResult['reason']) =>
+                this.inputDeliveryStore.updatePendingPhase(
+                  workerId,
+                  durableReceipt.delivery_id,
+                  reason === 'input_pending' ? 'pending_in_ui' : 'waiting_for_safe_input',
+                  this.deps.now(),
+                ).then(() => undefined),
+              shouldDeliver: async () =>
+                (await this.inputDeliveryStore.get(workerId, durableReceipt.delivery_id))?.state === 'pending',
+              onSettled: async (settlement, detail) => {
+                await this.settleDurableInput(durableReceipt, text, settlement, detail)
+                await opts?.onSettled?.(settlement, detail)
+              },
+            }
+          : opts?.onSettled ? { onSettled: opts.onSettled } : {}),
         ...(opts?.dedupeKey ? { dedupe_key: opts.dedupeKey } : {}),
         ...(opts?.legacyContinuationAuth ? { legacy_continuation_auth: opts.legacyContinuationAuth } : {}),
       }
-      enqueued = opts?.dedupeKey ? inbox.enqueueUnique(item) : (inbox.enqueue(item), true)
+      enqueued = opts?.dedupeKey && !durableReceipt ? inbox.enqueueUnique(item) : (inbox.enqueue(item), true)
     })
 
     if (!enqueued) opts?.onDeduplicated?.()
-    await this.flushInbox(workerId)
+    try {
+      await this.flushInbox(workerId)
+    } catch (error) {
+      if (!receipt) throw error
+      await this.failDurableInputAttempt(receipt, inbox, error, text)
+    }
+
+    if (!receipt) return
+    let current: WorkerInputDeliveryReceipt
+    try {
+      current = await this.inputDeliveryStore.readForToolResult(
+        workerId,
+        receipt.delivery_id,
+        this.deps.now(),
+      )
+    } catch (error) {
+      this.inputDeliveryControllers.get(receipt.delivery_id)?.abort()
+      try {
+        await this.failDurableInputAttempt(receipt, inbox, error, text)
+      } catch (settlementError) {
+        throw new Error(`delivery receipt unavailable after acceptance: ${sanitizeOperationFailureReason(
+          settlementError,
+          this.deps.redactFailureReason,
+          text,
+          'receipt store failed',
+        )}`)
+      }
+      const settled = await this.inputDeliveryStore.get(workerId, receipt.delivery_id)
+      if (!settled) throw error
+      current = settled
+    }
+    return this.toSendToWorkerResult(current)
+  }
+
+  private async settleDurableInput(
+    receipt: WorkerInputDeliveryReceipt,
+    text: string,
+    settlement: InboxSettlement,
+    detail?: { readonly seq?: number; readonly reason?: string; readonly certainty?: 'not_delivered' | 'unknown' },
+  ): Promise<void> {
+    this.inputDeliveryControllers.delete(receipt.delivery_id)
+    if (settlement === 'delivered') {
+      await this.inputDeliveryStore.settleDelivered(receipt.worker_id, receipt.delivery_id, this.deps.now())
+      await this.appendAuditEvent(receipt.worker_id, detail?.seq ?? 0, 'input_sent', {
+        delivery_id: receipt.delivery_id,
+        text_len: text.length,
+      })
+      return
+    }
+
+    const reasonCode = isInputDeliveryFailureCode(detail?.reason)
+      ? detail.reason
+      : 'delivery_attempt_failed'
+    const failure: InputDeliveryFailure = {
+      reason_code: reasonCode,
+      reason: describeInputDeliveryFailure(reasonCode),
+      certainty: detail?.certainty ?? 'unknown',
+    }
+    await this.inputDeliveryStore.settleFailed(receipt.worker_id, receipt.delivery_id, failure, this.deps.now())
+    await this.appendAuditEvent(receipt.worker_id, detail?.seq ?? 0, 'input_delivery_failed', {
+      delivery_id: receipt.delivery_id,
+      ...failure,
+    })
+  }
+
+  private async failDurableInputAttempt(
+    receipt: WorkerInputDeliveryReceipt,
+    inbox: WorkerInbox,
+    error: unknown,
+    text: string,
+  ): Promise<void> {
+    const cancellation = await inbox.cancelDelivery(receipt.delivery_id)
+    const current = await this.inputDeliveryStore.get(receipt.worker_id, receipt.delivery_id)
+    if (!current || current.state !== 'pending') return
+
+    const reasonCode: InputDeliveryFailureCode = current.phase === 'continuing'
+      ? 'continuation_failed'
+      : 'delivery_attempt_failed'
+    const reportedCertainty = (error as { certainty?: unknown })?.certainty
+    let certainty: InputDeliveryFailure['certainty'] = 'unknown'
+    if (reportedCertainty === 'not_delivered' || reportedCertainty === 'unknown') {
+      certainty = reportedCertainty
+    } else if (cancellation === 'cancelled' && current.phase !== 'attempting') {
+      certainty = 'not_delivered'
+    }
+    const failure: InputDeliveryFailure = {
+      reason_code: reasonCode,
+      reason: sanitizeOperationFailureReason(
+        error,
+        this.deps.redactFailureReason,
+        text,
+        'input delivery attempt failed',
+      ),
+      certainty,
+    }
+    this.inputDeliveryControllers.delete(receipt.delivery_id)
+    await this.inputDeliveryStore.settleFailed(receipt.worker_id, receipt.delivery_id, failure, this.deps.now())
+    const found = await this.deps.ledger.findWorker(receipt.worker_id)
+    await this.appendAuditEvent(
+      receipt.worker_id,
+      found ? requireMainlineIncarnation(found.worker).seq : 0,
+      'input_delivery_failed',
+      { delivery_id: receipt.delivery_id, ...failure },
+    )
+  }
+
+  private toSendToWorkerResult(receipt: WorkerInputDeliveryReceipt): SendToWorkerResult {
+    if (receipt.state === 'delivered') {
+      return { status: 'delivered', delivery_id: receipt.delivery_id, worker_id: receipt.worker_id }
+    }
+    if (receipt.state === 'failed') {
+      if (!receipt.failure) throw new Error(`failed delivery ${receipt.delivery_id} has no failure detail`)
+      return {
+        status: 'failed',
+        delivery_id: receipt.delivery_id,
+        worker_id: receipt.worker_id,
+        ...receipt.failure,
+      }
+    }
+    return {
+      status: 'pending',
+      delivery_id: receipt.delivery_id,
+      worker_id: receipt.worker_id,
+      pending_reason: receipt.phase === 'queued' || receipt.phase === 'waiting_for_safe_input'
+        ? 'waiting_for_safe_input'
+        : 'submission_unconfirmed',
+      deadline_at: receipt.deadline_at,
+    }
+  }
+
+  private async inputAttemptOptions(
+    workerId: string,
+    deliveryId: string,
+  ): Promise<Pick<SendInputOptions, 'delivery_id' | 'deadline_at' | 'signal'>> {
+    const receipt = await this.inputDeliveryStore.get(workerId, deliveryId)
+    if (!receipt) throw new Error(`delivery receipt not found: ${deliveryId}`)
+    return {
+      delivery_id: deliveryId,
+      deadline_at: receipt.deadline_at,
+      signal: this.inputDeliveryControllers.get(deliveryId)?.signal,
+    }
   }
 
   /** Queue an untrusted wake only while the task is non-terminal; never revive it later. */
@@ -894,12 +1229,13 @@ export class WorkerHarness {
     handle: IncarnationHandle,
     text: string,
     raw: boolean,
+    delivery?: Pick<SendInputOptions, 'delivery_id' | 'deadline_at' | 'signal'>,
   ): Promise<InputAttempt> {
     const revisionKey = `${handle.worker_id}#${handle.impl}#${handle.seq}`
     const stateChangeRevision = this.stateChangeRevisions.get(revisionKey) ?? 0
     const inputOwnershipRevision = this.inputOwnershipRevision(handle.worker_id)
     try {
-      await adapter.sendInput(handle, text, { raw })
+      await adapter.sendInput(handle, text, { raw, ...delivery })
     } catch (error) {
       if (error instanceof WorkerExitedError) {
         return { kind: 'exited', endedReason: error.ended_reason }
@@ -945,7 +1281,8 @@ export class WorkerHarness {
     text: string,
     raw: boolean,
     attempt: SettledInputAttempt,
-  ): Promise<InboxSettlement | InboxDeliveryResult> {
+    item?: InboxItem,
+  ): Promise<InboxSettlement | InboxDeliveryResult | InboxSettledResult> {
     if (attempt.kind === 'stalled') {
       if (attempt.delivery.isCurrent?.()) {
         await this.recordCliInputResult(
@@ -960,7 +1297,13 @@ export class WorkerHarness {
 
     if (raw) {
       const inbox = this.getInbox(workerId)
-      await inbox.settleConsumed(rawAbandonsComposer(text) ? 'dead_letter' : 'delivered')
+      const abandonsComposer = rawAbandonsComposer(text)
+      await inbox.settleConsumed(
+        abandonsComposer ? 'dead_letter' : 'delivered',
+        abandonsComposer
+          ? { seq: attempt.handle.seq, reason: 'abandoned_by_control_input', certainty: 'not_delivered' }
+          : { seq: attempt.handle.seq },
+      )
       inbox.release('waiting_action')
       inbox.release('input_pending')
     }
@@ -973,6 +1316,9 @@ export class WorkerHarness {
         undefined,
         attempt.expectedStateChangeRevision,
       )
+    }
+    if (item?.delivery_id) {
+      return { action: 'settled', settlement: 'delivered', detail: { seq: attempt.handle.seq } }
     }
     await this.appendEvent(workerId, attempt.handle.seq, 'input_sent', { text_len: text.length })
     return 'delivered'
@@ -992,6 +1338,9 @@ export class WorkerHarness {
 
       if (isLegacyIncarnation(incarnation)) {
         if (item.allow_terminal_continuation === false) return 'delivered'
+        if (item.delivery_id) {
+          await this.inputDeliveryStore.updatePendingPhase(workerId, item.delivery_id, 'continuing', this.deps.now())
+        }
         const delivery = await this.continueLegacyWorker(workerId, item)
         if (isContinuationRetry(delivery)) {
           return this.continueTerminalWorker(
@@ -1001,6 +1350,7 @@ export class WorkerHarness {
             delivery.seq,
             item.raw,
             delivery.endedReason,
+            item,
           )
         }
         return delivery
@@ -1008,7 +1358,10 @@ export class WorkerHarness {
 
       if (incarnation.state === 'exited') {
         if (item.allow_terminal_continuation === false) return 'delivered'
-        return this.continueTerminalWorker(workerId, item.text, incarnation.impl, incarnation.seq, item.raw)
+        if (item.delivery_id) {
+          await this.inputDeliveryStore.updatePendingPhase(workerId, item.delivery_id, 'continuing', this.deps.now())
+        }
+        return this.continueTerminalWorker(workerId, item.text, incarnation.impl, incarnation.seq, item.raw, undefined, item)
       }
 
       const adapter = this.deps.adapters.get(incarnation.impl)
@@ -1021,9 +1374,26 @@ export class WorkerHarness {
         impl: incarnation.impl,
         session_ref: incarnation.session_ref,
       }
-      const attempt = await this.attemptInput(adapter, handle, item.text, item.raw)
+      let deliveryOptions: Pick<SendInputOptions, 'delivery_id' | 'deadline_at' | 'signal'> | undefined
+      if (item.delivery_id) {
+        const current = await this.inputDeliveryStore.updatePendingPhase(
+          workerId,
+          item.delivery_id,
+          'attempting',
+          this.deps.now(),
+        )
+        deliveryOptions = {
+          delivery_id: item.delivery_id,
+          deadline_at: current.deadline_at,
+          signal: this.inputDeliveryControllers.get(item.delivery_id)?.signal,
+        }
+      }
+      const attempt = await this.attemptInput(adapter, handle, item.text, item.raw, deliveryOptions)
       if (attempt.kind === 'exited') {
         if (item.allow_terminal_continuation === false) return 'delivered'
+        if (item.delivery_id) {
+          await this.inputDeliveryStore.updatePendingPhase(workerId, item.delivery_id, 'continuing', this.deps.now())
+        }
         return this.continueTerminalWorker(
           workerId,
           item.text,
@@ -1031,9 +1401,10 @@ export class WorkerHarness {
           incarnation.seq,
           item.raw,
           attempt.endedReason,
+          item,
         )
       }
-      return this.settleInputAttempt(workerId, item.text, item.raw, attempt)
+      return this.settleInputAttempt(workerId, item.text, item.raw, attempt, item)
     })
   }
 
@@ -1051,7 +1422,13 @@ export class WorkerHarness {
           reason: 'task_cancelled',
           text_len: item.text.length,
         })
-        return 'dead_letter'
+        return item.delivery_id
+          ? {
+              action: 'settled',
+              settlement: 'dead_letter',
+              detail: { seq: mainlineIncarnation(worker)?.seq ?? 0, reason: 'task_cancelled', certainty: 'not_delivered' },
+            }
+          : 'dead_letter'
       }
 
       const legacy = requireMainlineIncarnation(worker)
@@ -1076,7 +1453,13 @@ export class WorkerHarness {
           reason: 'legacy_continuation_authorization_invalid',
           text_len: item.text.length,
         })
-        return 'dead_letter'
+        return item.delivery_id
+          ? {
+              action: 'settled',
+              settlement: 'dead_letter',
+              detail: { seq: legacy.seq, reason: 'continuation_failed', certainty: 'not_delivered' },
+            }
+          : 'dead_letter'
       }
 
       // Source material is read-only. No legacy adapter, resume/checkpoint replay, or
@@ -1363,11 +1746,12 @@ export class WorkerHarness {
      * `ended_reason` 真值;调用方是读台账 state==='exited' 走到这里的则不带(那种情形下
      * 台账已经有终态记录,reviveIncarnation 的回填段本就不会触发)。
      */
-    sourceEndReason?: IncarnationEndReason
-  ): Promise<InboxSettlement | InboxDeliveryResult> {
+    sourceEndReason?: IncarnationEndReason,
+    item?: InboxItem,
+  ): Promise<InboxSettlement | InboxDeliveryResult | InboxSettledResult> {
     const result = await this.withLock(
       workerId,
-      async (): Promise<InboxSettlement | InboxDeliveryResult | { attempt: SettledInputAttempt }> => {
+      async (): Promise<InboxSettlement | InboxDeliveryResult | InboxSettledResult | { attempt: SettledInputAttempt }> => {
       let curImpl = sourceImpl
       let curSeq = sourceSeq
       // 与 (curImpl, curSeq) 同步前进:每次改换源化身,这个原因也要跟着换成新源的,
@@ -1393,7 +1777,13 @@ export class WorkerHarness {
             reason: 'task_cancelled',
             text_len: text.length,
           })
-          return 'dead_letter'
+          return item?.delivery_id
+            ? {
+                action: 'settled',
+                settlement: 'dead_letter',
+                detail: { seq: curSeq, reason: 'task_cancelled', certainty: 'not_delivered' },
+              }
+            : 'dead_letter'
         }
 
         const mainline = requireMainlineIncarnation(worker)
@@ -1425,7 +1815,13 @@ export class WorkerHarness {
             impl: mainline.impl,
             session_ref: mainline.session_ref,
           }
-          const attempt = await this.attemptInput(adapter, handle, text, raw)
+          const attempt = await this.attemptInput(
+            adapter,
+            handle,
+            text,
+            raw,
+            item?.delivery_id ? await this.inputAttemptOptions(workerId, item.delivery_id) : undefined,
+          )
           if (attempt.kind === 'exited') {
             // adapter 侧权威判定这个"看起来存活"的新主线其实也已经终态(台账的异步状态
             // 回调还没追上)——同样不出锁,把它当作新的源头回到循环顶部转接续。
@@ -1506,8 +1902,16 @@ export class WorkerHarness {
           `for worker ${workerId}; mainline kept changing/exiting faster than this delivery could settle on a source`
       )
     })
-    if (typeof result === 'string' || !('attempt' in result)) return result
-    return this.settleInputAttempt(workerId, text, raw, result.attempt)
+    if (typeof result === 'object' && 'attempt' in result) {
+      return this.settleInputAttempt(workerId, text, raw, result.attempt, item)
+    }
+    if (!item?.delivery_id || typeof result !== 'string' || result !== 'delivered') return result
+    const found = await this.deps.ledger.findWorker(workerId)
+    return {
+      action: 'settled',
+      settlement: 'delivered',
+      detail: { seq: found ? requireMainlineIncarnation(found.worker).seq : sourceSeq },
+    }
   }
 
   /** capabilities().revive===true 分支:adapter.resume 拉起新化身,session 满保真接续。 */
@@ -1898,6 +2302,270 @@ export class WorkerHarness {
     return this.getEventLog(workerId).readAll()
   }
 
+  /** Restart recovery is fail-closed: pending input is never replayed. */
+  async reconcileInputDeliveriesOnStartup(): Promise<void> {
+    for (const receipt of await this.inputDeliveryStore.listPendingDeliveries()) {
+      this.inputDeliveryControllers.get(receipt.delivery_id)?.abort()
+      this.inputDeliveryControllers.delete(receipt.delivery_id)
+      await this.getInbox(receipt.worker_id).cancelDelivery(receipt.delivery_id)
+      const failure: InputDeliveryFailure = {
+        reason_code: 'confirmation_lost_after_restart',
+        reason: 'Agent restarted before input acceptance could be confirmed',
+        certainty: 'unknown',
+      }
+      await this.settlePendingInputFailure(receipt, failure)
+    }
+    await this.deliverInputOperationNotifications()
+  }
+
+  /** Restart recovery never re-runs a side query; every in-flight receipt becomes explicit unknown. */
+  async reconcileQueryReceiptsOnStartup(): Promise<void> {
+    for (const receipt of await this.queryReceiptStore.listInFlight()) {
+      const found = await this.deps.ledger.findWorker(receipt.worker_id)
+      const incarnation = found?.worker.incarnations.find((item) => item.query_id === receipt.query_id)
+
+      if (incarnation?.state === 'exited' && incarnation.ended_reason === 'completed') {
+        if (receipt.state === 'starting') {
+          await this.queryReceiptStore.markRunning(
+            receipt.worker_id,
+            receipt.query_id,
+            incarnation.seq,
+            this.deps.now(),
+          )
+        }
+        await this.queryReceiptStore.settleCompleted(
+          receipt.worker_id,
+          receipt.query_id,
+          this.deps.now(),
+        )
+        await this.appendAuditEvent(receipt.worker_id, incarnation.seq, 'query_completed', {
+          query_id: receipt.query_id,
+          fork_seq: incarnation.seq,
+        })
+        continue
+      }
+
+      const executionWasEstablished = receipt.state === 'running' || incarnation !== undefined
+      const executionEnded = incarnation?.state === 'exited'
+      let failure: QueryFailure
+      if (executionEnded) {
+        failure = {
+          reason_code: 'query_execution_failed',
+          reason: incarnation.ended_reason
+            ? `query fork exited with reason '${incarnation.ended_reason}'`
+            : 'query fork exited without a completion reason',
+          phase: 'execution',
+          certainty: 'failed',
+        }
+      } else if (executionWasEstablished) {
+        failure = {
+          reason_code: 'query_execution_lost_after_restart',
+          reason: 'Agent restarted before query execution completion could be confirmed',
+          phase: 'execution',
+          certainty: 'unknown',
+        }
+      } else {
+        failure = {
+          reason_code: 'fork_establishment_lost_after_restart',
+          reason: 'Agent restarted before fork establishment could be confirmed',
+          phase: 'establishment',
+          certainty: 'unknown',
+        }
+      }
+      await this.queryReceiptStore.settleFailed(
+        receipt.worker_id,
+        receipt.query_id,
+        failure,
+        this.deps.now(),
+      )
+      await this.appendAuditEvent(
+        receipt.worker_id,
+        incarnation?.seq ?? 0,
+        'query_failed',
+        {
+          query_id: receipt.query_id,
+          ...(incarnation ? { fork_seq: incarnation.seq } : {}),
+          ...failure,
+        },
+      )
+      if (incarnation && incarnation.state !== 'exited' && isExecutableIncarnation(incarnation)) {
+        const adapter = this.deps.adapters.get(incarnation.impl)
+        if (adapter) {
+          try {
+            await adapter.kill({
+              worker_id: receipt.worker_id,
+              seq: incarnation.seq,
+              impl: incarnation.impl,
+              session_ref: incarnation.session_ref,
+              query_id: receipt.query_id,
+            })
+          } catch (error) {
+            console.error(`[WorkerHarness] failed to stop recovered query ${receipt.query_id}:`, error)
+          }
+        }
+      }
+    }
+    await this.deliverQueryOperationNotifications()
+  }
+
+  private async reconcileInputDeliveryOperations(): Promise<void> {
+    const nowMs = Date.parse(this.deps.now())
+    for (const receipt of await this.inputDeliveryStore.listPendingDeliveries()) {
+      if (Date.parse(receipt.deadline_at) > nowMs) continue
+      this.inputDeliveryControllers.get(receipt.delivery_id)?.abort()
+      const cancellation = await this.getInbox(receipt.worker_id).cancelDelivery(receipt.delivery_id)
+      const current = await this.inputDeliveryStore.get(receipt.worker_id, receipt.delivery_id)
+      if (!current || current.state !== 'pending') continue
+
+      const safelyWithdrawn = cancellation === 'cancelled'
+      const failure: InputDeliveryFailure = safelyWithdrawn
+        ? {
+            reason_code: 'input_surface_timeout',
+            reason: 'input did not reach a safe input surface before the 5 minute deadline',
+            certainty: 'not_delivered',
+          }
+        : {
+            reason_code: 'submission_unconfirmed_timeout',
+            reason: 'input acceptance could not be confirmed before the 5 minute deadline',
+            certainty: 'unknown',
+          }
+      this.inputDeliveryControllers.delete(receipt.delivery_id)
+      await this.settlePendingInputFailure(current, failure)
+    }
+    await this.deliverInputOperationNotifications()
+  }
+
+  private async settlePendingInputFailure(
+    receipt: WorkerInputDeliveryReceipt,
+    failure: InputDeliveryFailure,
+  ): Promise<void> {
+    const settled = await this.inputDeliveryStore.settleFailed(
+      receipt.worker_id,
+      receipt.delivery_id,
+      failure,
+      this.deps.now(),
+    )
+    const found = await this.deps.ledger.findWorker(receipt.worker_id)
+    const seq = found ? requireMainlineIncarnation(found.worker).seq : 0
+    await this.appendAuditEvent(receipt.worker_id, seq, 'input_delivery_failed', {
+      delivery_id: receipt.delivery_id,
+      ...settled.failure,
+    })
+  }
+
+  private async deliverInputOperationNotifications(): Promise<void> {
+    if (!this.deps.onOperationNotification) return
+    for (const receipt of await this.inputDeliveryStore.listPendingNotifications()) {
+      const found = await this.deps.ledger.findWorker(receipt.worker_id)
+      const seq = found ? requireMainlineIncarnation(found.worker).seq : 0
+      const event = this.buildEvent(
+        receipt.worker_id,
+        seq,
+        receipt.state === 'delivered' ? 'input_sent' : 'input_delivery_failed',
+        {
+          delivery_id: receipt.delivery_id,
+          text_preview: receipt.text_preview,
+          ...(receipt.failure ?? {}),
+          text: renderInputDeliveryNotification(receipt),
+        },
+      )
+      try {
+        const delivery = await this.deps.onOperationNotification(receipt.manager_key, event)
+        if (delivery?.consumed === true) {
+          await this.inputDeliveryStore.markNotificationConsumed(
+            receipt.worker_id,
+            receipt.delivery_id,
+            this.deps.now(),
+          )
+        }
+      } catch (error) {
+        console.error(
+          `[WorkerHarness] input delivery notification failed for ${receipt.delivery_id}:`,
+          error,
+        )
+      }
+    }
+  }
+
+  private async deliverQueryOperationNotifications(): Promise<void> {
+    if (!this.deps.onOperationNotification) return
+    for (const receipt of await this.queryReceiptStore.listPendingNotifications()) {
+      const event = this.buildEvent(
+        receipt.worker_id,
+        receipt.fork_seq ?? 0,
+        receipt.state === 'completed' ? 'query_completed' : 'query_failed',
+        {
+          query_id: receipt.query_id,
+          ...(receipt.fork_seq === undefined ? {} : { fork_seq: receipt.fork_seq }),
+          question_preview: receipt.question_preview,
+          ...(receipt.failure ?? {}),
+          text: renderQueryNotification(receipt),
+        },
+      )
+      try {
+        const delivery = await this.deps.onOperationNotification(receipt.manager_key, event)
+        if (delivery?.consumed === true) {
+          await this.queryReceiptStore.markNotificationConsumed(
+            receipt.worker_id,
+            receipt.query_id,
+            this.deps.now(),
+          )
+        }
+      } catch (error) {
+        console.error(`[WorkerHarness] query notification failed for ${receipt.query_id}:`, error)
+      }
+    }
+  }
+
+  /** A transient settlement write must not leave a synchronous query receipt starting forever. */
+  private async reconcileQueryEstablishmentOperations(): Promise<void> {
+    const nowMs = Date.parse(this.deps.now())
+    for (const receipt of await this.queryReceiptStore.listInFlight()) {
+      if (receipt.state !== 'starting' || Date.parse(receipt.establishment_deadline_at) > nowMs) continue
+      const failure: QueryFailure = {
+        reason_code: 'fork_establishment_timeout',
+        reason: 'fork establishment could not be committed before the 30 second deadline',
+        phase: 'establishment',
+        certainty: 'unknown',
+      }
+      try {
+        await this.queryReceiptStore.settleFailed(
+          receipt.worker_id,
+          receipt.query_id,
+          failure,
+          this.deps.now(),
+        )
+      } catch (error) {
+        const current = await this.queryReceiptStore.get(receipt.worker_id, receipt.query_id)
+        if (current?.state === 'completed' || current?.state === 'failed') continue
+        throw error
+      }
+      const found = await this.deps.ledger.findWorker(receipt.worker_id)
+      const incarnation = found?.worker.incarnations.find((item) => item.query_id === receipt.query_id)
+      await this.appendAuditEvent(receipt.worker_id, incarnation?.seq ?? 0, 'query_failed', {
+        query_id: receipt.query_id,
+        ...(incarnation ? { fork_seq: incarnation.seq } : {}),
+        ...failure,
+      })
+      if (incarnation && incarnation.state !== 'exited' && isExecutableIncarnation(incarnation)) {
+        const adapter = this.deps.adapters.get(incarnation.impl)
+        if (adapter) {
+          try {
+            await adapter.kill({
+              worker_id: receipt.worker_id,
+              seq: incarnation.seq,
+              impl: incarnation.impl,
+              session_ref: incarnation.session_ref,
+              query_id: receipt.query_id,
+            })
+          } catch (error) {
+            console.error(`[WorkerHarness] failed to stop expired query ${receipt.query_id}:`, error)
+          }
+        }
+      }
+    }
+  }
+
   /**
    * 崩溃恢复对账(protocol-agent-v3 §12,替代 admin 的一刀切自愈)。agent 进程重启后调用
    * 一次:巡检台账里所有非终态 worker 的主线化身,凭 adapter.state() 判定它到底是"进程
@@ -2037,6 +2705,9 @@ export class WorkerHarness {
     if (this.sweepInFlight) return
     this.sweepInFlight = true
     try {
+      await this.reconcileInputDeliveryOperations()
+      await this.reconcileQueryEstablishmentOperations()
+      await this.deliverQueryOperationNotifications()
       const nowMs = Date.parse(this.deps.now())
       const all = await this.deps.ledger.listAllWorkers()
       const reports: Array<Promise<void>> = []
@@ -2377,7 +3048,11 @@ export class WorkerHarness {
           text_len: item.text.length,
         })
         try {
-          await item.onSettled?.('dead_letter')
+          await item.onSettled?.('dead_letter', {
+            seq: incarnation.seq,
+            reason: 'task_cancelled',
+            certainty: 'unknown',
+          })
         } catch (error) {
           console.warn(`[WorkerHarness] dead-letter settlement failed for ${workerId}:`, error)
         }
@@ -2386,177 +3061,307 @@ export class WorkerHarness {
   }
 
   /**
-   * P4 Task 4 收口(review 实证 A):adapter.fork 挪出 per-worker 锁,范式对齐 sendToWorker
-   * 的 adapter.sendInput(见文件头"慢调用是否在锁内")。三段式:
+   * 同步建立侧问：锁内创建 receipt/捕获发起时主线，锁外等待 adapter 建立 fork 与接受首问，
+   * 再锁内按 query_id 提交 fork ledger + running receipt。回答生成不在这次调用里等待。
    *
-   *   1. 锁内"判定段":读台账、定位主线化身、校验 adapter 存在 + capabilities().fork、
-   *      构造 fork 请求所需的 IncarnationRef——不含 adapter.fork 调用,失败(worker 不存在/
-   *      无 adapter/不支持 fork)在这段原地 appendEvent('query_failed') 后 rethrow(见下方
-   *      "失败留痕"一节)。
-   *   2. 锁外"慢调用段":`await adapter.fork(ref, question)`。cc 的 fork() 是
-   *      `execFileAsync` 整个无头 `claude -p` 子进程跑完,几十秒到数分钟——锁外执行意味着
-   *      这段时间内同一 worker 上的 kill_worker/send_to_worker/再次 query_worker 都不会
-   *      被这次侧问卡住。
-   *   3. 重新取锁的"落账段":把 fork 化身追加进台账 + appendEvent('state_changed', {kind:
-   *      'fork'})。
-   *
-   * "锁释放期间世界会变"怎么处理(brief 明确要求的收口点):第 2 步执行期间,这个 worker
-   * 完全有可能被并发的 killWorker/handoff 改变——task 转 cancelled、主线化身换了新的
-   * (impl, seq)。第 3 步重新取锁后不假设世界还是第 1 步看到的样子,只做两件事:
-   *   - `!found`(worker 记录本身从台账消失):理论上不会发生(harness 没有删除 worker
-   *     记录的路径,防御性分支),warn + appendEvent('query_failed', {reason:
-   *     'worker_disappeared'}) + 原样抛 WorkerNotFoundError——fork 已经真实跑过但没有
-   *     台账可挂,只能弃掉,不静默吞掉这次失败(避免"侧问其实成功了但完全查不到"这种比
-   *     "失败"更差的沉默状态)。
-   *   - `found` 存在(worker 还在,不论 task.status 是否已经变成终态,不论主线是否已经
-   *     被 handoff 换成别的 impl/seq):无条件追加 fork 化身。选择"始终追加、不因主线
-   *     终态/切换而放弃"的理由——fork 已经真实执行完并产出了结果(cc 的场景下是一次真实
-   *     的 `claude -p` 调用,有真实输出),协议不变量是"fork 不影响主线"(§5.3),不是
-   *     "主线状态决定 fork 结果是否有效";这两件事本就正交,没有理由因为主线在 fork
-   *     进行期间被 kill/交接就把这个已经跑完、已经产出答案的化身凭空丢弃——那样人类此前
-   *     发起的侧问会人间蒸发,查无此 fork,比"记录一个挂在已终止主线下的侧问"更违反
-   *     "不得既投递又丢失"这条要求。`forked_from` 固定为第 1 步捕获的源 seq(发起侧问那一刻
-   *     的主线),不是落账时重新读到的主线——fork 语义上永远从"发起时刻的那个主线化身"
-   *     分叉,与它之后是否还是主线无关(和 processStateChange/sendToWorker 各处"按
-   *     (impl,seq) 精确定位,不用运行时才知道的最新主线回填"是同一纪律)。
-   *
-   * 失败留痕(review 实证 B):`query_worker` 工具是字面 fire-and-forget(见
-   * manager/tools/worker-tools.ts 文件头),调用方那次 tool_result 里已经拿不到失败原因,
-   * `appendEvent('query_failed', ...)` 是 protocol-agent-v3 §10 要求的可观测性的唯一出口——
-   * 没有它,`debug-agent.mjs trace` 排查不到任何侧问失败的痕迹。四种失败原因(worker 不存在/
-   * 无 adapter/不支持 fork/fork 抛错)detail.reason 分别是 'worker_not_found' /
-   * 'no_adapter' / 'capability_not_supported' / 'fork_failed'(+ 防御性的
-   * 'worker_disappeared',见上)。worker 不存在时没有任何已知 seq 可挂,用 0 作 sentinel——
-   * 全系统真实 seq 从 1 起分配,0 不会和任何真实化身撞号,读者据此就能识别"这条事件不对应
-   * 任何具体化身"。
+   * adapter 慢调用必须留在 worker 锁外，保证并发 kill/send/query 不被整轮回答阻塞；锁释放
+   * 期间主线即使被 kill 或 handoff，已真实建立的 fork 仍按发起时的 source seq 落账。任何
+   * 建立或持久提交失败都在本次调用抛 QueryEstablishmentError，并由 query receipt 保留通知
+   * 责任；不会再合成第二条 fire-and-forget wake。
    */
-  async queryWorker(workerId: string, question: string): Promise<{ forkSeq: number }> {
-    // Admission precedes even read/trace bookkeeping: stale config must not cause an adapter fork,
-    // workspace/ledger/inbox/event side effect through this fire-and-forget entry.
+  async queryWorker(
+    workerId: string,
+    question: string,
+    opts?: { readonly managerKey?: ManagerKey },
+  ): Promise<QueryWorkerStartedResult> {
     this.deps.assertExecutionAdmission?.()
     interface QueryPrep {
       readonly adapter: WorkerAdapter
       readonly implId: WorkerImplId
       readonly ref: IncarnationRef
       readonly workspace: string
+      readonly managerKey: ManagerKey
+      readonly receipt: WorkerQueryReceipt
     }
 
     const prep = await this.withLock(workerId, async (): Promise<QueryPrep> => {
       const found = await this.deps.ledger.findWorker(workerId)
-      if (!found) {
-        await this.appendEvent(workerId, 0, 'query_failed', { reason: 'worker_not_found' })
-        throw new WorkerNotFoundError(workerId)
-      }
-      const { worker } = found
-      // 侧问永远从当前主线化身分叉,不是"数组最后一个"——否则连续两次 query_worker 会让
-      // 第二次 fork 挂在第一次 fork 的分支下面,而不是都从主线分叉(protocol-agent-v3 §5.3)。
-      const incarnation = requireExecutableIncarnation(requireMainlineIncarnation(worker))
-      const implId = incarnation.impl
-      const adapter = this.deps.adapters.get(implId)
-      if (!adapter) {
-        await this.appendEvent(workerId, incarnation.seq, 'query_failed', { reason: 'no_adapter', impl: implId })
-        throw new Error(`WorkerHarness.queryWorker: no adapter registered for impl '${implId}'`)
-      }
-      if (!adapter.capabilities().fork) {
-        await this.appendEvent(workerId, incarnation.seq, 'query_failed', {
-          reason: 'capability_not_supported',
-          impl: implId,
+      if (!found) throw new WorkerNotFoundError(workerId)
+      const incarnation = requireExecutableIncarnation(requireMainlineIncarnation(found.worker))
+      const queryId = randomUUID()
+      const createdAt = this.deps.now()
+      let receipt: WorkerQueryReceipt
+      try {
+        receipt = await this.queryReceiptStore.create({
+          query_id: queryId,
+          worker_id: workerId,
+          manager_key: opts?.managerKey ?? found.managerKey,
+          question_preview: question,
+          created_at: createdAt,
+          updated_at: createdAt,
+          establishment_deadline_at: new Date(
+            Date.parse(createdAt) + QUERY_ESTABLISHMENT_TIMEOUT_MS,
+          ).toISOString(),
+          state: 'starting',
+          manager_notification: { status: 'not_required' },
         })
-        throw new CapabilityNotSupportedError(implId, 'fork')
+      } catch (error) {
+        throw new Error(`query receipt unavailable: ${sanitizeOperationFailureReason(
+          error,
+          this.deps.redactFailureReason,
+          question,
+          'receipt store failed',
+        )}`)
       }
-      const ref: IncarnationRef = {
-        worker_id: workerId,
-        seq: incarnation.seq,
-        session_ref: incarnation.session_ref,
+      const adapter = this.deps.adapters.get(incarnation.impl)
+      if (!adapter || !adapter.capabilities().fork) {
+        await this.failQueryEstablishment(
+          receipt,
+          'fork_capability_unavailable',
+          adapter
+            ? `${incarnation.impl} does not support fork`
+            : `no adapter registered for impl '${incarnation.impl}'`,
+          'not_started',
+        )
       }
-      return { adapter, implId, ref, workspace: incarnation.workspace }
+      return {
+        adapter: adapter!,
+        implId: incarnation.impl,
+        ref: {
+          worker_id: workerId,
+          seq: incarnation.seq,
+          session_ref: incarnation.session_ref,
+        },
+        workspace: incarnation.workspace,
+        managerKey: found.managerKey,
+        receipt,
+      }
     })
 
-    // 锁外:见方法注释"锁外慢调用段"。
-    // P6-B §6.5：fork（侧问）同样 operation-time admission——进程重启后主线 runtime 的
-    // connectionEnv 已随内存丢失，现解析现注入，不回落宿主原生凭证。
-    const admission = await this.deps.admitWorkerConnection?.(prep.implId, workerId)
-    let forkHandle: IncarnationHandle
+    let admission: Awaited<ReturnType<NonNullable<HarnessDeps['admitWorkerConnection']>>> | undefined
+    let forkHandle: IncarnationHandle | undefined
+    const disposeAdmission = async (): Promise<void> => {
+      const owned = admission
+      admission = undefined
+      if (!owned) return
+      try {
+        await owned.dispose()
+      } catch (error) {
+        console.error(`[WorkerHarness] failed to dispose query admission ${prep.receipt.query_id}:`, error)
+      }
+    }
     try {
-      forkHandle = await prep.adapter.fork(prep.ref, question, admission && Object.keys(admission.env).length > 0 ? { connection_env: admission.env } : undefined)
-    } catch (err) {
-      if (admission) await admission.dispose()
-      await this.appendEvent(workerId, prep.ref.seq, 'query_failed', {
-        reason: 'fork_failed',
-        message: err instanceof Error ? err.message : String(err),
-      })
-      throw err
+      admission = await this.deps.admitWorkerConnection?.(prep.implId, workerId)
+      const forkOptions: ForkOptions = {
+        query_id: prep.receipt.query_id,
+        establishment_deadline_at: prep.receipt.establishment_deadline_at,
+        ...(admission && Object.keys(admission.env).length > 0 ? { connection_env: admission.env } : {}),
+      }
+      const remainingMs = Date.parse(prep.receipt.establishment_deadline_at) - Date.parse(this.deps.now())
+      if (!Number.isFinite(remainingMs) || remainingMs <= 0) {
+        throw new ForkEstablishmentError(
+          'timeout',
+          'fork establishment deadline expired before the adapter was started',
+          'not_started',
+        )
+      }
+      forkHandle = await this.awaitForkEstablishment(
+        prep.adapter.fork(prep.ref, question, forkOptions),
+        prep.adapter,
+        remainingMs,
+      )
+      if (forkHandle.query_id !== prep.receipt.query_id) {
+        throw new Error('adapter returned a fork handle with a mismatched query_id')
+      }
+    } catch (error) {
+      if (forkHandle) {
+        try {
+          await prep.adapter.kill(forkHandle)
+        } catch (killError) {
+          console.error(`[WorkerHarness] failed to stop rejected query fork ${prep.receipt.query_id}:`, killError)
+        }
+      }
+      await disposeAdmission()
+      return this.failQueryEstablishment(
+        prep.receipt,
+        queryFailureCode(error),
+        sanitizeOperationFailureReason(
+          error,
+          this.deps.redactFailureReason,
+          question,
+          'query establishment failed',
+        ),
+        queryFailureCertainty(error),
+      )
     }
 
-    // 重新取锁:见方法注释"锁释放期间世界会变"一节。
-    return this.withLock(workerId, async () => {
-      const found = await this.deps.ledger.findWorker(workerId)
-      if (!found) {
-        console.warn(
-          `[WorkerHarness] queryWorker: worker ${workerId} disappeared from ledger while adapter.fork was in ` +
-            `flight; fork result (seq=${forkHandle.seq}) discarded`
+    let forkRecorded = false
+    try {
+      await this.withLock(workerId, async () => {
+        const found = await this.deps.ledger.findWorker(workerId)
+        if (!found) throw new WorkerNotFoundError(workerId)
+        const now = this.deps.now()
+        const committed = await this.deps.ledger.upsertWorker(prep.managerKey, workerId, (prevWorker) => {
+          if (!prevWorker) return undefined
+          const forkIncarnation: Incarnation = {
+            seq: forkHandle!.seq,
+            impl: prep.implId,
+            state: 'running',
+            workspace: prep.workspace,
+            session_ref: forkHandle!.session_ref,
+            started_at: now,
+            forked_from: prep.ref.seq,
+            query_id: prep.receipt.query_id,
+          }
+          return {
+            ...prevWorker,
+            incarnations: [...prevWorker.incarnations, forkIncarnation],
+            updated_at: now,
+          }
+        })
+        if (!committed) throw new WorkerNotFoundError(workerId)
+        forkRecorded = true
+        await this.queryReceiptStore.markRunning(
+          workerId,
+          prep.receipt.query_id,
+          forkHandle!.seq,
+          this.deps.now(),
         )
-        await this.appendEvent(workerId, forkHandle.seq, 'query_failed', { reason: 'worker_disappeared' })
-        throw new WorkerNotFoundError(workerId)
-      }
-      const { managerKey } = found
-
-      const now = this.deps.now()
-      // P4 Task 4 第四轮收口(复审 PoC 实证):不能再硬编码 'running' 落账——
-      // ClaudeCodeAdapter.fork()(adapter.ts:452-460)在 `return handle` 之前就
-      // `await transitionExited(...)`,后者同步调用 `onStateChange` → handleStateChange →
-      // processStateChange → `await withLock(...)`。AsyncMutex.run 的入队在第一个 await 之前
-      // 就同步完成(见 async-mutex.ts),这次入队必然发生在 fork() 返回、这里重新取锁之前,
-      // 所以 processStateChange 100% 先于这段执行——此时台账里还没有这条 fork 化身,
-      // `findIncarnation` 落空,命中 processStateChange 的 `if (!target) return` 被永久
-      // 丢弃(cc 场景下 fork 是同步跑完的一次性 `claude -p` 调用,落地时几乎总已经是
-      // exited)。以 `adapter.state(forkHandle)` 现读现取为准,而不是假设为 running——
-      // cc 这类"fork 返回时已经跑完"的实现落账即是终态;builtin 的 fork() 把
-      // runForkBurst 做成 fire-and-forget(未 await 就返回 handle),这里读到的仍是
-      // running,后续真正的 onStateChange 回调到时台账里已经有这条化身,能正常找到并
-      // 修正,不会重演同一个丢弃。
-      if (admission) await admission.dispose()
-      const observedState = await prep.adapter.state(forkHandle)
-      const exitedOnCommit = observedState === 'exited'
-      await this.deps.ledger.upsertWorker(managerKey, workerId, (prevWorker) => {
-        if (!prevWorker) return undefined
-        // fork 是一次性侧问,不影响主线 task.status(protocol-agent-v3 §5.3:"不影响主线")——
-        // 无条件追加,不因这段时间里主线是否已转终态/被 handoff 换掉而改变这个决定(理由见
-        // 方法注释)。forked_from 固定为发起侧问那一刻捕获的源 seq(prep.ref.seq),不是这里
-        // 重新读到的、可能已经不同的主线;session_ref 取 forkHandle 自己的引用,不是父化身的
-        // (§6.1 IncarnationHandle 自描述,handle.session_ref 就是 fork 化身真值)。
-        const forkIncarnation: Incarnation = {
-          seq: forkHandle.seq,
-          impl: prep.implId,
-          state: observedState,
-          workspace: prep.workspace,
-          session_ref: forkHandle.session_ref,
-          started_at: now,
-          forked_from: prep.ref.seq,
-          // adapter.state() 只回答 running/idle/exited 三态,不携带 endReason;fork 是
-          // 一次性侧问,正常跑完(cc 场景下是 `claude -p` 子进程退出)就是 completed——
-          // 真正的崩溃辨别依赖 adapter 主动上报的回调,但那次回调已经被上面的竞态吞掉、
-          // 不会再发生第二次,这里只能取这个合理缺省。
-          // 注意与 processStateChange 的区别:那条路径已经改成取 adapter 上报的真值,
-          // 这里取不到——`WorkerContractState` 是三态契约、结构上不携带原因,要拿到真值
-          // 得改契约。如实留作已知限制(不影响主线 task.status,fork 只更新自己的化身条目)。
-          ...(exitedOnCommit ? { ended_at: now, ended_reason: 'completed' as IncarnationEndReason } : {}),
+        if (admission) {
+          this.connectionDisposers.set(`${workerId}:${forkHandle!.seq}`, admission.dispose)
+          admission = undefined
         }
-        return { ...prevWorker, incarnations: [...prevWorker.incarnations, forkIncarnation], updated_at: now }
       })
-      // HarnessEventKind 没有专门的"fork/query"档位(worker-events.ts 是既定契约,Task 7
-      // 不新增枚举值),用 state_changed 承载,detail 里标明是 fork 产生的新化身。
-      await this.appendEvent(workerId, forkHandle.seq, 'state_changed', { kind: 'fork', from_seq: prep.ref.seq })
-      if (exitedOnCommit) {
-        // 补发被 processStateChange 丢弃的那次回调本该产生的"侧问已结束"事件——否则
-        // manager 收不到唤醒,query_worker 形同虚设(protocol-agent-v3 §4.1)。用 'exited'
-        // 这个既有 kind(而不是 processStateChange 正常路径用的 'state_changed')区分两条
-        // 路径,天然不会重复:这次回调已经在竞态里被 `!target` 吞掉,不会再触发第二次
-        // 'state_changed' 事件,所以这里补发的 'exited' 永远只会发生一次。
-        await this.appendEvent(workerId, forkHandle.seq, 'exited', { reason: 'completed', kind: 'fork' })
+    } catch (error) {
+      let forkStopped = false
+      try {
+        await prep.adapter.kill(forkHandle)
+        forkStopped = true
+      } catch {
+        // The fork may still be running; the receipt must preserve that uncertainty.
       }
-      return { forkSeq: forkHandle.seq }
+      if (forkRecorded && forkStopped) {
+        try {
+          await this.withLock(workerId, async () => {
+            const found = await this.deps.ledger.findWorker(workerId)
+            if (!found) return
+            const target = found.worker.incarnations.find(
+              (incarnation) => incarnation.query_id === prep.receipt.query_id,
+            )
+            if (!target || target.state === 'exited') return
+            const endedAt = this.deps.now()
+            await this.deps.ledger.upsertWorker(found.managerKey, workerId, (prev) => {
+              if (!prev) return undefined
+              return {
+                ...prev,
+                incarnations: patchIncarnationBySeq(prev.incarnations, target.impl, target.seq, {
+                  state: 'exited',
+                  ended_at: endedAt,
+                  ended_reason: 'killed',
+                }),
+                updated_at: endedAt,
+              }
+            })
+          })
+        } catch (cleanupError) {
+          console.error(`[WorkerHarness] failed to close rejected query fork ${prep.receipt.query_id}:`, cleanupError)
+        }
+      }
+      await disposeAdmission()
+      return this.failQueryEstablishment(
+        prep.receipt,
+        'fork_record_failed',
+        sanitizeOperationFailureReason(
+          error,
+          this.deps.redactFailureReason,
+          question,
+          'query establishment failed',
+        ),
+        'unknown',
+      )
+    }
+
+    await this.appendAuditEvent(workerId, forkHandle.seq, 'state_changed', {
+      kind: 'fork',
+      query_id: prep.receipt.query_id,
+      from_seq: prep.ref.seq,
     })
+
+    const pendingState = this.pendingQueryStateChanges.get(prep.receipt.query_id)
+    if (pendingState) {
+      this.pendingQueryStateChanges.delete(prep.receipt.query_id)
+      await this.processStateChange(pendingState.h, pendingState.state, pendingState.report)
+    }
+
+    return {
+      status: 'started',
+      query_id: prep.receipt.query_id,
+      worker_id: workerId,
+      fork_seq: forkHandle.seq,
+    }
+  }
+
+  private async awaitForkEstablishment(
+    forkPromise: Promise<IncarnationHandle>,
+    adapter: WorkerAdapter,
+    remainingMs: number,
+  ): Promise<IncarnationHandle> {
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const timeout = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => {
+        reject(new ForkEstablishmentError(
+          'timeout',
+          'fork establishment exceeded the 30 second deadline',
+          'unknown',
+        ))
+      }, remainingMs)
+      timer.unref?.()
+    })
+    try {
+      return await Promise.race([forkPromise, timeout])
+    } catch (error) {
+      if (error instanceof ForkEstablishmentError && error.stage === 'timeout') {
+        void forkPromise.then((handle) => adapter.kill(handle)).catch((lateError) => {
+          console.error('[WorkerHarness] late query fork cleanup failed:', lateError)
+        })
+      }
+      throw error
+    } finally {
+      if (timer) clearTimeout(timer)
+    }
+  }
+
+  private async failQueryEstablishment(
+    receipt: WorkerQueryReceipt,
+    reasonCode: QueryFailureCode,
+    reason: string,
+    certainty: QueryFailure['certainty'],
+  ): Promise<never> {
+    this.pendingQueryStateChanges.delete(receipt.query_id)
+    const failure: QueryFailure = {
+      reason_code: reasonCode,
+      reason,
+      phase: 'establishment',
+      certainty,
+    }
+    const current = await this.queryReceiptStore.get(receipt.worker_id, receipt.query_id)
+    if (current && current.state !== 'completed' && current.state !== 'failed') {
+      try {
+        await this.queryReceiptStore.settleFailed(
+          receipt.worker_id,
+          receipt.query_id,
+          failure,
+          this.deps.now(),
+        )
+        await this.appendAuditEvent(receipt.worker_id, 0, 'query_failed', {
+          query_id: receipt.query_id,
+          ...failure,
+        })
+      } catch (error) {
+        console.error(`[WorkerHarness] failed to persist query establishment failure ${receipt.query_id}:`, error)
+      }
+    }
+    throw new QueryEstablishmentError(receipt.query_id, reasonCode, reason, certainty)
   }
 
   // ---- 内部 ----
@@ -2675,7 +3480,15 @@ export class WorkerHarness {
       const { worker, managerKey } = found
 
       const target = findIncarnation(worker, h.impl, h.seq)
-      if (!target) return // 未知化身(理论不该发生),防御性丢弃
+      if (!target) {
+        if (h.query_id) {
+          const receipt = await this.queryReceiptStore.get(h.worker_id, h.query_id)
+          if (receipt?.state === 'starting') {
+            this.pendingQueryStateChanges.set(h.query_id, { h, state, ...(report ? { report } : {}) })
+          }
+        }
+        return
+      }
 
       // endReason 一律取 adapter 上报的真值:三个 adapter 的 transitionExited 形参本就是
       // 必填的 ended_reason,且都在调回调之前已经把它写进自己的 meta,所以常规路径上
@@ -2710,7 +3523,19 @@ export class WorkerHarness {
           )
           return { ...prev, incarnations, updated_at: now }
         })
-        await this.appendEvent(h.worker_id, h.seq, 'state_changed', { to: state, ...wakeDetail })
+        if (target.query_id) {
+          if (state === 'exited') {
+            await this.settleQueryExecution(target.query_id, h, endReason, wakeDetail)
+          } else {
+            await this.appendAuditEvent(h.worker_id, h.seq, 'state_changed', {
+              to: state,
+              query_id: target.query_id,
+              ...wakeDetail,
+            })
+          }
+        } else {
+          await this.appendEvent(h.worker_id, h.seq, 'state_changed', { to: state, ...wakeDetail })
+        }
         if (state === 'exited') this.fireIncarnationTerminal(h)
         return
       }
@@ -2781,6 +3606,38 @@ export class WorkerHarness {
       inbox.release('waiting_action')
       await this.flushInbox(h.worker_id)
     }
+  }
+
+  private async settleQueryExecution(
+    queryId: string,
+    h: IncarnationHandle,
+    endReason: IncarnationEndReason | undefined,
+    wakeDetail: Record<string, string>,
+  ): Promise<void> {
+    const receipt = await this.queryReceiptStore.get(h.worker_id, queryId)
+    if (!receipt || receipt.state !== 'running') return
+    if (endReason === 'completed') {
+      await this.queryReceiptStore.settleCompleted(h.worker_id, queryId, this.deps.now())
+      await this.appendAuditEvent(h.worker_id, h.seq, 'query_completed', {
+        query_id: queryId,
+        fork_seq: h.seq,
+        ...wakeDetail,
+      })
+      return
+    }
+    const failure: QueryFailure = {
+      reason_code: 'query_execution_failed',
+      reason: endReason ? `query fork exited with reason '${endReason}'` : 'query fork exited without a completion reason',
+      phase: 'execution',
+      certainty: 'failed',
+    }
+    await this.queryReceiptStore.settleFailed(h.worker_id, queryId, failure, this.deps.now())
+    await this.appendAuditEvent(h.worker_id, h.seq, 'query_failed', {
+      query_id: queryId,
+      fork_seq: h.seq,
+      ...failure,
+      ...wakeDetail,
+    })
   }
 
   private withLock<T>(workerId: string, fn: () => Promise<T>): Promise<T> {
@@ -2856,6 +3713,24 @@ export class WorkerHarness {
     const event = this.buildEvent(workerId, seq, kind, detail)
     await this.getEventLog(workerId).append(event)
     return (await this.deps.onEvent?.(event)) ?? undefined
+  }
+
+  /** Persist operation evidence without using the ordinary Manager route or affecting operation truth. */
+  private async appendAuditEvent(
+    workerId: string,
+    seq: number,
+    kind: HarnessEventKind,
+    detail?: Record<string, unknown>,
+  ): Promise<void> {
+    try {
+      await this.getEventLog(workerId).append(this.buildEvent(workerId, seq, kind, detail))
+    } catch (error) {
+      console.error(
+        `[WorkerHarness] failed to append operation audit event ` +
+          `(worker=${workerId}, seq=${seq}, kind=${kind}):`,
+        error,
+      )
+    }
   }
 
   /** 化身终态收割钩子（P6-A §8.10）：fire-and-forget，异常只记不打断。 */

--- a/crabot-agent/src/workers/harness/inbox.ts
+++ b/crabot-agent/src/workers/harness/inbox.ts
@@ -24,14 +24,32 @@ import type { LegacyContinuationAuth } from './legacy-continuation-auth.js'
 
 export type InboxSettlement = 'delivered' | 'dead_letter'
 
+export interface InboxSettlementDetail {
+  readonly seq?: number
+  readonly reason?: string
+  readonly certainty?: 'not_delivered' | 'unknown'
+}
+
+export interface InboxSettledResult {
+  readonly action: 'settled'
+  readonly settlement: InboxSettlement
+  readonly detail?: InboxSettlementDetail
+}
+
 export interface InboxItem {
   readonly text: string
   readonly raw: boolean
   readonly enqueued_at: string
+  /** Stable identity for Manager-originated input. */
+  readonly delivery_id?: string
   /** False for untrusted wakeups that must never revive a terminal task. */
   readonly allow_terminal_continuation?: boolean
   /** Process-local receipt; durable truth remains with the producer. */
-  readonly onSettled?: (settlement: InboxSettlement) => void | Promise<void>
+  readonly onSettled?: (settlement: InboxSettlement, detail?: InboxSettlementDetail) => void | Promise<void>
+  /** Pending is diagnostic only and never settles the producer receipt. */
+  readonly onPending?: (reason: InboxDeliveryResult['reason']) => void | Promise<void>
+  /** Recheck durable receipt state immediately before any adapter side effect. */
+  readonly shouldDeliver?: () => boolean | Promise<boolean>
   /** Prevent a producer retry from enqueueing the same durable item twice in one process. */
   readonly dedupe_key?: string
   /** Opaque, in-process-only authorization for one legacy continuation. */
@@ -58,7 +76,10 @@ export class WorkerInbox {
   private inFlight: InboxItem | null = null
   /** Items pasted into a CLI composer: UI owns the text, but durable receipts still need settlement. */
   private consumedPending: InboxItem[] = []
+  /** Serializes queue state transitions shared by flush and cancellation. */
   private readonly mutex = new AsyncMutex()
+  /** Prevents two flush drivers from delivering concurrently without holding the state mutex across adapter IO. */
+  private readonly flushMutex = new AsyncMutex()
 
   constructor(private readonly workerId: string) {}
 
@@ -111,10 +132,26 @@ export class WorkerInbox {
   }
 
   /** Settle durable receipts whose text was pasted and later submitted/abandoned via raw input. */
-  async settleConsumed(settlement: InboxSettlement): Promise<number> {
+  async settleConsumed(settlement: InboxSettlement, detail?: InboxSettlementDetail): Promise<number> {
     const items = this.consumedPending.splice(0)
-    for (const item of items) await this.settle(item, settlement)
+    for (const item of items) await this.settle(item, settlement, detail)
     return items.length
+  }
+
+  /** Remove a delivery that has not entered the adapter. In-flight/composer-owned input is unsafe. */
+  async cancelDelivery(deliveryId: string): Promise<'cancelled' | 'unsafe' | 'not_found'> {
+    return this.mutex.run(async () => {
+      if (
+        this.inFlight?.delivery_id === deliveryId ||
+        this.consumedPending.some((item) => item.delivery_id === deliveryId)
+      ) {
+        return 'unsafe'
+      }
+      const index = this.queue.findIndex((item) => item.delivery_id === deliveryId)
+      if (index < 0) return 'not_found'
+      this.queue.splice(index, 1)
+      return 'cancelled'
+    })
   }
 
   /** A pane incarnation ended; replay consumed durable items in the next incarnation. */
@@ -139,20 +176,38 @@ export class WorkerInbox {
    * 取出(shift),所以 pending 不计入 in-flight 条目。
    */
   async flush(
-    deliver: (item: InboxItem) => Promise<InboxSettlement | InboxDeliveryResult | void>,
+    deliver: (item: InboxItem) => Promise<InboxSettlement | InboxDeliveryResult | InboxSettledResult | void>,
   ): Promise<number> {
-    return this.mutex.run(async () => {
+    return this.flushMutex.run(async () => {
       let delivered = 0
-      while (this.queue.length > 0) {
-        if (this.held && !this.rawBypassOnly) break
-        const index = this.held ? this.queue.findIndex((candidate) => candidate.raw) : 0
-        if (index < 0) break
-        const [item] = this.queue.splice(index, 1)
-        this.inFlight = item
+      while (true) {
+        const item = await this.mutex.run(async () => {
+          if (this.queue.length === 0 || (this.held && !this.rawBypassOnly)) return undefined
+          const index = this.held ? this.queue.findIndex((candidate) => candidate.raw) : 0
+          if (index < 0) return undefined
+          const [next] = this.queue.splice(index, 1)
+          this.inFlight = next
+          return next
+        })
+        if (!item) break
         try {
+          if (item.shouldDeliver && !await item.shouldDeliver()) {
+            await this.mutex.run(async () => { this.inFlight = null })
+            continue
+          }
           const result = await deliver(item)
-          this.inFlight = null
-          if (typeof result === 'object') {
+          const keepFlushing = await this.mutex.run(async () => {
+            this.inFlight = null
+            if (typeof result !== 'object') {
+              delivered++
+              await this.settle(item, typeof result === 'string' ? result : 'delivered')
+              return true
+            }
+            if (result.action === 'settled') {
+              delivered++
+              await this.settle(item, result.settlement, result.detail)
+              return true
+            }
             const retainedItem = result.replacement
               ? { ...item, text: result.replacement.text, raw: result.replacement.raw }
               : item
@@ -163,7 +218,7 @@ export class WorkerInbox {
               } else {
                 this.queue.unshift(retainedItem)
               }
-              continue
+              return true
             }
             this.hold(result.reason)
             if (result.action === 'hold_requeue') {
@@ -175,13 +230,18 @@ export class WorkerInbox {
               if (retainedItem.onSettled) this.consumedPending.push(retainedItem)
               delivered++
             }
-            break
-          }
-          delivered++
-          await this.settle(item, typeof result === 'string' ? result : 'delivered')
+            await this.markPending(item, result.reason)
+            return false
+          })
+          if (!keepFlushing) break
         } catch (err) {
-          this.inFlight = null
-          if (this.drainedInFlight === item) {
+          const dropAfterDrain = await this.mutex.run(async () => {
+            this.inFlight = null
+            if (this.drainedInFlight !== item) {
+              // post-drain enqueue 的条目或其他情况:走正常语义(放回、抛出)
+              this.queue.unshift(item)
+              return false
+            }
             // 该条正好是 drain 当刻的 in-flight:化身已终结,drain 早已把 queue 清空并
             // 作为 dead-letter 交给调用方。这条已经没有队列可放回、也没有人再等这次
             // flush 的结果——放回会造成"凭空复活"的幽灵条目,原样向上抛则可能砸向已不再
@@ -192,10 +252,9 @@ export class WorkerInbox {
               }`
             )
             await this.settle(item, 'dead_letter')
-            return delivered
-          }
-          // post-drain enqueue 的条目或其他情况:走正常语义(放回、抛出)
-          this.queue.unshift(item)
+            return true
+          })
+          if (dropAfterDrain) return delivered
           throw err
         }
       }
@@ -203,15 +262,25 @@ export class WorkerInbox {
     })
   }
 
-  private async settle(item: InboxItem, settlement: InboxSettlement): Promise<void> {
+  private async settle(item: InboxItem, settlement: InboxSettlement, detail?: InboxSettlementDetail): Promise<void> {
     if (!item.onSettled) return
     try {
-      await item.onSettled(settlement)
+      if (detail) await item.onSettled(settlement, detail)
+      else await item.onSettled(settlement)
     } catch (error) {
       // Delivery already happened (or was durably dead-lettered). Requeueing here
       // would duplicate input; the producer keeps its durable pending receipt and
-      // may replay after restart.
+      // reconciles it without automatically replaying the input.
       console.warn(`[WorkerInbox:${this.workerId}] settlement callback failed:`, error)
+    }
+  }
+
+  private async markPending(item: InboxItem, reason: InboxDeliveryResult['reason']): Promise<void> {
+    if (!item.onPending) return
+    try {
+      await item.onPending(reason)
+    } catch (error) {
+      console.warn(`[WorkerInbox:${this.workerId}] pending callback failed:`, error)
     }
   }
 

--- a/crabot-agent/src/workers/harness/input-delivery-store.ts
+++ b/crabot-agent/src/workers/harness/input-delivery-store.ts
@@ -1,0 +1,241 @@
+import { promises as fs } from 'fs'
+import { AsyncMutex } from '../async-mutex'
+import type { ManagerKey } from './ledger-types'
+import { normalizeReceiptPreview, readReceiptFile, receiptFilePath, writeReceiptFile } from './receipt-store-io'
+
+export type InputDeliveryFailureCode =
+  | 'target_unavailable'
+  | 'task_cancelled'
+  | 'continuation_failed'
+  | 'input_surface_timeout'
+  | 'submission_unconfirmed_timeout'
+  | 'delivery_attempt_failed'
+  | 'abandoned_by_control_input'
+  | 'confirmation_lost_after_restart'
+
+export type InputDeliveryFailure = {
+  reason_code: InputDeliveryFailureCode
+  reason: string
+  certainty: 'not_delivered' | 'unknown'
+}
+
+export interface WorkerInputDeliveryReceipt {
+  delivery_id: string
+  worker_id: string
+  manager_key: ManagerKey
+  raw: boolean
+  text_preview: string
+  created_at: string
+  updated_at: string
+  deadline_at: string
+  state: 'pending' | 'delivered' | 'failed'
+  phase?: 'queued' | 'attempting' | 'waiting_for_safe_input' | 'pending_in_ui' | 'continuing'
+  failure?: InputDeliveryFailure
+  manager_notification: {
+    status: 'not_required' | 'pending' | 'consumed'
+    consumed_at?: string
+  }
+}
+
+export type SendToWorkerResult =
+  | { status: 'delivered'; delivery_id: string; worker_id: string }
+  | {
+      status: 'pending'
+      delivery_id: string
+      worker_id: string
+      pending_reason: 'waiting_for_safe_input' | 'submission_unconfirmed'
+      deadline_at: string
+    }
+  | {
+      status: 'failed'
+      delivery_id: string
+      worker_id: string
+      reason_code: InputDeliveryFailureCode
+      reason: string
+      certainty: 'not_delivered' | 'unknown'
+    }
+
+const FILENAME = 'input-deliveries.json'
+
+export class InputDeliveryStore {
+  private readonly mutexes = new Map<string, AsyncMutex>()
+
+  constructor(private readonly workersDir: string) {}
+
+  async create(receipt: WorkerInputDeliveryReceipt): Promise<WorkerInputDeliveryReceipt> {
+    if (receipt.state !== 'pending' || receipt.manager_notification.status !== 'not_required') {
+      throw new Error('new input delivery receipt must be pending with notification not_required')
+    }
+    const normalized: WorkerInputDeliveryReceipt = {
+      ...receipt,
+      text_preview: normalizeReceiptPreview(receipt.text_preview),
+    }
+    return this.mutate(receipt.worker_id, (receipts) => {
+      if (receipts.some((item) => item.delivery_id === receipt.delivery_id)) {
+        throw new Error(`duplicate delivery_id: ${receipt.delivery_id}`)
+      }
+      receipts.push(normalized)
+      return normalized
+    })
+  }
+
+  async get(workerId: string, deliveryId: string): Promise<WorkerInputDeliveryReceipt | undefined> {
+    return this.getMutex(workerId).run(async () => {
+      const receipts = await this.read(workerId)
+      return receipts.find((receipt) => receipt.delivery_id === deliveryId)
+    })
+  }
+
+  async list(workerId: string): Promise<WorkerInputDeliveryReceipt[]> {
+    return this.getMutex(workerId).run(() => this.read(workerId))
+  }
+
+  async listPendingNotifications(): Promise<WorkerInputDeliveryReceipt[]> {
+    const result: WorkerInputDeliveryReceipt[] = []
+    for (const workerId of await this.workerIds()) {
+      result.push(...(await this.list(workerId)).filter((receipt) =>
+        receipt.state !== 'pending' && receipt.manager_notification.status === 'pending'))
+    }
+    return result
+  }
+
+  async listPendingDeliveries(): Promise<WorkerInputDeliveryReceipt[]> {
+    const result: WorkerInputDeliveryReceipt[] = []
+    for (const workerId of await this.workerIds()) {
+      result.push(...(await this.list(workerId)).filter((receipt) => receipt.state === 'pending'))
+    }
+    return result
+  }
+
+  async updatePendingPhase(
+    workerId: string,
+    deliveryId: string,
+    phase: NonNullable<WorkerInputDeliveryReceipt['phase']>,
+    updatedAt: string,
+  ): Promise<WorkerInputDeliveryReceipt> {
+    return this.mutateReceipt(workerId, deliveryId, (receipt) => {
+      if (receipt.state !== 'pending') return receipt
+      return { ...receipt, phase, updated_at: updatedAt }
+    })
+  }
+
+  async readForToolResult(workerId: string, deliveryId: string, updatedAt: string): Promise<WorkerInputDeliveryReceipt> {
+    return this.getMutex(workerId).run(async () => {
+      const receipts = await this.read(workerId)
+      const index = receipts.findIndex((receipt) => receipt.delivery_id === deliveryId)
+      if (index < 0) throw new Error(`delivery receipt not found: ${deliveryId}`)
+      const receipt = receipts[index]
+      if (receipt.state !== 'pending' || receipt.manager_notification.status !== 'not_required') return receipt
+      const next: WorkerInputDeliveryReceipt = {
+        ...receipt,
+        updated_at: updatedAt,
+        manager_notification: { status: 'pending' },
+      }
+      receipts[index] = next
+      await writeReceiptFile(this.path(workerId), receipts)
+      return next
+    })
+  }
+
+  async settleDelivered(workerId: string, deliveryId: string, updatedAt: string): Promise<WorkerInputDeliveryReceipt> {
+    return this.mutateReceipt(workerId, deliveryId, (receipt) => {
+      this.assertPending(receipt)
+      return { ...receipt, state: 'delivered', updated_at: updatedAt }
+    })
+  }
+
+  async settleFailed(
+    workerId: string,
+    deliveryId: string,
+    failure: InputDeliveryFailure,
+    updatedAt: string,
+  ): Promise<WorkerInputDeliveryReceipt> {
+    return this.mutateReceipt(workerId, deliveryId, (receipt) => {
+      this.assertPending(receipt)
+      return {
+        ...receipt,
+        state: 'failed',
+        failure,
+        updated_at: updatedAt,
+        manager_notification: { status: 'pending' },
+      }
+    })
+  }
+
+  async markNotificationConsumed(
+    workerId: string,
+    deliveryId: string,
+    consumedAt: string,
+  ): Promise<WorkerInputDeliveryReceipt> {
+    return this.mutateReceipt(workerId, deliveryId, (receipt) => {
+      if (receipt.state === 'pending' || receipt.manager_notification.status !== 'pending') {
+        throw new Error(`delivery ${deliveryId} has no pending terminal notification`)
+      }
+      return {
+        ...receipt,
+        updated_at: consumedAt,
+        manager_notification: { status: 'consumed', consumed_at: consumedAt },
+      }
+    })
+  }
+
+  private assertPending(receipt: WorkerInputDeliveryReceipt): void {
+    if (receipt.state !== 'pending') {
+      throw new Error(`delivery ${receipt.delivery_id} is already terminal (${receipt.state})`)
+    }
+  }
+
+  private async mutateReceipt(
+    workerId: string,
+    deliveryId: string,
+    mutator: (receipt: WorkerInputDeliveryReceipt) => WorkerInputDeliveryReceipt,
+  ): Promise<WorkerInputDeliveryReceipt> {
+    return this.mutate(workerId, (receipts) => {
+      const index = receipts.findIndex((receipt) => receipt.delivery_id === deliveryId)
+      if (index < 0) throw new Error(`delivery receipt not found: ${deliveryId}`)
+      const next = mutator(receipts[index])
+      receipts[index] = next
+      return next
+    })
+  }
+
+  private async mutate<T>(
+    workerId: string,
+    mutator: (receipts: WorkerInputDeliveryReceipt[]) => T,
+  ): Promise<T> {
+    return this.getMutex(workerId).run(async () => {
+      const receipts = await this.read(workerId)
+      const result = mutator(receipts)
+      await writeReceiptFile(this.path(workerId), receipts)
+      return result
+    })
+  }
+
+  private read(workerId: string): Promise<WorkerInputDeliveryReceipt[]> {
+    return readReceiptFile(this.path(workerId))
+  }
+
+  private path(workerId: string): string {
+    return receiptFilePath(this.workersDir, workerId, FILENAME)
+  }
+
+  private getMutex(workerId: string): AsyncMutex {
+    let mutex = this.mutexes.get(workerId)
+    if (!mutex) {
+      mutex = new AsyncMutex()
+      this.mutexes.set(workerId, mutex)
+    }
+    return mutex
+  }
+
+  private async workerIds(): Promise<string[]> {
+    try {
+      return (await fs.readdir(this.workersDir, { withFileTypes: true }))
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => entry.name)
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return []
+      throw error
+    }
+  }
+}

--- a/crabot-agent/src/workers/harness/ledger-types.ts
+++ b/crabot-agent/src/workers/harness/ledger-types.ts
@@ -15,6 +15,7 @@ interface IncarnationBase {
   ended_at?: string
   ended_reason?: IncarnationEndReason
   forked_from?: number
+  query_id?: string
 }
 
 export interface ExecutableIncarnation extends IncarnationBase {

--- a/crabot-agent/src/workers/harness/query-receipt-store.ts
+++ b/crabot-agent/src/workers/harness/query-receipt-store.ts
@@ -1,0 +1,217 @@
+import { promises as fs } from 'fs'
+import { AsyncMutex } from '../async-mutex'
+import type { ManagerKey } from './ledger-types'
+import { normalizeReceiptPreview, readReceiptFile, receiptFilePath, writeReceiptFile } from './receipt-store-io'
+
+export type QueryFailureCode =
+  | 'fork_capability_unavailable'
+  | 'fork_create_failed'
+  | 'query_submit_failed'
+  | 'fork_record_failed'
+  | 'fork_establishment_timeout'
+  | 'fork_establishment_lost_after_restart'
+  | 'query_execution_failed'
+  | 'query_execution_lost_after_restart'
+
+export type QueryFailure = {
+  reason_code: QueryFailureCode
+  reason: string
+  phase: 'establishment' | 'execution'
+  certainty: 'not_started' | 'failed' | 'unknown'
+}
+
+export interface WorkerQueryReceipt {
+  query_id: string
+  worker_id: string
+  manager_key: ManagerKey
+  question_preview: string
+  created_at: string
+  updated_at: string
+  establishment_deadline_at: string
+  state: 'starting' | 'running' | 'completed' | 'failed'
+  fork_seq?: number
+  failure?: QueryFailure
+  manager_notification: {
+    status: 'not_required' | 'pending' | 'consumed'
+    consumed_at?: string
+  }
+}
+
+export interface QueryWorkerStartedResult {
+  status: 'started'
+  query_id: string
+  worker_id: string
+  fork_seq: number
+}
+
+const FILENAME = 'query-receipts.json'
+
+export class QueryReceiptStore {
+  private readonly mutexes = new Map<string, AsyncMutex>()
+
+  constructor(private readonly workersDir: string) {}
+
+  async create(receipt: WorkerQueryReceipt): Promise<WorkerQueryReceipt> {
+    if (receipt.state !== 'starting' || receipt.manager_notification.status !== 'not_required') {
+      throw new Error('new query receipt must be starting with notification not_required')
+    }
+    const normalized: WorkerQueryReceipt = {
+      ...receipt,
+      question_preview: normalizeReceiptPreview(receipt.question_preview),
+    }
+    return this.mutate(receipt.worker_id, (receipts) => {
+      if (receipts.some((item) => item.query_id === receipt.query_id)) {
+        throw new Error(`duplicate query_id: ${receipt.query_id}`)
+      }
+      receipts.push(normalized)
+      return normalized
+    })
+  }
+
+  async get(workerId: string, queryId: string): Promise<WorkerQueryReceipt | undefined> {
+    return this.getMutex(workerId).run(async () => {
+      const receipts = await this.read(workerId)
+      return receipts.find((receipt) => receipt.query_id === queryId)
+    })
+  }
+
+  async list(workerId: string): Promise<WorkerQueryReceipt[]> {
+    return this.getMutex(workerId).run(() => this.read(workerId))
+  }
+
+  async listPendingNotifications(): Promise<WorkerQueryReceipt[]> {
+    const result: WorkerQueryReceipt[] = []
+    for (const workerId of await this.workerIds()) {
+      result.push(...(await this.list(workerId)).filter((receipt) =>
+        (receipt.state === 'completed' || receipt.state === 'failed') &&
+        receipt.manager_notification.status === 'pending'))
+    }
+    return result
+  }
+
+  async listInFlight(): Promise<WorkerQueryReceipt[]> {
+    const result: WorkerQueryReceipt[] = []
+    for (const workerId of await this.workerIds()) {
+      result.push(...(await this.list(workerId)).filter((receipt) =>
+        receipt.state === 'starting' || receipt.state === 'running'))
+    }
+    return result
+  }
+
+  async markRunning(
+    workerId: string,
+    queryId: string,
+    forkSeq: number,
+    updatedAt: string,
+  ): Promise<WorkerQueryReceipt> {
+    return this.mutateReceipt(workerId, queryId, (receipt) => {
+      this.assertNotTerminal(receipt)
+      if (receipt.state !== 'starting') throw new Error(`query ${queryId} is not starting`)
+      return { ...receipt, state: 'running', fork_seq: forkSeq, updated_at: updatedAt }
+    })
+  }
+
+  async settleCompleted(workerId: string, queryId: string, updatedAt: string): Promise<WorkerQueryReceipt> {
+    return this.mutateReceipt(workerId, queryId, (receipt) => {
+      this.assertNotTerminal(receipt)
+      if (receipt.state !== 'running') throw new Error(`query ${queryId} must be running before completion`)
+      return {
+        ...receipt,
+        state: 'completed',
+        updated_at: updatedAt,
+        manager_notification: { status: 'pending' },
+      }
+    })
+  }
+
+  async settleFailed(
+    workerId: string,
+    queryId: string,
+    failure: QueryFailure,
+    updatedAt: string,
+  ): Promise<WorkerQueryReceipt> {
+    return this.mutateReceipt(workerId, queryId, (receipt) => {
+      this.assertNotTerminal(receipt)
+      return {
+        ...receipt,
+        state: 'failed',
+        failure,
+        updated_at: updatedAt,
+        manager_notification: { status: 'pending' },
+      }
+    })
+  }
+
+  async markNotificationConsumed(workerId: string, queryId: string, consumedAt: string): Promise<WorkerQueryReceipt> {
+    return this.mutateReceipt(workerId, queryId, (receipt) => {
+      if (receipt.state === 'starting' || receipt.state === 'running') {
+        throw new Error(`query ${queryId} is not terminal`)
+      }
+      if (receipt.manager_notification.status !== 'pending') {
+        throw new Error(`query ${queryId} has no pending terminal notification`)
+      }
+      return {
+        ...receipt,
+        updated_at: consumedAt,
+        manager_notification: { status: 'consumed', consumed_at: consumedAt },
+      }
+    })
+  }
+
+  private assertNotTerminal(receipt: WorkerQueryReceipt): void {
+    if (receipt.state === 'completed' || receipt.state === 'failed') {
+      throw new Error(`query ${receipt.query_id} is already terminal (${receipt.state})`)
+    }
+  }
+
+  private async mutateReceipt(
+    workerId: string,
+    queryId: string,
+    mutator: (receipt: WorkerQueryReceipt) => WorkerQueryReceipt,
+  ): Promise<WorkerQueryReceipt> {
+    return this.mutate(workerId, (receipts) => {
+      const index = receipts.findIndex((receipt) => receipt.query_id === queryId)
+      if (index < 0) throw new Error(`query receipt not found: ${queryId}`)
+      const next = mutator(receipts[index])
+      receipts[index] = next
+      return next
+    })
+  }
+
+  private async mutate<T>(workerId: string, mutator: (receipts: WorkerQueryReceipt[]) => T): Promise<T> {
+    return this.getMutex(workerId).run(async () => {
+      const receipts = await this.read(workerId)
+      const result = mutator(receipts)
+      await writeReceiptFile(this.path(workerId), receipts)
+      return result
+    })
+  }
+
+  private read(workerId: string): Promise<WorkerQueryReceipt[]> {
+    return readReceiptFile(this.path(workerId))
+  }
+
+  private path(workerId: string): string {
+    return receiptFilePath(this.workersDir, workerId, FILENAME)
+  }
+
+  private getMutex(workerId: string): AsyncMutex {
+    let mutex = this.mutexes.get(workerId)
+    if (!mutex) {
+      mutex = new AsyncMutex()
+      this.mutexes.set(workerId, mutex)
+    }
+    return mutex
+  }
+
+  private async workerIds(): Promise<string[]> {
+    try {
+      return (await fs.readdir(this.workersDir, { withFileTypes: true }))
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => entry.name)
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return []
+      throw error
+    }
+  }
+}

--- a/crabot-agent/src/workers/harness/receipt-store-io.ts
+++ b/crabot-agent/src/workers/harness/receipt-store-io.ts
@@ -1,0 +1,49 @@
+import { randomUUID } from 'crypto'
+import { promises as fs } from 'fs'
+import { dirname, join } from 'path'
+
+interface ReceiptFile<T> {
+  version: 1
+  receipts: T[]
+}
+
+export function normalizeReceiptPreview(value: string): string {
+  return value.replace(/\s+/g, ' ').trim().slice(0, 200)
+}
+
+export function receiptFilePath(workersDir: string, workerId: string, filename: string): string {
+  if (!workerId || workerId.includes('/') || workerId.includes('\\')) {
+    throw new Error(`invalid worker_id for receipt path: ${workerId}`)
+  }
+  return join(workersDir, workerId, filename)
+}
+
+export async function readReceiptFile<T>(path: string): Promise<T[]> {
+  let raw: string
+  try {
+    raw = await fs.readFile(path, 'utf8')
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return []
+    throw error
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<ReceiptFile<T>>
+    if (parsed.version !== 1 || !Array.isArray(parsed.receipts)) throw new Error('invalid receipt file shape')
+    return parsed.receipts
+  } catch (error) {
+    throw new Error(`invalid receipt file ${path}: ${(error as Error).message}`)
+  }
+}
+
+export async function writeReceiptFile<T>(path: string, receipts: T[]): Promise<void> {
+  await fs.mkdir(dirname(path), { recursive: true })
+  const tmpPath = join(dirname(path), `.${randomUUID()}.tmp.json`)
+  try {
+    await fs.writeFile(tmpPath, JSON.stringify({ version: 1, receipts }, null, 2), 'utf8')
+    await fs.rename(tmpPath, path)
+  } catch (error) {
+    await fs.unlink(tmpPath).catch(() => undefined)
+    throw error
+  }
+}

--- a/crabot-agent/src/workers/harness/worker-events.ts
+++ b/crabot-agent/src/workers/harness/worker-events.ts
@@ -24,16 +24,14 @@ export type HarnessEventKind =
   | 'superseded'
   | 'handoff_started'
   | 'resumed'
+  | 'input_delivery_failed'
   /**
-   * P4 Task 4 additive:`queryWorker`(侧问 fork)自己的失败路径——worker 不存在、目标 impl
-   * 未注册 adapter、`capabilities().fork` 为 false、`adapter.fork` 抛错——都落这个 kind。
-   * `query_worker` 工具是字面 fire-and-forget(见 manager/tools/worker-tools.ts 文件头),
-   * 失败不再能在那次调用内回传给 LLM,这是失败留痕的唯一出口(protocol-agent-v3 §10 可观测
-   * 性预期),供 `debug-agent.mjs trace`/`onEvent` 订阅方排查。`detail.reason` 取值:
-   * 'worker_not_found' | 'no_adapter' | 'capability_not_supported' | 'fork_failed' |
-   * 'worker_disappeared'(见 harness.ts queryWorker 注释,理论上不会发生的防御性分支)。
+   * query 建立或执行失败的持久审计事件。建立失败同时在原工具调用返回结构化错误；执行失败
+   * 通过 query receipt 的 operation notification 唤醒 owning Manager。稳定关联字段为
+   * `detail.query_id`，已建立 fork 的终态另外带 `detail.fork_seq`。
    */
   | 'query_failed'
+  | 'query_completed'
   /** v2 import history record: persisted only, never bridged to a Manager wake. */
   | 'legacy_imported'
 

--- a/crabot-agent/src/workers/input-delivery-control.ts
+++ b/crabot-agent/src/workers/input-delivery-control.ts
@@ -1,0 +1,30 @@
+import type { SendInputOptions } from './types.js'
+
+export class InputDeliveryInterruptedError extends Error {
+  constructor(
+    message: string,
+    readonly certainty: 'not_delivered' | 'unknown',
+  ) {
+    super(message)
+    this.name = 'InputDeliveryInterruptedError'
+  }
+}
+
+export function assertInputDeliveryActive(
+  opts: SendInputOptions | undefined,
+  certainty: 'not_delivered' | 'unknown',
+): void {
+  if (!opts?.delivery_id) return
+  if (opts.signal?.aborted) {
+    throw new InputDeliveryInterruptedError(
+      `input delivery ${opts.delivery_id} was cancelled before the next adapter action`,
+      certainty,
+    )
+  }
+  if (opts.deadline_at && Date.now() >= Date.parse(opts.deadline_at)) {
+    throw new InputDeliveryInterruptedError(
+      `input delivery ${opts.delivery_id} exceeded its deadline before the next adapter action`,
+      certainty,
+    )
+  }
+}

--- a/crabot-agent/src/workers/tmux/input-commit.ts
+++ b/crabot-agent/src/workers/tmux/input-commit.ts
@@ -14,6 +14,7 @@ export interface InputCommitDriver {
 export interface InputCommitOptions {
   settleTimeoutMs?: number
   intervalMs?: number
+  beforeSideEffect?: (phase: 'paste' | 'enter') => void
 }
 
 /** Generic guarded paste transaction; implementation-specific UI semantics stay in callbacks. */
@@ -39,6 +40,7 @@ export async function commitInput(
   }
   if (beforePaste !== 'empty') return { disposition: 'not_pasted', snapshot }
 
+  opts.beforeSideEffect?.('paste')
   await driver.pasteText(text)
   snapshot = await waitUntil(driver, timeoutMs, intervalMs, (current) => probe(current, 'after_paste') !== 'empty')
   let currentProbe = probe(snapshot, 'after_paste')
@@ -48,6 +50,7 @@ export async function commitInput(
   if (currentProbe === 'empty') return { disposition: 'not_pasted', snapshot }
   if (currentProbe !== 'pending') return { disposition: 'pending_in_ui', snapshot }
 
+  opts.beforeSideEffect?.('enter')
   await driver.sendEnter()
   snapshot = await waitUntil(
     driver,
@@ -59,6 +62,7 @@ export async function commitInput(
 
   currentProbe = probe(snapshot, 'after_paste')
   if (currentProbe === 'pending') {
+    opts.beforeSideEffect?.('enter')
     await driver.sendEnter()
     snapshot = await waitUntil(
       driver,

--- a/crabot-agent/src/workers/trace/composite-reader.ts
+++ b/crabot-agent/src/workers/trace/composite-reader.ts
@@ -83,7 +83,25 @@ function harnessSummary(event: HarnessEvent): string {
     case 'spawned':
       return detail.impl ? `spawned (${String(detail.impl)})` : 'spawned'
     case 'input_sent':
-      return 'input_sent'
+      return typeof detail.delivery_id === 'string'
+        ? `input_sent delivery_id=${detail.delivery_id}`
+        : 'input_sent'
+    case 'input_delivery_failed': {
+      const deliveryId = typeof detail.delivery_id === 'string' ? ` delivery_id=${detail.delivery_id}` : ''
+      const reasonCode = typeof detail.reason_code === 'string' ? ` reason_code=${detail.reason_code}` : ''
+      return `input_delivery_failed${deliveryId}${reasonCode}`
+    }
+    case 'query_completed': {
+      const queryId = typeof detail.query_id === 'string' ? ` query_id=${detail.query_id}` : ''
+      const forkSeq = typeof detail.fork_seq === 'number' ? ` fork_seq=${detail.fork_seq}` : ''
+      return `query_completed${queryId}${forkSeq}`
+    }
+    case 'query_failed': {
+      const queryId = typeof detail.query_id === 'string' ? ` query_id=${detail.query_id}` : ''
+      const forkSeq = typeof detail.fork_seq === 'number' ? ` fork_seq=${detail.fork_seq}` : ''
+      const reasonCode = typeof detail.reason_code === 'string' ? ` reason_code=${detail.reason_code}` : ''
+      return `query_failed${queryId}${forkSeq}${reasonCode}`
+    }
     default: {
       const message = typeof detail.message === 'string' ? detail.message
         : typeof detail.error === 'string' ? detail.error

--- a/crabot-agent/src/workers/types.ts
+++ b/crabot-agent/src/workers/types.ts
@@ -90,6 +90,19 @@ export interface Workspace { readonly root: string }
 export interface OutputCursor { readonly offset: number }
 export interface TraceCursor { readonly offset: number }
 
+export interface SendInputOptions {
+  readonly raw?: boolean
+  readonly delivery_id?: string
+  readonly deadline_at?: string
+  readonly signal?: AbortSignal
+}
+
+export interface ForkOptions {
+  readonly query_id: string
+  readonly establishment_deadline_at: string
+  readonly connection_env?: Record<string, string>
+}
+
 export interface NormalizedTraceEvent {
   readonly ts: string
   readonly kind: 'message' | 'tool_call' | 'tool_result' | 'thinking' | 'lifecycle'
@@ -166,6 +179,8 @@ export interface IncarnationHandle {
    * builtin: 本化身当前 tip node_id;CLI: 原生 session id(resume 沿用 prev 不变;fork 化身
    * 填 fork 自己的引用,不是父化身的)。handle 自描述,调用方无需事后反查(protocol-agent-v3 §6.1)。 */
   readonly session_ref: string
+  /** Fork handles carry the stable query operation identity; mainline handles omit it. */
+  readonly query_id?: string
   /** CLI spawn/resume 首投的事实；builtin/fork 省略并按既有行为处理。 */
   readonly initial_input?: InitialInputResult
 }
@@ -273,8 +288,8 @@ export interface WorkerAdapter {
   provision(ws: Workspace, caps: CapabilityBundle): Promise<void>
   spawn(spec: SpawnSpec): Promise<IncarnationHandle>
   resume(prev: IncarnationRef, wakeInput: string, opts?: { connection_env?: Record<string, string> }): Promise<IncarnationHandle>
-  fork(prev: IncarnationRef, forkInput: string, opts?: { connection_env?: Record<string, string> }): Promise<IncarnationHandle>
-  sendInput(h: IncarnationHandle, text: string, opts?: { raw?: boolean }): Promise<void>
+  fork(prev: IncarnationRef, forkInput: string, opts: ForkOptions): Promise<IncarnationHandle>
+  sendInput(h: IncarnationHandle, text: string, opts?: SendInputOptions): Promise<void>
   readOutput(h: IncarnationHandle, cursor: OutputCursor): Promise<{ chunk: string; nextCursor: OutputCursor }>
   state(h: IncarnationHandle): Promise<WorkerContractState>
   /**

--- a/crabot-agent/tests/manager/bootstrap.test.ts
+++ b/crabot-agent/tests/manager/bootstrap.test.ts
@@ -6,7 +6,7 @@
  *    见该用例内的注释;
  * ② harness.ts 文件头的四步接线契约成立(空 Map → harness → adapter 拿 handleStateChange →
  *    set 回同一 Map),且 adapter 的状态回调真的能被 harness 收到并落账;
- * ③ `onAsyncError` 经 registry 的 toolFace 工厂端到端接到 worker-tools 的 `query_worker`;
+ * ③ `query_worker` 在同一次工具调用返回建立错误，不注入额外异步 wake;
  * ④ `reconcileManagerStack` 对空台账快速返回空三桶。
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
@@ -20,7 +20,7 @@ import { LedgerStore } from '../../src/workers/harness/ledger-store.js'
 import { BuiltinWorkerAdapter } from '../../src/workers/builtin/adapter.js'
 import { ClaudeCodeAdapter } from '../../src/workers/claude-code/adapter.js'
 import { CodexWorkerAdapter } from '../../src/workers/codex/adapter.js'
-import { CapabilityNotSupportedError } from '../../src/workers/errors.js'
+import { QueryEstablishmentError } from '../../src/workers/errors.js'
 import { type ManagerKey, type LedgerWorker } from '../../src/workers/harness/ledger-types.js'
 import type { WorkerAdapter, WorkerImplId, IncarnationHandle, StateChangeReport, WorkerContractState } from '../../src/workers/types.js'
 import type { LLMAdapter, LLMStreamParams } from '../../src/engine/index.js'
@@ -291,16 +291,21 @@ describe('manager bootstrap（P5 Task 1）', () => {
     expect(after?.worker.incarnations[0].state).toBe('exited')
 
     // step 4 的另一面：harness 按需从同一个底层 Map 取 adapter——codex 是构造 harness 之后才
-    // set 进去的，能命中它自己的 capabilities().fork===false 分支，就证明 Map 引用是共享的
-    // （若没共享，抛的会是 "no adapter registered for impl 'codex'"）。
+    // set 进去的，能命中它自己的 capabilities().fork===false 分支并包装成同步建立错误，
+    // 就证明 Map 引用是共享的（若没共享，错误原因会是 no adapter registered）。
     await stack.ledger.upsertWorker(managerKey, 'w-codex-1', () =>
       makeLedgerWorker({ workerId: 'w-codex-1', impl: 'codex', spawnedBySession: 'wechat::sess-boot' as ManagerKey }),
     )
-    await expect(stack.harness.queryWorker('w-codex-1', '进展如何？')).rejects.toBeInstanceOf(CapabilityNotSupportedError)
+    await expect(stack.harness.queryWorker('w-codex-1', '进展如何？')).rejects.toMatchObject({
+      name: 'QueryEstablishmentError',
+      reason_code: 'fork_capability_unavailable',
+      certainty: 'not_started',
+    } satisfies Partial<QueryEstablishmentError>)
 
-    // onEvent → registry.routeWorkerEvent 确实接上了（state_changed 与 query_failed 各一条）
-    await waitUntil(() => routeSpy.mock.calls.length >= 2)
-    expect(routeSpy.mock.calls.map(([e]) => e.kind)).toEqual(['state_changed', 'query_failed'])
+    // 普通 onEvent → registry.routeWorkerEvent 确实接上了。query_failed 是 operation audit，
+    // 由 receipt 通知器另路可靠投递，不再走普通 fire-and-forget 事件口。
+    await waitUntil(() => routeSpy.mock.calls.length >= 1)
+    expect(routeSpy.mock.calls.map(([e]) => e.kind)).toEqual(['state_changed'])
     await Promise.allSettled(routeSpy.mock.results.map((r) => r.value as Promise<unknown>))
   })
 
@@ -323,9 +328,9 @@ describe('manager bootstrap（P5 Task 1）', () => {
     expect(routeSpy).not.toHaveBeenCalled()
   })
 
-  // --- ③ onAsyncError 端到端 ---
+  // --- ③ query_worker 建立错误同步返回 ---
 
-  it('known-ID authorization happens before query_worker fire-and-forget: an unknown worker returns an error and no async wake is injected', async () => {
+  it('known-ID authorization happens before query receipt creation: an unknown worker returns an error and no async wake is injected', async () => {
     let triggered = false
     const managerLLM: LLMAdapter = {
       async *stream(params: LLMStreamParams) {
@@ -335,7 +340,7 @@ describe('manager bootstrap（P5 Task 1）', () => {
           const queryWorkerTool = params.tools.find((t) => t.name === 'query_worker')
           expect(queryWorkerTool).toBeDefined()
           const result = await queryWorkerTool!.call({ worker_id: 'w-not-in-ledger', question: '进展如何？' }, {} as never)
-          // Authorization completes before a fire-and-forget fork can begin.
+          // Authorization completes before a query receipt or fork can begin.
           expect(result.isError).toBe(true)
         }
         yield* chunksFromContent([{ type: 'text', text: '收到' }], 'end_turn', { inputTokens: 10, outputTokens: 5 })

--- a/crabot-agent/tests/manager/manager-integration.test.ts
+++ b/crabot-agent/tests/manager/manager-integration.test.ts
@@ -329,7 +329,7 @@ async function setupAssembly(opts: AssemblyOptions): Promise<Assembly> {
     managerKeyFor,
     adapter: () => opts.managerAdapter,
     model: () => 'test-manager-model',
-    toolFace: (key, isSystemThread, onAsyncError) => {
+    toolFace: (key, isSystemThread) => {
       const tools = buildManagerToolFace({
         harness,
         workerContext: () => ({
@@ -341,7 +341,6 @@ async function setupAssembly(opts: AssemblyOptions): Promise<Assembly> {
         memoryServer,
         callAdmin: async () => ({}),
         isSystemThread,
-        onAsyncError,
       })
       // 记录每次真实工具调用(名称+入参),供断言"工具调用序列符合预期" / "send_master_private
       // 是否被调用"——不干预调用本身,只是在真实 call 前后各插一条日志。
@@ -632,19 +631,20 @@ describe('manager-integration（P4 Task 10：真实 ManagerRegistry + 真实 Wor
     expect(wake2Call.messages.length).toBe(1 + KEEP_RECENT + 1)
   })
 
-  // --- 场景四：onAsyncError 真实装配路径接通（Task 8 复审遗留验证） ---
+  // --- 场景四：query_worker 同步建立失败 + 持久通知责任 ---
 
   it(
-    '场景四：capabilities().fork===false 的 worker（如实实现,非桩造异常）上调 query_worker，' +
-      '失败经真实 harness.queryWorker 的能力校验分支 + 真实 onAsyncError 转发链 → manager 最终被唤醒/事件入队',
+    '场景四：capabilities().fork===false 的 worker 上调 query_worker，' +
+      '同一工具调用返回结构化错误，并留下待通知 query receipt',
     async () => {
       const key = 'wechat::sess-fork' as ManagerKey
       const managerNowMs = Date.parse('2026-01-01T00:00:00.000Z')
 
       let workerId = ''
       let turnIndex = 0
+      let secondTurnMessages = ''
       const adapter: LLMAdapter = {
-        async *stream() {
+        async *stream(params) {
           turnIndex++
           if (turnIndex === 1) {
             yield* chunksFromContent(
@@ -654,13 +654,9 @@ describe('manager-integration（P4 Task 10：真实 ManagerRegistry + 真实 Wor
             )
             return
           }
-          // turn 2：给 query_worker 的游离 promise 一个宏任务窗口 reject 并触发 onAsyncError——
-          // harness.queryWorker 的 capability_not_supported 拒绝虽是纯逻辑判断（无真实 IO），
-          // 仍经过 AsyncMutex 排队等若干 microtask，这里等一个宏任务窗口，与 registry.test.ts
-          // 现有 e2e 用例同款做法。此刻 episode 仍在跑（activeEpisodes>0），预期走
-          // enqueueDuringEpisode 分支。
-          await new Promise((resolve) => setTimeout(resolve, 20))
-          yield* chunksFromContent([{ type: 'text', text: '已发起侧问，等待结果。' }], 'end_turn', { inputTokens: 10, outputTokens: 5 })
+          // turn 2：engine 已把同步 tool error 放回上下文；Manager 当轮即可读到稳定原因。
+          secondTurnMessages = JSON.stringify(params.messages)
+          yield* chunksFromContent([{ type: 'text', text: '侧问未能建立。' }], 'end_turn', { inputTokens: 10, outputTokens: 5 })
         },
         updateConfig: () => {},
       }
@@ -694,15 +690,23 @@ describe('manager-integration（P4 Task 10：真实 ManagerRegistry + 真实 Wor
 
       // 真实工具面里确实调用过 query_worker（不是手工伪造的回调）
       expect(assembly.toolCallLog.some((c) => c.name === 'query_worker')).toBe(true)
+      expect(secondTurnMessages).toContain('fork_capability_unavailable')
 
-      // manager 最终被唤醒/事件入队：episode 仍在跑，走 enqueueDuringEpisode 分支
-      expect(enqueueSpy).toHaveBeenCalledTimes(1)
-      expect(JSON.stringify(enqueueSpy.mock.calls[0][0])).toContain('query_failed')
+      // 建立失败不再合成第二条 mid-episode wake；tool result 已在当前 turn 返回。
+      expect(enqueueSpy).not.toHaveBeenCalled()
 
-      // 真实失败留痕：harness.queryWorker 自己也把这次失败 appendEvent('query_failed', ...)
-      const queryFailedEvent = assembly.events.find((e) => e.worker_id === workerId && e.kind === 'query_failed')
+      // 真实失败留痕与通知责任都已持久化；通知器后续按 owning manager 重试。
+      const queryFailedEvent = (await assembly.harness.readWorkerEvents(workerId))
+        .find((e) => e.kind === 'query_failed')
       expect(queryFailedEvent).toBeDefined()
-      expect(queryFailedEvent?.detail?.reason).toBe('capability_not_supported')
+      expect(queryFailedEvent?.detail?.reason_code).toBe('fork_capability_unavailable')
+      const queryReceipts = JSON.parse(
+        await fs.readFile(join(dataDir, 'workers', workerId, 'query-receipts.json'), 'utf8'),
+      ) as { receipts: Array<Record<string, unknown>> }
+      expect(queryReceipts.receipts[0]).toMatchObject({
+        state: 'failed',
+        manager_notification: { status: 'pending' },
+      })
     },
     15000,
   )

--- a/crabot-agent/tests/manager/p5-integration.test.ts
+++ b/crabot-agent/tests/manager/p5-integration.test.ts
@@ -290,10 +290,10 @@ describe('P5 集成：manager 栈启动接线（Task 6）', () => {
   it('manager 工具面接 enableFeishuDocTool：无飞书实例时三件套不出现，探测到实例后出现，feishu_write 始终不出现', () => {
     boot()
     const registryDeps = (internals.managerStack as unknown as {
-      registry: { deps: { toolFace: (k: ManagerKey, sys: boolean, onErr: () => void) => ReadonlyArray<ToolDefinition> } }
+      registry: { deps: { toolFace: (k: ManagerKey, sys: boolean) => ReadonlyArray<ToolDefinition> } }
     }).registry.deps
     const namesNow = (): string[] =>
-      registryDeps.toolFace('wechat::sess-1' as ManagerKey, false, () => {}).map((t) => t.name)
+      registryDeps.toolFace('wechat::sess-1' as ManagerKey, false).map((t) => t.name)
 
     const feishuReadOnly = ['read_feishu_document', 'feishu_raw_get', 'feishu_download_file']
 

--- a/crabot-agent/tests/manager/registry.test.ts
+++ b/crabot-agent/tests/manager/registry.test.ts
@@ -8,7 +8,6 @@ import {
   SYSTEM_TASKS_MANAGER_KEY,
   MAX_SELF_WAKE_CHAIN,
   type ManagerRegistryDeps,
-  type OnAsyncError,
 } from '../../src/manager/registry.js'
 import {
   laneBatchToWakeEvent,
@@ -27,7 +26,7 @@ import type { LLMAdapter, LLMStreamParams, EngineMessage } from '../../src/engin
 import { chunksFromContent } from '../engine/helpers/mock-stream.js'
 import { buildManagerToolFace } from '../../src/manager/tools/tool-face.js'
 import { createCrabMemoryServer } from '../../src/mcp/crab-memory.js'
-import { CapabilityNotSupportedError } from '../../src/workers/errors.js'
+import { QueryEstablishmentError } from '../../src/workers/errors.js'
 
 // --- Fixtures / helpers（与 tests/manager/loop.test.ts 同一套约定） ---
 
@@ -304,7 +303,7 @@ describe('ManagerRegistry', () => {
           onHumanWake: async (key, principal) => {
             wakeCalls.push({ key, friendId: principal.friend?.id, sessionType: principal.sessionType })
           },
-          toolFace: (_k, _s, _e, _sched, humanPrincipal) => {
+          toolFace: (_k, _s, _sched, humanPrincipal) => {
             toolFaceCalls.push({ friendId: humanPrincipal?.friend?.id, sessionType: humanPrincipal?.sessionType })
             return []
           },
@@ -333,7 +332,7 @@ describe('ManagerRegistry', () => {
       const registry = new ManagerRegistry(
         baseRegistryDeps({
           adapter,
-          toolFace: (_k, _s, _e, _sched, humanPrincipal) => {
+          toolFace: (_k, _s, _sched, humanPrincipal) => {
             toolFaceCalls.push({ friendId: humanPrincipal?.friend?.id, sessionType: humanPrincipal?.sessionType })
             return []
           },
@@ -374,6 +373,44 @@ describe('ManagerRegistry', () => {
 
     const state = await store.load(SYSTEM_TASKS_MANAGER_KEY)
     expect(state.recent.length).toBeGreaterThan(0)
+  })
+
+  it('operation notification 在 owning Manager 正执行时 deferred，不塞进当前 mailbox', async () => {
+    const calls: LLMStreamParams[] = []
+    const entered = deferred()
+    const release = deferred()
+    let turn = 0
+    const adapter: LLMAdapter = {
+      async *stream(params) {
+        calls.push({ ...params, messages: [...params.messages] })
+        turn++
+        if (turn === 1) {
+          entered.resolve()
+          await release.promise
+        }
+        yield* chunksFromContent([{ type: 'text', text: 'ok' }], 'end_turn', { inputTokens: 1, outputTokens: 1 })
+      },
+      updateConfig: () => {},
+    }
+    const registry = new ManagerRegistry(baseRegistryDeps({ adapter }))
+    const key = 'wechat::operation-owner' as ManagerKey
+    const event: HarnessEvent = {
+      ts: '2026-01-01T00:00:00.000Z',
+      kind: 'input_delivery_failed',
+      worker_id: 'w-operation',
+      seq: 1,
+      detail: { delivery_id: 'delivery-1' },
+    }
+
+    const active = registry.routeHumanMessages('wechat', 'operation-owner', [makeChannelMessage('先处理这条')])
+    await entered.promise
+    await expect(registry.routeOperationNotification(key, event)).resolves.toEqual({ consumed: false })
+    expect(calls).toHaveLength(1)
+
+    release.resolve()
+    await active
+    await expect(registry.routeOperationNotification(key, event)).resolves.toEqual({ consumed: true })
+    expect(calls).toHaveLength(2)
   })
 
   // --- routeSchedule ---
@@ -651,20 +688,19 @@ describe('ManagerRegistry', () => {
     const key = 'wechat::sess-closing-self-wake' as ManagerKey
     const { adapter, calls } = makeAdapter()
     let closing = false
-    let capturedOnAsyncError: OnAsyncError | undefined
     const registry = new ManagerRegistry(baseRegistryDeps({
       adapter,
       isClosing: () => closing,
-      toolFace: (_key, _isSystemThread, onAsyncError) => {
-        capturedOnAsyncError = onAsyncError
-        return []
-      },
     }))
 
     const origAppend = store.appendEpisodeLog.bind(store)
     vi.spyOn(store, 'appendEpisodeLog').mockImplementation(async (managerKey, episodeId, messages) => {
       await origAppend(managerKey, episodeId, messages)
-      capturedOnAsyncError?.({ tool: 'query_worker', worker_id: 'w-closing', error: 'fork failed' })
+      await registry.routeMediaNotification({
+        channelId: 'wechat',
+        sessionId: 'sess-closing-self-wake',
+        text: 'late notification',
+      })
       closing = true
     })
 
@@ -682,30 +718,24 @@ describe('ManagerRegistry', () => {
     queue.push({ text: '第一个 episode 收口', stopReason: 'end_turn' })
     queue.push({ text: '自唤醒 episode 的回复', stopReason: 'end_turn' })
 
-    let capturedOnAsyncError: OnAsyncError | undefined
-    const registry = new ManagerRegistry(
-      baseRegistryDeps({
-        adapter,
-        toolFace: (_key, _isSystemThread, onAsyncError) => {
-          capturedOnAsyncError = onAsyncError
-          return []
-        },
-      })
-    )
+    const registry = new ManagerRegistry(baseRegistryDeps({ adapter }))
 
     // 复现窗口：query-loop 在 end_turn 收口前做**最后一次** drainPending（query-loop.ts:551），
     // 此后到达的注入没有任何消费者在等。这里用 store.appendEpisodeLog 作确定性锚点——它在
     // runEngine 已经返回之后、wakeUp 尚未 resolve 之前被调用（loop.ts runEpisodeBody），
-    // 此刻 registry 仍把该 key 计为在途（activeEpisodes > 0），因此走的正是生产路径
-    // handleAsyncToolError 的 enqueueDuringEpisode 分支（真实触发者是 query_worker 那条
-    // 游离 promise 恰好在最后一次 drain 之后才 reject）。不靠定时器猜时间窗口。
+    // 此刻 registry 仍把该 key 计为在途（activeEpisodes > 0），因此普通媒体通知走
+    // enqueueDuringEpisode 分支。不靠定时器猜时间窗口。
     const origAppend = store.appendEpisodeLog.bind(store)
     let injected = false
     vi.spyOn(store, 'appendEpisodeLog').mockImplementation(async (k, episodeId, messages) => {
       await origAppend(k, episodeId, messages)
       if (!injected) {
         injected = true
-        capturedOnAsyncError?.({ tool: 'query_worker', worker_id: 'w-late', error: 'fork failed' })
+        void registry.routeMediaNotification({
+          channelId: 'wechat',
+          sessionId: 'sess-stall',
+          text: 'late notification',
+        })
       }
     })
 
@@ -717,11 +747,11 @@ describe('ManagerRegistry', () => {
     await vi.waitFor(
       async () => {
         const state = await store.load(key)
-        expect(JSON.stringify(state.recent)).toContain('query_failed')
+        expect(JSON.stringify(state.recent)).toContain('late notification')
       },
       { timeout: 2000, interval: 10 }
     )
-    const occurrences = (JSON.stringify((await store.load(key)).recent).match(/query_failed/g) ?? []).length
+    const occurrences = (JSON.stringify((await store.load(key)).recent).match(/late notification/g) ?? []).length
     expect(occurrences).toBe(1)
   })
 
@@ -789,19 +819,10 @@ describe('ManagerRegistry', () => {
     const key = 'wechat::sess-chain' as ManagerKey
     const { adapter, calls } = makeAdapter()
 
-    let capturedOnAsyncError: OnAsyncError | undefined
-    const registry = new ManagerRegistry(
-      baseRegistryDeps({
-        adapter,
-        toolFace: (_key, _isSystemThread, onAsyncError) => {
-          capturedOnAsyncError = onAsyncError
-          return []
-        },
-      })
-    )
+    const registry = new ManagerRegistry(baseRegistryDeps({ adapter }))
 
-    // 病态注入源：**每个** episode 收口后都再产生一条注入（模拟某 worker 上 query_worker
-    // 恒失败这类稳定复发故障）。没有上限的话这就是一条无限的 episode 链。
+    // 病态注入源：**每个** episode 收口后都再产生一条普通通知。没有上限的话这就是
+    // 一条无限的 episode 链。
     let keepInjecting = true
     let injections = 0
     const origAppend = store.appendEpisodeLog.bind(store)
@@ -809,7 +830,11 @@ describe('ManagerRegistry', () => {
       await origAppend(k, episodeId, messages)
       if (keepInjecting) {
         injections++
-        capturedOnAsyncError?.({ tool: 'query_worker', worker_id: `w-${injections}`, error: 'fork failed' })
+        void registry.routeMediaNotification({
+          channelId: 'wechat',
+          sessionId: 'sess-chain',
+          text: `notification-${injections}`,
+        })
       }
     })
 
@@ -829,7 +854,7 @@ describe('ManagerRegistry', () => {
     keepInjecting = false
     await registry.routeHumanMessages('wechat', 'sess-chain', [makeChannelMessage('还在吗')])
     const lastCall = calls[calls.length - 1]
-    expect(JSON.stringify(lastCall.messages)).toContain(`w-${1 + MAX_SELF_WAKE_CHAIN}`)
+    expect(JSON.stringify(lastCall.messages)).toContain(`notification-${1 + MAX_SELF_WAKE_CHAIN}`)
   })
 
   // --- media notification: 独立 manager 唤醒，不伪装 schedule/bg ---
@@ -890,97 +915,9 @@ describe('ManagerRegistry', () => {
     expect(wakeUpSpy).toHaveBeenCalledTimes(1)
   })
 
-  // --- onAsyncError 接线（Task 4 遗留出口） ---
+  // --- query_worker 同步建立错误 ---
 
-  it('onAsyncError: episode 运行中收到异步错误 → enqueueDuringEpisode，不额外开新 episode', async () => {
-    const key = 'wechat::sess-async' as ManagerKey
-    let capturedOnAsyncError: OnAsyncError | undefined
-    let triggered = false
-    const adapter: LLMAdapter = {
-      async *stream(params: LLMStreamParams) {
-        // tools() 在 callNonStreaming 之前同步求值（query-loop.ts），此刻 capturedOnAsyncError
-        // 必然已经就绪；只在第一轮 turn 触发一次模拟 query_worker 的异步失败，此时 episode
-        // 仍在跑（registry.runWake 已经把 key 标进 activeEpisodes，wakeUp 尚未 resolve）。
-        // enqueueDuringEpisode 把它推进 mailbox 后，query-loop 在本轮 end_turn 收口前会
-        // drainPending 发现新内容，注入一条 supplement 消息并继续跑下一轮（而不是结束当前
-        // episode）——这正是"mid-episode 注入"要验证的行为，第二轮不再触发，让它正常收口。
-        if (!triggered) {
-          triggered = true
-          capturedOnAsyncError?.({ tool: 'query_worker', worker_id: 'w-1', error: 'fork failed' })
-        }
-        yield* chunksFromContent([{ type: 'text', text: '收到' }], 'end_turn', { inputTokens: 10, outputTokens: 5 })
-      },
-      updateConfig: () => {},
-    }
-    const registry = new ManagerRegistry(
-      baseRegistryDeps({
-        adapter,
-        toolFace: (_key, _isSystemThread, onAsyncError) => {
-          capturedOnAsyncError = onAsyncError
-          return []
-        },
-      })
-    )
-    const loop = registry.getOrCreate(key)
-    const enqueueSpy = vi.spyOn(loop, 'enqueueDuringEpisode')
-    const wakeUpSpy = vi.spyOn(loop, 'wakeUp')
-
-    await registry.routeHumanMessages('wechat', 'sess-async', [makeChannelMessage('你好')])
-
-    expect(enqueueSpy).toHaveBeenCalledTimes(1)
-    const syntheticEnvelope = enqueueSpy.mock.calls[0][0]
-    expect(syntheticEnvelope.received_at).toBe('2026-01-01T08:00:00+08:00')
-    expect(syntheticEnvelope.occurred_at).toBe('2026-01-01T00:00:00.000Z')
-    expect(syntheticEnvelope.wake).toMatchObject({
-      kind: 'worker_event',
-      event: { kind: 'query_failed', ts: '2026-01-01T00:00:00.000Z' },
-    })
-    // wakeUp 只被 routeHumanMessages 自己调用了一次；onAsyncError 没有额外触发第二次 wakeUp
-    expect(wakeUpSpy).toHaveBeenCalledTimes(1)
-  })
-
-  it('onAsyncError: 无 episode 在跑时收到异步错误 → wakeUp 开一个新 episode', async () => {
-    const key = 'wechat::sess-async-idle' as ManagerKey
-    let capturedOnAsyncError: OnAsyncError | undefined
-    const { adapter, queue } = makeAdapter()
-    queue.push({ text: '初次回复', stopReason: 'end_turn' })
-    const registry = new ManagerRegistry(
-      baseRegistryDeps({
-        adapter,
-        toolFace: (_key, _isSystemThread, onAsyncError) => {
-          capturedOnAsyncError = onAsyncError
-          return []
-        },
-      })
-    )
-
-    // 先跑一次正常 episode，让 toolFace 工厂被求值一次，拿到 capturedOnAsyncError；
-    // 此时该 episode 已经结束（wakeUp 已 resolve），activeEpisodes 里已经没有这个 key。
-    await registry.routeHumanMessages('wechat', 'sess-async-idle', [makeChannelMessage('你好')])
-    const loop = registry.getOrCreate(key)
-    const enqueueSpy = vi.spyOn(loop, 'enqueueDuringEpisode')
-    const wakeUpSpy = vi.spyOn(loop, 'wakeUp')
-
-    queue.push({ text: '处理异步错误', stopReason: 'end_turn' })
-    capturedOnAsyncError?.({ tool: 'query_worker', worker_id: 'w-2', error: 'fork failed' })
-    // handleAsyncToolError 内部 `void this.runWake(...)` 是字面 fire-and-forget，但
-    // `runWake` 对 `loop.wakeUp(event)` 的调用本身（不是它的 await）在上面这行同步完成——
-    // 拿到 spy 记录的 promise 显式 await 它，而不是猜测需要多少个事件循环 tick。
-    expect(wakeUpSpy).toHaveBeenCalledTimes(1)
-    await wakeUpSpy.mock.results[0].value
-
-    expect(enqueueSpy).not.toHaveBeenCalled()
-    const state = await store.load(key)
-    // 两次唤醒（人类消息 + 异步错误）都在历史里
-    expect(JSON.stringify(state.recent)).toContain('query_failed')
-  })
-
-  it('onAsyncError 全链路打通（不只是类型上通）：经 registry 装配的真实工具面调用 query_worker，fork 恒失败 → onAsyncError 触发 → episode 内 enqueueDuringEpisode', async () => {
-    // 与上面两个用例的关键区别：这里不手工伪造 onAsyncError 回调，而是走
-    // buildManagerToolFace（真实生产代码，装配四个来源的完整工具面）产出的 query_worker
-    // 工具——验证 ToolFaceDeps.onAsyncError → buildWorkerTools 这条转发链真的接上了，不是
-    // 只在类型层面通过。fake harness.queryWorker 恒拒绝，模拟 codex worker 上 fork 恒
-    // CapabilityNotSupportedError 的真机场景（见 codex adapter：fork capability 恒 false）。
+  it('真实工具面调用 query_worker 建立失败时，同一次调用返回结构化错误且不注入 synthetic wake', async () => {
     const key = 'wechat::sess-e2e-toolface' as ManagerKey
     const fakeHarness = {
       listWorkers: async (): Promise<LedgerWorker[]> => [],
@@ -994,11 +931,17 @@ describe('ManagerRegistry', () => {
         },
       }),
       queryWorker: async (): Promise<never> => {
-        throw new CapabilityNotSupportedError('codex', 'fork')
+        throw new QueryEstablishmentError(
+          'query-e2e',
+          'fork_capability_unavailable',
+          'codex does not support fork',
+          'not_started',
+        )
       },
     } as unknown as WorkerHarness
 
     let triggered = false
+    let toolResult: Awaited<ReturnType<ToolDefinition['call']>> | undefined
     const adapter: LLMAdapter = {
       async *stream(params: LLMStreamParams) {
         if (!triggered) {
@@ -1007,12 +950,11 @@ describe('ManagerRegistry', () => {
           // （而不是自己手搓一个），证明调用的是生产链路上真正会喂给 LLM 的那个工具定义。
           const queryWorkerTool = params.tools.find((t) => t.name === 'query_worker')
           expect(queryWorkerTool).toBeDefined()
-          const result = await queryWorkerTool!.call({ worker_id: 'w-codex-1', question: '现在进展如何？' }, {} as never)
-          // query_worker 本身是 fire-and-forget：调用不因后台失败而报错。
-          expect(result.isError).toBe(false)
-          // 给游离 promise 一个宏任务窗口 reject 并被 .catch() 触发 onAsyncError（同一 turn
-          // 内、episode 尚未收口，仍处于 activeEpisodes 计数 > 0 的窗口）。
-          await new Promise((resolve) => setTimeout(resolve, 20))
+          toolResult = await queryWorkerTool!.call(
+            { worker_id: 'w-codex-1', question: '现在进展如何？' },
+            {} as never,
+          )
+          expect(toolResult.isError).toBe(true)
         }
         yield* chunksFromContent([{ type: 'text', text: '收到' }], 'end_turn', { inputTokens: 10, outputTokens: 5 })
       },
@@ -1023,7 +965,7 @@ describe('ManagerRegistry', () => {
       baseRegistryDeps({
         adapter,
         harness: fakeHarness,
-        toolFace: (k, isSystemThread, onAsyncError) =>
+        toolFace: (k, isSystemThread) =>
           buildManagerToolFace({
             harness: fakeHarness,
             workerContext: () => ({
@@ -1034,7 +976,6 @@ describe('ManagerRegistry', () => {
             memoryServer: makeMemoryServer(),
             callAdmin: async () => ({}),
             isSystemThread,
-            onAsyncError,
           }),
       })
     )
@@ -1044,11 +985,14 @@ describe('ManagerRegistry', () => {
     const result = await registry.routeHumanMessages('wechat', 'sess-e2e-toolface', [makeChannelMessage('侧问一下 worker')])
 
     expect(result.outcome).toBe('completed')
-    // 链路真的通了：registry 按 key 绑定的 onAsyncError 被触发，且因为此刻 episode 仍在跑
-    // （query_worker.call 是在 adapter.stream 内部同步发起的，尚未收口），走的是
-    // enqueueDuringEpisode 分支，不是额外开一个新 episode。
-    expect(enqueueSpy).toHaveBeenCalledTimes(1)
-    expect(JSON.stringify(enqueueSpy.mock.calls[0][0])).toContain('query_failed')
+    expect(toolResult).toMatchObject({ isError: true })
+    expect(JSON.parse(toolResult!.output)).toEqual({
+      query_id: 'query-e2e',
+      reason_code: 'fork_capability_unavailable',
+      reason: 'codex does not support fork',
+      certainty: 'not_started',
+    })
+    expect(enqueueSpy).not.toHaveBeenCalled()
   })
 })
 

--- a/crabot-agent/tests/manager/worker-tools.test.ts
+++ b/crabot-agent/tests/manager/worker-tools.test.ts
@@ -21,6 +21,8 @@ import type {
   CapabilityBundle,
   AdapterCapabilities,
   DetectResult,
+  ForkOptions,
+  SendInputOptions,
 } from '../../src/workers/types'
 
 // ---- FakeAdapter：实现 WorkerAdapter 契约的可编程桩，不碰 tmux/LLM（照抄
@@ -34,14 +36,14 @@ interface FakeAdapterOpts {
   readonly implId?: WorkerImplId
   readonly caps?: Partial<AdapterCapabilities>
   readonly onStateChange?: (h: IncarnationHandle, state: WorkerContractState) => void
-  readonly sendInputBehavior?: (h: IncarnationHandle, text: string, opts?: { raw?: boolean }) => void
+  readonly sendInputBehavior?: (h: IncarnationHandle, text: string, opts?: SendInputOptions) => void
   readonly outputChunk?: string
 }
 
 class FakeAdapter implements WorkerAdapter {
   readonly implId: WorkerImplId
   readonly spawnCalls: SpawnSpec[] = []
-  readonly sendInputCalls: Array<{ h: IncarnationHandle; text: string; opts?: { raw?: boolean } }> = []
+  readonly sendInputCalls: Array<{ h: IncarnationHandle; text: string; opts?: SendInputOptions }> = []
   readonly killCalls: IncarnationHandle[] = []
   readonly readOutputCalls: Array<{ h: IncarnationHandle; cursor: OutputCursor }> = []
   private readonly states = new Map<string, WorkerContractState>()
@@ -68,14 +70,20 @@ class FakeAdapter implements WorkerAdapter {
     throw new Error('FakeAdapter.resume: not exercised by worker-tools tests')
   }
 
-  async fork(prev: IncarnationRef, _forkInput: string): Promise<IncarnationHandle> {
+  async fork(prev: IncarnationRef, _forkInput: string, opts: ForkOptions): Promise<IncarnationHandle> {
     const seq = this.nextForkSeq++
-    const handle: IncarnationHandle = { worker_id: prev.worker_id, seq, impl: this.implId, session_ref: `fork-ref-${prev.worker_id}#${seq}` }
+    const handle: IncarnationHandle = {
+      worker_id: prev.worker_id,
+      seq,
+      impl: this.implId,
+      session_ref: `fork-ref-${prev.worker_id}#${seq}`,
+      query_id: opts.query_id,
+    }
     this.states.set(handleKey(handle), 'running')
     return handle
   }
 
-  async sendInput(h: IncarnationHandle, text: string, opts?: { raw?: boolean }): Promise<void> {
+  async sendInput(h: IncarnationHandle, text: string, opts?: SendInputOptions): Promise<void> {
     this.sendInputCalls.push({ h, text, opts })
     if (this.opts.sendInputBehavior) this.opts.sendInputBehavior(h, text, opts)
   }
@@ -260,7 +268,7 @@ describe('spawn_worker', () => {
 // ---- send_to_worker ----
 
 describe('send_to_worker', () => {
-  it('异步返回简短确认，text/raw 原样透传给 adapter.sendInput', async () => {
+  it('返回真实 delivered 回执，text/raw 与 delivery_id 透传给 adapter.sendInput', async () => {
     const { harness, fake } = await makeHarness()
     const worker = await harness.spawnWorker(directSpawnParams())
     const tools = buildWorkerTools({ harness, context: () => CTX })
@@ -269,11 +277,12 @@ describe('send_to_worker', () => {
     const result = await sendToWorker.call({ worker_id: worker.worker_id, text: '继续', raw: true }, {})
     expect(result.isError).toBe(false)
     const parsed = parseOutput(result.output)
-    expect(parsed).toEqual({ status: 'sent', worker_id: worker.worker_id })
+    expect(parsed).toMatchObject({ status: 'delivered', worker_id: worker.worker_id })
+    expect(parsed.delivery_id).toMatch(/^[0-9a-f-]{36}$/)
 
     expect(fake.sendInputCalls).toHaveLength(1)
     expect(fake.sendInputCalls[0].text).toBe('继续')
-    expect(fake.sendInputCalls[0].opts).toEqual({ raw: true })
+    expect(fake.sendInputCalls[0].opts).toMatchObject({ raw: true, delivery_id: parsed.delivery_id })
   })
 
   it('worker 不存在 → WorkerNotFoundError 转成可读 tool_result（isError:true，不抛出）', async () => {
@@ -298,7 +307,7 @@ describe('send_to_worker', () => {
     expect(result.output).toMatch(/cancelled/)
   })
 
-  it('自动 handoff 目标全部用过 → ImplAlreadyUsedError 转成可读 tool_result（isError:true，不抛出）', async () => {
+  it('receipt 创建后的自动 handoff 失败 → 返回 failed 回执和明确原因', async () => {
     // 照抄 tests/workers/harness/harness-continuation.test.ts 里触发 ImplAlreadyUsedError 的
     // 最小配方：只注册一个（已被用过的）impl，sendInput 权威判定化身已终态，revive:false
     // 逼 continueTerminalWorker 走自动 handoff，pickUnusedImpl 无处可选，pre-flight 抛错。
@@ -313,23 +322,19 @@ describe('send_to_worker', () => {
     const sendToWorker = tools.find((t) => t.name === 'send_to_worker')!
 
     const result = await sendToWorker.call({ worker_id: worker.worker_id, text: '接着做完' }, {})
-    expect(result.isError).toBe(true)
-    expect(result.output).toMatch(/already has an incarnation/)
+    expect(result.isError).toBe(false)
+    expect(parseOutput(result.output)).toMatchObject({
+      status: 'failed',
+      worker_id: worker.worker_id,
+      reason_code: 'continuation_failed',
+      certainty: 'not_delivered',
+      reason: expect.stringMatching(/already has an incarnation/),
+    })
   })
 })
 
-// ---- query_worker（fire-and-forget：不等 harness.queryWorker 落地，立即返回） ----
-//
-// 与其它五个工具不同：cc worker 的 harness.queryWorker → adapter.fork 会 await 一整个无头
-// `claude -p` 子进程跑完（几十秒到数分钟），完整 await 会把 manager 的整个 turn 阻塞住，
-// 违反 protocol-agent-v3 §4.1/§4.3"慢工具异步发起即返回，结果作为事件唤醒"。因此本工具
-// 改为字面 JS fire-and-forget：调用 harness.queryWorker 后不 await，立即返回简短确认；
-// 游离 promise 用 .catch() 兜住，任何失败（含 WorkerNotFoundError/CapabilityNotSupportedError）
-// 只记诊断日志，不再能在这次调用内回传给 LLM——这是相对其余五个工具的一处刻意语义偏离，
-// 见 controller 决定（task-4-report.md 追加记录）。forkSeq 因此在返回时还不存在，不写进
-// 输出；answer/fork 化身就绪由事件唤醒，届时用 read_worker_output 传 seq 读取。
 describe('query_worker', () => {
-  it('harness.queryWorker 迟迟不 resolve（卡在 adapter.fork）时，工具仍在毫秒级返回，不等它落地', async () => {
+  it('等待 fork 建立后返回 started + query_id + fork_seq，但不等待回答完成', async () => {
     let releaseFork!: () => void
     const forkGate = new Promise<void>((resolve) => {
       releaseFork = resolve
@@ -337,136 +342,77 @@ describe('query_worker', () => {
     const { harness, fake } = await makeHarness({ caps: { fork: true } })
     const worker = await harness.spawnWorker(directSpawnParams())
     const originalFork = fake.fork.bind(fake)
-    fake.fork = async (prev, forkInput) => {
+    fake.fork = async (prev, forkInput, opts) => {
       await forkGate
-      return originalFork(prev, forkInput)
+      return originalFork(prev, forkInput, opts)
     }
     const tools = buildWorkerTools({ harness, context: () => CTX })
     const queryWorker = tools.find((t) => t.name === 'query_worker')!
 
-    const start = Date.now()
-    const result = await queryWorker.call({ worker_id: worker.worker_id, question: '现在进展如何？' }, {})
-    const elapsed = Date.now() - start
+    let settled = false
+    const resultPromise = queryWorker.call({ worker_id: worker.worker_id, question: '现在进展如何？' }, {})
+      .then((result) => { settled = true; return result })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(settled).toBe(false)
 
-    // adapter.fork 卡在 forkGate 上，永不在测试超时内自行 resolve；工具在毫秒级返回证明
-    // 它没有 await harness.queryWorker 的落地。
-    expect(elapsed).toBeLessThan(200)
-    expect(result.isError).toBe(false)
-    const parsed = parseOutput(result.output)
-    // 拿不到 fork_seq（它在 adapter.fork 落地之后才由 harness 生成）——只回确认式简短输出。
-    expect(parsed).toEqual({ status: 'queried', worker_id: worker.worker_id })
-
-    // 收尾：放开卡住的 fork，避免遗留 pending promise 影响其它用例。
     releaseFork()
-    await new Promise((resolve) => setTimeout(resolve, 10))
-  })
-
-  it('游离 promise 落地后（fork 能力开启），侧问化身确实在后台异步建成——不是彻底扔掉不管', async () => {
-    const { harness } = await makeHarness({ caps: { fork: true } })
-    const worker = await harness.spawnWorker(directSpawnParams())
-    const tools = buildWorkerTools({ harness, context: () => CTX })
-    const queryWorker = tools.find((t) => t.name === 'query_worker')!
-
-    const result = await queryWorker.call({ worker_id: worker.worker_id, question: '现在进展如何？' }, {})
-    expect(parseOutput(result.output)).toEqual({ status: 'queried', worker_id: worker.worker_id })
-
-    await waitUntil(async () => {
-      const [w] = await harness.listWorkers(CTX.managerKey)
-      return w.incarnations.length === 2
+    const result = await resultPromise
+    expect(result.isError).toBe(false)
+    expect(parseOutput(result.output)).toMatchObject({
+      status: 'started',
+      worker_id: worker.worker_id,
+      fork_seq: 2,
+      query_id: expect.any(String),
     })
     const [w] = await harness.listWorkers(CTX.managerKey)
-    expect(w.incarnations[1]).toMatchObject({ seq: 2, forked_from: 1 })
+    expect(w.incarnations[1]).toMatchObject({
+      seq: 2,
+      forked_from: 1,
+      query_id: expect.any(String),
+      state: 'running',
+    })
   })
 
-  it('unknown worker is rejected synchronously without an action or unhandled rejection', async () => {
+  it('unknown worker is rejected before creating a query receipt', async () => {
     const { harness } = await makeHarness({ caps: { fork: true } })
     const tools = buildWorkerTools({ harness, context: () => CTX })
     const queryWorker = tools.find((t) => t.name === 'query_worker')!
-
-    const unhandled: unknown[] = []
-    const onUnhandledRejection = (reason: unknown) => unhandled.push(reason)
-    process.on('unhandledRejection', onUnhandledRejection)
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-
     try {
       const result = await queryWorker.call({ worker_id: 'w-nope', question: '？' }, {})
-      // 不再是 isError:true——失败发生在锁外的游离 promise 里，这次调用本身不知道。
       expect(result.isError).toBe(true)
       expect(result.output).toContain('不存在或当前会话无权访问')
-
-      // Authorization happens before fire-and-forget work.
-      await new Promise((resolve) => setTimeout(resolve, 20))
-
-      expect(unhandled).toHaveLength(0)
-      expect(errorSpy).toHaveBeenCalled()
-      const loggedArgs = errorSpy.mock.calls.map((args) => args.join(' ')).join('\n')
-      expect(loggedArgs).toContain('不存在或当前会话无权访问')
+      await expect(fs.access(join(dataDir, 'workers', 'w-nope', 'query-receipts.json'))).rejects.toThrow()
     } finally {
-      process.off('unhandledRejection', onUnhandledRejection)
       errorSpy.mockRestore()
     }
   })
 
-  it('目标实现不支持 fork（CapabilityNotSupportedError）同样只是游离 reject，不产生 unhandledRejection', async () => {
+  it('fork 能力不可用时在同一次调用返回带 query_id 的结构化 tool error', async () => {
     const { harness } = await makeHarness({ caps: { fork: false } })
     const worker = await harness.spawnWorker(directSpawnParams())
     const tools = buildWorkerTools({ harness, context: () => CTX })
     const queryWorker = tools.find((t) => t.name === 'query_worker')!
-
-    const unhandled: unknown[] = []
-    const onUnhandledRejection = (reason: unknown) => unhandled.push(reason)
-    process.on('unhandledRejection', onUnhandledRejection)
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-
     try {
       const result = await queryWorker.call({ worker_id: worker.worker_id, question: '？' }, {})
-      expect(result.isError).toBe(false)
-
-      await new Promise((resolve) => setTimeout(resolve, 20))
-
-      expect(unhandled).toHaveLength(0)
-      expect(errorSpy).toHaveBeenCalled()
-    } finally {
-      process.off('unhandledRejection', onUnhandledRejection)
-      errorSpy.mockRestore()
-    }
-  })
-
-  // ---- P4 Task 4 additive:deps.onAsyncError 扩展点 ----
-  //
-  // query_worker 的失败发生在锁外的游离 promise 里，调用本身早已返回，manager 这次 turn
-  // 已经拿不到失败原因（见上面两个用例）。onAsyncError 是留给 Task 7/8"把这条错误接成唤醒
-  // 本 manager 的信号"的扩展点——本任务只提供出口、验证它确实带着正确的 { tool, worker_id,
-  // error } 被调用，不接线到任何真实唤醒机制。
-  it('authorization rejection does not invoke onAsyncError', async () => {
-    const { harness } = await makeHarness({ caps: { fork: true } })
-    const onAsyncError = vi.fn()
-    const tools = buildWorkerTools({ harness, context: () => CTX, onAsyncError })
-    const queryWorker = tools.find((t) => t.name === 'query_worker')!
-
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-    try {
-      await queryWorker.call({ worker_id: 'w-nope', question: '？' }, {})
-      await new Promise((resolve) => setTimeout(resolve, 20))
-
-      expect(onAsyncError).not.toHaveBeenCalled()
-
-    } finally {
-      errorSpy.mockRestore()
-    }
-  })
-
-  it('unknown worker without onAsyncError returns a synchronous denial', async () => {
-    const { harness } = await makeHarness({ caps: { fork: true } })
-    const tools = buildWorkerTools({ harness, context: () => CTX }) // 不传 onAsyncError
-    const queryWorker = tools.find((t) => t.name === 'query_worker')!
-
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-    try {
-      const result = await queryWorker.call({ worker_id: 'w-nope', question: '？' }, {})
       expect(result.isError).toBe(true)
-      await new Promise((resolve) => setTimeout(resolve, 20))
-      expect(errorSpy).toHaveBeenCalled()
+      expect(parseOutput(result.output)).toMatchObject({
+        query_id: expect.any(String),
+        reason_code: 'fork_capability_unavailable',
+        reason: expect.any(String),
+        certainty: 'not_started',
+      })
+      const receiptFile = JSON.parse(
+        await fs.readFile(join(dataDir, 'workers', worker.worker_id, 'query-receipts.json'), 'utf-8'),
+      ) as { receipts: Array<Record<string, unknown>> }
+      const receipts = receiptFile.receipts
+      expect(receipts).toHaveLength(1)
+      expect(receipts[0]).toMatchObject({
+        query_id: expect.any(String),
+        state: 'failed',
+        manager_notification: { status: 'pending' },
+      })
     } finally {
       errorSpy.mockRestore()
     }

--- a/crabot-agent/tests/workers/builtin-adapter.test.ts
+++ b/crabot-agent/tests/workers/builtin-adapter.test.ts
@@ -16,6 +16,13 @@ import { chunksFromContent } from '../engine/helpers/mock-stream.js'
  *  send_message 工具，这段文案一旦出现在它的上下文里就是 bug。 */
 const FORCED_SUMMARY_MARKER = '你刚才以 end_turn 结束但还没有向人类发送任何内容'
 
+function forkOptions() {
+  return {
+    query_id: randomUUID(),
+    establishment_deadline_at: new Date(Date.now() + 30_000).toISOString(),
+  }
+}
+
 function makeAdapter(
   responses: Array<{
     text?: string
@@ -359,11 +366,11 @@ describe('BuiltinWorkerAdapter', () => {
       await adapter.sendInput(h, '运行中追加的输入')
       expect(await adapter.lastActivityAt(h)).toBe(4_000)
 
-      const fork = await adapter.fork(h, '侧问')
+      const fork = await adapter.fork(h, '侧问', forkOptions())
       await vi.waitFor(() => expect(runEngineSpy).toHaveBeenCalledTimes(2))
       now = 5_000
-      const forkOptions = runEngineSpy.mock.calls[1][0].options
-      forkOptions.onLiveProgress!({ type: 'tools_end', results: [] })
+      const forkEngineOptions = runEngineSpy.mock.calls[1][0].options
+      forkEngineOptions.onLiveProgress!({ type: 'tools_end', results: [] })
       expect(await adapter.lastActivityAt(fork)).toBe(5_000)
 
       now = 6_000
@@ -684,7 +691,7 @@ describe('BuiltinWorkerAdapter', () => {
     expect(mainTip).not.toBeNull()
 
     const prevRef: IncarnationRef = { worker_id: s.worker_id, seq: 1, session_ref: mainTip! }
-    const forkHandle = await adapter.fork(prevRef, '侧问问题')
+    const forkHandle = await adapter.fork(prevRef, '侧问问题', forkOptions())
     expect(forkHandle.seq).toBe(2)
 
     // forkHandle.session_ref 是 fork 自己的引用(fork 分支节点自己的 tip node_id)，不是主线
@@ -758,7 +765,7 @@ describe('BuiltinWorkerAdapter', () => {
 
     const tree = await SessionTree.load(join(tmp, s.worker_id, 'session.jsonl'))
     const prevRef: IncarnationRef = { worker_id: s.worker_id, seq: 1, session_ref: tree.latestTip()! }
-    const forkHandle = await workerAdapter.fork(prevRef, '侧问问题')
+    const forkHandle = await workerAdapter.fork(prevRef, '侧问问题', forkOptions())
     await waitState(workerAdapter, forkHandle, 'exited')
 
     const streamMock = llm.stream as unknown as { mock: { calls: Array<[{ messages: unknown }]> } }
@@ -789,7 +796,7 @@ describe('BuiltinWorkerAdapter', () => {
     expect(rootTip).not.toBeNull()
     const prevRef: IncarnationRef = { worker_id: s.worker_id, seq: 1, session_ref: rootTip! }
 
-    const forkHandle = await adapter.fork(prevRef, '侧问问题')
+    const forkHandle = await adapter.fork(prevRef, '侧问问题', forkOptions())
     expect(forkHandle.seq).toBe(2)
 
     gate.resolve()
@@ -820,7 +827,7 @@ describe('BuiltinWorkerAdapter', () => {
     const tree1 = await SessionTree.load(join(tmp, s.worker_id, 'session.jsonl'))
     const mainTip = tree1.latestTip()!
     const forkRef: IncarnationRef = { worker_id: s.worker_id, seq: 1, session_ref: mainTip }
-    const forkHandle = await adapter.fork(forkRef, '侧问问题')
+    const forkHandle = await adapter.fork(forkRef, '侧问问题', forkOptions())
     expect(forkHandle.seq).toBe(2)
     await waitState(adapter, forkHandle, 'exited')
 
@@ -863,7 +870,7 @@ describe('BuiltinWorkerAdapter', () => {
     const tree1 = await SessionTree.load(join(tmp, s.worker_id, 'session.jsonl'))
     const mainTip = tree1.latestTip()!
     const forkRef: IncarnationRef = { worker_id: s.worker_id, seq: 1, session_ref: mainTip }
-    const forkHandle = await adapter.fork(forkRef, '侧问问题')
+    const forkHandle = await adapter.fork(forkRef, '侧问问题', forkOptions())
     expect(forkHandle.seq).toBe(2)
     await waitState(adapter, forkHandle, 'exited')
 
@@ -918,7 +925,7 @@ describe('BuiltinWorkerAdapter', () => {
     const prevRef: IncarnationRef = { worker_id: s.worker_id, seq: 1, session_ref: mainTip }
 
     // fork 调用会触发 fork burst，其中会卡在 gate（因为是第二次调用）
-    const forkHandle = await adapter.fork(prevRef, '侧问问题')
+    const forkHandle = await adapter.fork(prevRef, '侧问问题', forkOptions())
     expect(forkHandle.seq).toBe(2)
 
     // 等待足够长的时间让 fork burst 进入卡在 gate 的状态
@@ -1534,7 +1541,7 @@ describe('BuiltinWorkerAdapter', () => {
         { text: '侧问第二轮', stopReason: 'end_turn' },
       ])
 
-      const forkHandle = await adapter.fork(prevRef, '侧问一下')
+      const forkHandle = await adapter.fork(prevRef, '侧问一下', forkOptions())
       const forkInstance = (adapterAny.instances as Map<string, { outputLog: { append: (t: string) => Promise<void> } }>).get(
         `${s.worker_id}#${forkHandle.seq}`,
       )
@@ -1747,14 +1754,14 @@ describe('BuiltinWorkerAdapter', () => {
       return originalWriteMeta(...args)
     })
 
-    await expect(adapter.fork(prevRef, '侧问')).rejects.toThrow(/simulated writeMeta disk error \(fork\)/)
+    await expect(adapter.fork(prevRef, '侧问', forkOptions())).rejects.toThrow(/simulated writeMeta disk error \(fork\)/)
 
     // writeMeta 失败了，instances 里不应该有 seq=2 的孤儿条目。
     const key2 = `${s.worker_id}#2`
     expect((adapterAny.instances as Map<string, unknown>).has(key2)).toBe(false)
 
     // 重试应该能成功（fork 没有像 resume 那样的"重复"标记，重试是无副作用的）。
-    const retryHandle = await adapter.fork(prevRef, '侧问-重试')
+    const retryHandle = await adapter.fork(prevRef, '侧问-重试', forkOptions())
     expect(retryHandle.seq).toBe(2)
     await waitState(adapter, retryHandle, 'exited')
   })
@@ -1827,7 +1834,7 @@ describe('BuiltinWorkerAdapter', () => {
 
     // 从这个未压缩的老节点 fork：能跑通，且 fork burst 自己也开着压缩（否则老链 fork 必撞窗口）。
     const compactionCallsBeforeFork = llm.compactionCalls
-    const forkH = await adapter.fork({ worker_id: s.worker_id, seq: 1, session_ref: oldTip }, '侧问一句')
+    const forkH = await adapter.fork({ worker_id: s.worker_id, seq: 1, session_ref: oldTip }, '侧问一句', forkOptions())
     await waitState(adapter, forkH, 'exited')
     const forkMeta = JSON.parse(await fs.readFile(join(tmp, s.worker_id, 'meta-2.json'), 'utf-8')) as {
       ended_reason: string
@@ -1904,7 +1911,7 @@ describe('BuiltinWorkerAdapter', () => {
     const h = await adapter.spawn(s)
     await waitState(adapter, h, 'idle')
     const meta = JSON.parse(await fs.readFile(join(tmp, s.worker_id, 'meta-1.json'), 'utf-8')) as { tip_node_id: string }
-    const forkH = await adapter.fork({ worker_id: s.worker_id, seq: 1, session_ref: meta.tip_node_id }, '侧问')
+    const forkH = await adapter.fork({ worker_id: s.worker_id, seq: 1, session_ref: meta.tip_node_id }, '侧问', forkOptions())
     await waitState(adapter, forkH, 'exited')
 
     expect(runEngineSpy.mock.calls[0]?.[0]?.options?.disableCompaction).toBe(false)
@@ -1961,7 +1968,7 @@ describe('BuiltinWorkerAdapter', () => {
     await waitState(adapter, h, 'exited')
     const meta = JSON.parse(await fs.readFile(join(tmp, s.worker_id, 'meta-1.json'), 'utf-8')) as { tip_node_id: string }
 
-    const forkH = await adapter.fork({ worker_id: s.worker_id, seq: 1, session_ref: meta.tip_node_id }, '侧问')
+    const forkH = await adapter.fork({ worker_id: s.worker_id, seq: 1, session_ref: meta.tip_node_id }, '侧问', forkOptions())
     await waitState(adapter, forkH, 'exited')
     const forkMeta = JSON.parse(await fs.readFile(join(tmp, s.worker_id, 'meta-2.json'), 'utf-8')) as {
       ended_reason: string

--- a/crabot-agent/tests/workers/builtin-injection.test.ts
+++ b/crabot-agent/tests/workers/builtin-injection.test.ts
@@ -43,6 +43,13 @@ import type {
 } from '../../src/workers/types'
 import type { LLMAdapter } from '../../src/engine/llm-adapter-types.js'
 import { defineTool } from '../../src/engine/index.js'
+
+function forkOptions() {
+  return {
+    query_id: randomUUID(),
+    establishment_deadline_at: new Date(Date.now() + 30_000).toISOString(),
+  }
+}
 import type { ToolDefinition } from '../../src/engine/index.js'
 import { createBashTool } from '../../src/engine/tools/bash-tool.js'
 import { createSetCwdTool } from '../../src/engine/tools/set-cwd-tool.js'
@@ -378,7 +385,7 @@ describe('builtin worker 运行配置在起化身时现取', () => {
     await waitState(adapter, h, 'idle')
 
     state.model = 'model-B'
-    const forkHandle = await adapter.fork({ worker_id: workerId, seq: 1, session_ref: h.session_ref }, '侧问一句')
+    const forkHandle = await adapter.fork({ worker_id: workerId, seq: 1, session_ref: h.session_ref }, '侧问一句', forkOptions())
     await waitState(adapter, forkHandle, 'exited')
 
     const models = runEngineSpy.mock.calls.map((c) => c[0].options.model)
@@ -598,7 +605,7 @@ describe('builtin worker 的安全项（hookRegistry / 权限档位）', () => {
     const adapter = new BuiltinWorkerAdapter({ dataDir, resolveRuntime: factory })
     const h = await spawnWith(adapter, factory, { worker_id: workerId, prompt: '干活', workspace: { root: dataDir } })
     await waitState(adapter, h, 'idle')
-    const forkHandle = await adapter.fork({ worker_id: workerId, seq: 1, session_ref: h.session_ref }, '侧问')
+    const forkHandle = await adapter.fork({ worker_id: workerId, seq: 1, session_ref: h.session_ref }, '侧问', forkOptions())
     await waitState(adapter, forkHandle, 'exited')
 
     expect(runEngineSpy.mock.calls).toHaveLength(2)

--- a/crabot-agent/tests/workers/claude-code-adapter.test.ts
+++ b/crabot-agent/tests/workers/claude-code-adapter.test.ts
@@ -8,6 +8,7 @@ import { ClaudeCodeAdapter, eventsFilePath, WorkerExitedError } from '../../src/
 import { TmuxDriver, type TmuxSessionSpec } from '../../src/workers/tmux/driver.js'
 import { BRACKETED_PASTE_ENABLE } from '../../src/workers/tmux/paste-ready.js'
 import { CliEventChannel } from '../../src/workers/cli-events.js'
+import type { ForkEstablishmentError } from '../../src/workers/errors.js'
 import type { IncarnationHandle, SpawnSpec, WorkerContractState } from '../../src/workers/types.js'
 
 function detectTmux(): boolean {
@@ -47,6 +48,13 @@ function fakeClaudeConfig(dataDir: string): string {
 const MOCK_CLI = path.resolve(__dirname, 'fixtures/mock-cli.mjs')
 const FAKE_CLAUDE_VERSION = path.resolve(__dirname, 'fixtures/fake-claude-version.mjs')
 const FAKE_CLAUDE_FORK = path.resolve(__dirname, 'fixtures/fake-claude-fork.mjs')
+
+function forkOptions() {
+  return {
+    query_id: randomUUID(),
+    establishment_deadline_at: new Date(Date.now() + 30_000).toISOString(),
+  }
+}
 
 interface MockStep {
   output?: string
@@ -612,7 +620,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — 四轮 review PoC 回归:
       const meta1 = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8')) as { session_id: string }
 
       // 重启前:fork 侧问 #2(无头一击,落自己的 meta-2.json/output-2.log)。
-      const h2 = await adapterA.fork({ worker_id: workerId, seq: 1, session_ref: meta1.session_id }, '侧问一下')
+      const h2 = await adapterA.fork({ worker_id: workerId, seq: 1, session_ref: meta1.session_id }, '侧问一下', forkOptions())
       expect(h2.seq).toBe(2)
       await waitForState(adapterA, h2, 'exited')
       const meta2Before = await fs.readFile(path.join(dataDir, workerId, 'meta-2.json'), 'utf-8')
@@ -1090,7 +1098,7 @@ describe('ClaudeCodeAdapter — session_ref UUID 边界校验', () => {
     const maliciousSessionRef = 'x; touch /tmp/pwned'
 
     await expect(
-      adapter.fork({ worker_id: workerId, seq: 1, session_ref: maliciousSessionRef }, 'payload'),
+      adapter.fork({ worker_id: workerId, seq: 1, session_ref: maliciousSessionRef }, 'payload', forkOptions()),
     ).rejects.toThrow(/invalid.*session_ref|UUID|session reference/i)
 
     // 验证没有副作用文件产生
@@ -1118,7 +1126,7 @@ describe('ClaudeCodeAdapter — session_ref UUID 边界校验', () => {
 
     for (const ref of invalidRefs) {
       await expect(
-        adapter.fork({ worker_id: workerId, seq: 1, session_ref: ref }, 'payload'),
+        adapter.fork({ worker_id: workerId, seq: 1, session_ref: ref }, 'payload', forkOptions()),
       ).rejects.toThrow(/invalid.*session_ref|UUID|session reference/i)
     }
   })
@@ -1140,7 +1148,7 @@ describe('ClaudeCodeAdapter — session_ref UUID 边界校验', () => {
     const validUuid = randomUUID()
 
     // 会因为"不存在该化身"抛错,但不是 session_ref 格式错误
-    await expect(adapter.fork({ worker_id: workerId, seq: 1, session_ref: validUuid }, 'payload')).rejects.toThrow(
+    await expect(adapter.fork({ worker_id: workerId, seq: 1, session_ref: validUuid }, 'payload', forkOptions())).rejects.toThrow(
       /no such incarnation|not resident/i,
     )
   })
@@ -1300,6 +1308,172 @@ class CountingTmux extends TmuxDriver {
   }
 }
 
+class ForkOnlyTmux extends TmuxDriver {
+  async isAlive(_name: string): Promise<boolean> {
+    return false
+  }
+}
+
+describe('ClaudeCodeAdapter.fork — streaming establishment without tmux', () => {
+  let dataDir: string
+  let workspaceRoot: string
+  let workerId: string
+  let parentSessionId: string
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'cc-stream-fork-data-'))
+    workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'cc-stream-fork-ws-'))
+    workerId = `cctest-${randomUUID().slice(0, 8)}`
+    parentSessionId = randomUUID()
+    const workerDir = path.join(dataDir, workerId)
+    await fs.mkdir(workerDir, { recursive: true })
+    await fs.writeFile(path.join(workerDir, 'meta-1.json'), JSON.stringify({
+      seq: 1,
+      state: 'running',
+      session_id: parentSessionId,
+      workspace_root: workspaceRoot,
+    }))
+  })
+
+  afterEach(async () => {
+    await fs.rm(dataDir, { recursive: true, force: true })
+    await fs.rm(workspaceRoot, { recursive: true, force: true })
+  })
+
+  it('init 后立即返回真实 session，长回答在后台完成且 result 不重复 delta', async () => {
+    const forkSessionId = randomUUID()
+    const states: WorkerContractState[] = []
+    const claudeBin = [
+      `env FAKE_FORK_SESSION_ID=${forkSessionId}`,
+      'FAKE_FORK_STDOUT=streamed-answer',
+      'FAKE_FORK_RESULT=streamed-answer',
+      'FAKE_FORK_DELAY_AFTER_INIT_MS=200',
+      `node ${shQuote(FAKE_CLAUDE_FORK)}`,
+    ].join(' ')
+    const adapter = new ClaudeCodeAdapter({
+      dataDir,
+      claudeConfigPath: fakeClaudeConfig(dataDir),
+      tmux: new ForkOnlyTmux(),
+      claudeBin,
+      onStateChange: (_handle, state) => states.push(state),
+    })
+
+    const handle = await adapter.fork(
+      { worker_id: workerId, seq: 1, session_ref: parentSessionId },
+      '侧问',
+      forkOptions(),
+    )
+
+    expect(handle.session_ref).toBe(forkSessionId)
+    expect(handle.session_ref).not.toBe(parentSessionId)
+    expect(await adapter.state(handle)).toBe('running')
+    await waitForState(adapter, handle, 'exited')
+    const { chunk } = await adapter.readOutput(handle, { offset: 0 })
+    expect(chunk).toBe('streamed-answer')
+    expect(states.filter((state) => state === 'exited')).toHaveLength(1)
+  })
+
+  it('30 秒契约 deadline 到期前无 init 时终止整个 fork 进程组并返回 timeout', async () => {
+    const terminationFile = path.join(dataDir, 'terminated.log')
+    const claudeBin = [
+      'env FAKE_FORK_INIT_DELAY_MS=1000',
+      `FAKE_FORK_TERMINATION_FILE=${shQuote(terminationFile)}`,
+      `node ${shQuote(FAKE_CLAUDE_FORK)}`,
+    ].join(' ')
+    const adapter = new ClaudeCodeAdapter({
+      dataDir,
+      claudeConfigPath: fakeClaudeConfig(dataDir),
+      tmux: new ForkOnlyTmux(),
+      claudeBin,
+    })
+
+    await expect(adapter.fork(
+      { worker_id: workerId, seq: 1, session_ref: parentSessionId },
+      '侧问',
+      {
+        query_id: randomUUID(),
+        establishment_deadline_at: new Date(Date.now() + 100).toISOString(),
+      },
+    )).rejects.toMatchObject({ name: 'ForkEstablishmentError', stage: 'timeout' })
+    expect(await fs.readFile(terminationFile, 'utf8')).toContain('SIGTERM')
+    await expect(fs.access(path.join(dataDir, workerId, 'meta-2.json'))).rejects.toThrow()
+  })
+
+  it('无 init 但子进程已经产出结果时不能宣称首问确定未开始', async () => {
+    const claudeBin = [
+      'env FAKE_FORK_SKIP_INIT=1',
+      'FAKE_FORK_STDOUT=answer-without-init',
+      `node ${shQuote(FAKE_CLAUDE_FORK)}`,
+    ].join(' ')
+    const adapter = new ClaudeCodeAdapter({
+      dataDir,
+      claudeConfigPath: fakeClaudeConfig(dataDir),
+      tmux: new ForkOnlyTmux(),
+      claudeBin,
+    })
+
+    await expect(adapter.fork(
+      { worker_id: workerId, seq: 1, session_ref: parentSessionId },
+      '侧问',
+      forkOptions(),
+    )).rejects.toMatchObject({
+      name: 'ForkEstablishmentError',
+      stage: 'fork_create',
+      certainty: 'unknown',
+    } satisfies Partial<ForkEstablishmentError>)
+    await expect(fs.access(path.join(dataDir, workerId, 'meta-2.json'))).rejects.toThrow()
+  })
+
+  it('binary 解析在 runtime 分配后失败时清理内存化身', async () => {
+    const adapter = new ClaudeCodeAdapter({
+      dataDir,
+      claudeConfigPath: fakeClaudeConfig(dataDir),
+      tmux: new ForkOnlyTmux(),
+      resolveUserLevelBinary: async () => { throw new Error('binary resolver unavailable') },
+    })
+
+    await expect(adapter.fork(
+      { worker_id: workerId, seq: 1, session_ref: parentSessionId },
+      '侧问',
+      forkOptions(),
+    )).rejects.toMatchObject({
+      name: 'ForkEstablishmentError',
+      stage: 'fork_create',
+      certainty: 'not_started',
+    } satisfies Partial<ForkEstablishmentError>)
+
+    expect((adapter as unknown as { runtimes: Map<string, unknown> }).runtimes.size).toBe(1)
+    await expect(fs.access(path.join(dataDir, workerId, 'meta-2.json'))).rejects.toThrow()
+  })
+
+  it('kill 已建立的 fork 时等待 headless 子进程真正退出', async () => {
+    const terminationFile = path.join(dataDir, 'kill-terminated.log')
+    const forkSessionId = randomUUID()
+    const claudeBin = [
+      `env FAKE_FORK_SESSION_ID=${forkSessionId}`,
+      'FAKE_FORK_DELAY_AFTER_INIT_MS=10000',
+      `FAKE_FORK_TERMINATION_FILE=${shQuote(terminationFile)}`,
+      `node ${shQuote(FAKE_CLAUDE_FORK)}`,
+    ].join(' ')
+    const adapter = new ClaudeCodeAdapter({
+      dataDir,
+      claudeConfigPath: fakeClaudeConfig(dataDir),
+      tmux: new ForkOnlyTmux(),
+      claudeBin,
+    })
+    const handle = await adapter.fork(
+      { worker_id: workerId, seq: 1, session_ref: parentSessionId },
+      '侧问',
+      forkOptions(),
+    )
+
+    await adapter.kill(handle)
+
+    expect(await adapter.state(handle)).toBe('exited')
+    expect(await fs.readFile(terminationFile, 'utf8')).toContain('SIGTERM')
+  })
+})
+
 describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter.fork', () => {
   let dataDir: string
   let workspaceRoot: string
@@ -1339,6 +1513,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter.fork', () => {
       const h2 = await adapter.fork(
         { worker_id: workerId, seq: 1, session_ref: meta1.session_id },
         '这个函数为什么报错?',
+        forkOptions(),
       )
       expect(h2.worker_id).toBe(workerId)
       expect(h2.seq).toBe(2)
@@ -1346,8 +1521,7 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter.fork', () => {
       // fork 全程没有调用任何 tmux 方法——不进 tmux。
       expect(tmux.calls).toEqual(callsBeforeFork)
 
-      const state2 = await adapter.state(h2)
-      expect(state2).toBe('exited')
+      await waitForState(adapter, h2, 'exited')
 
       const meta2 = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-2.json'), 'utf-8')) as {
         state: WorkerContractState
@@ -1371,7 +1545,9 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter.fork', () => {
         meta1.session_id,
         '--fork-session',
         '--output-format',
-        'text',
+        'stream-json',
+        '--verbose',
+        '--include-partial-messages',
         '--mcp-config',
         '.mcp.json',
         '--strict-mcp-config',
@@ -1395,7 +1571,8 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter.fork', () => {
       const h1 = await adapter.spawn({ worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } })
       const meta1 = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8')) as { session_id: string }
 
-      const h2 = await adapter.fork({ worker_id: workerId, seq: 1, session_ref: meta1.session_id }, '触发崩溃')
+      const h2 = await adapter.fork({ worker_id: workerId, seq: 1, session_ref: meta1.session_id }, '触发崩溃', forkOptions())
+      await waitForState(adapter, h2, 'exited')
 
       const meta2 = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-2.json'), 'utf-8')) as {
         ended_reason?: string
@@ -1421,14 +1598,16 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter.fork', () => {
       const h1 = await adapter.spawn({ worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } })
       const meta1 = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8')) as { session_id: string }
 
-      const h2 = await adapter.fork({ worker_id: workerId, seq: 1, session_ref: meta1.session_id }, '第一次侧问')
+      const h2 = await adapter.fork({ worker_id: workerId, seq: 1, session_ref: meta1.session_id }, '第一次侧问', forkOptions())
       expect(h2.seq).toBe(2)
+      await waitForState(adapter, h2, 'exited')
 
       // 对同一个 prev(h1)再 fork 一次:fork 化身常驻不删,旧实现用固定公式 prev.seq+1 算出
       // seq=2,与 h2 撞号,抛"already exists"。新实现用 nextSeq()(该 worker 现存所有化身
       // max seq + 1)分配到 3。
-      const h3 = await adapter.fork({ worker_id: workerId, seq: 1, session_ref: meta1.session_id }, '第二次侧问')
+      const h3 = await adapter.fork({ worker_id: workerId, seq: 1, session_ref: meta1.session_id }, '第二次侧问', forkOptions())
       expect(h3.seq).toBe(3)
+      await waitForState(adapter, h3, 'exited')
 
       const meta3 = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-3.json'), 'utf-8')) as { state: WorkerContractState }
       expect(meta3.state).toBe('exited')
@@ -1451,8 +1630,9 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter.fork', () => {
       const h1 = await adapter.spawn({ worker_id: workerId, prompt: '你好', workspace: { root: workspaceRoot } })
       const meta1 = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8')) as { session_id: string }
 
-      const h2 = await adapter.fork({ worker_id: workerId, seq: 1, session_ref: meta1.session_id }, '侧问')
+      const h2 = await adapter.fork({ worker_id: workerId, seq: 1, session_ref: meta1.session_id }, '侧问', forkOptions())
       expect(h2.seq).toBe(2)
+      await waitForState(adapter, h2, 'exited')
 
       // 主线还在跑,先 kill 让它落 exited,满足 resume 的前置条件。
       await adapter.kill(h1)
@@ -2159,7 +2339,8 @@ describe('ClaudeCodeAdapter.fork — 侧问收尾不污染主线 stop 计数', (
     const workerId = `cctest-${randomUUID().slice(0, 8)}`
     const h1 = await adapter.spawn({ worker_id: workerId, prompt: '干活', workspace: { root: workspaceRoot } })
 
-    const h2 = await adapter.fork({ worker_id: workerId, seq: 1, session_ref: h1.session_ref }, '侧问一下')
+    const h2 = await adapter.fork({ worker_id: workerId, seq: 1, session_ref: h1.session_ref }, '侧问一下', forkOptions())
+    await waitForState(adapter, h2, 'exited')
 
     // 前提:假二进制确实执行了 provision 写下的那条 Stop hook(否则本组用例是空跑)。
     expect(await stopCountIn(path.join(dataDir, workerId, `fork-events-${h2.seq}.jsonl`))).toBe(1)
@@ -2187,7 +2368,8 @@ describe('ClaudeCodeAdapter.fork — 侧问收尾不污染主线 stop 计数', (
     const h1 = await adapter.spawn({ worker_id: workerId, prompt: '干活', workspace: { root: workspaceRoot } })
 
     // 侧问在主线还在跑的时候发起。
-    await adapter.fork({ worker_id: workerId, seq: 1, session_ref: h1.session_ref }, '侧问一下')
+    const h2 = await adapter.fork({ worker_id: workerId, seq: 1, session_ref: h1.session_ref }, '侧问一下', forkOptions())
+    await waitForState(adapter, h2, 'exited')
 
     // ① 侧问收尾之后(留足 watcher 快路径 + 2s 轮询兜底的时间),主线不能被判成 idle。
     await new Promise((r) => setTimeout(r, 2500))

--- a/crabot-agent/tests/workers/codex-adapter.test.ts
+++ b/crabot-agent/tests/workers/codex-adapter.test.ts
@@ -5,7 +5,8 @@ import * as fs from 'node:fs/promises'
 import * as os from 'node:os'
 import * as path from 'node:path'
 import { parse as parseToml } from 'smol-toml'
-import { CodexWorkerAdapter, eventsFilePath, WorkerExitedError, CapabilityNotSupportedError } from '../../src/workers/codex/adapter.js'
+import { CodexWorkerAdapter, eventsFilePath, WorkerExitedError } from '../../src/workers/codex/adapter.js'
+import { ForkEstablishmentError } from '../../src/workers/errors.js'
 import { TmuxDriver, type TmuxSessionSpec } from '../../src/workers/tmux/driver.js'
 import { BRACKETED_PASTE_ENABLE } from '../../src/workers/tmux/paste-ready.js'
 import { CliEventChannel } from '../../src/workers/cli-events.js'
@@ -41,6 +42,7 @@ async function cleanupTmuxSessions(prefix = 'crabot-w-codextest-'): Promise<void
 
 const MOCK_CLI = path.resolve(__dirname, 'fixtures/mock-cli.mjs')
 const FAKE_CODEX_VERSION = path.resolve(__dirname, 'fixtures/fake-codex-version.mjs')
+const FAKE_CODEX_APP_SERVER = path.resolve(__dirname, 'fixtures/fake-codex-app-server.mjs')
 
 interface MockStep {
   output?: string
@@ -1343,30 +1345,212 @@ describe('CodexWorkerAdapter — session_ref UUID 边界校验(resume)', () => {
   })
 })
 
-describe('CodexWorkerAdapter.fork — capabilities.fork=false', () => {
+describe('CodexWorkerAdapter.fork — app-server', () => {
   let dataDir: string
+  let workspaceRoot: string
+  let codexHome: string
+  let workerId: string
+  let parentSessionId: string
 
   beforeEach(async () => {
     dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-adapter-fork-data-'))
+    workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-adapter-fork-ws-'))
+    codexHome = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-adapter-fork-home-'))
+    await fs.writeFile(path.join(codexHome, 'config.toml'), '', 'utf8')
+    workerId = `codextest-${randomUUID().slice(0, 8)}`
+    parentSessionId = randomUUID()
+    const workerDir = path.join(dataDir, workerId)
+    await fs.mkdir(workerDir, { recursive: true })
+    await fs.writeFile(path.join(workerDir, 'meta-1.json'), JSON.stringify({
+      seq: 1,
+      state: 'running',
+      session_id: parentSessionId,
+      session_discovery: 'placeholder',
+      workspace_root: workspaceRoot,
+      codex_home: codexHome,
+    }))
   })
 
   afterEach(async () => {
     await fs.rm(dataDir, { recursive: true, force: true }).catch(() => {})
+    await fs.rm(workspaceRoot, { recursive: true, force: true }).catch(() => {})
+    await fs.rm(codexHome, { recursive: true, force: true }).catch(() => {})
   })
 
-  it('capabilities().fork === false', () => {
-    const adapter = new CodexWorkerAdapter({ dataDir, codexBin: 'unused' })
+  function appServerBin(mode = 'happy', extra = ''): string {
+    return `env FAKE_APP_SERVER_MODE=${mode} ${extra} node ${shQuote(FAKE_CODEX_APP_SERVER)}`
+  }
+
+  function options(timeoutMs = 2000) {
+    return {
+      query_id: randomUUID(),
+      establishment_deadline_at: new Date(Date.now() + timeoutMs).toISOString(),
+      connection_env: { CODEX_HOME: codexHome },
+    }
+  }
+
+  it('detect fail closed；当前 binary 通过方法/字段探测后才声明 fork=true', async () => {
+    const unsupported = new CodexWorkerAdapter({
+      dataDir,
+      codexHomeSource: codexHome,
+      codexBin: appServerBin('unsupported'),
+    })
+    await unsupported.detect()
+    expect(unsupported.capabilities().fork).toBe(false)
+
+    const supported = new CodexWorkerAdapter({
+      dataDir,
+      codexHomeSource: codexHome,
+      codexBin: appServerBin(),
+    })
+    await supported.detect()
+    expect(supported.capabilities().fork).toBe(true)
+  })
+
+  it('detect 切换到同版本的另一 binary 时重新探测 fork capability', async () => {
+    const unsupportedBin = path.join(dataDir, 'codex-unsupported')
+    const supportedBin = path.join(dataDir, 'codex-supported')
+    const wrapper = (mode: string) =>
+      `#!/bin/sh\nexec env FAKE_APP_SERVER_MODE=${mode} node ${shQuote(FAKE_CODEX_APP_SERVER)} "$@"\n`
+    await fs.writeFile(unsupportedBin, wrapper('unsupported'), { mode: 0o755 })
+    await fs.writeFile(supportedBin, wrapper('happy'), { mode: 0o755 })
+    let activeBin = unsupportedBin
+    const adapter = new CodexWorkerAdapter({
+      dataDir,
+      codexHomeSource: codexHome,
+      resolveUserLevelBinary: async () => ({ binary: activeBin, global_detected: false }),
+    })
+
+    await adapter.detect()
     expect(adapter.capabilities().fork).toBe(false)
+
+    activeBin = supportedBin
+    await adapter.detect()
+    expect(adapter.capabilities().fork).toBe(true)
   })
 
-  it('fork() 始终抛 CapabilityNotSupportedError,不触碰 tmux/子进程', async () => {
-    const adapter = new CodexWorkerAdapter({ dataDir, codexBin: 'unused' })
-    const workerId = `codextest-${randomUUID().slice(0, 8)}`
-    const validUuid = randomUUID()
+  it('turn/start 接受后立即返回真实 fork thread，回答随后异步完成并写 output', async () => {
+    const forkThreadId = randomUUID()
+    const states: Array<{ state: WorkerContractState; endReason?: string }> = []
+    const adapter = new CodexWorkerAdapter({
+      dataDir,
+      codexHomeSource: codexHome,
+      tmux: new NoopTmux(),
+      codexBin: appServerBin('happy', `FAKE_FORK_THREAD_ID=${forkThreadId} FAKE_COMPLETION_DELAY_MS=200`),
+      onStateChange: (_handle, state, report) => states.push({ state, endReason: report?.endReason }),
+    })
+    await adapter.detect()
 
-    await expect(adapter.fork({ worker_id: workerId, seq: 1, session_ref: validUuid }, '侧问问题')).rejects.toBeInstanceOf(
-      CapabilityNotSupportedError,
+    const handle = await adapter.fork(
+      { worker_id: workerId, seq: 1, session_ref: parentSessionId },
+      '侧问问题',
+      options(),
     )
+
+    expect(handle).toMatchObject({
+      worker_id: workerId,
+      seq: 2,
+      impl: 'codex',
+      session_ref: forkThreadId,
+    })
+    expect(handle.session_ref).not.toBe(parentSessionId)
+    expect(await adapter.state(handle)).toBe('running')
+
+    await waitForState(adapter, handle, 'exited')
+    const { chunk } = await adapter.readOutput(handle, { offset: 0 })
+    expect(chunk).toBe('侧问回答')
+    expect(states).toContainEqual({ state: 'exited', endReason: 'completed' })
+  })
+
+  it('turn/start 明确拒绝时在同一次 fork 调用返回 query_submit 失败并收口进程', async () => {
+    const terminationFile = path.join(dataDir, 'terminated.log')
+    const adapter = new CodexWorkerAdapter({
+      dataDir,
+      codexHomeSource: codexHome,
+      tmux: new NoopTmux(),
+      codexBin: appServerBin('turn_error', `FAKE_TERMINATION_FILE=${shQuote(terminationFile)}`),
+    })
+    await adapter.detect()
+
+    await expect(adapter.fork(
+      { worker_id: workerId, seq: 1, session_ref: parentSessionId },
+      '侧问问题',
+      options(),
+    )).rejects.toMatchObject({
+      name: 'ForkEstablishmentError',
+      stage: 'query_submit',
+      certainty: 'not_started',
+    } satisfies Partial<ForkEstablishmentError>)
+    expect(await fs.readFile(terminationFile, 'utf8')).toContain('SIGTERM')
+    await expect(fs.access(path.join(dataDir, workerId, 'meta-2.json'))).rejects.toThrow()
+  })
+
+  it('turn/start 返回不兼容 shape 时不能宣称首问确定未开始', async () => {
+    const adapter = new CodexWorkerAdapter({
+      dataDir,
+      codexHomeSource: codexHome,
+      tmux: new NoopTmux(),
+      codexBin: appServerBin('bad_turn_shape'),
+    })
+    await adapter.detect()
+
+    await expect(adapter.fork(
+      { worker_id: workerId, seq: 1, session_ref: parentSessionId },
+      '侧问问题',
+      options(),
+    )).rejects.toMatchObject({
+      name: 'ForkEstablishmentError',
+      stage: 'query_submit',
+      certainty: 'unknown',
+    } satisfies Partial<ForkEstablishmentError>)
+    await expect(fs.access(path.join(dataDir, workerId, 'meta-2.json'))).rejects.toThrow()
+  })
+
+  it('建立 deadline 到期会失败并终止 app-server，不留下可误认成功的 meta', async () => {
+    const terminationFile = path.join(dataDir, 'timeout-terminated.log')
+    const adapter = new CodexWorkerAdapter({
+      dataDir,
+      codexHomeSource: codexHome,
+      tmux: new NoopTmux(),
+      codexBin: appServerBin('hang_fork', `FAKE_TERMINATION_FILE=${shQuote(terminationFile)}`),
+    })
+    await adapter.detect()
+
+    await expect(adapter.fork(
+      { worker_id: workerId, seq: 1, session_ref: parentSessionId },
+      '侧问问题',
+      options(100),
+    )).rejects.toMatchObject({ name: 'ForkEstablishmentError', stage: 'timeout', certainty: 'unknown' })
+    expect(await fs.readFile(terminationFile, 'utf8')).toContain('SIGTERM')
+    await expect(fs.access(path.join(dataDir, workerId, 'meta-2.json'))).rejects.toThrow()
+  })
+
+  it('环境组装在 runtime 分配后失败时清理内存化身', async () => {
+    let resolveCalls = 0
+    const adapter = new CodexWorkerAdapter({
+      dataDir,
+      codexHomeSource: codexHome,
+      tmux: new NoopTmux(),
+      resolveUserLevelBinary: async () => {
+        resolveCalls += 1
+        if (resolveCalls === 1) return { binary: appServerBin(), global_detected: false }
+        throw new Error('connection environment unavailable')
+      },
+    })
+    ;(adapter as unknown as { appServerForkSupported: boolean }).appServerForkSupported = true
+
+    await expect(adapter.fork(
+      { worker_id: workerId, seq: 1, session_ref: parentSessionId },
+      '侧问问题',
+      options(),
+    )).rejects.toMatchObject({
+      name: 'ForkEstablishmentError',
+      stage: 'fork_create',
+      certainty: 'not_started',
+    } satisfies Partial<ForkEstablishmentError>)
+
+    expect((adapter as unknown as { runtimes: Map<string, unknown> }).runtimes.size).toBe(1)
+    await expect(fs.access(path.join(dataDir, workerId, 'meta-2.json'))).rejects.toThrow()
   })
 })
 

--- a/crabot-agent/tests/workers/codex-app-server-client.test.ts
+++ b/crabot-agent/tests/workers/codex-app-server-client.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { promises as fs } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+import {
+  CodexAppServerClient,
+  CodexAppServerRpcError,
+  probeCodexAppServerFork,
+} from '../../src/workers/codex/app-server-client.js'
+
+const FIXTURE = resolve(__dirname, 'fixtures/fake-codex-app-server.mjs')
+
+function quote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`
+}
+
+describe('CodexAppServerClient', () => {
+  let dir: string
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(join(tmpdir(), 'codex-app-server-client-'))
+  })
+
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true })
+  })
+
+  it('按 request id 关联乱序响应，stderr 与无关 notification 不破坏 JSONL', async () => {
+    const client = new CodexAppServerClient({
+      command: `node ${quote(FIXTURE)} app-server --stdio`,
+      cwd: dir,
+      env: { PATH: process.env.PATH ?? '', CODEX_HOME: dir },
+    })
+    const notifications: string[] = []
+    client.onNotification((notification) => notifications.push(notification.method))
+    const deadline = new Date(Date.now() + 2000).toISOString()
+    await client.initialize(deadline)
+
+    const [fork, turn] = await Promise.allSettled([
+      client.request('thread/fork', {
+        threadId: '00000000-0000-0000-0000-000000000001',
+        ephemeral: true,
+        excludeTurns: true,
+      }, deadline),
+      client.request('turn/start', {
+        threadId: '00000000-0000-0000-0000-000000000002',
+        input: [{ type: 'text', text: 'probe' }],
+      }, deadline),
+    ])
+
+    expect(fork.status).toBe('rejected')
+    expect(turn.status).toBe('rejected')
+    expect((fork as PromiseRejectedResult).reason).toMatchObject({ message: expect.stringContaining('no rollout') })
+    expect((turn as PromiseRejectedResult).reason).toMatchObject({ message: expect.stringContaining('thread not found') })
+    expect((fork as PromiseRejectedResult).reason).toBeInstanceOf(CodexAppServerRpcError)
+    expect(notifications).toContain('unrelated/notification')
+    expect(client.stderrTail).toContain('initialized')
+    await client.terminate()
+  })
+
+  it('capability probe 只在 app-server 同时接受 fork fields 与结构化 turn input 时返回 true', async () => {
+    await expect(probeCodexAppServerFork({
+      command: `node ${quote(FIXTURE)} app-server --stdio`,
+      cwd: dir,
+      env: { PATH: process.env.PATH ?? '', CODEX_HOME: dir },
+    })).resolves.toBe(true)
+
+    await expect(probeCodexAppServerFork({
+      command: `env FAKE_APP_SERVER_MODE=unsupported node ${quote(FIXTURE)} app-server --stdio`,
+      cwd: dir,
+      env: { PATH: process.env.PATH ?? '', CODEX_HOME: dir },
+    })).resolves.toBe(false)
+  })
+
+  it('子进程关闭 stdin 时把 EPIPE 收口为 RPC 失败', async () => {
+    const client = new CodexAppServerClient({
+      command: `exec node -e ${quote('process.stdin.destroy(); setTimeout(() => {}, 1000)')}`,
+      cwd: dir,
+      env: { PATH: process.env.PATH ?? '', CODEX_HOME: dir },
+    })
+
+    await expect(client.initialize(new Date(Date.now() + 2000).toISOString())).rejects.toThrow()
+    await client.terminate()
+  })
+})

--- a/crabot-agent/tests/workers/composite-trace.test.ts
+++ b/crabot-agent/tests/workers/composite-trace.test.ts
@@ -33,8 +33,19 @@ function makeWorker(over: Partial<LedgerWorker> = {}): LedgerWorker {
   } as LedgerWorker
 }
 
-function harnessEvent(seq: number, kind: string, ts: string): HarnessEvent {
-  return { ts, kind: kind as HarnessEvent['kind'], worker_id: WORKER_ID, seq }
+function harnessEvent(
+  seq: number,
+  kind: string,
+  ts: string,
+  detail?: Record<string, unknown>,
+): HarnessEvent {
+  return {
+    ts,
+    kind: kind as HarnessEvent['kind'],
+    worker_id: WORKER_ID,
+    seq,
+    ...(detail ? { detail } : {}),
+  }
 }
 
 function nativeEvent(text: string, ts: string): NormalizedTraceEvent {
@@ -103,6 +114,32 @@ describe('readCompositeWorkerTrace', () => {
     const result = await readCompositeWorkerTrace(deps(), { worker_id: WORKER_ID })
     expect(result.events.map((event) => event.source)).toEqual(['harness', 'native', 'native', 'harness'])
     expect(result.next_cursor).toBeTruthy()
+  })
+
+  it('可靠操作终态摘要带稳定关联字段和失败原因码', async () => {
+    harnessEvents = [
+      harnessEvent(1, 'input_delivery_failed', '2026-08-01T00:00:01.000Z', {
+        delivery_id: 'delivery-1',
+        reason_code: 'delivery_deadline_exceeded',
+      }),
+      harnessEvent(1, 'query_completed', '2026-08-01T00:00:02.000Z', {
+        query_id: 'query-1',
+        fork_seq: 2,
+      }),
+      harnessEvent(1, 'query_failed', '2026-08-01T00:00:03.000Z', {
+        query_id: 'query-2',
+        fork_seq: 3,
+        reason_code: 'query_execution_failed',
+      }),
+    ]
+
+    const result = await readCompositeWorkerTrace(deps(), { worker_id: WORKER_ID })
+
+    expect(result.events.map((event) => event.summary)).toEqual([
+      'input_delivery_failed delivery_id=delivery-1 reason_code=delivery_deadline_exceeded',
+      'query_completed query_id=query-1 fork_seq=2',
+      'query_failed query_id=query-2 fork_seq=3 reason_code=query_execution_failed',
+    ])
   })
 
   it('同一 cursor 重放返回同一逻辑窗口，后续追加不影响', async () => {

--- a/crabot-agent/tests/workers/connection-translators.test.ts
+++ b/crabot-agent/tests/workers/connection-translators.test.ts
@@ -96,8 +96,8 @@ describe('fork connection_env 透传（R10 回归钉死）', () => {
   it('claude adapter fork 接收并使用 opts.connection_env（不被静默丢弃）', async () => {
     // 直接读源码断言签名与消费——TS 允许实现少收形参无告警，这条钉死「接口扩了实现没跟上」。
     const source = await import('node:fs/promises').then((fs) => fs.readFile(new URL('../../src/workers/claude-code/adapter.ts', import.meta.url), 'utf-8'))
-    expect(source).toMatch(/async fork\(prev: IncarnationRef, forkInput: string, opts\?: \{ connection_env\?: Record<string, string> \}\)/)
-    expect(source).toMatch(/opts\?\.connection_env \?\? prevRuntime\.connectionEnv/)
+    expect(source).toMatch(/async fork\(prev: IncarnationRef, forkInput: string, opts: ForkOptions\)/)
+    expect(source).toMatch(/opts\.connection_env \?\? prevRuntime\.connectionEnv/)
   })
 })
 

--- a/crabot-agent/tests/workers/contract-suite.ts
+++ b/crabot-agent/tests/workers/contract-suite.ts
@@ -198,13 +198,19 @@ export function runContractSuite(name: string, makeFixture: MakeFixture): void {
         const caps = fx.adapter.capabilities()
 
         if (caps.fork) {
-          const forkHandle = await fx.adapter.fork(ref, '侧问问题')
+          const forkHandle = await fx.adapter.fork(ref, '侧问问题', {
+            query_id: randomUUID(),
+            establishment_deadline_at: new Date(Date.now() + 30_000).toISOString(),
+          })
           expect(forkHandle.worker_id).toBe(h.worker_id)
           await waitForState(fx.adapter, forkHandle, 'exited')
           const output = await fx.adapter.readOutput(forkHandle, { offset: 0 })
           expect(typeof output.chunk).toBe('string')
         } else {
-          await expect(fx.adapter.fork(ref, '侧问问题')).rejects.toBeTruthy()
+          await expect(fx.adapter.fork(ref, '侧问问题', {
+            query_id: randomUUID(),
+            establishment_deadline_at: new Date(Date.now() + 30_000).toISOString(),
+          })).rejects.toBeTruthy()
         }
       },
       15000,

--- a/crabot-agent/tests/workers/fixtures/fake-claude-fork.mjs
+++ b/crabot-agent/tests/workers/fixtures/fake-claude-fork.mjs
@@ -14,12 +14,18 @@
 import { appendFileSync, readFileSync } from 'node:fs'
 import { execFileSync } from 'node:child_process'
 import { join } from 'node:path'
+import { randomUUID } from 'node:crypto'
 
 const argv = process.argv.slice(2)
 const argvFile = process.env.FAKE_ARGV_FILE
 if (argvFile) appendFileSync(argvFile, JSON.stringify(argv) + '\n')
 
 if (argv.includes('-p')) {
+  const terminationFile = process.env.FAKE_FORK_TERMINATION_FILE
+  process.on('SIGTERM', () => {
+    if (terminationFile) appendFileSync(terminationFile, `${process.pid}:SIGTERM\n`)
+    process.exit(0)
+  })
   if (process.env.FAKE_FORK_RUN_STOP_HOOK === '1') {
     try {
       const settings = JSON.parse(readFileSync(join(process.cwd(), '.claude', 'settings.json'), 'utf-8'))
@@ -30,12 +36,39 @@ if (argv.includes('-p')) {
     }
   }
   const stdout = process.env.FAKE_FORK_STDOUT ?? ''
-  if (stdout) process.stdout.write(stdout)
-  process.exit(Number(process.env.FAKE_FORK_EXIT_CODE ?? '0'))
+  if (argv.includes('stream-json')) {
+    const sessionId = process.env.FAKE_FORK_SESSION_ID ?? randomUUID()
+    if (process.env.FAKE_FORK_SKIP_INIT === '1') {
+      process.stdout.write(JSON.stringify({ type: 'result', result: stdout }) + '\n')
+      process.exit(Number(process.env.FAKE_FORK_EXIT_CODE ?? '0'))
+    }
+    const emitInit = () => {
+      process.stdout.write(JSON.stringify({ type: 'system', subtype: 'init', session_id: sessionId }) + '\n')
+      setTimeout(() => {
+        if (stdout) {
+          process.stdout.write(JSON.stringify({
+            type: 'stream_event',
+            event: { type: 'content_block_delta', delta: { type: 'text_delta', text: stdout } },
+          }) + '\n')
+        }
+        process.stdout.write(JSON.stringify({
+          type: 'result',
+          result: process.env.FAKE_FORK_RESULT ?? stdout,
+        }) + '\n')
+        process.exit(Number(process.env.FAKE_FORK_EXIT_CODE ?? '0'))
+      }, Number(process.env.FAKE_FORK_DELAY_AFTER_INIT_MS ?? '0'))
+    }
+    setTimeout(emitInit, Number(process.env.FAKE_FORK_INIT_DELAY_MS ?? '0'))
+  } else if (stdout) {
+    process.stdout.write(stdout)
+    process.exit(Number(process.env.FAKE_FORK_EXIT_CODE ?? '0'))
+  }
 }
 
-// 交互态:先请求 bracketed paste(真实 cc/codex TUI 启动时都会发这个 DECSET 2004 序列),
-// 再空转等测试结束后由 kill/进程回收清理。adapter 的启动期就绪握手等的正是这个信号——
-// 不发的话每次 spawn 都要白等一次握手超时(见 src/workers/tmux/paste-ready.ts)。
-process.stdout.write('\x1b[?2004h')
-setInterval(() => {}, 1_000_000)
+if (!argv.includes('-p')) {
+  // 交互态:先请求 bracketed paste(真实 cc/codex TUI 启动时都会发这个 DECSET 2004 序列),
+  // 再空转等测试结束后由 kill/进程回收清理。adapter 的启动期就绪握手等的正是这个信号——
+  // 不发的话每次 spawn 都要白等一次握手超时(见 src/workers/tmux/paste-ready.ts)。
+  process.stdout.write('\x1b[?2004h')
+  setInterval(() => {}, 1_000_000)
+}

--- a/crabot-agent/tests/workers/fixtures/fake-codex-app-server.mjs
+++ b/crabot-agent/tests/workers/fixtures/fake-codex-app-server.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+import { appendFileSync } from 'node:fs'
+import readline from 'node:readline'
+
+const argv = process.argv.slice(2)
+if (argv.includes('--version')) {
+  process.stdout.write(`${process.env.FAKE_CODEX_VERSION ?? 'codex-cli 0.147.0'}\n`)
+  process.exit(0)
+}
+
+if (!argv.includes('app-server')) process.exit(2)
+
+const mode = process.env.FAKE_APP_SERVER_MODE ?? 'happy'
+const forkThreadId = process.env.FAKE_FORK_THREAD_ID ?? '019d0000-0000-7000-8000-000000000001'
+const turnId = process.env.FAKE_TURN_ID ?? '019d0000-0000-7000-8000-000000000002'
+const delayMs = Number(process.env.FAKE_COMPLETION_DELAY_MS ?? '20')
+const terminationFile = process.env.FAKE_TERMINATION_FILE
+
+function recordTermination(signal) {
+  if (terminationFile) appendFileSync(terminationFile, `${process.pid}:${signal}\n`)
+  process.exit(0)
+}
+process.on('SIGTERM', () => recordTermination('SIGTERM'))
+process.on('SIGINT', () => recordTermination('SIGINT'))
+
+function send(message) {
+  process.stdout.write(`${JSON.stringify(message)}\n`)
+}
+
+function error(id, message, code = -32600) {
+  send({ id, error: { code, message } })
+}
+
+const rl = readline.createInterface({ input: process.stdin })
+rl.on('line', (line) => {
+  const message = JSON.parse(line)
+  if (message.method === 'initialize') {
+    if (mode === 'hang_initialize') return
+    send({
+      id: message.id,
+      result: {
+        userAgent: 'fake-codex-app-server/0.147.0',
+        codexHome: process.env.CODEX_HOME ?? process.cwd(),
+        platformFamily: 'unix',
+        platformOs: 'test',
+      },
+    })
+    return
+  }
+  if (message.method === 'initialized') {
+    process.stderr.write('fake app-server initialized\n')
+    send({ method: 'unrelated/notification', params: { ignored: true } })
+    return
+  }
+  if (message.method === 'thread/fork') {
+    if (mode === 'unsupported') {
+      error(message.id, 'method not found', -32601)
+      return
+    }
+    if (message.params?.threadId === '00000000-0000-0000-0000-000000000001') {
+      setTimeout(() => error(message.id, `no rollout found for thread id ${message.params.threadId}`), 20)
+      return
+    }
+    if (mode === 'hang_fork') return
+    if (mode === 'fork_error') {
+      error(message.id, 'fork refused')
+      return
+    }
+    if (mode === 'bad_fork_shape') {
+      send({ id: message.id, result: { thread: {} } })
+      return
+    }
+    send({ id: message.id, result: { thread: { id: forkThreadId } } })
+    return
+  }
+  if (message.method === 'turn/start') {
+    if (message.params?.threadId === '00000000-0000-0000-0000-000000000002') {
+      error(message.id, `thread not found: ${message.params.threadId}`)
+      return
+    }
+    if (mode === 'turn_error') {
+      error(message.id, 'turn rejected')
+      return
+    }
+    if (mode === 'bad_turn_shape') {
+      send({ id: message.id, result: { turn: {} } })
+      return
+    }
+    send({ id: message.id, result: { turn: { id: turnId, status: 'inProgress', items: [] } } })
+    setTimeout(() => {
+      send({
+        method: 'item/agentMessage/delta',
+        params: { threadId: forkThreadId, turnId, itemId: 'item-1', delta: process.env.FAKE_REPLY ?? '侧问回答' },
+      })
+      send({
+        method: 'turn/completed',
+        params: {
+          threadId: forkThreadId,
+          turn: {
+            id: turnId,
+            status: mode === 'turn_failed' ? 'failed' : 'completed',
+            items: [],
+            ...(mode === 'turn_failed' ? { error: { message: 'simulated turn failure' } } : {}),
+          },
+        },
+      })
+    }, delayMs)
+  }
+})

--- a/crabot-agent/tests/workers/fixtures/mock-cli.mjs
+++ b/crabot-agent/tests/workers/fixtures/mock-cli.mjs
@@ -55,13 +55,20 @@ import { exec } from 'node:child_process'
 import { promisify } from 'node:util'
 import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
+import { randomUUID } from 'node:crypto'
 
 const execAsync = promisify(exec)
 
 const pFlagIndex = process.argv.indexOf('-p')
 if (pFlagIndex !== -1) {
   const forkInput = process.argv[pFlagIndex + 1] ?? ''
-  process.stdout.write(`mock headless reply: ${forkInput}\n`)
+  const reply = `mock headless reply: ${forkInput}`
+  if (process.argv.includes('stream-json')) {
+    process.stdout.write(JSON.stringify({ type: 'system', subtype: 'init', session_id: randomUUID() }) + '\n')
+    process.stdout.write(JSON.stringify({ type: 'result', result: reply }) + '\n')
+  } else {
+    process.stdout.write(`${reply}\n`)
+  }
   process.exit(0)
 }
 

--- a/crabot-agent/tests/workers/harness/harness-lifecycle.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-lifecycle.test.ts
@@ -7,7 +7,8 @@ import { LedgerStore } from '../../../src/workers/harness/ledger-store'
 import { WorkspaceManager } from '../../../src/workers/harness/workspace-manager'
 import { } from '../../../src/workers/harness/ledger-types'
 import { WorkerEventLog, type HarnessEvent } from '../../../src/workers/harness/worker-events'
-import { CapabilityNotSupportedError, CliInputStallError } from '../../../src/workers/errors'
+import { QueryReceiptStore } from '../../../src/workers/harness/query-receipt-store'
+import { CliInputStallError, QueryEstablishmentError } from '../../../src/workers/errors'
 import { describeStartupStall } from '../../../src/workers/tmux/paste-ready'
 import type {
   WorkerAdapter,
@@ -23,6 +24,8 @@ import type {
   CapabilityBundle,
   AdapterCapabilities,
   InitialInputResult,
+  ForkOptions,
+  SendInputOptions,
 } from '../../../src/workers/types'
 
 // ---- FakeAdapter:实现 WorkerAdapter 契约的可编程桩,不碰 tmux/LLM ----
@@ -37,7 +40,7 @@ interface FakeAdapterOpts {
   readonly onStateChange?: (h: IncarnationHandle, state: WorkerContractState, report?: StateChangeReport) => void
   readonly spawnShouldFail?: Error
   readonly forkShouldFail?: Error
-  readonly sendInputBehavior?: (h: IncarnationHandle, text: string, opts?: { raw?: boolean }) => Promise<void> | void
+  readonly sendInputBehavior?: (h: IncarnationHandle, text: string, opts?: SendInputOptions) => Promise<void> | void
   readonly sendInputState?: WorkerContractState
   readonly acceptedExitReport?: StateChangeReport
   readonly updatedSessionRef?: string
@@ -52,9 +55,9 @@ class FakeAdapter implements WorkerAdapter {
   readonly implId: WorkerImplId
   readonly provisionCalls: Array<{ ws: Workspace; caps: CapabilityBundle }> = []
   readonly spawnCalls: SpawnSpec[] = []
-  readonly sendInputCalls: Array<{ h: IncarnationHandle; text: string; opts?: { raw?: boolean } }> = []
+  readonly sendInputCalls: Array<{ h: IncarnationHandle; text: string; opts?: SendInputOptions }> = []
   readonly killCalls: IncarnationHandle[] = []
-  readonly forkCalls: Array<{ prev: IncarnationRef; forkInput: string }> = []
+  readonly forkCalls: Array<{ prev: IncarnationRef; forkInput: string; opts: ForkOptions }> = []
   readonly readOutputCalls: IncarnationHandle[] = []
   private readonly states = new Map<string, WorkerContractState>()
   private acceptedExitReport?: StateChangeReport
@@ -91,13 +94,19 @@ class FakeAdapter implements WorkerAdapter {
     throw new Error('FakeAdapter.resume: not exercised by Task 7 tests')
   }
 
-  async fork(prev: IncarnationRef, forkInput: string): Promise<IncarnationHandle> {
-    this.forkCalls.push({ prev, forkInput })
+  async fork(prev: IncarnationRef, forkInput: string, opts: ForkOptions): Promise<IncarnationHandle> {
+    this.forkCalls.push({ prev, forkInput, opts })
     if (this.opts.forkShouldFail) throw this.opts.forkShouldFail
     const seq = this.nextForkSeq++
     // fork 自己的 session_ref，刻意与 prev.session_ref(父化身/主线的引用)不同，好让
     // 回归测试能验证 harness 没有把父化身的引用错抄给 fork 化身(protocol-agent-v3 §6.1)。
-    const handle: IncarnationHandle = { worker_id: prev.worker_id, seq, impl: this.implId, session_ref: `fork-ref-${prev.worker_id}#${seq}` }
+    const handle: IncarnationHandle = {
+      worker_id: prev.worker_id,
+      seq,
+      impl: this.implId,
+      session_ref: `fork-ref-${prev.worker_id}#${seq}`,
+      query_id: opts.query_id,
+    }
     if (this.opts.forkSyncExitBeforeReturn) {
       // 严格复刻 cc adapter 的 fork():在这个同步语句执行到 `return handle` 之前，就已经
       // 把化身状态转到 exited 并调用 onStateChange——AsyncMutex.run 的入队是同步的
@@ -113,7 +122,7 @@ class FakeAdapter implements WorkerAdapter {
     return handle
   }
 
-  async sendInput(h: IncarnationHandle, text: string, opts?: { raw?: boolean }): Promise<void> {
+  async sendInput(h: IncarnationHandle, text: string, opts?: SendInputOptions): Promise<void> {
     this.sendInputCalls.push({ h, text, opts })
     if (this.opts.sendInputBehavior) await this.opts.sendInputBehavior(h, text, opts)
     if (this.opts.updatedSessionRef) this.updatedSessionRef = this.opts.updatedSessionRef
@@ -192,8 +201,17 @@ function now(): string {
 
 async function makeHarness(
   fakeOpts: FakeAdapterOpts = {},
-  depsOverrides: Partial<Pick<HarnessDeps, 'hasRunningBg' | 'capabilityBundle'>> = {},
-): Promise<{ harness: WorkerHarness; fake: FakeAdapter; adaptersMap: Map<WorkerImplId, WorkerAdapter>; workersDir: string }> {
+  depsOverrides: Partial<Pick<
+    HarnessDeps,
+    'hasRunningBg' | 'capabilityBundle' | 'onOperationNotification' | 'admitWorkerConnection' | 'redactFailureReason'
+  >> = {},
+): Promise<{
+  harness: WorkerHarness
+  fake: FakeAdapter
+  adaptersMap: Map<WorkerImplId, WorkerAdapter>
+  ledger: LedgerStore
+  workersDir: string
+}> {
   const ledgersDir = join(dataDir, 'ledgers')
   const workspacesRoot = join(dataDir, 'workspaces')
   const workersDir = join(dataDir, 'workers')
@@ -220,7 +238,7 @@ async function makeHarness(
   const fake = new FakeAdapter({ ...fakeOpts, onStateChange: harness.handleStateChange })
   adaptersMap.set(fake.implId, fake)
 
-  return { harness, fake, adaptersMap, workersDir }
+  return { harness, fake, adaptersMap, ledger, workersDir }
 }
 
 function spawnParams(overrides: Partial<SpawnWorkerParams> = {}): SpawnWorkerParams {
@@ -880,6 +898,363 @@ describe('WorkerHarness.handleStateChange', () => {
 })
 
 describe('WorkerHarness.sendToWorker', () => {
+  it('Manager 输入先落 receipt，再以同一 delivery_id 结算 delivered 和写事件', async () => {
+    const { harness, fake, workersDir } = await makeHarness()
+    const worker = await harness.spawnWorker(spawnParams())
+    events.length = 0
+
+    const result = await harness.sendToWorker(worker.worker_id, '可靠投递', {
+      managerKey: `test::friend-1` as ManagerKey,
+    })
+
+    expect(result).toMatchObject({
+      status: 'delivered',
+      worker_id: worker.worker_id,
+    })
+    expect(result.delivery_id).toMatch(/^[0-9a-f-]{36}$/)
+    expect(fake.sendInputCalls[0].opts).toMatchObject({ delivery_id: result.delivery_id })
+
+    const persisted = JSON.parse(
+      await fs.readFile(join(workersDir, worker.worker_id, 'input-deliveries.json'), 'utf8'),
+    ) as { receipts: Array<Record<string, unknown>> }
+    expect(persisted.receipts[0]).toMatchObject({
+      delivery_id: result.delivery_id,
+      manager_key: 'test::friend-1',
+      state: 'delivered',
+    })
+    expect((await harness.readWorkerEvents(worker.worker_id)).filter((event) => event.kind === 'input_sent')).toEqual([
+      expect.objectContaining({
+        worker_id: worker.worker_id,
+        detail: expect.objectContaining({ delivery_id: result.delivery_id }),
+      }),
+    ])
+  })
+
+  it('输入面暂不可用时返回 pending，而不是伪装成 sent', async () => {
+    const { harness, workersDir } = await makeHarness({
+      implId: 'claude-code',
+      sendInputBehavior: () => {
+        throw new CliInputStallError('not_pasted', 'running', { waitReason: 'waiting_action' })
+      },
+    })
+    const worker = await harness.spawnWorker({ ...spawnParams(), impl: 'claude-code' })
+
+    const result = await harness.sendToWorker(worker.worker_id, '稍后提交', {
+      managerKey: `test::friend-1` as ManagerKey,
+    })
+
+    expect(result).toMatchObject({
+      status: 'pending',
+      worker_id: worker.worker_id,
+      pending_reason: 'waiting_for_safe_input',
+    })
+    const persisted = JSON.parse(
+      await fs.readFile(join(workersDir, worker.worker_id, 'input-deliveries.json'), 'utf8'),
+    ) as { receipts: Array<Record<string, unknown>> }
+    expect(persisted.receipts[0]).toMatchObject({
+      delivery_id: result.delivery_id,
+      state: 'pending',
+      phase: 'waiting_for_safe_input',
+      manager_notification: { status: 'pending' },
+    })
+    expect(events.some((event) => event.kind === 'input_sent')).toBe(false)
+  })
+
+  it('adapter 已接手后 phase 写失败时保守返回 submission_unconfirmed', async () => {
+    const { harness } = await makeHarness({
+      implId: 'claude-code',
+      sendInputBehavior: () => {
+        throw new CliInputStallError('pending_in_ui', 'running', { waitReason: 'input_pending' })
+      },
+    })
+    const worker = await harness.spawnWorker({ ...spawnParams(), impl: 'claude-code' })
+    const receiptStore = (harness as unknown as {
+      inputDeliveryStore: {
+        updatePendingPhase(workerId: string, deliveryId: string, phase: string, updatedAt: string): Promise<unknown>
+      }
+    }).inputDeliveryStore
+    const updatePendingPhase = receiptStore.updatePendingPhase.bind(receiptStore)
+    vi.spyOn(receiptStore, 'updatePendingPhase').mockImplementation(
+      (workerId, deliveryId, phase, updatedAt) => phase === 'pending_in_ui'
+        ? Promise.reject(new Error('phase disk unavailable'))
+        : updatePendingPhase(workerId, deliveryId, phase, updatedAt),
+    )
+
+    const result = await harness.sendToWorker(worker.worker_id, '可能已经在输入框', {
+      managerKey: `test::friend-1` as ManagerKey,
+    })
+
+    expect(result).toMatchObject({
+      status: 'pending',
+      pending_reason: 'submission_unconfirmed',
+    })
+  })
+
+  it('pending 通知责任写失败时中止后续投递并结算 failed', async () => {
+    const { harness, fake } = await makeHarness({
+      implId: 'claude-code',
+      sendInputBehavior: () => {
+        throw new CliInputStallError('not_pasted', 'running', { waitReason: 'waiting_action' })
+      },
+    })
+    const worker = await harness.spawnWorker({ ...spawnParams(), impl: 'claude-code' })
+    const receiptStore = (harness as unknown as {
+      inputDeliveryStore: {
+        readForToolResult(workerId: string, deliveryId: string, updatedAt: string): Promise<unknown>
+      }
+    }).inputDeliveryStore
+    vi.spyOn(receiptStore, 'readForToolResult').mockRejectedValueOnce(new Error('notification arm disk unavailable'))
+
+    const result = await harness.sendToWorker(worker.worker_id, '不能在通知责任丢失后继续', {
+      managerKey: `test::friend-1` as ManagerKey,
+    })
+
+    expect(result).toMatchObject({
+      status: 'failed',
+      reason_code: 'delivery_attempt_failed',
+      reason: 'notification arm disk unavailable',
+      certainty: 'not_delivered',
+    })
+    expect(fake.sendInputCalls).toHaveLength(1)
+    expect((harness as unknown as { getInbox(id: string): { pending: number } })
+      .getInbox(worker.worker_id).pending).toBe(0)
+  })
+
+  it('adapter 已开始投递后抛普通错误时保守结算 unknown', async () => {
+    const { harness, fake } = await makeHarness({
+      sendInputBehavior: () => {
+        throw new Error('input transport failed')
+      },
+    })
+    const worker = await harness.spawnWorker(spawnParams())
+
+    const result = await harness.sendToWorker(worker.worker_id, '可能已进入输入面', {
+      managerKey: `test::friend-1` as ManagerKey,
+    })
+
+    expect(fake.sendInputCalls).toHaveLength(1)
+    expect(result).toMatchObject({
+      status: 'failed',
+      reason_code: 'delivery_attempt_failed',
+      reason: 'input transport failed',
+      certainty: 'unknown',
+    })
+  })
+
+  it('持久失败原因会移除正文、凭证和本地路径', async () => {
+    const text = '不要把这段完整正文写进 receipt'
+    const { harness } = await makeHarness(
+      {
+        sendInputBehavior: () => {
+          throw new Error(`transport failed for ${text} with provider-secret at /Users/test/private.sock and sk-testcredential`)
+        },
+      },
+      { redactFailureReason: (value) => value.replace('provider-secret', '[REDACTED]') },
+    )
+    const worker = await harness.spawnWorker(spawnParams())
+
+    const result = await harness.sendToWorker(worker.worker_id, text, {
+      managerKey: `test::friend-1` as ManagerKey,
+    })
+
+    expect(result).toMatchObject({ status: 'failed', reason_code: 'delivery_attempt_failed' })
+    if (result.status !== 'failed') throw new Error('expected failed delivery')
+    expect(result.reason).toContain('<message>')
+    expect(result.reason).toContain('[REDACTED]')
+    expect(result.reason).toContain('<path>')
+    expect(result.reason).toContain('<redacted>')
+    expect(result.reason).not.toContain(text)
+    expect(result.reason).not.toContain('/Users/test/private.sock')
+    expect(result.reason).not.toContain('sk-testcredential')
+  })
+
+  it('kill_worker 清空 pending 输入时以 task_cancelled 结算 receipt', async () => {
+    const { harness, workersDir } = await makeHarness()
+    const worker = await harness.spawnWorker(spawnParams())
+    const inbox = (harness as unknown as {
+      getInbox(id: string): { hold(reason: string): void }
+    }).getInbox(worker.worker_id)
+    inbox.hold('handoff')
+
+    const result = await harness.sendToWorker(worker.worker_id, '尚未进入输入面', {
+      managerKey: `test::friend-1` as ManagerKey,
+    })
+    expect(result.status).toBe('pending')
+
+    await harness.killWorker(worker.worker_id, '用户取消')
+
+    const persisted = JSON.parse(
+      await fs.readFile(join(workersDir, worker.worker_id, 'input-deliveries.json'), 'utf8'),
+    ) as { receipts: Array<Record<string, unknown>> }
+    expect(persisted.receipts[0]).toMatchObject({
+      delivery_id: result.delivery_id,
+      state: 'failed',
+      failure: {
+        reason_code: 'task_cancelled',
+        certainty: 'unknown',
+      },
+      manager_notification: { status: 'pending' },
+    })
+  })
+
+  it('receipt 创建失败时不入 inbox，也不调用 adapter', async () => {
+    const { harness, fake } = await makeHarness()
+    const worker = await harness.spawnWorker(spawnParams())
+    const receiptStore = (harness as unknown as {
+      inputDeliveryStore: { create(receipt: unknown): Promise<unknown> }
+    }).inputDeliveryStore
+    vi.spyOn(receiptStore, 'create').mockRejectedValueOnce(new Error('receipt disk unavailable'))
+
+    await expect(harness.sendToWorker(worker.worker_id, '不能碰输入面', {
+      managerKey: `test::friend-1` as ManagerKey,
+    })).rejects.toThrow('delivery receipt unavailable')
+
+    expect(fake.sendInputCalls).toHaveLength(0)
+    expect((harness as unknown as { getInbox(id: string): { pending: number } })
+      .getInbox(worker.worker_id).pending).toBe(0)
+  })
+
+  it('pending 超过 5 分钟后结算失败，通知只有 consumed 后才确认', async () => {
+    const deliveries: HarnessEvent[] = []
+    let consumed = false
+    const { harness, fake, workersDir } = await makeHarness(
+      {
+        implId: 'claude-code',
+        sendInputBehavior: () => {
+          throw new CliInputStallError('not_pasted', 'running', { waitReason: 'waiting_action' })
+        },
+      },
+      {
+        onOperationNotification: async (_managerKey, event) => {
+          deliveries.push(event)
+          return { consumed }
+        },
+      },
+    )
+    const worker = await harness.spawnWorker({ ...spawnParams(), impl: 'claude-code' })
+    const result = await harness.sendToWorker(worker.worker_id, '会超时的输入', {
+      managerKey: `test::friend-1` as ManagerKey,
+    })
+    expect(result.status).toBe('pending')
+
+    nowValue += 5 * 60_000
+    await harness.sweepLiveness()
+    let persisted = JSON.parse(
+      await fs.readFile(join(workersDir, worker.worker_id, 'input-deliveries.json'), 'utf8'),
+    ) as { receipts: Array<Record<string, any>> }
+    expect(persisted.receipts[0]).toMatchObject({
+      state: 'failed',
+      failure: { reason_code: 'input_surface_timeout', certainty: 'not_delivered' },
+      manager_notification: { status: 'pending' },
+    })
+    expect(deliveries).toHaveLength(1)
+    expect(deliveries[0].detail?.delivery_id).toBe(result.delivery_id)
+    expect(fake.sendInputCalls).toHaveLength(1)
+
+    consumed = true
+    await harness.sweepLiveness()
+    persisted = JSON.parse(
+      await fs.readFile(join(workersDir, worker.worker_id, 'input-deliveries.json'), 'utf8'),
+    ) as { receipts: Array<Record<string, any>> }
+    expect(persisted.receipts[0].manager_notification.status).toBe('consumed')
+    expect(deliveries).toHaveLength(2)
+
+    await harness.sweepLiveness()
+    expect(deliveries).toHaveLength(2)
+  })
+
+  it('adapter 永久挂起时仍按 deadline 结算并通知 Manager', async () => {
+    const notifications: HarnessEvent[] = []
+    let markAttempting!: () => void
+    const attempting = new Promise<void>((resolve) => { markAttempting = resolve })
+    let releaseAdapter!: () => void
+    const adapterGate = new Promise<void>((resolve) => { releaseAdapter = resolve })
+    const { harness, workersDir } = await makeHarness(
+      {
+        sendInputBehavior: async () => {
+          markAttempting()
+          await adapterGate
+        },
+      },
+      {
+        onOperationNotification: async (_managerKey, event) => {
+          notifications.push(event)
+          return { consumed: true }
+        },
+      },
+    )
+    const worker = await harness.spawnWorker(spawnParams())
+    const send = harness.sendToWorker(worker.worker_id, 'adapter 卡住的输入', {
+      managerKey: `test::friend-1` as ManagerKey,
+    })
+    await attempting
+
+    nowValue += 5 * 60_000
+    const sweepResult = await Promise.race([
+      harness.sweepLiveness().then(() => 'completed'),
+      new Promise<string>((resolve) => setTimeout(() => resolve('timed_out'), 100)),
+    ])
+    expect(sweepResult).toBe('completed')
+
+    const persisted = JSON.parse(
+      await fs.readFile(join(workersDir, worker.worker_id, 'input-deliveries.json'), 'utf8'),
+    ) as { receipts: Array<Record<string, any>> }
+    expect(persisted.receipts[0]).toMatchObject({
+      state: 'failed',
+      failure: { reason_code: 'submission_unconfirmed_timeout', certainty: 'unknown' },
+      manager_notification: { status: 'consumed' },
+    })
+    expect(notifications).toHaveLength(1)
+    expect(notifications[0]).toMatchObject({
+      kind: 'input_delivery_failed',
+      detail: { reason_code: 'submission_unconfirmed_timeout', certainty: 'unknown' },
+    })
+
+    releaseAdapter()
+    await expect(send).resolves.toMatchObject({
+      status: 'failed',
+      reason_code: 'submission_unconfirmed_timeout',
+      certainty: 'unknown',
+    })
+  })
+
+  it('启动恢复把未结算输入标为 unknown 失败，且不自动重发', async () => {
+    const notifications: HarnessEvent[] = []
+    const { harness, fake, workersDir } = await makeHarness(
+      {
+        implId: 'claude-code',
+        sendInputBehavior: () => {
+          throw new CliInputStallError('pending_in_ui', 'running', { waitReason: 'input_pending' })
+        },
+      },
+      {
+        onOperationNotification: async (_managerKey, event) => {
+          notifications.push(event)
+          return { consumed: true }
+        },
+      },
+    )
+    const worker = await harness.spawnWorker({ ...spawnParams(), impl: 'claude-code' })
+    const result = await harness.sendToWorker(worker.worker_id, '可能已经 paste', {
+      managerKey: `test::friend-1` as ManagerKey,
+    })
+    expect(result.status).toBe('pending')
+    expect(fake.sendInputCalls).toHaveLength(1)
+
+    await harness.reconcileInputDeliveriesOnStartup()
+
+    expect(fake.sendInputCalls).toHaveLength(1)
+    const persisted = JSON.parse(
+      await fs.readFile(join(workersDir, worker.worker_id, 'input-deliveries.json'), 'utf8'),
+    ) as { receipts: Array<Record<string, any>> }
+    expect(persisted.receipts[0]).toMatchObject({
+      state: 'failed',
+      failure: { reason_code: 'confirmation_lost_after_restart', certainty: 'unknown' },
+      manager_notification: { status: 'consumed' },
+    })
+    expect(notifications[0].detail?.text).toMatch(/禁止盲目重发/)
+  })
+
   it('正常投递:running worker 收到输入,adapter.sendInput 被正确调用,事件 input_sent 外发', async () => {
     const { harness, fake } = await makeHarness()
     const worker = await harness.spawnWorker(spawnParams())
@@ -1030,7 +1405,7 @@ describe('WorkerHarness.sendToWorker', () => {
   })
 
   it('fork或旧化身的exited回调不清除当前pane的transport hold', async () => {
-    const { harness, fake } = await makeHarness({ implId: 'claude-code', caps: { fork: true } })
+    const { harness, fake, workersDir } = await makeHarness({ implId: 'claude-code', caps: { fork: true } })
     const worker = await harness.spawnWorker({ ...spawnParams(), impl: 'claude-code' })
     await harness.queryWorker(worker.worker_id, '侧问一下')
     const inbox = (harness as any).getInbox(worker.worker_id)
@@ -1046,6 +1421,8 @@ describe('WorkerHarness.sendToWorker', () => {
       const [current] = await harness.listWorkers(`test::friend-1` as ManagerKey)
       return current.incarnations.find((incarnation) => incarnation.seq === 2)?.state === 'exited'
     })
+    await waitUntil(async () => (await new WorkerEventLog(join(workersDir, worker.worker_id)).readAll())
+      .some((event) => event.kind === 'query_completed' && event.seq === 2))
 
     expect(inbox.held).toBe(true)
   })
@@ -1300,63 +1677,114 @@ describe('WorkerHarness.queryWorker', () => {
     expect(await new WorkerEventLog(join(workersDir, worker.worker_id)).readAll()).toEqual(before)
   })
 
-  it('capabilities().fork 为 false → 抛 CapabilityNotSupportedError,不调用 adapter.fork,失败落 query_failed 事件(读 events.jsonl 核实)', async () => {
+  it('capabilities().fork 为 false → 同步返回带 query_id 的建立失败，adapter 零调用', async () => {
     const { harness, fake, workersDir } = await makeHarness({ caps: { fork: false } })
     const worker = await harness.spawnWorker(spawnParams())
     events.length = 0
 
-    await expect(harness.queryWorker(worker.worker_id, '侧问一下')).rejects.toThrow(CapabilityNotSupportedError)
+    await expect(harness.queryWorker(worker.worker_id, '侧问一下')).rejects.toMatchObject({
+      reason_code: 'fork_capability_unavailable',
+      certainty: 'not_started',
+      query_id: expect.any(String),
+    })
     expect(fake.forkCalls).toHaveLength(0)
 
-    // P4 Task 4:失败路径必须留痕(protocol-agent-v3 §10 可观测性),query_worker 是
-    // fire-and-forget,appendEvent 是排查失败的唯一出口——直接读 events.jsonl(而不只是
-    // 内存里的 onEvent 回调数组)核实真的落了盘。
     const log = new WorkerEventLog(join(workersDir, worker.worker_id))
     const onDisk = await log.readAll()
     const failedOnDisk = onDisk.filter((e) => e.kind === 'query_failed')
     expect(failedOnDisk).toHaveLength(1)
-    expect(failedOnDisk[0]).toMatchObject({ seq: 1, detail: { reason: 'capability_not_supported', impl: 'builtin' } })
+    expect(failedOnDisk[0]).toMatchObject({
+      seq: 0,
+      detail: {
+        query_id: expect.any(String),
+        reason_code: 'fork_capability_unavailable',
+        phase: 'establishment',
+      },
+    })
 
-    const failedEvents = events.filter((e) => e.kind === 'query_failed')
-    expect(failedEvents).toHaveLength(1)
-    expect(failedEvents[0]).toMatchObject({ seq: 1, detail: { reason: 'capability_not_supported', impl: 'builtin' } })
+    expect(events.filter((e) => e.kind === 'query_failed')).toHaveLength(0)
   })
 
-  it('目标 impl 未注册 adapter → 抛错,失败落 query_failed 事件(reason: no_adapter)', async () => {
-    const { harness, fake, adaptersMap } = await makeHarness()
+  it('建立失败通知不走普通事件口，直到 owning Manager consumed 才确认', async () => {
+    const notifications: HarnessEvent[] = []
+    const { harness, workersDir } = await makeHarness(
+      { caps: { fork: false } },
+      {
+        onOperationNotification: async (_managerKey, event) => {
+          notifications.push(event)
+          return { consumed: true }
+        },
+      },
+    )
+    const worker = await harness.spawnWorker(spawnParams())
+
+    await expect(harness.queryWorker(worker.worker_id, '无法建立的侧问', {
+      managerKey: `test::friend-1` as ManagerKey,
+    })).rejects.toBeInstanceOf(QueryEstablishmentError)
+    expect(notifications).toHaveLength(0)
+
+    await harness.sweepLiveness()
+    expect(notifications).toEqual([
+      expect.objectContaining({
+        kind: 'query_failed',
+        worker_id: worker.worker_id,
+        seq: 0,
+        detail: expect.objectContaining({
+          query_id: expect.any(String),
+          reason_code: 'fork_capability_unavailable',
+        }),
+      }),
+    ])
+    expect(notifications[0].detail).not.toHaveProperty('fork_seq')
+
+    const persisted = JSON.parse(
+      await fs.readFile(join(workersDir, worker.worker_id, 'query-receipts.json'), 'utf8'),
+    ) as { receipts: Array<Record<string, unknown>> }
+    expect(persisted.receipts[0]).toMatchObject({
+      state: 'failed',
+      manager_notification: { status: 'consumed' },
+    })
+  })
+
+  it('目标 impl 未注册 adapter → 结算 fork_capability_unavailable', async () => {
+    const { harness, fake, adaptersMap, workersDir } = await makeHarness()
     const worker = await harness.spawnWorker(spawnParams())
     adaptersMap.delete(fake.implId)
     events.length = 0
 
-    await expect(harness.queryWorker(worker.worker_id, '侧问一下')).rejects.toThrow(/no adapter registered/)
+    await expect(harness.queryWorker(worker.worker_id, '侧问一下')).rejects.toMatchObject({
+      reason_code: 'fork_capability_unavailable',
+      certainty: 'not_started',
+    })
 
-    const failedEvents = events.filter((e) => e.kind === 'query_failed')
-    expect(failedEvents).toHaveLength(1)
-    expect(failedEvents[0]).toMatchObject({ seq: 1, detail: { reason: 'no_adapter', impl: 'builtin' } })
+    const onDisk = await new WorkerEventLog(join(workersDir, worker.worker_id)).readAll()
+    expect(onDisk.filter((e) => e.kind === 'query_failed')).toHaveLength(1)
   })
 
-  it('worker_id 不存在 → WorkerNotFoundError,失败落 query_failed 事件(没有已知 seq,用 sentinel 0)', async () => {
-    const { harness } = await makeHarness({ caps: { fork: true } })
+  it('worker_id 不存在 → 操作未被接受，不创建 receipt 或 query 事件', async () => {
+    const { harness, workersDir } = await makeHarness({ caps: { fork: true } })
     events.length = 0
 
     await expect(harness.queryWorker('w-does-not-exist', '侧问一下')).rejects.toThrow(WorkerNotFoundError)
 
-    const failedEvents = events.filter((e) => e.kind === 'query_failed')
-    expect(failedEvents).toHaveLength(1)
-    expect(failedEvents[0]).toMatchObject({ seq: 0, worker_id: 'w-does-not-exist', detail: { reason: 'worker_not_found' } })
+    expect(events.filter((e) => e.kind === 'query_failed')).toHaveLength(0)
+    await expect(fs.access(join(workersDir, 'w-does-not-exist', 'query-receipts.json'))).rejects.toThrow()
   })
 
-  it('adapter.fork 抛错 → 原样把错误抛给调用方,且失败落 query_failed 事件(reason: fork_failed,带 message)', async () => {
+  it('adapter.fork 抛错 → 同一次调用返回 fork_create_failed 并持久留痕', async () => {
     const boom = new Error('fork 侧的 claude -p 炸了')
-    const { harness } = await makeHarness({ caps: { fork: true }, forkShouldFail: boom })
+    const { harness, workersDir } = await makeHarness({ caps: { fork: true }, forkShouldFail: boom })
     const worker = await harness.spawnWorker(spawnParams())
     events.length = 0
 
-    await expect(harness.queryWorker(worker.worker_id, '侧问一下')).rejects.toThrow('fork 侧的 claude -p 炸了')
+    await expect(harness.queryWorker(worker.worker_id, '侧问一下')).rejects.toMatchObject({
+      reason_code: 'fork_create_failed',
+      reason: 'fork 侧的 claude -p 炸了',
+      certainty: 'unknown',
+    })
 
-    const failedEvents = events.filter((e) => e.kind === 'query_failed')
-    expect(failedEvents).toHaveLength(1)
-    expect(failedEvents[0]).toMatchObject({ seq: 1, detail: { reason: 'fork_failed', message: 'fork 侧的 claude -p 炸了' } })
+    const onDisk = await new WorkerEventLog(join(workersDir, worker.worker_id)).readAll()
+    expect(onDisk.filter((e) => e.kind === 'query_failed')).toHaveLength(1)
 
     // 主线台账完全不受 fork 失败影响(fork 从未落账,不该有半成品化身)。
     const [w] = await harness.listWorkers(`test::friend-1` as ManagerKey)
@@ -1364,20 +1792,288 @@ describe('WorkerHarness.queryWorker', () => {
     expect(w.task.status).toBe('running')
   })
 
-  it('capabilities().fork 为 true → adapter.fork 被调用,新化身入化身链,事件外发,主线 task.status 不受影响', async () => {
+  it('建立失败 receipt 写暂时失败时仍返回 query_id，并由 deadline 巡检收口', async () => {
+    const { harness, workersDir } = await makeHarness({
+      caps: { fork: true },
+      forkShouldFail: new Error('fork process failed'),
+    })
+    const worker = await harness.spawnWorker(spawnParams())
+    const queryStore = (harness as unknown as { queryReceiptStore: QueryReceiptStore }).queryReceiptStore
+    vi.spyOn(queryStore, 'settleFailed').mockRejectedValueOnce(new Error('query receipt disk unavailable'))
+
+    await expect(harness.queryWorker(worker.worker_id, '侧问一下')).rejects.toMatchObject({
+      query_id: expect.any(String),
+      reason_code: 'fork_create_failed',
+      reason: 'fork process failed',
+    })
+    expect((await queryStore.list(worker.worker_id))[0]).toMatchObject({ state: 'starting' })
+
+    nowValue += 30_000
+    await harness.sweepLiveness()
+
+    expect((await queryStore.list(worker.worker_id))[0]).toMatchObject({
+      state: 'failed',
+      failure: {
+        reason_code: 'fork_establishment_timeout',
+        certainty: 'unknown',
+      },
+      manager_notification: { status: 'pending' },
+    })
+    expect((await new WorkerEventLog(join(workersDir, worker.worker_id)).readAll())
+      .filter((event) => event.kind === 'query_failed')).toHaveLength(1)
+  })
+
+  it('侧问建立失败原因会移除问题正文、凭证和本地路径', async () => {
+    const question = '这是不能写进失败原因的完整侧问'
+    const failure = new Error(`fork failed for ${question}: provider-secret /Users/test/query.json sk-querycredential`)
+    const { harness } = await makeHarness(
+      { caps: { fork: true }, forkShouldFail: failure },
+      { redactFailureReason: (value) => value.replace('provider-secret', '[REDACTED]') },
+    )
+    const worker = await harness.spawnWorker(spawnParams())
+
+    let caught: QueryEstablishmentError | undefined
+    try {
+      await harness.queryWorker(worker.worker_id, question)
+    } catch (error) {
+      caught = error as QueryEstablishmentError
+    }
+
+    expect(caught).toBeInstanceOf(QueryEstablishmentError)
+    expect(caught?.reason).toContain('<message>')
+    expect(caught?.reason).toContain('[REDACTED]')
+    expect(caught?.reason).toContain('<path>')
+    expect(caught?.reason).toContain('<redacted>')
+    expect(caught?.reason).not.toContain(question)
+    expect(caught?.reason).not.toContain('/Users/test/query.json')
+    expect(caught?.reason).not.toContain('sk-querycredential')
+  })
+
+  it('连接准入耗时计入 30 秒建立期限，harness 只等待 receipt 的剩余时间', async () => {
+    vi.useFakeTimers()
+    let resolveFork!: (handle: IncarnationHandle) => void
+    let queryId = ''
+    let signalForkStarted!: () => void
+    const forkStarted = new Promise<void>((resolve) => { signalForkStarted = resolve })
+    try {
+      const { harness, fake } = await makeHarness(
+        { caps: { fork: true } },
+        {
+          admitWorkerConnection: async () => {
+            nowValue += 28_000
+            return { env: {}, dispose: async () => {} }
+          },
+        },
+      )
+      const worker = await harness.spawnWorker(spawnParams())
+      vi.spyOn(fake, 'fork').mockImplementationOnce((prev, _forkInput, opts) => {
+        queryId = opts.query_id
+        signalForkStarted()
+        return new Promise<IncarnationHandle>((resolve) => {
+          resolveFork = resolve
+        })
+      })
+
+      let rejection: unknown
+      let signalRejected!: () => void
+      const rejected = new Promise<void>((resolve) => { signalRejected = resolve })
+      const query = harness.queryWorker(worker.worker_id, '慢准入后的侧问').catch((error) => {
+        rejection = error
+        signalRejected()
+      })
+      await forkStarted
+      await vi.advanceTimersByTimeAsync(1_100)
+      await rejected
+
+      expect(rejection).toMatchObject({
+        reason_code: 'fork_establishment_timeout',
+        certainty: 'unknown',
+      })
+
+      resolveFork({
+        worker_id: worker.worker_id,
+        seq: 2,
+        impl: 'builtin',
+        session_ref: 'late-fork-after-timeout',
+        query_id: queryId,
+      })
+      await query
+      await vi.waitFor(() => expect(fake.killCalls).toHaveLength(1))
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('建立失败后的迟到 fork callback 不会重新暂存或生成完成事件', async () => {
+    const { harness, fake, workersDir } = await makeHarness({ caps: { fork: true } })
+    const worker = await harness.spawnWorker(spawnParams())
+    let rejectedHandle: IncarnationHandle | undefined
+    vi.spyOn(fake, 'fork').mockImplementationOnce(async (prev, _forkInput, opts) => {
+      rejectedHandle = {
+        worker_id: prev.worker_id,
+        seq: 2,
+        impl: 'builtin',
+        session_ref: 'late-fork-ref',
+        query_id: opts.query_id,
+      }
+      throw new Error('fork failed before ledger commit')
+    })
+
+    await expect(harness.queryWorker(worker.worker_id, '侧问一下')).rejects.toMatchObject({
+      reason_code: 'fork_create_failed',
+      query_id: expect.any(String),
+    })
+    expect(rejectedHandle).toBeDefined()
+
+    const queryStore = (harness as unknown as { queryReceiptStore: QueryReceiptStore }).queryReceiptStore
+    const pendingStateChanges = (harness as unknown as {
+      pendingQueryStateChanges: Map<string, unknown>
+    }).pendingQueryStateChanges
+    const getSpy = vi.spyOn(queryStore, 'get')
+    harness.handleStateChange(rejectedHandle!, 'exited', { endReason: 'completed' })
+    await waitUntil(() => getSpy.mock.calls.some(([, queryId]) => queryId === rejectedHandle!.query_id))
+    await Promise.resolve()
+
+    expect(pendingStateChanges.has(rejectedHandle!.query_id!)).toBe(false)
+    const [persisted] = await harness.listWorkers(`test::friend-1` as ManagerKey)
+    expect(persisted.incarnations).toHaveLength(1)
+    const onDisk = await new WorkerEventLog(join(workersDir, worker.worker_id)).readAll()
+    expect(onDisk.some((event) =>
+      event.kind === 'query_completed' && event.detail?.query_id === rejectedHandle!.query_id,
+    )).toBe(false)
+  })
+
+  it('fork 失败后的 admission dispose 错误不覆盖原失败或遗失 receipt', async () => {
+    const dispose = vi.fn().mockRejectedValue(new Error('dispose failed'))
+    const { harness, workersDir } = await makeHarness(
+      { caps: { fork: true }, forkShouldFail: new Error('fork failed') },
+      {
+        admitWorkerConnection: async () => ({ env: {}, dispose }),
+      },
+    )
+    const worker = await harness.spawnWorker(spawnParams())
+
+    await expect(harness.queryWorker(worker.worker_id, '侧问一下')).rejects.toMatchObject({
+      reason_code: 'fork_create_failed',
+      reason: 'fork failed',
+    })
+    expect(dispose).toHaveBeenCalledTimes(1)
+
+    const persisted = JSON.parse(
+      await fs.readFile(join(workersDir, worker.worker_id, 'query-receipts.json'), 'utf8'),
+    ) as { receipts: Array<Record<string, unknown>> }
+    expect(persisted.receipts[0]).toMatchObject({
+      state: 'failed',
+      failure: { reason_code: 'fork_create_failed' },
+      manager_notification: { status: 'pending' },
+    })
+  })
+
+  it('adapter 返回错误 query_id 时拒绝落账并尽力停止已建立分支', async () => {
     const { harness, fake } = await makeHarness({ caps: { fork: true } })
+    const worker = await harness.spawnWorker(spawnParams())
+    vi.spyOn(fake, 'fork').mockResolvedValueOnce({
+      worker_id: worker.worker_id,
+      seq: 2,
+      impl: 'builtin',
+      session_ref: 'fork-ref-mismatch',
+      query_id: 'wrong-query-id',
+    })
+
+    await expect(harness.queryWorker(worker.worker_id, '侧问一下')).rejects.toMatchObject({
+      reason_code: 'fork_create_failed',
+      reason: 'adapter returned a fork handle with a mismatched query_id',
+      certainty: 'unknown',
+    })
+    expect(fake.killCalls).toEqual([
+      expect.objectContaining({ seq: 2, query_id: 'wrong-query-id' }),
+    ])
+    const [persisted] = await harness.listWorkers(`test::friend-1` as ManagerKey)
+    expect(persisted.incarnations).toHaveLength(1)
+  })
+
+  it('operation 审计写失败不推翻已经提交的 query started 结果', async () => {
+    const { harness, workersDir } = await makeHarness({ caps: { fork: true } })
+    const worker = await harness.spawnWorker(spawnParams())
+    const eventLog = new WorkerEventLog(join(workersDir, worker.worker_id))
+    ;(harness as unknown as { eventLogs: Map<string, WorkerEventLog> }).eventLogs.set(worker.worker_id, eventLog)
+    vi.spyOn(eventLog, 'append').mockRejectedValueOnce(new Error('audit disk unavailable'))
+
+    await expect(harness.queryWorker(worker.worker_id, '侧问一下')).resolves.toMatchObject({
+      status: 'started',
+      query_id: expect.any(String),
+      fork_seq: 2,
+    })
+    const [persisted] = await harness.listWorkers(`test::friend-1` as ManagerKey)
+    expect(persisted.incarnations).toHaveLength(2)
+    expect(persisted.incarnations[1]).toMatchObject({ state: 'running', forked_from: 1 })
+  })
+
+  it('fork 已建立但 ledger 提交失败时尽力 kill，并以 unknown 返回 fork_record_failed', async () => {
+    const { harness, fake, ledger } = await makeHarness({ caps: { fork: true } })
+    const worker = await harness.spawnWorker(spawnParams())
+    vi.spyOn(ledger, 'upsertWorker').mockRejectedValueOnce(new Error('ledger unavailable'))
+
+    await expect(harness.queryWorker(worker.worker_id, '侧问一下', {
+      managerKey: `test::friend-1` as ManagerKey,
+    })).rejects.toMatchObject({
+      reason_code: 'fork_record_failed',
+      reason: 'ledger unavailable',
+      certainty: 'unknown',
+    })
+
+    expect(fake.killCalls).toEqual([
+      expect.objectContaining({ worker_id: worker.worker_id, seq: 2 }),
+    ])
+    const [persisted] = await harness.listWorkers(`test::friend-1` as ManagerKey)
+    expect(persisted.incarnations).toHaveLength(1)
+    expect(persisted.task.status).toBe('running')
+  })
+
+  it('ledger 已提交但 running receipt 写失败时，kill 并收口半提交 fork 化身', async () => {
+    const { harness, fake } = await makeHarness({ caps: { fork: true } })
+    const worker = await harness.spawnWorker(spawnParams())
+    const queryStore = (harness as unknown as { queryReceiptStore: QueryReceiptStore }).queryReceiptStore
+    vi.spyOn(queryStore, 'markRunning').mockRejectedValueOnce(new Error('query receipt unavailable'))
+
+    await expect(harness.queryWorker(worker.worker_id, '侧问一下')).rejects.toMatchObject({
+      reason_code: 'fork_record_failed',
+      reason: 'query receipt unavailable',
+      certainty: 'unknown',
+    })
+
+    expect(fake.killCalls).toEqual([
+      expect.objectContaining({ worker_id: worker.worker_id, seq: 2 }),
+    ])
+    const [persisted] = await harness.listWorkers(`test::friend-1` as ManagerKey)
+    expect(persisted.task.status).toBe('running')
+    expect(persisted.incarnations[1]).toMatchObject({
+      seq: 2,
+      query_id: expect.any(String),
+      state: 'exited',
+      ended_reason: 'killed',
+    })
+  })
+
+  it('capabilities().fork 为 true → 返回 started 并以同一 query_id 落 handle/ledger/receipt', async () => {
+    const { harness, fake, workersDir } = await makeHarness({ caps: { fork: true } })
     const worker = await harness.spawnWorker(spawnParams())
     events.length = 0
 
     const result = await harness.queryWorker(worker.worker_id, '侧问一下')
 
-    expect(result.forkSeq).toBe(2)
+    expect(result).toMatchObject({ status: 'started', fork_seq: 2, query_id: expect.any(String) })
     expect(fake.forkCalls).toHaveLength(1)
     expect(fake.forkCalls[0].forkInput).toBe('侧问一下')
 
     const [w] = await harness.listWorkers(`test::friend-1` as ManagerKey)
     expect(w.incarnations).toHaveLength(2)
-    expect(w.incarnations[1]).toMatchObject({ seq: 2, impl: 'builtin', state: 'running' })
+    expect(w.incarnations[1]).toMatchObject({
+      seq: 2,
+      impl: 'builtin',
+      state: 'running',
+      query_id: result.query_id,
+    })
     expect(w.task.status).toBe('running') // fork 不影响主线状态
 
     // forked_from 标记它不在主线化身链上(protocol-agent-v3 §3);session_ref 取
@@ -1385,10 +2081,142 @@ describe('WorkerHarness.queryWorker', () => {
     expect(w.incarnations[1].forked_from).toBe(1)
     expect(w.incarnations[1].session_ref).not.toBe(w.incarnations[0].session_ref)
 
-    const stateEvents = events.filter((e) => e.kind === 'state_changed')
-    expect(stateEvents).toHaveLength(1)
-    expect(stateEvents[0].seq).toBe(2)
-    expect(stateEvents[0].detail).toEqual({ kind: 'fork', from_seq: 1 })
+    const onDisk = await new WorkerEventLog(join(workersDir, worker.worker_id)).readAll()
+    expect(onDisk.filter((e) => e.detail?.query_id === result.query_id)).toHaveLength(1)
+  })
+
+  it('回答终态通知在 deferred/route throw 时保持 pending，只有 consumed 后停止重报', async () => {
+    const notifications: HarnessEvent[] = []
+    let attempt = 0
+    const { harness, fake, workersDir } = await makeHarness(
+      { caps: { fork: true } },
+      {
+        onOperationNotification: async (_managerKey, event) => {
+          notifications.push(event)
+          attempt++
+          if (attempt === 1) return { consumed: false }
+          if (attempt === 2) throw new Error('manager route unavailable')
+          return { consumed: true }
+        },
+      },
+    )
+    const worker = await harness.spawnWorker(spawnParams())
+    const result = await harness.queryWorker(worker.worker_id, '可靠通知侧问', {
+      managerKey: `test::friend-1` as ManagerKey,
+    })
+    fake.emitStateChange({
+      worker_id: worker.worker_id,
+      seq: result.fork_seq,
+      impl: 'builtin',
+      session_ref: `fork-ref-${worker.worker_id}#${result.fork_seq}`,
+      query_id: result.query_id,
+    }, 'exited', '侧问答案', 'completed')
+
+    const queryStore = (harness as unknown as { queryReceiptStore: QueryReceiptStore }).queryReceiptStore
+    await waitUntil(async () => (await queryStore.get(worker.worker_id, result.query_id))?.state === 'completed')
+
+    await harness.sweepLiveness()
+    expect((await queryStore.get(worker.worker_id, result.query_id))?.manager_notification.status).toBe('pending')
+    await harness.sweepLiveness()
+    expect((await queryStore.get(worker.worker_id, result.query_id))?.manager_notification.status).toBe('pending')
+    await harness.sweepLiveness()
+    expect((await queryStore.get(worker.worker_id, result.query_id))?.manager_notification.status).toBe('consumed')
+    await harness.sweepLiveness()
+
+    expect(notifications).toHaveLength(3)
+    for (const event of notifications) {
+      expect(event).toMatchObject({
+        kind: 'query_completed',
+        worker_id: worker.worker_id,
+        seq: result.fork_seq,
+        detail: {
+          query_id: result.query_id,
+          fork_seq: result.fork_seq,
+        },
+      })
+    }
+    const persisted = JSON.parse(
+      await fs.readFile(join(workersDir, worker.worker_id, 'query-receipts.json'), 'utf8'),
+    ) as { receipts: Array<Record<string, unknown>> }
+    expect(persisted.receipts[0]).toMatchObject({ state: 'completed' })
+  })
+
+  it('重启对账不重跑 running query，结算 unknown 并尽力终止原 fork', async () => {
+    const { harness, fake } = await makeHarness({ caps: { fork: true } })
+    const worker = await harness.spawnWorker(spawnParams())
+    const result = await harness.queryWorker(worker.worker_id, '重启中的侧问', {
+      managerKey: `test::friend-1` as ManagerKey,
+    })
+    expect(fake.forkCalls).toHaveLength(1)
+
+    await harness.reconcileQueryReceiptsOnStartup()
+
+    expect(fake.forkCalls).toHaveLength(1)
+    expect(fake.killCalls).toEqual([
+      expect.objectContaining({
+        worker_id: worker.worker_id,
+        seq: result.fork_seq,
+        query_id: result.query_id,
+      }),
+    ])
+    const queryStore = (harness as unknown as { queryReceiptStore: QueryReceiptStore }).queryReceiptStore
+    expect(await queryStore.get(worker.worker_id, result.query_id)).toMatchObject({
+      state: 'failed',
+      failure: {
+        reason_code: 'query_execution_lost_after_restart',
+        phase: 'execution',
+        certainty: 'unknown',
+      },
+      manager_notification: { status: 'pending' },
+    })
+  })
+
+  it('重启对账遇到 ledger 已明确完成但 receipt 仍 starting 时，据实结算 completed 且不建第二个 fork', async () => {
+    const { harness, fake, ledger } = await makeHarness({ caps: { fork: true } })
+    const worker = await harness.spawnWorker(spawnParams())
+    const queryStore = (harness as unknown as { queryReceiptStore: QueryReceiptStore }).queryReceiptStore
+    const queryId = 'query-crash-window-completed'
+    const createdAt = now()
+    await queryStore.create({
+      query_id: queryId,
+      worker_id: worker.worker_id,
+      manager_key: `test::friend-1` as ManagerKey,
+      question_preview: '已完成但 receipt 尚未提交',
+      created_at: createdAt,
+      updated_at: createdAt,
+      establishment_deadline_at: new Date(Date.parse(createdAt) + 30_000).toISOString(),
+      state: 'starting',
+      manager_notification: { status: 'not_required' },
+    })
+    await ledger.upsertWorker(`test::friend-1` as ManagerKey, worker.worker_id, (prev) => prev && ({
+      ...prev,
+      incarnations: [
+        ...prev.incarnations,
+        {
+          seq: 2,
+          impl: 'builtin',
+          state: 'exited',
+          workspace: prev.incarnations[0].workspace,
+          session_ref: 'fork-ref-completed',
+          started_at: createdAt,
+          ended_at: now(),
+          ended_reason: 'completed',
+          forked_from: 1,
+          query_id: queryId,
+        },
+      ],
+      updated_at: now(),
+    }))
+
+    await harness.reconcileQueryReceiptsOnStartup()
+
+    expect(fake.forkCalls).toHaveLength(0)
+    expect(fake.killCalls).toHaveLength(0)
+    expect(await queryStore.get(worker.worker_id, queryId)).toMatchObject({
+      state: 'completed',
+      fork_seq: 2,
+      manager_notification: { status: 'pending' },
+    })
   })
 
   // ---- P4 Task 4 第四轮:fork 落地即已终态的回调竞态(复审 PoC)----
@@ -1411,7 +2239,7 @@ describe('WorkerHarness.queryWorker', () => {
     events.length = 0
 
     const result = await harness.queryWorker(worker.worker_id, '侧问一下')
-    expect(result.forkSeq).toBe(2)
+    expect(result.fork_seq).toBe(2)
 
     const [w] = await harness.listWorkers(`test::friend-1` as ManagerKey)
     const forkEntry = w.incarnations.find((i) => i.seq === 2)!
@@ -1426,12 +2254,7 @@ describe('WorkerHarness.queryWorker', () => {
     const log = new WorkerEventLog(join(workersDir, worker.worker_id))
     const onDisk = await log.readAll()
     const forkSeqEvents = onDisk.filter((e) => e.seq === 2)
-    expect(forkSeqEvents.some((e) => e.kind === 'exited')).toBe(true)
-    // 不能重复:processStateChange 正常路径本该发的是 kind:'state_changed'、detail:{to:'exited'}——
-    // 那次回调已经被 `!target` 吞掉，不会再触发第二次 appendEvent，所以不应该出现这个形状的
-    // 事件(与 lock2 无条件都会发的 `state_changed{kind:'fork', from_seq}` 落账事件是两码事，
-    // 那条不受本次竞态影响，始终存在)。
-    expect(forkSeqEvents.some((e) => e.kind === 'state_changed' && (e.detail as { to?: string } | undefined)?.to === 'exited')).toBe(false)
+    expect(forkSeqEvents.filter((e) => e.kind === 'query_completed')).toHaveLength(1)
 
     // 断言③:主线(seq=1)台账完全不受这条竞态影响。
     const mainEntry = w.incarnations.find((i) => i.seq === 1)!
@@ -1464,16 +2287,16 @@ describe('WorkerHarness.queryWorker — adapter.fork 挪出锁(P4 Task 4 review 
       release = resolve
     })
     const originalFork = fake.fork.bind(fake)
-    fake.fork = async (prev, forkInput) => {
+    fake.fork = async (prev, forkInput, opts) => {
       resolveEntered()
       await forkGate
-      return originalFork(prev, forkInput)
+      return originalFork(prev, forkInput, opts)
     }
     return { forkEnteredPromise, release }
   }
 
   it('adapter.fork 卡住未落地期间,同一 worker 上的 send_to_worker 毫秒级完成,不排队等待 fork', async () => {
-    const { harness, fake } = await makeHarness({ caps: { fork: true } })
+    const { harness, fake, workersDir } = await makeHarness({ caps: { fork: true } })
     const worker = await harness.spawnWorker(spawnParams())
     const { forkEnteredPromise, release } = gateFork(fake)
 
@@ -1513,7 +2336,7 @@ describe('WorkerHarness.queryWorker — adapter.fork 挪出锁(P4 Task 4 review 
   })
 
   it('锁释放期间 worker 被 kill(task 已 cancelled)→ fork 落地后仍记录该 fork 化身(它确实跑过、有输出),但不改主线已终态的记录', async () => {
-    const { harness, fake } = await makeHarness({ caps: { fork: true } })
+    const { harness, fake, workersDir } = await makeHarness({ caps: { fork: true } })
     const worker = await harness.spawnWorker(spawnParams())
     const { forkEnteredPromise, release } = gateFork(fake)
 
@@ -1528,7 +2351,7 @@ describe('WorkerHarness.queryWorker — adapter.fork 挪出锁(P4 Task 4 review 
     // 真实执行完的动作,不因主线在它进行期间被 kill 而凭空丢弃——见 harness.ts queryWorker
     // 方法注释"锁释放期间世界会变"一节)。
     const result = await queryPromise
-    expect(result.forkSeq).toBe(2)
+    expect(result.fork_seq).toBe(2)
 
     const [w] = await harness.listWorkers(`test::friend-1` as ManagerKey)
     // 主线(seq=1)保持 killWorker 落定的记录,完全不被这次迟到的 fork 落账污染。
@@ -1543,10 +2366,11 @@ describe('WorkerHarness.queryWorker — adapter.fork 挪出锁(P4 Task 4 review 
     expect(forkEntry.forked_from).toBe(1)
     expect(forkEntry.state).toBe('running')
 
-    const stateEvents = events.filter((e) => e.kind === 'state_changed')
+    const stateEvents = (await new WorkerEventLog(join(workersDir, worker.worker_id)).readAll())
+      .filter((e) => e.kind === 'state_changed' && e.detail?.query_id === result.query_id)
     expect(stateEvents).toHaveLength(1)
     expect(stateEvents[0].seq).toBe(2)
-    expect(stateEvents[0].detail).toEqual({ kind: 'fork', from_seq: 1 })
+    expect(stateEvents[0].detail).toMatchObject({ kind: 'fork', from_seq: 1, query_id: result.query_id })
   })
 })
 
@@ -1603,11 +2427,11 @@ describe('WorkerHarness 锁纪律', () => {
 
 describe('WorkerHarness — fork 不劫持主线(protocol-agent-v3 §5.3 回归)', () => {
   it('queryWorker fork 之后,sendToWorker/readWorkerOutput/killWorker 仍作用于主线化身(seq=1),不被 fork(seq=2)顶替', async () => {
-    const { harness, fake } = await makeHarness({ caps: { fork: true } })
+    const { harness, fake, workersDir } = await makeHarness({ caps: { fork: true } })
     const worker = await harness.spawnWorker(spawnParams())
     events.length = 0
 
-    const { forkSeq } = await harness.queryWorker(worker.worker_id, '侧问一下')
+    const { fork_seq: forkSeq } = await harness.queryWorker(worker.worker_id, '侧问一下')
     expect(forkSeq).toBe(2)
 
     // 修复前:lastIncarnation() 取数组最后一个,fork 之后就是 seq=2 的侧问分支——
@@ -1635,7 +2459,7 @@ describe('WorkerHarness — fork 不劫持主线(protocol-agent-v3 §5.3 回归)
   })
 
   it('processStateChange:fork 化身(seq=2)自己的状态变化只更新它自己的化身条目,不推进主线 task.status', async () => {
-    const { harness, fake } = await makeHarness({ caps: { fork: true } })
+    const { harness, fake, workersDir } = await makeHarness({ caps: { fork: true } })
     const worker = await harness.spawnWorker(spawnParams())
     await harness.queryWorker(worker.worker_id, '侧问一下')
     events.length = 0
@@ -1659,9 +2483,11 @@ describe('WorkerHarness — fork 不劫持主线(protocol-agent-v3 §5.3 回归)
     expect(forkEntry.state).toBe('exited')
     expect(forkEntry.ended_reason).toBe('completed')
 
-    const stateEvents = events.filter((e) => e.kind === 'state_changed' && e.seq === 2)
-    expect(stateEvents).toHaveLength(1)
-    expect(stateEvents[0].detail).toEqual({ to: 'exited' })
+    await waitUntil(async () => (await new WorkerEventLog(join(workersDir, worker.worker_id)).readAll())
+      .some((event) => event.kind === 'query_completed' && event.seq === 2))
+    const terminalEvents = (await new WorkerEventLog(join(workersDir, worker.worker_id)).readAll())
+      .filter((event) => event.kind === 'query_completed' && event.seq === 2)
+    expect(terminalEvents).toHaveLength(1)
   })
 })
 
@@ -1695,7 +2521,7 @@ describe('WorkerHarness.readWorkerOutput', () => {
   it('给 opts.seq → 读取该 seq 对应化身(如 fork 分支)的输出,不是主线', async () => {
     const { harness, fake } = await makeHarness({ caps: { fork: true } })
     const worker = await harness.spawnWorker(spawnParams())
-    const { forkSeq } = await harness.queryWorker(worker.worker_id, '侧问一下')
+    const { fork_seq: forkSeq } = await harness.queryWorker(worker.worker_id, '侧问一下')
 
     const result = await harness.readWorkerOutput(worker.worker_id, { offset: 0 }, { seq: forkSeq })
 
@@ -1843,25 +2669,27 @@ describe('HarnessEvent.task_status —— 事件自带落账后的 task 状态',
   })
 
   it('非迁移点:query_failed 不带 task_status', async () => {
-    const { harness } = await makeHarness({ caps: { fork: false } })
+    const { harness, workersDir } = await makeHarness({ caps: { fork: false } })
     const worker = await harness.spawnWorker(spawnParams())
     events.length = 0
 
-    await expect(harness.queryWorker(worker.worker_id, '侧问')).rejects.toThrow(CapabilityNotSupportedError)
+    await expect(harness.queryWorker(worker.worker_id, '侧问')).rejects.toThrow(QueryEstablishmentError)
 
-    const queryFailed = events.filter((e) => e.kind === 'query_failed')
+    const queryFailed = (await new WorkerEventLog(join(workersDir, worker.worker_id)).readAll())
+      .filter((e) => e.kind === 'query_failed')
     expect(queryFailed).toHaveLength(1)
     expect(queryFailed[0].task_status).toBeUndefined()
   })
 
   it('非迁移点:fork 化身的落账事件不带 task_status(§5.3 fork 不影响主线)', async () => {
-    const { harness } = await makeHarness({ caps: { fork: true } })
+    const { harness, workersDir } = await makeHarness({ caps: { fork: true } })
     const worker = await harness.spawnWorker(spawnParams())
     events.length = 0
 
     await harness.queryWorker(worker.worker_id, '侧问')
 
-    const forkEvents = events.filter((e) => e.seq === 2)
+    const forkEvents = (await new WorkerEventLog(join(workersDir, worker.worker_id)).readAll())
+      .filter((e) => e.seq === 2)
     expect(forkEvents.length).toBeGreaterThan(0)
     for (const e of forkEvents) expect(e.task_status).toBeUndefined()
     // 台账确实没动主线 task.status——事件不带这个字段与台账事实一致

--- a/crabot-agent/tests/workers/harness/inbox.test.ts
+++ b/crabot-agent/tests/workers/harness/inbox.test.ts
@@ -243,6 +243,93 @@ describe('WorkerInbox', () => {
     expect(inbox.pending).toBe(0)
   })
 
+  it('reports the per-item pending phase without settling the receipt', async () => {
+    const inbox = new WorkerInbox('worker-1')
+    const pending = vi.fn()
+    const settled = vi.fn()
+    inbox.enqueue(makeItem('queued input', {
+      delivery_id: 'delivery-1',
+      onPending: pending,
+      onSettled: settled,
+    }))
+
+    await inbox.flush(async () => ({ action: 'hold_requeue', reason: 'waiting_action' }))
+
+    expect(pending).toHaveBeenCalledWith('waiting_action')
+    expect(settled).not.toHaveBeenCalled()
+  })
+
+  it('cancels a queued delivery by ID but reports consumed/in-flight items as unsafe', async () => {
+    const queued = new WorkerInbox('worker-queued')
+    queued.enqueue(makeItem('queued', { delivery_id: 'delivery-queued' }))
+    await expect(queued.cancelDelivery('delivery-queued')).resolves.toBe('cancelled')
+    expect(queued.pending).toBe(0)
+
+    const consumed = new WorkerInbox('worker-consumed')
+    consumed.enqueue(makeItem('consumed', { delivery_id: 'delivery-consumed', onSettled: vi.fn() }))
+    await consumed.flush(async () => ({ action: 'hold_consumed', reason: 'input_pending' }))
+    await expect(consumed.cancelDelivery('delivery-consumed')).resolves.toBe('unsafe')
+  })
+
+  it('reports an in-flight delivery as unsafe without waiting for a blocked adapter', async () => {
+    const inbox = new WorkerInbox('worker-in-flight')
+    inbox.enqueue(makeItem('in flight', { delivery_id: 'delivery-in-flight' }))
+
+    let markEntered!: () => void
+    const entered = new Promise<void>((resolve) => { markEntered = resolve })
+    let releaseDelivery!: () => void
+    const deliveryGate = new Promise<void>((resolve) => { releaseDelivery = resolve })
+    const flush = inbox.flush(async () => {
+      markEntered()
+      await deliveryGate
+    })
+    await entered
+
+    let cancellation: string
+    try {
+      cancellation = await Promise.race([
+        inbox.cancelDelivery('delivery-in-flight'),
+        new Promise<string>((resolve) => setTimeout(() => resolve('timed_out'), 50)),
+      ])
+    } finally {
+      releaseDelivery()
+      await flush
+    }
+
+    expect(cancellation).toBe('unsafe')
+  })
+
+  it('drops an invalidated receipt immediately before delivery without invoking settlement', async () => {
+    const inbox = new WorkerInbox('worker-1')
+    const settled = vi.fn()
+    const delivered = vi.fn()
+    inbox.enqueue(makeItem('expired', {
+      delivery_id: 'delivery-expired',
+      shouldDeliver: async () => false,
+      onSettled: settled,
+    }))
+
+    await inbox.flush(delivered)
+
+    expect(delivered).not.toHaveBeenCalled()
+    expect(settled).not.toHaveBeenCalled()
+    expect(inbox.pending).toBe(0)
+  })
+
+  it('passes terminal settlement detail to the producer receipt callback', async () => {
+    const inbox = new WorkerInbox('worker-1')
+    const settled = vi.fn()
+    inbox.enqueue(makeItem('delivered', { onSettled: settled }))
+
+    await inbox.flush(async () => ({
+      action: 'settled',
+      settlement: 'delivered',
+      detail: { seq: 3 },
+    }))
+
+    expect(settled).toHaveBeenCalledWith('delivered', { seq: 3 })
+  })
+
   it('handoff replacement preserves the original durable receipt, dedupe key, and raw mode', async () => {
     const inbox = new WorkerInbox('worker-1')
     const settled = vi.fn()

--- a/crabot-agent/tests/workers/harness/input-delivery-store.test.ts
+++ b/crabot-agent/tests/workers/harness/input-delivery-store.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { promises as fs } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import {
+  InputDeliveryStore,
+  type WorkerInputDeliveryReceipt,
+} from '../../../src/workers/harness/input-delivery-store'
+import type { ManagerKey } from '../../../src/workers/harness/ledger-types'
+
+let root: string
+const workerId = 'w-input-receipt'
+const managerKey = 'wechat::session-1' as ManagerKey
+
+function receipt(overrides: Partial<WorkerInputDeliveryReceipt> = {}): WorkerInputDeliveryReceipt {
+  return {
+    delivery_id: 'delivery-1',
+    worker_id: workerId,
+    manager_key: managerKey,
+    raw: false,
+    text_preview: '继续处理昨天的任务',
+    created_at: '2026-08-17T01:00:00.000Z',
+    updated_at: '2026-08-17T01:00:00.000Z',
+    deadline_at: '2026-08-17T01:05:00.000Z',
+    state: 'pending',
+    phase: 'queued',
+    manager_notification: { status: 'not_required' },
+    ...overrides,
+  }
+}
+
+beforeEach(async () => {
+  root = await fs.mkdtemp(join(tmpdir(), 'input-delivery-store-'))
+})
+
+afterEach(async () => {
+  await fs.rm(root, { recursive: true, force: true })
+})
+
+describe('InputDeliveryStore', () => {
+  it('原子保存 receipt，正文不落盘，preview 最长 200 字符', async () => {
+    const store = new InputDeliveryStore(root)
+    const fullText = `secret-full-body-${'x'.repeat(400)}`
+    const created = await store.create({
+      ...receipt(),
+      text_preview: fullText,
+    })
+
+    expect(created.text_preview).toHaveLength(200)
+    const raw = await fs.readFile(join(root, workerId, 'input-deliveries.json'), 'utf8')
+    expect(raw).not.toContain(fullText)
+    expect((await store.get(workerId, created.delivery_id))?.text_preview).toBe(fullText.slice(0, 200))
+  })
+
+  it('pending 只允许结算到一个终态，失败总是挂起 Manager 通知', async () => {
+    const store = new InputDeliveryStore(root)
+    await store.create(receipt())
+
+    const failed = await store.settleFailed(workerId, 'delivery-1', {
+      reason_code: 'delivery_attempt_failed',
+      reason: 'tmux command failed',
+      certainty: 'unknown',
+    }, '2026-08-17T01:01:00.000Z')
+
+    expect(failed).toMatchObject({
+      state: 'failed',
+      manager_notification: { status: 'pending' },
+    })
+    await expect(store.settleDelivered(workerId, 'delivery-1', '2026-08-17T01:02:00.000Z'))
+      .rejects.toThrow('terminal')
+  })
+
+  it('工具返回 pending 前原子挂通知；随后 delivered 保留通知责任直到 consumed', async () => {
+    const store = new InputDeliveryStore(root)
+    await store.create(receipt())
+
+    const pending = await store.readForToolResult(workerId, 'delivery-1', '2026-08-17T01:00:01.000Z')
+    expect(pending.manager_notification.status).toBe('pending')
+
+    const delivered = await store.settleDelivered(workerId, 'delivery-1', '2026-08-17T01:00:02.000Z')
+    expect(delivered.manager_notification.status).toBe('pending')
+
+    const consumed = await store.markNotificationConsumed(workerId, 'delivery-1', '2026-08-17T01:00:03.000Z')
+    expect(consumed.manager_notification).toEqual({
+      status: 'consumed',
+      consumed_at: '2026-08-17T01:00:03.000Z',
+    })
+  })
+
+  it('同步 delivered 在工具读取终态时不制造重复通知', async () => {
+    const store = new InputDeliveryStore(root)
+    await store.create(receipt())
+    await store.settleDelivered(workerId, 'delivery-1', '2026-08-17T01:00:01.000Z')
+    const path = join(root, workerId, 'input-deliveries.json')
+    const before = await fs.stat(path)
+
+    const delivered = await store.readForToolResult(workerId, 'delivery-1', '2026-08-17T01:00:02.000Z')
+    expect(delivered.manager_notification.status).toBe('not_required')
+    expect((await fs.stat(path)).ino).toBe(before.ino)
+  })
+})

--- a/crabot-agent/tests/workers/harness/query-receipt-store.test.ts
+++ b/crabot-agent/tests/workers/harness/query-receipt-store.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { promises as fs } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import {
+  QueryReceiptStore,
+  type WorkerQueryReceipt,
+} from '../../../src/workers/harness/query-receipt-store'
+import type { ManagerKey } from '../../../src/workers/harness/ledger-types'
+
+let root: string
+const workerId = 'w-query-receipt'
+
+function receipt(overrides: Partial<WorkerQueryReceipt> = {}): WorkerQueryReceipt {
+  return {
+    query_id: 'query-1',
+    worker_id: workerId,
+    manager_key: 'wechat::session-1' as ManagerKey,
+    question_preview: '现在进行到哪一步？',
+    created_at: '2026-08-17T01:00:00.000Z',
+    updated_at: '2026-08-17T01:00:00.000Z',
+    establishment_deadline_at: '2026-08-17T01:00:30.000Z',
+    state: 'starting',
+    manager_notification: { status: 'not_required' },
+    ...overrides,
+  }
+}
+
+beforeEach(async () => {
+  root = await fs.mkdtemp(join(tmpdir(), 'query-receipt-store-'))
+})
+
+afterEach(async () => {
+  await fs.rm(root, { recursive: true, force: true })
+})
+
+describe('QueryReceiptStore', () => {
+  it('starting → running → completed，并把 query 终态通知保持到 consumed', async () => {
+    const store = new QueryReceiptStore(root)
+    await store.create(receipt())
+
+    const running = await store.markRunning(workerId, 'query-1', 2, '2026-08-17T01:00:01.000Z')
+    expect(running).toMatchObject({ state: 'running', fork_seq: 2 })
+
+    const completed = await store.settleCompleted(workerId, 'query-1', '2026-08-17T01:00:02.000Z')
+    expect(completed).toMatchObject({
+      state: 'completed',
+      manager_notification: { status: 'pending' },
+    })
+
+    const consumed = await store.markNotificationConsumed(workerId, 'query-1', '2026-08-17T01:00:03.000Z')
+    expect(consumed.manager_notification.status).toBe('consumed')
+  })
+
+  it('建立失败保留 query_id 与准确失败阶段，且不能再转 running', async () => {
+    const store = new QueryReceiptStore(root)
+    await store.create(receipt())
+
+    const failed = await store.settleFailed(workerId, 'query-1', {
+      reason_code: 'fork_capability_unavailable',
+      reason: 'codex app-server fork unavailable',
+      phase: 'establishment',
+      certainty: 'not_started',
+    }, '2026-08-17T01:00:01.000Z')
+
+    expect(failed).toMatchObject({
+      query_id: 'query-1',
+      state: 'failed',
+      manager_notification: { status: 'pending' },
+    })
+    await expect(store.markRunning(workerId, 'query-1', 2, '2026-08-17T01:00:02.000Z'))
+      .rejects.toThrow('terminal')
+  })
+
+  it('拒绝 running 之前完成，也拒绝 completed 与 failed 互相翻转', async () => {
+    const store = new QueryReceiptStore(root)
+    await store.create(receipt())
+
+    await expect(store.settleCompleted(workerId, 'query-1', '2026-08-17T01:00:01.000Z'))
+      .rejects.toThrow('running')
+
+    await store.markRunning(workerId, 'query-1', 2, '2026-08-17T01:00:02.000Z')
+    await store.settleCompleted(workerId, 'query-1', '2026-08-17T01:00:03.000Z')
+    await expect(store.settleFailed(workerId, 'query-1', {
+      reason_code: 'query_execution_failed',
+      reason: 'late error',
+      phase: 'execution',
+      certainty: 'failed',
+    }, '2026-08-17T01:00:04.000Z')).rejects.toThrow('terminal')
+  })
+
+  it('只持久化 200 字符问题预览', async () => {
+    const store = new QueryReceiptStore(root)
+    const question = `question-${'y'.repeat(400)}`
+    await store.create(receipt({ question_preview: question }))
+
+    const raw = await fs.readFile(join(root, workerId, 'query-receipts.json'), 'utf8')
+    expect(raw).not.toContain(question)
+    expect((await store.get(workerId, 'query-1'))?.question_preview).toBe(question.slice(0, 200))
+  })
+})

--- a/crabot-agent/tests/workers/input-commit.test.ts
+++ b/crabot-agent/tests/workers/input-commit.test.ts
@@ -5,6 +5,46 @@ import type { PaneSnapshot } from '../../src/workers/tmux/driver.js'
 const snapshot = (text: string): PaneSnapshot => ({ text })
 
 describe('commitInput', () => {
+  it('runs the side-effect guard before paste and every Enter attempt', async () => {
+    const phases: string[] = []
+    const frames = [snapshot('empty'), snapshot('pending'), snapshot('pending'), snapshot('pending')]
+    const result = await commitInput(
+      { pasteText: async () => {}, sendEnter: async () => {}, capture: async () => frames.shift()! },
+      frame => frame.text as InputProbe,
+      () => false,
+      'task',
+      { settleTimeoutMs: 0, beforeSideEffect: phase => { phases.push(phase) } },
+    )
+
+    expect(result.disposition).toBe('pending_in_ui')
+    expect(phases).toEqual(['paste', 'enter', 'enter'])
+  })
+
+  it('a guard failure before Enter never performs that Enter', async () => {
+    let pastes = 0
+    let enters = 0
+    const frames = [snapshot('empty'), snapshot('pending')]
+
+    await expect(commitInput(
+      {
+        pasteText: async () => { pastes++ },
+        sendEnter: async () => { enters++ },
+        capture: async () => frames.shift()!,
+      },
+      frame => frame.text as InputProbe,
+      () => false,
+      'task',
+      {
+        settleTimeoutMs: 0,
+        beforeSideEffect: phase => {
+          if (phase === 'enter') throw new Error('delivery expired after paste')
+        },
+      },
+    )).rejects.toThrow('delivery expired after paste')
+    expect(pastes).toBe(1)
+    expect(enters).toBe(0)
+  })
+
   it('pastes once and commits once after empty -> pending', async () => {
     const frames = [snapshot('empty'), snapshot('pending'), snapshot('accepted')]
     let pastes = 0; let enters = 0


### PR DESCRIPTION
## 背景

双 Agent 改版后，`send_to_worker` 把“进入进程内输入路径”当成“已经提交给 Worker”，导致消息只排队、只 paste 或 Enter 未确认时仍返回成功；后续失败也可能没有被 Manager 真正消费。旧 `query_worker` 则在 fork 建立前就返回 `queried`，能力缺失、fork 创建失败和首问提交失败只能事后补报。

根因是缺少从 Manager 工具结果，到 Worker adapter 接受，再到终态失败被原 Manager 消费的端到端操作契约。

## 改动

- 为 Manager-originated 输入增加持久 `delivery_id` receipt，`send_to_worker` 准确返回 `delivered / pending / failed`。
- pending 在 5 分钟内有限结算；失败和 pending 后终态在 owning Manager 返回 `consumedEvents=true` 前持续保留通知责任。
- Agent 重启不自动重发输入；无法确认的窗口结算为 `failed + certainty: unknown`，避免重复执行。
- `query_worker` 改为同步建立 fork 和提交首问，成功返回 `started + query_id + fork_seq`，回答继续异步运行。
- builtin、Claude Code、Codex 统一“fork 与首问接受后返回”的契约；Claude Code 使用流式 print 子进程，Codex 使用 app-server `thread/fork + turn/start`，均不经过主 TUI 输入队列。
- 对半提交、deadline、进程退出和 receipt 写入失败做显式收口，并在持久失败原因进入磁盘前移除消息正文、Provider secret 和本地路径。

## 当前边界

- 已 rebase 到包含 #99（模块关闭与孤儿回收）和 #100（Traces 与 retention）的 `main`；关闭后的 adapter 拒绝新操作、watcher 释放及现有 retention 语义均被保留。
- 本实现不承诺消息永远送达，也不做自动 replay/rerun；无法可靠确认时允许失败，但失败原因和送达确定性必须可靠通知 Manager。
- 设计与协议：crabot-docs commit `d4b4e50`。

## 验证

- 可靠交付核心定向测试：17 files，`468/468`
- Manager 定向：`113/113`
- Harness 定向：`104/104`
- Agent 全量：`2781 passed / 4 failed / 2 skipped`
  - 3 条为干净 main 同样复现的 macOS `/var` realpath 基线失败
  - 1 条 tmux 探测超时单独重跑通过
- Codex runtime 清理精确回归：`1/1`
- Claude streaming fork 精确回归：`5/5`
- 本次 rebase 后：Agent TypeScript build 通过；Manager registry `31/31`；非交互定向子集 225 项通过；Claude/Codex adapter 的关闭生命周期回归各 `1/1`。
- `git diff --check` 通过