### PR TITLE
[codex] 修复 Codex worker 工具调用 trace

### DIFF
--- a/crabot-agent/src/workers/codex/adapter.ts
+++ b/crabot-agent/src/workers/codex/adapter.ts
@@ -1491,8 +1491,8 @@ export class CodexWorkerAdapter implements WorkerAdapter {
     // 游标会在这些被跳过的行上重复读或漏读(P2 review #4,同 cc adapter 修复)。
     let consumed = start
     for (let i = start; i < lines.length; i++) {
-      const event = normalizeRolloutLine(lines[i])
-      if (event) events.push({ ...event, source_offset: i })
+      const lineEvents = normalizeRolloutLine(lines[i])
+      events.push(...lineEvents.map((event) => ({ ...event, source_offset: i })))
       consumed = i + 1
     }
     return { events, nextCursor: { offset: consumed } }
@@ -1814,8 +1814,10 @@ function truncate(text: string, max: number): string {
  * - `session_meta`:payload 有 `session_id`(权威,比文件名解析出的 uuid 更可靠,见 spawn()
  *   的"session 发现"节)、`cli_version`、`cwd`、`model_provider`、`context_window`、
  *   `originator`——映射为 lifecycle。
- * - `event_msg`:payload 有 `type`(如 `task_started`)、`turn_id`、`started_at`、
- *   `model_context_window`——映射为 lifecycle,摘要取 payload.type。
+ * - `event_msg`:大多数 payload 有 `type`(如 `task_started`)、`turn_id`、`started_at`、
+ *   `model_context_window`——映射为 lifecycle,摘要取 payload.type。codex-cli 0.147 把普通
+ *   命令和文件修改作为 `item_completed` 记录，其中 `CommandExecution`/`FileChange` 分别展开
+ *   为同一 call_id 的工具调用和结果；其余 completed item 仍视为协议噪音。
  * - `response_item`:见 normalizeResponseItem()。
  * - `world_state`:payload 是全量状态快照(`full`/`state`),对"发生了什么"的摘要时间线没有
  *   直接信息量(它是状态,不是事件),跳过——需要全量状态可以直接读原始 rollout 文件
@@ -1824,34 +1826,128 @@ function truncate(text: string, max: number): string {
  * - `turn_context`:payload 是回合配置(`model`/`effort`/`cwd`/`approval_policy`/`summary`
  *   等),同样不是"发生的事",跳过。
  */
-function normalizeRolloutLine(line: string): NormalizedTraceEvent | null {
+function normalizeRolloutLine(line: string): NormalizedTraceEvent[] {
   let parsed: { type?: unknown; timestamp?: unknown; payload?: unknown }
   try {
     parsed = JSON.parse(line)
   } catch {
-    return null
+    return []
   }
-  if (!parsed || typeof parsed !== 'object') return null
+  if (!parsed || typeof parsed !== 'object') return []
   const ts = typeof parsed.timestamp === 'string' ? parsed.timestamp : ''
   const payload = parsed.payload as Record<string, unknown> | undefined
 
   if (parsed.type === 'session_meta') {
     const meta = payload as { session_id?: string; cli_version?: string; cwd?: string } | undefined
     const summary = `session_meta session_id=${meta?.session_id ?? ''} cli_version=${meta?.cli_version ?? ''} cwd=${meta?.cwd ?? ''}`
-    return { ts, kind: 'lifecycle', role: 'system', summary: truncate(summary, 200), detail: payload }
+    return [{ ts, kind: 'lifecycle', role: 'system', summary: truncate(summary, 200), detail: payload }]
   }
 
   if (parsed.type === 'event_msg') {
+    const completed = normalizeCompletedItem(payload, ts)
+    if (completed) return completed
     const eventType = typeof payload?.type === 'string' ? payload.type : 'event_msg'
-    return { ts, kind: 'lifecycle', role: 'system', summary: eventType, detail: payload }
+    return [{ ts, kind: 'lifecycle', role: 'system', summary: eventType, detail: payload }]
   }
 
   if (parsed.type === 'response_item') {
-    return normalizeResponseItem(payload, ts)
+    const event = normalizeResponseItem(payload, ts)
+    return event ? [event] : []
   }
 
   // world_state/turn_context(以及其它未在真机实测里见过的顶层 type)跳过,见函数头注释。
-  return null
+  return []
+}
+
+/**
+ * 从 codex-cli 0.147 的 `event_msg/item_completed` 展开已知工具记录。一个原生行可生成一对
+ * 事件，但二者保留同一 source_offset，cursor 仍只按原生行号推进。
+ */
+function normalizeCompletedItem(payload: Record<string, unknown> | undefined, fallbackTs: string): NormalizedTraceEvent[] | undefined {
+  if (payload?.type !== 'item_completed' || !isRecord(payload.item)) return undefined
+  const item = payload.item
+  const callId = typeof item.id === 'string' ? item.id : undefined
+  if (!callId) return undefined
+
+  if (item.type === 'CommandExecution') {
+    const command = stringArray(item.command)
+    const input = { command }
+    const startedAt = timestampFromEpochMs(payload.started_at_ms, fallbackTs)
+    const completedAt = timestampFromEpochMs(payload.completed_at_ms, fallbackTs)
+    const status = typeof item.status === 'string' ? item.status : 'completed'
+    const exitCode = typeof item.exit_code === 'number' ? item.exit_code : undefined
+    const output = commandOutput(item, status, exitCode)
+    const resultSummary = status === 'completed' && exitCode === 0
+      ? 'command completed'
+      : 'command ' + status + (exitCode === undefined ? '' : ' (exit ' + exitCode + ')')
+    return [
+      {
+        ts: startedAt,
+        kind: 'tool_call',
+        role: 'assistant',
+        summary: truncate('exec_command(' + command.join(' ') + ')', 200),
+        detail: { type: 'command_execution', call_id: callId, name: 'exec_command', input },
+      },
+      {
+        ts: completedAt,
+        kind: 'tool_result',
+        summary: truncate(resultSummary, 200),
+        detail: {
+          type: 'command_execution_result',
+          call_id: callId,
+          output,
+          is_error: status !== 'completed' || (exitCode !== undefined && exitCode !== 0),
+        },
+      },
+    ]
+  }
+
+  if (item.type === 'FileChange') {
+    const paths = isRecord(item.changes) ? Object.keys(item.changes) : []
+    const completedAt = timestampFromEpochMs(payload.completed_at_ms, fallbackTs)
+    const output = paths.length === 0 ? 'file change completed' : 'updated ' + paths.length + ' file' + (paths.length === 1 ? '' : 's')
+    return [
+      {
+        ts: timestampFromEpochMs(payload.started_at_ms, fallbackTs),
+        kind: 'tool_call',
+        role: 'assistant',
+        summary: truncate('apply_patch(' + paths.join(', ') + ')', 200),
+        detail: { type: 'file_change', call_id: callId, name: 'apply_patch', input: { paths } },
+      },
+      {
+        ts: completedAt,
+        kind: 'tool_result',
+        summary: output,
+        detail: { type: 'file_change_result', call_id: callId, output, is_error: false },
+      },
+    ]
+  }
+
+  return undefined
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((part): part is string => typeof part === 'string') : []
+}
+
+function timestampFromEpochMs(value: unknown, fallback: string): string {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return fallback
+  const timestamp = new Date(value)
+  return Number.isNaN(timestamp.getTime()) ? fallback : timestamp.toISOString()
+}
+
+function commandOutput(item: Record<string, unknown>, status: string, exitCode: number | undefined): string {
+  for (const field of ['aggregated_output', 'stdout', 'stderr']) {
+    const output = item[field]
+    if (typeof output === 'string' && output) return output
+  }
+  return status === 'completed' && exitCode === 0
+    ? 'command completed without output'
+    : 'command ' + status + (exitCode === undefined ? '' : ' with exit code ' + exitCode)
 }
 
 /**

--- a/crabot-agent/src/workers/trace/composite-reader.ts
+++ b/crabot-agent/src/workers/trace/composite-reader.ts
@@ -216,8 +216,11 @@ export async function readCompositeWorkerTrace(
           nativeEvents.push({ event: { ...event, source: 'native' }, source: 'native', sourceOrdinal: event.source_offset ?? (positions.native + ordinal) })
         })
         nativeEnd = replayBound ? replayBound.native : native.nextCursor.offset
-        // 每次成功 native read 把脱敏、属于本化身的记录增量写 Agent-owned copy（§8.10）。
-        await deps.nativeCopy.append(params.worker_id, incarnation.seq, fingerprint, native.events, deps.redact)
+        // 从头成功读取到的是该化身的完整 native 快照：替换旧 copy，使 adapter 归一化修复
+        // 能回填历史保留副本。增量页仍按 source_offset 追加，不能覆盖完整副本。
+        await deps.nativeCopy.append(params.worker_id, incarnation.seq, fingerprint, native.events, deps.redact, {
+          replace: positions.native === 0 && !replayBound,
+        })
       } catch (error) {
         // live source 不可用时回退 Agent-owned copy（终态收割/上次增量写入的结果）。
         const copied = await deps.nativeCopy.read(params.worker_id, incarnation.seq, fingerprint)

--- a/crabot-agent/tests/workers/codex-adapter.test.ts
+++ b/crabot-agent/tests/workers/codex-adapter.test.ts
@@ -1718,6 +1718,38 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter.readTrace(已发现 rollout 
       },
       { type: 'world_state', timestamp: '2026-07-30T01:00:09Z', payload: { full: true, state: {} } },
       { type: 'response_item', timestamp: '2026-07-30T01:00:10Z', payload: { type: 'web_search_call', query: 'typescript typeerror' } },
+      {
+        type: 'event_msg',
+        timestamp: '2026-07-30T01:00:12Z',
+        payload: {
+          type: 'item_completed',
+          started_at_ms: Date.parse('2026-07-30T01:00:11Z'),
+          completed_at_ms: Date.parse('2026-07-30T01:00:12Z'),
+          item: {
+            type: 'CommandExecution',
+            id: 'exec-1',
+            command: ['rg', '-n', 'TODO'],
+            status: 'failed',
+            stdout: '',
+            stderr: 'no matches',
+            exit_code: 1,
+          },
+        },
+      },
+      {
+        type: 'event_msg',
+        timestamp: '2026-07-30T01:00:14Z',
+        payload: {
+          type: 'item_completed',
+          started_at_ms: Date.parse('2026-07-30T01:00:13Z'),
+          completed_at_ms: Date.parse('2026-07-30T01:00:14Z'),
+          item: {
+            type: 'FileChange',
+            id: 'exec-2',
+            changes: { '/tmp/result.txt': { type: 'add' } },
+          },
+        },
+      },
     ]
     return lines.map((l) => JSON.stringify(l)).join('\n') + '\nnot valid json{{{\n'
   }
@@ -1747,11 +1779,9 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter.readTrace(已发现 rollout 
     await fs.writeFile(rolloutFile, sampleRolloutJsonl(rolloutUuid), 'utf-8')
 
     const { events, nextCursor } = await adapter.readTrace(h)
-    // 11 行原始数据(session_meta/turn_context/developer msg/user msg/function_call/
-    // function_call_output/reasoning/assistant msg/event_msg/world_state/web_search_call)
-    // + 1 条坏 JSON = 12 行;turn_context/world_state/web_search_call(未识别子类型)/坏
-    // JSON 四条跳过,产生 8 条事件。
-    expect(events).toHaveLength(8)
+    // 13 行原始数据 + 1 条坏 JSON。两个 item_completed 各展开为同 call_id 的调用/结果，
+    // 但 cursor 仍按原始行推进。
+    expect(events).toHaveLength(12)
     expect(events[0]).toMatchObject({ kind: 'lifecycle', role: 'system', ts: '2026-07-30T01:00:00Z' })
     expect(events[0].summary).toContain(rolloutUuid)
     expect(events[0].summary).toContain('0.144.1')
@@ -1770,14 +1800,15 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter.readTrace(已发现 rollout 
     expect(events[6]).toMatchObject({ kind: 'message', role: 'assistant' })
     expect(events[6].summary).toContain('问题在于第 12 行没有判空。')
     expect(events[7]).toMatchObject({ kind: 'lifecycle', role: 'system', summary: 'turn_complete', ts: '2026-07-30T01:00:08Z' })
-    expect(nextCursor.offset).toBe(12)
+    expect(events[8]).toMatchObject({ kind: 'tool_call', role: 'assistant', ts: '2026-07-30T01:00:11.000Z', detail: { call_id: 'exec-1', name: 'exec_command', input: { command: ['rg', '-n', 'TODO'] } } })
+    expect(events[9]).toMatchObject({ kind: 'tool_result', ts: '2026-07-30T01:00:12.000Z', detail: { call_id: 'exec-1', output: 'no matches', is_error: true } })
+    expect(events[10]).toMatchObject({ kind: 'tool_call', role: 'assistant', ts: '2026-07-30T01:00:13.000Z', detail: { call_id: 'exec-2', name: 'apply_patch', input: { paths: ['/tmp/result.txt'] } } })
+    expect(events[11]).toMatchObject({ kind: 'tool_result', ts: '2026-07-30T01:00:14.000Z', detail: { call_id: 'exec-2', output: 'updated 1 file', is_error: false } })
+    expect(nextCursor.offset).toBe(14)
 
-    const partial = await adapter.readTrace(h, { offset: 6 })
-    expect(partial.events).toHaveLength(3)
-    expect(partial.events[0].kind).toBe('thinking')
-    expect(partial.events[1].kind).toBe('message')
-    expect(partial.events[2].kind).toBe('lifecycle')
-    expect(partial.nextCursor.offset).toBe(12)
+    const partial = await adapter.readTrace(h, { offset: 11 })
+    expect(partial.events.map((event) => event.detail && (event.detail as { call_id?: string }).call_id)).toEqual(['exec-1', 'exec-1', 'exec-2', 'exec-2'])
+    expect(partial.nextCursor.offset).toBe(14)
 
     await adapter.kill(h)
   }, 15000)

--- a/crabot-agent/tests/workers/composite-trace.test.ts
+++ b/crabot-agent/tests/workers/composite-trace.test.ts
@@ -199,6 +199,38 @@ describe('readCompositeWorkerTrace', () => {
     expect(second.unavailable_reason).toContain('copy')
   })
 
+  it('从头重读 live source 会替换旧 copy，回退时保留同一 source_offset 的展开事件', async () => {
+    nativeLines = [nativeEventAt('old lifecycle', '2026-08-01T00:00:02.000Z', 0)]
+    await readCompositeWorkerTrace(deps(), { worker_id: WORKER_ID })
+
+    nativeLines = [
+      {
+        ts: '2026-08-01T00:00:02.000Z',
+        kind: 'tool_call',
+        role: 'assistant',
+        summary: 'exec_command(pwd)',
+        detail: { call_id: 'cmd-1', name: 'exec_command' },
+        source_offset: 0,
+      },
+      {
+        ts: '2026-08-01T00:00:03.000Z',
+        kind: 'tool_result',
+        summary: 'command completed',
+        detail: { call_id: 'cmd-1', output: '/tmp' },
+        source_offset: 0,
+      },
+    ]
+    await readCompositeWorkerTrace(deps(), { worker_id: WORKER_ID })
+
+    nativeShouldThrow = 'file gone'
+    const fallback = await readCompositeWorkerTrace(deps(), { worker_id: WORKER_ID })
+    expect(fallback.events.filter((event) => event.source === 'native')).toMatchObject([
+      { kind: 'tool_call', detail: { call_id: 'cmd-1', name: 'exec_command' } },
+      { kind: 'tool_result', detail: { call_id: 'cmd-1', output: '/tmp' } },
+    ])
+    expect(fallback.events.some((event) => event.summary === 'old lifecycle')).toBe(false)
+  })
+
   it('copy 指纹不匹配不混读（seq 碰撞防御）', async () => {
     setNative([nativeEvent('x', '2026-08-01T00:00:02.000Z')])
     await readCompositeWorkerTrace(deps(), { worker_id: WORKER_ID })


### PR DESCRIPTION
## 变更

- 将 Codex CLI 0.147 的 `event_msg/item_completed` 中 `CommandExecution` 与 `FileChange` 归一化为可关联的工具调用/结果对。
- 完整读取 live native trace 时刷新保留副本，使历史 worker 在原始 rollout 不可用后仍保留修复后的工具时间线。

## 根因

普通 Codex 命令和文件修改不再使用旧的 `response_item/function_call`，而是记录为 `item_completed`。旧 adapter 一律将其标为 lifecycle；Worker 详情按既有 Spec 隐藏该协议噪音，因而只剩旧格式的 `wait` 可见。

## 验证

- `npm test -- --run tests/workers/codex-adapter.test.ts --silent --reporter=dot`：84 passed
- `npm test -- --run tests/workers/composite-trace.test.ts --silent --reporter=dot`：9 passed
- `npm run build`（`crabot-agent`）
- 本机重启 Crabot 后读取 `w-b7ab8124-bc7f-4c41-92d1-ca73fb0b829f`：142 个 `exec_command`、15 个 `apply_patch` 及等量结果均可见；保留副本已同步刷新。

## 失败路径

未知或畸形 `item_completed` 继续作为 lifecycle 噪音处理；缺失时间戳退回 rollout 信封时间；增量页保持追加语义，不会覆盖完整保留副本。