### PR TITLE
[codex] Worker 详情页改为人话优先活动流

### DIFF
--- a/crabot-admin/web/src/pages/Traces/WorkerDetail.tsx
+++ b/crabot-admin/web/src/pages/Traces/WorkerDetail.tsx
@@ -1,9 +1,8 @@
 /**
- * P6-A §10.4：Worker 详情 —— owner/report_to/origin/workspace、化身链、
- * composite timeline（opaque cursor 增量）、terminal output（offset cursor）。
- * INVALID_PARAMS（cursor 失效/GC/化身变化）显式提示重载，不静默拼接重复数据。
+ * Worker 详情：以主线化身为默认视角，把已归一化的 trace 投影为人能理解的活动流。
+ * 默认隐藏的协议事件仍可在「技术事件」模式查看，cursor 与读接口语义不变。
  */
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
 import { Loading } from '../../components/Common/Loading'
 import { MainLayout } from '../../components/Layout/MainLayout'
@@ -15,9 +14,11 @@ import {
   type WorkerTraceEvent,
 } from '../../services/agent-observability'
 
-const SOURCE_LABEL: Record<string, string> = { harness: 'harness', native: 'native', legacy: 'legacy' }
-const KIND_LABEL: Record<WorkerTraceEvent['kind'], string> = {
-  message: '消息', tool_call: '工具调用', tool_result: '结果', thinking: '思考', lifecycle: '生命周期',
+const IMPL_LABEL: Record<WorkerIncarnation['impl'], string> = {
+  builtin: '内置',
+  'claude-code': 'Claude Code',
+  codex: 'Codex',
+  legacy: '旧版记录',
 }
 const STATUS_LABEL: Record<WorkerTaskStatus, string> = {
   queued: '排队', running: '执行中', waiting_input: '等输入',
@@ -27,14 +28,227 @@ const STATUS_COLOR: Record<WorkerTaskStatus, string> = {
   queued: 'var(--text-muted)', running: 'var(--info)', waiting_input: 'var(--warning)',
   completed: 'var(--success)', failed: 'var(--error)', cancelled: 'var(--text-muted)',
 }
+const INCARNATION_STATE_LABEL: Record<string, string> = {
+  running: '执行中', idle: '等输入', exited: '已结束',
+}
+const SOURCE_LABEL: Record<string, string> = { harness: 'harness', native: 'native', legacy: 'legacy' }
+const KIND_LABEL: Record<WorkerTraceEvent['kind'], string> = {
+  message: '消息', tool_call: '工具调用', tool_result: '工具结果', thinking: '思考', lifecycle: '生命周期',
+}
+const ACTIVITY_TONE_COLOR: Record<ActivityTone, string> = {
+  manager: 'var(--info)', worker: 'var(--success)', tool: 'var(--warning)', status: 'var(--text-muted)', failure: 'var(--error)',
+}
 
-function TimelineEvent({ event }: { event: WorkerTraceEvent }) {
+type DetailRecord = Record<string, unknown>
+type ActivityTone = 'manager' | 'worker' | 'tool' | 'status' | 'failure'
+
+interface ActivityEntry {
+  event: WorkerTraceEvent
+  label: string
+  tone: ActivityTone
+  body: string
+  title?: string
+  result?: string
+}
+
+function asRecord(value: unknown): DetailRecord | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as DetailRecord : undefined
+}
+
+function textBlocks(content: unknown): string | undefined {
+  if (typeof content === 'string' && content.trim()) return content
+  if (!Array.isArray(content)) return undefined
+  const text = content
+    .flatMap((item) => {
+      const block = asRecord(item)
+      return typeof block?.text === 'string' ? [block.text] : []
+    })
+    .filter(Boolean)
+    .join('\n')
+  return text || undefined
+}
+
+function messageText(event: WorkerTraceEvent): string {
+  const detail = asRecord(event.detail)
+  return textBlocks(detail?.content) ?? textBlocks(asRecord(detail?.message)?.content) ?? event.summary
+}
+
+function toolName(event: WorkerTraceEvent): string | undefined {
+  const name = asRecord(event.detail)?.name
+  return typeof name === 'string' && name.trim() ? name : undefined
+}
+
+function toolArguments(event: WorkerTraceEvent): string {
+  const detail = asRecord(event.detail)
+  if (typeof detail?.arguments === 'string' && detail.arguments.trim()) return detail.arguments
+  if (typeof detail?.input === 'string' && detail.input.trim()) return detail.input
+  const input = asRecord(detail?.input)
+  return input ? JSON.stringify(input) : event.summary
+}
+
+function toolResult(event: WorkerTraceEvent): string {
+  const detail = asRecord(event.detail)
+  const output = detail?.output
+  if (typeof output === 'string' && output.trim()) return output
+  if (typeof detail?.content === 'string' && detail.content.trim()) return detail.content
+  if (typeof event.detail === 'string' && event.detail.trim()) return event.detail
+  return event.summary
+}
+
+function callId(event: WorkerTraceEvent): string | undefined {
+  const value = asRecord(event.detail)?.call_id
+  return typeof value === 'string' && value ? value : undefined
+}
+
+function failureReason(detail: DetailRecord | undefined, fallback: string): string {
+  if (typeof detail?.message === 'string' && detail.message) return detail.message
+  if (typeof detail?.error === 'string' && detail.error) return detail.error
+  if (typeof detail?.reason === 'string' && detail.reason) return detail.reason
+  return fallback
+}
+
+function lifecycleActivity(event: WorkerTraceEvent): ActivityEntry | undefined {
+  if (event.source !== 'harness') return undefined
+  const detail = asRecord(event.detail)
+  if (event.summary.startsWith('spawned')) {
+    const impl = typeof detail?.impl === 'string' ? IMPL_LABEL[detail.impl as WorkerIncarnation['impl']] ?? detail.impl : undefined
+    return { event, label: 'Worker 状态', tone: 'status', body: impl ? `已由 ${impl} 启动` : '已启动' }
+  }
+  if (event.summary.startsWith('state_changed')) {
+    const state = typeof detail?.to === 'string' ? INCARNATION_STATE_LABEL[detail.to] ?? detail.to : undefined
+    const reason = typeof detail?.reason === 'string' ? detail.reason : undefined
+    if (detail?.to === 'exited' && reason && reason !== 'completed') {
+      return { event, label: 'Worker 异常退出', tone: 'failure', body: `已结束：${reason}` }
+    }
+    return { event, label: 'Worker 状态', tone: 'status', body: state ? `状态变为：${state}` : event.summary }
+  }
+  if (event.summary.startsWith('exited')) {
+    const reason = failureReason(detail, event.summary)
+    return { event, label: 'Worker 异常退出', tone: 'failure', body: `已结束：${reason}` }
+  }
+  if (event.summary.startsWith('killed')) {
+    const reason = typeof detail?.reason === 'string' ? `：${detail.reason}` : ''
+    return { event, label: 'Worker 状态', tone: 'status', body: `已停止${reason}` }
+  }
+  if (event.summary.startsWith('superseded')) {
+    return { event, label: 'Worker 状态', tone: 'status', body: '已交接到新的化身' }
+  }
+  if (event.summary.startsWith('resumed')) {
+    const fromSeq = typeof detail?.from_seq === 'number' ? `从化身 #${detail.from_seq} ` : ''
+    return { event, label: 'Worker 状态', tone: 'status', body: `已${fromSeq}恢复执行` }
+  }
+  if (event.summary.startsWith('input_sent')) {
+    return { event, label: '指令投递', tone: 'status', body: 'Manager 的补充指令已确认送达' }
+  }
+  if (event.summary.startsWith('input_delivery_failed')) {
+    return { event, label: '投递失败', tone: 'failure', body: failureReason(detail, event.summary) }
+  }
+  if (event.summary.startsWith('query_completed')) {
+    return { event, label: '侧问完成', tone: 'status', body: '临时侧问已完成，可在相应化身中查看结果' }
+  }
+  if (event.summary.startsWith('query_failed')) {
+    return { event, label: '侧问失败', tone: 'failure', body: failureReason(detail, event.summary) }
+  }
+  return undefined
+}
+
+function activityFor(event: WorkerTraceEvent): ActivityEntry | undefined {
+  if (event.source === 'native' && event.kind === 'message' && event.role === 'user') {
+    return { event, label: 'Manager 指令', tone: 'manager', body: messageText(event) }
+  }
+  if (event.source === 'native' && event.kind === 'message' && event.role === 'assistant') {
+    return { event, label: 'Worker 输出', tone: 'worker', body: messageText(event) }
+  }
+  if (event.kind === 'tool_call') {
+    return { event, label: '工具调用', tone: 'tool', title: toolName(event), body: toolArguments(event) }
+  }
+  if (event.kind === 'tool_result') {
+    return { event, label: '工具结果', tone: 'tool', body: toolResult(event) }
+  }
+  if (event.kind === 'lifecycle') return lifecycleActivity(event)
+  return undefined
+}
+
+function projectTimeline(events: WorkerTraceEvent[]): { human: ActivityEntry[]; technical: WorkerTraceEvent[] } {
+  const human: ActivityEntry[] = []
+  const technical: WorkerTraceEvent[] = []
+  const calls = new Map<string, ActivityEntry>()
+
+  for (const event of events) {
+    const activity = activityFor(event)
+    if (!activity) {
+      technical.push(event)
+      continue
+    }
+    if (event.kind === 'tool_result') {
+      const id = callId(event)
+      const pairedCall = id ? calls.get(id) : undefined
+      if (pairedCall) {
+        pairedCall.result = activity.body
+        continue
+      }
+    }
+    human.push(activity)
+    if (event.kind === 'tool_call') {
+      const id = callId(event)
+      if (id) calls.set(id, activity)
+    }
+  }
+  return { human, technical }
+}
+
+function mainlineIncarnation(incarnations: WorkerIncarnation[]): WorkerIncarnation | undefined {
+  for (let index = incarnations.length - 1; index >= 0; index -= 1) {
+    if (incarnations[index].forked_from === undefined) return incarnations[index]
+  }
+  return incarnations[incarnations.length - 1]
+}
+
+function CollapsibleText({ children }: { children: string }) {
+  const [expanded, setExpanded] = useState(false)
+  const canCollapse = children.length > 360
   return (
-    <div style={{ display: 'flex', gap: 8, fontSize: 12, padding: '3px 0', fontFamily: 'var(--font-mono)' }}>
-      <span style={{ color: 'var(--text-muted)', minWidth: 64 }}>{event.ts ? new Date(event.ts).toLocaleTimeString('zh-CN', { hour12: false }) : ''}</span>
-      <span style={{ color: 'var(--text-muted)', minWidth: 56 }}>{event.source ? SOURCE_LABEL[event.source] ?? event.source : ''}</span>
-      <span style={{ color: 'var(--text-muted)', minWidth: 88 }}>{KIND_LABEL[event.kind]}</span>
-      <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{event.summary}</span>
+    <>
+      <div style={{ whiteSpace: 'pre-wrap', overflowWrap: 'anywhere', ...(expanded || !canCollapse ? {} : { maxHeight: 88, overflow: 'hidden' }) }}>
+        {children}
+      </div>
+      {canCollapse && (
+        <button type="button" onClick={() => setExpanded((value) => !value)} style={{ marginTop: 6, fontSize: 12 }}>
+          {expanded ? '收起' : '展开全文'}
+        </button>
+      )}
+    </>
+  )
+}
+
+function TimelineEvent({ entry }: { entry: ActivityEntry }) {
+  return (
+    <div style={{ display: 'flex', gap: 12, alignItems: 'flex-start', flexWrap: 'wrap', padding: '12px 0', borderTop: '1px solid var(--border)' }}>
+      <time style={{ color: 'var(--text-muted)', width: 56, paddingTop: 1, fontFamily: 'var(--font-mono)', fontSize: 12 }}>
+        {entry.event.ts ? new Date(entry.event.ts).toLocaleTimeString('zh-CN', { hour12: false }) : ''}
+      </time>
+      <div style={{ color: ACTIVITY_TONE_COLOR[entry.tone], width: 100, paddingTop: 1, fontSize: 12, fontWeight: 600 }}>{entry.label}</div>
+      <div style={{ flex: '1 1 360px', minWidth: 0, fontSize: 13 }}>
+        {entry.title && <div style={{ fontFamily: 'var(--font-mono)', fontWeight: 600, marginBottom: 4 }}>{entry.title}</div>}
+        <CollapsibleText>{entry.body}</CollapsibleText>
+        {entry.result && (
+          <div style={{ borderLeft: '3px solid var(--warning)', marginTop: 10, paddingLeft: 10 }}>
+            <div style={{ color: 'var(--text-muted)', fontSize: 12, marginBottom: 4 }}>工具结果</div>
+            <CollapsibleText>{entry.result}</CollapsibleText>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function TechnicalEvent({ event }: { event: WorkerTraceEvent }) {
+  return (
+    <div style={{ display: 'flex', gap: 12, alignItems: 'flex-start', flexWrap: 'wrap', padding: '8px 0', borderTop: '1px solid var(--border)', color: 'var(--text-muted)', fontFamily: 'var(--font-mono)', fontSize: 12 }}>
+      <time style={{ width: 56 }}>{event.ts ? new Date(event.ts).toLocaleTimeString('zh-CN', { hour12: false }) : ''}</time>
+      <span style={{ width: 64 }}>{event.source ? SOURCE_LABEL[event.source] ?? event.source : '—'}</span>
+      <span style={{ width: 72 }}>{KIND_LABEL[event.kind]}</span>
+      <span style={{ flex: '1 1 280px', minWidth: 0, overflowWrap: 'anywhere' }}>{event.summary || '（无摘要）'}</span>
     </div>
   )
 }
@@ -46,6 +260,8 @@ function Timeline({ workerId, seq }: { workerId: string; seq?: number }) {
   const [unavailableReason, setUnavailableReason] = useState<string | undefined>(undefined)
   const [cursorInvalid, setCursorInvalid] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [mode, setMode] = useState<'human' | 'technical'>('human')
+  const projected = useMemo(() => projectTimeline(events), [events])
 
   const load = useCallback(async (cursor?: string) => {
     try {
@@ -75,33 +291,46 @@ function Timeline({ workerId, seq }: { workerId: string; seq?: number }) {
     setEvents([])
     setNextCursor(undefined)
     setHasMore(true)
+    setUnavailableReason(undefined)
     setCursorInvalid(false)
     setError(null)
+    setMode('human')
     void load(undefined)
   }, [load])
 
-  if (error) return <div style={{ color: 'var(--text-muted)', padding: 12 }}>时间线暂不可用：{error}</div>
+  if (error) return <div style={{ color: 'var(--text-muted)', padding: 12 }}>活动记录暂不可用：{error}</div>
 
+  const visibleEvents = mode === 'human' ? projected.human : projected.technical
   return (
     <div>
-      {unavailableReason && (
-        <div style={{ fontSize: 12, color: 'var(--color-warning, #d97706)', padding: '4px 0' }}>{unavailableReason}</div>
-      )}
-      {events.length === 0 ? (
-        <div style={{ color: 'var(--text-muted)', padding: 12 }}>该化身暂无事件。</div>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8, flexWrap: 'wrap', marginBottom: 8 }}>
+        <div style={{ display: 'inline-flex', border: '1px solid var(--border)' }}>
+          <button type="button" aria-pressed={mode === 'human'} onClick={() => setMode('human')} style={{ border: 0, padding: '5px 8px', background: mode === 'human' ? 'var(--bg-muted)' : undefined }}>
+            对话与操作
+          </button>
+          <button type="button" aria-pressed={mode === 'technical'} onClick={() => setMode('technical')} style={{ border: 0, borderLeft: '1px solid var(--border)', padding: '5px 8px', background: mode === 'technical' ? 'var(--bg-muted)' : undefined }}>
+            技术事件 {projected.technical.length}
+          </button>
+        </div>
+      </div>
+      {unavailableReason && <div style={{ fontSize: 12, color: 'var(--color-warning, #d97706)', padding: '4px 0' }}>{unavailableReason}</div>}
+      {visibleEvents.length === 0 ? (
+        <div style={{ color: 'var(--text-muted)', padding: 12 }}>{mode === 'human' ? '该化身暂无可读活动。' : '该化身暂无技术事件。'}</div>
+      ) : mode === 'human' ? (
+        projected.human.map((entry, index) => <TimelineEvent key={`${entry.event.ts}-${entry.event.kind}-${index}`} entry={entry} />)
       ) : (
-        events.map((event, index) => <TimelineEvent key={index} event={event} />)
+        projected.technical.map((event, index) => <TechnicalEvent key={`${event.ts}-${event.kind}-${index}`} event={event} />)
       )}
       {cursorInvalid && (
         <div style={{ fontSize: 12, color: 'var(--color-warning, #d97706)', padding: '8px 0' }}>
           游标已失效。
-          <button onClick={() => { setCursorInvalid(false); setEvents([]); void load(undefined) }} style={{ marginLeft: 8 }}>
+          <button type="button" onClick={() => { setCursorInvalid(false); setEvents([]); void load(undefined) }} style={{ marginLeft: 8 }}>
             从头重新加载
           </button>
         </div>
       )}
       {!cursorInvalid && hasMore && nextCursor && (
-        <button onClick={() => void load(nextCursor)} style={{ marginTop: 8 }}>
+        <button type="button" onClick={() => void load(nextCursor)} style={{ marginTop: 8 }}>
           {events.length === 0 ? '刷新/检查新内容' : '加载更多'}
         </button>
       )}
@@ -139,36 +368,36 @@ function OutputPanel({ workerId, seq }: { workerId: string; seq?: number }) {
 
   return (
     <div>
-      <pre style={{ background: 'var(--bg-muted, #f6f6f6)', padding: 12, borderRadius: 8, maxHeight: 320, overflow: 'auto', fontSize: 12 }}>
+      <pre style={{ background: 'var(--bg-muted, #f6f6f6)', padding: 12, borderRadius: 8, maxHeight: 320, overflow: 'auto', fontSize: 12, whiteSpace: 'pre-wrap', overflowWrap: 'anywhere' }}>
         {chunk || '（无输出）'}
       </pre>
       {cursorInvalid && (
         <div style={{ fontSize: 12, color: 'var(--color-warning, #d97706)' }}>
           游标已失效。
-          <button onClick={() => { setCursorInvalid(false); setChunk(''); void load(undefined) }} style={{ marginLeft: 8 }}>从头重新加载</button>
+          <button type="button" onClick={() => { setCursorInvalid(false); setChunk(''); void load(undefined) }} style={{ marginLeft: 8 }}>从头重新加载</button>
         </div>
       )}
-      {!cursorInvalid && hasMore && nextCursor && (
-        <button onClick={() => void load(nextCursor)}>加载更多</button>
-      )}
+      {!cursorInvalid && hasMore && nextCursor && <button type="button" onClick={() => void load(nextCursor)}>加载更多</button>}
     </div>
   )
 }
 
-function IncarnationRow({ incarnation, current, onSelect, selected }: {
+function IncarnationRow({ incarnation, mainline, onSelect, selected }: {
   incarnation: WorkerIncarnation
-  current: boolean
+  mainline: boolean
   selected: boolean
   onSelect: () => void
 }) {
+  const role = mainline ? '主线' : incarnation.forked_from !== undefined ? `临时侧问（来自 #${incarnation.forked_from}）` : '历史化身'
   return (
-    <tr
-      onClick={onSelect}
-      style={{ borderTop: '1px solid var(--border)', cursor: 'pointer', background: selected ? 'var(--bg-muted, #eef2ff)' : undefined }}
-    >
-      <td style={{ padding: '6px 12px' }}>#{incarnation.seq}{current ? '（主线）' : ''}{incarnation.forked_from ? ` fork←#${incarnation.forked_from}` : ''}</td>
-      <td style={{ padding: '6px 12px' }}>{incarnation.impl}</td>
-      <td style={{ padding: '6px 12px' }}>{incarnation.state}{incarnation.ended_reason ? ` · ${incarnation.ended_reason}` : ''}</td>
+    <tr style={{ borderTop: '1px solid var(--border)', background: selected ? 'var(--bg-muted, #eef2ff)' : undefined }}>
+      <td style={{ padding: '6px 12px' }}>
+        <button type="button" onClick={onSelect} style={{ font: 'inherit', padding: 0, border: 0, background: 'transparent', textAlign: 'left', cursor: 'pointer' }}>
+          #{incarnation.seq} · {role}
+        </button>
+      </td>
+      <td style={{ padding: '6px 12px' }}>{IMPL_LABEL[incarnation.impl]}</td>
+      <td style={{ padding: '6px 12px' }}>{INCARNATION_STATE_LABEL[incarnation.state] ?? incarnation.state}{incarnation.ended_reason ? ` · ${incarnation.ended_reason}` : ''}</td>
       <td style={{ padding: '6px 12px', fontSize: 12, color: 'var(--text-muted)' }}>
         {new Date(incarnation.started_at).toLocaleString()}
         {incarnation.ended_at ? ` → ${new Date(incarnation.ended_at).toLocaleString()}` : ' → 现在'}
@@ -192,57 +421,39 @@ const WorkerDetailContent: React.FC = () => {
       .then((result) => {
         if (cancelled) return
         setWorker(result.worker)
-        const mainline = result.worker.incarnations[result.worker.incarnations.length - 1]
-        setSelectedSeq(mainline?.seq)
+        setSelectedSeq(mainlineIncarnation(result.worker.incarnations)?.seq)
       })
       .catch((err) => {
-        if (cancelled) return
-        setError(err instanceof Error ? err.message : String(err))
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err))
       })
-      .finally(() => {
-        if (!cancelled) setLoading(false)
-      })
-    return () => {
-      cancelled = true
-    }
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
   }, [workerId])
 
   if (loading) return <Loading />
-  if (error || !worker) {
-    return <div style={{ color: 'var(--text-muted)', padding: 24 }}>Worker 详情暂不可用（unknown）：{error ?? 'not found'}</div>
-  }
+  if (error || !worker) return <div style={{ color: 'var(--text-muted)', padding: 24 }}>Worker 详情暂不可用：{error ?? 'not found'}</div>
 
-  const mainlineSeq = worker.incarnations[worker.incarnations.length - 1]?.seq
-  const mainline = worker.incarnations[worker.incarnations.length - 1]
-
+  const mainline = mainlineIncarnation(worker.incarnations)
+  const mainlineSeq = mainline?.seq
   return (
     <div>
-      <div style={{ marginBottom: 16 }}>
+      <div style={{ marginBottom: 18 }}>
         <Link to="/traces" style={{ color: 'var(--text-muted)', fontSize: 12 }}>← 返回 Workers</Link>
-        <h2 style={{ fontFamily: 'var(--font-mono)', fontSize: 16, margin: '8px 0' }}>{worker.worker_id}</h2>
+        <h2 style={{ fontSize: 18, margin: '8px 0 4px' }}>{worker.task.title}</h2>
+        <div style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--text-muted)' }}>{worker.worker_id}</div>
+      </div>
+      <div style={{ display: 'flex', gap: 20, flexWrap: 'wrap', padding: '10px 0', marginBottom: 16, borderTop: '1px solid var(--border)', borderBottom: '1px solid var(--border)', fontSize: 13 }}>
+        <div><strong>状态：</strong><span style={{ color: STATUS_COLOR[worker.task.status] }}>{STATUS_LABEL[worker.task.status]}</span>{worker.task.outcome ? ` · ${worker.task.outcome}` : ''}</div>
+        <div><strong>主线实现：</strong>{mainline ? IMPL_LABEL[mainline.impl] : '—'}</div>
+        {worker.task.type && <div><strong>任务类型：</strong>{worker.task.type}</div>}
+        <div><strong>回报目标：</strong>{worker.report_to.channel_id} / {worker.report_to.session_id}</div>
       </div>
       <div style={{ fontSize: 13, marginBottom: 16, display: 'grid', gap: 4 }}>
-        <div><strong>标题：</strong>{worker.task.title}</div>
-        <div><strong>状态：</strong><span style={{ color: STATUS_COLOR[worker.task.status] }}>{STATUS_LABEL[worker.task.status]}</span>{worker.task.outcome ? ` · ${worker.task.outcome}` : ''}</div>
+        <div><strong>Owner：</strong><Link to={`/traces/managers/${encodeURIComponent(worker.manager_key)}`} style={{ fontFamily: 'var(--font-mono)' }}>{worker.manager_key}</Link></div>
+        {mainline?.workspace && <div><strong>工作区：</strong><span style={{ fontFamily: 'var(--font-mono)', fontSize: 12 }}>{mainline.workspace}</span></div>}
         <div>
-          <strong>Owner：</strong>
-          <Link to={`/traces/managers/${encodeURIComponent(worker.manager_key)}`} style={{ fontFamily: 'var(--font-mono)' }}>{worker.manager_key}</Link>
-        </div>
-        <div><strong>回报目标：</strong>{worker.report_to.channel_id} / {worker.report_to.session_id}</div>
-        {mainline?.workspace && (
-          <div><strong>工作区：</strong><span style={{ fontFamily: 'var(--font-mono)', fontSize: 12 }}>{mainline.workspace}</span></div>
-        )}
-        <div>
-          <strong>来源：</strong>
-          {worker.origin.trigger_type}
-          {worker.origin.spawned_by_episode ? (
-            <>
-              {' · episode '}
-              <Link to={`/traces/managers/${encodeURIComponent(worker.manager_key)}`} style={{ fontFamily: 'var(--font-mono)' }}>
-                {worker.origin.spawned_by_episode.slice(0, 8)}
-              </Link>
-            </>
-          ) : null}
+          <strong>来源：</strong>{worker.origin.trigger_type}
+          {worker.origin.spawned_by_episode && <> · episode <Link to={`/traces/managers/${encodeURIComponent(worker.manager_key)}`} style={{ fontFamily: 'var(--font-mono)' }}>{worker.origin.spawned_by_episode.slice(0, 8)}</Link></>}
         </div>
         {worker.legacy_source && (
           <div style={{ background: 'var(--warning-bg)', border: '1px solid var(--warning-border)', borderRadius: 6, padding: 10, margin: '8px 0', color: 'var(--warning-text)' }}>
@@ -253,24 +464,21 @@ const WorkerDetailContent: React.FC = () => {
       </div>
 
       <h3 style={{ fontSize: 14, margin: '12px 0 8px' }}>化身链</h3>
-      <table style={{ width: '100%', borderCollapse: 'collapse', marginBottom: 16 }}>
-        <tbody>
-          {worker.incarnations.map((incarnation) => (
-            <IncarnationRow
-              key={incarnation.seq}
-              incarnation={incarnation}
-              current={incarnation.seq === mainlineSeq && incarnation.impl === worker.incarnations[worker.incarnations.length - 1]?.impl}
-              selected={incarnation.seq === selectedSeq}
-              onSelect={() => setSelectedSeq(incarnation.seq)}
-            />
-          ))}
-        </tbody>
-      </table>
+      <div style={{ overflowX: 'auto', marginBottom: 20 }}>
+        <table style={{ width: '100%', minWidth: 620, borderCollapse: 'collapse' }}>
+          <thead><tr style={{ textAlign: 'left', color: 'var(--text-muted)', fontSize: 12 }}><th style={{ padding: '6px 12px' }}>化身</th><th style={{ padding: '6px 12px' }}>实现</th><th style={{ padding: '6px 12px' }}>状态</th><th style={{ padding: '6px 12px' }}>时间</th></tr></thead>
+          <tbody>
+            {worker.incarnations.map((incarnation) => (
+              <IncarnationRow key={incarnation.seq} incarnation={incarnation} mainline={incarnation.seq === mainlineSeq} selected={incarnation.seq === selectedSeq} onSelect={() => setSelectedSeq(incarnation.seq)} />
+            ))}
+          </tbody>
+        </table>
+      </div>
 
-      <h3 style={{ fontSize: 14, margin: '12px 0 8px' }}>时间线（化身 #{selectedSeq ?? '—'}）</h3>
+      <h3 style={{ fontSize: 14, margin: '12px 0 8px' }}>活动记录（化身 #{selectedSeq ?? '—'}）</h3>
       <Timeline workerId={worker.worker_id} seq={selectedSeq} />
 
-      <h3 style={{ fontSize: 14, margin: '16px 0 8px' }}>终端输出</h3>
+      <h3 style={{ fontSize: 14, margin: '20px 0 8px' }}>终端原始输出</h3>
       <OutputPanel workerId={worker.worker_id} seq={selectedSeq} />
     </div>
   )

--- a/crabot-admin/web/src/pages/Traces/WorkerDetail.tsx
+++ b/crabot-admin/web/src/pages/Traces/WorkerDetail.tsx
@@ -110,6 +110,9 @@ function failureReason(detail: DetailRecord | undefined, fallback: string): stri
 function lifecycleActivity(event: WorkerTraceEvent): ActivityEntry | undefined {
   if (event.source !== 'harness') return undefined
   const detail = asRecord(event.detail)
+  if (event.summary.startsWith('legacy_imported')) {
+    return { event, label: '历史记录', tone: 'status', body: '已导入旧版运行记录' }
+  }
   if (event.summary.startsWith('spawned')) {
     const impl = typeof detail?.impl === 'string' ? IMPL_LABEL[detail.impl as WorkerIncarnation['impl']] ?? detail.impl : undefined
     return { event, label: 'Worker 状态', tone: 'status', body: impl ? `已由 ${impl} 启动` : '已启动' }
@@ -153,6 +156,9 @@ function lifecycleActivity(event: WorkerTraceEvent): ActivityEntry | undefined {
 }
 
 function activityFor(event: WorkerTraceEvent): ActivityEntry | undefined {
+  if (event.source === 'legacy') {
+    return { event, label: '历史记录', tone: 'status', body: event.summary }
+  }
   if (event.source === 'native' && event.kind === 'message' && event.role === 'user') {
     return { event, label: 'Manager 指令', tone: 'manager', body: messageText(event) }
   }

--- a/crabot-admin/web/src/pages/Traces/WorkersView.test.tsx
+++ b/crabot-admin/web/src/pages/Traces/WorkersView.test.tsx
@@ -29,7 +29,7 @@ function workerFixture() {
     report_to: { channel_id: 'wechat', session_id: 'sess-1' },
     incarnations: [
       { seq: 1, impl: 'builtin' as const, state: 'exited', workspace: '/tmp/ws', started_at: '2026-08-01T00:00:00.000Z', ended_reason: 'completed', session_ref: 'r1' },
-      { seq: 2, impl: 'builtin' as const, state: 'running', workspace: '/tmp/ws', started_at: '2026-08-01T00:05:00.000Z', session_ref: 'r2' },
+      { seq: 2, impl: 'builtin' as const, state: 'running', workspace: '/tmp/ws', started_at: '2026-08-01T00:05:00.000Z', session_ref: 'r2', forked_from: 1 },
     ],
     updated_at: '2026-08-01T00:05:00.000Z',
   }
@@ -102,17 +102,17 @@ describe('WorkerDetail', () => {
     mocked.readWorkerOutput = vi.fn().mockResolvedValue({ chunk: '', next_cursor: '0' })
 
     renderDetail()
-    await waitFor(() => expect(screen.getByText('spawned')).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByText('已启动')).toBeInTheDocument())
     // 化身链两行
-    expect(screen.getByText('#1')).toBeInTheDocument()
-    expect(screen.getByText((content) => content.startsWith('#2'))).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /#1.*主线/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /#2.*临时侧问/ })).toBeInTheDocument()
 
     // 加载更多 → cursor 失效 → 显式提示
     fireEvent.click(screen.getByText('加载更多'))
     await waitFor(() => expect(screen.getByText(/游标已失效/)).toBeInTheDocument())
     // 从头重载
     fireEvent.click(screen.getByText('从头重新加载'))
-    await waitFor(() => expect(screen.getAllByText('spawned').length).toBeGreaterThan(0))
+    await waitFor(() => expect(screen.getAllByText('已启动').length).toBeGreaterThan(0))
   })
 
   it('native degraded 时 harness 事件仍显示，且 reason 独立呈现', async () => {
@@ -124,7 +124,87 @@ describe('WorkerDetail', () => {
     })
     mocked.readWorkerOutput = vi.fn().mockResolvedValue({ chunk: '', next_cursor: '0' })
     renderDetail()
-    await waitFor(() => expect(screen.getByText('spawned')).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByText('已启动')).toBeInTheDocument())
     expect(screen.getByText(/native unavailable/)).toBeInTheDocument()
+  })
+
+  it('切换临时侧问后，活动流与终端输出同步切换', async () => {
+    mocked.getWorkerDetail = vi.fn().mockResolvedValue({ worker: workerFixture() })
+    mocked.getWorkerTrace = vi.fn().mockResolvedValue({ events: [], next_cursor: 'tok-1' })
+    mocked.readWorkerOutput = vi.fn().mockResolvedValue({ chunk: '', next_cursor: '0' })
+    renderDetail()
+
+    await waitFor(() => expect(screen.getByRole('button', { name: /#2.*临时侧问/ })).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: /#2.*临时侧问/ }))
+    await waitFor(() => expect(mocked.getWorkerTrace).toHaveBeenLastCalledWith('w-1234567890ab', { seq: 2 }))
+    expect(mocked.readWorkerOutput).toHaveBeenLastCalledWith('w-1234567890ab', { seq: 2 })
+  })
+
+  it('投递失败和异常退出保留在默认活动流', async () => {
+    mocked.getWorkerDetail = vi.fn().mockResolvedValue({ worker: workerFixture() })
+    mocked.getWorkerTrace = vi.fn().mockResolvedValue({
+      events: [
+        { ts: '2026-08-01T00:00:01.000Z', kind: 'lifecycle', summary: 'input_delivery_failed reason_code=delivery_deadline_exceeded', source: 'harness', detail: { reason: '投递期限已过' } },
+        { ts: '2026-08-01T00:00:02.000Z', kind: 'lifecycle', summary: 'state_changed -> exited', source: 'harness', detail: { to: 'exited', reason: 'adapter crashed' } },
+      ],
+      next_cursor: 'tok-1',
+    })
+    mocked.readWorkerOutput = vi.fn().mockResolvedValue({ chunk: '', next_cursor: '0' })
+    renderDetail()
+
+    await waitFor(() => expect(screen.getByText('投递失败')).toBeInTheDocument())
+    expect(screen.getByText('投递期限已过')).toBeInTheDocument()
+    expect(screen.getByText('Worker 异常退出')).toBeInTheDocument()
+    expect(screen.getByText('已结束：adapter crashed')).toBeInTheDocument()
+  })
+
+  it('Claude Code 的工具参数与结果内容使用已归一化 detail', async () => {
+    mocked.getWorkerDetail = vi.fn().mockResolvedValue({ worker: workerFixture() })
+    mocked.getWorkerTrace = vi.fn().mockResolvedValue({
+      events: [
+        { ts: '2026-08-01T00:00:01.000Z', kind: 'tool_call', role: 'assistant', summary: 'Read(...)', source: 'native', detail: { name: 'Read', input: { file_path: '/tmp/x.ts' } } },
+        { ts: '2026-08-01T00:00:02.000Z', kind: 'tool_result', role: 'user', summary: '文件内容摘要', source: 'native', detail: { content: '文件内容摘要' } },
+      ],
+      next_cursor: 'tok-1',
+    })
+    mocked.readWorkerOutput = vi.fn().mockResolvedValue({ chunk: '', next_cursor: '0' })
+    renderDetail()
+
+    await waitFor(() => expect(screen.getByText('Read')).toBeInTheDocument())
+    expect(screen.getByText('{"file_path":"/tmp/x.ts"}')).toBeInTheDocument()
+    expect(screen.getByText('文件内容摘要')).toBeInTheDocument()
+  })
+
+  it('默认选择主线，并把消息、工具与技术事件分开显示', async () => {
+    const instruction = '请先在隔离环境验证坐标与朝向，再比较五个非对称地标。'.repeat(20)
+    mocked.getWorkerDetail = vi.fn().mockResolvedValue({ worker: workerFixture() })
+    mocked.getWorkerTrace = vi.fn().mockResolvedValue({
+      events: [
+        { ts: '2026-08-01T00:00:01.000Z', kind: 'lifecycle', role: 'system', summary: 'item_completed', source: 'native' },
+        { ts: '2026-08-01T00:00:02.000Z', kind: 'message', role: 'user', summary: instruction.slice(0, 200), source: 'native', detail: { content: [{ type: 'input_text', text: instruction }] } },
+        { ts: '2026-08-01T00:00:03.000Z', kind: 'tool_call', role: 'assistant', summary: 'shell()', source: 'native', detail: { call_id: 'call-1', name: 'shell', arguments: '读取验证报告' } },
+        { ts: '2026-08-01T00:00:04.000Z', kind: 'tool_result', summary: '完成', source: 'native', detail: { call_id: 'call-1', output: '已完成隔离环境读取' } },
+        { ts: '2026-08-01T00:00:05.000Z', kind: 'message', role: 'assistant', summary: '正在重新验证方向', source: 'native', detail: { content: [{ type: 'output_text', text: '正在重新验证方向，正式端口尚未切换。' }] } },
+      ],
+      next_cursor: 'tok-1',
+    })
+    mocked.readWorkerOutput = vi.fn().mockResolvedValue({ chunk: '', next_cursor: '0' })
+
+    renderDetail()
+
+    await waitFor(() => expect(screen.getByText('Manager 指令')).toBeInTheDocument())
+    expect(screen.getByText('Worker 输出')).toBeInTheDocument()
+    expect(screen.getByText('工具调用')).toBeInTheDocument()
+    expect(screen.getByText('工具结果')).toBeInTheDocument()
+    expect(screen.queryByText('item_completed')).not.toBeInTheDocument()
+    expect(screen.getByText('主线实现：').parentElement).toHaveTextContent('内置')
+    expect(mocked.getWorkerTrace).toHaveBeenCalledWith('w-1234567890ab', { seq: 1 })
+    expect(mocked.readWorkerOutput).toHaveBeenCalledWith('w-1234567890ab', { seq: 1 })
+
+    fireEvent.click(screen.getByRole('button', { name: '展开全文' }))
+    expect(screen.getByRole('button', { name: '收起' })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: '技术事件 1' }))
+    expect(screen.getByText('item_completed')).toBeInTheDocument()
   })
 })

--- a/crabot-admin/web/src/pages/Traces/WorkersView.test.tsx
+++ b/crabot-admin/web/src/pages/Traces/WorkersView.test.tsx
@@ -35,6 +35,17 @@ function workerFixture() {
   }
 }
 
+function legacyWorkerFixture() {
+  const worker = workerFixture()
+  return {
+    ...worker,
+    incarnations: [
+      { seq: 1, impl: 'legacy' as const, state: 'exited', started_at: '2026-08-01T00:00:00.000Z', ended_at: '2026-08-01T00:01:00.000Z', ended_reason: 'pre_migration', session_ref: 'legacy-1' },
+    ],
+    legacy_source: { trace_ids: ['legacy-trace-1'] },
+  }
+}
+
 function listResult() {
   return {
     items: [workerFixture()],
@@ -126,6 +137,20 @@ describe('WorkerDetail', () => {
     renderDetail()
     await waitFor(() => expect(screen.getByText('已启动')).toBeInTheDocument())
     expect(screen.getByText(/native unavailable/)).toBeInTheDocument()
+  })
+
+  it('legacy 化身在默认活动流回退到历史摘要', async () => {
+    mocked.getWorkerDetail = vi.fn().mockResolvedValue({ worker: legacyWorkerFixture() })
+    mocked.getWorkerTrace = vi.fn().mockResolvedValue({
+      events: [{ ts: '2026-08-01T00:00:01.000Z', kind: 'lifecycle', summary: '旧版任务已完成', source: 'legacy' }],
+      next_cursor: 'tok-1',
+    })
+    mocked.readWorkerOutput = vi.fn().mockResolvedValue({ chunk: '', next_cursor: '0' })
+    renderDetail()
+
+    await waitFor(() => expect(screen.getByText('历史记录')).toBeInTheDocument())
+    expect(screen.getByText('旧版任务已完成')).toBeInTheDocument()
+    expect(screen.queryByText('该化身暂无可读活动。')).not.toBeInTheDocument()
   })
 
   it('切换临时侧问后，活动流与终端输出同步切换', async () => {


### PR DESCRIPTION
## 变更

- 默认选择主线化身，明确区分主线与临时侧问，并显示实际运行实现。
- 将 trace 投影为 Manager 指令、Worker 输出、工具调用/结果和关键生命周期；工具结果按 `call_id` 归入调用。
- 隐藏高频协议噪音到“技术事件”，长消息、工具结果和终端输出支持换行与展开。
- 保留投递失败、侧问失败和异常退出；补充主线选择、侧问切换、Claude 工具 detail、失败和折叠的回归测试。

## 边界

只消费既有 `NormalizedTraceEvent` 与已脱敏 `detail`，不改 Agent、RPC/REST、持久化、Worker 生命周期或投递语义。

## 验证

- `node_modules/.bin/vitest run src/pages/Traces/WorkersView.test.tsx`
- `node_modules/.bin/vite build`
- `node_modules/.bin/tsc` 仍被未修改的 `WorkersView.tsx:126` 使用 `Array.at()` 阻断；该错误在本分支基线已存在。

本地浏览器可到达 Admin，但当前会话未登录，真实 Worker 页面的人眼验证需登录后执行。