### PR TITLE
[codex] add worker supervision

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,6 +1,6 @@
 # Crabot 项目进度
 
-> 最后整理：2026-08-18
+> 最后整理：2026-08-19
 > 本文件只保留当前状态、明确 follow-up 和阶段性里程碑；详细实施流水、逐轮 review 与历史测试输出见 Git 历史。压缩前完整版本可用 `git show 49b9cb4:PROGRESS.md` 查看。
 
 ## 当前状态
@@ -29,6 +29,11 @@
 - 实现分支 `feat/manager-worker-operation-reliability` 已 rebase 到包含 #99/#100 的主线；adapter 关闭保护与可靠投递契约均保留，待 PR review。
 - **2026-08-18 tmux 投递热修已发布**（main `9138713`，本机实例已重启验证健康）：tmux pane 不再继承 `TERM=dumb`；Manager 的 `raw: true` 仅接受 tmux 控制键并在投递前拒绝混入任务正文的 payload，普通任务文本仍走既有 WorkerInbox 生命周期。尚待自然新流量验证实际启动确认与后续正文投递。
 
+### Worker 任务巡检与定期汇报（实现完成，待 PR review）
+
+- 已确认并发布设计和 `protocol-agent-v3` 3.2.2 契约（crabot-docs `bbcea9e`）：默认每 15 分钟例行巡检与人类明确的定期汇报是 stable `worker_id` 上互斥的监督规则；前者可在仅工具活动时由 Harness 静默过滤，后者必须由 Manager 向固定会话成功 `send_message` 才消费。
+- 实现分支 `feat/worker-supervision`：三种 adapter 以原生结构化 trace 分类 `text / tool_only / none / unknown`；Harness 持久化游标、到期责任与退避；Manager 提供设置/清除定期汇报工具、严格消费条件和默认只读巡检片段压缩。定向 Harness/Manager 295/295、adapter 212/212、TypeScript 检查均通过，待 PR review。
+
 ### 最近验证基线（2026-08-18，可靠交付实现分支）
 
 - Agent 可靠交付核心定向测试 17 文件 `468/468`；Manager 定向 `113/113`；Harness 定向 `104/104`；Codex runtime 清理与 Claude streaming fork 精确回归均通过。
@@ -56,6 +61,7 @@
 
 ### 技术债与既有 follow-up（P6 后或并行确认）
 
+- **关闭窗口终态事件补投**：Worker 的终态事件已落盘但 Manager 正在关闭窗口时，现有启动对账会跳过终态记录，Manager 可能不知道 Worker 已异常结束。需独立设计持久化待消费终态事件的恢复与去重；任务巡检不替代此修复。
 - **移除 Agent 内部 legacy `roles` seam**：`AgentLayerConfig.roles` 是 v2 前多 Agent 时代残留（正式协议从未包含），现仅作内部测试 seam/恒真分支；应替换为显式的 worker-layer 开关后删除。
 - 失败 Manager episode 的通用带退避 mailbox retry；跨 session 代发目标 Manager 持久注记（§4.2）；Admin skill → worker capability 接线（skill 仍硬编码 `[]`）；Codex provision `auth.json` 错误吞没；P8 调试工具/内部文档重写。
 - incarnation seq 碰撞（已接受边界，根治需协议变更）；Claude project-scope MCP 文件（已接受边界）；权限 schema 纪律（新增 schema 前先迁移历史 worker context）。

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -62,6 +62,7 @@
 ### 技术债与既有 follow-up（P6 后或并行确认）
 
 - **关闭窗口终态事件补投**：Worker 的终态事件已落盘但 Manager 正在关闭窗口时，现有启动对账会跳过终态记录，Manager 可能不知道 Worker 已异常结束。需独立设计持久化待消费终态事件的恢复与去重；任务巡检不替代此修复。
+- **Worker 巡检调度收口**：启动对账与周期巡检应共享 due 投递排他；避免单个 Worker 的长锁阻塞全局活性巡检；默认巡检在全局 LLM 故障时需要有界的失败告警去重/退避。三项均需独立设计，不纳入当前任务巡检 PR。
 - **移除 Agent 内部 legacy `roles` seam**：`AgentLayerConfig.roles` 是 v2 前多 Agent 时代残留（正式协议从未包含），现仅作内部测试 seam/恒真分支；应替换为显式的 worker-layer 开关后删除。
 - 失败 Manager episode 的通用带退避 mailbox retry；跨 session 代发目标 Manager 持久注记（§4.2）；Admin skill → worker capability 接线（skill 仍硬编码 `[]`）；Codex provision `auth.json` 错误吞没；P8 调试工具/内部文档重写。
 - incarnation seq 碰撞（已接受边界，根治需协议变更）；Claude project-scope MCP 文件（已接受边界）；权限 schema 纪律（新增 schema 前先迁移历史 worker context）。

--- a/crabot-agent/src/manager/bootstrap.ts
+++ b/crabot-agent/src/manager/bootstrap.ts
@@ -235,6 +235,17 @@ function channelSessionFromManagerKey(key: ManagerKey): { channel_id: string; se
   return { channel_id: channelId, session_id: sessionId }
 }
 
+function periodicReportTarget(event: import('../workers/harness/worker-events.js').HarnessEvent):
+  { channel_id: string; session_id: string } | undefined {
+  if (event.kind !== 'supervision_due' || event.detail?.mode !== 'periodic_report') return undefined
+  const target = event.detail.report_to
+  if (!target || typeof target !== 'object') return undefined
+  const { channel_id, session_id } = target as Record<string, unknown>
+  return typeof channel_id === 'string' && typeof session_id === 'string'
+    ? { channel_id, session_id }
+    : undefined
+}
+
 /**
  * 解析出来的身份档位 → crab-memory 的 `MemoryTaskContext`。
  *
@@ -366,8 +377,17 @@ export function buildManagerStack(deps: BootstrapDeps): ManagerStack {
 
       if (deps.isClosing?.()) return { consumed: false }
       if (!registry || !shouldWakeOnHarnessEvent(event)) return { consumed: false }
-      return registry.routeWorkerEvent(event).then(
+      const routed = event.kind === 'supervision_due'
+        ? registry.routeSupervisionDue(event)
+        : registry.routeWorkerEvent(event)
+      return routed.then(
         async (result) => {
+          // A set/clear/expiry/terminal transition can invalidate a due while it was queued, or
+          // during its Manager episode. It remains in trace/events.jsonl but must not affect the
+          // replacement rule. `undefined` from the narrow route is the before-wake stale case.
+          if (event.kind === 'supervision_due' && (result === undefined || !await harness.isSupervisionDueCurrent(event))) {
+            return { consumed: true }
+          }
           // fail-loud 的判据必须双管:`.catch` 只抓得到 F2(中途抛错),而最常见的 F1(LLM 挂 /
           // key 过期 / 限流耗尽)是**正常 resolve 且 outcome='failed'**——只 catch 等于对它全瞎。
           if (result?.outcome === 'failed' || result?.outcome === 'aborted') {
@@ -380,7 +400,15 @@ export function buildManagerStack(deps: BootstrapDeps): ManagerStack {
           // 巡检拿到"未消费"因而下一轮还能重报(这里)。`ManagerLoop` 只在
           // outcome ∈ {completed, max_turns} 时置 consumedEvents,所以失败分支这一句必然
           // 返回 false,两条语义天然对齐,不需要在这里另判一次。
-          return { consumed: result?.consumedEvents === true }
+          if (event.kind !== 'supervision_due') return { consumed: result?.consumedEvents === true }
+          if (result?.consumedEvents !== true) return { consumed: false }
+          const target = periodicReportTarget(event)
+          if (!target) return { consumed: true }
+          return {
+            consumed: result.successfulSendMessageTargets.some(
+              (sent) => sent.channel_id === target.channel_id && sent.session_id === target.session_id,
+            ),
+          }
         },
         async (err) => {
           console.error(`[manager-bootstrap] routeWorkerEvent 失败 (worker=${event.worker_id}, kind=${event.kind}):`, err)
@@ -405,6 +433,7 @@ export function buildManagerStack(deps: BootstrapDeps): ManagerStack {
     assertExecutionAdmission: deps.assertExecutionAdmission,
     capabilityBundle: deps.capabilityBundle,
     hasRunningBg: deps.hasRunningBg,
+    isClosing: deps.isClosing,
     validateLegacyContinuationAuth: (auth) => principals.validateLegacyContinuationAuth(auth),
   }
 
@@ -588,5 +617,6 @@ export async function reconcileManagerStack(stack: ManagerStack): Promise<Reconc
   const report = await stack.harness.reconcileOnStartup()
   await stack.harness.reconcileInputDeliveriesOnStartup()
   await stack.harness.reconcileQueryReceiptsOnStartup()
+  await stack.harness.reconcileSupervisionOnStartup()
   return report
 }

--- a/crabot-agent/src/manager/loop.ts
+++ b/crabot-agent/src/manager/loop.ts
@@ -161,6 +161,8 @@ export interface EpisodeResult {
    * ——工具执行结果是否 is_error 不参与判定。
    */
   readonly repliedToHuman: boolean
