### PR TITLE
feat(workers): notify managers of restart crashes

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -64,6 +64,7 @@
 
 - **Traces 人话视图 + 有界决策视野**：**已合并**（PR #100 → `f7e3aaf`，@claude approve 后自动合并）。Managers 用 `渠道·会话标题`、active worker 数和最近活动替代裸 ManagerKey/Episodes/历史总数；Manager detail 上浮消息摘录/回复/动作并按 worker 因果链折叠；Workers 默认只显示非终态。恢复 v2 dispatcher 不变量：`list_workers` 默认只看 `queued/running/waiting_input`，终态续办需显式分页 `include_terminal=true`；Manager 页面计数与工具视野同源。生产实测 system-tasks 2389 历史→6 active，工具实际 12 active/53 terminal。协议：agent v3.2.0、admin v0.2.2。
 - **统一 Worker Runtime（v3.6.0，待 PR review）**：本次统一替代原 v3.4/v3.5 的分离待审状态；CLI 的 pane 只用于 bracketed-paste 控制和 Manager 按需诊断，不再作为正常进度或 handoff 来源。Claude `Notification`、Codex `PermissionRequest` 与重连检查识别到的未知 UI 以一次性 snapshot + adapter 固定 action descriptor 交给 Manager，不能形成自由 tmux 按键入口；原生 session activity、完成回合、可核验 stop 与私有 handoff package 同属该 PR。
+- **Worker 重启恢复通知（已实现，待 PR review）**：主线执行载体确认消失时，Harness 与 `crashed` 原子写入持久 `recovery_notices`，在既有对账完成后只唤醒 owning Manager；首次立即尝试、未消费按 `30 秒 -> 1 分钟 -> 2 分钟 -> 5 分钟` 持久退避。仅重启 Agent 而 tmux 仍存活时重连；builtin `idle` 在下一条输入按同一会话按需重建。Harness 不自动续跑、重启、handoff 或向人类汇报。
 - **统一 observability retention（PR B，已确认 spec/协议/计划，待实施）**：自动回收终态 Worker 的 adapter output/session、events/context、ledger、过期 Manager episode/TraceStore；孤儿 adapter/events 24h grace；output log 10MB cap；删除失真的 Trace 清理 UI/API/cron。**所有 workspace 零自动删除**——`$DATA_DIR/workspaces/<taskId>` 是用户项目/任务产物，不是 cache；当前 nomi-ai-companion 的 1GB Flutter workspace 必须保留。workspace 管理/显式删除以后独立设计。
 
 ### P6 主线（严格串行）
@@ -76,7 +77,6 @@
 
 ### 技术债与既有 follow-up（P6 后或并行确认）
 
-- **关闭窗口终态事件补投**：Worker 的终态事件已落盘但 Manager 正在关闭窗口时，现有启动对账会跳过终态记录，Manager 可能不知道 Worker 已异常结束。需独立设计持久化待消费终态事件的恢复与去重；任务巡检不替代此修复。
 - **Worker 巡检调度收口**：启动对账与周期巡检应共享 due 投递排他；避免单个 Worker 的长锁阻塞全局活性巡检；默认巡检在全局 LLM 故障时需要有界的失败告警去重/退避。三项均需独立设计，不纳入当前任务巡检 PR。
 - **移除 Agent 内部 legacy `roles` seam**：`AgentLayerConfig.roles` 是 v2 前多 Agent 时代残留（正式协议从未包含），现仅作内部测试 seam/恒真分支；应替换为显式的 worker-layer 开关后删除。
 - **普通 Channel 未消费人类 wake 的跨重启恢复**：2026-08-19 实测，飞书私聊消息已落 Channel journal、reaction 已发且同 session Manager episode 已创建，但 Agent 在首次 LLM 调用前 OOM 重启；启动恢复只将遗留 episode 标为 `interrupted`，未将该 wake 重放，后续 worker 事件遂基于旧上下文回复。需独立设计普通 Channel 的持久化入站 wake、成功消费后结算、重启按原始顺序幂等重放；不得用扩大 Manager recent、滚动摘要或 prompt 约束替代。

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -3909,6 +3909,8 @@ export class UnifiedAgent extends ModuleBase {
         this.managerReconciliationSettled = true
         if (this.runtimeClosing) return
         await this.agentHandler?.releaseRecoveredWorkerShellExits()
+        await stack.harness.reconcileRecoveryNoticesOnStartup()
+        if (this.runtimeClosing) return
         stack.harness.startLivenessSweep()
       })
   }
@@ -3924,6 +3926,7 @@ export class UnifiedAgent extends ModuleBase {
     this.attentionScheduler.stopAll()
     this.traceStore.stopFlushTimer()
     this.managerStack?.harness.stopLivenessSweep()
+    this.managerStack?.harness.stopRecoveryNoticeDelivery()
 
     try {
       await this.managerStack?.dispose()

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -3909,7 +3909,12 @@ export class UnifiedAgent extends ModuleBase {
         this.managerReconciliationSettled = true
         if (this.runtimeClosing) return
         await this.agentHandler?.releaseRecoveredWorkerShellExits()
-        await stack.harness.reconcileRecoveryNoticesOnStartup()
+        // Notice routing may run a whole Manager episode. It starts only after all existing
+        // recovery work above, but must not hold startup's liveness drain or escape this chain.
+        void stack.harness.reconcileRecoveryNoticesOnStartup().catch((error) => {
+          const message = error instanceof Error ? error.message : String(error)
+          console.warn(`[${this.config.moduleId}] worker recovery notice delivery startup failed（不影响启动）:`, message)
+        })
         if (this.runtimeClosing) return
         stack.harness.startLivenessSweep()
       })

--- a/crabot-agent/src/workers/builtin/adapter.ts
+++ b/crabot-agent/src/workers/builtin/adapter.ts
@@ -615,7 +615,8 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
       return undefined
     }
 
-    const sessionTree = await SessionTree.load(join(dir, 'session.jsonl'))
+    const sessionTree = this.findSessionTreeForWorker(h.worker_id) ??
+      await SessionTree.load(join(dir, 'session.jsonl'))
     // Validate the persisted tip before registering any resident state. A corrupted tree must be
     // reported through the normal input receipt, not rewritten into a fabricated crash.
     sessionTree.pathTo(meta.tip_node_id)

