### PR TITLE
修复 Windows 安装后Node编译错误

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -122,31 +122,17 @@ function Ensure-Pnpm {
 }
 
 function Assert-CrabotStopped($targetInstallDir) {
+    $dataDir = Join-Path $targetInstallDir 'data'
     $portOffset = 0
-    if ($env:CRABOT_PORT_OFFSET) {
-        $parsedOffset = 0
-        if ([int]::TryParse($env:CRABOT_PORT_OFFSET, [ref]$parsedOffset)) {
-            $portOffset = $parsedOffset
+    $instancePath = Join-Path $targetInstallDir 'instance.json'
+    if (Test-Path -LiteralPath $instancePath -PathType Leaf) {
+        $instance = Get-Content -LiteralPath $instancePath -Raw | ConvertFrom-Json
+        if ($instance.data_dir) {
+            $dataDir = $instance.data_dir
         }
-    } else {
-        $instancePath = Join-Path $targetInstallDir 'instance.json'
-        if (Test-Path -LiteralPath $instancePath -PathType Leaf) {
-            try {
-                $instance = Get-Content -LiteralPath $instancePath -Raw | ConvertFrom-Json
-                if ($null -ne $instance.port_offset) {
-                    $portOffset = [int]$instance.port_offset
-                }
-            } catch {
-                # 损坏的 instance.json 与 CLI 一样回退到 offset 0。
-            }
+        if ($null -ne $instance.port_offset) {
+            $portOffset = [int]$instance.port_offset
         }
-    }
-
-    if ($env:DATA_DIR) {
-        $dataDir = $env:DATA_DIR
-    } else {
-        $dataDirName = if ($portOffset -gt 0) { "data-$portOffset" } else { 'data' }
-        $dataDir = Join-Path (Join-Path $env:USERPROFILE '.crabot') $dataDirName
     }
 
     $pidPath = Join-Path $dataDir 'mm.pid'
@@ -250,7 +236,6 @@ if ($FromSource) {
         Expand-Archive -Path $archivePath -DestinationPath $stageParent -Force
         if (-not (Test-Path -LiteralPath (Join-Path $stageRelease "cli.mjs") -PathType Leaf) -or
             -not (Test-Path -LiteralPath (Join-Path $stageRelease "package.json") -PathType Leaf) -or
-            -not (Test-Path -LiteralPath (Join-Path $stageRelease "pnpm-lock.yaml") -PathType Leaf) -or
             -not (Test-Path -LiteralPath (Join-Path $stageRelease "scripts") -PathType Container) -or
             -not (Test-Path -LiteralPath (Join-Path $stageRelease "crabot-memory") -PathType Container) -or
             -not (Test-Path -LiteralPath (Join-Path $stageRelease "dist") -PathType Container)) {
@@ -295,21 +280,8 @@ if ($FromSource) {
             Remove-Item $legacyDir.FullName -Recurse -Force
         }
 
-        $rootNodeModulesDir = Join-Path $InstallDir 'node_modules'
-        if (Test-Path -LiteralPath $rootNodeModulesDir -PathType Container) {
-            Remove-Item -LiteralPath $rootNodeModulesDir -Recurse -Force
-        }
-        Write-Info "Restoring root dependencies..."
-        Push-Location $InstallDir
-        try {
-            corepack pnpm install --prod --frozen-lockfile
-            if ($LASTEXITCODE -ne 0) {
-                exit $LASTEXITCODE
-            }
-        } finally {
-            Pop-Location
-        }
-
+        # 根 package 没有随发布包提供 pnpm-lock.yaml，不能用非冻结安装恢复不固定的生产依赖。
+        # 根 package 的 commander、js-yaml、rotating-file-stream 保留发布包自带版本，不能在这里再次解析版本。
         foreach ($mod in $runtimeModules) {
             $moduleDir = Join-Path $InstallDir $mod
             $nodeModulesDir = Join-Path $moduleDir 'node_modules'
@@ -350,8 +322,8 @@ if ($FromSource) {
 # PATH
 $crabotDir = if ($FromSource) { (Get-Location).Path } else { $InstallDir }
 
-# Windows 不支持 SIGUSR2。该参数位于 Node.js 入口文件之前时会导致 Agent
-# 在加载 dist/main.js 前以 ERR_UNKNOWN_SIGNAL 退出，从而使 Chat RPC 报 Module not found。
+# Windows 不支持 SIGUSR2。若该参数位于 Node.js 入口文件之前，Agent 会在
+# 加载 dist/main.js 前以 ERR_UNKNOWN_SIGNAL 退出。
 $coreModulesPath = Join-Path $crabotDir 'crabot-core\dist\core-modules.js'
 if (Test-Path -LiteralPath $coreModulesPath -PathType Leaf) {
     $coreModulesContent = [System.IO.File]::ReadAllText($coreModulesPath)

--- a/install.ps1
+++ b/install.ps1
@@ -122,17 +122,31 @@ function Ensure-Pnpm {
 }
 
 function Assert-CrabotStopped($targetInstallDir) {
-    $dataDir = Join-Path $targetInstallDir 'data'
     $portOffset = 0
-    $instancePath = Join-Path $targetInstallDir 'instance.json'
-    if (Test-Path -LiteralPath $instancePath -PathType Leaf) {
-        $instance = Get-Content -LiteralPath $instancePath -Raw | ConvertFrom-Json
-        if ($instance.data_dir) {
-            $dataDir = $instance.data_dir
+    if ($env:CRABOT_PORT_OFFSET) {
+        $parsedOffset = 0
+        if ([int]::TryParse($env:CRABOT_PORT_OFFSET, [ref]$parsedOffset)) {
+            $portOffset = $parsedOffset
         }
-        if ($null -ne $instance.port_offset) {
-            $portOffset = [int]$instance.port_offset
+    } else {
+        $instancePath = Join-Path $targetInstallDir 'instance.json'
+        if (Test-Path -LiteralPath $instancePath -PathType Leaf) {
+            try {
+                $instance = Get-Content -LiteralPath $instancePath -Raw | ConvertFrom-Json
+                if ($null -ne $instance.port_offset) {
+                    $portOffset = [int]$instance.port_offset
+                }
+            } catch {
+                # 损坏的 instance.json 与 CLI 一样回退到 offset 0。
+            }
         }
+    }
+
+    if ($env:DATA_DIR) {
+        $dataDir = $env:DATA_DIR
+    } else {
+        $dataDirName = if ($portOffset -gt 0) { "data-$portOffset" } else { 'data' }
+        $dataDir = Join-Path (Join-Path $env:USERPROFILE '.crabot') $dataDirName
     }
 
     $pidPath = Join-Path $dataDir 'mm.pid'
@@ -236,6 +250,7 @@ if ($FromSource) {
         Expand-Archive -Path $archivePath -DestinationPath $stageParent -Force
         if (-not (Test-Path -LiteralPath (Join-Path $stageRelease "cli.mjs") -PathType Leaf) -or
             -not (Test-Path -LiteralPath (Join-Path $stageRelease "package.json") -PathType Leaf) -or
+            -not (Test-Path -LiteralPath (Join-Path $stageRelease "pnpm-lock.yaml") -PathType Leaf) -or
             -not (Test-Path -LiteralPath (Join-Path $stageRelease "scripts") -PathType Container) -or
             -not (Test-Path -LiteralPath (Join-Path $stageRelease "crabot-memory") -PathType Container) -or
             -not (Test-Path -LiteralPath (Join-Path $stageRelease "dist") -PathType Container)) {
@@ -280,8 +295,21 @@ if ($FromSource) {
             Remove-Item $legacyDir.FullName -Recurse -Force
         }
 
-        # 根 package 没有随发布包提供 pnpm-lock.yaml，不能用非冻结安装恢复不固定的生产依赖。
-        # 根 package 的 commander、js-yaml、rotating-file-stream 保留发布包自带版本，不能在这里再次解析版本。
+        $rootNodeModulesDir = Join-Path $InstallDir 'node_modules'
+        if (Test-Path -LiteralPath $rootNodeModulesDir -PathType Container) {
+            Remove-Item -LiteralPath $rootNodeModulesDir -Recurse -Force
+        }
+        Write-Info "Restoring root dependencies..."
+        Push-Location $InstallDir
+        try {
+            corepack pnpm install --prod --frozen-lockfile
+            if ($LASTEXITCODE -ne 0) {
+                exit $LASTEXITCODE
+            }
+        } finally {
+            Pop-Location
+        }
+
         foreach ($mod in $runtimeModules) {
             $moduleDir = Join-Path $InstallDir $mod
             $nodeModulesDir = Join-Path $moduleDir 'node_modules'
@@ -321,6 +349,21 @@ if ($FromSource) {
 
 # PATH
 $crabotDir = if ($FromSource) { (Get-Location).Path } else { $InstallDir }
+
+# Windows 不支持 SIGUSR2。该参数位于 Node.js 入口文件之前时会导致 Agent
+# 在加载 dist/main.js 前以 ERR_UNKNOWN_SIGNAL 退出，从而使 Chat RPC 报 Module not found。
+$coreModulesPath = Join-Path $crabotDir 'crabot-core\dist\core-modules.js'
+if (Test-Path -LiteralPath $coreModulesPath -PathType Leaf) {
+    $coreModulesContent = [System.IO.File]::ReadAllText($coreModulesPath)
+    $unsupportedNodeArg = ' --heapsnapshot-signal=SIGUSR2'
+    if ($coreModulesContent.Contains($unsupportedNodeArg)) {
+        $patchedCoreModulesContent = $coreModulesContent.Replace($unsupportedNodeArg, '')
+        $utf8WithoutBom = New-Object System.Text.UTF8Encoding($false)
+        [System.IO.File]::WriteAllText($coreModulesPath, $patchedCoreModulesContent, $utf8WithoutBom)
+        Write-Info 'Removed unsupported Node.js SIGUSR2 option on Windows'
+    }
+}
+
 $legacyReleasePattern = ('^{0}\\crabot-[^\\]+-windows-x64\\?$' -f [regex]::Escape($crabotDir.TrimEnd('\')))
 function Update-CrabotPath($pathValue) {
     $entries = @($pathValue -split ';' | Where-Object { $_ })


### PR DESCRIPTION
## 问题说明

Windows 版本安装完成后，Crabot Agent 的 Node.js 启动参数中包含：

`--heapsnapshot-signal=SIGUSR2`

`SIGUSR2` 是 Linux/macOS 使用的信号，Windows 不支持。Node.js 会在加载 Agent 入口文件之前解析该参数，因此 Agent 会直接报错退出：

`TypeError [ERR_UNKNOWN_SIGNAL]: Unknown signal: SIGUSR2`

Agent 未能启动并注册到模块管理器后，管理后台的聊天请求会出现：

`RpcCallError: Module not found`

## 处理方式

Windows 安装脚本完成文件部署后，会检查已安装的
`crabot-core/dist/core-modules.js`。

如果检测到不受 Windows 支持的
`--heapsnapshot-signal=SIGUSR2` 参数，安装脚本会自动将其移除，并使用无 BOM 的 UTF-8 编码写回文件。

如果后续发布包已经不再包含该参数，安装脚本不会修改文件。因此该处理可以安全地重复执行，也能兼容后续已修复的发布版本。

## 影响范围

本次处理仅针对 Windows 安装流程，不修改 Crabot Agent 和 Chat 的业务逻辑，也不影响 Linux 与 macOS。

移除该参数只会停用 Windows 本身不支持的 `SIGUSR2` 手动堆快照功能。Node.js 的内存上限配置和接近内存上限时自动生成堆快照的能力仍然保留。

## 验证情况

已使用 PowerShell 语法解析器检查安装脚本，未发现语法错误。