+  /** Successful `send_message` deliveries, paired with their tool results by tool_use_id. */
+  readonly successfulSendMessageTargets: ReadonlyArray<{ readonly channel_id: string; readonly session_id: string }>
 }
 
 export interface ManagerLoopDeps {
@@ -374,7 +376,14 @@ export class ManagerLoop {
     if (envelope === undefined && carriedEnvelopes.length === 0) {
       // 自唤醒但 mailbox 已空(残留被排在前面的另一个 episode 顺带 drain 走了)——
       // 没有任何新内容,直接空转返回,不开 episode(见 drainMailbox 注释)。
-      return { episodeId, outcome: 'completed', turns: 0, consumedEvents: true, repliedToHuman: false }
+      return {
+        episodeId,
+        outcome: 'completed',
+        turns: 0,
+        consumedEvents: true,
+        repliedToHuman: false,
+        successfulSendMessageTargets: [],
+      }
     }
     const eventText = envelope === undefined ? undefined : this.renderEnvelope(envelope)
     this.currentEpisodeInjected = []
@@ -513,9 +522,13 @@ export class ManagerLoop {
 
     let attempt = await this.runAttempt(episodeId, state, tailMessages, adapter, model)
     let totalTurnsUsed = attempt.result.totalTurns
+    let usedForceHotRetry = false
     // 与 totalTurnsUsed 同一套累加纪律:兜底重试会整体丢弃首次尝试的 finalMessages,但首次
     // 尝试里已经发出去的话人类是真的收到了——只看重试那一份会把"说过话"错报成"没说过"。
     let repliedToHuman = detectRepliedToHuman(attempt.result.finalMessages)
+    let successfulSendMessageTargets = successfulSendMessageTargetsOf(
+      attempt.result.finalMessages.slice(attempt.initialMessageCount),
+    )
 
     // max_tokens 兜底(§4.2):disableCompaction 关掉了 engine 自己的强压重试路径,
     // 这里识别到"上下文超限收场"时强制 force_hot 折叠一次并重试一次,仍失败就放弃。
@@ -532,6 +545,7 @@ export class ManagerLoop {
       // envelopes and mid-episode supplements are a protected tail (§14.4).
       const forceDecision = forceHotFold(state, this.deps.policy, this.deps.estimateTokens, nowMs)
       if (forceDecision.kind !== 'none') {
+        usedForceHotRetry = true
         state = await this.applyFoldWithSpan(episodeId, state, forceDecision, adapter, model)
         // 清空 mailbox 残留后缀(见上方注释),再按 currentEpisodeInjected 的到达顺序整体追加
         this.mailbox.drainEnvelopes()
@@ -543,6 +557,10 @@ export class ManagerLoop {
         const retryAttempt = await this.runAttempt(episodeId, state, retryTailMessages, adapter, model)
         totalTurnsUsed += retryAttempt.result.totalTurns
         repliedToHuman = repliedToHuman || detectRepliedToHuman(retryAttempt.result.finalMessages)
+        successfulSendMessageTargets = [
+          ...successfulSendMessageTargets,
+          ...successfulSendMessageTargetsOf(retryAttempt.result.finalMessages.slice(retryAttempt.initialMessageCount)),
+        ]
         attempt = retryAttempt
       }
       // forceDecision.kind === 'none':无法进一步压缩,直接接受第一次尝试的结果,不重试
@@ -562,9 +580,29 @@ export class ManagerLoop {
     const consumedEvents = attempt.result.outcome === 'completed' || attempt.result.outcome === 'max_turns'
 
     if (consumedEvents) {
+      const priorRecent = state.recent
       const newRecent = attempt.result.finalMessages.slice(attempt.hasSummaryMarker ? 1 : 0)
       state = { ...state, recent: newRecent, lastActiveAt: this.deps.now().toISOString() }
       await this.deps.store.save(state)
+      const localSupervisionSummary = defaultSupervisionHistorySummary({
+        envelope,
+        carriedEnvelopes,
+        injectedEnvelopes: this.currentEpisodeInjected ?? [],
+        outcome: attempt.result.outcome,
+        usedForceHotRetry,
+        priorRecentCount: priorRecent.length,
+        hasSummaryMarker: attempt.hasSummaryMarker,
+        finalMessages: attempt.result.finalMessages,
+        startedAt: envelope?.received_at,
+        endedAt: this.deps.now().toISOString(),
+      })
+      if (localSupervisionSummary) {
+        state = {
+          ...state,
+          recent: [...priorRecent, createUserMessage(localSupervisionSummary)],
+        }
+        await this.deps.store.save(state)
+      }
     } else {
       // 放弃 episode:已落盘的折叠不回滚(见文件头)——若本次途中发生过 force_hot 折叠
       // (上面 max_tokens 兜底重试路径),carriedTexts/eventText 有可能已经作为
@@ -590,6 +628,7 @@ export class ManagerLoop {
       turns: totalTurnsUsed,
       consumedEvents,
       repliedToHuman,
+      successfulSendMessageTargets,
     }
     this.deps.onEpisodeEnd?.(result)
     return result
@@ -737,7 +776,7 @@ export class ManagerLoop {
     tailMessages: ReadonlyArray<EngineMessage>,
     adapter: LLMAdapter,
     model: string,
-  ): Promise<{ readonly result: EngineResult; readonly hasSummaryMarker: boolean }> {
+  ): Promise<{ readonly result: EngineResult; readonly hasSummaryMarker: boolean; readonly initialMessageCount: number }> {
     this.attemptCounter += 1
     let assistantTextEndTurnReminderSent = false
     const hasSummaryMarker = state.rollingSummary !== undefined
@@ -789,7 +828,7 @@ export class ManagerLoop {
       initialMessages,
     })
 
-    return { result, hasSummaryMarker }
+    return { result, hasSummaryMarker, initialMessageCount: initialMessages.length }
   }
 
 }
@@ -874,6 +913,38 @@ function detectRepliedToHuman(finalMessages: ReadonlyArray<EngineMessage>): bool
     }
   }
   return false
+}
+
+/**
+ * `send_message` has delivery semantics that are narrower than the generic "replied" signal.
+ * Pair each assistant tool_use with its following tool result so a failed call, or a successful
+ * call to another session, cannot consume a worker's periodic-report responsibility.
+ */
+function successfulSendMessageTargetsOf(
+  finalMessages: ReadonlyArray<EngineMessage>,
+): Array<{ readonly channel_id: string; readonly session_id: string }> {
+  const pending = new Map<string, { readonly channel_id: string; readonly session_id: string }>()
+  const targets: Array<{ readonly channel_id: string; readonly session_id: string }> = []
+  for (const message of finalMessages) {
+    if (message.role === 'assistant') {
+      for (const block of message.content) {
+        if (block.type !== 'tool_use' || block.name !== 'send_message') continue
+        const channelId = block.input.channel_id
+        const sessionId = block.input.session_id
+        if (typeof channelId === 'string' && typeof sessionId === 'string') {
+          pending.set(block.id, { channel_id: channelId, session_id: sessionId })
+        }
+      }
+      continue
+    }
+    if (!('toolResults' in message)) continue
+    for (const result of message.toolResults) {
+      const target = pending.get(result.tool_use_id)
+      pending.delete(result.tool_use_id)
+      if (target && !result.is_error) targets.push(target)
+    }
+  }
+  return targets
 }
 
 /** Manager-only mailbox: envelopes remain authoritative; the engine receives deterministic text. */
@@ -1003,6 +1074,76 @@ function renderWorkerEvent(event: HarnessEvent): string {
   if (typeof text === 'string' && text.length > 0) parts.push(`worker 最后说:\n${text}`)
   if (typeof summary === 'string' && summary.length > 0) parts.push(`worker 的收尾结论:\n${summary}`)
   return parts.join('\n')
+}
+
+const SUPERVISION_READ_ONLY_TOOL_NAMES = new Set([
+  'read_worker_output',
+  'list_workers',
+  'get_worker_detail',
+  'get_history',
+  'get_message',
+  'lookup_friend',
+  'list_sessions',
+  'list_contacts',
+  'list_groups',
+  'list_group_members',
+  'fetch_media',
+  'read_feishu_document',
+  'feishu_raw_get',
+  'feishu_download_file',
+  'get_system_status',
+  'get_deployment_info',
+  'list_schedules',
+  'get_config_summary',
+  'list_capabilities',
+  'get_friend_permissions',
+  'mcp__crab-memory__search_memory',
+  'mcp__crab-memory__get_memory_detail',
+  'mcp__crab-memory__search_long_term',
+  'mcp__crab-memory__list_recent',
+  'mcp__crab-memory__list_entries',
+  'mcp__crab-memory__get_stats',
+  'mcp__crab-memory__get_evolution_mode',
+  'mcp__crab-memory__get_scene_profile',
+])
+
+function defaultSupervisionHistorySummary(args: {
+  readonly envelope: TimedWakeEnvelope | undefined
+  readonly carriedEnvelopes: ReadonlyArray<TimedWakeEnvelope>
+  readonly injectedEnvelopes: ReadonlyArray<TimedWakeEnvelope>
+  readonly outcome: EpisodeResult['outcome']
+  readonly usedForceHotRetry: boolean
+  readonly priorRecentCount: number
+  readonly hasSummaryMarker: boolean
+  readonly finalMessages: ReadonlyArray<EngineMessage>
+  readonly startedAt: string | undefined
+  readonly endedAt: string
+}): string | undefined {
+  const event = args.envelope?.wake.kind === 'worker_event' ? args.envelope.wake.event : undefined
+  if (
+    event?.kind !== 'supervision_due' ||
+    event.detail?.mode !== 'default' ||
+    args.carriedEnvelopes.length !== 0 ||
+    args.injectedEnvelopes.length !== 0 ||
+    args.outcome !== 'completed' ||
+    args.usedForceHotRetry
+  ) return undefined
+
+  const start = (args.hasSummaryMarker ? 1 : 0) + args.priorRecentCount + 1
+  const episodeMessages = args.finalMessages.slice(start)
+  for (const message of episodeMessages) {
+    if (message.role !== 'assistant') continue
+    for (const block of message.content) {
+      if (block.type === 'tool_use' && !SUPERVISION_READ_ONLY_TOOL_NAMES.has(block.name)) return undefined
+    }
+  }
+
+  const observation = typeof event.detail.observation === 'string' ? event.detail.observation : 'unknown'
+  return (
+    `[任务巡检摘要] worker_id=${event.worker_id}; ` +
+    `时间=${args.startedAt ?? event.ts} 至 ${args.endedAt}; ` +
+    `进展分类=${observation}; 未执行外部动作。`
+  )
 }
 
 /**

--- a/crabot-agent/src/manager/prompt.ts
+++ b/crabot-agent/src/manager/prompt.ts
@@ -30,7 +30,7 @@ Crabot 把"对话"和"干活"拆成了两层：
 
 - **你自己不干活**——你不写代码、不查资料、不操作系统，你负责判断、决策、派发和转述；
 - **干活的是 worker**——worker 有多种实现（内置 loop、claude code、codex），各自能力不同，你按任务特征和部署偏好挑一种去 \`spawn_worker\`；
-- 你对 worker 能做的事只有：**派活、送话、侧问、看输出、终止**（\`spawn_worker\` / \`send_to_worker\` / \`query_worker\` / \`read_worker_output\` / \`kill_worker\`）；
+- 你对 worker 能做的事只有：**派活、送话、侧问、看输出、终止、设置定期汇报**（\`spawn_worker\` / \`send_to_worker\` / \`query_worker\` / \`read_worker_output\` / \`kill_worker\` / \`set_worker_periodic_report\` / \`clear_worker_periodic_report\`）；
 - **worker 与人类之间隔着你**——worker 不直接面对人类，worker 说的话不会直接到人类那里，人类看到的每一句话都必须经你之手（\`send_message\`）转述出去。
 
 ### 管家纪律
@@ -52,6 +52,8 @@ Crabot 把"对话"和"干活"拆成了两层：
 **等待即 end_turn**：你的 loop 里没有阻塞等待原语。需要等任何事时直接结束回合，结果会唤醒你——不管等的是 worker 干活、侧问答案还是人类回复，都不要空转、不要反复查询。
 
 **慢工具是异步的**：\`spawn_worker\` / \`send_to_worker\` / \`query_worker\` 发起后立即返回，只代表编排动作已落地，不代表事情做完了。worker 每跑完一轮（转 idle）或结束时会有事件唤醒你，事件里带着它这一轮最后说的那段话——够你判断的就直接据此汇报。要了解一轮进行到哪儿了，或者要看事件里那段话之外的完整输出，用 \`read_worker_output\` 主动读。
+
+**人类约定定期汇报时**：人类明确要求“每 N 分钟汇报某个 worker”时，使用 \`set_worker_periodic_report\` 把规则挂在该 worker 上，绝不创建或模拟全局 Schedule。收到 \`supervision_due\` 且 detail 中 \`mode=periodic_report\` 的事件时，先检查该 worker 的状态和输出，再向 detail 指定的 \`report_to\` 用 \`send_message\` 发送一条如实汇报；普通文字加 \`end_turn\` 不会送达人类，也不能完成这次约定。人类取消约定时使用 \`clear_worker_periodic_report\` 恢复默认例行巡检。
 
 **结论拿不到就回去问 worker**：worker 已经结束、但事件和 \`read_worker_output\` 里都没有你要的结论时，用 \`send_to_worker\` 把问题直接发给它——它会带着原会话的完整上下文醒过来回答你。这是你自己能解决的事，问过它确实答不上来，才轮到找人类。
 

--- a/crabot-agent/src/manager/registry.ts
+++ b/crabot-agent/src/manager/registry.ts
@@ -342,6 +342,16 @@ export class ManagerRegistry {
     return this.runWake(key, envelope)
   }
 
+  /**
+   * A supervision due has a persistent pending identity. Check it immediately before admission so
+   * a rule replaced while the event was queued stays audit-only and never creates a Manager episode.
+   */
+  async routeSupervisionDue(event: HarnessEvent): Promise<EpisodeResult | undefined> {
+    if (event.kind !== 'supervision_due') throw new Error('routeSupervisionDue requires supervision_due')
+    if (!await this.deps.harness.isSupervisionDueCurrent(event)) return undefined
+    return this.routeWorkerEvent(event)
+  }
+
   /** Durable operation notifications never join an already-running episode's in-memory mailbox. */
   async routeOperationNotification(
     key: ManagerKey,
@@ -371,6 +381,7 @@ export class ManagerRegistry {
         turns: 0,
         consumedEvents: true,
         repliedToHuman: false,
+        successfulSendMessageTargets: [],
       }
     }
     return this.runWake(key, envelope)

--- a/crabot-agent/src/manager/tools/worker-tools.ts
+++ b/crabot-agent/src/manager/tools/worker-tools.ts
@@ -161,6 +161,8 @@ function summarizeWorker(worker: LedgerWorker) {
     title: worker.task.title,
     task_status: worker.task.status,
     ...(mainline ? { incarnation_state: mainline.state, impl: mainline.impl } : {}),
+    supervision_mode: worker.supervision?.mode ?? 'default',
+    ...(worker.supervision?.next_due_at ? { next_due_at: worker.supervision.next_due_at } : {}),
     updated_at: worker.updated_at,
   }
 }
@@ -464,6 +466,81 @@ export function buildWorkerTools(deps: WorkerToolsDeps): ToolDefinition[] {
     },
   })
 