--- a/crabot-agent/src/workers/builtin/adapter.ts
+++ b/crabot-agent/src/workers/builtin/adapter.ts
@@ -524,9 +524,15 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     // "两次背靠背 sendInput 都读到 idle、拿同一 tip"的 check-then-act 竞态（跨 await 边界）。
     const mutex = this.getMutex(h.worker_id)
     const startBurst = await mutex.run(async () => {
-      const instance = this.instances.get(instanceKey(h.worker_id, h.seq))
+      let instance = this.instances.get(instanceKey(h.worker_id, h.seq))
+      let rehydratedRuntime: NonNullable<SpawnSpec['builtin']> | undefined
       if (!instance) {
-        throw new Error(`BuiltinWorkerAdapter.sendInput: no such incarnation ${h.worker_id}#${h.seq} resident in this process`)
+        const rehydrated = await this.rehydrateIdleInstance(h)
+        if (!rehydrated) {
+          throw new Error(`BuiltinWorkerAdapter.sendInput: no such incarnation ${h.worker_id}#${h.seq} resident in this process`)
+        }
+        instance = rehydrated.instance
+        rehydratedRuntime = rehydrated.runtime
       }
 
       if (instance.state === 'exited') {
@@ -545,7 +551,7 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
       // idle → 追加新一轮用户消息，转 running。起 burst 留到锁外（见下）。
       // 运行配置现取：idle 态下没有 burst 在跑，重新解析一次不会干扰任何正在执行的东西，
       // 语义与"起化身现取"一致（正在跑的 burst 用旧配置，见 runBurst 续 burst 路径）。
-      const builtin = await this.runtimeFor(h.worker_id, 'sendInput', instance.workspaceInstructions)
+      const builtin = rehydratedRuntime ?? await this.runtimeFor(h.worker_id, 'sendInput', instance.workspaceInstructions)
       instance.tip = await instance.sessionTree.append(instance.tip, createUserMessage(text))
       await this.transitionState(instance, h, 'running')
       instance.activityAt = Date.now()
@@ -580,6 +586,57 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     const raw = await fs.readFile(metaPath, 'utf-8')
     const meta = JSON.parse(raw) as { state: WorkerContractState }
     return meta.state
+  }
+
+  /**
+   * A persisted idle meta means no engine was running when the process stopped. Rebuild only that
+   * exact incarnation under the caller's worker mutex; a running/exited meta deliberately remains
+   * outside this path so scanOrphans and normal terminal handling keep their crash semantics.
+   */
+  private async rehydrateIdleInstance(
+    h: IncarnationHandle,
+  ): Promise<{ instance: WorkerInstance; runtime: NonNullable<SpawnSpec['builtin']> } | undefined> {
+    const dir = join(this.deps.dataDir, h.worker_id)
+    const metaPath = join(dir, `meta-${h.seq}.json`)
+    let raw: string
+    try {
+      raw = await fs.readFile(metaPath, 'utf-8')
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined
+      throw error
+    }
+    const meta = JSON.parse(raw) as {
+      seq?: number
+      state?: WorkerContractState
+      tip_node_id?: string
+      trace_id?: string
+    }
+    if (meta.seq !== h.seq || meta.state !== 'idle' || typeof meta.tip_node_id !== 'string' || !meta.tip_node_id) {
+      return undefined
+    }
+
+    const sessionTree = await SessionTree.load(join(dir, 'session.jsonl'))
+    // Validate the persisted tip before registering any resident state. A corrupted tree must be
+    // reported through the normal input receipt, not rewritten into a fabricated crash.
+    sessionTree.pathTo(meta.tip_node_id)
+    const context = await this.loadContext(h.worker_id)
+    const runtime = await this.runtimeFor(h.worker_id, 'sendInput', context?.workspace_instructions)
+    const instance: WorkerInstance = {
+      worker_id: h.worker_id,
+      incarnation_id: h.incarnation_id,
+      seq: h.seq,
+      dir,
+      sessionTree,
+      outputLog: new OutputLog(join(dir, `output-${h.seq}.log`)),
+      tip: meta.tip_node_id,
+      activityAt: Date.now(),
+      ...(typeof meta.trace_id === 'string' ? { traceId: meta.trace_id } : {}),
+      state: 'idle',
+      pendingInputs: [],
+      ...(context?.workspace_instructions !== undefined ? { workspaceInstructions: context.workspace_instructions } : {}),
+    }
+    this.instances.set(instanceKey(h.worker_id, h.seq), instance)
+    return { instance, runtime }
   }
 
   /**

--- a/crabot-agent/src/workers/harness/harness.ts
+++ b/crabot-agent/src/workers/harness/harness.ts
@@ -5232,7 +5232,11 @@ export class WorkerHarness {
       )
     })
     await this.deliverNativeActivityNotifications(h.worker_id)
-    if (recoveryNoticeCreated) await this.deliverRecoveryNotices()
+    if (recoveryNoticeCreated) {
+      void this.deliverRecoveryNotices().catch((error) => {
+        console.error(`[WorkerHarness] recovery notice delivery failed after crash of ${h.worker_id}#${h.seq}:`, error)
+      })
+    }
     if (state === 'exited') this.fireIncarnationTerminal(h)
 
     if (!report?.notification && settledCurrentExit) {

--- a/crabot-agent/src/workers/harness/harness.ts
+++ b/crabot-agent/src/workers/harness/harness.ts
@@ -106,6 +106,7 @@ import {
   type LedgerWorker,
   type ManagerKey,
   type TaskStatus,
+  type WorkerRecoveryNotice,
   type WorkerSupervision,
 } from './ledger-types'
 import type { LedgerStore } from './ledger-store'
@@ -421,6 +422,7 @@ export const LIVENESS_STALL_MS = 30 * 60_000
 export const LIVENESS_SWEEP_INTERVAL_MS = 5 * 60_000
 export const SUPERVISION_DEFAULT_INTERVAL_MS = 15 * 60_000
 const SUPERVISION_RETRY_INTERVAL_MS = 5 * 60_000
+const RECOVERY_NOTICE_RETRY_DELAYS_MS = [30_000, 60_000, 120_000, 300_000] as const
 
 // findWorker() reloads and validates the worker's whole owning ledger. A manager can own thousands
 // of workers, so a harness sweep must not start an unbounded number of those reads at once.
@@ -471,6 +473,40 @@ function describeLivenessRetry(opts: { impl: WorkerImplId; staleMs: number }): s
  */
 function retryDelayMs(attempts: number): number {
   return LIVENESS_STALL_MS * 2 ** Math.min(Math.max(attempts - 1, 0), 2)
+}
+
+function recoveryNoticeRetryDelayMs(attempts: number): number {
+  return RECOVERY_NOTICE_RETRY_DELAYS_MS[
+    Math.min(Math.max(attempts - 1, 0), RECOVERY_NOTICE_RETRY_DELAYS_MS.length - 1)
+  ]
+}
+
+function recoveryNoticeDue(notice: WorkerRecoveryNotice, now: string): boolean {
+  return notice.retry_after_at === undefined || Date.parse(notice.retry_after_at) <= Date.parse(now)
+}
+
+function appendRecoveryNotice(
+  notices: readonly WorkerRecoveryNotice[] | undefined,
+  incarnationId: IncarnationId,
+  now: string,
+): { notices: WorkerRecoveryNotice[]; created: boolean } {
+  const current = notices ?? []
+  if (current.some((notice) => notice.incarnation_id === incarnationId)) {
+    return { notices: [...current], created: false }
+  }
+  return {
+    notices: [
+      ...current,
+      {
+        notice_id: randomUUID(),
+        incarnation_id: incarnationId,
+        status: 'pending',
+        created_at: now,
+        attempts: 0,
+      },
+    ],
+    created: true,
+  }
 }
 
 /**
@@ -753,6 +789,7 @@ export class WorkerHarness {
   private readonly uiSnapshotStore: WorkerUiSnapshotStore
   private readonly nativeActivityNotificationMutexes = new Map<string, AsyncMutex>()
   private readonly controlNotificationMutexes = new Map<string, AsyncMutex>()
+  private readonly recoveryNoticeNotificationMutexes = new Map<string, AsyncMutex>()
   private readonly inputDeliveryControllers = new Map<string, AbortController>()
   private readonly pendingQueryStateChanges = new Map<
     string,
@@ -789,6 +826,9 @@ export class WorkerHarness {
   private sweepTimer?: ReturnType<typeof setInterval>
   /** `stopLivenessSweep` 置位后不再接受 `startLivenessSweep`(见该方法注释的停机竞态)。 */
   private sweepStopped = false
+  private recoveryNoticeDrainInFlight = false
+  private recoveryNoticeTimer?: ReturnType<typeof setTimeout>
+  private recoveryNoticeDeliveryStopped = false
 
   constructor(private readonly deps: HarnessDeps) {
     this.contextStore = new WorkerContextStore(deps.workersDir)
@@ -3554,6 +3594,127 @@ export class WorkerHarness {
   }
 
   /**
+   * Startup calls this only after the existing carrier/input/query/control/bg-shell reconciliation
+   * has opened the Manager route. Historical crashed workers without a persisted notice are never
+   * inferred here.
+   */
+  async reconcileRecoveryNoticesOnStartup(): Promise<void> {
+    await this.deliverRecoveryNotices()
+  }
+
+  /** Stops scheduled recovery routes while retaining pending ledger facts for the next process. */
+  stopRecoveryNoticeDelivery(): void {
+    this.recoveryNoticeDeliveryStopped = true
+    if (this.recoveryNoticeTimer) {
+      clearTimeout(this.recoveryNoticeTimer)
+      this.recoveryNoticeTimer = undefined
+    }
+  }
+
+  private async deliverRecoveryNotices(): Promise<void> {
+    if (this.recoveryNoticeDeliveryStopped || this.deps.isClosing?.() || !this.deps.onOperationNotification) return
+    if (this.recoveryNoticeDrainInFlight) return
+    this.recoveryNoticeDrainInFlight = true
+    try {
+      const now = this.deps.now()
+      const nowMs = Date.parse(now)
+      const due = (await this.deps.ledger.listAllWorkers()).flatMap(({ worker }) =>
+        (worker.recovery_notices ?? [])
+          .filter((notice) => notice.status === 'pending' &&
+            (notice.retry_after_at === undefined || Date.parse(notice.retry_after_at) <= nowMs))
+          .map((notice) => ({ worker_id: worker.worker_id, notice_id: notice.notice_id })),
+      )
+      for (const item of due) {
+        try {
+          await this.deliverRecoveryNotice(item.worker_id, item.notice_id)
+        } catch (error) {
+          console.error(`[WorkerHarness] recovery notice settlement failed for ${item.worker_id}/${item.notice_id}:`, error)
+        }
+      }
+    } finally {
+      this.recoveryNoticeDrainInFlight = false
+      await this.armRecoveryNoticeTimer()
+    }
+  }
+
+  private async deliverRecoveryNotice(workerId: string, noticeId: string): Promise<void> {
+    const mutex = this.recoveryNoticeNotificationMutexes.get(workerId) ?? new AsyncMutex()
+    this.recoveryNoticeNotificationMutexes.set(workerId, mutex)
+    await mutex.run(async () => {
+      const prepared = await this.withLock(workerId, async () => {
+        const found = await this.deps.ledger.findWorker(workerId)
+        const notice = found?.worker.recovery_notices?.find((item) => item.notice_id === noticeId)
+        if (!found || !notice || notice.status !== 'pending' || !recoveryNoticeDue(notice, this.deps.now())) return undefined
+        const incarnation = found.worker.incarnations.find((item) => item.incarnation_id === notice.incarnation_id)
+        if (!incarnation || !isExecutableIncarnation(incarnation)) return undefined
+        return {
+          managerKey: found.managerKey,
+          event: this.buildEvent(workerId, incarnation.seq, 'worker_recovery_required', {
+            notice_id: notice.notice_id,
+            incarnation_id: notice.incarnation_id,
+            text: '[crabot] worker 的执行载体在重启后确认已中断。请先读取 worker 状态和必要的原生会话活动，再决定继续、交接、汇报或停止。',
+          }),
+        }
+      })
+      if (!prepared) return
+      if (this.recoveryNoticeDeliveryStopped || this.deps.isClosing?.()) return
+
+      let consumed = false
+      try {
+        consumed = (await this.deps.onOperationNotification?.(prepared.managerKey, prepared.event))?.consumed === true
+      } catch (error) {
+        console.error(`[WorkerHarness] recovery notice delivery failed for ${workerId}/${noticeId}:`, error)
+      }
+
+      await this.withLock(workerId, async () => {
+        // A route that overlapped shutdown has no durable consumption confirmation. Keep the
+        // notice untouched so the next process can route it again after its gate opens.
+        if (this.recoveryNoticeDeliveryStopped || this.deps.isClosing?.()) return
+        const now = this.deps.now()
+        await this.deps.ledger.upsertWorker(prepared.managerKey, workerId, (prev) => {
+          if (!prev) return undefined
+          const notices = prev.recovery_notices ?? []
+          const index = notices.findIndex((item) => item.notice_id === noticeId)
+          const current = index < 0 ? undefined : notices[index]
+          if (!current || current.status !== 'pending') return prev
+          const next = [...notices]
+          next[index] = consumed
+            ? { ...current, status: 'consumed', consumed_at: now, retry_after_at: undefined }
+            : {
+                ...current,
+                attempts: current.attempts + 1,
+                retry_after_at: plusMs(now, recoveryNoticeRetryDelayMs(current.attempts + 1)),
+              }
+          return { ...prev, recovery_notices: next, updated_at: now }
+        })
+      })
+    })
+  }
+
+  private async armRecoveryNoticeTimer(): Promise<void> {
+    if (this.recoveryNoticeDeliveryStopped || this.deps.isClosing?.() || !this.deps.onOperationNotification) return
+    let earliest: number | undefined
+    const now = Date.parse(this.deps.now())
+    for (const { worker } of await this.deps.ledger.listAllWorkers()) {
+      for (const notice of worker.recovery_notices ?? []) {
+        if (notice.status !== 'pending') continue
+        const dueAt = notice.retry_after_at === undefined ? now : Date.parse(notice.retry_after_at)
+        if (!Number.isFinite(dueAt)) continue
+        earliest = earliest === undefined ? dueAt : Math.min(earliest, dueAt)
+      }
+    }
+    if (earliest === undefined) return
+    if (this.recoveryNoticeTimer) clearTimeout(this.recoveryNoticeTimer)
+    this.recoveryNoticeTimer = setTimeout(() => {
+      this.recoveryNoticeTimer = undefined
+      void this.deliverRecoveryNotices().catch((error) => {
+        console.error('[WorkerHarness] recovery notice delivery sweep failed:', error)
+      })
+    }, Math.max(0, earliest - now))
+    this.recoveryNoticeTimer.unref?.()
+  }
+
+  /**
    * 启动 / 停止周期性的活性巡检(protocol-agent-v3 §6.3 第 3 条的兜底)。
    *
    * 装配层(`unified-agent.ts`)在启动对账之后开、停机时关。`unref()`:巡检是后台兜底,
@@ -4063,6 +4224,7 @@ export class WorkerHarness {
     const now = this.deps.now()
     const crashed = await this.deps.ledger.upsertWorker(managerKey, worker.worker_id, (prev) => {
       if (!prev) return undefined
+      const current = findIncarnation(prev, mainline.impl, mainline.seq)
       const nextTask = transitionTaskTo(prev.task, 'failed', { error: detailReason, now })
       const incarnations = patchIncarnationBySeq(prev.incarnations, mainline.impl, mainline.seq, {
         state: 'exited',
@@ -4076,7 +4238,17 @@ export class WorkerHarness {
         mainline.seq,
         now,
       )
-      return { ...prev, task: nextTask, incarnations, ...(supervision ? { supervision } : {}), updated_at: now }
+      const recovery = current?.forked_from === undefined && current?.state !== 'exited' && current?.incarnation_id
+        ? appendRecoveryNotice(prev.recovery_notices, current.incarnation_id, now)
+        : undefined
+      return {
+        ...prev,
+        task: nextTask,
+        incarnations,
+        ...(supervision ? { supervision } : {}),
+        ...(recovery ? { recovery_notices: recovery.notices } : {}),
+        updated_at: now,
+      }
     })
     await this.appendEvent(
       worker.worker_id,
@@ -4868,6 +5040,7 @@ export class WorkerHarness {
     report?: StateChangeReport,
   ): Promise<void> {
     let settledCurrentExit = false
+    let recoveryNoticeCreated = false
     // 被动唤醒只携带 adapter 已经结构化识别出的 assistant text。tmux capture 是调用方
     // 显式请求的诊断视图，不能因一次状态回调被常规塞进 manager 上下文。
     const wakeText = truncateWakeText(report?.lastText, WAKE_TEXT_MAX_CHARS, '', 'head')
@@ -5021,7 +5194,19 @@ export class WorkerHarness {
           h.seq,
           now,
         )
-        return { ...prev, task: nextTask, incarnations, ...(supervision ? { supervision } : {}), updated_at: now }
+        const recovery = state === 'exited' && endReason === 'crashed' && !preserveTaskForStop &&
+          current?.forked_from === undefined && current?.state !== 'exited' && current?.incarnation_id
+          ? appendRecoveryNotice(prev.recovery_notices, current.incarnation_id, now)
+          : undefined
+        recoveryNoticeCreated ||= recovery?.created === true
+        return {
+          ...prev,
+          task: nextTask,
+          incarnations,
+          ...(supervision ? { supervision } : {}),
+          ...(recovery ? { recovery_notices: recovery.notices } : {}),
+          updated_at: now,
+        }
       })
       settledCurrentExit = state === 'exited' && committed !== undefined
       const turn = shouldCreateTurn && committed
@@ -5047,6 +5232,7 @@ export class WorkerHarness {
       )
     })
     await this.deliverNativeActivityNotifications(h.worker_id)
+    if (recoveryNoticeCreated) await this.deliverRecoveryNotices()
     if (state === 'exited') this.fireIncarnationTerminal(h)
 
     if (!report?.notification && settledCurrentExit) {

--- a/crabot-agent/src/workers/harness/ledger-store.ts
+++ b/crabot-agent/src/workers/harness/ledger-store.ts
@@ -342,6 +342,59 @@ function isTerminalTaskStatus(status: LedgerWorker['task']['status']): boolean {
 function assertWorkerLegacyShape(worker: LedgerWorker): void {
   const hasLegacyIncarnation = worker.incarnations.some((incarnation) => incarnation.impl === 'legacy')
   if (worker.legacy_source || hasLegacyIncarnation) assertLegacyWorker(worker)
+  assertRecoveryNotices(worker)
+}
+
+function assertRecoveryNotices(worker: LedgerWorker): void {
+  const notices = worker.recovery_notices
+  if (notices === undefined) return
+  if (!Array.isArray(notices)) {
+    throw new Error(`[LedgerStore] recovery_notices must be an array for ${worker.worker_id}`)
+  }
+
+  const mainlineIds = new Set(
+    worker.incarnations
+      .filter((incarnation) => incarnation.impl !== 'legacy' && incarnation.forked_from === undefined)
+      .map((incarnation) => incarnation.incarnation_id)
+      .filter((incarnationId): incarnationId is string => typeof incarnationId === 'string' && incarnationId.length > 0),
+  )
+  const noticeIds = new Set<string>()
+  const incarnationIds = new Set<string>()
+  for (const notice of notices) {
+    if (!notice || typeof notice.notice_id !== 'string' || notice.notice_id.length === 0) {
+      throw new Error(`[LedgerStore] recovery notice has invalid notice_id for ${worker.worker_id}`)
+    }
+    if (!noticeIds.add(notice.notice_id)) {
+      throw new Error(`[LedgerStore] duplicate recovery notice_id '${notice.notice_id}' for ${worker.worker_id}`)
+    }
+    if (typeof notice.incarnation_id !== 'string' || notice.incarnation_id.length === 0) {
+      throw new Error(`[LedgerStore] recovery notice has invalid incarnation_id for ${worker.worker_id}`)
+    }
+    if (!incarnationIds.add(notice.incarnation_id)) {
+      throw new Error(`[LedgerStore] duplicate recovery notice incarnation_id '${notice.incarnation_id}' for ${worker.worker_id}`)
+    }
+    if (!mainlineIds.has(notice.incarnation_id)) {
+      throw new Error(`[LedgerStore] recovery notice must reference an executable mainline incarnation for ${worker.worker_id}`)
+    }
+    if (notice.status !== 'pending' && notice.status !== 'consumed') {
+      throw new Error(`[LedgerStore] recovery notice has invalid status for ${worker.worker_id}`)
+    }
+    if (typeof notice.created_at !== 'string' || !Number.isFinite(Date.parse(notice.created_at)) ||
+      !Number.isInteger(notice.attempts) || notice.attempts < 0) {
+      throw new Error(`[LedgerStore] recovery notice has invalid metadata for ${worker.worker_id}`)
+    }
+    if (notice.retry_after_at !== undefined &&
+      (typeof notice.retry_after_at !== 'string' || !Number.isFinite(Date.parse(notice.retry_after_at)))) {
+      throw new Error(`[LedgerStore] recovery notice has invalid retry_after_at for ${worker.worker_id}`)
+    }
+    if (notice.status === 'consumed' &&
+      (typeof notice.consumed_at !== 'string' || !Number.isFinite(Date.parse(notice.consumed_at)))) {
+      throw new Error(`[LedgerStore] consumed recovery notice has no consumed_at for ${worker.worker_id}`)
+    }
+    if (notice.status === 'pending' && notice.consumed_at !== undefined) {
+      throw new Error(`[LedgerStore] pending recovery notice has consumed_at for ${worker.worker_id}`)
+    }
+  }
 }
 
 function assertLegacyWorker(worker: LedgerWorker, initialImport = false): void {

--- a/crabot-agent/src/workers/harness/ledger-types.ts
+++ b/crabot-agent/src/workers/harness/ledger-types.ts
@@ -101,6 +101,17 @@ export interface WorkerSupervision {
   }
 }
 
+/** Durable responsibility to wake the owning Manager after a mainline execution carrier crashed. */
+export interface WorkerRecoveryNotice {
+  notice_id: string
+  incarnation_id: IncarnationId
+  status: 'pending' | 'consumed'
+  created_at: string
+  attempts: number
+  retry_after_at?: string
+  consumed_at?: string
+}
+
 export interface LedgerWorker {
   worker_id: string
   /** Immutable session owner: storage, lookup, routing and read model all use this field. */
@@ -127,6 +138,8 @@ export interface LedgerWorker {
   report_to: { channel_id: ModuleId; session_id: SessionId }
   incarnations: Incarnation[]
   supervision?: WorkerSupervision
+  /** Missing on historical ledgers means no recovery work is inferred. */
+  recovery_notices?: WorkerRecoveryNotice[]
   legacy_source?: LegacySourceRef
   updated_at: string
 }

--- a/crabot-agent/src/workers/harness/worker-events.ts
+++ b/crabot-agent/src/workers/harness/worker-events.ts
@@ -36,6 +36,8 @@ export type HarnessEventKind =
   | 'query_failed'
   | 'query_completed'
   | 'supervision_due'
+  /** Durable wake for a mainline execution carrier that was confirmed crashed after restart. */
+  | 'worker_recovery_required'
   /** v2 import history record: persisted only, never bridged to a Manager wake. */
   | 'legacy_imported'
 

--- a/crabot-agent/tests/manager/p5-integration.test.ts
+++ b/crabot-agent/tests/manager/p5-integration.test.ts
@@ -671,15 +671,20 @@ describe('P5 集成：manager 栈启动接线（Task 6）', () => {
     expect(sweep).toHaveBeenCalledOnce()
   })
 
-  it('启动对账收尾按 bg-shell 结算、恢复提醒、活性巡检的顺序释放 Manager 路由', async () => {
+  it('启动对账收尾在 bg-shell 结算后后台投递恢复提醒，不阻塞活性巡检', async () => {
     boot()
     const stack = internals.managerStack!
     const order: string[] = []
+    let releaseRecovery!: () => void
+    let recoveryFinished = false
+    const recoveryGate = new Promise<void>((resolve) => { releaseRecovery = resolve })
     internals.agentHandler = {
       releaseRecoveredWorkerShellExits: vi.fn(async () => { order.push('bg-shell') }),
     } as any
     vi.spyOn(stack.harness, 'reconcileRecoveryNoticesOnStartup').mockImplementation(async () => {
       order.push('recovery-notices')
+      await recoveryGate
+      recoveryFinished = true
     })
     vi.spyOn(stack.harness, 'startLivenessSweep').mockImplementation(() => { order.push('liveness') })
 
@@ -687,6 +692,26 @@ describe('P5 集成：manager 栈启动接线（Task 6）', () => {
     await waitUntil(() => order.length === 3)
 
     expect(order).toEqual(['bg-shell', 'recovery-notices', 'liveness'])
+    releaseRecovery()
+    await waitUntil(() => recoveryFinished)
+  })
+
+  it('恢复提醒后台投递失败只告警，不会阻塞巡检或形成未处理拒绝', async () => {
+    boot()
+    const stack = internals.managerStack!
+    const failure = new Error('recovery notice ledger unavailable')
+    vi.spyOn(stack.harness, 'reconcileRecoveryNoticesOnStartup').mockRejectedValue(failure)
+    const sweep = vi.spyOn(stack.harness, 'startLivenessSweep').mockImplementation(() => {})
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    agent.startManagerStackReconciliation()
+    await waitUntil(() => sweep.mock.calls.length === 1)
+    await waitUntil(() => warn.mock.calls.some((args) => String(args[0]).includes('worker recovery notice delivery startup failed')))
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('worker recovery notice delivery startup failed'),
+      failure.message,
+    )
   })
 
   it('shutdown 已开始时，迟到的启动对账不再释放 recovered bg exits 或启动巡检', async () => {

--- a/crabot-agent/tests/manager/p5-integration.test.ts
+++ b/crabot-agent/tests/manager/p5-integration.test.ts
@@ -671,6 +671,24 @@ describe('P5 集成：manager 栈启动接线（Task 6）', () => {
     expect(sweep).toHaveBeenCalledOnce()
   })
 
+  it('启动对账收尾按 bg-shell 结算、恢复提醒、活性巡检的顺序释放 Manager 路由', async () => {
+    boot()
+    const stack = internals.managerStack!
+    const order: string[] = []
+    internals.agentHandler = {
+      releaseRecoveredWorkerShellExits: vi.fn(async () => { order.push('bg-shell') }),
+    } as any
+    vi.spyOn(stack.harness, 'reconcileRecoveryNoticesOnStartup').mockImplementation(async () => {
+      order.push('recovery-notices')
+    })
+    vi.spyOn(stack.harness, 'startLivenessSweep').mockImplementation(() => { order.push('liveness') })
+
+    agent.startManagerStackReconciliation()
+    await waitUntil(() => order.length === 3)
+
+    expect(order).toEqual(['bg-shell', 'recovery-notices', 'liveness'])
+  })
+
   it('shutdown 已开始时，迟到的启动对账不再释放 recovered bg exits 或启动巡检', async () => {
     boot()
     const stack = internals.managerStack!

--- a/crabot-agent/tests/workers/builtin-adapter.test.ts
+++ b/crabot-agent/tests/workers/builtin-adapter.test.ts
@@ -669,6 +669,45 @@ describe('BuiltinWorkerAdapter', () => {
     expect(JSON.stringify(tree.pathTo(meta.tip_node_id))).toContain('重建后的回复')
   })
 
+  it('重启后先 fork 再重建 idle 主线时复用已驻留的 session tree', async () => {
+    const workerId = randomUUID()
+    const adapter1 = new BuiltinWorkerAdapter({ dataDir: tmp })
+    const h = await adapter1.spawn(spec({
+      worker_id: workerId,
+      adapter: makeAdapter([{ text: '第一轮回复', stopReason: 'end_turn' }]),
+    }))
+    await waitState(adapter1, h, 'idle')
+    const initialMeta = JSON.parse(await fs.readFile(join(tmp, workerId, 'meta-1.json'), 'utf-8'))
+
+    const adapter2 = new BuiltinWorkerAdapter({
+      dataDir: tmp,
+      resolveRuntime: () => ({
+        adapter: makeAdapter([{ text: '重建后的回复', stopReason: 'end_turn' }]),
+        model: 'test',
+        systemPrompt: '',
+        tools: [],
+      }),
+    })
+    const firstFork = await adapter2.fork({
+      worker_id: workerId,
+      seq: 1,
+      session_ref: initialMeta.tip_node_id,
+    }, '重启后先侧问', forkOptions())
+    await waitState(adapter2, firstFork, 'exited')
+
+    await adapter2.sendInput(h, '重启后继续')
+    await waitState(adapter2, h, 'idle')
+    const continuedMeta = JSON.parse(await fs.readFile(join(tmp, workerId, 'meta-1.json'), 'utf-8'))
+
+    const secondFork = await adapter2.fork({
+      worker_id: workerId,
+      seq: 1,
+      session_ref: continuedMeta.tip_node_id,
+    }, '从继续后的主线侧问', forkOptions())
+    expect(secondFork.seq).toBe(3)
+    await waitState(adapter2, secondFork, 'exited')
+  })
+
   it('scanOrphans 已标 crashed 的 running 化身不能被 idle 重建路径复活', async () => {
     const workerId = randomUUID()
     const gate = deferred<void>()

--- a/crabot-agent/tests/workers/builtin-adapter.test.ts
+++ b/crabot-agent/tests/workers/builtin-adapter.test.ts
@@ -639,6 +639,64 @@ describe('BuiltinWorkerAdapter', () => {
     })
   })
 
+  it('进程重启后的 idle 化身按下一条普通输入重建同一 session，并起新的 burst', async () => {
+    const workerId = randomUUID()
+    const adapter1 = new BuiltinWorkerAdapter({ dataDir: tmp })
+    const h = await adapter1.spawn(spec({
+      worker_id: workerId,
+      adapter: makeAdapter([{ text: '第一轮回复', stopReason: 'end_turn' }]),
+    }))
+    await waitState(adapter1, h, 'idle')
+
+    const adapter2 = new BuiltinWorkerAdapter({
+      dataDir: tmp,
+      resolveRuntime: () => ({
+        adapter: makeAdapter([{ text: '重建后的回复', stopReason: 'end_turn' }]),
+        model: 'test',
+        systemPrompt: '',
+        tools: [],
+      }),
+    })
+
+    await adapter2.sendInput(h, '重启后继续')
+    await waitState(adapter2, h, 'idle')
+
+    const meta = JSON.parse(await fs.readFile(join(tmp, workerId, 'meta-1.json'), 'utf-8'))
+    expect(meta.state).toBe('idle')
+    const tree = await SessionTree.load(join(tmp, workerId, 'session.jsonl'))
+    expect(JSON.stringify(tree.pathTo(meta.tip_node_id))).toContain('第一轮回复')
+    expect(JSON.stringify(tree.pathTo(meta.tip_node_id))).toContain('重启后继续')
+    expect(JSON.stringify(tree.pathTo(meta.tip_node_id))).toContain('重建后的回复')
+  })
+
+  it('scanOrphans 已标 crashed 的 running 化身不能被 idle 重建路径复活', async () => {
+    const workerId = randomUUID()
+    const gate = deferred<void>()
+    const adapter1 = new BuiltinWorkerAdapter({ dataDir: tmp })
+    const h = await adapter1.spawn(spec({
+      worker_id: workerId,
+      adapter: makeGatedAdapter(gate.promise, [{ text: '不会完成', stopReason: 'end_turn' }]),
+    }))
+    expect(await adapter1.state(h)).toBe('running')
+    await BuiltinWorkerAdapter.scanOrphans(tmp)
+
+    const adapter2 = new BuiltinWorkerAdapter({
+      dataDir: tmp,
+      resolveRuntime: () => ({
+        adapter: makeAdapter([{ text: '不应执行', stopReason: 'end_turn' }]),
+        model: 'test',
+        systemPrompt: '',
+        tools: [],
+      }),
+    })
+    await expect(adapter2.sendInput(h, '不应被接收')).rejects.toThrow(/no such incarnation/)
+    expect(JSON.parse(await fs.readFile(join(tmp, workerId, 'meta-1.json'), 'utf-8'))).toMatchObject({
+      state: 'exited',
+      ended_reason: 'crashed',
+    })
+    gate.resolve()
+  })
+
   it('sendInput(running) → 进入待注入队列，burst 间隙自动续 burst，消息不丢', async () => {
     const runEngineSpy = vi.spyOn(engineModule, 'runEngine')
     const gate = deferred<void>()

--- a/crabot-agent/tests/workers/harness/harness-recovery.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-recovery.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { promises as fs } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
@@ -109,7 +109,9 @@ function now(): string {
   return new Date(nowValue).toISOString()
 }
 
-async function makeHarness(): Promise<{ harness: WorkerHarness; ledger: LedgerStore; adaptersMap: Map<WorkerImplId, WorkerAdapter> }> {
+async function makeHarness(
+  overrides: Pick<HarnessDeps, 'onOperationNotification' | 'now' | 'isClosing'> = {},
+): Promise<{ harness: WorkerHarness; ledger: LedgerStore; adaptersMap: Map<WorkerImplId, WorkerAdapter> }> {
   const ledgersDir = join(dataDir, 'ledgers')
   const workspacesRoot = join(dataDir, 'workspaces')
   const workersDir = join(dataDir, 'workers')
@@ -124,8 +126,9 @@ async function makeHarness(): Promise<{ harness: WorkerHarness; ledger: LedgerSt
     ledger,
     workspaces,
     workersDir,
-    now,
+    now: overrides.now ?? now,
     onEvent: (e) => events.push(e),
+    ...overrides,
   }
   const harness = new WorkerHarness(deps)
   return { harness, ledger, adaptersMap }
@@ -476,6 +479,143 @@ describe('WorkerHarness.reconcileOnStartup — 幂等', () => {
     expect(events.filter((e) => e.worker_id === 'w-repeat')).toHaveLength(1)
     const afterSecond = await getWorker(ledger, 'w-repeat')
     expect(afterSecond).toEqual(afterFirst) // 台账没有被第二次改写
+  })
+})
+
+describe('WorkerHarness restart recovery notices', () => {
+  it('首次主线 crash 原子落 pending notice；未消费按退避重试，消费后停止', async () => {
+    let shouldConsume = false
+    let instant = Date.parse('2026-02-01T00:00:00.000Z')
+    const delivered: HarnessEvent[] = []
+    const { harness, ledger, adaptersMap } = await makeHarness({
+      now: () => new Date(instant).toISOString(),
+      onOperationNotification: async (_managerKey, event) => {
+        delivered.push(event)
+        return { consumed: shouldConsume }
+      },
+    })
+    const fake = new FakeAdapter('builtin')
+    adaptersMap.set('builtin', fake)
+    await seed(ledger, DIALOG, makeWorker('w-recovery-notice'))
+    fake.setState({ worker_id: 'w-recovery-notice', seq: 1 }, 'exited')
+
+    await harness.reconcileOnStartup()
+    const crashed = await getWorker(ledger, 'w-recovery-notice')
+    expect(crashed.task.status).toBe('failed')
+    expect(crashed.recovery_notices).toEqual([expect.objectContaining({
+      incarnation_id: crashed.incarnations[0].incarnation_id,
+      status: 'pending',
+      attempts: 0,
+    })])
+
+    await harness.reconcileOnStartup()
+    expect((await getWorker(ledger, 'w-recovery-notice')).recovery_notices).toHaveLength(1)
+
+    for (const [index, delay] of [30_000, 60_000, 120_000, 300_000, 300_000].entries()) {
+      await harness.reconcileRecoveryNoticesOnStartup()
+      expect(delivered).toHaveLength(index + 1)
+      expect(delivered[index]).toMatchObject({
+        kind: 'worker_recovery_required',
+        worker_id: 'w-recovery-notice',
+        detail: expect.objectContaining({ notice_id: crashed.recovery_notices?.[0].notice_id }),
+      })
+      const pending = (await getWorker(ledger, 'w-recovery-notice')).recovery_notices?.[0]
+      expect(pending).toMatchObject({ status: 'pending', attempts: index + 1 })
+      expect(pending?.retry_after_at).toBe(new Date(instant + delay).toISOString())
+      instant = Date.parse(pending!.retry_after_at!)
+    }
+
+    instant -= 1
+    await harness.reconcileRecoveryNoticesOnStartup()
+    expect(delivered).toHaveLength(5)
+
+    shouldConsume = true
+    instant += 1
+    await harness.reconcileRecoveryNoticesOnStartup()
+    expect(delivered).toHaveLength(6)
+    expect((await getWorker(ledger, 'w-recovery-notice')).recovery_notices?.[0]).toMatchObject({
+      status: 'consumed',
+      consumed_at: expect.any(String),
+    })
+  })
+
+  it('没有 recovery_notices 的历史 crashed worker 不会被扫描或唤醒', async () => {
+    const delivered: HarnessEvent[] = []
+    const { harness, ledger } = await makeHarness({
+      onOperationNotification: async (_managerKey, event) => {
+        delivered.push(event)
+        return { consumed: true }
+      },
+    })
+    await seed(ledger, DIALOG, makeWorker('w-historical-crash', {
+      task: { id: 'task-w-historical-crash', title: '历史失败', status: 'failed', created_at: now(), completed_at: now() },
+      incarnations: [{
+        seq: 1,
+        impl: 'builtin',
+        state: 'exited',
+        workspace: '/tmp/ws',
+        session_ref: 'historic-session',
+        started_at: now(),
+        ended_at: now(),
+        ended_reason: 'crashed',
+      }],
+    }))
+
+    await harness.reconcileRecoveryNoticesOnStartup()
+    expect(delivered).toEqual([])
+  })
+
+  it('通知 route 与 shutdown 交叠时不确认消费，留给下次启动重投', async () => {
+    let closing = false
+    let releaseRoute!: () => void
+    const routeGate = new Promise<void>((resolve) => { releaseRoute = resolve })
+    const route = vi.fn(async () => {
+      await routeGate
+      return { consumed: true }
+    })
+    const { harness, ledger, adaptersMap } = await makeHarness({
+      isClosing: () => closing,
+      onOperationNotification: route,
+    })
+    const fake = new FakeAdapter('builtin')
+    adaptersMap.set('builtin', fake)
+    await seed(ledger, DIALOG, makeWorker('w-notice-shutdown-race'))
+    fake.setState({ worker_id: 'w-notice-shutdown-race', seq: 1 }, 'exited')
+    await harness.reconcileOnStartup()
+
+    const delivery = harness.reconcileRecoveryNoticesOnStartup()
+    await vi.waitFor(() => expect(route).toHaveBeenCalledOnce())
+    closing = true
+    releaseRoute()
+    await delivery
+
+    expect((await getWorker(ledger, 'w-notice-shutdown-race')).recovery_notices?.[0]).toMatchObject({
+      status: 'pending',
+      attempts: 0,
+    })
+  })
+
+  it('运行期主线回调以 crashed 结束时同样创建 recovery notice', async () => {
+    const { harness, ledger } = await makeHarness()
+    await seed(ledger, DIALOG, makeWorker('w-runtime-crash'))
+    const worker = await getWorker(ledger, 'w-runtime-crash')
+    const incarnation = worker.incarnations[0]
+
+    harness.handleStateChange({
+      worker_id: worker.worker_id,
+      incarnation_id: incarnation.incarnation_id,
+      seq: incarnation.seq,
+      impl: 'builtin',
+      session_ref: incarnation.session_ref,
+    }, 'exited', { endReason: 'crashed' })
+
+    await vi.waitFor(async () => {
+      expect((await getWorker(ledger, worker.worker_id)).recovery_notices).toHaveLength(1)
+    })
+    expect((await getWorker(ledger, worker.worker_id)).recovery_notices?.[0]).toMatchObject({
+      incarnation_id: incarnation.incarnation_id,
+      status: 'pending',
+    })
   })
 })
 

--- a/crabot-agent/tests/workers/harness/harness-recovery.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-recovery.test.ts
@@ -110,7 +110,7 @@ function now(): string {
 }
 
 async function makeHarness(
-  overrides: Pick<HarnessDeps, 'onOperationNotification' | 'now' | 'isClosing'> = {},
+  overrides: Pick<HarnessDeps, 'onOperationNotification' | 'onIncarnationTerminal' | 'now' | 'isClosing'> = {},
 ): Promise<{ harness: WorkerHarness; ledger: LedgerStore; adaptersMap: Map<WorkerImplId, WorkerAdapter> }> {
   const ledgersDir = join(dataDir, 'ledgers')
   const workspacesRoot = join(dataDir, 'workspaces')
@@ -615,6 +615,53 @@ describe('WorkerHarness restart recovery notices', () => {
     expect((await getWorker(ledger, worker.worker_id)).recovery_notices?.[0]).toMatchObject({
       incarnation_id: incarnation.incarnation_id,
       status: 'pending',
+    })
+  })
+
+  it('运行期 crash 不等待其他 worker 卡住的恢复通知投递，仍立即收割本化身', async () => {
+    let releaseRoute!: () => void
+    const routeGate = new Promise<void>((resolve) => { releaseRoute = resolve })
+    const terminals: IncarnationHandle[] = []
+    const route = vi.fn(async (_managerKey: ManagerKey, event: HarnessEvent) => {
+      if (event.worker_id === 'w-blocking-notice') await routeGate
+      return { consumed: true }
+    })
+    const { harness, ledger, adaptersMap } = await makeHarness({
+      onOperationNotification: route,
+      onIncarnationTerminal: (handle) => terminals.push(handle),
+    })
+    const fake = new FakeAdapter('builtin')
+    adaptersMap.set('builtin', fake)
+    await seed(ledger, DIALOG, makeWorker('w-blocking-notice'))
+    fake.setState({ worker_id: 'w-blocking-notice', seq: 1 }, 'exited')
+    await harness.reconcileOnStartup()
+
+    await seed(ledger, DIALOG, makeWorker('w-runtime-crash-blocked'))
+    const crashed = await getWorker(ledger, 'w-runtime-crash-blocked')
+    const incarnation = crashed.incarnations[0]
+    harness.handleStateChange({
+      worker_id: crashed.worker_id,
+      incarnation_id: incarnation.incarnation_id,
+      seq: incarnation.seq,
+      impl: incarnation.impl,
+      session_ref: incarnation.session_ref,
+    }, 'exited', { endReason: 'crashed' })
+
+    try {
+      await vi.waitFor(() => expect(route).toHaveBeenCalledWith(
+        DIALOG,
+        expect.objectContaining({ worker_id: 'w-blocking-notice', kind: 'worker_recovery_required' }),
+      ))
+      await vi.waitFor(() => expect(terminals).toContainEqual(expect.objectContaining({
+        worker_id: crashed.worker_id,
+        incarnation_id: incarnation.incarnation_id,
+      })))
+    } finally {
+      releaseRoute()
+    }
+    await vi.waitFor(async () => {
+      expect((await getWorker(ledger, 'w-blocking-notice')).recovery_notices?.[0]?.status).toBe('consumed')
+      expect((await getWorker(ledger, crashed.worker_id)).recovery_notices?.[0]?.status).toBe('consumed')
     })
   })
 })

--- a/crabot-agent/tests/workers/harness/ledger-store.test.ts
+++ b/crabot-agent/tests/workers/harness/ledger-store.test.ts
@@ -137,6 +137,54 @@ describe('LedgerStore', () => {
     expect(ledger.workers).toHaveLength(0)
   })
 
+  it('recovery notice 只能关联唯一的可执行主线化身', async () => {
+    const id = `test::recovery-notice` as ManagerKey
+    const now = new Date().toISOString()
+    const worker = makeWorker('worker-recovery-notice', {
+      manager_key: id,
+      incarnations: [{
+        incarnation_id: 'inc-mainline',
+        seq: 1,
+        impl: 'builtin',
+        state: 'exited',
+        workspace: '/tmp/ws',
+        session_ref: 'session-mainline',
+        started_at: now,
+        ended_at: now,
+        ended_reason: 'crashed',
+      }],
+      recovery_notices: [{
+        notice_id: 'notice-mainline',
+        incarnation_id: 'inc-mainline',
+        status: 'pending',
+        created_at: now,
+        attempts: 0,
+      }],
+    })
+
+    await expect(store.upsertWorker(id, worker.worker_id, () => worker)).resolves.toMatchObject({
+      recovery_notices: [{ notice_id: 'notice-mainline', incarnation_id: 'inc-mainline' }],
+    })
+
+    const forkOnly = {
+      ...worker,
+      worker_id: 'worker-recovery-fork',
+      incarnations: [{
+        ...worker.incarnations[0],
+        incarnation_id: 'inc-fork',
+        forked_from: 'inc-parent',
+      }],
+      recovery_notices: [{
+        notice_id: 'notice-fork',
+        incarnation_id: 'inc-fork',
+        status: 'pending' as const,
+        created_at: now,
+        attempts: 0,
+      }],
+    }
+    await expect(store.upsertWorker(id, forkOnly.worker_id, () => forkOnly)).rejects.toThrow(/recovery notice.*mainline/i)
+  })
+
   it('legacy source and first incarnation are immutable while ordinary upserts may append v3 incarnations', async () => {
     const key = 'test::legacy' as ManagerKey
     const now = new Date().toISOString()


### PR DESCRIPTION
## 变更内容

- 主线 Worker 的执行载体确认消失时，在同一次台账更新中写入 `crashed` 和持久恢复通知。
- 恢复通知仅唤醒所属 Manager；未消费时按 `30 秒 -> 1 分钟 -> 2 分钟 -> 5 分钟` 持久退避，关闭竞态保留待办。
- builtin 的持久 `idle` 化身在下一条普通输入时重建同一会话；运行中或已退出化身不走这条路径。
- 清理已被本实现覆盖的关闭窗口终态补投 follow-up。

## 原因与边界

服务重启后，Manager 需要知道哪些执行载体确实已中断，并自行查询状态、决定继续、交接、汇报或停止。Harness 不猜测业务下一步，不自动重跑、重启、handoff 或向人类发送消息。仅重启 Agent 而 tmux 仍存活的 CLI Worker 会重连，不产生恢复通知。

## 验证

- `corepack pnpm exec vitest run tests/workers/harness/ledger-store.test.ts tests/workers/harness/harness-recovery.test.ts tests/workers/builtin-adapter.test.ts tests/manager/p5-integration.test.ts`（95 passed）
- `corepack pnpm exec tsc --noEmit`
- `git diff --check`
