### PR TITLE
feat(agent): separate builtin worker assistant text from tool traces

### DIFF
--- a/crabot-admin/web/src/pages/Traces/WorkerDetail.tsx
+++ b/crabot-admin/web/src/pages/Traces/WorkerDetail.tsx
@@ -37,7 +37,7 @@ const ORIGIN_LABEL: Record<LedgerWorker['origin']['trigger_type'], string> = {
   message: '消息', scheduled: '定时任务', system: '系统',
 }
 const KIND_LABEL: Record<WorkerTraceEvent['kind'], string> = {
-  message: '消息', tool_call: '工具调用', tool_result: '工具结果', thinking: '思考', lifecycle: '生命周期',
+  message: '消息', llm_call: '模型调用', tool_call: '工具调用', tool_result: '工具结果', thinking: '思考', lifecycle: '生命周期',
 }
 const ACTIVITY_TONE_COLOR: Record<ActivityTone, string> = {
   manager: 'var(--info)', worker: 'var(--success)', tool: 'var(--warning)', status: 'var(--text-muted)', failure: 'var(--error)',
@@ -174,7 +174,7 @@ function activityFor(event: WorkerTraceEvent): ActivityEntry | undefined {
     return { event, label: '管理会话指令', tone: 'manager', body: messageText(event) }
   }
   if (event.source === 'native' && event.kind === 'message' && event.role === 'assistant') {
-    return { event, label: '任务输出', tone: 'worker', body: messageText(event) }
+    return { event, label: 'Worker 文本', tone: 'worker', body: messageText(event) }
   }
   if (event.kind === 'tool_call') {
     return { event, label: '工具调用', tone: 'tool', title: toolName(event), body: toolArguments(event) }

--- a/crabot-admin/web/src/pages/Traces/WorkersView.test.tsx
+++ b/crabot-admin/web/src/pages/Traces/WorkersView.test.tsx
@@ -226,7 +226,7 @@ describe('WorkerDetail', () => {
     renderDetail()
 
     await waitFor(() => expect(screen.getByText('管理会话指令')).toBeInTheDocument())
-    expect(screen.getByText('任务输出')).toBeInTheDocument()
+    expect(screen.getByText('Worker 文本')).toBeInTheDocument()
     const toolRow = screen.getByRole('button', { name: /工具调用：调用 shell · 已返回结果.*展开详情/ })
     expect(toolRow).toHaveAttribute('aria-expanded', 'false')
     expect(screen.queryByText('item_completed')).not.toBeInTheDocument()
@@ -243,6 +243,45 @@ describe('WorkerDetail', () => {
 
     fireEvent.click(screen.getByRole('button', { name: '技术事件 1' }))
     expect(screen.getByText('item_completed')).toBeInTheDocument()
+  })
+
+  it('builtin assistant text 与模型调用分开，纯工具轮不伪造 Worker 文本', async () => {
+    mocked.getWorkerDetail = vi.fn().mockResolvedValue({ worker: workerFixture() })
+    mocked.getWorkerTrace = vi.fn().mockResolvedValue({
+      events: [
+        { ts: '2026-08-01T00:00:01.000Z', kind: 'llm_call', summary: 'llm tool_use', source: 'native', detail: { stop_reason: 'tool_use' } },
+        { ts: '2026-08-01T00:00:02.000Z', kind: 'tool_call', role: 'assistant', summary: 'shell', source: 'native', detail: { name: 'shell', arguments: 'pwd' } },
+      ],
+      next_cursor: 'tok-1',
+    })
+    mocked.getWorkerTerminal = vi.fn().mockResolvedValue({ kind: 'live_terminal', text: '', captured_at: '2026-08-01T00:00:00.000Z' })
+
+    renderDetail()
+
+    await screen.findByRole('button', { name: /工具调用：调用 shell.*展开详情/ })
+    expect(screen.queryByText('Worker 文本')).not.toBeInTheDocument()
+    expect(screen.queryByText('任务输出')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: '技术事件 1' }))
+    expect(await screen.findByRole('button', { name: /原生记录 · 模型调用：llm tool_use/ })).toBeInTheDocument()
+  })
+
+  it('builtin assistant text 在默认活动流中显示为 Worker 文本', async () => {
+    mocked.getWorkerDetail = vi.fn().mockResolvedValue({ worker: workerFixture() })
+    mocked.getWorkerTrace = vi.fn().mockResolvedValue({
+      events: [
+        { ts: '2026-08-01T00:00:01.000Z', kind: 'llm_call', summary: 'llm end_turn', source: 'native', detail: { stop_reason: 'end_turn' } },
+        { ts: '2026-08-01T00:00:01.000Z', kind: 'message', role: 'assistant', summary: '已完成核对', source: 'native', detail: { content: '已完成核对，等待下一步。' } },
+      ],
+      next_cursor: 'tok-1',
+    })
+    mocked.getWorkerTerminal = vi.fn().mockResolvedValue({ kind: 'live_terminal', text: '', captured_at: '2026-08-01T00:00:00.000Z' })
+
+    renderDetail()
+
+    expect(await screen.findByText('Worker 文本')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Worker 文本：已完成核对，等待下一步。/ })).toBeInTheDocument()
+    expect(screen.queryByText('模型调用')).not.toBeInTheDocument()
   })
 
   it('活动记录分页且切换页面不会保留展开状态', async () => {

--- a/crabot-admin/web/src/services/agent-observability.ts
+++ b/crabot-admin/web/src/services/agent-observability.ts
@@ -134,7 +134,7 @@ export interface WorkerListResult extends PaginatedResult<LedgerWorker> {
 
 export interface WorkerTraceEvent {
   ts: string
-  kind: 'message' | 'tool_call' | 'tool_result' | 'thinking' | 'lifecycle'
+  kind: 'message' | 'llm_call' | 'tool_call' | 'tool_result' | 'thinking' | 'lifecycle'
   role?: 'assistant' | 'user' | 'system'
   summary: string
   detail?: unknown

--- a/crabot-agent/src/types.ts
+++ b/crabot-agent/src/types.ts
@@ -1017,6 +1017,8 @@ export interface LlmCallDetails {
   attempt?: number
   input_summary?: string
   output_summary?: string
+  /** builtin worker 本轮产生的脱敏 assistant text；仅用于 worker trace read model。 */
+  assistant_text?: string
   stop_reason?: string
   tool_calls_count?: number
   full_input?: string

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -3299,11 +3299,13 @@ export class UnifiedAgent extends ModuleBase {
         return trace.trace_id
       },
       appendTurn: (traceId, event) => {
+        const assistantText = redact(event.assistantText)
         const llmSpan = this.traceStore.startSpan(traceId, {
           type: 'llm_call',
           details: {
             model: '',
             stop_reason: event.stopReason,
+            ...(assistantText.trim() ? { assistant_text: assistantText } : {}),
             ...(event.usage ? { usage: event.usage } : {}),
           } as import('./types.js').AgentSpanDetails,
           started_at_ms: event.llmStartedAtMs,

--- a/crabot-agent/src/workers/builtin/adapter.ts
+++ b/crabot-agent/src/workers/builtin/adapter.ts
@@ -578,23 +578,29 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
   private async readTraceWindow(
     h: IncarnationHandle,
     cursor?: import('../types.js').TraceCursor,
-  ): Promise<{ sourceAvailable: boolean; events: import('../types.js').NormalizedTraceEvent[]; nextCursor: import('../types.js').TraceCursor }> {
+  ): Promise<{
+    sourceAvailable: boolean
+    spans: ReadonlyArray<import('../../types.js').AgentSpan>
+    events: import('../types.js').NormalizedTraceEvent[]
+    nextCursor: import('../types.js').TraceCursor
+  }> {
     const metaPath = join(this.deps.dataDir, h.worker_id, `meta-${h.seq}.json`)
     let traceId: string | undefined
     try {
       const meta = JSON.parse(await fs.readFile(metaPath, 'utf-8')) as { trace_id?: string }
       traceId = typeof meta.trace_id === 'string' ? meta.trace_id : undefined
     } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return { sourceAvailable: false, events: [], nextCursor: cursor ?? { offset: 0 } }
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return { sourceAvailable: false, spans: [], events: [], nextCursor: cursor ?? { offset: 0 } }
       throw error
     }
     if (!traceId || !this.deps.traceReader) {
       // 老 meta（升级前写入）没有 trace_id：退化为空、cursor 原样透传（可续读）。
-      return { sourceAvailable: false, events: [], nextCursor: cursor ?? { offset: 0 } }
+      return { sourceAvailable: false, spans: [], events: [], nextCursor: cursor ?? { offset: 0 } }
     }
     const trace = await this.deps.traceReader.readTrace(traceId)
-    if (!trace) return { sourceAvailable: false, events: [], nextCursor: cursor ?? { offset: 0 } }
+    if (!trace) return { sourceAvailable: false, spans: [], events: [], nextCursor: cursor ?? { offset: 0 } }
     const start = cursor?.offset ?? 0
+    const spans = trace.spans.slice(start)
     const events: import('../types.js').NormalizedTraceEvent[] = []
     let consumed = start
     for (let i = start; i < trace.spans.length; i++) {
@@ -602,7 +608,7 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
       events.push(...normalizedEvents.map((event) => ({ ...event, source_offset: i })))
       consumed = i + 1
     }
-    return { sourceAvailable: true, events, nextCursor: { offset: consumed } }
+    return { sourceAvailable: true, spans, events, nextCursor: { offset: consumed } }
   }
 
   async inspectSupervisionActivity(
@@ -612,6 +618,8 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     try {
       const trace = await this.readTraceWindow(h, cursor)
       if (!trace.sourceAvailable) return { kind: 'unknown', next_cursor: cursor ?? { offset: 0 } }
+      // 页面 read model 不得改变既有 Manager 巡检语义：任何 LLM turn 都延续为 text。
+      if (trace.spans.some((span) => span.type === 'llm_call')) return { kind: 'text', next_cursor: trace.nextCursor }
       return classifySupervisionActivity(trace.events, trace.nextCursor)
     } catch {
       return { kind: 'unknown', next_cursor: cursor ?? { offset: 0 } }

--- a/crabot-agent/src/workers/builtin/adapter.ts
+++ b/crabot-agent/src/workers/builtin/adapter.ts
@@ -598,8 +598,8 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     const events: import('../types.js').NormalizedTraceEvent[] = []
     let consumed = start
     for (let i = start; i < trace.spans.length; i++) {
-      const event = normalizeBuiltinSpan(trace.spans[i])
-      if (event) events.push({ ...event, source_offset: i })
+      const normalizedEvents = normalizeBuiltinSpan(trace.spans[i])
+      events.push(...normalizedEvents.map((event) => ({ ...event, source_offset: i })))
       consumed = i + 1
     }
     return { sourceAvailable: true, events, nextCursor: { offset: consumed } }
@@ -1426,26 +1426,37 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
 }
 
 /** builtin trace span → NormalizedTraceEvent（P6-A §8.4）。 */
-function normalizeBuiltinSpan(span: import('../../types.js').AgentSpan): import('../types.js').NormalizedTraceEvent | null {
+function normalizeBuiltinSpan(span: import('../../types.js').AgentSpan): import('../types.js').NormalizedTraceEvent[] {
   const details = (span.details ?? {}) as Record<string, unknown>
   const base = { ts: span.started_at }
   switch (span.type) {
-    case 'llm_call':
-      return {
+    case 'llm_call': {
+      const { assistant_text: assistantText, ...technicalDetails } = details
+      const events: import('../types.js').NormalizedTraceEvent[] = [{
         ...base,
-        kind: 'message',
-        role: 'assistant',
+        kind: 'llm_call',
         summary: typeof details.stop_reason === 'string' ? `llm ${details.stop_reason}` : 'llm call',
-        detail: details,
+        detail: technicalDetails,
+      }]
+      if (typeof assistantText === 'string' && assistantText.trim()) {
+        events.push({
+          ...base,
+          kind: 'message',
+          role: 'assistant',
+          summary: assistantText.replace(/\s+/g, ' ').trim().slice(0, 200),
+          detail: { content: assistantText },
+        })
       }
+      return events
+    }
     case 'tool_call':
-      return {
+      return [{
         ...base,
         kind: 'tool_call',
         summary: typeof details.name === 'string' ? String(details.name) : 'tool call',
         detail: details,
-      }
+      }]
     default:
-      return { ...base, kind: 'lifecycle', summary: span.type, detail: details }
+      return [{ ...base, kind: 'lifecycle', summary: span.type, detail: details }]
   }
 }

--- a/crabot-agent/src/workers/types.ts
+++ b/crabot-agent/src/workers/types.ts
@@ -123,7 +123,7 @@ export interface ForkOptions {
 
 export interface NormalizedTraceEvent {
   readonly ts: string
-  readonly kind: 'message' | 'tool_call' | 'tool_result' | 'thinking' | 'lifecycle'
+  readonly kind: 'message' | 'llm_call' | 'tool_call' | 'tool_result' | 'thinking' | 'lifecycle'
   readonly role?: 'assistant' | 'user' | 'system'
   readonly summary: string
   readonly detail?: unknown

--- a/crabot-agent/tests/agent/builtin-trace-hooks.test.ts
+++ b/crabot-agent/tests/agent/builtin-trace-hooks.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest'
+import { UnifiedAgent } from '../../src/unified-agent.js'
+import type { EngineTurnEvent } from '../../src/engine/types.js'
+import type { BuiltinTraceHooks } from '../../src/workers/builtin/adapter.js'
+
+type BuiltinTraceHookFactory = {
+  builtinTraceHooks(): BuiltinTraceHooks
+}
+
+describe('UnifiedAgent builtin trace hooks', () => {
+  it('持久化脱敏后的非空 assistant text，空文本不写字段', () => {
+    const traceStore = {
+      startSpan: vi.fn(() => ({ span_id: 'span-1' })),
+      endSpan: vi.fn(),
+    }
+    const hooks = (UnifiedAgent.prototype as unknown as BuiltinTraceHookFactory).builtinTraceHooks.call({
+      traceStore,
+      knownSecrets: new Set(['secret-value']),
+      config: { moduleId: 'agent-test' },
+    })
+
+    hooks.appendTurn('trace-1', {
+      assistantText: '结果包含 secret-value。',
+      stopReason: 'end_turn',
+      toolCalls: [],
+      llmStartedAtMs: 100,
+      llmCallMs: 50,
+    } as EngineTurnEvent)
+    hooks.appendTurn('trace-1', {
+      assistantText: ' \n ',
+      stopReason: 'tool_use',
+      toolCalls: [],
+    } as EngineTurnEvent)
+
+    expect(traceStore.startSpan.mock.calls[0][1]).toMatchObject({
+      type: 'llm_call',
+      details: { assistant_text: '结果包含 [REDACTED]。', stop_reason: 'end_turn' },
+      started_at_ms: 100,
+    })
+    expect(traceStore.endSpan).toHaveBeenCalledWith('trace-1', 'span-1', 'completed', undefined, 150)
+    expect(traceStore.startSpan.mock.calls[1][1].details).not.toHaveProperty('assistant_text')
+  })
+})

--- a/crabot-agent/tests/workers/builtin-adapter.test.ts
+++ b/crabot-agent/tests/workers/builtin-adapter.test.ts
@@ -9,6 +9,7 @@ import type { SpawnSpec, IncarnationHandle, IncarnationRef, StateChangeReport, W
 import type { LLMAdapter } from '../../src/engine/llm-adapter-types.js'
 import { defineTool } from '../../src/engine/index.js'
 import type { EngineMessage, ToolDefinition } from '../../src/engine/index.js'
+import type { AgentTrace } from '../../src/types.js'
 import * as engineModule from '../../src/engine/query-loop.js'
 import { chunksFromContent } from '../engine/helpers/mock-stream.js'
 
@@ -351,6 +352,52 @@ describe('BuiltinWorkerAdapter', () => {
     })
 
     await adapter.kill(h)
+  })
+
+  it('llm span 分开投影模型调用与 assistant 文本，且 cursor 按 span 推进一次', async () => {
+    const trace = {
+      spans: [
+        {
+          type: 'llm_call',
+          started_at: '2026-08-20T01:00:00.000Z',
+          details: { stop_reason: 'tool_use', assistant_text: '先检查当前配置。\n然后读取日志。', usage: { input_tokens: 10, output_tokens: 5 } },
+        },
+        {
+          type: 'tool_call',
+          started_at: '2026-08-20T01:00:01.000Z',
+          details: { name: 'shell', input_summary: 'pwd' },
+        },
+        {
+          type: 'llm_call',
+          started_at: '2026-08-20T01:00:02.000Z',
+          details: { stop_reason: 'tool_use' },
+        },
+      ],
+    } as unknown as AgentTrace
+    const adapter = new BuiltinWorkerAdapter({
+      dataDir: tmp,
+      traceHooks: {
+        startIncarnationTrace: () => 'trace-1',
+        appendTurn: () => {},
+        finishIncarnationTrace: () => {},
+      },
+      traceReader: { readTrace: async () => trace },
+    })
+    const h = await adapter.spawn(spec({ adapter: makeAdapter([{ stopReason: 'end_turn' }]) }))
+    await waitState(adapter, h, 'idle')
+
+    const first = await adapter.readTrace(h)
+
+    expect(first.events).toMatchObject([
+      { kind: 'llm_call', summary: 'llm tool_use', source_offset: 0, detail: { stop_reason: 'tool_use' } },
+      { kind: 'message', role: 'assistant', summary: '先检查当前配置。 然后读取日志。', source_offset: 0, detail: { content: '先检查当前配置。\n然后读取日志。' } },
+      { kind: 'tool_call', summary: 'shell', source_offset: 1 },
+      { kind: 'llm_call', summary: 'llm tool_use', source_offset: 2 },
+    ])
+    expect(first.events[0].detail).not.toHaveProperty('assistant_text')
+    expect(first.nextCursor).toEqual({ offset: 3 })
+
+    await expect(adapter.readTrace(h, first.nextCursor)).resolves.toEqual({ events: [], nextCursor: { offset: 3 } })
   })
 
   it('常驻化身只以真实 engine/input 进展更新时间，主线与 fork 回调均接线', async () => {

--- a/crabot-agent/tests/workers/builtin-adapter.test.ts
+++ b/crabot-agent/tests/workers/builtin-adapter.test.ts
@@ -398,6 +398,10 @@ describe('BuiltinWorkerAdapter', () => {
     expect(first.nextCursor).toEqual({ offset: 3 })
 
     await expect(adapter.readTrace(h, first.nextCursor)).resolves.toEqual({ events: [], nextCursor: { offset: 3 } })
+    await expect(adapter.inspectSupervisionActivity(h, { offset: 2 })).resolves.toEqual({
+      kind: 'text',
+      next_cursor: { offset: 3 },
+    })
   })
 
   it('常驻化身只以真实 engine/input 进展更新时间，主线与 fork 回调均接线', async () => {

--- a/crabot-agent/tests/workers/composite-trace.test.ts
+++ b/crabot-agent/tests/workers/composite-trace.test.ts
@@ -9,7 +9,7 @@ import { tmpdir } from 'os'
 import { join } from 'path'
 
 import { readCompositeWorkerTrace } from '../../src/workers/trace/composite-reader.js'
-import { TraceCursorStore } from '../../src/workers/trace/cursor-store.js'
+import { TraceCursorStore, incarnationFingerprint } from '../../src/workers/trace/cursor-store.js'
 import { NativeTraceCopyStore } from '../../src/workers/trace/native-copy.js'
 import type { Incarnation, LedgerWorker } from '../../src/workers/harness/ledger-types.js'
 import type { NormalizedTraceEvent, WorkerAdapter } from '../../src/workers/types.js'
@@ -206,27 +206,42 @@ describe('readCompositeWorkerTrace', () => {
     nativeLines = [
       {
         ts: '2026-08-01T00:00:02.000Z',
-        kind: 'tool_call',
+        kind: 'llm_call',
+        summary: 'llm tool_use',
+        detail: { stop_reason: 'tool_use' },
+        source_offset: 0,
+      },
+      {
+        ts: '2026-08-01T00:00:02.000Z',
+        kind: 'message',
         role: 'assistant',
-        summary: 'exec_command(pwd)',
-        detail: { call_id: 'cmd-1', name: 'exec_command' },
+        summary: '先检查当前目录',
+        detail: { content: '先检查当前目录' },
         source_offset: 0,
       },
       {
         ts: '2026-08-01T00:00:03.000Z',
-        kind: 'tool_result',
-        summary: 'command completed',
-        detail: { call_id: 'cmd-1', output: '/tmp' },
-        source_offset: 0,
+        kind: 'tool_call',
+        role: 'assistant',
+        summary: 'exec_command(pwd)',
+        detail: { call_id: 'cmd-1', name: 'exec_command' },
+        source_offset: 1,
       },
     ]
     await readCompositeWorkerTrace(deps(), { worker_id: WORKER_ID })
+    const copy = await nativeCopy.read(WORKER_ID, 1, incarnationFingerprint({
+      impl: 'claude-code',
+      seq: 1,
+      started_at: '2026-08-01T00:00:00.000Z',
+    }))
+    expect(copy?.events.map((event) => event.source_offset)).toEqual([0, 0, 1])
 
     nativeShouldThrow = 'file gone'
     const fallback = await readCompositeWorkerTrace(deps(), { worker_id: WORKER_ID })
     expect(fallback.events.filter((event) => event.source === 'native')).toMatchObject([
+      { kind: 'llm_call', detail: { stop_reason: 'tool_use' } },
+      { kind: 'message', role: 'assistant', detail: { content: '先检查当前目录' } },
       { kind: 'tool_call', detail: { call_id: 'cmd-1', name: 'exec_command' } },
-      { kind: 'tool_result', detail: { call_id: 'cmd-1', output: '/tmp' } },
     ])
     expect(fallback.events.some((event) => event.summary === 'old lifecycle')).toBe(false)
   })


### PR DESCRIPTION
## 背景

builtin worker 的每个 `llm_call` 过去都会被投影成“任务输出”，即使该轮只有工具调用。页面因此只有 `llm tool_use` 和工具记录，无法判断 worker 是否产生可读文本。

## 变更

- 将 Worker trace read model 扩展为独立的 `llm_call` 技术事件。
- builtin TraceStore 在有非空 assistant text 时持久化脱敏后的 `assistant_text`。
- builtin adapter 将同一 span 投影为“模型调用”及可选的“Worker 文本”，并保持同一 source offset、cursor 和 native copy 语义。
- Worker 详情页将文本展示为“Worker 文本”，模型调用仅放入“技术事件”。

## 兼容与失败路径

- 空文本、脱敏后空文本和旧 trace 中缺少 `assistant_text` 的 span 仅显示技术模型调用，不伪造输出。
- assistant text 不是 channel 投递或最终任务结论。
- 同一 source offset 下的展开事件完整保留到 native copy，公开 REST/RPC 仍不泄漏内部 offset。

## 验证

- `crabot-agent`：60 项定向 Vitest 通过。
- `crabot-admin/web`：12 项 WorkerDetail Vitest 通过。
- Agent TypeScript 编译通过；Vite production bundling 通过。
- Web 正式 TypeScript 配置仍被既有 `WorkersView.tsx` 的 ES2020 `.at()` 不兼容阻断；以 ES2022 lib 的无输出检查通过。