+  const setWorkerPeriodicReport = defineTool({
+    name: 'set_worker_periodic_report',
+    description:
+      '为一个仍在进行中的 worker 设置人类明确要求的定期汇报。规则绑定该 worker 的完整主线链，' +
+      '首次从现在起按 interval_minutes 到期；它不是定时任务，也不会创建 Admin Schedule。',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        worker_id: { type: 'string', description: '目标 worker id' },
+        interval_minutes: { type: 'number', description: '正整数分钟' },
+        expires_at: { type: 'string', description: '可选的未来绝对到期时间（ISO 8601）' },
+      },
+      required: ['worker_id', 'interval_minutes'],
+    },
+    isReadOnly: false,
+    call: async (input): Promise<ToolCallResult> => {
+      const { worker_id, interval_minutes, expires_at } = input as {
+        worker_id?: string
+        interval_minutes?: number
+        expires_at?: string
+      }
+      if (!worker_id || typeof worker_id !== 'string') return invalid('set_worker_periodic_report: worker_id 必填且为字符串')
+      if (typeof interval_minutes !== 'number' || !Number.isInteger(interval_minutes) || interval_minutes <= 0) {
+        return invalid('set_worker_periodic_report: interval_minutes 必须是正整数')
+      }
+      if (expires_at !== undefined && typeof expires_at !== 'string') {
+        return invalid('set_worker_periodic_report: expires_at 必须是 ISO 8601 字符串')
+      }
+      try {
+        await authorizeWorker(worker_id)
+        const supervision = await harness.setWorkerPeriodicReport(
+          worker_id,
+          context().reportTo,
+          interval_minutes * 60_000,
+          expires_at,
+        )
+        return ok({
+          worker_id,
+          mode: 'periodic_report',
+          interval_minutes,
+          next_due_at: supervision.next_due_at,
+          ...(supervision.periodic_report?.expires_at ? { expires_at: supervision.periodic_report.expires_at } : {}),
+        })
+      } catch (error) {
+        return mapError(`set_worker_periodic_report(${worker_id})`, error)
+      }
+    },
+  })
+
+  const clearWorkerPeriodicReport = defineTool({
+    name: 'clear_worker_periodic_report',
+    description: '取消 worker 的定期汇报，立即恢复默认例行巡检。',
+    inputSchema: {
+      type: 'object',
+      properties: { worker_id: { type: 'string', description: '目标 worker id' } },
+      required: ['worker_id'],
+    },
+    isReadOnly: false,
+    call: async (input): Promise<ToolCallResult> => {
+      const worker_id = (input as { worker_id?: string }).worker_id
+      if (!worker_id || typeof worker_id !== 'string') return invalid('clear_worker_periodic_report: worker_id 必填且为字符串')
+      try {
+        await authorizeWorker(worker_id)
+        const supervision = await harness.clearWorkerPeriodicReport(worker_id)
+        return ok({
+          worker_id,
+          mode: 'default',
+          ...(supervision.next_due_at ? { next_due_at: supervision.next_due_at } : {}),
+        })
+      } catch (error) {
+        return mapError(`clear_worker_periodic_report(${worker_id})`, error)
+      }
+    },
+  })
+
   const listAllWorkers = capturedAuthorization ? defineTool({
     name: 'list_all_workers',
     description: '仅 Master 可用：跨会话列出 worker 精简摘要，支持 manager_key/status/分页过滤。',
@@ -521,5 +598,17 @@ export function buildWorkerTools(deps: WorkerToolsDeps): ToolDefinition[] {
     },
   })
 
-  return [spawnWorker, sendToWorker, queryWorker, readWorkerOutput, listWorkers, getWorkerDetail, listWorkerImplementations, ...(listAllWorkers ? [listAllWorkers] : []), killWorker]
+  return [
+    spawnWorker,
+    sendToWorker,
+    queryWorker,
+    readWorkerOutput,
+    listWorkers,
+    getWorkerDetail,
+    listWorkerImplementations,
+    setWorkerPeriodicReport,
+    clearWorkerPeriodicReport,
+    ...(listAllWorkers ? [listAllWorkers] : []),
+    killWorker,
+  ]
 }

--- a/crabot-agent/src/mcp/crab-messaging.ts
+++ b/crabot-agent/src/mcp/crab-messaging.ts
@@ -1079,7 +1079,7 @@ crabot 系统给你的所有信号——system prompt、supplement 注入、tool
         } catch (err) {
           // send 失败 → state 完全不变（task 仍 executing，无 barrier）
           const msg = err instanceof Error ? err.message : String(err)
-          return wrapText({ error: `发送失败: ${msg}` })
+          return wrapText({ error: `发送失败: ${msg}` }, { isError: true })
         }
 
         // === Step 2 & 3: send 成功后处理 ask_human 后置逻辑 ===

--- a/crabot-agent/src/workers/builtin/adapter.ts
+++ b/crabot-agent/src/workers/builtin/adapter.ts
@@ -84,6 +84,8 @@ import type {
   WorkerContractState,
   Workspace,
 } from '../types.js'
+import { classifySupervisionActivity } from '../types.js'
+import type { SupervisionObservation } from '../types.js'
 
 /** fork 是一次性侧问，maxTurns 取小值，避免侧问跑成一次完整任务。 */
 const FORK_MAX_TURNS = 8
@@ -568,21 +570,29 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
    * cursor.offset 是已消费 span 数。
    */
   async readTrace(h: IncarnationHandle, cursor?: import('../types.js').TraceCursor): Promise<{ events: import('../types.js').NormalizedTraceEvent[]; nextCursor: import('../types.js').TraceCursor }> {
+    const { events, nextCursor } = await this.readTraceWindow(h, cursor)
+    return { events, nextCursor }
+  }
+
+  private async readTraceWindow(
+    h: IncarnationHandle,
+    cursor?: import('../types.js').TraceCursor,
+  ): Promise<{ sourceAvailable: boolean; events: import('../types.js').NormalizedTraceEvent[]; nextCursor: import('../types.js').TraceCursor }> {
     const metaPath = join(this.deps.dataDir, h.worker_id, `meta-${h.seq}.json`)
     let traceId: string | undefined
     try {
       const meta = JSON.parse(await fs.readFile(metaPath, 'utf-8')) as { trace_id?: string }
       traceId = typeof meta.trace_id === 'string' ? meta.trace_id : undefined
     } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return { events: [], nextCursor: cursor ?? { offset: 0 } }
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return { sourceAvailable: false, events: [], nextCursor: cursor ?? { offset: 0 } }
       throw error
     }
     if (!traceId || !this.deps.traceReader) {
       // 老 meta（升级前写入）没有 trace_id：退化为空、cursor 原样透传（可续读）。
-      return { events: [], nextCursor: cursor ?? { offset: 0 } }
+      return { sourceAvailable: false, events: [], nextCursor: cursor ?? { offset: 0 } }
     }
     const trace = await this.deps.traceReader.readTrace(traceId)
-    if (!trace) return { events: [], nextCursor: cursor ?? { offset: 0 } }
+    if (!trace) return { sourceAvailable: false, events: [], nextCursor: cursor ?? { offset: 0 } }
     const start = cursor?.offset ?? 0
     const events: import('../types.js').NormalizedTraceEvent[] = []
     let consumed = start
@@ -591,7 +601,20 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
       if (event) events.push({ ...event, source_offset: i })
       consumed = i + 1
     }
-    return { events, nextCursor: { offset: consumed } }
+    return { sourceAvailable: true, events, nextCursor: { offset: consumed } }
+  }
+
+  async inspectSupervisionActivity(
+    h: IncarnationHandle,
+    cursor?: { readonly offset: number },
+  ): Promise<SupervisionObservation> {
+    try {
+      const trace = await this.readTraceWindow(h, cursor)
+      if (!trace.sourceAvailable) return { kind: 'unknown', next_cursor: cursor ?? { offset: 0 } }
+      return classifySupervisionActivity(trace.events, trace.nextCursor)
+    } catch {
+      return { kind: 'unknown', next_cursor: cursor ?? { offset: 0 } }
+    }
   }
 
   async kill(h: IncarnationHandle): Promise<void> {

--- a/crabot-agent/src/workers/claude-code/adapter.ts
+++ b/crabot-agent/src/workers/claude-code/adapter.ts
@@ -66,6 +66,8 @@ import type {
   WorkerContractState,
   Workspace,
 } from '../types.js'
+import { classifySupervisionActivity } from '../types.js'
+import type { SupervisionObservation } from '../types.js'
 
 const execFileAsync = promisify(execFile)
 
@@ -1113,6 +1115,14 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
   }
 
   async readTrace(h: IncarnationHandle, cursor?: TraceCursor): Promise<{ events: NormalizedTraceEvent[]; nextCursor: TraceCursor }> {
+    const { events, nextCursor } = await this.readTraceWindow(h, cursor)
+    return { events, nextCursor }
+  }
+
+  private async readTraceWindow(
+    h: IncarnationHandle,
+    cursor?: TraceCursor,
+  ): Promise<{ sourceAvailable: boolean; events: NormalizedTraceEvent[]; nextCursor: TraceCursor }> {
     // 四轮 review 修复:trace 文件路径依赖 workspace root,以前这个信息只存在于内存 runtime
     // 里(meta.json 不落它),不像 readOutput 那样有约定路径可以脱离内存重建——ensureRuntime
     // 现在从 meta 里的 workspace_root 字段(本轮新增持久化)重建它,readTrace 因此也能在
@@ -1138,7 +1148,7 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
     } catch (err) {
       // 文件缺失(化身还没写过 trace,或 fork 化身的占位 session_id 本就对不上真实文件)
       // 退化为空数组,cursor 原样透传——没有新内容可消费,调用方下次仍从原位置续读。
-      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return { events: [], nextCursor: cursor ?? { offset: 0 } }
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return { sourceAvailable: false, events: [], nextCursor: cursor ?? { offset: 0 } }
       throw err
     }
 
@@ -1162,7 +1172,20 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
       if (event) events.push({ ...event, source_offset: i })
       consumed = i + 1
     }
-    return { events, nextCursor: { offset: consumed } }
+    return { sourceAvailable: true, events, nextCursor: { offset: consumed } }
+  }
+
+  async inspectSupervisionActivity(
+    h: IncarnationHandle,
+    cursor?: { readonly offset: number },
+  ): Promise<SupervisionObservation> {
+    try {
+      const trace = await this.readTraceWindow(h, cursor)
+      if (!trace.sourceAvailable) return { kind: 'unknown', next_cursor: cursor ?? { offset: 0 } }
+      return classifySupervisionActivity(trace.events, trace.nextCursor)
+    } catch {
+      return { kind: 'unknown', next_cursor: cursor ?? { offset: 0 } }
+    }
   }
 
   async kill(h: IncarnationHandle): Promise<void> {

--- a/crabot-agent/src/workers/codex/adapter.ts
+++ b/crabot-agent/src/workers/codex/adapter.ts
@@ -70,6 +70,8 @@ import type {
   WorkerContractState,
   Workspace,
 } from '../types.js'
+import { classifySupervisionActivity } from '../types.js'
+import type { SupervisionObservation } from '../types.js'
 
 const execFileAsync = promisify(execFile)
 
@@ -1454,6 +1456,14 @@ export class CodexWorkerAdapter implements WorkerAdapter {
   }
 
   async readTrace(h: IncarnationHandle, cursor?: TraceCursor): Promise<{ events: NormalizedTraceEvent[]; nextCursor: TraceCursor }> {
+    const { events, nextCursor } = await this.readTraceWindow(h, cursor)
+    return { events, nextCursor }
+  }
+
+  private async readTraceWindow(
+    h: IncarnationHandle,
+    cursor?: TraceCursor,
+  ): Promise<{ sourceAvailable: boolean; events: NormalizedTraceEvent[]; nextCursor: TraceCursor }> {
     // 四轮 review 修复:以前只能对本进程内常驻的化身调用(rolloutPath 只存在于内存
     // runtime)。ensureRuntime 现在从 meta 的 session_discovery + workspace_root(本轮新增
     // 持久化)重新推导出 rolloutPath(见 findRolloutFileBySessionId),readTrace 因此也能在
@@ -1466,14 +1476,14 @@ export class CodexWorkerAdapter implements WorkerAdapter {
     if (!runtime.rolloutPath) {
       // spawn 时没能发现 rollout 文件(占位 session_id,已知限制)——没有路径可读,退化为空
       // 数组,cursor 原样透传。
-      return { events: [], nextCursor: cursor ?? { offset: 0 } }
+      return { sourceAvailable: false, events: [], nextCursor: cursor ?? { offset: 0 } }
     }
 
     let raw: string
     try {
       raw = await fs.readFile(runtime.rolloutPath, 'utf-8')
     } catch (err) {
-      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return { events: [], nextCursor: cursor ?? { offset: 0 } }
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return { sourceAvailable: false, events: [], nextCursor: cursor ?? { offset: 0 } }
       throw err
     }
 
@@ -1495,7 +1505,20 @@ export class CodexWorkerAdapter implements WorkerAdapter {
       if (event) events.push({ ...event, source_offset: i })
       consumed = i + 1
     }
-    return { events, nextCursor: { offset: consumed } }
+    return { sourceAvailable: true, events, nextCursor: { offset: consumed } }
+  }
+
+  async inspectSupervisionActivity(
+    h: IncarnationHandle,
+    cursor?: { readonly offset: number },
+  ): Promise<SupervisionObservation> {
+    try {
+      const trace = await this.readTraceWindow(h, cursor)
+      if (!trace.sourceAvailable) return { kind: 'unknown', next_cursor: cursor ?? { offset: 0 } }
+      return classifySupervisionActivity(trace.events, trace.nextCursor)
+    } catch {
+      return { kind: 'unknown', next_cursor: cursor ?? { offset: 0 } }
+    }
   }
 
   async kill(h: IncarnationHandle): Promise<void> {

--- a/crabot-agent/src/workers/harness/harness.ts
+++ b/crabot-agent/src/workers/harness/harness.ts
@@ -100,6 +100,7 @@ import {
   type LedgerWorker,
   type ManagerKey,
   type TaskStatus,
+  type WorkerSupervision,
 } from './ledger-types'
 import type { LedgerStore } from './ledger-store'
 import type { WorkspaceManager } from './workspace-manager'
@@ -381,6 +382,8 @@ export const LIVENESS_STALL_MS = 30 * 60_000
  * 量级)可以忽略不计。
  */
 export const LIVENESS_SWEEP_INTERVAL_MS = 5 * 60_000
+export const SUPERVISION_DEFAULT_INTERVAL_MS = 15 * 60_000
+const SUPERVISION_RETRY_INTERVAL_MS = 5 * 60_000
 
 /**
  * 巡检发现停摆时,随唤醒事件交给 manager 的那段正文:pane 输出尾部 + 一句合成指引。
@@ -452,6 +455,14 @@ interface StallReportMark {
   /** 下一次重试最早可以发生的时刻(epoch ms);只在 `delivery === 'failed'` 时有意义。 */
   retryAfterMs: number
 }
+
+interface PreparedSupervisionDue {
+  readonly handle: IncarnationHandle
+  readonly event?: HarnessEvent
+  readonly stateToSync?: WorkerContractState
+}
+
+type SupervisionProbe = WorkerContractState | 'failed'
 
 /** 请求的 worker_id 在台账中不存在。 */
 export class WorkerNotFoundError extends Error {
@@ -575,6 +586,8 @@ export interface HarnessDeps {
   readonly hasRunningBg?: (workerId: string) => Promise<boolean>
   /** Validates an opaque legacy continuation credential immediately before side effects. */
   readonly validateLegacyContinuationAuth?: (auth: LegacyContinuationAuth) => Promise<boolean>
+  /** Stops periodic supervision from creating new work during shutdown. */
+  readonly isClosing?: () => boolean
 }
 
 export interface SpawnWorkerParams {
@@ -952,7 +965,15 @@ export class WorkerHarness {
             ? { ended_at: now, ended_reason: initialInput?.report?.endReason ?? 'crashed' }
             : {}),
         })
-        return { ...prev, task: nextTask, incarnations, updated_at: now }
+        const supervision = supervisionAfterMainlineTransition(
+          prev.supervision,
+          nextTask.status,
+          initialState,
+          1,
+          now,
+          true,
+        )
+        return { ...prev, task: nextTask, incarnations, ...(supervision ? { supervision } : {}), updated_at: now }
       })
 
       // runtime file（如 codex admin_provider 的 CODEX_HOME）必须活到化身终态——
@@ -1989,7 +2010,21 @@ export class WorkerHarness {
           : prev.incarnations
       let nextTask = reopenTaskForContinuation(prev.task, now)
       nextTask = settleCliTask(nextTask, initialState, initialInput?.report, now)
-      return { ...prev, task: nextTask, incarnations: [...incarnations, newIncarnation], updated_at: now }
+      const supervision = supervisionAfterMainlineTransition(
+        prev.supervision,
+        nextTask.status,
+        initialState,
+        newHandle.seq,
+        now,
+        true,
+      )
+      return {
+        ...prev,
+        task: nextTask,
+        incarnations: [...incarnations, newIncarnation],
+        ...(supervision ? { supervision } : {}),
+        updated_at: now,
+      }
     })
 
     this.bumpInputOwnershipRevision(worker.worker_id)
@@ -2194,7 +2229,21 @@ export class WorkerHarness {
       }
       let nextTask = reopenTaskForContinuation(prev.task, now)
       nextTask = settleCliTask(nextTask, initialState, initialInput?.report, now)
-      return { ...prev, task: nextTask, incarnations: [...prev.incarnations, newIncarnation], updated_at: now }
+      const supervision = supervisionAfterMainlineTransition(
+        prev.supervision,
+        nextTask.status,
+        initialState,
+        newHandle.seq,
+        now,
+        true,
+      )
+      return {
+        ...prev,
+        task: nextTask,
+        incarnations: [...prev.incarnations, newIncarnation],
+        ...(supervision ? { supervision } : {}),
+        updated_at: now,
+      }
     })
 
     this.bumpInputOwnershipRevision(worker.worker_id)
@@ -2282,6 +2331,80 @@ export class WorkerHarness {
 
   async findWorker(workerId: string): Promise<{ managerKey: ManagerKey; worker: LedgerWorker } | undefined> {
     return this.deps.ledger.findWorker(workerId)
+  }
+
+  async setWorkerPeriodicReport(
+    workerId: string,
+    reportTo: LedgerWorker['report_to'],
+    intervalMs: number,
+    expiresAt?: string,
+  ): Promise<WorkerSupervision> {
+    if (!Number.isInteger(intervalMs) || intervalMs <= 0) throw new Error('interval_minutes 必须是正整数')
+    const now = this.deps.now()
+    if (expiresAt !== undefined) {
+      const expiresAtMs = Date.parse(expiresAt)
+      if (!Number.isFinite(expiresAtMs) || expiresAtMs <= Date.parse(now)) {
+        throw new Error('expires_at 必须是晚于当前时间的有效绝对时间')
+      }
+    }
+    return this.withLock(workerId, async () => {
+      const found = await this.deps.ledger.findWorker(workerId)
+      if (!found) throw new WorkerNotFoundError(workerId)
+      if (isTerminalStatus(found.worker.task.status)) throw new Error(`worker ${workerId} 已结束，不能设置定期汇报`)
+      const supervision: WorkerSupervision = {
+        version: 1,
+        mode: 'periodic_report',
+        next_due_at: plusMs(now, intervalMs),
+        periodic_report: {
+          interval_ms: intervalMs,
+          ...(expiresAt ? { expires_at: expiresAt } : {}),
+          report_to: reportTo,
+        },
+      }
+      const updated = await this.deps.ledger.upsertWorker(found.managerKey, workerId, (prev) => prev && ({
+        ...prev,
+        supervision,
+        updated_at: now,
+      }))
+      if (!updated?.supervision) throw new Error(`worker ${workerId} 的定期汇报规则未能保存`)
+      return updated.supervision
+    })
+  }
+
+  async clearWorkerPeriodicReport(workerId: string): Promise<WorkerSupervision> {
+    const now = this.deps.now()
+    return this.withLock(workerId, async () => {
+      const found = await this.deps.ledger.findWorker(workerId)
+      if (!found) throw new WorkerNotFoundError(workerId)
+      if (isTerminalStatus(found.worker.task.status)) throw new Error(`worker ${workerId} 已结束，不能清除定期汇报`)
+      const mainline = mainlineIncarnation(found.worker)
+      const running = found.worker.task.status === 'running' && mainline?.state === 'running'
+      const supervision: WorkerSupervision = {
+        version: 1,
+        mode: 'default',
+        ...(running ? { next_due_at: plusMs(now, SUPERVISION_DEFAULT_INTERVAL_MS) } : {}),
+      }
+      const updated = await this.deps.ledger.upsertWorker(found.managerKey, workerId, (prev) => prev && ({
+        ...prev,
+        supervision,
+        updated_at: now,
+      }))
+      if (!updated?.supervision) throw new Error(`worker ${workerId} 的例行巡检规则未能保存`)
+      return updated.supervision
+    })
+  }
+
+  /** Stale queued supervision events must not wake a Manager or mutate a replacement rule. */
+  async isSupervisionDueCurrent(event: HarnessEvent): Promise<boolean> {
+    if (event.kind !== 'supervision_due') return false
+    return this.withLock(event.worker_id, async () => {
+      const found = await this.deps.ledger.findWorker(event.worker_id)
+      const pending = found?.worker.supervision?.pending
+      return pending !== undefined
+        && pending.due_id === event.detail?.due_id
+        && pending.kind === supervisionKindForMode(event.detail?.mode)
+        && found?.worker.supervision?.mode === event.detail?.mode
+    })
   }
 
   async listAllWorkers(): Promise<Array<{ managerKey: ManagerKey; worker: LedgerWorker }>> {
@@ -2708,6 +2831,7 @@ export class WorkerHarness {
       await this.reconcileInputDeliveryOperations()
       await this.reconcileQueryEstablishmentOperations()
       await this.deliverQueryOperationNotifications()
+      await this.sweepSupervision()
       const nowMs = Date.parse(this.deps.now())
       const all = await this.deps.ledger.listAllWorkers()
       const reports: Array<Promise<void>> = []
@@ -2775,6 +2899,205 @@ export class WorkerHarness {
     } finally {
       this.sweepInFlight = false
     }
+  }
+
+  /** Startup recovery reuses the normal sweep: overdue windows coalesce into one pending due. */
+  async reconcileSupervisionOnStartup(): Promise<void> {
+    await this.sweepSupervision()
+  }
+
+  private async sweepSupervision(): Promise<void> {
+    if (this.deps.isClosing?.()) return
+    const now = this.deps.now()
+    const prepared = await Promise.all((await this.deps.ledger.listAllWorkers()).map(
+      ({ worker }) => this.prepareSupervisionDue(worker.worker_id, now),
+    ))
+    for (const item of prepared) {
+      if (item?.stateToSync) {
+        await this.processStateChange(item.handle, item.stateToSync)
+      }
+    }
+    if (this.deps.isClosing?.()) return
+    await Promise.allSettled(prepared.flatMap((item) => item?.event ? [this.deliverSupervisionDue(item.event)] : []))
+  }
+
+  private async prepareSupervisionDue(
+    workerId: string,
+    now: string,
+  ): Promise<PreparedSupervisionDue | undefined> {
+    return this.withLock(workerId, async () => {
+      const found = await this.deps.ledger.findWorker(workerId)
+      if (!found || isTerminalStatus(found.worker.task.status)) return undefined
+      const worker = found.worker
+      const mainline = mainlineIncarnation(worker)
+      if (!mainline || !isExecutableIncarnation(mainline)) return undefined
+      const handle: IncarnationHandle = {
+        worker_id: worker.worker_id,
+        seq: mainline.seq,
+        impl: mainline.impl,
+        session_ref: mainline.session_ref,
+      }
+      const adapter = this.deps.adapters.get(mainline.impl)
+      let supervision = worker.supervision
+      if (!supervision) {
+        if (worker.task.status !== 'running' || mainline.state !== 'running') return undefined
+        supervision = { version: 1, mode: 'default', next_due_at: plusMs(now, SUPERVISION_DEFAULT_INTERVAL_MS) }
+        await this.updateSupervision(found.managerKey, workerId, supervision, now)
+        return undefined
+      }
+
+      if (supervision.mode === 'default' && (worker.task.status !== 'running' || mainline.state !== 'running')) {
+        if (supervision.next_due_at || supervision.pending) {
+          await this.updateSupervision(found.managerKey, workerId, { version: 1, mode: 'default' }, now)
+        }
+        return undefined
+      }
+      if (supervision.mode === 'periodic_report' && supervision.periodic_report?.expires_at && Date.parse(supervision.periodic_report.expires_at) <= Date.parse(now)) {
+        const defaultRule: WorkerSupervision = {
+          version: 1,
+          mode: 'default',
+          ...(worker.task.status === 'running' && mainline.state === 'running'
+            ? { next_due_at: plusMs(now, SUPERVISION_DEFAULT_INTERVAL_MS) }
+            : {}),
+        }
+        await this.updateSupervision(found.managerKey, workerId, defaultRule, now)
+        return undefined
+      }
+
+      if (supervision.pending) {
+        if (supervision.pending.retry_after_at && Date.parse(supervision.pending.retry_after_at) > Date.parse(now)) return undefined
+        return {
+          handle,
+          event: this.buildSupervisionEvent(worker, handle, supervision, supervision.pending.due_id, 'unknown'),
+        }
+      }
+      if (!supervision.next_due_at || Date.parse(supervision.next_due_at) > Date.parse(now)) return undefined
+
+      let observation: 'text' | 'tool_only' | 'none' | 'unknown' = 'unknown'
+      let cursor = supervision.observation?.mainline_seq === mainline.seq ? supervision.observation.cursor : undefined
+      try {
+        if (adapter) {
+          const result = await adapter.inspectSupervisionActivity(handle, cursor)
+          observation = result.kind
+          cursor = result.next_cursor
+        }
+      } catch {
+        observation = 'unknown'
+      }
+
+      const observed = {
+        ...supervision,
+        observation: cursor ? { mainline_seq: mainline.seq, cursor } : undefined,
+        last_observed_at: now,
+      }
+      if (observed.mode === 'default' && observation === 'tool_only') {
+        await this.updateSupervision(found.managerKey, workerId, {
+          ...observed,
+          next_due_at: plusMs(now, SUPERVISION_DEFAULT_INTERVAL_MS),
+        }, now)
+        return undefined
+      }
+
+      let probe: SupervisionProbe | undefined
+      if (observation === 'none' || observation === 'unknown') {
+        try {
+          probe = adapter ? await adapter.state(handle) : 'failed'
+        } catch {
+          probe = 'failed'
+        }
+        if (probe === 'exited' || (observed.mode === 'default' && probe === 'idle')) {
+          await this.updateSupervision(found.managerKey, workerId, observed, now)
+          return { handle, stateToSync: probe }
+        }
+      }
+
+      const pending = {
+        due_id: randomUUID(),
+        kind: observed.mode === 'periodic_report' ? 'periodic_report' as const : 'default_review' as const,
+        due_at: now,
+        attempts: 0,
+      }
+      const dueRule: WorkerSupervision = { ...observed, pending }
+      await this.updateSupervision(found.managerKey, workerId, dueRule, now)
+      return {
+        handle,
+        ...(observed.mode === 'periodic_report' && probe === 'idle' && worker.task.status === 'running'
+          ? { stateToSync: 'idle' as const }
+          : {}),
+        event: this.buildSupervisionEvent(worker, handle, dueRule, pending.due_id, observation, probe),
+      }
+    })
+  }
+
+  private async deliverSupervisionDue(event: HarnessEvent): Promise<void> {
+    let delivery: HarnessEventDelivery | undefined
+    try {
+      delivery = await this.appendPreparedEventAwaitingDelivery(event)
+    } catch (error) {
+      console.error(`[WorkerHarness] supervision delivery failed for ${event.worker_id}:`, error)
+    }
+    await this.withLock(event.worker_id, async () => {
+      const found = await this.deps.ledger.findWorker(event.worker_id)
+      const current = found?.worker.supervision
+      const pending = current?.pending
+      if (!found || !current || !pending || pending.due_id !== event.detail?.due_id || pending.kind !== supervisionKindForMode(event.detail?.mode) || current.mode !== event.detail?.mode) return
+      const now = this.deps.now()
+      if (delivery?.consumed) {
+        const interval = current.mode === 'periodic_report'
+          ? current.periodic_report?.interval_ms
+          : SUPERVISION_DEFAULT_INTERVAL_MS
+        if (!interval) return
+        await this.updateSupervision(found.managerKey, event.worker_id, {
+          ...current,
+          pending: undefined,
+          next_due_at: plusMs(now, interval),
+          last_effective_review_at: now,
+        }, now)
+        return
+      }
+      const attempts = pending.attempts + 1
+      await this.updateSupervision(found.managerKey, event.worker_id, {
+        ...current,
+        pending: {
+          ...pending,
+          attempts,
+          retry_after_at: plusMs(now, SUPERVISION_RETRY_INTERVAL_MS * Math.min(2 ** (attempts - 1), 4)),
+        },
+      }, now)
+    })
+  }
+
+  private buildSupervisionEvent(
+    worker: LedgerWorker,
+    handle: IncarnationHandle,
+    supervision: WorkerSupervision,
+    dueId: string,
+    observation: 'text' | 'tool_only' | 'none' | 'unknown',
+    probe?: SupervisionProbe,
+  ): HarnessEvent {
+    return this.buildEvent(worker.worker_id, handle.seq, 'supervision_due', {
+      mode: supervision.mode,
+      due_id: dueId,
+      mainline_seq: handle.seq,
+      observation,
+      ...(probe ? { probe } : {}),
+      ...(supervision.mode === 'periodic_report' && supervision.periodic_report
+        ? { report_to: supervision.periodic_report.report_to }
+        : {}),
+    })
+  }
+
+  private async updateSupervision(
+    managerKey: ManagerKey,
+    workerId: string,
+    supervision: WorkerSupervision,
+    now: string,
+  ): Promise<void> {
+    await this.deps.ledger.upsertWorker(managerKey, workerId, (worker) => worker && ({
+      ...worker,
+      supervision,
+      updated_at: now,
+    }))
   }
 
   /**
@@ -2910,7 +3233,8 @@ export class WorkerHarness {
     const failed = await this.deps.ledger.upsertWorker(managerKey, worker.worker_id, (prev) => {
       if (!prev) return undefined
       const nextTask = transitionTaskTo(prev.task, 'failed', { error: message, now })
-      return { ...prev, task: nextTask, updated_at: now }
+      const supervision = supervisionAfterMainlineTransition(prev.supervision, nextTask.status, 'exited', 0, now)
+      return { ...prev, task: nextTask, ...(supervision ? { supervision } : {}), updated_at: now }
     })
     await this.appendEvent(
       worker.worker_id,
@@ -2941,7 +3265,14 @@ export class WorkerHarness {
         ended_at: now,
         ended_reason: 'crashed',
       })
-      return { ...prev, task: nextTask, incarnations, updated_at: now }
+      const supervision = supervisionAfterMainlineTransition(
+        prev.supervision,
+        nextTask.status,
+        'exited',
+        mainline.seq,
+        now,
+      )
+      return { ...prev, task: nextTask, incarnations, ...(supervision ? { supervision } : {}), updated_at: now }
     })
     await this.appendEvent(
       worker.worker_id,
@@ -2981,7 +3312,14 @@ export class WorkerHarness {
       const incarnations = stateChanged
         ? patchIncarnationBySeq(prev.incarnations, mainline.impl, mainline.seq, { state: observed })
         : prev.incarnations
-      return { ...prev, task: nextTask, incarnations, updated_at: now }
+      const supervision = supervisionAfterMainlineTransition(
+        prev.supervision,
+        nextTask.status,
+        observed,
+        mainline.seq,
+        now,
+      )
+      return { ...prev, task: nextTask, incarnations, ...(supervision ? { supervision } : {}), updated_at: now }
     })
     // 这条事件可能只改了化身 state 而没动 task.status(stateChanged 单独成立);带上落账后的
     // 状态是无害的——订阅方拿它与上次已知状态比对,相同即静默。
@@ -3029,7 +3367,14 @@ export class WorkerHarness {
           ended_at: now,
           ended_reason: 'killed',
         })
-        return { ...prev, task: nextTask, incarnations, updated_at: now }
+        const supervision = supervisionAfterMainlineTransition(
+          prev.supervision,
+          nextTask.status,
+          'exited',
+          incarnation.seq,
+          now,
+        )
+        return { ...prev, task: nextTask, incarnations, ...(supervision ? { supervision } : {}), updated_at: now }
       })
       await this.appendEvent(workerId, incarnation.seq, 'killed', reason ? { reason } : undefined, cancelled?.task.status)
 
@@ -3579,7 +3924,14 @@ export class WorkerHarness {
             ? { state, ended_at: now, ended_reason: endReason, session_ref: h.session_ref }
             : { state, session_ref: h.session_ref }
         )
-        return { ...prev, task: nextTask, incarnations, updated_at: now }
+        const supervision = supervisionAfterMainlineTransition(
+          prev.supervision,
+          nextTask.status,
+          state,
+          h.seq,
+          now,
+        )
+        return { ...prev, task: nextTask, incarnations, ...(supervision ? { supervision } : {}), updated_at: now }
       })
       settledCurrentExit = state === 'exited' && committed !== undefined
       // 主线分支是 task 状态机的主要推进点——事件必须自带落账后的状态,否则订阅方现读台账
@@ -3715,6 +4067,12 @@ export class WorkerHarness {
     return (await this.deps.onEvent?.(event)) ?? undefined
   }
 
+  /** Persist and route a previously prepared event without changing its audit timestamp or detail. */
+  private async appendPreparedEventAwaitingDelivery(event: HarnessEvent): Promise<HarnessEventDelivery | undefined> {
+    await this.getEventLog(event.worker_id).append(event)
+    return (await this.deps.onEvent?.(event)) ?? undefined
+  }
+
   /** Persist operation evidence without using the ordinary Manager route or affecting operation truth. */
   private async appendAuditEvent(
     workerId: string,
@@ -3783,6 +4141,74 @@ export class WorkerHarness {
 export function mainlineIncarnation(worker: LedgerWorker): Incarnation | undefined {
   const mainline = worker.incarnations.filter((inc) => inc.forked_from === undefined)
   return mainline[mainline.length - 1]
+}
+
+function plusMs(now: string, durationMs: number): string {
+  return new Date(Date.parse(now) + durationMs).toISOString()
+}
+
+function supervisionKindForMode(mode: unknown): 'default_review' | 'periodic_report' | undefined {
+  if (mode === 'default') return 'default_review'
+  if (mode === 'periodic_report') return 'periodic_report'
+  return undefined
+}
+
+/**
+ * Applies the supervision lifecycle rules at the same ledger mutation that changes the mainline.
+ * It deliberately does not observe or control a Worker; the caller already owns the state change.
+ */
+function supervisionAfterMainlineTransition(
+  current: WorkerSupervision | undefined,
+  taskStatus: TaskStatus,
+  mainlineState: WorkerContractState,
+  mainlineSeq: number,
+  now: string,
+  newMainline = false,
+): WorkerSupervision | undefined {
+  if (isTerminalStatus(taskStatus)) {
+    return current ? { version: 1, mode: 'default' } : undefined
+  }
+
+  const supervision = current ?? { version: 1, mode: 'default' as const }
+  const observation = supervision.observation?.mainline_seq === mainlineSeq
+    ? supervision.observation
+    : undefined
+
+  if (supervision.mode === 'periodic_report' && supervision.periodic_report) {
+    return {
+      ...supervision,
+      ...(observation ? { observation } : { observation: undefined }),
+      ...(supervision.next_due_at
+        ? {}
+        : { next_due_at: plusMs(now, supervision.periodic_report.interval_ms) }),
+    }
+  }
+
+  const {
+    next_due_at: _nextDueAt,
+    pending: _pending,
+    periodic_report: _periodicReport,
+    observation: _observation,
+    ...defaultFields
+  } = supervision
+  if (taskStatus !== 'running' || mainlineState !== 'running') {
+    return {
+      ...defaultFields,
+      version: 1,
+      mode: 'default',
+      ...(observation ? { observation } : {}),
+    }
+  }
+  return {
+    ...defaultFields,
+    version: 1,
+    mode: 'default',
+    ...(observation ? { observation } : {}),
+    next_due_at: !newMainline && supervision.next_due_at
+      ? supervision.next_due_at
+      : plusMs(now, SUPERVISION_DEFAULT_INTERVAL_MS),
+    ...(!newMainline && supervision.pending ? { pending: supervision.pending } : {}),
+  }
 }
 
 function requireMainlineIncarnation(worker: LedgerWorker): Incarnation {

--- a/crabot-agent/src/workers/harness/ledger-types.ts
+++ b/crabot-agent/src/workers/harness/ledger-types.ts
@@ -49,6 +49,27 @@ export interface LegacySourceRef {
   imported_at: string
 }
 
+export interface WorkerSupervision {
+  version: 1
+  mode: 'default' | 'periodic_report'
+  next_due_at?: string
+  last_observed_at?: string
+  last_effective_review_at?: string
+  observation?: { mainline_seq: number; cursor: { offset: number } }
+  pending?: {
+    due_id: string
+    kind: 'default_review' | 'periodic_report'
+    due_at: string
+    attempts: number
+    retry_after_at?: string
+  }
+  periodic_report?: {
+    interval_ms: number
+    expires_at?: string
+    report_to: { channel_id: ModuleId; session_id: SessionId }
+  }
+}
+
 export interface LedgerWorker {
   worker_id: string
   /** Immutable session owner: storage, lookup, routing and read model all use this field. */
@@ -74,6 +95,7 @@ export interface LedgerWorker {
   }
   report_to: { channel_id: ModuleId; session_id: SessionId }
   incarnations: Incarnation[]
+  supervision?: WorkerSupervision
   legacy_source?: LegacySourceRef
   updated_at: string
 }

--- a/crabot-agent/src/workers/harness/worker-events.ts
+++ b/crabot-agent/src/workers/harness/worker-events.ts
@@ -32,6 +32,7 @@ export type HarnessEventKind =
    */
   | 'query_failed'
   | 'query_completed'
+  | 'supervision_due'
   /** v2 import history record: persisted only, never bridged to a Manager wake. */
   | 'legacy_imported'
 

--- a/crabot-agent/src/workers/types.ts
+++ b/crabot-agent/src/workers/types.ts
@@ -90,6 +90,25 @@ export interface Workspace { readonly root: string }
 export interface OutputCursor { readonly offset: number }
 export interface TraceCursor { readonly offset: number }
 
+export interface SupervisionObservation {
+  readonly kind: 'text' | 'tool_only' | 'none' | 'unknown'
+  readonly next_cursor: { readonly offset: number }
+}
+
+/** Shared classification for each adapter's native structured trace reader. */
+export function classifySupervisionActivity(
+  events: ReadonlyArray<NormalizedTraceEvent>,
+  next_cursor: { readonly offset: number },
+): SupervisionObservation {
+  if (events.some((event) => event.kind === 'message' && event.role === 'assistant' && event.summary.trim())) {
+    return { kind: 'text', next_cursor }
+  }
+  if (events.some((event) => event.kind === 'tool_call' || event.kind === 'tool_result')) {
+    return { kind: 'tool_only', next_cursor }
+  }
+  return { kind: 'none', next_cursor }
+}
+
 export interface SendInputOptions {
   readonly raw?: boolean
   readonly delivery_id?: string
@@ -299,6 +318,10 @@ export interface WorkerAdapter {
    * builtin 以真实 engine 进展更新、无常驻实例时以 meta 兜底。
    */
   lastActivityAt?(h: IncarnationHandle): Promise<number | undefined>
+  inspectSupervisionActivity(
+    h: IncarnationHandle,
+    cursor?: { readonly offset: number },
+  ): Promise<SupervisionObservation>
   readTrace?(h: IncarnationHandle, cursor?: TraceCursor): Promise<{ events: NormalizedTraceEvent[]; nextCursor: TraceCursor }>
   kill(h: IncarnationHandle): Promise<void>
   /** Release adapter-owned runtime resources without terminating independent tmux workers. */

--- a/crabot-agent/tests/agent/worker-mcp-capability.test.ts
+++ b/crabot-agent/tests/agent/worker-mcp-capability.test.ts
@@ -71,6 +71,10 @@ class RecordingAdapter implements WorkerAdapter {
     return 'running'
   }
 
+  async inspectSupervisionActivity(_h: IncarnationHandle, cursor?: { offset: number }) {
+    return { kind: 'unknown' as const, next_cursor: cursor ?? { offset: 0 } }
+  }
+
   async kill(_h: IncarnationHandle): Promise<void> {}
 
   capabilities(): AdapterCapabilities {

--- a/crabot-agent/tests/manager/loop.test.ts
+++ b/crabot-agent/tests/manager/loop.test.ts
@@ -21,6 +21,19 @@ const FIXED_RECEIVED_AT = '2026-01-01T08:00:00+08:00'
 function timed(wake: WakeEvent): TimedWakeEnvelope { return { wake, received_at: FIXED_RECEIVED_AT, timezone: 'Asia/Shanghai' } }
 const DIALOG_OBJECT_ID = (`test::${'friend-loop'}` as ManagerKey)
 
+function defaultSupervisionWake(workerId: string, dueId: string): TimedWakeEnvelope {
+  return timed({
+    kind: 'worker_event',
+    event: {
+      ts: '2026-01-01T00:00:00.000Z',
+      kind: 'supervision_due',
+      worker_id: workerId,
+      seq: 1,
+      detail: { mode: 'default', due_id: dueId, mainline_seq: 1, observation: 'text' },
+    },
+  })
+}
+
 /** compaction.ts foldIntoSummary 的 system prompt 常量特征串,用它区分"这是折叠 LLM 调用
  *  还是普通 engine turn 调用",不需要 vi.mock/vi.spyOn 侵入模块内部。 */
 const FOLD_SYSTEM_PROMPT_MARKER = '对话历史压缩助手'
@@ -995,6 +1008,109 @@ describe('ManagerLoop', () => {
       const result = await loop.drainMailbox()
       expect(result.turns).toBe(0)
       expect(result.repliedToHuman).toBe(false)
+    })
+  })
+
+  describe('任务巡检 episode', () => {
+    it('只读的默认巡检会在完整 trace 落账后压缩为本地历史摘要', async () => {
+      const { adapter, queue } = makeAdapter()
+      queue.push(
+        { toolCalls: [{ name: 'read_worker_output', id: 'read-1', input: { worker_id: 'w-supervised' } }], stopReason: 'tool_use' },
+        { stopReason: 'end_turn' },
+      )
+      const loop = new ManagerLoop(baseDeps({
+        store,
+        adapter,
+        toolFace: () => [defineTool({
+          name: 'read_worker_output',
+          description: 'read only',
+          inputSchema: { type: 'object', properties: { worker_id: { type: 'string' } } },
+          isReadOnly: true,
+          call: async () => ({ output: 'worker output', isError: false }),
+        })],
+      }))
+
+      const result = await loop.wakeUp(defaultSupervisionWake('w-supervised', 'due-read-only'))
+
+      expect(result.outcome).toBe('completed')
+      const state = await store.load(KEY)
+      expect(state.recent).toHaveLength(1)
+      expect(JSON.stringify(state.recent)).toContain('[任务巡检摘要] worker_id=w-supervised')
+      expect(JSON.stringify(state.recent)).not.toContain('due-read-only')
+    })
+
+    it('默认巡检一旦发送消息或写记忆，就保留完整 episode 历史', async () => {
+      for (const toolName of ['send_message', 'mcp__crab-memory__store_memory']) {
+        const { adapter, queue } = makeAdapter()
+        queue.push(
+          { toolCalls: [{ name: toolName, id: `call-${toolName}`, input: {} }], stopReason: 'tool_use' },
+          { stopReason: 'end_turn' },
+        )
+        const isolatedStore = new ManagerSessionStore(join(dataDir, `supervision-${toolName}`))
+        const loop = new ManagerLoop(baseDeps({
+          store: isolatedStore,
+          adapter,
+          toolFace: () => [defineTool({
+            name: toolName,
+            description: 'side effect',
+            inputSchema: { type: 'object', properties: {} },
+            call: async () => ({ output: 'ok', isError: false }),
+          })],
+        }))
+
+        await loop.wakeUp(defaultSupervisionWake('w-supervised', `due-${toolName}`))
+
+        const state = await isolatedStore.load(KEY)
+        expect(JSON.stringify(state.recent)).toContain(`due-${toolName}`)
+        expect(JSON.stringify(state.recent)).not.toContain('[任务巡检摘要]')
+      }
+    })
+  })
+
+  describe('EpisodeResult.successfulSendMessageTargets', () => {
+    async function runSendMessageCase(input: Record<string, unknown>, isError = false) {
+      const { adapter, queue } = makeAdapter()
+      queue.push(
+        { toolCalls: [{ name: 'send_message', id: 'send-1', input }], stopReason: 'tool_use' },
+        { stopReason: 'end_turn' },
+      )
+      const loop = new ManagerLoop(baseDeps({
+        store,
+        adapter,
+        toolFace: () => [defineTool({
+          name: 'send_message',
+          description: 'deliver',
+          inputSchema: { type: 'object', properties: {} },
+          call: async () => ({ output: 'delivery result', isError }),
+        })],
+      }))
+      return loop.wakeUp(timed({
+        kind: 'worker_event',
+        event: {
+          ts: '2026-01-01T00:00:00.000Z',
+          kind: 'supervision_due',
+          worker_id: 'w-periodic',
+          seq: 1,
+          detail: {
+            mode: 'periodic_report',
+            due_id: 'due-periodic',
+            mainline_seq: 1,
+            observation: 'tool_only',
+            report_to: { channel_id: 'feishu', session_id: 'target-session' },
+          },
+        },
+      }))
+    }
+
+    it('只记录成功 send_message 的精确目标', async () => {
+      const success = await runSendMessageCase({ channel_id: 'feishu', session_id: 'target-session', content: '进度' })
+      expect(success.successfulSendMessageTargets).toEqual([{ channel_id: 'feishu', session_id: 'target-session' }])
+
+      const wrongTarget = await runSendMessageCase({ channel_id: 'feishu', session_id: 'another-session', content: '进度' })
+      expect(wrongTarget.successfulSendMessageTargets).toEqual([{ channel_id: 'feishu', session_id: 'another-session' }])
+
+      const failed = await runSendMessageCase({ channel_id: 'feishu', session_id: 'target-session', content: '进度' }, true)
+      expect(failed.successfulSendMessageTargets).toEqual([])
     })
   })
 

--- a/crabot-agent/tests/manager/manager-integration.test.ts
+++ b/crabot-agent/tests/manager/manager-integration.test.ts
@@ -207,6 +207,9 @@ class ForklessStubAdapter implements WorkerAdapter {
   async state(): Promise<WorkerContractState> {
     return 'running'
   }
+  async inspectSupervisionActivity(_h: IncarnationHandle, cursor?: { offset: number }) {
+    return { kind: 'unknown' as const, next_cursor: cursor ?? { offset: 0 } }
+  }
   async kill(): Promise<void> {}
   capabilities(): AdapterCapabilities {
     return { fork: false, revive: false, goalMode: false, subagent: false, structuredTrace: false }

--- a/crabot-agent/tests/manager/registry.test.ts
+++ b/crabot-agent/tests/manager/registry.test.ts
@@ -384,6 +384,26 @@ describe('ManagerRegistry', () => {
     expect(state.recent.length).toBeGreaterThan(0)
   })
 
+  it('routeSupervisionDue: 已被 clear 或替换的 due 不创建 Manager episode', async () => {
+    const { adapter, calls } = makeAdapter()
+    const isCurrent = vi.fn(async () => false)
+    const registry = new ManagerRegistry(baseRegistryDeps({
+      adapter,
+      harness: { ...FAKE_HARNESS, isSupervisionDueCurrent: isCurrent } as unknown as WorkerHarness,
+    }))
+    const event: HarnessEvent = {
+      ts: '2026-01-01T00:00:00.000Z',
+      kind: 'supervision_due',
+      worker_id: 'w-stale',
+      seq: 1,
+      detail: { mode: 'periodic_report', due_id: 'old-due', mainline_seq: 1, observation: 'none' },
+    }
+
+    await expect(registry.routeSupervisionDue(event)).resolves.toBeUndefined()
+    expect(isCurrent).toHaveBeenCalledWith(event)
+    expect(calls).toHaveLength(0)
+  })
+
   it('operation notification 在 owning Manager 正执行时 deferred，不塞进当前 mailbox', async () => {
     const calls: LLMStreamParams[] = []
     const entered = deferred()

--- a/crabot-agent/tests/manager/worker-tools.test.ts
+++ b/crabot-agent/tests/manager/worker-tools.test.ts
@@ -98,6 +98,10 @@ class FakeAdapter implements WorkerAdapter {
     return this.states.get(handleKey(h)) ?? 'exited'
   }
 
+  async inspectSupervisionActivity(_h: IncarnationHandle, cursor?: { offset: number }) {
+    return { kind: 'unknown' as const, next_cursor: cursor ?? { offset: 0 } }
+  }
+
   async kill(h: IncarnationHandle): Promise<void> {
     this.killCalls.push(h)
     this.states.set(handleKey(h), 'exited')
@@ -193,12 +197,23 @@ afterEach(async () => {
 // ---- 工具面形状 ----
 
 describe('buildWorkerTools — 工具面形状', () => {
-  it('普通 Manager 有八项 worker 工具；read_worker_output/list_workers/get_worker_detail/list_worker_implementations 为只读', async () => {
+  it('普通 Manager 有十项 worker 工具；read_worker_output/list_workers/get_worker_detail/list_worker_implementations 为只读', async () => {
     const { harness } = await makeHarness()
     const tools = buildWorkerTools({ harness, context: () => CTX })
 
     expect(tools.map((t) => t.name).sort()).toEqual(
-      ['get_worker_detail', 'kill_worker', 'list_worker_implementations', 'list_workers', 'query_worker', 'read_worker_output', 'send_to_worker', 'spawn_worker'].sort()
+      [
+        'clear_worker_periodic_report',
+        'get_worker_detail',
+        'kill_worker',
+        'list_worker_implementations',
+        'list_workers',
+        'query_worker',
+        'read_worker_output',
+        'send_to_worker',
+        'set_worker_periodic_report',
+        'spawn_worker',
+      ].sort()
     )
 
     const readOnlyNames = tools.filter((t) => t.isReadOnly).map((t) => t.name).sort()
@@ -466,6 +481,66 @@ describe('read_worker_output', () => {
   })
 })
 
+// ---- 定期汇报规则（stable worker 属性） ----
+
+describe('worker periodic report tools', () => {
+  it('把规则固定到当前 Manager 会话，覆盖旧状态并在清除后恢复默认巡检', async () => {
+    const { harness } = await makeHarness()
+    const worker = await harness.spawnWorker(directSpawnParams())
+    const tools = buildWorkerTools({ harness, context: () => CTX })
+    const setRule = tools.find((tool) => tool.name === 'set_worker_periodic_report')!
+    const clearRule = tools.find((tool) => tool.name === 'clear_worker_periodic_report')!
+
+    const setResult = await setRule.call({
+      worker_id: worker.worker_id,
+      interval_minutes: 10,
+      expires_at: '2026-01-01T01:00:00.000Z',
+    }, {})
+
+    expect(setResult.isError).toBe(false)
+    expect(parseOutput(setResult.output)).toMatchObject({
+      worker_id: worker.worker_id,
+      mode: 'periodic_report',
+      interval_minutes: 10,
+      expires_at: '2026-01-01T01:00:00.000Z',
+    })
+    expect((await harness.findWorker(worker.worker_id))!.worker.supervision).toMatchObject({
+      mode: 'periodic_report',
+      periodic_report: {
+        interval_ms: 10 * 60_000,
+        expires_at: '2026-01-01T01:00:00.000Z',
+        report_to: CTX.reportTo,
+      },
+    })
+
+    const clearResult = await clearRule.call({ worker_id: worker.worker_id }, {})
+    expect(clearResult.isError).toBe(false)
+    expect(parseOutput(clearResult.output)).toMatchObject({ worker_id: worker.worker_id, mode: 'default', next_due_at: expect.any(String) })
+    expect((await harness.findWorker(worker.worker_id))!.worker.supervision).toMatchObject({
+      mode: 'default',
+      next_due_at: expect.any(String),
+    })
+  })
+
+  it('拒绝非法频率、已到期时间以及其他 Manager 的 worker，且不会写入规则', async () => {
+    const { harness } = await makeHarness()
+    const foreign = await harness.spawnWorker(directSpawnParams({ managerKey: 'feishu::other' as ManagerKey }))
+    const tools = buildWorkerTools({ harness, context: () => CTX })
+    const setRule = tools.find((tool) => tool.name === 'set_worker_periodic_report')!
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    try {
+      expect((await setRule.call({ worker_id: foreign.worker_id, interval_minutes: 0 }, {})).isError).toBe(true)
+      expect((await setRule.call({ worker_id: foreign.worker_id, interval_minutes: 10, expires_at: 'not-a-date' }, {})).isError).toBe(true)
+      expect((await setRule.call({ worker_id: foreign.worker_id, interval_minutes: 10 }, {})).isError).toBe(true)
+    } finally {
+      errorSpy.mockRestore()
+    }
+    expect((await harness.findWorker(foreign.worker_id))!.worker.supervision).toMatchObject({ mode: 'default' })
+    expect((await harness.findWorker(foreign.worker_id))!.worker.supervision?.periodic_report).toBeUndefined()
+  })
+})
+
 // ---- list_workers（同步，默认只返回决策视野） ----
 
 describe('list_workers', () => {
@@ -480,7 +555,7 @@ describe('list_workers', () => {
     const current = await listWorkers.call({}, {})
     expect(current.isError).toBe(false)
     expect(parseOutput(current.output)).toMatchObject({
-      workers: [{ worker_id: active.worker_id }],
+      workers: [{ worker_id: active.worker_id, supervision_mode: 'default', next_due_at: expect.any(String) }],
       total_active: 1,
       total_terminal: 1,
       pagination: { page: 1, page_size: 20, total_items: 1, total_pages: 1 },

--- a/crabot-agent/tests/mcp/crab-messaging-system-session.test.ts
+++ b/crabot-agent/tests/mcp/crab-messaging-system-session.test.ts
@@ -89,4 +89,29 @@ describe('send_message rejects SYSTEM_SESSION sentinel', () => {
 
     expect(callMock).toHaveBeenCalled()
   })
+
+  it('marks a channel delivery failure as a tool error', async () => {
+    const callMock = vi.fn().mockRejectedValue(new Error('channel offline'))
+    const tools = buildWorkerMessagingTools({
+      rpcClient: { call: callMock } as never,
+      moduleId: 'worker-test',
+      getAdminPort: async () => 19001,
+      resolveChannelPort: async () => 19009,
+      getTaskContext: () => ({
+        taskId: 't1',
+        humanQueue: new HumanMessageQueue(),
+        triggerType: 'message' as const,
+        hasGoal: () => false,
+      }),
+    })
+
+    const result = await findTool(tools, 'send_message').handler({
+      channel_id: 'wechat-real',
+      session_id: 'sess-real',
+      content: 'should fail',
+    })
+
+    expect(result.isError).toBe(true)
+    expect(JSON.parse(result.content[0].text)).toMatchObject({ error: '发送失败: channel offline' })
+  })
 })

--- a/crabot-agent/tests/workers/builtin-adapter.test.ts
+++ b/crabot-agent/tests/workers/builtin-adapter.test.ts
@@ -337,6 +337,20 @@ describe('BuiltinWorkerAdapter', () => {
     expect(chunk).toContain('A 还是 B')
   })
 
+  it('没有可读结构化 trace 时，巡检保守返回 unknown', async () => {
+    const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+    const h = await adapter.spawn(spec({
+      adapter: makeAdapter([{ stopReason: 'end_turn' }]),
+    }))
+
+    await expect(adapter.inspectSupervisionActivity(h, { offset: 3 })).resolves.toEqual({
+      kind: 'unknown',
+      next_cursor: { offset: 3 },
+    })
+
+    await adapter.kill(h)
+  })
+
   it('常驻化身只以真实 engine/input 进展更新时间，主线与 fork 回调均接线', async () => {
     let now = 1_000
     const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now)

--- a/crabot-agent/tests/workers/claude-code-adapter.test.ts
+++ b/crabot-agent/tests/workers/claude-code-adapter.test.ts
@@ -1980,6 +1980,11 @@ describe('ClaudeCodeAdapter.readTrace', () => {
     expect(events2).toEqual([])
     expect(nextCursor2).toEqual({ offset: 3 })
 
+    await expect(adapter.inspectSupervisionActivity(h, { offset: 3 })).resolves.toEqual({
+      kind: 'unknown',
+      next_cursor: { offset: 3 },
+    })
+
     await adapter.kill(h)
   })
 

--- a/crabot-agent/tests/workers/codex-adapter.test.ts
+++ b/crabot-agent/tests/workers/codex-adapter.test.ts
@@ -1610,6 +1610,11 @@ describe('CodexWorkerAdapter.readTrace', () => {
     expect(events2).toEqual([])
     expect(nextCursor2).toEqual({ offset: 3 })
 
+    await expect(adapter.inspectSupervisionActivity(h, { offset: 3 })).resolves.toEqual({
+      kind: 'unknown',
+      next_cursor: { offset: 3 },
+    })
+
     await adapter.kill(h)
   })
 

--- a/crabot-agent/tests/workers/harness/harness-continuation.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-continuation.test.ts
@@ -147,6 +147,10 @@ class FakeAdapter implements WorkerAdapter {
     return this.states.get(handleKey(h)) ?? 'exited'
   }
 
+  async inspectSupervisionActivity(_h: IncarnationHandle, cursor?: { offset: number }) {
+    return { kind: 'unknown' as const, next_cursor: cursor ?? { offset: 0 } }
+  }
+
   async kill(h: IncarnationHandle): Promise<void> {
     this.killCalls.push(h)
     this.states.set(handleKey(h), 'exited')

--- a/crabot-agent/tests/workers/harness/harness-lifecycle.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-lifecycle.test.ts
@@ -157,6 +157,10 @@ class FakeAdapter implements WorkerAdapter {
     return this.states.get(handleKey(h)) ?? 'exited'
   }
 
+  async inspectSupervisionActivity(_h: IncarnationHandle, cursor?: { offset: number }) {
+    return { kind: 'unknown' as const, next_cursor: cursor ?? { offset: 0 } }
+  }
+
   async kill(h: IncarnationHandle): Promise<void> {
     this.killCalls.push(h)
     this.states.set(handleKey(h), 'exited')

--- a/crabot-agent/tests/workers/harness/harness-liveness.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-liveness.test.ts
@@ -79,6 +79,9 @@ class CliLikeAdapter implements WorkerAdapter {
   async state(h: IncarnationHandle): Promise<WorkerContractState> {
     return this.states.get(handleKey(h)) ?? 'exited'
   }
+  async inspectSupervisionActivity(_h: IncarnationHandle, cursor?: { offset: number }) {
+    return { kind: 'unknown' as const, next_cursor: cursor ?? { offset: 0 } }
+  }
   async lastActivityAt(h: IncarnationHandle): Promise<number | undefined> {
     this.lastActivityAtCalls.push(handleKey(h))
     return this.activity.get(handleKey(h))
@@ -334,20 +337,18 @@ describe.each<WorkerImplId>(['claude-code', 'codex'])('WorkerHarness.sweepLivene
     expect(adapter.readOutputCalls).toHaveLength(1)
   })
 
-  it('⑥ 台账一字不改:巡检前后 task.status 与化身 state 完全一致', async () => {
+  it('⑥ 活性巡检不改变 task.status 或主线化身 state', async () => {
     const { harness, ledger, workerId } = await spawnRunning()
 
     clockMs += STALL_MS + MINUTE
-    const before = JSON.stringify((await ledger.findWorker(workerId))!.worker)
+    const before = (await ledger.findWorker(workerId))!.worker
     await harness.sweepLiveness()
     await harness.sweepLiveness()
-    const after = JSON.stringify((await ledger.findWorker(workerId))!.worker)
+    const after = (await ledger.findWorker(workerId))!.worker
 
     expect(wakeEvents(workerId)).toHaveLength(1) // 确认这一轮真的报了(否则断言是空转)
-    expect(after).toBe(before)
-    const worker = (await ledger.findWorker(workerId))!.worker
-    expect(worker.task.status).toBe('running')
-    expect(worker.incarnations[0].state).toBe('running')
+    expect(after.task).toEqual(before.task)
+    expect(after.incarnations).toEqual(before.incarnations)
   })
 
   it('⑦ 只看主线化身:fork 侧问分支零输出不算停摆', async () => {

--- a/crabot-agent/tests/workers/harness/harness-recovery.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-recovery.test.ts
@@ -88,6 +88,10 @@ class FakeAdapter implements WorkerAdapter {
     return this.states.get(handleKey(h)) ?? 'exited'
   }
 
+  async inspectSupervisionActivity(_h: IncarnationHandle, cursor?: { offset: number }) {
+    return { kind: 'unknown' as const, next_cursor: cursor ?? { offset: 0 } }
+  }
+
   async kill(_h: IncarnationHandle): Promise<void> {}
 
   capabilities(): AdapterCapabilities {
@@ -230,6 +234,16 @@ describe('WorkerHarness.reconcileOnStartup — 三态判定', () => {
       origin: {
       trigger_type: 'system' },
       incarnations: [],
+      supervision: {
+        version: 1,
+        mode: 'periodic_report',
+        next_due_at: now(),
+        pending: { due_id: 'due-maintenance', kind: 'periodic_report', due_at: now(), attempts: 0 },
+        periodic_report: {
+          interval_ms: 5 * 60_000,
+          report_to: { channel_id: 'wechat', session_id: 'sess-recovery' },
+        },
+      },
     })
     await seed(ledger, DIALOG, worker)
 
@@ -241,6 +255,7 @@ describe('WorkerHarness.reconcileOnStartup — 三态判定', () => {
     expect(after.task.status).toBe('failed')
     expect(after.task.error).toBe('agent restart: execution context lost for agent-native system task')
     expect(after.incarnations).toEqual([])
+    expect(after.supervision).toEqual({ version: 1, mode: 'default' })
     const taskEvents = events.filter((e) => e.worker_id === 'w-maintenance')
     expect(taskEvents).toHaveLength(1)
     expect(taskEvents[0]).toMatchObject({

--- a/crabot-agent/tests/workers/harness/harness-supervision.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-supervision.test.ts
@@ -1,0 +1,257 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { promises as fs } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { WorkerHarness, type HarnessDeps, type SpawnWorkerParams } from '../../../src/workers/harness/harness'
+import { LedgerStore } from '../../../src/workers/harness/ledger-store'
+import { WorkspaceManager } from '../../../src/workers/harness/workspace-manager'
+import type { HarnessEvent, HarnessEventDelivery } from '../../../src/workers/harness/worker-events'
+import type {
+  AdapterCapabilities,
+  CapabilityBundle,
+  DetectResult,
+  ForkOptions,
+  IncarnationHandle,
+  IncarnationRef,
+  OutputCursor,
+  SpawnSpec,
+  SupervisionObservation,
+  WorkerAdapter,
+  WorkerContractState,
+  WorkerImplId,
+  Workspace,
+} from '../../../src/workers/types'
+import type { ManagerKey } from '../../../src/workers/harness/ledger-types'
+
+const MINUTE = 60_000
+
+class SupervisionAdapter implements WorkerAdapter {
+  readonly implId: WorkerImplId = 'builtin'
+  observation: SupervisionObservation = { kind: 'none', next_cursor: { offset: 0 } }
+  contractState: WorkerContractState = 'running'
+  inspectCalls = 0
+  stateCalls = 0
+  sendInputCalls = 0
+  resumeCalls = 0
+  killCalls = 0
+
+  async detect(): Promise<DetectResult> { return { installed: true, activated: true } }
+  async provision(_ws: Workspace, _caps: CapabilityBundle): Promise<void> {}
+  async spawn(spec: SpawnSpec): Promise<IncarnationHandle> {
+    return { worker_id: spec.worker_id, seq: 1, impl: this.implId, session_ref: `session-${spec.worker_id}` }
+  }
+  async resume(_prev: IncarnationRef, _input: string): Promise<IncarnationHandle> {
+    this.resumeCalls += 1
+    throw new Error('not used by supervision')
+  }
+  async fork(_prev: IncarnationRef, _input: string, _opts: ForkOptions): Promise<IncarnationHandle> {
+    throw new Error('not used by supervision')
+  }
+  async sendInput(): Promise<void> { this.sendInputCalls += 1 }
+  async readOutput(_h: IncarnationHandle, cursor: OutputCursor): Promise<{ chunk: string; nextCursor: OutputCursor }> {
+    return { chunk: '', nextCursor: cursor }
+  }
+  async state(): Promise<WorkerContractState> { this.stateCalls += 1; return this.contractState }
+  async inspectSupervisionActivity(): Promise<SupervisionObservation> {
+    this.inspectCalls += 1
+    return this.observation
+  }
+  async kill(): Promise<void> { this.killCalls += 1; this.contractState = 'exited' }
+  async dispose(): Promise<void> {}
+  capabilities(): AdapterCapabilities {
+    return { fork: false, revive: true, goalMode: false, subagent: false, structuredTrace: true }
+  }
+}
+
+let dataDir: string
+let clockMs: number
+let delivery: HarnessEventDelivery = { consumed: true }
+let events: HarnessEvent[]
+
+function now(): string {
+  return new Date(clockMs).toISOString()
+}
+
+function params(): SpawnWorkerParams {
+  return {
+    managerKey: 'feishu::session-1' as ManagerKey,
+    title: '巡检测试',
+    prompt: '执行任务',
+    origin: { trigger_type: 'message' },
+    report_to: { channel_id: 'feishu', session_id: 'session-1' },
+  }
+}
+
+async function makeHarness(): Promise<{ harness: WorkerHarness; adapter: SupervisionAdapter }> {
+  const adapter = new SupervisionAdapter()
+  const harness = new WorkerHarness({
+    adapters: new Map([[adapter.implId, adapter]]),
+    defaultImpl: adapter.implId,
+    ledger: new LedgerStore(join(dataDir, 'ledgers')),
+    workspaces: new WorkspaceManager(join(dataDir, 'workspaces')),
+    workersDir: join(dataDir, 'workers'),
+    now,
+    onEvent: (event) => {
+      events.push(event)
+      return delivery
+    },
+  } satisfies HarnessDeps)
+  return { harness, adapter }
+}
+
+async function spawnRunning(harness: WorkerHarness): Promise<string> {
+  return (await harness.spawnWorker(params())).worker_id
+}
+
+function supervisionEvents(workerId: string): HarnessEvent[] {
+  return events.filter((event) => event.worker_id === workerId && event.kind === 'supervision_due')
+}
+
+beforeEach(async () => {
+  dataDir = await fs.mkdtemp(join(tmpdir(), 'harness-supervision-test-'))
+  clockMs = Date.parse('2026-08-19T00:00:00.000Z')
+  delivery = { consumed: true }
+  events = []
+})
+
+afterEach(async () => {
+  await fs.rm(dataDir, { recursive: true, force: true })
+})
+
+describe('WorkerHarness task supervision', () => {
+  it('default tool-only activity advances the cursor and next due without waking Manager', async () => {
+    const { harness, adapter } = await makeHarness()
+    const workerId = await spawnRunning(harness)
+    events = []
+    adapter.observation = { kind: 'tool_only', next_cursor: { offset: 4 } }
+    clockMs += 15 * MINUTE
+
+    await harness.sweepLiveness()
+
+    const worker = (await harness.findWorker(workerId))!.worker
+    expect(supervisionEvents(workerId)).toHaveLength(0)
+    expect(worker.supervision).toMatchObject({
+      mode: 'default',
+      observation: { mainline_seq: 1, cursor: { offset: 4 } },
+      next_due_at: new Date(clockMs + 15 * MINUTE).toISOString(),
+    })
+    expect(adapter.stateCalls).toBe(0)
+    expect(adapter.sendInputCalls).toBe(0)
+    expect(adapter.resumeCalls).toBe(0)
+    expect(adapter.killCalls).toBe(0)
+  })
+
+  it('default text activity creates one due and advances only after Manager consumes it', async () => {
+    const { harness, adapter } = await makeHarness()
+    const workerId = await spawnRunning(harness)
+    events = []
+    adapter.observation = { kind: 'text', next_cursor: { offset: 2 } }
+    clockMs += 15 * MINUTE
+
+    await harness.sweepLiveness()
+
+    const event = supervisionEvents(workerId).at(-1)!
+    expect(event.detail).toMatchObject({ mode: 'default', observation: 'text', mainline_seq: 1 })
+    const worker = (await harness.findWorker(workerId))!.worker
+    expect(worker.supervision).toMatchObject({
+      mode: 'default',
+      last_effective_review_at: now(),
+      next_due_at: new Date(clockMs + 15 * MINUTE).toISOString(),
+    })
+    expect(worker.supervision?.pending).toBeUndefined()
+  })
+
+  it('none first probes state; idle takes the existing lifecycle path instead of inventing a due', async () => {
+    const { harness, adapter } = await makeHarness()
+    const workerId = await spawnRunning(harness)
+    events = []
+    adapter.observation = { kind: 'none', next_cursor: { offset: 0 } }
+    adapter.contractState = 'idle'
+    clockMs += 15 * MINUTE
+
+    await harness.sweepLiveness()
+
+    const worker = (await harness.findWorker(workerId))!.worker
+    expect(adapter.stateCalls).toBe(1)
+    expect(supervisionEvents(workerId)).toHaveLength(0)
+    expect(worker.task.status).toBe('waiting_input')
+    expect(worker.supervision).toMatchObject({ version: 1, mode: 'default', last_observed_at: now() })
+    expect(worker.supervision?.next_due_at).toBeUndefined()
+    expect(worker.supervision?.pending).toBeUndefined()
+  })
+
+  it('periodic report never filters tool-only activity and retains the same pending due after failed delivery', async () => {
+    const { harness, adapter } = await makeHarness()
+    const workerId = await spawnRunning(harness)
+    await harness.setWorkerPeriodicReport(workerId, { channel_id: 'feishu', session_id: 'session-1' }, 5 * MINUTE)
+    events = []
+    delivery = { consumed: false }
+    adapter.observation = { kind: 'tool_only', next_cursor: { offset: 8 } }
+    clockMs += 5 * MINUTE
+
+    await harness.sweepLiveness()
+
+    const first = supervisionEvents(workerId).at(-1)!
+    let worker = (await harness.findWorker(workerId))!.worker
+    expect(first.detail).toMatchObject({ mode: 'periodic_report', observation: 'tool_only' })
+    expect(worker.supervision?.pending).toMatchObject({ due_id: first.detail?.due_id, attempts: 1 })
+
+    delivery = { consumed: true }
+    clockMs += 5 * MINUTE
+    await harness.sweepLiveness()
+
+    worker = (await harness.findWorker(workerId))!.worker
+    expect(supervisionEvents(workerId).at(-1)?.detail?.due_id).toBe(first.detail?.due_id)
+    expect(worker.supervision?.pending).toBeUndefined()
+    expect(worker.supervision).toMatchObject({
+      mode: 'periodic_report',
+      last_effective_review_at: now(),
+      next_due_at: new Date(clockMs + 5 * MINUTE).toISOString(),
+    })
+  })
+
+  it('periodic report remains due when the mainline transitions to waiting_input', async () => {
+    const { harness, adapter } = await makeHarness()
+    const workerId = await spawnRunning(harness)
+    await harness.setWorkerPeriodicReport(workerId, { channel_id: 'feishu', session_id: 'session-1' }, 5 * MINUTE)
+    events = []
+    adapter.observation = { kind: 'none', next_cursor: { offset: 0 } }
+    adapter.contractState = 'idle'
+    clockMs += 5 * MINUTE
+
+    await harness.sweepLiveness()
+
+    const worker = (await harness.findWorker(workerId))!.worker
+    expect(supervisionEvents(workerId)).toHaveLength(1)
+    expect(supervisionEvents(workerId)[0].detail).toMatchObject({
+      mode: 'periodic_report',
+      observation: 'none',
+      probe: 'idle',
+    })
+    expect(worker.task.status).toBe('waiting_input')
+    expect(worker.supervision).toMatchObject({
+      mode: 'periodic_report',
+      next_due_at: new Date(clockMs + 5 * MINUTE).toISOString(),
+    })
+    expect(worker.supervision?.pending).toBeUndefined()
+  })
+
+  it('clearing a rule invalidates a queued due and terminal cleanup removes periodic configuration', async () => {
+    const { harness, adapter } = await makeHarness()
+    const workerId = await spawnRunning(harness)
+    await harness.setWorkerPeriodicReport(workerId, { channel_id: 'feishu', session_id: 'session-1' }, 5 * MINUTE)
+    events = []
+    delivery = { consumed: false }
+    clockMs += 5 * MINUTE
+    await harness.sweepLiveness()
+    const stale = supervisionEvents(workerId).at(-1)!
+
+    await harness.clearWorkerPeriodicReport(workerId)
+    expect(await harness.isSupervisionDueCurrent(stale)).toBe(false)
+
+    await harness.killWorker(workerId)
+    const worker = (await harness.findWorker(workerId))!.worker
+    expect(adapter.killCalls).toBe(1)
+    expect(worker.supervision).toEqual({ version: 1, mode: 'default' })
+  })
+})


### PR DESCRIPTION
## 变更内容

- 为持久化 Worker ledger 增加任务巡检状态：默认每 15 分钟进行低打扰巡检。
- 增加 `set_worker_periodic_report` / `clear_worker_periodic_report`，让 Manager 为稳定 `worker_id` 设置固定会话目标的定期汇报；该模式与默认巡检互斥，并沿主线恢复链生效，不跟随 query fork。
- 默认巡检在仅有 tool use 时静默推进；没有新数据或无法可靠读取原生 trace 时，只探测 adapter 状态，必要时才唤醒 Manager。
- 定期汇报使用持久化待投递、退避重试和到期清理；只有成功向规则指定会话 `send_message` 才会消费本次汇报责任。
- 将默认巡检产生的只读 Manager episode 压缩为 `[任务巡检摘要]`，保留完整 trace/audit。

## 原因与影响

Manager 派出 Worker 后缺少持续、低噪声的任务观察，也不能可靠承接用户明确要求的定期进度汇报。本改动将两种语义分开：默认巡检尽量不打扰，用户约定的汇报则按期负责投递。

原生 trace 缺失或不可读时保守归类为 `unknown`，不会把异常误认为“没有活动”。这避免错误地静默跳过需要处置的 Worker。

相关设计与协议已在独立文档仓发布：`bbcea9e`（2026-08-19 worker supervision）。

## 验证

- `crabot-agent` TypeScript 编译通过
- 10 个 Harness/Manager 定向套件：295/295 通过
- Adapter 套件：36 个套件、212 个测试通过
