### PR TITLE
[codex] 统一 Worker 子 Agent 可观测性

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -68,6 +68,7 @@
   Admin 不按执行器拆 tab；CLI child trace 运行时优先读取原生 child 会话/记录，终态 child 保存 Agent-owned 脱敏副本，后续统一 Worker retention（PR B）按同一 Worker 清理单元删除；副本待补齐或原生先丢失时保留详情并显示脱敏原因。
   定向测试、页面验收和构建已通过，待非 Draft PR review。
 - **CLI child Trace 收割节奏（待确认）**：本轮 review 发现原生记录高频变化会重复触发 CLI child 收割，且启动补齐扫描范围过宽。最小设计补充已写入 `crabot-docs/superpowers/specs/2026-08-23-cli-subagent-trace-harvest-scheduling-design.md`；在确认前不改变收割时机或恢复范围。单个 Worker 读取失败不再阻断后续 Worker 的既有补齐。
+- **builtin 子 Agent 身份留存（待确认）**：本轮 review 发现其身份记录会在通用 7 天 GC 后早于 Worker/Trace 消失，造成列表缺失和父 Trace 入口 404。最小设计补充已写入 `crabot-docs/superpowers/specs/2026-08-23-builtin-subagent-record-retention-design.md`；在确认前不改变后台实体的清理归属。
 
 - **Traces 人话视图 + 有界决策视野**：**已合并**（PR #100 → `f7e3aaf`，@claude approve 后自动合并）。Managers 用 `渠道·会话标题`、active worker 数和最近活动替代裸 ManagerKey/Episodes/历史总数；Manager detail 上浮消息摘录/回复/动作并按 worker 因果链折叠；Workers 默认只显示非终态。恢复 v2 dispatcher 不变量：`list_workers` 默认只看 `queued/running/waiting_input`，终态续办需显式分页 `include_terminal=true`；Manager 页面计数与工具视野同源。生产实测 system-tasks 2389 历史→6 active，工具实际 12 active/53 terminal。协议：agent v3.2.0、admin v0.2.2。
 - **统一 Worker Runtime（v3.6.0，待 PR review）**：本次统一替代原 v3.4/v3.5 的分离待审状态；CLI 的 pane 只用于 bracketed-paste 控制和 Manager 按需诊断，不再作为正常进度或 handoff 来源。Claude `Notification`、Codex `PermissionRequest` 与重连检查识别到的未知 UI 以一次性 snapshot + adapter 固定 action descriptor 交给 Manager，不能形成自由 tmux 按键入口；原生 session activity、完成回合、可核验 stop 与私有 handoff package 同属该 PR。

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -67,6 +67,7 @@
   Codex 统一列出 Worker 直接启动的 child，Worker 详情读取分页 trace，child 详情读取自己的分页 trace。
   Admin 不按执行器拆 tab；CLI child trace 运行时优先读取原生 child 会话/记录，终态 child 保存 Agent-owned 脱敏副本，后续统一 Worker retention（PR B）按同一 Worker 清理单元删除；副本待补齐或原生先丢失时保留详情并显示脱敏原因。
   定向测试、页面验收和构建已通过，待非 Draft PR review。
+- **CLI child Trace 收割节奏（待确认）**：本轮 review 发现原生记录高频变化会重复触发 CLI child 收割，且启动补齐扫描范围过宽。最小设计补充已写入 `crabot-docs/superpowers/specs/2026-08-23-cli-subagent-trace-harvest-scheduling-design.md`；在确认前不改变收割时机或恢复范围。单个 Worker 读取失败不再阻断后续 Worker 的既有补齐。
 
 - **Traces 人话视图 + 有界决策视野**：**已合并**（PR #100 → `f7e3aaf`，@claude approve 后自动合并）。Managers 用 `渠道·会话标题`、active worker 数和最近活动替代裸 ManagerKey/Episodes/历史总数；Manager detail 上浮消息摘录/回复/动作并按 worker 因果链折叠；Workers 默认只显示非终态。恢复 v2 dispatcher 不变量：`list_workers` 默认只看 `queued/running/waiting_input`，终态续办需显式分页 `include_terminal=true`；Manager 页面计数与工具视野同源。生产实测 system-tasks 2389 历史→6 active，工具实际 12 active/53 terminal。协议：agent v3.2.0、admin v0.2.2。
 - **统一 Worker Runtime（v3.6.0，待 PR review）**：本次统一替代原 v3.4/v3.5 的分离待审状态；CLI 的 pane 只用于 bracketed-paste 控制和 Manager 按需诊断，不再作为正常进度或 handoff 来源。Claude `Notification`、Codex `PermissionRequest` 与重连检查识别到的未知 UI 以一次性 snapshot + adapter 固定 action descriptor 交给 Manager，不能形成自由 tmux 按键入口；原生 session activity、完成回合、可核验 stop 与私有 handoff package 同属该 PR。

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -65,7 +65,7 @@
 - **Worker 直接 subagent 可观测性（v3.6.7，`feat/worker-subagent-observability`）**：按已确认的
   `crabot-docs` 设计与协议增补，builtin Worker 恢复 configured `delegate_task`；builtin、Claude Code、
   Codex 统一列出 Worker 直接启动的 child，Worker 详情读取分页 trace，child 详情读取自己的分页 trace。
-  Admin 不按执行器拆 tab；CLI child trace 只读原生 child 会话/记录，原生数据缺失时保留详情并显示脱敏原因。
+  Admin 不按执行器拆 tab；CLI child trace 运行时优先读取原生 child 会话/记录，终态 child 保存 Agent-owned 脱敏副本，后续统一 Worker retention（PR B）按同一 Worker 清理单元删除；副本待补齐或原生先丢失时保留详情并显示脱敏原因。
   定向测试、页面验收和构建已通过，待非 Draft PR review。
 
 - **Traces 人话视图 + 有界决策视野**：**已合并**（PR #100 → `f7e3aaf`，@claude approve 后自动合并）。Managers 用 `渠道·会话标题`、active worker 数和最近活动替代裸 ManagerKey/Episodes/历史总数；Manager detail 上浮消息摘录/回复/动作并按 worker 因果链折叠；Workers 默认只显示非终态。恢复 v2 dispatcher 不变量：`list_workers` 默认只看 `queued/running/waiting_input`，终态续办需显式分页 `include_terminal=true`；Manager 页面计数与工具视野同源。生产实测 system-tasks 2389 历史→6 active，工具实际 12 active/53 terminal。协议：agent v3.2.0、admin v0.2.2。

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -68,7 +68,7 @@
   Admin 不按执行器拆 tab；CLI child trace 运行时优先读取原生 child 会话/记录，终态 child 保存 Agent-owned 脱敏副本，后续统一 Worker retention（PR B）按同一 Worker 清理单元删除；副本待补齐或原生先丢失时保留详情并显示脱敏原因。
   定向测试、页面验收和构建已通过，待非 Draft PR review。
 - **CLI child Trace 收割节奏（已确认并实现）**：按 `crabot-docs/superpowers/specs/2026-08-23-cli-subagent-trace-harvest-scheduling-design.md`，activity 触发采用按 Worker 固定 30 秒合并窗口，同一 Worker 收割不并发；父 Worker 终态立即收割；启动恢复只读取已持久标记为 pending 的 child，并按 Worker 隔离失败。收割只影响显示副本，不持续捕获运行中 child 输出。
-- **builtin 子 Agent 身份留存（待确认）**：本轮 review 发现其身份记录会在通用 7 天 GC 后早于 Worker/Trace 消失，造成列表缺失和父 Trace 入口 404。最小设计补充已写入 `crabot-docs/superpowers/specs/2026-08-23-builtin-subagent-record-retention-design.md`；在确认前不改变后台实体的清理归属。
+- **builtin 子 Agent 身份留存（已确认并实现）**：按 `crabot-docs/superpowers/specs/2026-08-23-builtin-subagent-record-retention-design.md`，Worker `delegate_task` 创建的 builtin child 身份记录不参与普通后台实体 7 天 GC，跟随所属 Worker retention 事务清理；普通后台 Agent、未归属 Worker 的 Agent 和 shell 保持原有规则。
 
 - **Traces 人话视图 + 有界决策视野**：**已合并**（PR #100 → `f7e3aaf`，@claude approve 后自动合并）。Managers 用 `渠道·会话标题`、active worker 数和最近活动替代裸 ManagerKey/Episodes/历史总数；Manager detail 上浮消息摘录/回复/动作并按 worker 因果链折叠；Workers 默认只显示非终态。恢复 v2 dispatcher 不变量：`list_workers` 默认只看 `queued/running/waiting_input`，终态续办需显式分页 `include_terminal=true`；Manager 页面计数与工具视野同源。生产实测 system-tasks 2389 历史→6 active，工具实际 12 active/53 terminal。协议：agent v3.2.0、admin v0.2.2。
 - **统一 Worker Runtime（v3.6.0，待 PR review）**：本次统一替代原 v3.4/v3.5 的分离待审状态；CLI 的 pane 只用于 bracketed-paste 控制和 Manager 按需诊断，不再作为正常进度或 handoff 来源。Claude `Notification`、Codex `PermissionRequest` 与重连检查识别到的未知 UI 以一次性 snapshot + adapter 固定 action descriptor 交给 Manager，不能形成自由 tmux 按键入口；原生 session activity、完成回合、可核验 stop 与私有 handoff package 同属该 PR。

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -67,7 +67,7 @@
   Codex 统一列出 Worker 直接启动的 child，Worker 详情读取分页 trace，child 详情读取自己的分页 trace。
   Admin 不按执行器拆 tab；CLI child trace 运行时优先读取原生 child 会话/记录，终态 child 保存 Agent-owned 脱敏副本，后续统一 Worker retention（PR B）按同一 Worker 清理单元删除；副本待补齐或原生先丢失时保留详情并显示脱敏原因。
   定向测试、页面验收和构建已通过，待非 Draft PR review。
-- **CLI child Trace 收割节奏（待确认）**：本轮 review 发现原生记录高频变化会重复触发 CLI child 收割，且启动补齐扫描范围过宽。最小设计补充已写入 `crabot-docs/superpowers/specs/2026-08-23-cli-subagent-trace-harvest-scheduling-design.md`；在确认前不改变收割时机或恢复范围。单个 Worker 读取失败不再阻断后续 Worker 的既有补齐。
+- **CLI child Trace 收割节奏（已确认并实现）**：按 `crabot-docs/superpowers/specs/2026-08-23-cli-subagent-trace-harvest-scheduling-design.md`，activity 触发采用按 Worker 固定 30 秒合并窗口，同一 Worker 收割不并发；父 Worker 终态立即收割；启动恢复只读取已持久标记为 pending 的 child，并按 Worker 隔离失败。收割只影响显示副本，不持续捕获运行中 child 输出。
 - **builtin 子 Agent 身份留存（待确认）**：本轮 review 发现其身份记录会在通用 7 天 GC 后早于 Worker/Trace 消失，造成列表缺失和父 Trace 入口 404。最小设计补充已写入 `crabot-docs/superpowers/specs/2026-08-23-builtin-subagent-record-retention-design.md`；在确认前不改变后台实体的清理归属。
 
 - **Traces 人话视图 + 有界决策视野**：**已合并**（PR #100 → `f7e3aaf`，@claude approve 后自动合并）。Managers 用 `渠道·会话标题`、active worker 数和最近活动替代裸 ManagerKey/Episodes/历史总数；Manager detail 上浮消息摘录/回复/动作并按 worker 因果链折叠；Workers 默认只显示非终态。恢复 v2 dispatcher 不变量：`list_workers` 默认只看 `queued/running/waiting_input`，终态续办需显式分页 `include_terminal=true`；Manager 页面计数与工具视野同源。生产实测 system-tasks 2389 历史→6 active，工具实际 12 active/53 terminal。协议：agent v3.2.0、admin v0.2.2。

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -62,6 +62,12 @@
 
 ### P6 后 Traces / Worker 生命周期（当前主线）
 
+- **Worker 直接 subagent 可观测性（v3.6.7，`feat/worker-subagent-observability`）**：按已确认的
+  `crabot-docs` 设计与协议增补，builtin Worker 恢复 configured `delegate_task`；builtin、Claude Code、
+  Codex 统一列出 Worker 直接启动的 child，Worker 详情读取分页 trace，child 详情读取自己的分页 trace。
+  Admin 不按执行器拆 tab；CLI child trace 只读原生 child 会话/记录，原生数据缺失时保留详情并显示脱敏原因。
+  定向测试、页面验收和构建已通过，待非 Draft PR review。
+
 - **Traces 人话视图 + 有界决策视野**：**已合并**（PR #100 → `f7e3aaf`，@claude approve 后自动合并）。Managers 用 `渠道·会话标题`、active worker 数和最近活动替代裸 ManagerKey/Episodes/历史总数；Manager detail 上浮消息摘录/回复/动作并按 worker 因果链折叠；Workers 默认只显示非终态。恢复 v2 dispatcher 不变量：`list_workers` 默认只看 `queued/running/waiting_input`，终态续办需显式分页 `include_terminal=true`；Manager 页面计数与工具视野同源。生产实测 system-tasks 2389 历史→6 active，工具实际 12 active/53 terminal。协议：agent v3.2.0、admin v0.2.2。
 - **统一 Worker Runtime（v3.6.0，待 PR review）**：本次统一替代原 v3.4/v3.5 的分离待审状态；CLI 的 pane 只用于 bracketed-paste 控制和 Manager 按需诊断，不再作为正常进度或 handoff 来源。Claude `Notification`、Codex `PermissionRequest` 与重连检查识别到的未知 UI 以一次性 snapshot + adapter 固定 action descriptor 交给 Manager，不能形成自由 tmux 按键入口；原生 session activity、完成回合、可核验 stop 与私有 handoff package 同属该 PR。
 - **Worker 重启恢复通知（已实现，待 PR review）**：主线执行载体确认消失时，Harness 与 `crashed` 原子写入持久 `recovery_notices`，在既有对账完成后只唤醒 owning Manager；首次立即尝试、未消费按 `30 秒 -> 1 分钟 -> 2 分钟 -> 5 分钟` 持久退避。仅重启 Agent 而 tmux 仍存活时重连；builtin `idle` 在下一条输入按同一会话按需重建。Harness 不自动续跑、重启、handoff 或向人类汇报。

--- a/crabot-admin/src/admin-web-api.test.ts
+++ b/crabot-admin/src/admin-web-api.test.ts
@@ -1641,6 +1641,9 @@ describe('Admin Web API', () => {
       '/api/agent/workers/w-1',
       '/api/agent/workers/w-1/terminal',
       '/api/agent/workers/w-1/trace',
+      '/api/agent/workers/w-1/subagents',
+      '/api/agent/workers/w-1/subagents/child-1',
+      '/api/agent/workers/w-1/subagents/child-1/trace',
     ])('%s 未带 token → 401', async (path) => {
       const response = await makeWebRequest(TEST_WEB_PORT, path, 'GET', null, null)
       expect(response.statusCode).toBe(401)
@@ -1853,6 +1856,26 @@ describe('Admin Web API', () => {
       await makeWebRequest(TEST_WEB_PORT, '/api/agent/workers/w-1/trace', 'GET', null, token)
       expect(spy).toHaveBeenLastCalledWith('get_worker_trace', { worker_id: 'w-1' })
       expect('seq' in (spy.mock.lastCall![1] as object)).toBe(false)
+    })
+
+    it('subagent 路径转发 child 归属与 opaque cursor，并把跨 Worker child 查询视为 404', async () => {
+      const token = await loginAndGetToken()
+      const spy = spyAgentRpc()
+        .mockResolvedValueOnce({ subagents: [{ subagent_id: 'child-1' }] })
+        .mockResolvedValueOnce({ subagent: { subagent_id: 'child-1' } })
+        .mockResolvedValueOnce({ events: [], next_cursor: 'opaque-next' })
+
+      await makeWebRequest(TEST_WEB_PORT, '/api/agent/workers/w-1/subagents?incarnation_id=inc-1', 'GET', null, token)
+      expect(spy).toHaveBeenLastCalledWith('list_worker_subagents', { worker_id: 'w-1', incarnation_id: 'inc-1' })
+      await makeWebRequest(TEST_WEB_PORT, '/api/agent/workers/w-1/subagents/child-1', 'GET', null, token)
+      expect(spy).toHaveBeenLastCalledWith('get_worker_subagent_detail', { worker_id: 'w-1', subagent_id: 'child-1' })
+      await makeWebRequest(TEST_WEB_PORT, '/api/agent/workers/w-1/subagents/child-1/trace?cursor=opaque-in', 'GET', null, token)
+      expect(spy).toHaveBeenLastCalledWith('get_worker_subagent_trace', { worker_id: 'w-1', subagent_id: 'child-1', cursor: 'opaque-in' })
+
+      spy.mockRejectedValueOnce(new Error('Worker subagent not found: child-1'))
+      const denied = await makeWebRequest<{ error: string }>(TEST_WEB_PORT, '/api/agent/workers/w-other/subagents/child-1', 'GET', null, token)
+      expect(denied.statusCode).toBe(404)
+      expect(denied.body.error).toBe('Worker subagent not found: child-1')
     })
   })
 })

--- a/crabot-admin/src/index.ts
+++ b/crabot-admin/src/index.ts
@@ -426,7 +426,7 @@ function parseOptionalIntParam(raw: string | null): number | undefined {
 }
 
 /**
- * `/api/agent/workers*` 三个按 worker_id 读的端点统一的"worker 不存在 → 404"判定。
+ * `/api/agent/workers*` 按 Worker 或 child 读的端点统一的“不存在 → 404”判定。
  *
  * agent 侧同一件事有两处文案，大小写不同：`unified-agent.ts` 的 handler 显式抛
  * `Worker not found: <id>`（detail / trace），`harness.ts` 的 `WorkerNotFoundError` 抛
@@ -439,7 +439,8 @@ function parseOptionalIntParam(raw: string | null): number | undefined {
  * 继续落 500，否则前端分不清"这个 worker 没了"和"这个化身没了"。
  */
 function isWorkerNotFoundError(message: string): boolean {
-  return message.toLowerCase().includes('worker not found')
+  const normalized = message.toLowerCase()
+  return normalized.includes('worker not found') || normalized.includes('worker subagent not found')
 }
 
 function sendJson(res: ServerResponse, status: number, body: unknown): void {
@@ -2481,6 +2482,21 @@ export class AdminModule extends ModuleBase {
       const workerTraceMatch = pathname.match(/^\/api\/agent\/workers\/([^/]+)\/trace$/)
       if (workerTraceMatch && req.method === 'GET') {
         await this.handleGetWorkerTraceApi(req, res, workerTraceMatch[1], url)
+        return
+      }
+      const workerSubagentTraceMatch = pathname.match(/^\/api\/agent\/workers\/([^/]+)\/subagents\/([^/]+)\/trace$/)
+      if (workerSubagentTraceMatch && req.method === 'GET') {
+        await this.handleGetWorkerSubagentTraceApi(req, res, workerSubagentTraceMatch[1], workerSubagentTraceMatch[2], url)
+        return
+      }
+      const workerSubagentDetailMatch = pathname.match(/^\/api\/agent\/workers\/([^/]+)\/subagents\/([^/]+)$/)
+      if (workerSubagentDetailMatch && req.method === 'GET') {
+        await this.handleGetWorkerSubagentDetailApi(req, res, workerSubagentDetailMatch[1], workerSubagentDetailMatch[2])
+        return
+      }
+      const workerSubagentsMatch = pathname.match(/^\/api\/agent\/workers\/([^/]+)\/subagents$/)
+      if (workerSubagentsMatch && req.method === 'GET') {
+        await this.handleListWorkerSubagentsApi(req, res, workerSubagentsMatch[1], url)
         return
       }
       const workerDetailMatch = pathname.match(/^\/api\/agent\/workers\/([^/]+)$/)
@@ -10400,6 +10416,58 @@ export class AdminModule extends ModuleBase {
       {
         worker_id: workerId,
         ...(seq !== undefined ? { seq } : {}),
+        ...(cursor ? { cursor } : {}),
+      },
+      isWorkerNotFoundError,
+    )
+  }
+
+  private async handleListWorkerSubagentsApi(
+    _req: IncomingMessage,
+    res: ServerResponse,
+    workerId: string,
+    url: URL,
+  ): Promise<void> {
+    const incarnationId = url.searchParams.get('incarnation_id') || undefined
+    await this.proxyAgentRpc<{ worker_id: string; incarnation_id?: string }, { subagents: unknown[] }>(
+      res,
+      'list_worker_subagents',
+      { worker_id: decodeURIComponent(workerId), ...(incarnationId ? { incarnation_id: incarnationId } : {}) },
+      isWorkerNotFoundError,
+    )
+  }
+
+  private async handleGetWorkerSubagentDetailApi(
+    _req: IncomingMessage,
+    res: ServerResponse,
+    workerId: string,
+    subagentId: string,
+  ): Promise<void> {
+    await this.proxyAgentRpc<{ worker_id: string; subagent_id: string }, { subagent: unknown }>(
+      res,
+      'get_worker_subagent_detail',
+      { worker_id: decodeURIComponent(workerId), subagent_id: decodeURIComponent(subagentId) },
+      isWorkerNotFoundError,
+    )
+  }
+
+  private async handleGetWorkerSubagentTraceApi(
+    _req: IncomingMessage,
+    res: ServerResponse,
+    workerId: string,
+    subagentId: string,
+    url: URL,
+  ): Promise<void> {
+    const cursor = url.searchParams.get('cursor') || undefined
+    await this.proxyAgentRpc<
+      { worker_id: string; subagent_id: string; cursor?: string },
+      { events: unknown[]; next_cursor: string; unavailable_reason?: string }
+    >(
+      res,
+      'get_worker_subagent_trace',
+      {
+        worker_id: decodeURIComponent(workerId),
+        subagent_id: decodeURIComponent(subagentId),
         ...(cursor ? { cursor } : {}),
       },
       isWorkerNotFoundError,

--- a/crabot-admin/web/src/App.tsx
+++ b/crabot-admin/web/src/App.tsx
@@ -27,6 +27,7 @@ import { SubagentList } from './pages/Subagents/SubagentList'
 import { Traces } from './pages/Traces'
 import { ManagerDetail } from './pages/Traces/ManagerDetail'
 import { WorkerDetail } from './pages/Traces/WorkerDetail'
+import { SubagentDetail } from './pages/Traces/SubagentDetail'
 import { ScheduleList } from './pages/Schedules/ScheduleList'
 import { OpenClawImportWizard } from './pages/OpenClawImport/OpenClawImportWizard'
 import { BackupExportPage } from './pages/Backup/BackupExportPage'
@@ -240,6 +241,14 @@ const AppRoutes: React.FC = () => {
         element={
           <PrivateRoute>
             <ManagerDetail />
+          </PrivateRoute>
+        }
+      />
+      <Route
+        path="/traces/workers/:workerId/subagents/:subagentId"
+        element={
+          <PrivateRoute>
+            <SubagentDetail />
           </PrivateRoute>
         }
       />

--- a/crabot-admin/web/src/pages/Traces/SubagentDetail.tsx
+++ b/crabot-admin/web/src/pages/Traces/SubagentDetail.tsx
@@ -1,0 +1,70 @@
+import React, { useCallback, useEffect, useState } from 'react'
+import { Link, useParams } from 'react-router-dom'
+import { Loading } from '../../components/Common/Loading'
+import { MainLayout } from '../../components/Layout/MainLayout'
+import { agentObservabilityService, type WorkerSubagentSummary } from '../../services/agent-observability'
+import { Timeline } from './WorkerDetail'
+
+const IMPL_LABEL: Record<WorkerSubagentSummary['executor_impl'], string> = {
+  builtin: '内置 Worker',
+  'claude-code': 'Claude Code',
+  codex: 'Codex',
+}
+const STATUS_LABEL: Record<WorkerSubagentSummary['status'], string> = {
+  running: '执行中', completed: '已完成', failed: '失败', stopped: '已停止', interrupted: '已中断', unknown: '状态未知',
+}
+
+function formatTimestamp(value: string | undefined): string {
+  return value ? new Date(value).toLocaleString('zh-CN') : '—'
+}
+
+export const SubagentDetail: React.FC = () => {
+  const { workerId = '', subagentId = '' } = useParams()
+  const [subagent, setSubagent] = useState<WorkerSubagentSummary | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    agentObservabilityService.getWorkerSubagentDetail(workerId, subagentId)
+      .then((result) => { if (!cancelled) setSubagent(result.subagent) })
+      .catch((err) => { if (!cancelled) setError(err instanceof Error ? err.message : String(err)) })
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
+  }, [workerId, subagentId])
+
+  const loadTrace = useCallback((cursor?: string) => agentObservabilityService.getWorkerSubagentTrace(workerId, subagentId, cursor), [workerId, subagentId])
+
+  if (loading) return <MainLayout><Loading /></MainLayout>
+  if (error || !subagent) return <MainLayout><div style={{ color: 'var(--text-muted)', padding: 24 }}>子 Agent 详情暂不可用：{error ?? '未找到'}</div></MainLayout>
+
+  return (
+    <MainLayout>
+      <div style={{ maxWidth: 980 }}>
+        <div style={{ marginBottom: 18 }}>
+          <Link to={`/traces/workers/${encodeURIComponent(workerId)}`} style={{ color: 'var(--text-muted)', fontSize: 12 }}>← 返回 Worker 详情</Link>
+          <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 16, marginTop: 8, flexWrap: 'wrap' }}>
+            <div style={{ minWidth: 0 }}>
+              <h1 style={{ fontSize: 22, lineHeight: 1.3, margin: 0 }}>{subagent.name}</h1>
+              <div style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--text-muted)', marginTop: 5 }}>{subagent.subagent_id}</div>
+            </div>
+            <span style={{ flex: '0 0 auto', padding: '4px 8px', border: '1px solid var(--border)', fontSize: 12, fontWeight: 700 }}>{STATUS_LABEL[subagent.status]}</span>
+          </div>
+        </div>
+
+        <section aria-label="子 Agent 概览" style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))', margin: '22px 0 28px', borderTop: '1px solid var(--border)', borderBottom: '1px solid var(--border)' }}>
+          <div style={{ padding: '12px 14px 13px 0' }}><div style={{ color: 'var(--text-muted)', fontSize: 11, marginBottom: 3 }}>执行器</div><div style={{ fontSize: 13, fontWeight: 600 }}>{IMPL_LABEL[subagent.executor_impl]}</div></div>
+          <div style={{ padding: '12px 14px 13px', borderLeft: '1px solid var(--border)' }}><div style={{ color: 'var(--text-muted)', fontSize: 11, marginBottom: 3 }}>子 Agent 类型</div><div style={{ fontSize: 13, fontWeight: 600 }}>{subagent.type ?? '原生记录未提供'}</div></div>
+          <div style={{ padding: '12px 14px 13px', borderLeft: '1px solid var(--border)' }}><div style={{ color: 'var(--text-muted)', fontSize: 11, marginBottom: 3 }}>启动时间</div><div style={{ fontSize: 13 }}>{formatTimestamp(subagent.started_at)}</div></div>
+          <div style={{ padding: '12px 14px 13px', borderLeft: '1px solid var(--border)' }}><div style={{ color: 'var(--text-muted)', fontSize: 11, marginBottom: 3 }}>结束时间</div><div style={{ fontSize: 13 }}>{formatTimestamp(subagent.ended_at)}</div></div>
+        </section>
+
+        {subagent.task && <section style={{ marginBottom: 28 }}><div style={{ color: 'var(--text-muted)', fontSize: 12, marginBottom: 5 }}>任务</div><div style={{ padding: '10px 12px', background: 'var(--bg-muted)', whiteSpace: 'pre-wrap', overflowWrap: 'anywhere', fontSize: 13 }}>{subagent.task}</div></section>}
+        {subagent.unavailable_reason && <div style={{ color: 'var(--color-warning, #d97706)', fontSize: 12, marginBottom: 16 }}>部分数据不可用：{subagent.unavailable_reason}</div>}
+        <Timeline workerId={workerId} heading="子 Agent Trace" actorLabel="子 Agent" loadTrace={loadTrace} />
+      </div>
+    </MainLayout>
+  )
+}

--- a/crabot-admin/web/src/pages/Traces/SubagentDetail.tsx
+++ b/crabot-admin/web/src/pages/Traces/SubagentDetail.tsx
@@ -63,7 +63,7 @@ export const SubagentDetail: React.FC = () => {
 
         {subagent.task && <section style={{ marginBottom: 28 }}><div style={{ color: 'var(--text-muted)', fontSize: 12, marginBottom: 5 }}>任务</div><div style={{ padding: '10px 12px', background: 'var(--bg-muted)', whiteSpace: 'pre-wrap', overflowWrap: 'anywhere', fontSize: 13 }}>{subagent.task}</div></section>}
         {subagent.unavailable_reason && <div style={{ color: 'var(--color-warning, #d97706)', fontSize: 12, marginBottom: 16 }}>部分数据不可用：{subagent.unavailable_reason}</div>}
-        <Timeline workerId={workerId} heading="子 Agent Trace" actorLabel="子 Agent" loadTrace={loadTrace} />
+        <Timeline workerId={workerId} heading="子 Agent Trace" actorLabel="子 Agent" isSubagentTrace loadTrace={loadTrace} />
       </div>
     </MainLayout>
   )

--- a/crabot-admin/web/src/pages/Traces/WorkerDetail.tsx
+++ b/crabot-admin/web/src/pages/Traces/WorkerDetail.tsx
@@ -186,12 +186,12 @@ function lifecycleActivity(event: WorkerTraceEvent): ActivityEntry | undefined {
   return undefined
 }
 
-function activityFor(event: WorkerTraceEvent, actorLabel: string): ActivityEntry | undefined {
+function activityFor(event: WorkerTraceEvent, actorLabel: string, isSubagentTrace: boolean): ActivityEntry | undefined {
   if (event.source === 'legacy') {
     return { event, label: '历史记录', tone: 'status', body: event.summary }
   }
   if (event.kind === 'message' && event.role === 'user') {
-    return { event, label: event.source === 'native' ? '管理会话指令' : `${actorLabel} 指令`, tone: 'manager', body: messageText(event) }
+    return { event, label: !isSubagentTrace && event.source === 'native' ? '管理会话指令' : `${actorLabel} 指令`, tone: 'manager', body: messageText(event) }
   }
   if (event.kind === 'message' && event.role === 'assistant') {
     return { event, label: `${actorLabel} 文本`, tone: 'worker', body: messageText(event) }
@@ -206,14 +206,14 @@ function activityFor(event: WorkerTraceEvent, actorLabel: string): ActivityEntry
   return undefined
 }
 
-function projectTimeline(events: WorkerTraceEvent[], actorLabel: string): { human: ActivityEntry[]; technical: WorkerTraceEvent[] } {
+function projectTimeline(events: WorkerTraceEvent[], actorLabel: string, isSubagentTrace: boolean): { human: ActivityEntry[]; technical: WorkerTraceEvent[] } {
   const human: ActivityEntry[] = []
   const technical: WorkerTraceEvent[] = []
   const calls = new Map<string, ActivityEntry>()
   const uncorrelatedNativeCalls: ActivityEntry[] = []
 
   for (const event of events) {
-    const activity = activityFor(event, actorLabel)
+    const activity = activityFor(event, actorLabel, isSubagentTrace)
     if (!activity) {
       technical.push(event)
       continue
@@ -359,12 +359,14 @@ export function Timeline({
   seq,
   heading = '活动记录',
   actorLabel = 'Worker',
+  isSubagentTrace = false,
   loadTrace,
 }: {
   workerId: string
   seq?: number
   heading?: string
   actorLabel?: string
+  isSubagentTrace?: boolean
   loadTrace?: (cursor?: string) => Promise<{ events: WorkerTraceEvent[]; next_cursor?: string; unavailable_reason?: string }>
 }) {
   const [events, setEvents] = useState<WorkerTraceEvent[]>([])
@@ -376,7 +378,7 @@ export function Timeline({
   const [page, setPage] = useState(1)
   const [expandedEntry, setExpandedEntry] = useState<string | undefined>(undefined)
   const [refreshing, setRefreshing] = useState(false)
-  const projected = useMemo(() => projectTimeline(events, actorLabel), [events, actorLabel])
+  const projected = useMemo(() => projectTimeline(events, actorLabel, isSubagentTrace), [events, actorLabel, isSubagentTrace])
 
   const load = useCallback(async (cursor?: string) => {
     try {

--- a/crabot-admin/web/src/pages/Traces/WorkerDetail.tsx
+++ b/crabot-admin/web/src/pages/Traces/WorkerDetail.tsx
@@ -13,6 +13,7 @@ import {
   type WorkerTaskStatus,
   type WorkerTerminalView,
   type WorkerTraceEvent,
+  type WorkerSubagentSummary,
 } from '../../services/agent-observability'
 
 const IMPL_LABEL: Record<WorkerIncarnation['impl'], string> = {
@@ -54,6 +55,7 @@ interface ActivityEntry {
   body: string
   title?: string
   result?: string
+  subagentId?: string
 }
 
 function asRecord(value: unknown): DetailRecord | undefined {
@@ -109,6 +111,12 @@ function callId(event: WorkerTraceEvent): string | undefined {
   if (typeof value !== 'string' || !value) return undefined
   // Responses API 的内部 tool id 可能编码为 call_id|item_id；结果只带 call_id。
   return value.split('|', 1)[0]
+}
+
+function subagentId(event: WorkerTraceEvent): string | undefined {
+  if (typeof event.subagent_id === 'string' && event.subagent_id) return event.subagent_id
+  const value = asRecord(event.detail)?.subagent_id
+  return typeof value === 'string' && value ? value : undefined
 }
 
 function isUncorrelatedNativeToolCall(event: WorkerTraceEvent): boolean {
@@ -178,15 +186,15 @@ function lifecycleActivity(event: WorkerTraceEvent): ActivityEntry | undefined {
   return undefined
 }
 
-function activityFor(event: WorkerTraceEvent): ActivityEntry | undefined {
+function activityFor(event: WorkerTraceEvent, actorLabel: string): ActivityEntry | undefined {
   if (event.source === 'legacy') {
     return { event, label: '历史记录', tone: 'status', body: event.summary }
   }
-  if (event.source === 'native' && event.kind === 'message' && event.role === 'user') {
-    return { event, label: '管理会话指令', tone: 'manager', body: messageText(event) }
+  if (event.kind === 'message' && event.role === 'user') {
+    return { event, label: event.source === 'native' ? '管理会话指令' : `${actorLabel} 指令`, tone: 'manager', body: messageText(event) }
   }
-  if (event.source === 'native' && event.kind === 'message' && event.role === 'assistant') {
-    return { event, label: 'Worker 文本', tone: 'worker', body: messageText(event) }
+  if (event.kind === 'message' && event.role === 'assistant') {
+    return { event, label: `${actorLabel} 文本`, tone: 'worker', body: messageText(event) }
   }
   if (event.kind === 'tool_call') {
     return { event, label: '工具调用', tone: 'tool', title: toolName(event), body: toolArguments(event) }
@@ -198,14 +206,14 @@ function activityFor(event: WorkerTraceEvent): ActivityEntry | undefined {
   return undefined
 }
 
-function projectTimeline(events: WorkerTraceEvent[]): { human: ActivityEntry[]; technical: WorkerTraceEvent[] } {
+function projectTimeline(events: WorkerTraceEvent[], actorLabel: string): { human: ActivityEntry[]; technical: WorkerTraceEvent[] } {
   const human: ActivityEntry[] = []
   const technical: WorkerTraceEvent[] = []
   const calls = new Map<string, ActivityEntry>()
   const uncorrelatedNativeCalls: ActivityEntry[] = []
 
   for (const event of events) {
-    const activity = activityFor(event)
+    const activity = activityFor(event, actorLabel)
     if (!activity) {
       technical.push(event)
       continue
@@ -219,6 +227,7 @@ function projectTimeline(events: WorkerTraceEvent[]): { human: ActivityEntry[]; 
       const targetCall = pairedCall ?? fallbackCall
       if (targetCall) {
         targetCall.result = activity.body
+        targetCall.subagentId ??= subagentId(event)
         if (pairedCall) {
           const fallbackIndex = uncorrelatedNativeCalls.indexOf(pairedCall)
           if (fallbackIndex >= 0) uncorrelatedNativeCalls.splice(fallbackIndex, 1)
@@ -226,6 +235,7 @@ function projectTimeline(events: WorkerTraceEvent[]): { human: ActivityEntry[]; 
         continue
       }
     }
+    activity.subagentId = subagentId(event)
     human.push(activity)
     if (event.kind === 'tool_call') {
       const id = callId(event)
@@ -272,7 +282,7 @@ function DetailText({ children }: { children: string }) {
   )
 }
 
-function TimelineEvent({ entry, expanded, onToggle }: { entry: ActivityEntry; expanded: boolean; onToggle: () => void }) {
+function TimelineEvent({ entry, expanded, onToggle, workerId }: { entry: ActivityEntry; expanded: boolean; onToggle: () => void; workerId: string }) {
   const preview = activityPreview(entry)
   const action = expanded ? '收起详情' : '展开详情'
   return (
@@ -306,16 +316,22 @@ function TimelineEvent({ entry, expanded, onToggle }: { entry: ActivityEntry; ex
           ) : (
             <DetailText>{entry.body}</DetailText>
           )}
+          {entry.subagentId && (
+            <Link to={`/traces/workers/${encodeURIComponent(workerId)}/subagents/${encodeURIComponent(entry.subagentId)}`} style={{ display: 'inline-block', marginTop: 10, color: 'var(--primary)', fontSize: 12 }}>
+              查看子 Agent
+            </Link>
+          )}
         </div>
       )}
     </article>
   )
 }
 
-function TechnicalEvent({ event, expanded, onToggle }: { event: WorkerTraceEvent; expanded: boolean; onToggle: () => void }) {
+function TechnicalEvent({ event, expanded, onToggle, workerId }: { event: WorkerTraceEvent; expanded: boolean; onToggle: () => void; workerId: string }) {
   const source = event.source ? SOURCE_LABEL[event.source] ?? event.source : '—'
   const label = `${source} · ${KIND_LABEL[event.kind]}`
   const action = expanded ? '收起详情' : '展开详情'
+  const childId = subagentId(event)
   return (
     <article style={{ borderBottom: '1px solid var(--border)', color: 'var(--text-muted)' }}>
       <button type="button" aria-expanded={expanded} aria-label={`${label}：${oneLine(event.summary)}，${action}`} onClick={onToggle} style={{ display: 'grid', gridTemplateColumns: 'minmax(44px, 62px) minmax(76px, 112px) minmax(0, 1fr) auto', gap: 10, alignItems: 'center', width: '100%', padding: '9px 0', border: 0, borderRadius: 0, background: 'transparent', color: 'inherit', fontFamily: 'var(--font-mono)', fontSize: 12, textAlign: 'left', cursor: 'pointer' }}>
@@ -324,12 +340,33 @@ function TechnicalEvent({ event, expanded, onToggle }: { event: WorkerTraceEvent
         <span style={{ minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{oneLine(event.summary)}</span>
         <span aria-hidden="true">{expanded ? '收起' : '展开'}</span>
       </button>
-      {expanded && event.detail !== undefined && <div style={{ padding: '0 0 12px 72px' }}><DetailText>{JSON.stringify(event.detail)}</DetailText></div>}
+      {expanded && (
+        <div style={{ padding: '0 0 12px 72px' }}>
+          {event.detail !== undefined && <DetailText>{JSON.stringify(event.detail)}</DetailText>}
+          {childId && (
+            <Link to={`/traces/workers/${encodeURIComponent(workerId)}/subagents/${encodeURIComponent(childId)}`} style={{ display: 'inline-block', marginTop: 10, color: 'var(--primary)', fontSize: 12 }}>
+              查看子 Agent
+            </Link>
+          )}
+        </div>
+      )}
     </article>
   )
 }
 
-function Timeline({ workerId, seq }: { workerId: string; seq?: number }) {
+export function Timeline({
+  workerId,
+  seq,
+  heading = '活动记录',
+  actorLabel = 'Worker',
+  loadTrace,
+}: {
+  workerId: string
+  seq?: number
+  heading?: string
+  actorLabel?: string
+  loadTrace?: (cursor?: string) => Promise<{ events: WorkerTraceEvent[]; next_cursor?: string; unavailable_reason?: string }>
+}) {
   const [events, setEvents] = useState<WorkerTraceEvent[]>([])
   const [nextCursor, setNextCursor] = useState<string | undefined>(undefined)
   const [unavailableReason, setUnavailableReason] = useState<string | undefined>(undefined)
@@ -339,14 +376,16 @@ function Timeline({ workerId, seq }: { workerId: string; seq?: number }) {
   const [page, setPage] = useState(1)
   const [expandedEntry, setExpandedEntry] = useState<string | undefined>(undefined)
   const [refreshing, setRefreshing] = useState(false)
-  const projected = useMemo(() => projectTimeline(events), [events])
+  const projected = useMemo(() => projectTimeline(events, actorLabel), [events, actorLabel])
 
   const load = useCallback(async (cursor?: string) => {
     try {
-      const result = await agentObservabilityService.getWorkerTrace(workerId, {
-        ...(seq !== undefined ? { seq } : {}),
-        ...(cursor !== undefined ? { cursor } : {}),
-      })
+      const result = loadTrace
+        ? await loadTrace(cursor)
+        : await agentObservabilityService.getWorkerTrace(workerId, {
+          ...(seq !== undefined ? { seq } : {}),
+          ...(cursor !== undefined ? { cursor } : {}),
+        })
       setUnavailableReason(result.unavailable_reason)
       if (cursor === undefined) setEvents(result.events)
       else setEvents((previous) => [...previous, ...result.events])
@@ -360,7 +399,7 @@ function Timeline({ workerId, seq }: { workerId: string; seq?: number }) {
         setError(message)
       }
     }
-  }, [workerId, seq])
+  }, [workerId, seq, loadTrace])
 
   useEffect(() => {
     setEvents([])
@@ -395,7 +434,7 @@ function Timeline({ workerId, seq }: { workerId: string; seq?: number }) {
   return (
     <section style={{ maxWidth: 930 }} aria-label="任务活动">
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, flexWrap: 'wrap', marginBottom: 11 }}>
-        <h2 style={{ fontSize: 15, margin: 0 }}>活动记录</h2>
+        <h2 style={{ fontSize: 15, margin: 0 }}>{heading}</h2>
         <div style={{ display: 'inline-flex', gap: 2, padding: 2, border: '1px solid var(--border-highlight)', borderRadius: 6, background: 'var(--bg-primary)' }}>
           <button type="button" aria-pressed={mode === 'human'} onClick={() => selectMode('human')} style={{ border: 0, borderRadius: 4, padding: '5px 9px', background: mode === 'human' ? 'var(--primary)' : 'transparent', color: mode === 'human' ? 'var(--text-on-primary)' : 'var(--text-secondary)', fontWeight: mode === 'human' ? 600 : 400, transition: 'background 0.15s ease, color 0.15s ease' }}>
             对话与操作
@@ -412,12 +451,12 @@ function Timeline({ workerId, seq }: { workerId: string; seq?: number }) {
         ) : mode === 'human' ? (
           humanPageEvents.map((entry, index) => {
             const entryKey = `activity-${pageStart + index}-${entry.event.ts}-${entry.event.kind}-${callId(entry.event) ?? ''}`
-            return <TimelineEvent key={entryKey} entry={entry} expanded={expandedEntry === entryKey} onToggle={() => setExpandedEntry((current) => current === entryKey ? undefined : entryKey)} />
+            return <TimelineEvent key={entryKey} entry={entry} workerId={workerId} expanded={expandedEntry === entryKey} onToggle={() => setExpandedEntry((current) => current === entryKey ? undefined : entryKey)} />
           })
         ) : (
           technicalPageEvents.map((event, index) => {
             const entryKey = `technical-${pageStart + index}-${event.ts}-${event.kind}`
-            return <TechnicalEvent key={entryKey} event={event} expanded={expandedEntry === entryKey} onToggle={() => setExpandedEntry((current) => current === entryKey ? undefined : entryKey)} />
+            return <TechnicalEvent key={entryKey} event={event} workerId={workerId} expanded={expandedEntry === entryKey} onToggle={() => setExpandedEntry((current) => current === entryKey ? undefined : entryKey)} />
           })
         )}
         {cursorInvalid && (
@@ -439,6 +478,84 @@ function Timeline({ workerId, seq }: { workerId: string; seq?: number }) {
           </div>
         )}
       </div>
+    </section>
+  )
+}
+
+const SUBAGENT_STATUS_LABEL: Record<WorkerSubagentSummary['status'], string> = {
+  running: '执行中', completed: '已完成', failed: '失败', stopped: '已停止', interrupted: '已中断', unknown: '状态未知',
+}
+
+function formatSubagentStartedAt(value: string | undefined): string {
+  if (!value) return '开始时间未知'
+  return new Date(value).toLocaleString('zh-CN', {
+    month: 'numeric', day: 'numeric', hour: '2-digit', minute: '2-digit', hour12: false,
+  })
+}
+
+function formatSubagentDuration(subagent: WorkerSubagentSummary): string | undefined {
+  if (!subagent.started_at) return undefined
+  const start = Date.parse(subagent.started_at)
+  const end = Date.parse(subagent.ended_at ?? new Date().toISOString())
+  if (!Number.isFinite(start) || !Number.isFinite(end) || end < start) return undefined
+  const minutes = Math.floor((end - start) / 60_000)
+  if (minutes < 1) return subagent.status === 'running' ? '已运行不足 1 分钟' : '用时不足 1 分钟'
+  const hours = Math.floor(minutes / 60)
+  const label = subagent.status === 'running' ? '已运行' : '用时'
+  return hours > 0 ? `${label} ${hours} 小时 ${minutes % 60} 分钟` : `${label} ${minutes} 分钟`
+}
+
+function WorkerSubagentsPanel({ workerId }: { workerId: string }) {
+  const [subagents, setSubagents] = useState<WorkerSubagentSummary[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      setSubagents((await agentObservabilityService.listWorkerSubagents(workerId)).subagents)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLoading(false)
+    }
+  }, [workerId])
+
+  useEffect(() => { void load() }, [load])
+
+  return (
+    <section aria-label="子 Agent" style={{ maxWidth: 930, marginTop: 30 }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, marginBottom: 10 }}>
+        <div>
+          <h2 style={{ fontSize: 15, margin: 0 }}>子 Agent</h2>
+          <div style={{ color: 'var(--text-muted)', fontSize: 12, marginTop: 3 }}>该 Worker 直接启动的子 Agent</div>
+        </div>
+        <button type="button" onClick={() => void load()} disabled={loading}>{loading ? '读取中…' : '刷新'}</button>
+      </div>
+      {error && <div style={{ color: 'var(--color-warning, #d97706)', fontSize: 12, padding: '8px 0' }}>子 Agent 暂不可用：{error}</div>}
+      {!error && !loading && subagents.length === 0 && <div style={{ color: 'var(--text-muted)', fontSize: 13, padding: '12px 0', borderTop: '1px solid var(--border)' }}>该 Worker 尚未启动子 Agent。</div>}
+      {subagents.length > 0 && (
+        <div style={{ borderTop: '1px solid var(--border)' }}>
+          {subagents.map((subagent) => {
+            const duration = formatSubagentDuration(subagent)
+            return (
+              <Link key={subagent.subagent_id} to={`/traces/workers/${encodeURIComponent(workerId)}/subagents/${encodeURIComponent(subagent.subagent_id)}`} style={{ display: 'grid', gridTemplateColumns: 'minmax(0, 1fr) minmax(126px, .55fr) minmax(70px, auto) auto', gap: 12, alignItems: 'center', padding: '12px 0', borderBottom: '1px solid var(--border)', color: 'inherit', textDecoration: 'none' }}>
+                <span style={{ minWidth: 0 }}>
+                  <strong style={{ display: 'block', overflowWrap: 'anywhere' }}>{subagent.name}</strong>
+                  <span style={{ display: 'block', color: 'var(--text-muted)', fontSize: 12, marginTop: 3, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{subagent.task ?? subagent.subagent_id}</span>
+                </span>
+                <span style={{ minWidth: 0, color: 'var(--text-muted)', fontSize: 12 }}>
+                  <span style={{ display: 'block', whiteSpace: 'nowrap' }}>{formatSubagentStartedAt(subagent.started_at)}</span>
+                  {duration && <span style={{ display: 'block', marginTop: 3 }}>{duration}</span>}
+                </span>
+                <span style={{ fontSize: 12 }}>{SUBAGENT_STATUS_LABEL[subagent.status]}</span>
+                <span aria-hidden="true" style={{ color: 'var(--text-muted)' }}>查看 →</span>
+              </Link>
+            )
+          })}
+        </div>
+      )}
     </section>
   )
 }
@@ -613,6 +730,8 @@ const WorkerDetailContent: React.FC = () => {
       <div style={{ marginTop: 30 }}>
         <Timeline workerId={worker.worker_id} seq={selectedSeq} />
       </div>
+
+      <WorkerSubagentsPanel workerId={worker.worker_id} />
 
       <details style={{ maxWidth: 930, marginTop: 28, padding: '12px 14px', border: '1px solid var(--border)', background: 'var(--bg-muted)' }}>
         <summary style={{ cursor: 'pointer', fontSize: 13, fontWeight: 600 }}>终端画面</summary>

--- a/crabot-admin/web/src/pages/Traces/WorkersView.test.tsx
+++ b/crabot-admin/web/src/pages/Traces/WorkersView.test.tsx
@@ -6,6 +6,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { WorkersView } from './WorkersView'
 import { WorkerDetail } from './WorkerDetail'
+import { SubagentDetail } from './SubagentDetail'
 import { agentObservabilityService } from '../../services/agent-observability'
 
 vi.mock('../../services/agent-observability')
@@ -19,6 +20,9 @@ const mocked = agentObservabilityService as unknown as {
   getWorkerDetail: ReturnType<typeof vi.fn>
   getWorkerTrace: ReturnType<typeof vi.fn>
   getWorkerTerminal: ReturnType<typeof vi.fn>
+  listWorkerSubagents: ReturnType<typeof vi.fn>
+  getWorkerSubagentDetail: ReturnType<typeof vi.fn>
+  getWorkerSubagentTrace: ReturnType<typeof vi.fn>
 }
 
 function workerFixture() {
@@ -93,6 +97,7 @@ describe('WorkerDetail', () => {
       items: [{ manager_key: 'wechat::sess-1', display_name: '微信 · 测试账号 · 小付', active_worker_count: 0 }],
       pagination: { page: 1, page_size: 100, total_items: 1, total_pages: 1 },
     })
+    mocked.listWorkerSubagents = vi.fn().mockResolvedValue({ subagents: [] })
   })
 
   function renderDetail() {
@@ -206,6 +211,48 @@ describe('WorkerDetail', () => {
     expect(screen.getByText(/"file_path": "\/tmp\/x\.ts"/)).toBeInTheDocument()
     expect(screen.getByText('输出')).toBeInTheDocument()
     expect(screen.getByText('文件内容摘要')).toBeInTheDocument()
+  })
+
+  it('已确认子 Agent 身份的 Worker Trace 可直接打开该子 Agent 详情', async () => {
+    mocked.getWorkerDetail = vi.fn().mockResolvedValue({ worker: workerFixture() })
+    mocked.getWorkerTrace = vi.fn().mockResolvedValue({
+      events: [
+        { ts: '2026-08-01T00:00:01.000Z', kind: 'tool_call', summary: 'delegate_task', source: 'native', detail: { call_id: 'delegate-1', name: 'delegate_task', input: { task: '核对数据' } } },
+        { ts: '2026-08-01T00:00:02.000Z', kind: 'tool_result', summary: '子 Agent 已启动', source: 'native', subagent_id: 'agent-child-1', detail: { call_id: 'delegate-1', output: '子 Agent 已启动' } },
+      ],
+      next_cursor: 'tok-1',
+    })
+    mocked.getWorkerTerminal = vi.fn().mockResolvedValue({ kind: 'live_terminal', text: '', captured_at: '2026-08-01T00:00:00.000Z' })
+    renderDetail()
+
+    const toolRow = await screen.findByRole('button', { name: /工具调用：调用 delegate_task · 已返回结果.*展开详情/ })
+    fireEvent.click(toolRow)
+    expect(screen.getByRole('link', { name: '查看子 Agent' })).toHaveAttribute(
+      'href',
+      `/traces/workers/${encodeURIComponent('w-1234567890ab')}/subagents/${encodeURIComponent('agent-child-1')}`,
+    )
+  })
+
+  it('直接启动的子 Agent 显示任务、状态、时间和详情链接', async () => {
+    mocked.getWorkerDetail = vi.fn().mockResolvedValue({ worker: workerFixture() })
+    mocked.getWorkerTrace = vi.fn().mockResolvedValue({ events: [], next_cursor: 'tok-1' })
+    mocked.getWorkerTerminal = vi.fn().mockResolvedValue({ kind: 'live_terminal', text: '', captured_at: '2026-08-01T00:00:00.000Z' })
+    mocked.listWorkerSubagents = vi.fn().mockResolvedValue({
+      subagents: [{
+        subagent_id: 'agent-child-1', worker_id: 'w-1234567890ab', executor_impl: 'builtin', type: 'code_writer',
+        name: '代码助手', task: '核对接口契约', status: 'completed',
+        started_at: '2026-08-01T00:00:00.000Z', ended_at: '2026-08-01T00:02:00.000Z',
+      }],
+    })
+    renderDetail()
+
+    await screen.findByText('代码助手')
+    expect(screen.getByText('核对接口契约')).toBeInTheDocument()
+    expect(screen.getAllByText('已完成')).toHaveLength(2)
+    expect(screen.getByRole('link', { name: /代码助手.*核对接口契约.*用时 2 分钟.*已完成/ })).toHaveAttribute(
+      'href',
+      `/traces/workers/${encodeURIComponent('w-1234567890ab')}/subagents/${encodeURIComponent('agent-child-1')}`,
+    )
   })
 
   it('指令投递显示 receipt 中已有的受限正文预览', async () => {
@@ -326,5 +373,53 @@ describe('WorkerDetail', () => {
     expect(screen.getByText('第 2 / 2 页')).toBeInTheDocument()
     expect(screen.getByText('消息 20')).toBeInTheDocument()
     expect(screen.queryByText('消息 0')).not.toBeInTheDocument()
+  })
+})
+
+describe('SubagentDetail', () => {
+  beforeEach(() => { vi.resetAllMocks() })
+
+  function renderSubagentDetail() {
+    return render(
+      <MemoryRouter initialEntries={[`/traces/workers/${encodeURIComponent('w-1234567890ab')}/subagents/agent-child-1`]}>
+        <Routes>
+          <Route path="/traces/workers/:workerId/subagents/:subagentId" element={<SubagentDetail />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+  }
+
+  it('显示 child 自身信息，分页查看 trace，并能返回所属 Worker', async () => {
+    const events = Array.from({ length: 21 }, (_, index) => ({
+      ts: `2026-08-01T00:00:${String(index).padStart(2, '0')}.000Z`, kind: 'message' as const,
+      role: 'assistant' as const, summary: `子 Agent 记录 ${index}`, source: 'harness' as const,
+      detail: { content: `子 Agent 记录 ${index}` },
+    }))
+    mocked.getWorkerSubagentDetail = vi.fn().mockResolvedValue({
+      subagent: {
+        subagent_id: 'agent-child-1', worker_id: 'w-1234567890ab', executor_impl: 'codex', type: 'research',
+        name: '研究助手', task: '整理原生记录', status: 'completed',
+        started_at: '2026-08-01T00:00:00.000Z', ended_at: '2026-08-01T00:02:00.000Z',
+      },
+    })
+    mocked.getWorkerSubagentTrace = vi.fn().mockResolvedValue({ events, next_cursor: 'tok-1' })
+    renderSubagentDetail()
+
+    await screen.findByRole('heading', { name: '研究助手', level: 1 })
+    expect(screen.getByText('Codex')).toBeInTheDocument()
+    expect(screen.getByText('research')).toBeInTheDocument()
+    expect(screen.getByText('整理原生记录')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: '子 Agent Trace', level: 2 })).toBeInTheDocument()
+    expect(await screen.findAllByText('子 Agent 文本')).not.toHaveLength(0)
+    expect(screen.getByText('第 1 / 2 页')).toBeInTheDocument()
+    expect(screen.getByText('子 Agent 记录 0')).toBeInTheDocument()
+    expect(screen.queryByText('子 Agent 记录 20')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: '下一页' }))
+    expect(screen.getByText('第 2 / 2 页')).toBeInTheDocument()
+    expect(screen.getByText('子 Agent 记录 20')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: '← 返回 Worker 详情' })).toHaveAttribute(
+      'href',
+      `/traces/workers/${encodeURIComponent('w-1234567890ab')}`,
+    )
   })
 })

--- a/crabot-admin/web/src/pages/Traces/WorkersView.test.tsx
+++ b/crabot-admin/web/src/pages/Traces/WorkersView.test.tsx
@@ -390,11 +390,15 @@ describe('SubagentDetail', () => {
   }
 
   it('显示 child 自身信息，分页查看 trace，并能返回所属 Worker', async () => {
-    const events = Array.from({ length: 21 }, (_, index) => ({
+    const events = [{
+      ts: '2026-08-01T00:00:00.000Z', kind: 'message' as const,
+      role: 'user' as const, summary: '核对原生 child trace', source: 'native' as const,
+      detail: { content: '核对原生 child trace' },
+    }, ...Array.from({ length: 21 }, (_, index) => ({
       ts: `2026-08-01T00:00:${String(index).padStart(2, '0')}.000Z`, kind: 'message' as const,
       role: 'assistant' as const, summary: `子 Agent 记录 ${index}`, source: 'harness' as const,
       detail: { content: `子 Agent 记录 ${index}` },
-    }))
+    }))]
     mocked.getWorkerSubagentDetail = vi.fn().mockResolvedValue({
       subagent: {
         subagent_id: 'agent-child-1', worker_id: 'w-1234567890ab', executor_impl: 'codex', type: 'research',
@@ -410,6 +414,8 @@ describe('SubagentDetail', () => {
     expect(screen.getByText('research')).toBeInTheDocument()
     expect(screen.getByText('整理原生记录')).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: '子 Agent Trace', level: 2 })).toBeInTheDocument()
+    expect(screen.getByText('子 Agent 指令')).toBeInTheDocument()
+    expect(screen.queryByText('管理会话指令')).not.toBeInTheDocument()
     expect(await screen.findAllByText('子 Agent 文本')).not.toHaveLength(0)
     expect(screen.getByText('第 1 / 2 页')).toBeInTheDocument()
     expect(screen.getByText('子 Agent 记录 0')).toBeInTheDocument()

--- a/crabot-admin/web/src/services/agent-observability.ts
+++ b/crabot-admin/web/src/services/agent-observability.ts
@@ -88,6 +88,7 @@ export type WorkerTaskStatus =
   | 'queued' | 'running' | 'waiting_input' | 'completed' | 'failed' | 'cancelled'
 
 export interface WorkerIncarnation {
+  incarnation_id?: string
   seq: number
   impl: 'builtin' | 'claude-code' | 'codex' | 'legacy'
   state: string
@@ -96,7 +97,7 @@ export interface WorkerIncarnation {
   ended_at?: string
   ended_reason?: string
   session_ref?: string
-  forked_from?: number
+  forked_from?: number | string
 }
 
 export interface LedgerWorker {
@@ -137,6 +138,7 @@ export interface WorkerTraceEvent {
   kind: 'message' | 'llm_call' | 'tool_call' | 'tool_result' | 'thinking' | 'lifecycle'
   role?: 'assistant' | 'user' | 'system'
   summary: string
+  subagent_id?: string
   detail?: unknown
   source?: 'harness' | 'native' | 'legacy'
 }
@@ -144,6 +146,27 @@ export interface WorkerTraceEvent {
 export interface WorkerTraceResult {
   events: WorkerTraceEvent[]
   next_cursor?: string
+  unavailable_reason?: string
+}
+
+export type WorkerSubagentStatus = 'running' | 'completed' | 'failed' | 'stopped' | 'interrupted' | 'unknown'
+
+export interface WorkerSubagentSummary {
+  subagent_id: string
+  worker_id: string
+  executor_impl: 'builtin' | 'claude-code' | 'codex'
+  type?: string
+  name: string
+  task?: string
+  status: WorkerSubagentStatus
+  started_at?: string
+  ended_at?: string
+  unavailable_reason?: string
+}
+
+export interface WorkerSubagentTraceResult {
+  events: WorkerTraceEvent[]
+  next_cursor: string
   unavailable_reason?: string
 }
 
@@ -228,6 +251,24 @@ export const agentObservabilityService = {
     if (opts.seq !== undefined) search.set('seq', String(opts.seq))
     const suffix = search.toString()
     return api.get(`/agent/workers/${encodeURIComponent(workerId)}/terminal${suffix ? `?${suffix}` : ''}`)
+  },
+
+  listWorkerSubagents(workerId: string, incarnationId?: string): Promise<{ subagents: WorkerSubagentSummary[] }> {
+    const search = new URLSearchParams()
+    if (incarnationId) search.set('incarnation_id', incarnationId)
+    const suffix = search.toString()
+    return api.get(`/agent/workers/${encodeURIComponent(workerId)}/subagents${suffix ? `?${suffix}` : ''}`)
+  },
+
+  getWorkerSubagentDetail(workerId: string, subagentId: string): Promise<{ subagent: WorkerSubagentSummary }> {
+    return api.get(`/agent/workers/${encodeURIComponent(workerId)}/subagents/${encodeURIComponent(subagentId)}`)
+  },
+
+  getWorkerSubagentTrace(workerId: string, subagentId: string, cursor?: string): Promise<WorkerSubagentTraceResult> {
+    const search = new URLSearchParams()
+    if (cursor) search.set('cursor', cursor)
+    const suffix = search.toString()
+    return api.get(`/agent/workers/${encodeURIComponent(workerId)}/subagents/${encodeURIComponent(subagentId)}/trace${suffix ? `?${suffix}` : ''}`)
   },
 
   // ── 维护面 ──

--- a/crabot-agent/src/agent/agent-handler.ts
+++ b/crabot-agent/src/agent/agent-handler.ts
@@ -456,6 +456,8 @@ export interface AgentHandlerOptions {
   imageConnInfo?: ImageConnInfo
   /** 生图能力可用性，驱动 self-aware 提示词 */
   imageCapability?: { available: boolean; reason?: string }
+  /** UnifiedAgent 共享的 Worker background entity registry。 */
+  bgRegistry?: BgEntityRegistry
 }
 
 export interface ExecuteTriggerMessageParams {
@@ -552,12 +554,9 @@ export class AgentHandler {
   /** 对外 base URL（临时页面链接拼接用），注入 worker system prompt；未配置时为 undefined（不注入） */
   private tmpPageBaseUrl?: string
   /** Worker-singleton bg entity registry (persistent, disk-backed) */
-  private readonly bgRegistry = new BgEntityRegistry()
+  private readonly bgRegistry: BgEntityRegistry
   /** 监视跨重启认领回来、仍存活的 shell；退出时通知（唤醒 resumed worker + 持久通知）。 */
-  private readonly readoptReaper = new ReadoptReaper(
-    this.bgRegistry,
-    (info) => { void this.routeShellExit(info).catch((error) => console.error('[AgentHandler] readopt shell notification failed:', error)) },
-  )
+  private readonly readoptReaper: ReadoptReaper
   /** Per-task output cursor map: key = `${taskId}:${entityId}` → byte offset */
   private readonly bgCursorMap = new Map<string, number>()
   /** AbortControllers for running bg sub-agents (key=entity_id); shared with BgToolDeps */
@@ -601,6 +600,11 @@ export class AgentHandler {
     config: AgentHandlerConfig,
     options?: AgentHandlerOptions,
   ) {
+    this.bgRegistry = options?.bgRegistry ?? new BgEntityRegistry()
+    this.readoptReaper = new ReadoptReaper(
+      this.bgRegistry,
+      (info) => { void this.routeShellExit(info).catch((error) => console.error('[AgentHandler] readopt shell notification failed:', error)) },
+    )
     this.sdkEnv = sdkEnv
     this.mcpConfigFactory = options?.mcpConfigFactory
     this.deps = options?.deps
@@ -873,6 +877,10 @@ export class AgentHandler {
    * Supplies the shared persistent registry to a builtin worker. The legacy
    * handler remains its owner; a second registry would split shell ownership.
    */
+  getBuiltinBgEntityRegistry(): BgEntityRegistry {
+    return this.bgRegistry
+  }
+
   createBuiltinBgToolOptions(workerId: string): { bgEntityCtx: BashBgContext; bgToolDeps: BgToolDeps } {
     const owner: BgEntityOwner = { friend_id: `__system_${workerId}`, worker_id: workerId }
     const onShellExit: BashBgContext['onShellExit'] = (info) => {

--- a/crabot-agent/src/engine/bg-entities/bg-agent.ts
+++ b/crabot-agent/src/engine/bg-entities/bg-agent.ts
@@ -50,6 +50,8 @@ export interface SpawnPersistentAgentOpts {
   readonly permissionConfig?: ToolPermissionConfig
   readonly owner: BgEntityOwner
   readonly spawned_by_task_id: string
+  /** Actual configured child type, when the caller has one. */
+  readonly subagent_type?: string
   readonly registry: BgEntityRegistry
   /** Worker-maintained abort-controller map: written on spawn, deleted on finish/kill. */
   readonly abortControllers: Map<string, AbortController>
@@ -123,23 +125,6 @@ export async function spawnPersistentAgent(opts: SpawnPersistentAgentOpts): Prom
   const abortController = new AbortController()
   opts.abortControllers.set(entity_id, abortController)
 
-  const now = new Date().toISOString()
-  const record: BgAgentRegistryRecord = {
-    entity_id,
-    type: 'agent',
-    status: 'running',
-    task_description: opts.task_description,
-    messages_log_file: messagesLog,
-    result_file: null,
-    owner: opts.owner,
-    spawned_by_task_id: opts.spawned_by_task_id,
-    spawned_at: now,
-    exit_code: null,
-    ended_at: null,
-    last_activity_at: now,
-  }
-  await opts.registry.register(record)
-
   // 子 trace 在 fire-and-forget 外同步起，保证 spawn 返回时 Admin Traces 立刻可见。
   const subTrace = opts.subTrace
     ? opts.subTrace.traceStore.startTrace({
@@ -158,6 +143,25 @@ export async function spawnPersistentAgent(opts: SpawnPersistentAgentOpts): Prom
       })
     : undefined
   const subTraceStore = opts.subTrace?.traceStore
+
+  const now = new Date().toISOString()
+  const record: BgAgentRegistryRecord = {
+    entity_id,
+    type: 'agent',
+    ...(opts.subagent_type ? { subagent_type: opts.subagent_type } : {}),
+    ...(subTrace ? { trace_id: subTrace.trace_id } : {}),
+    status: 'running',
+    task_description: opts.task_description,
+    messages_log_file: messagesLog,
+    result_file: null,
+    owner: opts.owner,
+    spawned_by_task_id: opts.spawned_by_task_id,
+    spawned_at: now,
+    exit_code: null,
+    ended_at: null,
+    last_activity_at: now,
+  }
+  await opts.registry.register(record)
 
   const agentSpawnedAtMs = Date.now()
 

--- a/crabot-agent/src/engine/bg-entities/bg-agent.ts
+++ b/crabot-agent/src/engine/bg-entities/bg-agent.ts
@@ -48,6 +48,13 @@ export interface SpawnPersistentAgentOpts {
    * （2026-06-10 goal audit 死循环事故，spec 2026-06-10-audit-anchor-human-request §4.6）。
    */
   readonly permissionConfig?: ToolPermissionConfig
+  /** Worker execution hooks inherited by the child. */
+  readonly hookRegistry?: import('../../hooks/hook-registry.js').HookRegistry
+  readonly lspManager?: import('../../hooks/types.js').LspManagerLike
+  /** The child has no human identity of its own. */
+  readonly senderIsMaster?: boolean
+  /** Permission snapshot used by hooks such as the CLI permission gate. */
+  readonly resolvedPermissions?: import('../../types.js').ResolvedPermissions
   readonly owner: BgEntityOwner
   readonly spawned_by_task_id: string
   /** Actual configured child type, when the caller has one. */
@@ -177,6 +184,10 @@ export async function spawnPersistentAgent(opts: SpawnPersistentAgentOpts): Prom
           model: opts.model,
           ...(opts.maxTokens !== undefined ? { maxTokens: opts.maxTokens } : {}),
           ...(opts.permissionConfig ? { permissionConfig: opts.permissionConfig } : {}),
+          hookRegistry: opts.hookRegistry,
+          lspManager: opts.lspManager,
+          senderIsMaster: opts.senderIsMaster,
+          resolvedPermissions: opts.resolvedPermissions,
           abortSignal: abortController.signal,
           // 同 forkEngine：bg-agent 也是 subagent 派发路径，禁用 compaction。
           // 详见 EngineOptions.disableCompaction 注释。

--- a/crabot-agent/src/engine/bg-entities/registry.ts
+++ b/crabot-agent/src/engine/bg-entities/registry.ts
@@ -55,6 +55,13 @@ function hasPendingExitNotification(record: BgEntityRecord): boolean {
   return record.type === 'shell' && record.exit_notification?.status === 'pending'
 }
 
+/** Worker delegate_task identities belong to Worker observability retention, not the 7d entity GC. */
+function isWorkerOwnedBuiltinAgent(record: BgEntityRecord): boolean {
+  return record.type === 'agent'
+    && record.owner.worker_id !== undefined
+    && record.spawned_by_task_id === record.owner.worker_id
+}
+
 // ---------------------------------------------------------------------------
 // PID starttime helper：复用 bg-shell 的健壮版（带 ps-parse 失败兜底），避免重复实现，
 // 也避免本文件旧拷贝在某些 locale 下 `new Date(...).toISOString()` 在 execFile 回调里
@@ -275,6 +282,9 @@ export class BgEntityRegistry {
     const cutoffMs = now.getTime() - BG_ENTITY_GC_AFTER_DAYS * 24 * 60 * 60 * 1000
     const removed = await this.deleteEntriesWhere((rec) => {
       if (rec.status === 'running' || hasPendingExitNotification(rec)) return false
+      // Worker-owned builtin child identities remain addressable while their Worker is retained;
+      // the unified Worker retention transaction removes them with that Worker later.
+      if (isWorkerOwnedBuiltinAgent(rec)) return false
       const lastActivityMs = new Date(rec.last_activity_at).getTime()
       const endedMs = rec.ended_at ? new Date(rec.ended_at).getTime() : 0
       return Math.max(lastActivityMs, endedMs) < cutoffMs

--- a/crabot-agent/src/engine/bg-entities/types.ts
+++ b/crabot-agent/src/engine/bg-entities/types.ts
@@ -49,6 +49,10 @@ export interface BgShellRegistryRecord extends BgEntityBase {
 
 export interface BgAgentRegistryRecord extends BgEntityBase {
   readonly type: 'agent'
+  /** Present when this persistent agent was started through delegate_task. */
+  readonly subagent_type?: string
+  /** Its independent TraceStore trace, when the caller enabled tracing. */
+  readonly trace_id?: string
   readonly task_description: string
   readonly messages_log_file: string
   result_file: string | null

--- a/crabot-agent/src/engine/sub-agent.ts
+++ b/crabot-agent/src/engine/sub-agent.ts
@@ -1,5 +1,6 @@
 import type { LLMAdapter } from './llm-adapter'
 import type { ToolDefinition, EngineTurnEvent, EngineResult, ContentBlock, HumanMessageQueueLike, ToolPermissionConfig } from './types'
+import type { ResolvedPermissions } from '../types'
 import type { TraceStore } from '../core/trace-store'
 import { runEngine } from './query-loop'
 
@@ -35,6 +36,10 @@ export interface ForkEngineParams {
   readonly lspManager?: import('../hooks/types').LspManagerLike
   /** 继承自父（Worker）的 permissionConfig；sub-agent 使用的工具子集仍需遵循相同权限策略 */
   readonly permissionConfig?: ToolPermissionConfig
+  /** 继承自父 Worker 的权限快照，供 CLI permission gate 使用。 */
+  readonly resolvedPermissions?: ResolvedPermissions
+  /** 子 Agent 没有可验证的发起人身份，不能绕过 CLI permission gate。 */
+  readonly senderIsMaster?: boolean
 }
 
 export interface ForkEngineResult {
@@ -92,6 +97,8 @@ export async function forkEngine(params: ForkEngineParams): Promise<ForkEngineRe
       hookRegistry: params.hookRegistry,
       lspManager: params.lspManager,
       permissionConfig: params.permissionConfig,
+      resolvedPermissions: params.resolvedPermissions,
+      senderIsMaster: params.senderIsMaster,
       // subagent 内禁用 compaction：靠 maxTurns 控规模，避免父侧无感知的隐式压缩 +
       // 嵌套 LLM call。详见 EngineOptions.disableCompaction 注释。
       disableCompaction: true,

--- a/crabot-agent/src/engine/types.ts
+++ b/crabot-agent/src/engine/types.ts
@@ -126,6 +126,11 @@ export interface ToolCallContext {
   readonly onProgress?: (message: string) => void
   /** IANA 时区名（如 "Asia/Shanghai"），用于 tool_result 时间戳渲染 */
   readonly timezone?: string
+  /** Injected only while a builtin Worker invokes delegate_task. */
+  readonly worker_subagent?: {
+    readonly worker_id: string
+    readonly parent_trace_id?: string
+  }
 }
 
 export interface ToolCallResult {

--- a/crabot-agent/src/manager/bootstrap.ts
+++ b/crabot-agent/src/manager/bootstrap.ts
@@ -200,6 +200,8 @@ export interface BootstrapDeps {
   readonly builtinTraceReader?: import('../workers/builtin/adapter.js').BuiltinTraceReader
   /** P6-A §8.10：化身终态收割钩子（harness fire-and-forget；装配层做最后一次 native read）。 */
   readonly onIncarnationTerminal?: (handle: import('../workers/types.js').IncarnationHandle) => void
+  /** Parent native activity has been persisted; used only to notice terminal direct CLI children. */
+  readonly onNativeActivityCollected?: (handle: import('../workers/types.js').IncarnationHandle) => void
   /** P6-A §3.2：episode 消费后结算未 claim 的 Admin Chat request IDs（写 correlation store）。 */
   readonly onAdminChatWakeConsumed?: (key: import('../workers/harness/ledger-types.js').ManagerKey, requestIds: string[]) => void
   /**
@@ -354,6 +356,7 @@ export function buildManagerStack(deps: BootstrapDeps): ManagerStack {
     now: deps.now,
     // P6-A §8.10：化身终态时主动收割一次 native trace（最后一次 read → Agent-owned copy）。
     onIncarnationTerminal: deps.onIncarnationTerminal,
+    onNativeActivityCollected: deps.onNativeActivityCollected,
     // harness 事件 → 该 worker 的监护 manager(§4.4)。过滤复用 P4 的
     // `shouldWakeOnHarnessEvent`(input_sent 不唤醒:manager 发起 send_to_worker 时已在同一次
     // 工具调用里同步拿到结果)。

--- a/crabot-agent/src/manager/read-model.ts
+++ b/crabot-agent/src/manager/read-model.ts
@@ -32,7 +32,7 @@
 import type { PaginationParams, PaginatedResult } from 'crabot-shared'
 import type { ManagerKey, LedgerWorker, TaskStatus } from '../workers/harness/ledger-types.js'
 import { isDecisionVisibleWorker } from '../workers/harness/task-status.js'
-import type { NormalizedTraceEvent, WorkerImplId, WorkerTerminalView } from '../workers/types.js'
+import type { NormalizedTraceEvent, WorkerImplId, WorkerTerminalView, IncarnationId, WorkerSubagentSummary } from '../workers/types.js'
 
 /**
  * base-protocol §5.7 TimeRange。`crabot-shared` 目前没有导出它(只在协议文档和各 channel
@@ -108,6 +108,36 @@ export interface GetWorkerTraceParams {
 export interface GetWorkerTraceResult {
   events: NormalizedTraceEvent[]
   next_cursor?: string
+  unavailable_reason?: string
+}
+
+export interface ListWorkerSubagentsParams {
+  worker_id: string
+  incarnation_id?: IncarnationId
+}
+
+export interface ListWorkerSubagentsResult {
+  subagents: WorkerSubagentSummary[]
+}
+
+export interface GetWorkerSubagentDetailParams {
+  worker_id: string
+  subagent_id: string
+}
+
+export interface GetWorkerSubagentDetailResult {
+  subagent: WorkerSubagentSummary
+}
+
+export interface GetWorkerSubagentTraceParams {
+  worker_id: string
+  subagent_id: string
+  cursor?: string
+}
+
+export interface GetWorkerSubagentTraceResult {
+  events: NormalizedTraceEvent[]
+  next_cursor: string
   unavailable_reason?: string
 }
 

--- a/crabot-agent/src/prompts/assemble-agent.ts
+++ b/crabot-agent/src/prompts/assemble-agent.ts
@@ -37,6 +37,8 @@ export interface AssembleAgentPromptOptions {
     readonly toolName: string
     readonly workerHint: string
   }>
+  /** Worker only has delegate_task, not AgentHandler's subagent coordinator tools. */
+  readonly subagentGuidance?: 'agent' | 'builtin_worker'
   readonly imageCapability?: { readonly available: boolean }
 }
 
@@ -91,7 +93,7 @@ export function assembleAgentPrompt(opts: AssembleAgentPromptOptions): string {
       `1. 你的能力不足以完成某个子任务（如你没有视觉能力但需要分析图片）\n` +
       `2. 子任务的中间过程你不关心，只需要最终结果（避免污染你的上下文）`,
     )
-    parts.push(ASYNC_SUBAGENT_GUIDANCE)
+    parts.push(opts.subagentGuidance === 'builtin_worker' ? BUILTIN_WORKER_SUBAGENT_GUIDANCE : ASYNC_SUBAGENT_GUIDANCE)
   }
 
   return parts.join('\n\n')
@@ -123,3 +125,13 @@ subagent 完成时，系统自动推送 \`<sub_agent_notification>\` 到你的�
 **禁止的反模式：**
 - ❌ 用 \`get_subagent_output\` 轮询进度（等通知，不要主动查）
 - ❌ 用 \`list_active_subagents\` 反复轮询状态（只在用户问进度时才调）`
+
+const BUILTIN_WORKER_SUBAGENT_GUIDANCE = `## 子 Agent 委派
+
+调 \`delegate_task\` 默认异步：工具立即返回 \`{agent_id, status:"launched"}\`；可用时还会带 \`child_trace_id\`。
+
+子 Agent 完成或失败后，系统会在后续 turn 注入 \`<sub_agent_notification>…</sub_agent_notification>\`，其中包含子 Agent 名称、状态和最终结果或错误。收到通知后，基于结果继续当前 Worker 的任务。
+
+只有必须在同一 turn 取得结果后才能继续决策时，才使用 \`sync: true\`；此时结果直接在 \`delegate_task\` 返回值中。
+
+不要调用未提供的子 Agent 查询或管理工具。`

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -34,6 +34,7 @@ import type {
   SkillConfig,
   TaskOrigin,
   WorkerAgentContext,
+  SubAgentConfig,
 } from './types.js'
 import { SessionManager } from './orchestration/session-manager.js'
 import { PermissionChecker } from './orchestration/permission-checker.js'
@@ -52,11 +53,13 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { McpConnector, filterMcpServersForWorker } from './agent/mcp-connector.js'
 import { mcpServerToToolDefinitions } from './agent/mcp-tool-bridge.js'
 import { createTmpPageTools } from './agent/tmp-page-tools.js'
+import { createDelegateTaskTool } from './agent/delegate-task-tool.js'
 import { createCrabMessagingServer, type PathMapping, type TaskContext } from './mcp/crab-messaging.js'
 import { toImageConnInfo, imageToolsFor, type ImageConnInfo } from './mcp/crab-image.js'
 import { getAgentTraceDir, getAgentLogsDir, getAgentDataDir, getWorkspaceDir, getDataRootDir, getAdminDataDir } from './core/data-paths.js'
 import { ConfigLoader } from './core/config-loader.js'
 import { TraceStore } from './core/trace-store.js'
+import { BuiltinSubagentRunner } from './workers/builtin/subagent-runner.js'
 import { importV2LegacyTasks } from './workers/legacy-importer.js'
 import { PromptManager } from './prompt-manager.js'
 import { createLSPManager, type LSPManager } from './lsp/lsp-manager.js'
@@ -118,9 +121,15 @@ import {
   type GetWorkerTerminalResult,
   type GetWorkerTraceParams,
   type GetWorkerTraceResult,
+  type ListWorkerSubagentsParams,
+  type ListWorkerSubagentsResult,
+  type GetWorkerSubagentDetailParams,
+  type GetWorkerSubagentDetailResult,
+  type GetWorkerSubagentTraceParams,
+  type GetWorkerSubagentTraceResult,
 } from './manager/read-model.js'
 import { managerActivitySummary, projectManagerEpisode, withCausalParent, type EpisodeWorkerFact, type ManagerEpisodeProjection } from './manager/episode-projection.js'
-import type { NormalizedTraceEvent, SpawnSpec } from './workers/types.js'
+import type { NormalizedTraceEvent, SpawnSpec, WorkerSubagentSummary } from './workers/types.js'
 import {
   TaskCancelledError,
   WorkerHasNoIncarnationError,
@@ -131,6 +140,25 @@ import { SYSTEM_TASKS_MANAGER_KEY } from './manager/registry.js'
 import { splitManagerKey } from './manager/principal.js'
 
 const BARRIER_TIMEOUT_MS = 8_000
+
+function subagentTraceFingerprint(subagent: WorkerSubagentSummary): string {
+  return createHash('sha256')
+    .update(JSON.stringify({
+      executor_impl: subagent.executor_impl,
+      subagent_id: subagent.subagent_id,
+      started_at: subagent.started_at ?? '',
+    }))
+    .digest('hex')
+    .slice(0, 32)
+}
+
+function redactTraceDetail(detail: unknown, redact: (text: string) => string): unknown {
+  try {
+    return JSON.parse(redact(JSON.stringify(detail)))
+  } catch {
+    return '[unserializable detail removed]'
+  }
+}
 
 /**
  * fail-closed 兜底：权限解析失败时用最小权限（仅 messaging），避免未绑定模板或 Admin 不可用时放开全部工具。
@@ -488,6 +516,7 @@ export class UnifiedAgent extends ModuleBase {
   // Trace 存储
   private traceStore: TraceStore
   private lspManager: LSPManager
+  private builtinSubagentRunner: BuiltinSubagentRunner
   private traceCleanupInterval?: ReturnType<typeof setInterval>
   private promptManager: PromptManager
 
@@ -532,6 +561,13 @@ export class UnifiedAgent extends ModuleBase {
       ['traces-', 'traces-v3-'],
     )
     this.lspManager = createLSPManager()
+    this.builtinSubagentRunner = new BuiltinSubagentRunner(
+      this.traceStore,
+      this.lspManager,
+      async (workerId, text) => {
+        await this.requireManagerStack().harness.sendToWorker(workerId, text)
+      },
+    )
 
     this.promptManager = new PromptManager()
 
@@ -1002,7 +1038,7 @@ export class UnifiedAgent extends ModuleBase {
    *
    * **装**：内置文件/shell 工具 + skills、crab-memory、外部 MCP、tmp-page / 生图。
    * **不装**：全部 messaging（v3 语义：worker 不直接跟人类说话）、`set_cwd`、goal 相关、
-   * `delegate_task`、`todo`、`find_task` / `get_task_progress`、
+   * `todo`、`find_task` / `get_task_progress`、
    * subagent coordinator / `request_restart`。它们不是被过滤掉的，而是根本不组装进来。
    */
   private buildBuiltinWorkerTools(ctx: BuiltinRuntimeContext): ReadonlyArray<EngineToolDefinition> {
@@ -1072,7 +1108,18 @@ export class UnifiedAgent extends ModuleBase {
     // 权限档位过滤：adapter 的 `checkPermission` 是执行期的闸，这里守的是
     // "没权限的工具不进 prompt"——外部 MCP 里可能混进 `desktop` 类工具（computer-use）。
     // 档位 = worker 固定档位 ∩ 派活人档位（见 `narrowWorkerPermissions`）。
-    return filterToolsByPermission(configFiltered, this.getToolPermissionConfig(configFiltered, workerPerms))
+    const permitted = filterToolsByPermission(configFiltered, this.getToolPermissionConfig(configFiltered, workerPerms))
+    const subagents = this.agentConfig?.subagents ?? []
+    if (subagents.length === 0) return permitted
+    return [...permitted, createDelegateTaskTool({
+      subAgents: subagents,
+      runSubAgent: (subagent, input, toolContext) => this.builtinSubagentRunner.run(
+        subagent,
+        input,
+        toolContext,
+        permitted,
+      ),
+    })]
   }
 
   /**
@@ -1116,7 +1163,14 @@ export class UnifiedAgent extends ModuleBase {
       ...(this.agentConfig?.system_prompt ? { adminPersonality: this.agentConfig.system_prompt } : {}),
       ...(skillListing ? { skillListing } : {}),
       imageCapability: { available: this.imageCapability.available },
-      // availableSubAgents 不传：worker 不装 delegate_task。
+      ...(this.agentConfig?.subagents?.length
+        ? {
+            availableSubAgents: this.agentConfig.subagents.map((subagent) => ({
+              toolName: subagent.name,
+              workerHint: subagent.when_to_use.split('\n')[0] || subagent.description || subagent.name,
+            })),
+          }
+        : {}),
     })
     const workspaceInstructions = ctx.workspace_instructions?.snapshot.source === 'agents_md'
       && ctx.workspace_instructions.text !== undefined
@@ -1268,6 +1322,9 @@ export class UnifiedAgent extends ModuleBase {
     this.registerMethod('get_worker_detail', this.handleGetWorkerDetail.bind(this))
     this.registerMethod('get_worker_terminal', this.handleGetWorkerTerminal.bind(this))
     this.registerMethod('get_worker_trace', this.handleGetWorkerTrace.bind(this))
+    this.registerMethod('list_worker_subagents', this.handleListWorkerSubagents.bind(this))
+    this.registerMethod('get_worker_subagent_detail', this.handleGetWorkerSubagentDetail.bind(this))
+    this.registerMethod('get_worker_subagent_trace', this.handleGetWorkerSubagentTrace.bind(this))
   }
 
   // ============================================================================
@@ -3309,6 +3366,76 @@ export class UnifiedAgent extends ModuleBase {
     )
   }
 
+  private async handleListWorkerSubagents(params: ListWorkerSubagentsParams): Promise<ListWorkerSubagentsResult> {
+    if (!params || typeof params.worker_id !== 'string' || params.worker_id.length === 0) {
+      throw new Error('worker_id is required')
+    }
+    return {
+      subagents: await this.requireManagerStack().harness.listWorkerSubagents(params.worker_id, params.incarnation_id),
+    }
+  }
+
+  private async handleGetWorkerSubagentDetail(params: GetWorkerSubagentDetailParams): Promise<GetWorkerSubagentDetailResult> {
+    if (!params || typeof params.worker_id !== 'string' || typeof params.subagent_id !== 'string' || !params.worker_id || !params.subagent_id) {
+      throw new Error('worker_id and subagent_id are required')
+    }
+    const subagent = await this.requireManagerStack().harness.getWorkerSubagent(params.worker_id, params.subagent_id)
+    if (!subagent) throw new Error(`Worker subagent not found: ${params.subagent_id}`)
+    return { subagent }
+  }
+
+  private async handleGetWorkerSubagentTrace(params: GetWorkerSubagentTraceParams): Promise<GetWorkerSubagentTraceResult> {
+    if (!params || typeof params.worker_id !== 'string' || typeof params.subagent_id !== 'string' || !params.worker_id || !params.subagent_id) {
+      throw new Error('worker_id and subagent_id are required')
+    }
+    const stack = this.requireManagerStack()
+    const subagent = await stack.harness.getWorkerSubagent(params.worker_id, params.subagent_id)
+    if (!subagent) throw new Error(`Worker subagent not found: ${params.subagent_id}`)
+
+    const cursorWorkerId = `subagent:${params.worker_id}:${params.subagent_id}`
+    const fingerprint = subagentTraceFingerprint(subagent)
+    let cursorRecord: import('./workers/trace/cursor-store.js').TraceCursorRecord
+    if (params.cursor !== undefined) {
+      cursorRecord = await this.traceCursorStore().resolve(params.cursor, cursorWorkerId, fingerprint)
+    } else {
+      const token = await this.traceCursorStore().mint(cursorWorkerId, fingerprint, { harness: 0, native: 0, legacy: 0 })
+      cursorRecord = await this.traceCursorStore().resolve(token, cursorWorkerId, fingerprint)
+    }
+
+    const trace = await stack.harness.getWorkerSubagentTrace(
+      params.worker_id,
+      params.subagent_id,
+      { offset: cursorRecord.positions.native },
+    )
+    const replayBound = cursorRecord.window?.end.native
+    const events = trace.events.filter((event) => event.source_offset === undefined || replayBound === undefined || event.source_offset < replayBound)
+    const nativeEnd = replayBound ?? trace.nextCursor.offset
+    const cursorStore = this.traceCursorStore()
+    let nextToken: string
+    if (cursorRecord.window) {
+      nextToken = cursorRecord.window.nextToken
+    } else {
+      nextToken = await cursorStore.mint(cursorWorkerId, fingerprint, { harness: 0, native: nativeEnd, legacy: 0 })
+      await cursorStore.captureWindow(cursorRecord.token, {
+        end: { harness: 0, native: nativeEnd, legacy: 0 },
+        nextToken,
+      })
+    }
+    return {
+      events: events.map((event) => {
+        const source = event.source ?? (subagent.executor_impl === 'builtin' ? 'harness' : 'native')
+        return {
+          ...event,
+          source,
+          summary: redactSecrets(event.summary, [...this.knownSecrets]),
+          ...(event.detail === undefined ? {} : { detail: redactTraceDetail(event.detail, (text) => redactSecrets(text, [...this.knownSecrets])) }),
+        }
+      }),
+      next_cursor: nextToken,
+      ...(trace.unavailableReason ? { unavailable_reason: trace.unavailableReason } : {}),
+    }
+  }
+
   /**
    * Manager 的常规 worker 观察面只投射原生会话内容；Harness 生命周期事件保留给被动唤醒，
    * 不与 worker 的 assistant 正文混在一起。cursor 仍由 composite reader 统一维护；调用方
@@ -3397,12 +3524,20 @@ export class UnifiedAgent extends ModuleBase {
       finishIncarnationTrace: (traceId, patch) => {
         this.traceStore.endTrace(traceId, patch.status, { summary: redact(patch.summary) })
       },
+      stopWorkerSubagents: (workerId) => {
+        void this.builtinSubagentRunner.stopWorker(workerId).catch((error) => {
+          console.warn(`[${this.config.moduleId}] builtin subagent stop failed for ${workerId}:`, error)
+        })
+      },
     }
   }
 
   private builtinTraceReader(): import('./workers/builtin/adapter.js').BuiltinTraceReader {
     return {
       readTrace: async (traceId) => this.traceStore.getFullTrace(traceId),
+      listSubagents: (workerId) => this.builtinSubagentRunner.list(workerId),
+      getSubagent: (workerId, subagentId) => this.builtinSubagentRunner.get(workerId, subagentId),
+      readSubagentTrace: (workerId, subagentId, cursor) => this.builtinSubagentRunner.readTrace(workerId, subagentId, cursor),
     }
   }
 
@@ -3793,6 +3928,11 @@ export class UnifiedAgent extends ModuleBase {
   }
 
   protected override async onStart(): Promise<void> {
+    try {
+      await this.builtinSubagentRunner.recoverAfterRestart()
+    } catch (error) {
+      console.warn(`[${this.config.moduleId}] builtin subagent restart reconciliation failed:`, error)
+    }
     await this.importLegacyV2Tasks()
     // Business ingress is registered only after onStart resolves; initialize durable
     // subject bindings before any Manager tool face can mint a continuation credential.

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -1186,6 +1186,7 @@ export class UnifiedAgent extends ModuleBase {
               toolName: subagent.name,
               workerHint: subagent.when_to_use.split('\n')[0] || subagent.description || subagent.name,
             })),
+            subagentGuidance: 'builtin_worker' as const,
           }
         : {}),
     })

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -130,7 +130,7 @@ import {
   type GetWorkerSubagentTraceResult,
 } from './manager/read-model.js'
 import { managerActivitySummary, projectManagerEpisode, withCausalParent, type EpisodeWorkerFact, type ManagerEpisodeProjection } from './manager/episode-projection.js'
-import type { NormalizedTraceEvent, SpawnSpec, WorkerSubagentSummary } from './workers/types.js'
+import type { IncarnationHandle, NormalizedTraceEvent, SpawnSpec, WorkerAdapter, WorkerSubagentSummary } from './workers/types.js'
 import {
   TaskCancelledError,
   WorkerHasNoIncarnationError,
@@ -141,6 +141,25 @@ import { SYSTEM_TASKS_MANAGER_KEY } from './manager/registry.js'
 import { splitManagerKey } from './manager/principal.js'
 
 const BARRIER_TIMEOUT_MS = 8_000
+const CLI_SUBAGENT_HARVEST_DELAY_MS = 30_000
+
+interface CliSubagentHarvestWaiter {
+  readonly resolve: () => void
+  readonly reject: (error: unknown) => void
+}
+
+interface CliSubagentHarvestEntry {
+  readonly handle: IncarnationHandle
+  readonly adapter: WorkerAdapter
+  immediate: boolean
+  readonly waiters: CliSubagentHarvestWaiter[]
+}
+
+interface CliSubagentHarvestSchedule {
+  readonly pending: Map<string, CliSubagentHarvestEntry>
+  timer?: ReturnType<typeof setTimeout>
+  inFlight?: Promise<void>
+}
 
 function subagentTraceFingerprint(subagent: WorkerSubagentSummary): string {
   return createHash('sha256')
@@ -488,6 +507,8 @@ export class UnifiedAgent extends ModuleBase {
   private adminPort?: number
   private traceCursorStoreInstance?: TraceCursorStore
   private nativeTraceCopyStoreInstance?: NativeTraceCopyStore
+  /** CLI child trace reads are best-effort and must never fan out with native activity frequency. */
+  private readonly cliSubagentHarvestSchedules = new Map<string, CliSubagentHarvestSchedule>()
   private adminChatCorrelationStoreInstance?: import('./manager/chat-correlation-store.js').AdminChatCorrelationStore
   private memoryPort?: number
   // Session memory_scopes 缓存（TTL 60s，session config 变更不频繁）
@@ -818,11 +839,7 @@ export class UnifiedAgent extends ModuleBase {
       // are read here; running child output is never continuously captured.
       onNativeActivityCollected: (handle) => {
         const adapter = this.managerStack?.adapters.get(handle.impl)
-        if (adapter) {
-          void this.harvestTerminalCliSubagentTraces(handle, adapter).catch((error) => {
-            console.warn(`[${this.config.moduleId}] observed CLI child trace harvest failed:`, errorMessage(error))
-          })
-        }
+        if (adapter) void this.requestCliSubagentHarvest(handle, adapter)
       },
       // P6-A §3.2：episode 消费（含沉默终态）即结算未 claim 的 request IDs。
       onAdminChatWakeConsumed: async (key, ids) => { await this.adminChatCorrelationStore().settleInbound(key, ids) },
@@ -3730,10 +3747,120 @@ export class UnifiedAgent extends ModuleBase {
           console.warn(`[${this.config.moduleId}] parent native trace terminal harvest failed for ${handle.worker_id}#${handle.seq}:`, errorMessage(error))
         }
       }
-      await this.harvestTerminalCliSubagentTraces(handle, adapter)
+      await this.requestCliSubagentHarvest(handle, adapter, true)
     } catch (error) {
       console.warn(`[${this.config.moduleId}] native trace terminal harvest failed for ${handle.worker_id}#${handle.seq}:`,
         errorMessage(error))
+    }
+  }
+
+  /**
+   * Coalesce activity-triggered child reads. The worker-level queue is deliberately separate
+   * from the adapter state machine: a slow app-server probe can delay observability only, while
+   * never creating a second probe for the same Worker at the same time.
+   */
+  private requestCliSubagentHarvest(
+    handle: IncarnationHandle,
+    adapter: WorkerAdapter,
+    immediate = false,
+  ): Promise<void> {
+    if (this.runtimeClosing && !immediate) return Promise.resolve()
+    const workerId = handle.worker_id
+    let schedule = this.cliSubagentHarvestSchedules.get(workerId)
+    if (!schedule) {
+      schedule = { pending: new Map() }
+      this.cliSubagentHarvestSchedules.set(workerId, schedule)
+    }
+    const requestKey = `${handle.impl}#${handle.seq}#${handle.incarnation_id ?? handle.session_ref}`
+    let resolveWaiter: (() => void) | undefined
+    let rejectWaiter: ((error: unknown) => void) | undefined
+    const result = immediate
+      ? new Promise<void>((resolve, reject) => {
+        resolveWaiter = resolve
+        rejectWaiter = reject
+      })
+      : Promise.resolve()
+    let entry = schedule.pending.get(requestKey)
+    if (!entry) {
+      entry = { handle, adapter, immediate, waiters: [] }
+      schedule.pending.set(requestKey, entry)
+    } else if (immediate) {
+      entry.immediate = true
+    }
+    if (resolveWaiter && rejectWaiter) entry.waiters.push({ resolve: resolveWaiter, reject: rejectWaiter })
+
+    if (schedule.inFlight) return result
+    if (immediate) {
+      if (schedule.timer) {
+        clearTimeout(schedule.timer)
+        schedule.timer = undefined
+      }
+      void this.drainCliSubagentHarvest(workerId, schedule)
+    } else if (!schedule.timer) {
+      schedule.timer = setTimeout(() => {
+        schedule!.timer = undefined
+        void this.drainCliSubagentHarvest(workerId, schedule!)
+      }, CLI_SUBAGENT_HARVEST_DELAY_MS)
+      schedule.timer.unref?.()
+    }
+    return result
+  }
+
+  private async drainCliSubagentHarvest(workerId: string, schedule: CliSubagentHarvestSchedule): Promise<void> {
+    if (schedule.inFlight) return
+    const batch = Array.from(schedule.pending.values())
+    schedule.pending.clear()
+    if (batch.length === 0) {
+      if (this.cliSubagentHarvestSchedules.get(workerId) === schedule) this.cliSubagentHarvestSchedules.delete(workerId)
+      return
+    }
+
+    const inFlight = (async () => {
+      for (const entry of batch) {
+        try {
+          await this.harvestTerminalCliSubagentTraces(entry.handle, entry.adapter)
+          for (const waiter of entry.waiters) waiter.resolve()
+        } catch (error) {
+          console.warn(
+            `[${this.config.moduleId}] CLI child trace harvest failed for ${entry.handle.worker_id}#${entry.handle.seq}:`,
+            errorMessage(error),
+          )
+          for (const waiter of entry.waiters) waiter.reject(error)
+        }
+      }
+    })()
+    schedule.inFlight = inFlight
+    try {
+      await inFlight
+    } finally {
+      if (schedule.inFlight === inFlight) schedule.inFlight = undefined
+      if (schedule.pending.size > 0) {
+        const immediate = Array.from(schedule.pending.values()).some((entry) => entry.immediate)
+        if (immediate) {
+          void this.drainCliSubagentHarvest(workerId, schedule)
+        } else if (!schedule.timer) {
+          schedule.timer = setTimeout(() => {
+            schedule.timer = undefined
+            void this.drainCliSubagentHarvest(workerId, schedule)
+          }, CLI_SUBAGENT_HARVEST_DELAY_MS)
+          schedule.timer.unref?.()
+        }
+      } else if (this.cliSubagentHarvestSchedules.get(workerId) === schedule) {
+        this.cliSubagentHarvestSchedules.delete(workerId)
+      }
+    }
+  }
+
+  private stopCliSubagentHarvestScheduler(): void {
+    const error = new Error('CLI child trace harvest scheduler stopped')
+    for (const [workerId, schedule] of this.cliSubagentHarvestSchedules) {
+      if (schedule.timer) clearTimeout(schedule.timer)
+      schedule.timer = undefined
+      for (const entry of schedule.pending.values()) {
+        for (const waiter of entry.waiters) waiter.reject(error)
+      }
+      schedule.pending.clear()
+      if (!schedule.inFlight) this.cliSubagentHarvestSchedules.delete(workerId)
     }
   }
 
@@ -3784,29 +3911,34 @@ export class UnifiedAgent extends ModuleBase {
   private async recoverTerminalCliSubagentTraces(): Promise<void> {
     const stack = this.managerStack
     if (!stack) return
-    const workers = await stack.ledger.listAllWorkers()
-    for (const { worker } of workers) {
-      for (const incarnation of worker.incarnations) {
-        if (
-          (incarnation.impl !== 'claude-code' && incarnation.impl !== 'codex')
-        ) continue
-        const adapter = stack.adapters.get(incarnation.impl)
-        if (!adapter) continue
-        try {
-          await this.harvestTerminalCliSubagentTraces({
-            worker_id: worker.worker_id,
-            incarnation_id: incarnation.incarnation_id,
-            seq: incarnation.seq,
-            impl: incarnation.impl,
-            session_ref: incarnation.session_ref,
-            ...(incarnation.query_id ? { query_id: incarnation.query_id } : {}),
-          }, adapter)
-        } catch (error) {
-          console.warn(
-            `[${this.config.moduleId}] terminal CLI child trace recovery failed for ${worker.worker_id}#${incarnation.seq}:`,
-            errorMessage(error),
-          )
-        }
+    const pending = await this.nativeTraceCopyStore().listPendingSubagentCaptures()
+    const parentKeys = new Set<string>()
+    for (const capture of pending) {
+      if (capture.parent_incarnation_id) parentKeys.add(`${capture.worker_id}#${capture.parent_incarnation_id}`)
+    }
+    for (const parentKey of parentKeys) {
+      const separator = parentKey.indexOf('#')
+      const workerId = parentKey.slice(0, separator)
+      const incarnationId = parentKey.slice(separator + 1)
+      const found = await stack.ledger.findWorker(workerId)
+      const incarnation = found?.worker.incarnations.find((item) => item.incarnation_id === incarnationId)
+      if (!incarnation || (incarnation.impl !== 'claude-code' && incarnation.impl !== 'codex')) continue
+      const adapter = stack.adapters.get(incarnation.impl)
+      if (!adapter) continue
+      try {
+        await this.requestCliSubagentHarvest({
+          worker_id: workerId,
+          incarnation_id: incarnation.incarnation_id,
+          seq: incarnation.seq,
+          impl: incarnation.impl,
+          session_ref: incarnation.session_ref,
+          ...(incarnation.query_id ? { query_id: incarnation.query_id } : {}),
+        }, adapter, true)
+      } catch (error) {
+        console.warn(
+          `[${this.config.moduleId}] terminal CLI child trace recovery failed for ${workerId}#${incarnation.seq}:`,
+          errorMessage(error),
+        )
       }
     }
   }
@@ -4297,6 +4429,7 @@ export class UnifiedAgent extends ModuleBase {
 
   protected override async onStop(): Promise<void> {
     this.runtimeClosing = true
+    this.stopCliSubagentHarvestScheduler()
 
     // 优雅停机前补一次所有活跃 worker task 的 resume checkpoint flush，
     // 让 crabot stop 场景的停机窗口（最后一 turn 到进程退出之间）也无损。

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -153,6 +153,17 @@ function subagentTraceFingerprint(subagent: WorkerSubagentSummary): string {
     .slice(0, 32)
 }
 
+function isTerminalSubagent(subagent: WorkerSubagentSummary): boolean {
+  return subagent.status === 'completed'
+    || subagent.status === 'failed'
+    || subagent.status === 'stopped'
+    || subagent.status === 'interrupted'
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
 function subagentIdFromDelegateTaskOutput(output: string): string | undefined {
   try {
     const parsed: unknown = JSON.parse(output)
@@ -803,6 +814,16 @@ export class UnifiedAgent extends ModuleBase {
       readWorkerActivity: (params) => this.readWorkerActivity(params),
       // P6-A §8.10：化身终态主动收割（最后一次 native read → Agent-owned copy）。
       onIncarnationTerminal: (handle) => { void this.harvestIncarnationNativeTrace(handle) },
+      // Parent native activity is already persisted by Harness. Only terminal direct CLI children
+      // are read here; running child output is never continuously captured.
+      onNativeActivityCollected: (handle) => {
+        const adapter = this.managerStack?.adapters.get(handle.impl)
+        if (adapter) {
+          void this.harvestTerminalCliSubagentTraces(handle, adapter).catch((error) => {
+            console.warn(`[${this.config.moduleId}] observed CLI child trace harvest failed:`, errorMessage(error))
+          })
+        }
+      },
       // P6-A §3.2：episode 消费（含沉默终态）即结算未 claim 的 request IDs。
       onAdminChatWakeConsumed: async (key, ids) => { await this.adminChatCorrelationStore().settleInbound(key, ids) },
       // 人类消息渲染的时区（`formatChannelMessageLine` 的 ts 属性）。与 worker 侧
@@ -3390,16 +3411,15 @@ export class UnifiedAgent extends ModuleBase {
     if (!params || typeof params.worker_id !== 'string' || params.worker_id.length === 0) {
       throw new Error('worker_id is required')
     }
-    return {
-      subagents: await this.requireManagerStack().harness.listWorkerSubagents(params.worker_id, params.incarnation_id),
-    }
+    const stack = this.requireManagerStack()
+    return { subagents: await this.listWorkerSubagentSummaries(stack, params.worker_id, params.incarnation_id) }
   }
 
   private async handleGetWorkerSubagentDetail(params: GetWorkerSubagentDetailParams): Promise<GetWorkerSubagentDetailResult> {
     if (!params || typeof params.worker_id !== 'string' || typeof params.subagent_id !== 'string' || !params.worker_id || !params.subagent_id) {
       throw new Error('worker_id and subagent_id are required')
     }
-    const subagent = await this.requireManagerStack().harness.getWorkerSubagent(params.worker_id, params.subagent_id)
+    const subagent = await this.findWorkerSubagent(this.requireManagerStack(), params.worker_id, params.subagent_id)
     if (!subagent) throw new Error(`Worker subagent not found: ${params.subagent_id}`)
     return { subagent }
   }
@@ -3409,7 +3429,7 @@ export class UnifiedAgent extends ModuleBase {
       throw new Error('worker_id and subagent_id are required')
     }
     const stack = this.requireManagerStack()
-    const subagent = await stack.harness.getWorkerSubagent(params.worker_id, params.subagent_id)
+    const subagent = await this.findWorkerSubagent(stack, params.worker_id, params.subagent_id)
     if (!subagent) throw new Error(`Worker subagent not found: ${params.subagent_id}`)
 
     const cursorWorkerId = `subagent:${params.worker_id}:${params.subagent_id}`
@@ -3422,9 +3442,10 @@ export class UnifiedAgent extends ModuleBase {
       cursorRecord = await this.traceCursorStore().resolve(token, cursorWorkerId, fingerprint)
     }
 
-    const trace = await stack.harness.getWorkerSubagentTrace(
+    const trace = await this.readWorkerSubagentTrace(
+      stack,
       params.worker_id,
-      params.subagent_id,
+      subagent,
       { offset: cursorRecord.positions.native },
     )
     const replayBound = cursorRecord.window?.end.native
@@ -3453,6 +3474,110 @@ export class UnifiedAgent extends ModuleBase {
       }),
       next_cursor: nextToken,
       ...(trace.unavailableReason ? { unavailable_reason: trace.unavailableReason } : {}),
+    }
+  }
+
+  /** Native records are primary. Retained CLI child summaries only fill holes after host rotation. */
+  private async listWorkerSubagentSummaries(
+    stack: ManagerStack,
+    workerId: string,
+    incarnationId?: string,
+  ): Promise<WorkerSubagentSummary[]> {
+    const live = await stack.harness.listWorkerSubagents(workerId, incarnationId)
+    const retained = await this.nativeTraceCopyStore().listSubagents(workerId, incarnationId)
+    const byId = new Map<string, WorkerSubagentSummary>()
+    for (const subagent of retained) byId.set(subagent.subagent_id, subagent)
+    for (const subagent of live) byId.set(subagent.subagent_id, subagent)
+    return [...byId.values()].sort((left, right) => (right.started_at ?? '').localeCompare(left.started_at ?? ''))
+  }
+
+  private async findWorkerSubagent(
+    stack: ManagerStack,
+    workerId: string,
+    subagentId: string,
+  ): Promise<WorkerSubagentSummary | undefined> {
+    const live = await stack.harness.getWorkerSubagent(workerId, subagentId)
+    if (live) return live
+    return (await this.nativeTraceCopyStore().listSubagents(workerId)).find((subagent) => subagent.subagent_id === subagentId)
+  }
+
+  private async readWorkerSubagentTrace(
+    stack: ManagerStack,
+    workerId: string,
+    subagent: WorkerSubagentSummary,
+    cursor: { offset: number },
+  ): Promise<{ events: NormalizedTraceEvent[]; nextCursor: { offset: number }; unavailableReason?: string }> {
+    let live: { events: NormalizedTraceEvent[]; nextCursor: { offset: number }; unavailableReason?: string } | undefined
+    let liveError: string | undefined
+    try {
+      live = await stack.harness.getWorkerSubagentTrace(workerId, subagent.subagent_id, cursor)
+      if (!live.unavailableReason) {
+        await this.completePendingCliSubagentCaptureFromRead(stack, workerId, subagent)
+        return live
+      }
+    } catch (error) {
+      console.warn(`[${this.config.moduleId}] child native trace read failed for ${workerId}/${subagent.subagent_id}:`, errorMessage(error))
+      liveError = 'CLI child source is unavailable'
+    }
+
+    let copied: import('./workers/trace/native-copy.js').StoredSubagentTrace | null
+    try {
+      copied = await this.nativeTraceCopyStore().readSubagent(
+        workerId,
+        subagent.subagent_id,
+        subagentTraceFingerprint(subagent),
+      )
+    } catch (error) {
+      console.warn(`[${this.config.moduleId}] child trace copy read failed for ${workerId}/${subagent.subagent_id}:`, errorMessage(error))
+      return {
+        events: [],
+        nextCursor: cursor,
+        unavailableReason: 'native unavailable; retained child trace copy is unavailable',
+      }
+    }
+    if (copied?.capture_status === 'complete') {
+      return {
+        events: copied.events.filter((event) => event.source_offset === undefined || event.source_offset >= cursor.offset),
+        nextCursor: { offset: copied.next_cursor_offset ?? cursor.offset },
+        unavailableReason: `native degraded (served from agent-owned child copy): ${live?.unavailableReason ?? liveError ?? 'source unavailable'}`,
+      }
+    }
+
+    const unavailableReason = live?.unavailableReason ?? liveError ?? 'CLI child record is no longer available'
+    return {
+      events: [],
+      nextCursor: cursor,
+      unavailableReason: copied?.capture_status === 'pending'
+        ? `native unavailable before terminal child trace capture: ${copied.unavailable_reason ?? unavailableReason}`
+        : `native unavailable: ${unavailableReason}`,
+    }
+  }
+
+  /** A successful detail read is another bounded chance to finish an interrupted terminal snapshot. */
+  private async completePendingCliSubagentCaptureFromRead(
+    stack: ManagerStack,
+    workerId: string,
+    subagent: WorkerSubagentSummary,
+  ): Promise<void> {
+    if (!isTerminalSubagent(subagent) || (subagent.executor_impl !== 'claude-code' && subagent.executor_impl !== 'codex')) return
+    const fingerprint = subagentTraceFingerprint(subagent)
+    const copyStore = this.nativeTraceCopyStore()
+    try {
+      const existing = await copyStore.readSubagent(workerId, subagent.subagent_id, fingerprint)
+      if (existing?.capture_status !== 'pending') return
+      const trace = await stack.harness.getWorkerSubagentTrace(workerId, subagent.subagent_id, { offset: 0 })
+      if (trace.unavailableReason) return
+      await copyStore.completeSubagentCapture(
+        workerId,
+        existing.parent_incarnation_id,
+        subagent,
+        fingerprint,
+        trace.events,
+        trace.nextCursor.offset,
+        (text) => redactSecrets(text, [...this.knownSecrets]),
+      )
+    } catch (error) {
+      console.warn(`[${this.config.moduleId}] child native trace read retry failed for ${workerId}/${subagent.subagent_id}:`, errorMessage(error))
     }
   }
 
@@ -3566,8 +3691,8 @@ export class UnifiedAgent extends ModuleBase {
   }
 
   /**
-   * 化身终态收割（P6-A §8.10）：做最后一次 native read，把剩余增量写 Agent-owned copy。
-   * copy 只装本化身、脱敏后的归一化事件（不含 setup terminal / credential / 其它 session）。
+   * 化身终态收割（P6-A §8.10 / §10.3）：保留父化身和已确认终态 CLI child 的独立原生 trace。
+   * copy 只装本化身/child、脱敏后的归一化事件（不含 setup terminal / credential / 其它 session）。
    */
   private async harvestIncarnationNativeTrace(handle: import('./workers/types.js').IncarnationHandle): Promise<void> {
     try {
@@ -3578,30 +3703,104 @@ export class UnifiedAgent extends ModuleBase {
       const incarnation = found.worker.incarnations.find((item) => item.seq === handle.seq && item.impl === handle.impl)
       if (!incarnation) return
       const adapter = stack.adapters.get(handle.impl)
-      if (!adapter?.readTrace) return
-      const fingerprint = incarnationFingerprint({
-        incarnation_id: incarnation.incarnation_id,
-        impl: handle.impl as import('./workers/types.js').WorkerImplId,
-        seq: handle.seq,
-        started_at: (incarnation as { started_at?: string }).started_at,
-      })
-      // 终态收割是全量快照：copy 的「事件条数」≠ native 的「已消费行数」（坏行/未知行
-      // 也消费行号），拿它当 offset 会漏读+重写。终态时 live source 已完整，从头读并整体
-      // 覆盖 copy（append 的指纹替换语义保证不混入旧内容）。
-      const native = await adapter.readTrace(handle, { offset: 0 })
-      if (native.events.length > 0) {
-        await this.nativeTraceCopyStore().append(
-          handle.worker_id,
-          handle.seq,
-          fingerprint,
-          native.events,
-          (text) => redactSecrets(text, [...this.knownSecrets]),
-          { replace: true },
-        )
+      if (!adapter) return
+      if (adapter.readTrace) {
+        try {
+          const fingerprint = incarnationFingerprint({
+            incarnation_id: incarnation.incarnation_id,
+            impl: handle.impl as import('./workers/types.js').WorkerImplId,
+            seq: handle.seq,
+            started_at: (incarnation as { started_at?: string }).started_at,
+          })
+          // 终态收割是全量快照：copy 的「事件条数」≠ native 的「已消费行数」（坏行/未知行
+          // 也消费行号），拿它当 offset 会漏读+重写。终态时 live source 已完整，从头读并整体
+          // 覆盖 copy（append 的指纹替换语义保证不混入旧内容）。
+          const native = await adapter.readTrace(handle, { offset: 0 })
+          if (native.events.length > 0) {
+            await this.nativeTraceCopyStore().append(
+              handle.worker_id,
+              handle.seq,
+              fingerprint,
+              native.events,
+              (text) => redactSecrets(text, [...this.knownSecrets]),
+              { replace: true },
+            )
+          }
+        } catch (error) {
+          console.warn(`[${this.config.moduleId}] parent native trace terminal harvest failed for ${handle.worker_id}#${handle.seq}:`, errorMessage(error))
+        }
       }
+      await this.harvestTerminalCliSubagentTraces(handle, adapter)
     } catch (error) {
       console.warn(`[${this.config.moduleId}] native trace terminal harvest failed for ${handle.worker_id}#${handle.seq}:`,
-        error instanceof Error ? error.message : String(error))
+        errorMessage(error))
+    }
+  }
+
+  /** A CLI child becomes retainable only after its own native summary is terminal. */
+  private async harvestTerminalCliSubagentTraces(
+    handle: import('./workers/types.js').IncarnationHandle,
+    adapter: import('./workers/types.js').WorkerAdapter,
+  ): Promise<void> {
+    if ((handle.impl !== 'claude-code' && handle.impl !== 'codex') || !adapter.listSubagents || !adapter.readSubagentTrace) return
+    const redact = (text: string) => redactSecrets(text, [...this.knownSecrets])
+    const children = await adapter.listSubagents(handle)
+    for (const child of children) {
+      if (child.executor_impl !== handle.impl || !isTerminalSubagent(child)) continue
+      const fingerprint = subagentTraceFingerprint(child)
+      try {
+        const copyStore = this.nativeTraceCopyStore()
+        const existing = await copyStore.readSubagent(handle.worker_id, child.subagent_id, fingerprint)
+        if (existing?.capture_status === 'complete') continue
+        await copyStore.beginSubagentCapture(handle.worker_id, handle.incarnation_id, child, fingerprint, redact)
+        const trace = await adapter.readSubagentTrace(handle, child.subagent_id, { offset: 0 })
+        if (trace.unavailableReason) {
+          await copyStore.markSubagentCaptureUnavailable(
+            handle.worker_id,
+            handle.incarnation_id,
+            child,
+            fingerprint,
+            trace.unavailableReason,
+            redact,
+          )
+          continue
+        }
+        await copyStore.completeSubagentCapture(
+          handle.worker_id,
+          handle.incarnation_id,
+          child,
+          fingerprint,
+          trace.events,
+          trace.nextCursor.offset,
+          redact,
+        )
+      } catch (error) {
+        console.warn(`[${this.config.moduleId}] child native trace terminal harvest failed for ${handle.worker_id}/${child.subagent_id}:`, errorMessage(error))
+      }
+    }
+  }
+
+  /** Restart recovery retries pending child snapshots without treating a missing source as a fabricated trace. */
+  private async recoverTerminalCliSubagentTraces(): Promise<void> {
+    const stack = this.managerStack
+    if (!stack) return
+    const workers = await stack.ledger.listAllWorkers()
+    for (const { worker } of workers) {
+      for (const incarnation of worker.incarnations) {
+        if (
+          (incarnation.impl !== 'claude-code' && incarnation.impl !== 'codex')
+        ) continue
+        const adapter = stack.adapters.get(incarnation.impl)
+        if (!adapter) continue
+        await this.harvestTerminalCliSubagentTraces({
+          worker_id: worker.worker_id,
+          incarnation_id: incarnation.incarnation_id,
+          seq: incarnation.seq,
+          impl: incarnation.impl,
+          session_ref: incarnation.session_ref,
+          ...(incarnation.query_id ? { query_id: incarnation.query_id } : {}),
+        }, adapter)
+      }
     }
   }
 
@@ -4073,6 +4272,11 @@ export class UnifiedAgent extends ModuleBase {
         this.managerReconciliationSettled = true
         if (this.runtimeClosing) return
         await this.agentHandler?.releaseRecoveredWorkerShellExits()
+        // CLI child copy is a terminal artifact: retry only after the startup state reconciliation
+        // has decided which parent incarnations are actually terminal.
+        void this.recoverTerminalCliSubagentTraces().catch((error) => {
+          console.warn(`[${this.config.moduleId}] terminal CLI child trace recovery failed（不影响启动）:`, errorMessage(error))
+        })
         // Notice routing may run a whole Manager episode. It starts only after all existing
         // recovery work above, but must not hold startup's liveness drain or escape this chain.
         void stack.harness.reconcileRecoveryNoticesOnStartup().catch((error) => {

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -3792,14 +3792,21 @@ export class UnifiedAgent extends ModuleBase {
         ) continue
         const adapter = stack.adapters.get(incarnation.impl)
         if (!adapter) continue
-        await this.harvestTerminalCliSubagentTraces({
-          worker_id: worker.worker_id,
-          incarnation_id: incarnation.incarnation_id,
-          seq: incarnation.seq,
-          impl: incarnation.impl,
-          session_ref: incarnation.session_ref,
-          ...(incarnation.query_id ? { query_id: incarnation.query_id } : {}),
-        }, adapter)
+        try {
+          await this.harvestTerminalCliSubagentTraces({
+            worker_id: worker.worker_id,
+            incarnation_id: incarnation.incarnation_id,
+            seq: incarnation.seq,
+            impl: incarnation.impl,
+            session_ref: incarnation.session_ref,
+            ...(incarnation.query_id ? { query_id: incarnation.query_id } : {}),
+          }, adapter)
+        } catch (error) {
+          console.warn(
+            `[${this.config.moduleId}] terminal CLI child trace recovery failed for ${worker.worker_id}#${incarnation.seq}:`,
+            errorMessage(error),
+          )
+        }
       }
     }
   }

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -60,6 +60,7 @@ import { getAgentTraceDir, getAgentLogsDir, getAgentDataDir, getWorkspaceDir, ge
 import { ConfigLoader } from './core/config-loader.js'
 import { TraceStore } from './core/trace-store.js'
 import { BuiltinSubagentRunner } from './workers/builtin/subagent-runner.js'
+import { BgEntityRegistry } from './engine/bg-entities/registry.js'
 import { importV2LegacyTasks } from './workers/legacy-importer.js'
 import { PromptManager } from './prompt-manager.js'
 import { createLSPManager, type LSPManager } from './lsp/lsp-manager.js'
@@ -150,6 +151,17 @@ function subagentTraceFingerprint(subagent: WorkerSubagentSummary): string {
     }))
     .digest('hex')
     .slice(0, 32)
+}
+
+function subagentIdFromDelegateTaskOutput(output: string): string | undefined {
+  try {
+    const parsed: unknown = JSON.parse(output)
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return undefined
+    const agentId = (parsed as Record<string, unknown>).agent_id
+    return typeof agentId === 'string' && agentId ? agentId : undefined
+  } catch {
+    return undefined
+  }
 }
 
 function redactTraceDetail(detail: unknown, redact: (text: string) => string): unknown {
@@ -492,6 +504,8 @@ export class UnifiedAgent extends ModuleBase {
 
   /** Per-worker serialization preserves background-shell exit order across async log rendering. */
   private readonly builtinBgDeliveryTails = new Map<string, Promise<void>>()
+  /** One registry instance serializes Worker shells and builtin children across startup recovery. */
+  private readonly builtinBgRegistry = new BgEntityRegistry()
 
   /** fail-loud 兜底回复的按 key 冷却台账：`channel::session` → 上一条兜底回复发出的时刻。 */
   private readonly failLoudSentAt: Map<string, number> = new Map()
@@ -567,6 +581,7 @@ export class UnifiedAgent extends ModuleBase {
       async (workerId, text) => {
         await this.requireManagerStack().harness.sendToWorker(workerId, text)
       },
+      this.builtinBgRegistry,
     )
 
     this.promptManager = new PromptManager()
@@ -1111,6 +1126,7 @@ export class UnifiedAgent extends ModuleBase {
     const permitted = filterToolsByPermission(configFiltered, this.getToolPermissionConfig(configFiltered, workerPerms))
     const subagents = this.agentConfig?.subagents ?? []
     if (subagents.length === 0) return permitted
+    const childPermissionConfig = this.getToolPermissionConfig(permitted, workerPerms)
     return [...permitted, createDelegateTaskTool({
       subAgents: subagents,
       runSubAgent: (subagent, input, toolContext) => this.builtinSubagentRunner.run(
@@ -1118,6 +1134,7 @@ export class UnifiedAgent extends ModuleBase {
         input,
         toolContext,
         permitted,
+        { permissionConfig: childPermissionConfig, resolvedPermissions: workerPerms },
       ),
     })]
   }
@@ -1247,7 +1264,9 @@ export class UnifiedAgent extends ModuleBase {
       promptManager: this.promptManager,
       ...(imageConnInfo ? { imageConnInfo } : {}),
       imageCapability,
+      bgRegistry: this.builtinBgRegistry,
     })
+    this.builtinSubagentRunner.setRegistry(handler.getBuiltinBgEntityRegistry())
     this.attachBuiltinShellExitDispatcher(handler)
     return handler
   }
@@ -3422,8 +3441,8 @@ export class UnifiedAgent extends ModuleBase {
       })
     }
     return {
-      events: events.map((event) => {
-        const source = event.source ?? (subagent.executor_impl === 'builtin' ? 'harness' : 'native')
+      events: events.map(({ source_offset: _dropped, ...event }) => {
+        const source = event.source ?? 'native'
         return {
           ...event,
           source,
@@ -3507,6 +3526,9 @@ export class UnifiedAgent extends ModuleBase {
         this.traceStore.endSpan(traceId, llmSpan.span_id, 'completed', undefined,
           event.llmStartedAtMs !== undefined && event.llmCallMs !== undefined ? event.llmStartedAtMs + event.llmCallMs : undefined)
         for (const toolCall of event.toolCalls) {
+          const subagentId = toolCall.name === 'delegate_task'
+            ? subagentIdFromDelegateTaskOutput(toolCall.output)
+            : undefined
           const span = this.traceStore.startSpan(traceId, {
             type: 'tool_call',
             parent_span_id: llmSpan.span_id,
@@ -3514,6 +3536,7 @@ export class UnifiedAgent extends ModuleBase {
               name: toolCall.name,
               input_summary: redact(JSON.stringify(toolCall.input).slice(0, 300)),
               output_summary: redact(toolCall.output.slice(0, 300)),
+              ...(subagentId ? { subagent_id: subagentId } : {}),
             } as import('./types.js').AgentSpanDetails,
             started_at_ms: toolCall.startedAtMs,
           })

--- a/crabot-agent/src/workers/builtin/adapter.ts
+++ b/crabot-agent/src/workers/builtin/adapter.ts
@@ -1145,9 +1145,9 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
       initialMessages,
       options: {
         systemPrompt: builtin.systemPrompt,
-        // fork 不加 finish_task（一次性侧问），但工具集守卫与安全项与主线完全一致——
-        // 侧问同样是一次真实的 LLM + 工具执行，没有理由少一道闸。
-        tools: this.guardTools(builtin.tools),
+        // fork 是一次性侧问，不能派发异步 child；它和主线共享 worker_id，侧问收尾
+        // 不能拥有或停止主线 child。
+        tools: this.forkTools(builtin.tools),
         model: builtin.model,
         maxTurns: FORK_MAX_TURNS,
         ...this.safetyOptions(builtin),
@@ -1352,6 +1352,11 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     ]
   }
 
+  private forkTools(tools: Resolvable<ReadonlyArray<ToolDefinition>>): Resolvable<ReadonlyArray<ToolDefinition>> {
+    const guarded = this.guardTools(tools)
+    return () => resolve(guarded).filter((tool) => tool.name !== 'delegate_task')
+  }
+
   /**
    * 工具集守卫（spec 决策 3 / 决策 4）：`set_cwd` / `set_task_goal` 绝不许出现在 builtin
    * worker 的工具集里。放在 resolve 路径上而不是 spawn 一次性检查——`tools` 是 Resolvable，
@@ -1536,7 +1541,7 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
      */
     summary?: string,
   ): Promise<void> {
-    this.deps.traceHooks?.stopWorkerSubagents?.(instance.worker_id)
+    if (handle.query_id === undefined) this.deps.traceHooks?.stopWorkerSubagents?.(instance.worker_id)
     if (instance.pendingInputs.length > 0) {
       const deadLetterMsg = `[dead-letter] incarnation ${instance.worker_id}#${instance.seq} exited with ${instance.pendingInputs.length} unsent message(s): ${instance.pendingInputs.join(' | ')}\n`
       await instance.outputLog.append(deadLetterMsg)
@@ -1630,7 +1635,8 @@ function normalizeBuiltinSpan(span: import('../../types.js').AgentSpan): import(
       const input = typeof details.input_summary === 'string' ? details.input_summary : undefined
       const output = typeof details.output_summary === 'string' ? details.output_summary : undefined
       const error = typeof details.error === 'string' ? details.error : undefined
-      const subagentId = name === 'delegate_task' ? subagentIdFromOutput(output ?? error) : undefined
+      const recordedSubagentId = typeof details.subagent_id === 'string' ? details.subagent_id : undefined
+      const subagentId = recordedSubagentId ?? (name === 'delegate_task' ? subagentIdFromOutput(output ?? error) : undefined)
       const callId = span.span_id
       const call = {
         ...base,
@@ -1643,6 +1649,7 @@ function normalizeBuiltinSpan(span: import('../../types.js').AgentSpan): import(
           ...(input !== undefined ? { input } : {}),
           ...(subagentId ? { subagent_id: subagentId } : {}),
         },
+        ...(subagentId ? { subagent_id: subagentId } : {}),
       } as const
       const result = output ?? error
       if (!result) return [call]

--- a/crabot-agent/src/workers/builtin/adapter.ts
+++ b/crabot-agent/src/workers/builtin/adapter.ts
@@ -85,6 +85,9 @@ import type {
   Workspace,
   WorkspaceInstructionPayload,
   WorkerTerminalView,
+  WorkerSubagentSummary,
+  NormalizedTraceEvent,
+  TraceCursor,
 } from '../types.js'
 import { classifySupervisionActivity } from '../types.js'
 import type { SupervisionObservation } from '../types.js'
@@ -228,10 +231,18 @@ export interface BuiltinTraceHooks {
   startIncarnationTrace(params: { worker_id: string; seq: number; summary: string }): string
   appendTurn(traceId: string, event: import('../../engine/types.js').EngineTurnEvent): void
   finishIncarnationTrace(traceId: string, patch: { status: 'completed' | 'failed'; summary: string }): void
+  stopWorkerSubagents?(workerId: string): void
 }
 
 export interface BuiltinTraceReader {
   readTrace(traceId: string): Promise<import('../../types.js').AgentTrace | undefined>
+  listSubagents?(workerId: string): Promise<WorkerSubagentSummary[]>
+  getSubagent?(workerId: string, subagentId: string): Promise<WorkerSubagentSummary | undefined>
+  readSubagentTrace?(workerId: string, subagentId: string, cursor?: TraceCursor): Promise<{
+    events: NormalizedTraceEvent[]
+    nextCursor: TraceCursor
+    unavailableReason?: string
+  }>
 }
 
 
@@ -650,6 +661,25 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     return { events, nextCursor }
   }
 
+  async listSubagents(h: IncarnationHandle): Promise<WorkerSubagentSummary[]> {
+    return this.deps.traceReader?.listSubagents?.(h.worker_id) ?? []
+  }
+
+  async getSubagent(h: IncarnationHandle, subagentId: string): Promise<WorkerSubagentSummary | undefined> {
+    return this.deps.traceReader?.getSubagent?.(h.worker_id, subagentId)
+  }
+
+  async readSubagentTrace(h: IncarnationHandle, subagentId: string, cursor?: TraceCursor): Promise<{
+    events: NormalizedTraceEvent[]
+    nextCursor: TraceCursor
+    unavailableReason?: string
+  }> {
+    if (!this.deps.traceReader?.readSubagentTrace) {
+      return { events: [], nextCursor: cursor ?? { offset: 0 }, unavailableReason: 'builtin subagent trace unavailable' }
+    }
+    return this.deps.traceReader.readSubagentTrace(h.worker_id, subagentId, cursor)
+  }
+
   private async readTraceWindow(
     h: IncarnationHandle,
     cursor?: import('../types.js').TraceCursor,
@@ -944,7 +974,7 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
       initialMessages,
       options: {
         systemPrompt: builtin.systemPrompt,
-        tools: this.combineTools(builtin.tools),
+        tools: this.combineTools(builtin.tools, instance),
         model: builtin.model,
         ...(builtin.maxTurnsPerBurst !== undefined ? { maxTurns: builtin.maxTurnsPerBurst } : {}),
         ...this.safetyOptions(builtin),
@@ -1300,9 +1330,26 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     }
   }
 
-  private combineTools(tools: Resolvable<ReadonlyArray<ToolDefinition>>): Resolvable<ReadonlyArray<ToolDefinition>> {
+  private combineTools(
+    tools: Resolvable<ReadonlyArray<ToolDefinition>>,
+    instance?: WorkerInstance,
+  ): Resolvable<ReadonlyArray<ToolDefinition>> {
     const guarded = this.guardTools(tools)
-    return () => [...resolve(guarded), FINISH_TASK_TOOL]
+    return () => [
+      ...resolve(guarded).map((tool) => tool.name !== 'delegate_task' || !instance
+        ? tool
+        : {
+            ...tool,
+            call: (input: Record<string, unknown>, context: import('../../engine/types.js').ToolCallContext) => tool.call(input, {
+              ...context,
+              worker_subagent: {
+                worker_id: instance.worker_id,
+                ...(instance.traceId ? { parent_trace_id: instance.traceId } : {}),
+              },
+            }),
+          }),
+      FINISH_TASK_TOOL,
+    ]
   }
 
   /**
@@ -1489,6 +1536,7 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
      */
     summary?: string,
   ): Promise<void> {
+    this.deps.traceHooks?.stopWorkerSubagents?.(instance.worker_id)
     if (instance.pendingInputs.length > 0) {
       const deadLetterMsg = `[dead-letter] incarnation ${instance.worker_id}#${instance.seq} exited with ${instance.pendingInputs.length} unsent message(s): ${instance.pendingInputs.join(' | ')}\n`
       await instance.outputLog.append(deadLetterMsg)
@@ -1582,6 +1630,7 @@ function normalizeBuiltinSpan(span: import('../../types.js').AgentSpan): import(
       const input = typeof details.input_summary === 'string' ? details.input_summary : undefined
       const output = typeof details.output_summary === 'string' ? details.output_summary : undefined
       const error = typeof details.error === 'string' ? details.error : undefined
+      const subagentId = name === 'delegate_task' ? subagentIdFromOutput(output ?? error) : undefined
       const callId = span.span_id
       const call = {
         ...base,
@@ -1592,6 +1641,7 @@ function normalizeBuiltinSpan(span: import('../../types.js').AgentSpan): import(
           call_id: callId,
           name,
           ...(input !== undefined ? { input } : {}),
+          ...(subagentId ? { subagent_id: subagentId } : {}),
         },
       } as const
       const result = output ?? error
@@ -1607,10 +1657,21 @@ function normalizeBuiltinSpan(span: import('../../types.js').AgentSpan): import(
             output: result,
             ...(span.status === 'failed' ? { is_error: true } : {}),
           },
+          ...(subagentId ? { subagent_id: subagentId } : {}),
         },
       ]
     }
     default:
       return [{ ...base, kind: 'lifecycle', summary: span.type, detail: details }]
+  }
+}
+
+function subagentIdFromOutput(output: string | undefined): string | undefined {
+  if (!output) return undefined
+  try {
+    const parsed = JSON.parse(output) as { agent_id?: unknown }
+    return typeof parsed.agent_id === 'string' ? parsed.agent_id : undefined
+  } catch {
+    return undefined
   }
 }

--- a/crabot-agent/src/workers/builtin/subagent-runner.ts
+++ b/crabot-agent/src/workers/builtin/subagent-runner.ts
@@ -5,18 +5,24 @@ import { createAdapter } from '../../engine/llm-adapter.js'
 import { forkEngine } from '../../engine/sub-agent.js'
 import { recordSubAgentTurn } from '../../engine/sub-agent-trace.js'
 import { spawnPersistentAgent } from '../../engine/bg-entities/bg-agent.js'
-import { BgEntityRegistry } from '../../engine/bg-entities/registry.js'
+import type { BgEntityRegistry } from '../../engine/bg-entities/registry.js'
 import type { BgAgentRegistryRecord } from '../../engine/bg-entities/types.js'
-import { createSubAgentHookRegistry } from '../../hooks/defaults.js'
+import { createLspDiagnosticsHook } from '../../hooks/defaults.js'
 import { getBgEntitiesLogsDir } from '../../core/data-paths.js'
 import type { TraceStore } from '../../core/trace-store.js'
-import type { SubAgentConfig } from '../../types.js'
-import type { ToolCallContext, ToolCallResult, ToolDefinition } from '../../engine/types.js'
+import type { ResolvedPermissions, SubAgentConfig } from '../../types.js'
+import type { ToolCallContext, ToolCallResult, ToolDefinition, ToolPermissionConfig } from '../../engine/types.js'
 import type { NormalizedTraceEvent, TraceCursor, WorkerSubagentStatus, WorkerSubagentSummary } from '../types.js'
 import { filterToolsForSubAgent } from '../../agent/subagent-tool-filter.js'
 import { assembleSubAgentPrompt } from '../../agent/subagent-prompt-assembler.js'
+import { createBuiltinWorkerHookRegistry } from './runtime.js'
 
 const WORKER_OWNER = '__builtin_worker__'
+
+export interface BuiltinSubagentExecutionContext {
+  readonly permissionConfig: ToolPermissionConfig
+  readonly resolvedPermissions: ResolvedPermissions
+}
 
 function statusOf(status: BgAgentRegistryRecord['status']): WorkerSubagentStatus {
   switch (status) {
@@ -49,26 +55,34 @@ function summaryOf(workerId: string, record: BgAgentRegistryRecord): WorkerSubag
  */
 export class BuiltinSubagentRunner {
   private readonly abortControllers = new Map<string, AbortController>()
+  private registry?: BgEntityRegistry
 
   constructor(
     private readonly traceStore: TraceStore,
     private readonly lspManager: import('../../lsp/lsp-manager.js').LSPManager,
     private readonly deliverCompletion?: (workerId: string, text: string) => Promise<void>,
-    private readonly registry = new BgEntityRegistry(),
-  ) {}
+    registry?: BgEntityRegistry,
+  ) {
+    this.registry = registry
+  }
+
+  setRegistry(registry: BgEntityRegistry): void {
+    this.registry = registry
+  }
 
   /**
    * A builtin child runs in this process, so it cannot survive an Agent restart.
    * Mark only Worker-owned records as interrupted before the Admin read model opens.
    */
   async recoverAfterRestart(): Promise<number> {
-    const records = await this.registry.list({
+    const registry = this.requireRegistry()
+    const records = await registry.list({
       owner_friend_id: WORKER_OWNER,
       type: 'agent',
       status: ['running'],
     })
     const endedAt = new Date().toISOString()
-    await Promise.all(records.map((record) => this.registry.update(record.entity_id, {
+    await Promise.all(records.map((record) => registry.update(record.entity_id, {
       status: 'stalled',
       ended_at: endedAt,
     })))
@@ -80,12 +94,14 @@ export class BuiltinSubagentRunner {
     input: { task: string; context?: string; sync?: boolean },
     context: ToolCallContext,
     parentTools: ReadonlyArray<ToolDefinition>,
+    execution: BuiltinSubagentExecutionContext,
   ): Promise<ToolCallResult> {
+    const registry = this.requireRegistry()
     const worker = context.worker_subagent
     if (!worker?.parent_trace_id) {
       return { isError: true, output: 'builtin worker subagent trace is unavailable for this incarnation' }
     }
-    if (input.sync) return this.runSynchronously(subagent, input, context, parentTools, worker)
+    if (input.sync) return this.runSynchronously(subagent, input, context, parentTools, worker, execution)
 
     const entityId = await spawnPersistentAgent({
       prompt: input.task,
@@ -103,22 +119,27 @@ export class BuiltinSubagentRunner {
       }),
       owner: { friend_id: WORKER_OWNER, worker_id: worker.worker_id },
       spawned_by_task_id: worker.worker_id,
-      registry: this.registry,
+      registry,
       abortControllers: this.abortControllers,
+      permissionConfig: execution.permissionConfig,
+      resolvedPermissions: execution.resolvedPermissions,
+      senderIsMaster: false,
+      hookRegistry: this.childHookRegistry(subagent),
+      ...(subagent.hook_preset === 'lsp_diagnostics' ? { lspManager: this.lspManager } : {}),
       subTrace: {
         traceStore: this.traceStore,
         parentTraceId: worker.parent_trace_id,
         summaryPrefix: `[${subagent.name}]`,
       },
       onExit: async (info) => {
-        const current = await this.registry.get(info.entity_id)
+        const current = await registry.get(info.entity_id)
         if (current?.status === 'killed') return
         const outcome = info.status === 'completed' ? '已完成' : '失败'
         const detail = info.finalText || info.error || '无可读结果'
         await this.deliverCompletion?.(worker.worker_id, `<sub_agent_notification>\n${subagent.name} ${outcome}：${detail}\n</sub_agent_notification>`)
       },
     })
-    const record = await this.registry.get(entityId)
+    const record = await registry.get(entityId)
     return {
       isError: false,
       output: JSON.stringify({
@@ -130,7 +151,7 @@ export class BuiltinSubagentRunner {
   }
 
   async list(workerId: string): Promise<WorkerSubagentSummary[]> {
-    const records = await this.registry.list({ type: 'agent', spawned_by_task_id: workerId })
+    const records = await this.requireRegistry().list({ type: 'agent', spawned_by_task_id: workerId })
     return records
       .filter((record): record is BgAgentRegistryRecord => record.type === 'agent' && record.owner.worker_id === workerId)
       .map((record) => summaryOf(workerId, record))
@@ -138,7 +159,7 @@ export class BuiltinSubagentRunner {
   }
 
   async get(workerId: string, subagentId: string): Promise<WorkerSubagentSummary | undefined> {
-    const record = await this.registry.get(subagentId)
+    const record = await this.requireRegistry().get(subagentId)
     if (record?.type !== 'agent' || record.owner.worker_id !== workerId || record.spawned_by_task_id !== workerId) return undefined
     return summaryOf(workerId, record)
   }
@@ -148,7 +169,7 @@ export class BuiltinSubagentRunner {
     nextCursor: TraceCursor
     unavailableReason?: string
   }> {
-    const record = await this.registry.get(subagentId)
+    const record = await this.requireRegistry().get(subagentId)
     if (record?.type !== 'agent' || record.owner.worker_id !== workerId || record.spawned_by_task_id !== workerId) {
       throw new Error(`worker subagent not found: ${subagentId}`)
     }
@@ -166,12 +187,13 @@ export class BuiltinSubagentRunner {
   }
 
   async stopWorker(workerId: string): Promise<void> {
-    const records = await this.registry.list({ type: 'agent', spawned_by_task_id: workerId })
+    const registry = this.requireRegistry()
+    const records = await registry.list({ type: 'agent', spawned_by_task_id: workerId })
     await Promise.all(records
       .filter((record): record is BgAgentRegistryRecord => record.type === 'agent' && record.owner.worker_id === workerId && record.status === 'running')
       .map(async (record) => {
         this.abortControllers.get(record.entity_id)?.abort()
-        await this.registry.update(record.entity_id, { status: 'killed', ended_at: new Date().toISOString() })
+        await registry.update(record.entity_id, { status: 'killed', ended_at: new Date().toISOString() })
       }))
   }
 
@@ -181,7 +203,9 @@ export class BuiltinSubagentRunner {
     context: ToolCallContext,
     parentTools: ReadonlyArray<ToolDefinition>,
     worker: NonNullable<ToolCallContext['worker_subagent']>,
+    execution: BuiltinSubagentExecutionContext,
   ): Promise<ToolCallResult> {
+    const registry = this.requireRegistry()
     const entityId = `agent_${randomBytes(6).toString('hex')}`
     const now = new Date().toISOString()
     const trace = this.traceStore.startTrace({
@@ -191,7 +215,7 @@ export class BuiltinSubagentRunner {
     })
     const logsDir = getBgEntitiesLogsDir()
     await fs.mkdir(logsDir, { recursive: true })
-    await this.registry.register({
+    await registry.register({
       entity_id: entityId,
       type: 'agent',
       subagent_type: subagent.name,
@@ -230,10 +254,10 @@ export class BuiltinSubagentRunner {
         onTurn: (event) => recordSubAgentTurn(this.traceStore, trace.trace_id, event),
         supportsVision: subagent.model.supports_vision,
         ...(subagent.model.context_window !== undefined ? { contextWindowTokens: subagent.model.context_window } : {}),
-        hookRegistry: createSubAgentHookRegistry({
-          lspDiagnostics: subagent.hook_preset === 'lsp_diagnostics',
-          gitWriteFence: subagent.allowed_mcp_server_ids.includes('git'),
-        }),
+        permissionConfig: execution.permissionConfig,
+        resolvedPermissions: execution.resolvedPermissions,
+        senderIsMaster: false,
+        hookRegistry: this.childHookRegistry(subagent),
         lspManager: subagent.hook_preset === 'lsp_diagnostics' ? this.lspManager : undefined,
       })
       const completed = result.outcome === 'completed'
@@ -241,7 +265,7 @@ export class BuiltinSubagentRunner {
         summary: (result.output || result.error || '').slice(0, 200),
         ...(!completed && result.error ? { error: result.error.slice(0, 200) } : {}),
       })
-      await this.registry.update(entityId, {
+      await registry.update(entityId, {
         status: completed ? 'completed' : 'failed',
         result_file: null,
         exit_code: completed ? 0 : 1,
@@ -259,12 +283,25 @@ export class BuiltinSubagentRunner {
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       this.traceStore.endTrace(trace.trace_id, 'failed', { summary: message.slice(0, 200), error: message.slice(0, 200) })
-      await this.registry.update(entityId, { status: 'failed', error: message, exit_code: 1, ended_at: new Date().toISOString() })
+      await registry.update(entityId, { status: 'failed', error: message, exit_code: 1, ended_at: new Date().toISOString() })
       return { isError: true, output: JSON.stringify({ agent_id: entityId, status: 'failed', child_trace_id: trace.trace_id, error: message }) }
     } finally {
       context.abortSignal?.removeEventListener('abort', abortParent)
       this.abortControllers.delete(entityId)
     }
+  }
+
+  private requireRegistry(): BgEntityRegistry {
+    if (!this.registry) {
+      throw new Error('builtin subagent registry is unavailable before AgentHandler initialization')
+    }
+    return this.registry
+  }
+
+  private childHookRegistry(subagent: SubAgentConfig) {
+    const registry = createBuiltinWorkerHookRegistry()
+    if (subagent.hook_preset === 'lsp_diagnostics') registry.register(createLspDiagnosticsHook())
+    return registry
   }
 }
 

--- a/crabot-agent/src/workers/builtin/subagent-runner.ts
+++ b/crabot-agent/src/workers/builtin/subagent-runner.ts
@@ -1,0 +1,285 @@
+import { randomBytes } from 'node:crypto'
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import { createAdapter } from '../../engine/llm-adapter.js'
+import { forkEngine } from '../../engine/sub-agent.js'
+import { recordSubAgentTurn } from '../../engine/sub-agent-trace.js'
+import { spawnPersistentAgent } from '../../engine/bg-entities/bg-agent.js'
+import { BgEntityRegistry } from '../../engine/bg-entities/registry.js'
+import type { BgAgentRegistryRecord } from '../../engine/bg-entities/types.js'
+import { createSubAgentHookRegistry } from '../../hooks/defaults.js'
+import { getBgEntitiesLogsDir } from '../../core/data-paths.js'
+import type { TraceStore } from '../../core/trace-store.js'
+import type { SubAgentConfig } from '../../types.js'
+import type { ToolCallContext, ToolCallResult, ToolDefinition } from '../../engine/types.js'
+import type { NormalizedTraceEvent, TraceCursor, WorkerSubagentStatus, WorkerSubagentSummary } from '../types.js'
+import { filterToolsForSubAgent } from '../../agent/subagent-tool-filter.js'
+import { assembleSubAgentPrompt } from '../../agent/subagent-prompt-assembler.js'
+
+const WORKER_OWNER = '__builtin_worker__'
+
+function statusOf(status: BgAgentRegistryRecord['status']): WorkerSubagentStatus {
+  switch (status) {
+    case 'running': return 'running'
+    case 'completed': return 'completed'
+    case 'failed': return 'failed'
+    case 'killed': return 'stopped'
+    case 'stalled': return 'interrupted'
+  }
+}
+
+function summaryOf(workerId: string, record: BgAgentRegistryRecord): WorkerSubagentSummary {
+  return {
+    subagent_id: record.entity_id,
+    worker_id: workerId,
+    executor_impl: 'builtin',
+    ...(record.subagent_type ? { type: record.subagent_type } : {}),
+    name: record.subagent_type ?? record.entity_id,
+    ...(record.task_description ? { task: record.task_description } : {}),
+    status: statusOf(record.status),
+    ...(record.spawned_at ? { started_at: record.spawned_at } : {}),
+    ...(record.ended_at ? { ended_at: record.ended_at } : {}),
+  }
+}
+
+/**
+ * Small execution boundary for builtin Worker delegate_task. It shares the existing subagent
+ * prompt, capability filtering and persistent registry, but does not re-enter AgentHandler's
+ * old task loop or its delivery semantics.
+ */
+export class BuiltinSubagentRunner {
+  private readonly abortControllers = new Map<string, AbortController>()
+
+  constructor(
+    private readonly traceStore: TraceStore,
+    private readonly lspManager: import('../../lsp/lsp-manager.js').LSPManager,
+    private readonly deliverCompletion?: (workerId: string, text: string) => Promise<void>,
+    private readonly registry = new BgEntityRegistry(),
+  ) {}
+
+  /**
+   * A builtin child runs in this process, so it cannot survive an Agent restart.
+   * Mark only Worker-owned records as interrupted before the Admin read model opens.
+   */
+  async recoverAfterRestart(): Promise<number> {
+    const records = await this.registry.list({
+      owner_friend_id: WORKER_OWNER,
+      type: 'agent',
+      status: ['running'],
+    })
+    const endedAt = new Date().toISOString()
+    await Promise.all(records.map((record) => this.registry.update(record.entity_id, {
+      status: 'stalled',
+      ended_at: endedAt,
+    })))
+    return records.length
+  }
+
+  async run(
+    subagent: SubAgentConfig,
+    input: { task: string; context?: string; sync?: boolean },
+    context: ToolCallContext,
+    parentTools: ReadonlyArray<ToolDefinition>,
+  ): Promise<ToolCallResult> {
+    const worker = context.worker_subagent
+    if (!worker?.parent_trace_id) {
+      return { isError: true, output: 'builtin worker subagent trace is unavailable for this incarnation' }
+    }
+    if (input.sync) return this.runSynchronously(subagent, input, context, parentTools, worker)
+
+    const entityId = await spawnPersistentAgent({
+      prompt: input.task,
+      task_description: input.task,
+      subagent_type: subagent.name,
+      tools: filterToolsForSubAgent(parentTools, subagent.builtin_capabilities, subagent.allowed_mcp_server_ids, subagent.allowed_skill_ids),
+      systemPrompt: assembleSubAgentPrompt(subagent, { parentTaskId: worker.worker_id, callerLabel: 'builtin worker (async)' }),
+      model: subagent.model.model_id,
+      ...(subagent.model.max_tokens !== undefined ? { maxTokens: subagent.model.max_tokens } : {}),
+      adapter: createAdapter({
+        endpoint: subagent.model.endpoint,
+        apikey: subagent.model.apikey,
+        format: subagent.model.format,
+        ...(subagent.model.account_id ? { accountId: subagent.model.account_id } : {}),
+      }),
+      owner: { friend_id: WORKER_OWNER, worker_id: worker.worker_id },
+      spawned_by_task_id: worker.worker_id,
+      registry: this.registry,
+      abortControllers: this.abortControllers,
+      subTrace: {
+        traceStore: this.traceStore,
+        parentTraceId: worker.parent_trace_id,
+        summaryPrefix: `[${subagent.name}]`,
+      },
+      onExit: async (info) => {
+        const current = await this.registry.get(info.entity_id)
+        if (current?.status === 'killed') return
+        const outcome = info.status === 'completed' ? '已完成' : '失败'
+        const detail = info.finalText || info.error || '无可读结果'
+        await this.deliverCompletion?.(worker.worker_id, `<sub_agent_notification>\n${subagent.name} ${outcome}：${detail}\n</sub_agent_notification>`)
+      },
+    })
+    const record = await this.registry.get(entityId)
+    return {
+      isError: false,
+      output: JSON.stringify({
+        agent_id: entityId,
+        status: 'launched',
+        ...(record?.type === 'agent' && record.trace_id ? { child_trace_id: record.trace_id } : {}),
+      }),
+    }
+  }
+
+  async list(workerId: string): Promise<WorkerSubagentSummary[]> {
+    const records = await this.registry.list({ type: 'agent', spawned_by_task_id: workerId })
+    return records
+      .filter((record): record is BgAgentRegistryRecord => record.type === 'agent' && record.owner.worker_id === workerId)
+      .map((record) => summaryOf(workerId, record))
+      .sort((left, right) => (right.started_at ?? '').localeCompare(left.started_at ?? ''))
+  }
+
+  async get(workerId: string, subagentId: string): Promise<WorkerSubagentSummary | undefined> {
+    const record = await this.registry.get(subagentId)
+    if (record?.type !== 'agent' || record.owner.worker_id !== workerId || record.spawned_by_task_id !== workerId) return undefined
+    return summaryOf(workerId, record)
+  }
+
+  async readTrace(workerId: string, subagentId: string, cursor?: TraceCursor): Promise<{
+    events: NormalizedTraceEvent[]
+    nextCursor: TraceCursor
+    unavailableReason?: string
+  }> {
+    const record = await this.registry.get(subagentId)
+    if (record?.type !== 'agent' || record.owner.worker_id !== workerId || record.spawned_by_task_id !== workerId) {
+      throw new Error(`worker subagent not found: ${subagentId}`)
+    }
+    if (!record.trace_id) {
+      return { events: [], nextCursor: cursor ?? { offset: 0 }, unavailableReason: 'subagent trace unavailable' }
+    }
+    const trace = await this.traceStore.getFullTrace(record.trace_id)
+    if (!trace) return { events: [], nextCursor: cursor ?? { offset: 0 }, unavailableReason: 'subagent trace expired' }
+    const start = cursor?.offset ?? 0
+    const events: NormalizedTraceEvent[] = []
+    for (let index = start; index < trace.spans.length; index += 1) {
+      events.push(...normalizeTraceSpan(trace.spans[index]).map((event) => ({ ...event, source_offset: index })))
+    }
+    return { events, nextCursor: { offset: trace.spans.length } }
+  }
+
+  async stopWorker(workerId: string): Promise<void> {
+    const records = await this.registry.list({ type: 'agent', spawned_by_task_id: workerId })
+    await Promise.all(records
+      .filter((record): record is BgAgentRegistryRecord => record.type === 'agent' && record.owner.worker_id === workerId && record.status === 'running')
+      .map(async (record) => {
+        this.abortControllers.get(record.entity_id)?.abort()
+        await this.registry.update(record.entity_id, { status: 'killed', ended_at: new Date().toISOString() })
+      }))
+  }
+
+  private async runSynchronously(
+    subagent: SubAgentConfig,
+    input: { task: string; context?: string },
+    context: ToolCallContext,
+    parentTools: ReadonlyArray<ToolDefinition>,
+    worker: NonNullable<ToolCallContext['worker_subagent']>,
+  ): Promise<ToolCallResult> {
+    const entityId = `agent_${randomBytes(6).toString('hex')}`
+    const now = new Date().toISOString()
+    const trace = this.traceStore.startTrace({
+      module_id: 'sub-agent',
+      trigger: { type: 'sub_agent_call', summary: `[${subagent.name}] ${input.task}`.slice(0, 200) },
+      parent_trace_id: worker.parent_trace_id!,
+    })
+    const logsDir = getBgEntitiesLogsDir()
+    await fs.mkdir(logsDir, { recursive: true })
+    await this.registry.register({
+      entity_id: entityId,
+      type: 'agent',
+      subagent_type: subagent.name,
+      trace_id: trace.trace_id,
+      status: 'running',
+      task_description: input.task,
+      messages_log_file: path.join(logsDir, `${entityId}.jsonl`),
+      result_file: null,
+      owner: { friend_id: WORKER_OWNER, worker_id: worker.worker_id },
+      spawned_by_task_id: worker.worker_id,
+      spawned_at: now,
+      exit_code: null,
+      ended_at: null,
+      last_activity_at: now,
+    })
+    const controller = new AbortController()
+    this.abortControllers.set(entityId, controller)
+    const abortParent = () => controller.abort()
+    context.abortSignal?.addEventListener('abort', abortParent, { once: true })
+    try {
+      const result = await forkEngine({
+        prompt: input.task,
+        adapter: createAdapter({
+          endpoint: subagent.model.endpoint,
+          apikey: subagent.model.apikey,
+          format: subagent.model.format,
+          ...(subagent.model.account_id ? { accountId: subagent.model.account_id } : {}),
+        }),
+        model: subagent.model.model_id,
+        systemPrompt: assembleSubAgentPrompt(subagent, { parentTaskId: worker.worker_id, callerLabel: 'builtin worker' }),
+        tools: filterToolsForSubAgent(parentTools, subagent.builtin_capabilities, subagent.allowed_mcp_server_ids, subagent.allowed_skill_ids),
+        maxTurns: subagent.max_turns,
+        ...(subagent.model.max_tokens !== undefined ? { maxTokens: subagent.model.max_tokens } : {}),
+        ...(input.context ? { parentContext: input.context } : {}),
+        abortSignal: controller.signal,
+        onTurn: (event) => recordSubAgentTurn(this.traceStore, trace.trace_id, event),
+        supportsVision: subagent.model.supports_vision,
+        ...(subagent.model.context_window !== undefined ? { contextWindowTokens: subagent.model.context_window } : {}),
+        hookRegistry: createSubAgentHookRegistry({
+          lspDiagnostics: subagent.hook_preset === 'lsp_diagnostics',
+          gitWriteFence: subagent.allowed_mcp_server_ids.includes('git'),
+        }),
+        lspManager: subagent.hook_preset === 'lsp_diagnostics' ? this.lspManager : undefined,
+      })
+      const completed = result.outcome === 'completed'
+      this.traceStore.endTrace(trace.trace_id, completed ? 'completed' : 'failed', {
+        summary: (result.output || result.error || '').slice(0, 200),
+        ...(!completed && result.error ? { error: result.error.slice(0, 200) } : {}),
+      })
+      await this.registry.update(entityId, {
+        status: completed ? 'completed' : 'failed',
+        result_file: null,
+        exit_code: completed ? 0 : 1,
+        ended_at: new Date().toISOString(),
+      })
+      return {
+        isError: !completed,
+        output: JSON.stringify({
+          agent_id: entityId,
+          status: completed ? 'completed' : 'failed',
+          output: result.output,
+          child_trace_id: trace.trace_id,
+        }),
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      this.traceStore.endTrace(trace.trace_id, 'failed', { summary: message.slice(0, 200), error: message.slice(0, 200) })
+      await this.registry.update(entityId, { status: 'failed', error: message, exit_code: 1, ended_at: new Date().toISOString() })
+      return { isError: true, output: JSON.stringify({ agent_id: entityId, status: 'failed', child_trace_id: trace.trace_id, error: message }) }
+    } finally {
+      context.abortSignal?.removeEventListener('abort', abortParent)
+      this.abortControllers.delete(entityId)
+    }
+  }
+}
+
+function normalizeTraceSpan(span: import('../../types.js').AgentSpan): NormalizedTraceEvent[] {
+  const details = (span.details ?? {}) as Record<string, unknown>
+  if (span.type === 'llm_call') {
+    const assistantText = typeof details.output_summary === 'string' ? details.output_summary : undefined
+    return [{ ts: span.started_at, kind: 'llm_call', summary: typeof details.stop_reason === 'string' ? `llm ${details.stop_reason}` : 'llm call', detail: details }, ...(assistantText ? [{ ts: span.started_at, kind: 'message' as const, role: 'assistant' as const, summary: assistantText.slice(0, 200), detail: { content: assistantText } }] : [])]
+  }
+  if (span.type === 'tool_call') {
+    const name = typeof details.tool_name === 'string' ? details.tool_name : 'tool call'
+    return [
+      { ts: span.started_at, kind: 'tool_call', role: 'assistant', summary: name, detail: details },
+      ...(typeof details.output_summary === 'string' ? [{ ts: span.ended_at ?? span.started_at, kind: 'tool_result' as const, role: 'user' as const, summary: details.output_summary, detail: details }] : []),
+    ]
+  }
+  return [{ ts: span.started_at, kind: 'lifecycle', summary: span.type, detail: details }]
+}

--- a/crabot-agent/src/workers/claude-code/adapter.ts
+++ b/crabot-agent/src/workers/claude-code/adapter.ts
@@ -1495,7 +1495,9 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
     const terminal = nativeSubagentTerminal(records)
     const startedAt = typeof first.timestamp === 'string' ? first.timestamp : undefined
     const last = records.at(-1)
-    const endedAt = terminal !== undefined && typeof last?.timestamp === 'string' ? last.timestamp : undefined
+    const endedAt = (terminal === 'completed' || terminal === 'failed') && typeof last?.timestamp === 'string'
+      ? last.timestamp
+      : undefined
     return {
       filePath,
       summary: {

--- a/crabot-agent/src/workers/claude-code/adapter.ts
+++ b/crabot-agent/src/workers/claude-code/adapter.ts
@@ -72,6 +72,8 @@ import type {
   SpawnSpec,
   SendInputOptions,
   TraceCursor,
+  WorkerSubagentStatus,
+  WorkerSubagentSummary,
   WorkerAdapter,
   WorkerContractState,
   Workspace,
@@ -245,6 +247,52 @@ interface Runtime {
 }
 
 type CapturedPane = PaneSnapshot & { captured_at: string }
+
+interface ClaudeTraceRecord {
+  readonly agentId?: unknown
+  readonly agentType?: unknown
+  readonly agent_type?: unknown
+  readonly type?: unknown
+  readonly timestamp?: unknown
+  readonly message?: unknown
+  readonly content?: unknown
+  readonly stop_reason?: unknown
+  readonly toolUseResult?: unknown
+  readonly isSidechain?: unknown
+}
+
+interface ClaudeSubagentRecord {
+  readonly filePath: string
+  readonly summary: WorkerSubagentSummary
+}
+
+function isTraceRecord(value: unknown): value is ClaudeTraceRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function completeJsonlLines(raw: string): string[] {
+  const lines = raw.split('\n')
+  // Claude appends JSONL records with a newline. An unterminated final line is
+  // still being written and must be retried on the next read.
+  if (lines.length > 0) lines.pop()
+  return lines.filter((line) => line.length > 0)
+}
+
+function nativeSubagentType(record: ClaudeTraceRecord): string | undefined {
+  const candidates = [record.agentType, record.agent_type,
+    isTraceRecord(record.message) ? record.message.agentType : undefined,
+    isTraceRecord(record.message) ? record.message.agent_type : undefined]
+  return candidates.find((value): value is string => typeof value === 'string' && value.trim().length > 0)?.trim()
+}
+
+function nativeSubagentTerminal(records: ReadonlyArray<ClaudeTraceRecord>): WorkerSubagentStatus | undefined {
+  const assistant = [...records].reverse().find((record) => record.type === 'assistant' && isTraceRecord(record.message))
+  if (!assistant || !isTraceRecord(assistant.message)) return undefined
+  const stopReason = assistant.message.stop_reason
+  if (stopReason === 'end_turn') return 'completed'
+  if (stopReason === 'error' || stopReason === 'abort') return 'failed'
+  return 'running'
+}
 
 function controlMeta(runtime: Runtime): Record<string, string> {
   return runtime.controlEndpoint
@@ -1309,6 +1357,48 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
     return { events, nextCursor }
   }
 
+  async listSubagents(h: IncarnationHandle): Promise<WorkerSubagentSummary[]> {
+    return (await this.readSubagentRecords(h))
+      .map(({ summary }) => summary)
+      .sort((left, right) => (right.started_at ?? '').localeCompare(left.started_at ?? ''))
+  }
+
+  async getSubagent(h: IncarnationHandle, subagentId: string): Promise<WorkerSubagentSummary | undefined> {
+    return (await this.readSubagentRecords(h)).find(({ summary }) => summary.subagent_id === subagentId)?.summary
+  }
+
+  async readSubagentTrace(
+    h: IncarnationHandle,
+    subagentId: string,
+    cursor?: TraceCursor,
+  ): Promise<{ events: NormalizedTraceEvent[]; nextCursor: TraceCursor; unavailableReason?: string }> {
+    const child = (await this.readSubagentRecords(h)).find(({ summary }) => summary.subagent_id === subagentId)
+    if (!child) throw new Error(`ClaudeCodeAdapter: subagent not found: ${subagentId}`)
+    let raw: string
+    try {
+      raw = await fs.readFile(child.filePath, 'utf-8')
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return {
+          events: [],
+          nextCursor: cursor ?? { offset: 0 },
+          unavailableReason: 'Claude Code child record is no longer available',
+        }
+      }
+      throw error
+    }
+    const lines = completeJsonlLines(raw)
+    const start = cursor?.offset ?? 0
+    const events: NormalizedTraceEvent[] = []
+    let consumed = start
+    for (let index = start; index < lines.length; index += 1) {
+      const event = normalizeTraceLine(lines[index])
+      if (event) events.push({ ...event, source_offset: index })
+      consumed = index + 1
+    }
+    return { events, nextCursor: { offset: consumed } }
+  }
+
   private async readTraceWindow(
     h: IncarnationHandle,
     cursor?: TraceCursor,
@@ -1346,9 +1436,7 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
     // 读到写入中途是常态。split 末尾要么是空串(文本以 \n 结尾)要么是尚未写完的半行,两种
     // 情况都不能当"已消费的完整行"处理——统一 pop 掉,不产事件也不推进 nextCursor,保证
     // 下次连同补全后的内容重新完整读取该行,不会永久丢事件。
-    const rawLines = raw.split('\n')
-    rawLines.pop()
-    const lines = rawLines.filter((line) => line.length > 0)
+    const lines = completeJsonlLines(raw)
     const start = cursor?.offset ?? 0
     const events: NormalizedTraceEvent[] = []
     // nextCursor.offset 是"实际消费到的行号",不是 start + events.length——归一化失败/不认识
@@ -1363,6 +1451,65 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
       consumed = i + 1
     }
     return { sourceAvailable: true, events, nextCursor: { offset: consumed } }
+  }
+
+  private async readSubagentRecords(h: IncarnationHandle): Promise<ReadonlyArray<ClaudeSubagentRecord>> {
+    const runtime = await this.ensureRuntime(h)
+    if (!runtime?.workspaceRoot || !runtime.sessionId) return []
+    const childrenDir = join(this.claudeProjectsDir, projectSlug(runtime.workspaceRoot), runtime.sessionId, 'subagents')
+    let entries: import('node:fs').Dirent[]
+    try {
+      entries = await fs.readdir(childrenDir, { withFileTypes: true })
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return []
+      throw error
+    }
+    const children = await Promise.all(entries
+      .filter((entry) => entry.isFile() && /^agent-[a-zA-Z0-9]+\.jsonl$/.test(entry.name))
+      .map(async (entry) => this.readSubagentRecord(h.worker_id, join(childrenDir, entry.name))))
+    return children.filter((child): child is ClaudeSubagentRecord => child !== undefined)
+  }
+
+  private async readSubagentRecord(workerId: string, filePath: string): Promise<ClaudeSubagentRecord | undefined> {
+    let raw: string
+    try {
+      raw = await fs.readFile(filePath, 'utf-8')
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined
+      throw error
+    }
+    const records = completeJsonlLines(raw).flatMap((line) => {
+      try {
+        const parsed = JSON.parse(line)
+        return isTraceRecord(parsed) ? [parsed] : []
+      } catch {
+        return []
+      }
+    })
+    const first = records[0]
+    if (!first || typeof first.agentId !== 'string' || !first.agentId) return undefined
+    const type = nativeSubagentType(first)
+    const task = first.message && isTraceRecord(first.message)
+      ? extractMessageText(first.message.content)
+      : ''
+    const terminal = nativeSubagentTerminal(records)
+    const startedAt = typeof first.timestamp === 'string' ? first.timestamp : undefined
+    const last = records.at(-1)
+    const endedAt = terminal !== undefined && typeof last?.timestamp === 'string' ? last.timestamp : undefined
+    return {
+      filePath,
+      summary: {
+        subagent_id: first.agentId,
+        worker_id: workerId,
+        executor_impl: 'claude-code',
+        ...(type ? { type } : {}),
+        name: type ?? first.agentId,
+        ...(task ? { task: truncate(task, 500) } : {}),
+        status: terminal ?? 'unknown',
+        ...(startedAt ? { started_at: startedAt } : {}),
+        ...(endedAt ? { ended_at: endedAt } : {}),
+      },
+    }
   }
 
   async inspectSupervisionActivity(
@@ -1417,7 +1564,7 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
   }
 
   capabilities(): AdapterCapabilities {
-    return { fork: true, revive: true, goalMode: false, subagent: false, structuredTrace: true }
+    return { fork: true, revive: true, goalMode: false, subagent: true, structuredTrace: true }
   }
 
   // --- Internal ---

--- a/crabot-agent/src/workers/codex/adapter.ts
+++ b/crabot-agent/src/workers/codex/adapter.ts
@@ -1760,11 +1760,12 @@ export class CodexWorkerAdapter implements WorkerAdapter {
     }
     const child = (await this.readChildThreads(h)).find((thread) => thread.id === subagentId)
     if (!child) throw new Error(`CodexWorkerAdapter: subagent not found: ${subagentId}`)
-    const items = await this.readAllThreadItems(h, child.id)
+    const { items, startedAtByTurnId } = await this.readAllThreadItems(h, child.id)
     const start = cursor?.offset ?? 0
+    const fallbackTs = timestampFromEpochSeconds(child.createdAt, '1970-01-01T00:00:00.000Z')
     return {
       events: items.slice(start).flatMap((entry, index) => {
-        const event = normalizeCodexThreadItem(entry.item)
+        const event = normalizeCodexThreadItem(entry.item, startedAtByTurnId.get(entry.turnId) ?? fallbackTs)
         return event ? [{ ...event, source_offset: start + index }] : []
       }),
       nextCursor: { offset: items.length },
@@ -1896,11 +1897,14 @@ export class CodexWorkerAdapter implements WorkerAdapter {
     }
   }
 
-  private async readAllThreadItems(h: IncarnationHandle, threadId: string): Promise<ReadonlyArray<import('./app-server-client.js').CodexAppServerThreadItem>> {
+  private async readAllThreadItems(h: IncarnationHandle, threadId: string): Promise<{
+    items: ReadonlyArray<import('./app-server-client.js').CodexAppServerThreadItem>
+    startedAtByTurnId: ReadonlyMap<string, string>
+  }> {
     const runtime = await this.ensureRuntime(h)
-    if (!runtime?.workspaceRoot) return []
+    if (!runtime?.workspaceRoot) return { items: [], startedAtByTurnId: new Map() }
     const resolved = await this.resolveBinForCommand()
-    if (!resolved) return []
+    if (!resolved) return { items: [], startedAtByTurnId: new Map() }
     const client = new CodexAppServerClient({
       command: `${resolved.cmd} app-server --stdio`,
       cwd: runtime.workspaceRoot,
@@ -1916,7 +1920,19 @@ export class CodexWorkerAdapter implements WorkerAdapter {
         items.push(...page.data)
         cursor = page.nextCursor ?? undefined
       } while (cursor)
-      return items
+      // Thread items do not carry individual timestamps. Their turn does, so use the
+      // source-native turn start as a stable timeline anchor for every item in that turn.
+      const startedAtByTurnId = new Map<string, string>()
+      try {
+        const thread = await client.readThread(threadId, deadlineAt, true)
+        for (const turn of thread.turns) {
+          if (turn.startedAt !== null) startedAtByTurnId.set(turn.id, timestampFromEpochSeconds(turn.startedAt, '1970-01-01T00:00:00.000Z'))
+        }
+      } catch {
+        // Older app-server versions may not support includeTurns. The caller uses the
+        // child thread creation time as a stable fallback without losing its trace.
+      }
+      return { items, startedAtByTurnId }
     } finally {
       await client.terminate()
     }
@@ -2409,6 +2425,11 @@ function timestampFromEpochMs(value: unknown, fallback: string): string {
   return Number.isNaN(timestamp.getTime()) ? fallback : timestamp.toISOString()
 }
 
+function timestampFromEpochSeconds(value: unknown, fallback: string): string {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return fallback
+  return timestampFromEpochMs(value * 1000, fallback)
+}
+
 function commandOutput(item: Record<string, unknown>, status: string, exitCode: number | undefined): string {
   for (const field of ['aggregated_output', 'stdout', 'stderr']) {
     const output = item[field]
@@ -2439,8 +2460,7 @@ function codexSubagentSummary(
   }
 }
 
-function normalizeCodexThreadItem(item: Record<string, unknown>): NormalizedTraceEvent | undefined {
-  const ts = new Date().toISOString()
+function normalizeCodexThreadItem(item: Record<string, unknown>, ts: string): NormalizedTraceEvent | undefined {
   switch (item.type) {
     case 'userMessage': {
       const content = Array.isArray(item.content)

--- a/crabot-agent/src/workers/codex/adapter.ts
+++ b/crabot-agent/src/workers/codex/adapter.ts
@@ -49,6 +49,7 @@ import {
   CodexAppServerDeadlineError,
   CodexAppServerRpcError,
   probeCodexAppServerFork,
+  probeCodexAppServerSubagents,
   type AppServerNotification,
 } from './app-server-client.js'
 import { parse as parseToml, stringify as stringifyToml } from 'smol-toml'
@@ -72,6 +73,7 @@ import type {
   TraceCursor,
   WorkerAdapter,
   WorkerContractState,
+  WorkerSubagentSummary,
   Workspace,
   WorkerTerminalView,
   WorkerUiResponse,
@@ -499,6 +501,7 @@ export class CodexWorkerAdapter implements WorkerAdapter {
   private lastDetectedVersion?: string
   private lastGlobalDetected = false
   private appServerForkSupported = false
+  private appServerSubagentSupported = false
   private lastCapabilityProbeKey?: string
 
   /** 同 claude adapter：resolver 存在时只认其结论，无用户级绝不回落裸命令。
@@ -670,6 +673,15 @@ export class CodexWorkerAdapter implements WorkerAdapter {
         const probeHome = await fs.mkdtemp(join(tmpdir(), 'crabot-codex-app-server-probe-'))
         try {
           this.appServerForkSupported = await probeCodexAppServerFork({
+            command: `${effectiveBin} app-server --stdio`,
+            cwd: probeHome,
+            env: {
+              ...buildScrubbedChildEnv(),
+              PATH: binDir ? `${binDir}:${process.env.PATH ?? ''}` : (process.env.PATH ?? ''),
+              CODEX_HOME: probeHome,
+            },
+          })
+          this.appServerSubagentSupported = await probeCodexAppServerSubagents({
             command: `${effectiveBin} app-server --stdio`,
             cwd: probeHome,
             env: {
@@ -1728,6 +1740,37 @@ export class CodexWorkerAdapter implements WorkerAdapter {
     return { events, nextCursor }
   }
 
+  async listSubagents(h: IncarnationHandle): Promise<WorkerSubagentSummary[]> {
+    if (!this.appServerSubagentSupported) return []
+    const threads = await this.readChildThreads(h)
+    return threads.map((thread) => codexSubagentSummary(h.worker_id, thread))
+  }
+
+  async getSubagent(h: IncarnationHandle, subagentId: string): Promise<WorkerSubagentSummary | undefined> {
+    return (await this.listSubagents(h)).find((summary) => summary.subagent_id === subagentId)
+  }
+
+  async readSubagentTrace(
+    h: IncarnationHandle,
+    subagentId: string,
+    cursor?: TraceCursor,
+  ): Promise<{ events: NormalizedTraceEvent[]; nextCursor: TraceCursor; unavailableReason?: string }> {
+    if (!this.appServerSubagentSupported) {
+      return { events: [], nextCursor: cursor ?? { offset: 0 }, unavailableReason: 'Codex app-server child reads are unavailable' }
+    }
+    const child = (await this.readChildThreads(h)).find((thread) => thread.id === subagentId)
+    if (!child) throw new Error(`CodexWorkerAdapter: subagent not found: ${subagentId}`)
+    const items = await this.readAllThreadItems(h, child.id)
+    const start = cursor?.offset ?? 0
+    return {
+      events: items.slice(start).flatMap((entry, index) => {
+        const event = normalizeCodexThreadItem(entry.item)
+        return event ? [{ ...event, source_offset: start + index }] : []
+      }),
+      nextCursor: { offset: items.length },
+    }
+  }
+
   private async readTraceWindow(
     h: IncarnationHandle,
     cursor?: TraceCursor,
@@ -1824,7 +1867,59 @@ export class CodexWorkerAdapter implements WorkerAdapter {
   }
 
   capabilities(): AdapterCapabilities {
-    return { fork: this.appServerForkSupported, revive: true, goalMode: false, subagent: false, structuredTrace: true }
+    return { fork: this.appServerForkSupported, revive: true, goalMode: false, subagent: this.appServerSubagentSupported, structuredTrace: true }
+  }
+
+  private async readChildThreads(h: IncarnationHandle): Promise<ReadonlyArray<import('./app-server-client.js').CodexAppServerThread>> {
+    const runtime = await this.ensureRuntime(h)
+    if (!runtime?.sessionId || !runtime.workspaceRoot) return []
+    const resolved = await this.resolveBinForCommand()
+    if (!resolved) return []
+    const client = new CodexAppServerClient({
+      command: `${resolved.cmd} app-server --stdio`,
+      cwd: runtime.workspaceRoot,
+      env: await this.buildEnv({ CODEX_HOME: runtime.codexHome }),
+    })
+    const deadlineAt = new Date(Date.now() + 10_000).toISOString()
+    try {
+      await client.initialize(deadlineAt)
+      const children: import('./app-server-client.js').CodexAppServerThread[] = []
+      let cursor: string | undefined
+      do {
+        const page = await client.listThreads({ parentThreadId: runtime.sessionId, ...(cursor ? { cursor } : {}), limit: 100 }, deadlineAt)
+        children.push(...page.data.filter((thread) => thread.parentThreadId === runtime.sessionId))
+        cursor = page.nextCursor ?? undefined
+      } while (cursor)
+      return children
+    } finally {
+      await client.terminate()
+    }
+  }
+
+  private async readAllThreadItems(h: IncarnationHandle, threadId: string): Promise<ReadonlyArray<import('./app-server-client.js').CodexAppServerThreadItem>> {
+    const runtime = await this.ensureRuntime(h)
+    if (!runtime?.workspaceRoot) return []
+    const resolved = await this.resolveBinForCommand()
+    if (!resolved) return []
+    const client = new CodexAppServerClient({
+      command: `${resolved.cmd} app-server --stdio`,
+      cwd: runtime.workspaceRoot,
+      env: await this.buildEnv({ CODEX_HOME: runtime.codexHome }),
+    })
+    const deadlineAt = new Date(Date.now() + 10_000).toISOString()
+    try {
+      await client.initialize(deadlineAt)
+      const items: import('./app-server-client.js').CodexAppServerThreadItem[] = []
+      let cursor: string | undefined
+      do {
+        const page = await client.listThreadItems({ threadId, ...(cursor ? { cursor } : {}), limit: 100 }, deadlineAt)
+        items.push(...page.data)
+        cursor = page.nextCursor ?? undefined
+      } while (cursor)
+      return items
+    } finally {
+      await client.terminate()
+    }
   }
 
   // --- Internal ---
@@ -2322,6 +2417,60 @@ function commandOutput(item: Record<string, unknown>, status: string, exitCode: 
   return status === 'completed' && exitCode === 0
     ? 'command completed without output'
     : 'command ' + status + (exitCode === undefined ? '' : ' with exit code ' + exitCode)
+}
+
+function codexSubagentSummary(
+  workerId: string,
+  thread: import('./app-server-client.js').CodexAppServerThread,
+): WorkerSubagentSummary {
+  const status = thread.status.type === 'active'
+    ? 'running'
+    : thread.status.type === 'idle' ? 'completed' : 'unknown'
+  return {
+    subagent_id: thread.id,
+    worker_id: workerId,
+    executor_impl: 'codex',
+    ...(thread.agentRole ? { type: thread.agentRole } : {}),
+    name: thread.agentNickname ?? thread.agentRole ?? thread.id,
+    ...(thread.preview ? { task: truncate(thread.preview, 500) } : {}),
+    status,
+    ...(thread.createdAt ? { started_at: new Date(thread.createdAt * 1000).toISOString() } : {}),
+    ...(status !== 'running' && thread.updatedAt ? { ended_at: new Date(thread.updatedAt * 1000).toISOString() } : {}),
+  }
+}
+
+function normalizeCodexThreadItem(item: Record<string, unknown>): NormalizedTraceEvent | undefined {
+  const ts = new Date().toISOString()
+  switch (item.type) {
+    case 'userMessage': {
+      const content = Array.isArray(item.content)
+        ? item.content.map((part) => isRecord(part) && typeof part.text === 'string' ? part.text : '').filter(Boolean).join('\n')
+        : ''
+      return content ? { ts, kind: 'message', role: 'user', summary: truncate(content, 200), detail: item } : undefined
+    }
+    case 'agentMessage':
+      return typeof item.text === 'string' && item.text
+        ? { ts, kind: 'message', role: 'assistant', summary: truncate(item.text, 200), detail: item }
+        : undefined
+    case 'reasoning': {
+      const summary = Array.isArray(item.summary) ? item.summary.filter((part): part is string => typeof part === 'string').join('\n') : ''
+      return summary ? { ts, kind: 'thinking', role: 'assistant', summary: truncate(summary, 200), detail: item } : undefined
+    }
+    case 'commandExecution': {
+      const command = typeof item.command === 'string' ? item.command : 'command'
+      return { ts, kind: 'tool_call', role: 'assistant', summary: truncate(`exec_command(${command})`, 200), detail: item }
+    }
+    case 'fileChange':
+      return { ts, kind: 'tool_call', role: 'assistant', summary: 'apply_patch', detail: item }
+    case 'mcpToolCall':
+    case 'dynamicToolCall':
+    case 'collabAgentToolCall':
+      return { ts, kind: 'tool_call', role: 'assistant', summary: truncate(String(item.type), 200), detail: item }
+    case 'subAgentActivity':
+      return { ts, kind: 'lifecycle', role: 'system', summary: 'subagent activity', detail: item }
+    default:
+      return undefined
+  }
 }
 
 /**

--- a/crabot-agent/src/workers/codex/app-server-client.ts
+++ b/crabot-agent/src/workers/codex/app-server-client.ts
@@ -19,6 +19,14 @@ export interface CodexAppServerThread {
   readonly agentRole: string | null
   readonly createdAt: number
   readonly updatedAt: number
+  /** Present only from thread/read(includeTurns=true). */
+  readonly turns: ReadonlyArray<CodexAppServerTurn>
+}
+
+export interface CodexAppServerTurn {
+  readonly id: string
+  readonly startedAt: number | null
+  readonly completedAt: number | null
 }
 
 export interface CodexAppServerThreadPage {
@@ -189,8 +197,8 @@ export class CodexAppServerClient {
     return parseThreadPage(result, 'thread/list')
   }
 
-  async readThread(threadId: string, deadlineAt: string): Promise<CodexAppServerThread> {
-    const result = await this.request('thread/read', { threadId }, deadlineAt)
+  async readThread(threadId: string, deadlineAt: string, includeTurns = false): Promise<CodexAppServerThread> {
+    const result = await this.request('thread/read', { threadId, ...(includeTurns ? { includeTurns: true } : {}) }, deadlineAt)
     if (!isObject(result) || !isObject(result.thread)) {
       throw new Error('codex app-server thread/read returned an incompatible response')
     }
@@ -345,6 +353,16 @@ function parseThread(value: unknown, method: string): CodexAppServerThread {
     agentRole: typeof value.agentRole === 'string' ? value.agentRole : null,
     createdAt: typeof value.createdAt === 'number' ? value.createdAt : 0,
     updatedAt: typeof value.updatedAt === 'number' ? value.updatedAt : 0,
+    turns: Array.isArray(value.turns)
+      ? value.turns.flatMap((turn) => {
+        if (!isObject(turn) || typeof turn.id !== 'string') return []
+        return [{
+          id: turn.id,
+          startedAt: typeof turn.startedAt === 'number' ? turn.startedAt : null,
+          completedAt: typeof turn.completedAt === 'number' ? turn.completedAt : null,
+        }]
+      })
+      : [],
   }
 }
 

--- a/crabot-agent/src/workers/codex/app-server-client.ts
+++ b/crabot-agent/src/workers/codex/app-server-client.ts
@@ -10,6 +10,32 @@ interface PendingRequest {
   readonly timer: ReturnType<typeof setTimeout>
 }
 
+export interface CodexAppServerThread {
+  readonly id: string
+  readonly parentThreadId: string | null
+  readonly preview: string
+  readonly status: { readonly type: string }
+  readonly agentNickname: string | null
+  readonly agentRole: string | null
+  readonly createdAt: number
+  readonly updatedAt: number
+}
+
+export interface CodexAppServerThreadPage {
+  readonly data: ReadonlyArray<CodexAppServerThread>
+  readonly nextCursor: string | null
+}
+
+export interface CodexAppServerThreadItem {
+  readonly turnId: string
+  readonly item: Record<string, unknown>
+}
+
+export interface CodexAppServerThreadItemPage {
+  readonly data: ReadonlyArray<CodexAppServerThreadItem>
+  readonly nextCursor: string | null
+}
+
 export interface AppServerNotification {
   readonly method: string
   readonly params?: unknown
@@ -155,6 +181,40 @@ export class CodexAppServerClient {
     })
   }
 
+  async listThreads(
+    params: { readonly parentThreadId?: string; readonly cursor?: string; readonly limit?: number },
+    deadlineAt: string,
+  ): Promise<CodexAppServerThreadPage> {
+    const result = await this.request('thread/list', params, deadlineAt)
+    return parseThreadPage(result, 'thread/list')
+  }
+
+  async readThread(threadId: string, deadlineAt: string): Promise<CodexAppServerThread> {
+    const result = await this.request('thread/read', { threadId }, deadlineAt)
+    if (!isObject(result) || !isObject(result.thread)) {
+      throw new Error('codex app-server thread/read returned an incompatible response')
+    }
+    return parseThread(result.thread, 'thread/read')
+  }
+
+  async listThreadItems(
+    params: { readonly threadId: string; readonly cursor?: string; readonly limit?: number },
+    deadlineAt: string,
+  ): Promise<CodexAppServerThreadItemPage> {
+    const result = await this.request('thread/items/list', params, deadlineAt)
+    if (!isObject(result) || !Array.isArray(result.data) || !('nextCursor' in result)) {
+      throw new Error('codex app-server thread/items/list returned an incompatible response')
+    }
+    const data: CodexAppServerThreadItem[] = []
+    for (const entry of result.data) {
+      if (!isObject(entry) || typeof entry.turnId !== 'string' || !isObject(entry.item)) {
+        throw new Error('codex app-server thread/items/list returned an invalid item')
+      }
+      data.push({ turnId: entry.turnId, item: entry.item })
+    }
+    return { data, nextCursor: typeof result.nextCursor === 'string' ? result.nextCursor : null }
+  }
+
   notify(method: string, params: JsonObject): void {
     this.write({ method, params })
   }
@@ -262,6 +322,32 @@ function isObject(value: unknown): value is JsonObject {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
+function parseThreadPage(value: unknown, method: string): CodexAppServerThreadPage {
+  if (!isObject(value) || !Array.isArray(value.data) || !('nextCursor' in value)) {
+    throw new Error(`codex app-server ${method} returned an incompatible response`)
+  }
+  return {
+    data: value.data.map((thread) => parseThread(thread, method)),
+    nextCursor: typeof value.nextCursor === 'string' ? value.nextCursor : null,
+  }
+}
+
+function parseThread(value: unknown, method: string): CodexAppServerThread {
+  if (!isObject(value) || typeof value.id !== 'string' || typeof value.preview !== 'string' || !isObject(value.status)) {
+    throw new Error(`codex app-server ${method} returned an invalid thread`)
+  }
+  return {
+    id: value.id,
+    parentThreadId: typeof value.parentThreadId === 'string' ? value.parentThreadId : null,
+    preview: value.preview,
+    status: { type: typeof value.status.type === 'string' ? value.status.type : 'notLoaded' },
+    agentNickname: typeof value.agentNickname === 'string' ? value.agentNickname : null,
+    agentRole: typeof value.agentRole === 'string' ? value.agentRole : null,
+    createdAt: typeof value.createdAt === 'number' ? value.createdAt : 0,
+    updatedAt: typeof value.updatedAt === 'number' ? value.updatedAt : 0,
+  }
+}
+
 function provesThreadLookup(error: unknown): boolean {
   return error instanceof CodexAppServerRpcError &&
     error.code !== -32601 &&
@@ -292,6 +378,25 @@ export async function probeCodexAppServerFork(opts: {
     ])
     return fork.status === 'rejected' && provesThreadLookup(fork.reason) &&
       turn.status === 'rejected' && provesThreadLookup(turn.reason)
+  } catch {
+    return false
+  } finally {
+    await client.terminate()
+  }
+}
+
+export async function probeCodexAppServerSubagents(opts: {
+  readonly command: string
+  readonly cwd: string
+  readonly env: Record<string, string>
+  readonly timeoutMs?: number
+}): Promise<boolean> {
+  const deadlineAt = new Date(Date.now() + (opts.timeoutMs ?? 3000)).toISOString()
+  const client = new CodexAppServerClient(opts)
+  try {
+    await client.initialize(deadlineAt)
+    await client.listThreads({ parentThreadId: '00000000-0000-0000-0000-000000000001', limit: 1 }, deadlineAt)
+    return true
   } catch {
     return false
   } finally {

--- a/crabot-agent/src/workers/harness/harness.ts
+++ b/crabot-agent/src/workers/harness/harness.ts
@@ -86,6 +86,8 @@ import type {
   NormalizedTraceEvent,
   WorkerActivity,
   IncarnationId,
+  TraceCursor,
+  WorkerSubagentSummary,
 } from '../types'
 import type { BuiltinRuntimeFactory } from '../builtin/runtime'
 import type { ResolvedPermissions } from '../../types'
@@ -2663,6 +2665,59 @@ export class WorkerHarness {
       ...(incarnation.query_id ? { query_id: incarnation.query_id } : {}),
     }
     return adapter.readTerminal(handle)
+  }
+
+  /** Read the direct children reported by the selected Worker incarnation(s). */
+  async listWorkerSubagents(workerId: string, incarnationId?: IncarnationId): Promise<WorkerSubagentSummary[]> {
+    const found = await this.deps.ledger.findWorker(workerId)
+    if (!found) throw new WorkerNotFoundError(workerId)
+    const incarnations = incarnationId === undefined
+      ? found.worker.incarnations
+      : [found.worker.incarnations.find((candidate) => candidate.incarnation_id === incarnationId)].filter(Boolean)
+    if (incarnationId !== undefined && incarnations.length === 0) {
+      throw new Error(`WorkerHarness.listWorkerSubagents: no incarnation with incarnation_id=${incarnationId} found for worker ${workerId}`)
+    }
+    const summaries = new Map<string, WorkerSubagentSummary>()
+    for (const incarnation of incarnations) {
+      if (!incarnation || isLegacyIncarnation(incarnation)) continue
+      const adapter = this.deps.adapters.get(incarnation.impl)
+      if (!adapter?.listSubagents) continue
+      const children = await adapter.listSubagents(handleForIncarnation(workerId, incarnation))
+      for (const child of children) summaries.set(child.subagent_id, child)
+    }
+    return [...summaries.values()].sort((left, right) => (right.started_at ?? '').localeCompare(left.started_at ?? ''))
+  }
+
+  async getWorkerSubagent(workerId: string, subagentId: string): Promise<WorkerSubagentSummary | undefined> {
+    const found = await this.deps.ledger.findWorker(workerId)
+    if (!found) throw new WorkerNotFoundError(workerId)
+    for (const incarnation of found.worker.incarnations) {
+      if (isLegacyIncarnation(incarnation)) continue
+      const adapter = this.deps.adapters.get(incarnation.impl)
+      if (!adapter?.getSubagent) continue
+      const summary = await adapter.getSubagent(handleForIncarnation(workerId, incarnation), subagentId)
+      if (summary) return summary
+    }
+    return undefined
+  }
+
+  async getWorkerSubagentTrace(
+    workerId: string,
+    subagentId: string,
+    cursor?: TraceCursor,
+  ): Promise<{ events: NormalizedTraceEvent[]; nextCursor: TraceCursor; unavailableReason?: string }> {
+    const found = await this.deps.ledger.findWorker(workerId)
+    if (!found) throw new WorkerNotFoundError(workerId)
+    for (const incarnation of found.worker.incarnations) {
+      if (isLegacyIncarnation(incarnation)) continue
+      const adapter = this.deps.adapters.get(incarnation.impl)
+      if (!adapter?.getSubagent || !adapter.readSubagentTrace) continue
+      const handle = handleForIncarnation(workerId, incarnation)
+      if (await adapter.getSubagent(handle, subagentId)) {
+        return adapter.readSubagentTrace(handle, subagentId, cursor)
+      }
+    }
+    throw new Error(`worker subagent not found: ${subagentId}`)
   }
 
   async hasWorker(workerId: string): Promise<boolean> {

--- a/crabot-agent/src/workers/harness/harness.ts
+++ b/crabot-agent/src/workers/harness/harness.ts
@@ -588,6 +588,11 @@ export interface HarnessDeps {
    * 状态机推进（调用点已 catch）。
    */
   readonly onIncarnationTerminal?: (handle: IncarnationHandle) => void
+  /**
+   * A CLI parent native trace has been durably observed. The callback receives no raw content;
+   * assembly may use the opportunity to capture independently terminal child records.
+   */
+  readonly onNativeActivityCollected?: (handle: IncarnationHandle) => void
   /** 已 detect 过的可用实现。见文件头"onStateChange 接线契约"——底层 Map 引用可在构造后继续填充。 */
   readonly adapters: ReadonlyMap<WorkerImplId, WorkerAdapter>
   readonly defaultImpl: WorkerImplId
@@ -893,7 +898,14 @@ export class WorkerHarness {
    */
   readonly handleNativeActivity = (h: IncarnationHandle): void => {
     this.collectNativeActivity(h)
-      .then(() => this.deliverNativeActivityNotifications(h.worker_id))
+      .then(() => {
+        try {
+          this.deps.onNativeActivityCollected?.(h)
+        } catch (error) {
+          console.error(`[WorkerHarness] native activity collected callback failed for ${h.worker_id}#${h.seq}:`, error)
+        }
+        return this.deliverNativeActivityNotifications(h.worker_id)
+      })
       .catch((error) => console.error(`[WorkerHarness] native activity collection failed for ${h.worker_id}#${h.seq}:`, error))
   }
 

--- a/crabot-agent/src/workers/trace/native-copy.ts
+++ b/crabot-agent/src/workers/trace/native-copy.ts
@@ -7,15 +7,38 @@
  */
 
 import { promises as fs } from 'fs'
-import { join } from 'path'
+import { dirname, join } from 'path'
 import { randomBytes } from 'crypto'
-import type { NormalizedTraceEvent } from '../types.js'
+import type { NormalizedTraceEvent, WorkerSubagentSummary } from '../types.js'
 
 interface CopyHeader {
   readonly kind: 'native-trace-copy-header'
   readonly worker_id: string
   readonly seq: number
   readonly incarnation_fingerprint: string
+}
+
+interface SubagentCopyHeader {
+  readonly kind: 'native-subagent-trace-copy-header'
+  readonly worker_id: string
+  readonly parent_incarnation_id?: string
+  readonly subagent_id: string
+  readonly subagent_fingerprint: string
+  readonly summary: WorkerSubagentSummary
+  /** `pending` means the child identity is durable, but its terminal source was not copied yet. */
+  readonly capture_status: 'pending' | 'complete'
+  /** Native cursor after the full terminal read; preserves skipped raw records on fallback. */
+  readonly next_cursor_offset?: number
+  readonly unavailable_reason?: string
+}
+
+export interface StoredSubagentTrace {
+  readonly summary: WorkerSubagentSummary
+  readonly parent_incarnation_id?: string
+  readonly capture_status: 'pending' | 'complete'
+  readonly next_cursor_offset?: number
+  readonly unavailable_reason?: string
+  readonly events: NormalizedTraceEvent[]
 }
 
 export class NativeTraceCopyStore {
@@ -25,6 +48,10 @@ export class NativeTraceCopyStore {
 
   private fileFor(workerId: string, seq: number): string {
     return join(this.rootDir, encodeURIComponent(workerId), `seq-${seq}.jsonl`)
+  }
+
+  private subagentFileFor(workerId: string, subagentId: string): string {
+    return join(this.rootDir, encodeURIComponent(workerId), 'subagents', `${encodeURIComponent(subagentId)}.jsonl`)
   }
 
   /** 追加本化身的脱敏 native 事件；header 指纹不一致时整文件替换（旧 copy 属于死化身）。 */
@@ -211,5 +238,223 @@ export class NativeTraceCopyStore {
     // 后续 append 必须排在 header 升级之后，避免将旧副本误判为另一化身而覆盖。
     this.writeTails.set(key, next.then(() => undefined, () => undefined))
     return next
+  }
+
+  /**
+   * First durable step for a terminal CLI child. Keeping this marker before the
+   * native read means a failed final write remains discoverable and can be
+   * retried at the next terminal/startup harvest.
+   */
+  async beginSubagentCapture(
+    workerId: string,
+    parentIncarnationId: string | undefined,
+    summary: WorkerSubagentSummary,
+    fingerprint: string,
+    redact: (text: string) => string,
+  ): Promise<void> {
+    this.assertSubagentOwner(workerId, summary)
+    const key = `subagent:${workerId}:${summary.subagent_id}`
+    await this.enqueue(key, async () => {
+      const filePath = this.subagentFileFor(workerId, summary.subagent_id)
+      const existing = await this.readSubagentHeader(filePath)
+      if (
+        existing?.worker_id === workerId
+        && existing.subagent_id === summary.subagent_id
+        && existing.subagent_fingerprint === fingerprint
+        && existing.capture_status === 'complete'
+      ) return
+      await this.writeSubagentFile(filePath, {
+        kind: 'native-subagent-trace-copy-header',
+        worker_id: workerId,
+        ...(parentIncarnationId === undefined ? {} : { parent_incarnation_id: parentIncarnationId }),
+        subagent_id: summary.subagent_id,
+        subagent_fingerprint: fingerprint,
+        summary,
+        capture_status: 'pending',
+      }, [], redact)
+    })
+  }
+
+  /** Persist a complete, redacted terminal child trace after its native source was read. */
+  async completeSubagentCapture(
+    workerId: string,
+    parentIncarnationId: string | undefined,
+    summary: WorkerSubagentSummary,
+    fingerprint: string,
+    events: ReadonlyArray<NormalizedTraceEvent>,
+    nextCursorOffset: number,
+    redact: (text: string) => string,
+  ): Promise<void> {
+    this.assertSubagentOwner(workerId, summary)
+    const key = `subagent:${workerId}:${summary.subagent_id}`
+    await this.enqueue(key, async () => {
+      await this.writeSubagentFile(this.subagentFileFor(workerId, summary.subagent_id), {
+        kind: 'native-subagent-trace-copy-header',
+        worker_id: workerId,
+        ...(parentIncarnationId === undefined ? {} : { parent_incarnation_id: parentIncarnationId }),
+        subagent_id: summary.subagent_id,
+        subagent_fingerprint: fingerprint,
+        summary,
+        capture_status: 'complete',
+        next_cursor_offset: nextCursorOffset,
+      }, events, redact)
+    })
+  }
+
+  /** Keep the child identity visible when the source disappears before a final copy can be made. */
+  async markSubagentCaptureUnavailable(
+    workerId: string,
+    parentIncarnationId: string | undefined,
+    summary: WorkerSubagentSummary,
+    fingerprint: string,
+    unavailableReason: string,
+    redact: (text: string) => string,
+  ): Promise<void> {
+    this.assertSubagentOwner(workerId, summary)
+    const key = `subagent:${workerId}:${summary.subagent_id}`
+    await this.enqueue(key, async () => {
+      const filePath = this.subagentFileFor(workerId, summary.subagent_id)
+      const existing = await this.readSubagentHeader(filePath)
+      if (
+        existing?.worker_id === workerId
+        && existing.subagent_id === summary.subagent_id
+        && existing.subagent_fingerprint === fingerprint
+        && existing.capture_status === 'complete'
+      ) return
+      await this.writeSubagentFile(filePath, {
+        kind: 'native-subagent-trace-copy-header',
+        worker_id: workerId,
+        ...(parentIncarnationId === undefined ? {} : { parent_incarnation_id: parentIncarnationId }),
+        subagent_id: summary.subagent_id,
+        subagent_fingerprint: fingerprint,
+        summary,
+        capture_status: 'pending',
+        unavailable_reason: unavailableReason,
+      }, [], redact)
+    })
+  }
+
+  /** Read one retained child; mismatched identity is never allowed to cross a Worker boundary. */
+  async readSubagent(
+    workerId: string,
+    subagentId: string,
+    fingerprint: string,
+  ): Promise<StoredSubagentTrace | null> {
+    const filePath = this.subagentFileFor(workerId, subagentId)
+    let raw: string
+    try {
+      raw = await fs.readFile(filePath, 'utf-8')
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null
+      throw error
+    }
+    const header = this.parseSubagentHeader(raw)
+    if (
+      !header
+      || header.worker_id !== workerId
+      || header.subagent_id !== subagentId
+      || header.subagent_fingerprint !== fingerprint
+    ) return null
+    return {
+      summary: header.summary,
+      ...(header.parent_incarnation_id === undefined ? {} : { parent_incarnation_id: header.parent_incarnation_id }),
+      capture_status: header.capture_status,
+      ...(header.next_cursor_offset === undefined ? {} : { next_cursor_offset: header.next_cursor_offset }),
+      ...(header.unavailable_reason === undefined ? {} : { unavailable_reason: header.unavailable_reason }),
+      events: this.eventsFromRaw(raw),
+    }
+  }
+
+  /** Retained child summaries are the fallback only; live adapter records always take precedence. */
+  async listSubagents(workerId: string, parentIncarnationId?: string): Promise<WorkerSubagentSummary[]> {
+    const dir = join(this.rootDir, encodeURIComponent(workerId), 'subagents')
+    let entries: string[]
+    try {
+      entries = await fs.readdir(dir)
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return []
+      throw error
+    }
+    const summaries: WorkerSubagentSummary[] = []
+    for (const entry of entries) {
+      if (!entry.endsWith('.jsonl')) continue
+      const header = await this.readSubagentHeader(join(dir, entry))
+      if (
+        header?.worker_id === workerId
+        && header.summary.worker_id === workerId
+        && (parentIncarnationId === undefined || header.parent_incarnation_id === parentIncarnationId)
+      ) {
+        summaries.push(header.summary)
+      }
+    }
+    return summaries.sort((left, right) => (right.started_at ?? '').localeCompare(left.started_at ?? ''))
+  }
+
+  /** PR B's Worker-retention transaction removes this whole Worker-owned directory. */
+  async removeWorker(workerId: string): Promise<void> {
+    const prefix = `${workerId}#`
+    const childPrefix = `subagent:${workerId}:`
+    await Promise.all(Array.from(this.writeTails.entries())
+      .filter(([key]) => key.startsWith(prefix) || key.startsWith(childPrefix))
+      .map(([, tail]) => tail))
+    await fs.rm(join(this.rootDir, encodeURIComponent(workerId)), { recursive: true, force: true })
+  }
+
+  private assertSubagentOwner(workerId: string, summary: WorkerSubagentSummary): void {
+    if (summary.worker_id !== workerId) {
+      throw new Error(`subagent ${summary.subagent_id} does not belong to worker ${workerId}`)
+    }
+  }
+
+  private enqueue<T>(key: string, operation: () => Promise<T>): Promise<T> {
+    const tail = this.writeTails.get(key) ?? Promise.resolve()
+    const next = tail.then(operation)
+    this.writeTails.set(key, next.then(() => undefined, () => undefined))
+    return next
+  }
+
+  private async writeSubagentFile(
+    filePath: string,
+    header: SubagentCopyHeader,
+    events: ReadonlyArray<NormalizedTraceEvent>,
+    redact: (text: string) => string,
+  ): Promise<void> {
+    const lines = [
+      redact(JSON.stringify(header)),
+      ...events.map((event) => redact(JSON.stringify(event))),
+    ]
+    await fs.mkdir(dirname(filePath), { recursive: true, mode: 0o700 })
+    const tmpPath = `${filePath}.tmp-${randomBytes(6).toString('hex')}`
+    await fs.writeFile(tmpPath, `${lines.join('\n')}\n`, { mode: 0o600 })
+    await fs.rename(tmpPath, filePath)
+  }
+
+  private async readSubagentHeader(filePath: string): Promise<SubagentCopyHeader | null> {
+    let raw: string
+    try {
+      raw = await fs.readFile(filePath, 'utf-8')
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null
+      throw error
+    }
+    return this.parseSubagentHeader(raw)
+  }
+
+  private parseSubagentHeader(raw: string): SubagentCopyHeader | null {
+    const firstLine = raw.split('\n', 1)[0]
+    if (!firstLine) return null
+    try {
+      const parsed = JSON.parse(firstLine) as Partial<SubagentCopyHeader>
+      return parsed.kind === 'native-subagent-trace-copy-header'
+        && typeof parsed.worker_id === 'string'
+        && typeof parsed.subagent_id === 'string'
+        && typeof parsed.subagent_fingerprint === 'string'
+        && parsed.summary !== undefined
+        && (parsed.capture_status === 'pending' || parsed.capture_status === 'complete')
+        ? parsed as SubagentCopyHeader
+        : null
+    } catch {
+      return null
+    }
   }
 }

--- a/crabot-agent/src/workers/trace/native-copy.ts
+++ b/crabot-agent/src/workers/trace/native-copy.ts
@@ -41,6 +41,14 @@ export interface StoredSubagentTrace {
   readonly events: NormalizedTraceEvent[]
 }
 
+export interface PendingSubagentCapture {
+  readonly worker_id: string
+  readonly parent_incarnation_id?: string
+  readonly subagent_id: string
+  readonly subagent_fingerprint: string
+  readonly summary: WorkerSubagentSummary
+}
+
 export class NativeTraceCopyStore {
   private readonly writeTails = new Map<string, Promise<void>>()
 
@@ -363,6 +371,42 @@ export class NativeTraceCopyStore {
       ...(header.unavailable_reason === undefined ? {} : { unavailable_reason: header.unavailable_reason }),
       events: this.eventsFromRaw(raw),
     }
+  }
+
+  /** Enumerate only durable child captures that still need a terminal source read. */
+  async listPendingSubagentCaptures(): Promise<PendingSubagentCapture[]> {
+    let workerEntries: string[]
+    try {
+      workerEntries = await fs.readdir(this.rootDir)
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return []
+      throw error
+    }
+
+    const pending: PendingSubagentCapture[] = []
+    for (const workerEntry of workerEntries) {
+      const subagentsDir = join(this.rootDir, workerEntry, 'subagents')
+      let childEntries: string[]
+      try {
+        childEntries = await fs.readdir(subagentsDir)
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') continue
+        throw error
+      }
+      for (const childEntry of childEntries) {
+        if (!childEntry.endsWith('.jsonl')) continue
+        const header = await this.readSubagentHeader(join(subagentsDir, childEntry))
+        if (!header || header.capture_status !== 'pending') continue
+        pending.push({
+          worker_id: header.worker_id,
+          ...(header.parent_incarnation_id === undefined ? {} : { parent_incarnation_id: header.parent_incarnation_id }),
+          subagent_id: header.subagent_id,
+          subagent_fingerprint: header.subagent_fingerprint,
+          summary: header.summary,
+        })
+      }
+    }
+    return pending
   }
 
   /** Retained child summaries are the fallback only; live adapter records always take precedence. */

--- a/crabot-agent/src/workers/types.ts
+++ b/crabot-agent/src/workers/types.ts
@@ -200,6 +200,30 @@ export interface NormalizedTraceEvent {
    * 归一化跳过的行也消费行号，composite 钳制与 copy 回退必须按它而不是事件条数。
    */
   readonly source_offset?: number
+  /** Parent Worker trace entry may identify one directly-started child. */
+  readonly subagent_id?: string
+}
+
+export type WorkerSubagentStatus =
+  | 'running'
+  | 'completed'
+  | 'failed'
+  | 'stopped'
+  | 'interrupted'
+  | 'unknown'
+
+/** A directly-started child reported by a Worker implementation. */
+export interface WorkerSubagentSummary {
+  readonly subagent_id: string
+  readonly worker_id: string
+  readonly executor_impl: WorkerImplId
+  readonly type?: string
+  readonly name: string
+  readonly task?: string
+  readonly status: WorkerSubagentStatus
+  readonly started_at?: string
+  readonly ended_at?: string
+  readonly unavailable_reason?: string
 }
 
 export type WorkerActivityKind = 'assistant_text' | 'tool_call' | 'tool_result'
@@ -425,6 +449,14 @@ export interface WorkerAdapter {
     cursor?: { readonly offset: number },
   ): Promise<SupervisionObservation>
   readTrace?(h: IncarnationHandle, cursor?: TraceCursor): Promise<{ events: NormalizedTraceEvent[]; nextCursor: TraceCursor }>
+  /** Direct native child sessions only. Implementations must not infer children from parent tool text. */
+  listSubagents?(h: IncarnationHandle): Promise<WorkerSubagentSummary[]>
+  getSubagent?(h: IncarnationHandle, subagentId: string): Promise<WorkerSubagentSummary | undefined>
+  readSubagentTrace?(h: IncarnationHandle, subagentId: string, cursor?: TraceCursor): Promise<{
+    events: NormalizedTraceEvent[]
+    nextCursor: TraceCursor
+    unavailableReason?: string
+  }>
   /** Request only the active turn to stop. Completion is verified by Harness control operations. */
   interrupt?(h: IncarnationHandle): Promise<void>
   /** Stop the adapter-owned execution. Completion is verified by Harness control operations. */

--- a/crabot-agent/tests/engine/bg-entities/registry.test.ts
+++ b/crabot-agent/tests/engine/bg-entities/registry.test.ts
@@ -402,6 +402,42 @@ describe('BgEntityRegistry', () => {
     expect(existsSync(stderrFifo)).toBe(false)
   })
 
+  it('gcDeadEntities: retains Worker-owned builtin child identities for Worker retention', async () => {
+    const eightDaysAgo = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString()
+    await registry.register(makeAgentRecord({
+      entity_id: 'old-worker-child',
+      status: 'completed',
+      owner: { friend_id: '__builtin_worker__', worker_id: 'worker-1' },
+      spawned_by_task_id: 'worker-1',
+      spawned_at: eightDaysAgo,
+      ended_at: eightDaysAgo,
+      last_activity_at: eightDaysAgo,
+    }))
+    await registry.register(makeAgentRecord({
+      entity_id: 'old-friend-agent',
+      status: 'completed',
+      spawned_by_task_id: 'task-friend-agent',
+      spawned_at: eightDaysAgo,
+      ended_at: eightDaysAgo,
+      last_activity_at: eightDaysAgo,
+    }))
+    await registry.register(makeAgentRecord({
+      entity_id: 'old-incomplete-worker-agent',
+      status: 'completed',
+      owner: { friend_id: '__builtin_worker__' },
+      spawned_by_task_id: 'task-not-worker-id',
+      spawned_at: eightDaysAgo,
+      ended_at: eightDaysAgo,
+      last_activity_at: eightDaysAgo,
+    }))
+
+    const { removed } = await registry.gcDeadEntities(new Date())
+
+    expect(removed).toEqual(expect.arrayContaining(['old-friend-agent', 'old-incomplete-worker-agent']))
+    expect(removed).not.toContain('old-worker-child')
+    await expect(registry.get('old-worker-child')).resolves.toMatchObject({ status: 'completed' })
+  })
+
   it('gcDeadEntities: keeps entities ended less than 7 days ago', async () => {
     const sixDaysAgo = new Date(Date.now() - 6 * 24 * 60 * 60 * 1000).toISOString()
     const recentRec = makeShellRecord({

--- a/crabot-agent/tests/manager/rpc-handlers.test.ts
+++ b/crabot-agent/tests/manager/rpc-handlers.test.ts
@@ -1115,6 +1115,8 @@ describe('worker 直接 subagent 读模型（§10.3）', () => {
     try {
       const first = await agent.handleGetWorkerSubagentTrace({ worker_id: 'w-1', subagent_id: 'child-1' })
       expect(first.events.map((event) => event.summary)).toEqual(['第一条记录'])
+      expect(first.events[0]).not.toHaveProperty('source_offset')
+      expect(first.events[0]?.source).toBe('native')
 
       traceEvents.push({ ts: '2026-08-22T00:00:02.000Z', kind: 'message', role: 'assistant', summary: '第二条记录', source_offset: 1 })
       const second = await agent.handleGetWorkerSubagentTrace({ worker_id: 'w-1', subagent_id: 'child-1', cursor: first.next_cursor })

--- a/crabot-agent/tests/manager/rpc-handlers.test.ts
+++ b/crabot-agent/tests/manager/rpc-handlers.test.ts
@@ -1328,6 +1328,57 @@ describe('worker 直接 subagent 读模型（§10.3）', () => {
       await fs.rm(root, { recursive: true, force: true })
     }
   })
+
+  it('启动恢复中一个 Worker 的 child 列表读取失败，不阻断后续 Worker 的补齐', async () => {
+    const root = await fs.mkdtemp(join(tmpdir(), 'restart-child-copy-isolation-'))
+    const cliChild = { ...child, worker_id: 'w-2', executor_impl: 'codex' as const }
+    const firstIncarnation = {
+      incarnation_id: 'inc-1', seq: 1, impl: 'codex' as const, state: 'running' as const,
+      workspace: root, session_ref: 'first-thread', started_at: '2026-08-22T00:00:00.000Z',
+    }
+    const secondIncarnation = {
+      incarnation_id: 'inc-2', seq: 1, impl: 'codex' as const, state: 'running' as const,
+      workspace: root, session_ref: 'second-thread', started_at: '2026-08-22T00:00:00.000Z',
+    }
+    const adapter = {
+      listSubagents: async (handle: { worker_id: string }) => {
+        if (handle.worker_id === 'w-1') throw new Error('app-server unavailable')
+        return [cliChild]
+      },
+      readSubagentTrace: async () => ({
+        events: [{ ts: '2026-08-22T00:00:01.000Z', kind: 'message' as const, role: 'assistant' as const, summary: 'finished', source_offset: 0 }],
+        nextCursor: { offset: 1 },
+      }),
+    }
+    const agent = buildAgent({
+      ledger: {
+        listAllWorkers: async () => [
+          { managerKey: 'test::f1' as ManagerKey, worker: { ...makeLedgerWorker({ workerId: 'w-1', status: 'running' }), incarnations: [firstIncarnation] } },
+          { managerKey: 'test::f2' as ManagerKey, worker: { ...makeLedgerWorker({ workerId: 'w-2', status: 'running' }), incarnations: [secondIncarnation] } },
+        ],
+      },
+      adapters: new Map([['codex', adapter]]),
+    }) as unknown as Record<string, unknown>
+    const { NativeTraceCopyStore } = await import('../../src/workers/trace/native-copy.js')
+    const copyStore = new NativeTraceCopyStore(join(root, 'copies'))
+    agent.nativeTraceCopyStoreInstance = copyStore
+    agent.knownSecrets = []
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    try {
+      await (agent as unknown as { recoverTerminalCliSubagentTraces(): Promise<void> }).recoverTerminalCliSubagentTraces()
+      await expect(copyStore.readSubagent('w-2', cliChild.subagent_id, subagentFingerprint(cliChild))).resolves.toMatchObject({
+        capture_status: 'complete', events: [{ summary: 'finished' }],
+      })
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('terminal CLI child trace recovery failed for w-1#1'),
+        'app-server unavailable',
+      )
+    } finally {
+      warn.mockRestore()
+      await copyStore.flush()
+      await fs.rm(root, { recursive: true, force: true })
+    }
+  })
 })
 
 describe('读模型 handler 的 manager 栈前置门', () => {

--- a/crabot-agent/tests/manager/rpc-handlers.test.ts
+++ b/crabot-agent/tests/manager/rpc-handlers.test.ts
@@ -30,6 +30,12 @@ import type {
   GetWorkerTerminalResult,
   GetWorkerTraceParams,
   GetWorkerTraceResult,
+  ListWorkerSubagentsParams,
+  ListWorkerSubagentsResult,
+  GetWorkerSubagentDetailParams,
+  GetWorkerSubagentDetailResult,
+  GetWorkerSubagentTraceParams,
+  GetWorkerSubagentTraceResult,
 } from '../../src/manager/read-model.js'
 import type { TriggerScheduleParams, TriggerScheduleResult } from '../../src/unified-agent.js'
 
@@ -46,12 +52,16 @@ interface AgentUnderTest {
   handleGetWorkerDetail(p: GetWorkerDetailParams): Promise<GetWorkerDetailResult>
   handleGetWorkerTerminal(p: GetWorkerTerminalParams): Promise<GetWorkerTerminalResult>
   handleGetWorkerTrace(p: GetWorkerTraceParams): Promise<GetWorkerTraceResult>
+  handleListWorkerSubagents(p: ListWorkerSubagentsParams): Promise<ListWorkerSubagentsResult>
+  handleGetWorkerSubagentDetail(p: GetWorkerSubagentDetailParams): Promise<GetWorkerSubagentDetailResult>
+  handleGetWorkerSubagentTrace(p: GetWorkerSubagentTraceParams): Promise<GetWorkerSubagentTraceResult>
 }
 
 function buildAgent(managerStack?: unknown): AgentUnderTest {
   const agent = Object.create(UnifiedAgent.prototype) as Record<string, unknown>
   agent.agentConfig = { model_config: { powerful: { apikey: 'test-key', model_id: 'test-model' } } }
   agent.config = { moduleId: 'test-agent' }
+  agent.knownSecrets = []
   // 直接 test fixture：构造函数默认 runtime_config_authenticated=true；Object.create 绕过构造函数，这里补齐。
   agent.configAuthenticated = true
   agent.configStale = false
@@ -1040,6 +1050,87 @@ describe('get_worker_trace(§8.3 + §10.2，P6-A composite)', () => {
   })
 })
 
+describe('worker 直接 subagent 读模型（§10.3）', () => {
+  const child = {
+    subagent_id: 'child-1',
+    worker_id: 'w-1',
+    executor_impl: 'builtin' as const,
+    type: 'code_writer',
+    name: '代码助手',
+    task: '实现观察接口',
+    status: 'completed' as const,
+    started_at: '2026-08-22T00:00:00.000Z',
+    ended_at: '2026-08-22T00:01:00.000Z',
+  }
+
+  async function agentWithChild() {
+    const root = await fs.mkdtemp(join(tmpdir(), 'rpc-subagent-'))
+    const traceEvents = [
+      { ts: '2026-08-22T00:00:01.000Z', kind: 'message' as const, role: 'assistant' as const, summary: '第一条记录', source_offset: 0 },
+    ]
+    const traceCalls: Array<{ workerId: string; subagentId: string; offset: number }> = []
+    const agent = buildAgent({
+      harness: {
+        listWorkerSubagents: async (workerId: string) => workerId === 'w-1' ? [child] : [],
+        getWorkerSubagent: async (workerId: string, subagentId: string) => workerId === 'w-1' && subagentId === child.subagent_id ? child : undefined,
+        getWorkerSubagentTrace: async (workerId: string, subagentId: string, cursor?: { offset: number }) => {
+          traceCalls.push({ workerId, subagentId, offset: cursor?.offset ?? 0 })
+          const start = cursor?.offset ?? 0
+          return { events: traceEvents.slice(start), nextCursor: { offset: traceEvents.length } }
+        },
+      },
+    }) as unknown as Record<string, unknown>
+    const { TraceCursorStore } = await import('../../src/workers/trace/cursor-store.js')
+    const cursorStore = new TraceCursorStore(join(root, 'cursors'))
+    agent.traceCursorStoreInstance = cursorStore
+    return {
+      agent: agent as unknown as AgentUnderTest,
+      traceEvents,
+      traceCalls,
+      cleanup: async () => {
+        await cursorStore.flush()
+        await fs.rm(root, { recursive: true, force: true })
+      },
+    }
+  }
+
+  it('列出、读取详情，并拒绝把别的 Worker 的 child 当作自己的 child', async () => {
+    const { agent, cleanup } = await agentWithChild()
+    try {
+      await expect(agent.handleListWorkerSubagents({ worker_id: 'w-1' })).resolves.toEqual({ subagents: [child] })
+      await expect(agent.handleGetWorkerSubagentDetail({ worker_id: 'w-1', subagent_id: 'child-1' })).resolves.toEqual({ subagent: child })
+      await expect(agent.handleGetWorkerSubagentDetail({ worker_id: 'w-other', subagent_id: 'child-1' })).rejects.toThrow(
+        'Worker subagent not found: child-1',
+      )
+      await expect(agent.handleGetWorkerSubagentTrace({ worker_id: 'w-other', subagent_id: 'child-1' })).rejects.toThrow(
+        'Worker subagent not found: child-1',
+      )
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('opaque cursor 重放固定同一 child trace 窗口，后续追加不混进旧页', async () => {
+    const { agent, traceEvents, traceCalls, cleanup } = await agentWithChild()
+    try {
+      const first = await agent.handleGetWorkerSubagentTrace({ worker_id: 'w-1', subagent_id: 'child-1' })
+      expect(first.events.map((event) => event.summary)).toEqual(['第一条记录'])
+
+      traceEvents.push({ ts: '2026-08-22T00:00:02.000Z', kind: 'message', role: 'assistant', summary: '第二条记录', source_offset: 1 })
+      const second = await agent.handleGetWorkerSubagentTrace({ worker_id: 'w-1', subagent_id: 'child-1', cursor: first.next_cursor })
+      expect(second.events.map((event) => event.summary)).toEqual(['第二条记录'])
+
+      traceEvents.push({ ts: '2026-08-22T00:00:03.000Z', kind: 'message', role: 'assistant', summary: '第三条记录', source_offset: 2 })
+      const replay = await agent.handleGetWorkerSubagentTrace({ worker_id: 'w-1', subagent_id: 'child-1', cursor: first.next_cursor })
+      expect(replay.events.map((event) => event.summary)).toEqual(['第二条记录'])
+      expect(replay.next_cursor).toBe(second.next_cursor)
+      expect(traceCalls.map((call) => call.offset)).toEqual([0, 1, 1])
+    } finally {
+      await cleanup()
+    }
+  })
+})
+
 describe('读模型 handler 的 manager 栈前置门', () => {
   it('未装配 manager 栈时四个读端点都抛明确错误', async () => {
     const agent = buildAgent()
@@ -1049,6 +1140,9 @@ describe('读模型 handler 的 manager 栈前置门', () => {
       /Manager stack not initialized/,
     )
     await expect(agent.handleGetWorkerTrace({ worker_id: 'w', seq: 1 })).rejects.toThrow(/Manager stack not initialized/)
+    await expect(agent.handleListWorkerSubagents({ worker_id: 'w' })).rejects.toThrow(/Manager stack not initialized/)
+    await expect(agent.handleGetWorkerSubagentDetail({ worker_id: 'w', subagent_id: 'child' })).rejects.toThrow(/Manager stack not initialized/)
+    await expect(agent.handleGetWorkerSubagentTrace({ worker_id: 'w', subagent_id: 'child' })).rejects.toThrow(/Manager stack not initialized/)
   })
 })
 

--- a/crabot-agent/tests/manager/rpc-handlers.test.ts
+++ b/crabot-agent/tests/manager/rpc-handlers.test.ts
@@ -66,6 +66,8 @@ function buildAgent(managerStack?: unknown): AgentUnderTest {
   // 直接 test fixture：构造函数默认 runtime_config_authenticated=true；Object.create 绕过构造函数，这里补齐。
   agent.configAuthenticated = true
   agent.configStale = false
+  agent.runtimeClosing = false
+  agent.cliSubagentHarvestSchedules = new Map()
   if (managerStack !== undefined) {
     // composite reader 需要 adapters Map；mock 栈缺省时补空表（native 走 source-scoped reason）。
     if (typeof managerStack === 'object' && managerStack !== null && !('adapters' in managerStack)) {
@@ -1310,7 +1312,12 @@ describe('worker 直接 subagent 读模型（§10.3）', () => {
     }
     const worker = { ...makeLedgerWorker({ workerId: 'w-1', status: 'running' }), incarnations: [incarnation] }
     const agent = buildAgent({
-      ledger: { listAllWorkers: async () => [{ managerKey: 'test::f1' as ManagerKey, worker }] },
+      ledger: {
+        listAllWorkers: async () => { throw new Error('historical worker scan must not run') },
+        findWorker: async (workerId: string) => workerId === 'w-1'
+          ? { managerKey: 'test::f1' as ManagerKey, worker }
+          : undefined,
+      },
       adapters: new Map([['codex', adapter]]),
     }) as unknown as Record<string, unknown>
     const { NativeTraceCopyStore } = await import('../../src/workers/trace/native-copy.js')
@@ -1329,9 +1336,32 @@ describe('worker 直接 subagent 读模型（§10.3）', () => {
     }
   })
 
+  it('启动恢复不会查询没有 pending child 的历史 Worker', async () => {
+    const root = await fs.mkdtemp(join(tmpdir(), 'restart-child-copy-no-pending-'))
+    const findWorker = vi.fn(async () => undefined)
+    const agent = buildAgent({
+      ledger: {
+        listAllWorkers: async () => { throw new Error('historical worker scan must not run') },
+        findWorker,
+      },
+      adapters: new Map(),
+    }) as unknown as Record<string, unknown>
+    const { NativeTraceCopyStore } = await import('../../src/workers/trace/native-copy.js')
+    const copyStore = new NativeTraceCopyStore(join(root, 'copies'))
+    agent.nativeTraceCopyStoreInstance = copyStore
+    try {
+      await (agent as unknown as { recoverTerminalCliSubagentTraces(): Promise<void> }).recoverTerminalCliSubagentTraces()
+      expect(findWorker).not.toHaveBeenCalled()
+    } finally {
+      await copyStore.flush()
+      await fs.rm(root, { recursive: true, force: true })
+    }
+  })
+
   it('启动恢复中一个 Worker 的 child 列表读取失败，不阻断后续 Worker 的补齐', async () => {
     const root = await fs.mkdtemp(join(tmpdir(), 'restart-child-copy-isolation-'))
     const cliChild = { ...child, worker_id: 'w-2', executor_impl: 'codex' as const }
+    const firstChild = { ...child, executor_impl: 'codex' as const }
     const firstIncarnation = {
       incarnation_id: 'inc-1', seq: 1, impl: 'codex' as const, state: 'running' as const,
       workspace: root, session_ref: 'first-thread', started_at: '2026-08-22T00:00:00.000Z',
@@ -1352,10 +1382,12 @@ describe('worker 直接 subagent 读模型（§10.3）', () => {
     }
     const agent = buildAgent({
       ledger: {
-        listAllWorkers: async () => [
-          { managerKey: 'test::f1' as ManagerKey, worker: { ...makeLedgerWorker({ workerId: 'w-1', status: 'running' }), incarnations: [firstIncarnation] } },
-          { managerKey: 'test::f2' as ManagerKey, worker: { ...makeLedgerWorker({ workerId: 'w-2', status: 'running' }), incarnations: [secondIncarnation] } },
-        ],
+        listAllWorkers: async () => { throw new Error('historical worker scan must not run') },
+        findWorker: async (workerId: string) => workerId === 'w-1'
+          ? { managerKey: 'test::f1' as ManagerKey, worker: { ...makeLedgerWorker({ workerId: 'w-1', status: 'running' }), incarnations: [firstIncarnation] } }
+          : workerId === 'w-2'
+            ? { managerKey: 'test::f2' as ManagerKey, worker: { ...makeLedgerWorker({ workerId: 'w-2', status: 'running' }), incarnations: [secondIncarnation] } }
+            : undefined,
       },
       adapters: new Map([['codex', adapter]]),
     }) as unknown as Record<string, unknown>
@@ -1365,6 +1397,8 @@ describe('worker 直接 subagent 读模型（§10.3）', () => {
     agent.knownSecrets = []
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
     try {
+      await copyStore.beginSubagentCapture('w-1', 'inc-1', firstChild, subagentFingerprint(firstChild), (text) => text)
+      await copyStore.beginSubagentCapture('w-2', 'inc-2', cliChild, subagentFingerprint(cliChild), (text) => text)
       await (agent as unknown as { recoverTerminalCliSubagentTraces(): Promise<void> }).recoverTerminalCliSubagentTraces()
       await expect(copyStore.readSubagent('w-2', cliChild.subagent_id, subagentFingerprint(cliChild))).resolves.toMatchObject({
         capture_status: 'complete', events: [{ summary: 'finished' }],
@@ -1377,6 +1411,62 @@ describe('worker 直接 subagent 读模型（§10.3）', () => {
       warn.mockRestore()
       await copyStore.flush()
       await fs.rm(root, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('CLI child trace 收割调度', () => {
+  const handle = {
+    worker_id: 'w-harvest', incarnation_id: 'inc-harvest', seq: 1,
+    impl: 'codex' as const, session_ref: 'session-harvest',
+  }
+
+  async function flushMicrotasks(): Promise<void> {
+    for (let i = 0; i < 10; i++) await Promise.resolve()
+  }
+
+  it('activity 合并为 30 秒窗口，terminal 在 in-flight 后立即触发下一批', async () => {
+    vi.useFakeTimers()
+    const agent = Object.create(UnifiedAgent.prototype) as Record<string, unknown>
+    agent.config = { moduleId: 'test-agent' }
+    agent.runtimeClosing = false
+    agent.cliSubagentHarvestSchedules = new Map()
+
+    let releaseFirst: (() => void) | undefined
+    const firstHarvest = new Promise<void>((resolve) => { releaseFirst = resolve })
+    const harvest = vi.fn()
+      .mockReturnValueOnce(firstHarvest)
+      .mockResolvedValue(undefined)
+    agent.harvestTerminalCliSubagentTraces = harvest
+    const request = (immediate = false): Promise<void> => (
+      agent as unknown as {
+        requestCliSubagentHarvest(handle: typeof handle, adapter: unknown, immediate?: boolean): Promise<void>
+      }
+    ).requestCliSubagentHarvest(handle, {}, immediate)
+
+    try {
+      request()
+      request()
+      await vi.advanceTimersByTimeAsync(29_999)
+      expect(harvest).not.toHaveBeenCalled()
+
+      await vi.advanceTimersByTimeAsync(1)
+      await flushMicrotasks()
+      expect(harvest).toHaveBeenCalledTimes(1)
+
+      request()
+      const terminal = request(true)
+      let terminalSettled = false
+      void terminal.then(() => { terminalSettled = true })
+      releaseFirst?.()
+      await flushMicrotasks()
+
+      expect(harvest).toHaveBeenCalledTimes(2)
+      await terminal
+      expect(terminalSettled).toBe(true)
+    } finally {
+      ;(agent as unknown as { stopCliSubagentHarvestScheduler(): void }).stopCliSubagentHarvestScheduler()
+      vi.useRealTimers()
     }
   })
 })

--- a/crabot-agent/tests/manager/rpc-handlers.test.ts
+++ b/crabot-agent/tests/manager/rpc-handlers.test.ts
@@ -10,6 +10,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { promises as fs } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
+import { createHash } from 'crypto'
 
 import { UnifiedAgent } from '../../src/unified-agent.js'
 import type { PrincipalResolverDeps } from '../../src/manager/principal.js'
@@ -1063,17 +1064,28 @@ describe('worker 直接 subagent 读模型（§10.3）', () => {
     ended_at: '2026-08-22T00:01:00.000Z',
   }
 
-  async function agentWithChild() {
+  const subagentFingerprint = (subagent: { executor_impl: string; subagent_id: string; started_at?: string }): string => createHash('sha256')
+    .update(JSON.stringify({
+      executor_impl: subagent.executor_impl,
+      subagent_id: subagent.subagent_id,
+      started_at: subagent.started_at ?? '',
+    }))
+    .digest('hex')
+    .slice(0, 32)
+
+  async function agentWithChild(childSummary = child) {
     const root = await fs.mkdtemp(join(tmpdir(), 'rpc-subagent-'))
     const traceEvents = [
       { ts: '2026-08-22T00:00:01.000Z', kind: 'message' as const, role: 'assistant' as const, summary: '第一条记录', source_offset: 0 },
     ]
     const traceCalls: Array<{ workerId: string; subagentId: string; offset: number }> = []
+    let liveAvailable = true
     const agent = buildAgent({
       harness: {
-        listWorkerSubagents: async (workerId: string) => workerId === 'w-1' ? [child] : [],
-        getWorkerSubagent: async (workerId: string, subagentId: string) => workerId === 'w-1' && subagentId === child.subagent_id ? child : undefined,
+        listWorkerSubagents: async (workerId: string) => workerId === 'w-1' && liveAvailable ? [childSummary] : [],
+        getWorkerSubagent: async (workerId: string, subagentId: string) => workerId === 'w-1' && liveAvailable && subagentId === childSummary.subagent_id ? childSummary : undefined,
         getWorkerSubagentTrace: async (workerId: string, subagentId: string, cursor?: { offset: number }) => {
+          if (!liveAvailable) throw new Error('CLI child source gone')
           traceCalls.push({ workerId, subagentId, offset: cursor?.offset ?? 0 })
           const start = cursor?.offset ?? 0
           return { events: traceEvents.slice(start), nextCursor: { offset: traceEvents.length } }
@@ -1081,14 +1093,20 @@ describe('worker 直接 subagent 读模型（§10.3）', () => {
       },
     }) as unknown as Record<string, unknown>
     const { TraceCursorStore } = await import('../../src/workers/trace/cursor-store.js')
+    const { NativeTraceCopyStore } = await import('../../src/workers/trace/native-copy.js')
     const cursorStore = new TraceCursorStore(join(root, 'cursors'))
+    const copyStore = new NativeTraceCopyStore(join(root, 'copies'))
     agent.traceCursorStoreInstance = cursorStore
+    agent.nativeTraceCopyStoreInstance = copyStore
     return {
       agent: agent as unknown as AgentUnderTest,
       traceEvents,
       traceCalls,
+      copyStore,
+      setLiveAvailable: (value: boolean) => { liveAvailable = value },
       cleanup: async () => {
         await cursorStore.flush()
+        await copyStore.flush()
         await fs.rm(root, { recursive: true, force: true })
       },
     }
@@ -1129,6 +1147,185 @@ describe('worker 直接 subagent 读模型（§10.3）', () => {
       expect(traceCalls.map((call) => call.offset)).toEqual([0, 1, 1])
     } finally {
       await cleanup()
+    }
+  })
+
+  it('CLI 原生记录轮转后，仍从同一 Worker 的脱敏副本列出 child、读取详情和分页 trace', async () => {
+    const { agent, copyStore, setLiveAvailable, cleanup } = await agentWithChild()
+    try {
+      const fingerprint = subagentFingerprint(child)
+      await copyStore.completeSubagentCapture(
+        'w-1',
+        'inc-1',
+        child,
+        fingerprint,
+        [{
+          ts: '2026-08-22T00:00:01.000Z', kind: 'message', role: 'assistant',
+          summary: 'secret-result', detail: { content: 'secret-result' }, source_offset: 0,
+        }],
+        1,
+        (text) => text.replaceAll('secret', '[redacted]'),
+      )
+      setLiveAvailable(false)
+
+      await expect(agent.handleListWorkerSubagents({ worker_id: 'w-1' })).resolves.toEqual({ subagents: [child] })
+      await expect(agent.handleGetWorkerSubagentDetail({ worker_id: 'w-1', subagent_id: 'child-1' })).resolves.toEqual({ subagent: child })
+      const trace = await agent.handleGetWorkerSubagentTrace({ worker_id: 'w-1', subagent_id: 'child-1' })
+      expect(trace.events).toMatchObject([{ summary: '[redacted]-result', detail: { content: '[redacted]-result' }, source: 'native' }])
+      expect(trace.events[0]).not.toHaveProperty('source_offset')
+      expect(trace.unavailable_reason).toContain('agent-owned child copy')
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('终态 child 的副本尚未完成时保留详情，并如实报告 trace 不可用', async () => {
+    const { agent, copyStore, setLiveAvailable, cleanup } = await agentWithChild()
+    try {
+      await copyStore.beginSubagentCapture('w-1', 'inc-1', child, subagentFingerprint(child), (text) => text)
+      setLiveAvailable(false)
+
+      await expect(agent.handleGetWorkerSubagentDetail({ worker_id: 'w-1', subagent_id: 'child-1' })).resolves.toEqual({ subagent: child })
+      await expect(agent.handleGetWorkerSubagentTrace({ worker_id: 'w-1', subagent_id: 'child-1' })).resolves.toMatchObject({
+        events: [], unavailable_reason: expect.stringContaining('before terminal child trace capture'),
+      })
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('读取到已恢复的 CLI 原生记录时补齐 pending child 副本，之后可从副本回退', async () => {
+    const cliChild = { ...child, executor_impl: 'codex' as const }
+    const { agent, copyStore, setLiveAvailable, cleanup } = await agentWithChild(cliChild)
+    try {
+      const fingerprint = subagentFingerprint(cliChild)
+      await copyStore.beginSubagentCapture('w-1', 'inc-1', cliChild, fingerprint, (text) => text)
+
+      await expect(agent.handleGetWorkerSubagentTrace({ worker_id: 'w-1', subagent_id: 'child-1' })).resolves.toMatchObject({
+        events: [{ summary: '第一条记录' }],
+      })
+      await expect(copyStore.readSubagent('w-1', 'child-1', fingerprint)).resolves.toMatchObject({
+        parent_incarnation_id: 'inc-1', capture_status: 'complete', events: [{ summary: '第一条记录' }],
+      })
+
+      setLiveAvailable(false)
+      await expect(agent.handleGetWorkerSubagentTrace({ worker_id: 'w-1', subagent_id: 'child-1' })).resolves.toMatchObject({
+        events: [{ summary: '第一条记录', source: 'native' }],
+        unavailable_reason: expect.stringContaining('agent-owned child copy'),
+      })
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('child 副本读取失败不影响实时 CLI trace', async () => {
+    const cliChild = { ...child, executor_impl: 'claude-code' as const }
+    const { agent, copyStore, cleanup } = await agentWithChild(cliChild)
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    try {
+      vi.spyOn(copyStore, 'readSubagent').mockRejectedValueOnce(new Error('copy directory unavailable'))
+
+      await expect(agent.handleGetWorkerSubagentTrace({ worker_id: 'w-1', subagent_id: 'child-1' })).resolves.toMatchObject({
+        events: [{ summary: '第一条记录', source: 'native' }],
+      })
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('child native trace read retry failed'), 'copy directory unavailable')
+    } finally {
+      warn.mockRestore()
+      await cleanup()
+    }
+  })
+
+  it('原生和 child 副本均不可读时只返回脱敏的不可用原因', async () => {
+    const cliChild = { ...child, executor_impl: 'claude-code' as const }
+    const { agent, copyStore, setLiveAvailable, cleanup } = await agentWithChild(cliChild)
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    try {
+      await copyStore.completeSubagentCapture('w-1', 'inc-1', cliChild, subagentFingerprint(cliChild), [], 0, (text) => text)
+      setLiveAvailable(false)
+      vi.spyOn(copyStore, 'readSubagent').mockRejectedValueOnce(new Error('/private/host/secret child source failure'))
+
+      await expect(agent.handleGetWorkerSubagentTrace({ worker_id: 'w-1', subagent_id: 'child-1' })).resolves.toMatchObject({
+        events: [], unavailable_reason: 'native unavailable; retained child trace copy is unavailable',
+      })
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('child native trace read failed'), 'CLI child source gone')
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('child trace copy read failed'), '/private/host/secret child source failure')
+    } finally {
+      warn.mockRestore()
+      await cleanup()
+    }
+  })
+
+  it('父化身终态时保存 CLI child 的脱敏副本', async () => {
+    const root = await fs.mkdtemp(join(tmpdir(), 'terminal-child-copy-'))
+    const cliChild = { ...child, executor_impl: 'claude-code' as const, task: 'secret-task' }
+    const incarnation = {
+      incarnation_id: 'inc-1', seq: 1, impl: 'claude-code' as const, state: 'exited' as const,
+      workspace: root, session_ref: 'parent-session', started_at: '2026-08-22T00:00:00.000Z',
+    }
+    const adapter = {
+      listSubagents: async () => [cliChild],
+      readSubagentTrace: async () => ({
+        events: [{
+          ts: '2026-08-22T00:00:01.000Z', kind: 'message' as const, role: 'assistant' as const,
+          summary: 'secret-result', detail: { content: 'secret-result' }, source_offset: 0,
+        }],
+        nextCursor: { offset: 2 },
+      }),
+    }
+    const agent = buildAgent({
+      ledger: { findWorker: async () => ({ managerKey: 'test::f1' as ManagerKey, worker: { ...makeLedgerWorker({ workerId: 'w-1' }), incarnations: [incarnation] } }) },
+      adapters: new Map([['claude-code', adapter]]),
+    }) as unknown as Record<string, unknown>
+    const { NativeTraceCopyStore } = await import('../../src/workers/trace/native-copy.js')
+    const copyStore = new NativeTraceCopyStore(join(root, 'copies'))
+    agent.nativeTraceCopyStoreInstance = copyStore
+    agent.knownSecrets = ['secret']
+    try {
+      await (agent as unknown as { harvestIncarnationNativeTrace(handle: unknown): Promise<void> }).harvestIncarnationNativeTrace({
+        worker_id: 'w-1', incarnation_id: 'inc-1', seq: 1, impl: 'claude-code', session_ref: 'parent-session',
+      })
+      const stored = await copyStore.readSubagent('w-1', cliChild.subagent_id, subagentFingerprint(cliChild))
+      expect(stored).toMatchObject({ capture_status: 'complete', next_cursor_offset: 2 })
+      expect(JSON.stringify(stored)).not.toContain('secret')
+      expect(stored?.events).toMatchObject([{ source_offset: 0 }])
+    } finally {
+      await copyStore.flush()
+      await fs.rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('启动恢复会补齐仍在运行的父 Worker 下、已留 pending 标记的终态 CLI child 副本', async () => {
+    const root = await fs.mkdtemp(join(tmpdir(), 'restart-child-copy-'))
+    const cliChild = { ...child, executor_impl: 'codex' as const }
+    const incarnation = {
+      incarnation_id: 'inc-1', seq: 1, impl: 'codex' as const, state: 'running' as const,
+      workspace: root, session_ref: 'parent-thread', started_at: '2026-08-22T00:00:00.000Z',
+    }
+    const adapter = {
+      listSubagents: async () => [cliChild],
+      readSubagentTrace: async () => ({
+        events: [{ ts: '2026-08-22T00:00:01.000Z', kind: 'message' as const, role: 'assistant' as const, summary: 'finished', source_offset: 0 }],
+        nextCursor: { offset: 1 },
+      }),
+    }
+    const worker = { ...makeLedgerWorker({ workerId: 'w-1', status: 'running' }), incarnations: [incarnation] }
+    const agent = buildAgent({
+      ledger: { listAllWorkers: async () => [{ managerKey: 'test::f1' as ManagerKey, worker }] },
+      adapters: new Map([['codex', adapter]]),
+    }) as unknown as Record<string, unknown>
+    const { NativeTraceCopyStore } = await import('../../src/workers/trace/native-copy.js')
+    const copyStore = new NativeTraceCopyStore(join(root, 'copies'))
+    agent.nativeTraceCopyStoreInstance = copyStore
+    agent.knownSecrets = []
+    try {
+      await copyStore.beginSubagentCapture('w-1', 'inc-1', cliChild, subagentFingerprint(cliChild), (text) => text)
+      await (agent as unknown as { recoverTerminalCliSubagentTraces(): Promise<void> }).recoverTerminalCliSubagentTraces()
+      await expect(copyStore.readSubagent('w-1', cliChild.subagent_id, subagentFingerprint(cliChild))).resolves.toMatchObject({
+        capture_status: 'complete', events: [{ summary: 'finished' }],
+      })
+    } finally {
+      await copyStore.flush()
+      await fs.rm(root, { recursive: true, force: true })
     }
   })
 })

--- a/crabot-agent/tests/prompts/assemble-agent.test.ts
+++ b/crabot-agent/tests/prompts/assemble-agent.test.ts
@@ -88,6 +88,21 @@ describe('assembleAgentPrompt 可选段渲染', () => {
     expect(prompt).toContain('Sub-agent')
     expect(prompt).toContain('reviewer')
   })
+
+  it('builtin worker 使用与 delegate_task 实际能力一致的委派说明', () => {
+    const prompt = assembleAgentPrompt({
+      goalModeEnabled: false,
+      availableSubAgents: [{ toolName: 'reviewer', workerHint: '代码评审' }],
+      subagentGuidance: 'builtin_worker',
+    })
+
+    const guidance = prompt.slice(prompt.indexOf('## 子 Agent 委派'))
+    expect(guidance).toContain('<sub_agent_notification>')
+    expect(guidance).toContain('child_trace_id')
+    expect(guidance).not.toContain('get_subagent_output')
+    expect(guidance).not.toContain('list_active_subagents')
+    expect(guidance).not.toContain('send_message')
+  })
 })
 
 describe('assembleAgentPrompt goalModeEnabled 分支', () => {

--- a/crabot-agent/tests/workers/builtin-adapter.test.ts
+++ b/crabot-agent/tests/workers/builtin-adapter.test.ts
@@ -407,6 +407,40 @@ describe('BuiltinWorkerAdapter', () => {
     })
   })
 
+  it('delegate_task 的完整 child id 落在 span 后，截断输出仍可跳转 child', async () => {
+    const trace = {
+      spans: [{
+        span_id: 'delegate-1',
+        type: 'tool_call',
+        started_at: '2026-08-22T00:00:00.000Z',
+        details: {
+          name: 'delegate_task',
+          input_summary: '{"task":"实现"}',
+          output_summary: `{"agent_id":"agent-child","output":"${'x'.repeat(500)}`,
+          subagent_id: 'agent-child',
+        },
+      }],
+    } as unknown as AgentTrace
+    const adapter = new BuiltinWorkerAdapter({
+      dataDir: tmp,
+      traceHooks: {
+        startIncarnationTrace: () => 'trace-1',
+        appendTurn: () => {},
+        finishIncarnationTrace: () => {},
+      },
+      traceReader: { readTrace: async () => trace },
+    })
+    const h = await adapter.spawn(spec({ adapter: makeAdapter([{ stopReason: 'end_turn' }]) }))
+    await waitState(adapter, h, 'idle')
+
+    await expect(adapter.readTrace(h)).resolves.toMatchObject({
+      events: [
+        { kind: 'tool_call', subagent_id: 'agent-child' },
+        { kind: 'tool_result', subagent_id: 'agent-child' },
+      ],
+    })
+  })
+
   it('子 Agent read model 只委托给 Worker 所属的 trace reader', async () => {
     const child = {
       subagent_id: 'agent-child', worker_id: 'worker-parent', executor_impl: 'builtin' as const,
@@ -480,6 +514,49 @@ describe('BuiltinWorkerAdapter', () => {
       runEngineSpy.mockRestore()
       nowSpy.mockRestore()
     }
+  })
+
+  it('fork 不装 delegate_task，且收尾不停止主线的 child', async () => {
+    const stopWorkerSubagents = vi.fn()
+    const delegateTask = defineTool({
+      name: 'delegate_task',
+      description: '派发子 Agent',
+      inputSchema: { type: 'object', properties: {} },
+      call: async () => ({ isError: false, output: 'launched' }),
+    })
+    const llm = makeAdapter([
+      { text: '主线待命', stopReason: 'end_turn' },
+      { text: '侧问结果', stopReason: 'end_turn' },
+      { toolCalls: [{ name: 'finish_task', id: 'finish-main', input: { outcome: 'completed', summary: '主线完成' } }], stopReason: 'tool_use' },
+    ])
+    const adapter = new BuiltinWorkerAdapter({
+      dataDir: tmp,
+      traceHooks: {
+        startIncarnationTrace: () => 'trace-1',
+        appendTurn: () => {},
+        finishIncarnationTrace: () => {},
+        stopWorkerSubagents,
+      },
+    })
+    const s = spec({ adapter: llm, tools: [delegateTask] })
+    const h = await adapter.spawn(s)
+    await waitState(adapter, h, 'idle')
+
+    const tree = await SessionTree.load(join(tmp, s.worker_id, 'session.jsonl'))
+    const forkHandle = await adapter.fork(
+      { worker_id: s.worker_id, seq: h.seq, session_ref: tree.latestTip()! },
+      '侧问',
+      forkOptions(),
+    )
+    await waitState(adapter, forkHandle, 'exited')
+
+    const forkCall = (llm.stream as unknown as { mock: { calls: Array<[{ tools: ReadonlyArray<ToolDefinition> }]> } }).mock.calls[1][0]
+    expect(forkCall.tools.map((tool) => tool.name)).not.toContain('delegate_task')
+    expect(stopWorkerSubagents).not.toHaveBeenCalled()
+
+    await adapter.sendInput(h, '结束主线')
+    await waitState(adapter, h, 'exited')
+    expect(stopWorkerSubagents).toHaveBeenCalledWith(s.worker_id)
   })
 
   it('finish_task → exited(completed)', async () => {

--- a/crabot-agent/tests/workers/builtin-adapter.test.ts
+++ b/crabot-agent/tests/workers/builtin-adapter.test.ts
@@ -407,6 +407,36 @@ describe('BuiltinWorkerAdapter', () => {
     })
   })
 
+  it('子 Agent read model 只委托给 Worker 所属的 trace reader', async () => {
+    const child = {
+      subagent_id: 'agent-child', worker_id: 'worker-parent', executor_impl: 'builtin' as const,
+      type: 'code_writer', name: 'code_writer', task: '实现变更', status: 'running' as const,
+      started_at: '2026-08-22T00:00:00.000Z',
+    }
+    const readSubagentTrace = vi.fn(async () => ({
+      events: [{ ts: '2026-08-22T00:00:01.000Z', kind: 'message' as const, role: 'assistant' as const, summary: '正在实现' }],
+      nextCursor: { offset: 1 },
+    }))
+    const adapter = new BuiltinWorkerAdapter({
+      dataDir: tmp,
+      traceReader: {
+        readTrace: async () => undefined,
+        listSubagents: async (workerId) => workerId === 'worker-parent' ? [child] : [],
+        getSubagent: async (workerId, subagentId) => workerId === 'worker-parent' && subagentId === child.subagent_id ? child : undefined,
+        readSubagentTrace,
+      },
+    })
+    const h = await adapter.spawn(spec({ worker_id: 'worker-parent', adapter: makeAdapter([{ stopReason: 'end_turn' }]) }))
+    await waitState(adapter, h, 'idle')
+
+    await expect(adapter.listSubagents(h)).resolves.toEqual([child])
+    await expect(adapter.getSubagent(h, child.subagent_id)).resolves.toEqual(child)
+    await expect(adapter.readSubagentTrace(h, child.subagent_id, { offset: 0 })).resolves.toMatchObject({
+      events: [{ summary: '正在实现' }], nextCursor: { offset: 1 },
+    })
+    expect(readSubagentTrace).toHaveBeenCalledWith('worker-parent', child.subagent_id, { offset: 0 })
+  })
+
   it('常驻化身只以真实 engine/input 进展更新时间，主线与 fork 回调均接线', async () => {
     let now = 1_000
     const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now)

--- a/crabot-agent/tests/workers/builtin-subagent-runner.test.ts
+++ b/crabot-agent/tests/workers/builtin-subagent-runner.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { promises as fs } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { BuiltinSubagentRunner } from '../../src/workers/builtin/subagent-runner.js'
+import { BgEntityRegistry } from '../../src/engine/bg-entities/registry.js'
+import type { TraceStore } from '../../src/core/trace-store.js'
+import type { LSPManager } from '../../src/lsp/lsp-manager.js'
+
+describe('BuiltinSubagentRunner restart recovery', () => {
+  it('marks only Worker-owned running children as interrupted after an Agent restart', async () => {
+    const dir = await fs.mkdtemp(join(tmpdir(), 'builtin-subagent-recovery-'))
+    try {
+      const registry = new BgEntityRegistry(join(dir, 'registry.json'))
+      await registry.register({
+        entity_id: 'agent-worker-child', type: 'agent', status: 'running',
+        subagent_type: 'code_writer', trace_id: 'trace-child', task_description: '实现变更',
+        messages_log_file: join(dir, 'child.jsonl'), result_file: null,
+        owner: { friend_id: '__builtin_worker__', worker_id: 'worker-1' }, spawned_by_task_id: 'worker-1',
+        spawned_at: '2026-08-22T00:00:00.000Z', exit_code: null, ended_at: null, last_activity_at: '2026-08-22T00:00:00.000Z',
+      })
+      await registry.register({
+        entity_id: 'agent-other-owner', type: 'agent', status: 'running',
+        task_description: '不属于 Worker', messages_log_file: join(dir, 'other.jsonl'), result_file: null,
+        owner: { friend_id: 'friend-1' }, spawned_by_task_id: 'task-1',
+        spawned_at: '2026-08-22T00:00:00.000Z', exit_code: null, ended_at: null, last_activity_at: '2026-08-22T00:00:00.000Z',
+      })
+      const runner = new BuiltinSubagentRunner({} as TraceStore, {} as LSPManager, undefined, registry)
+
+      await expect(runner.recoverAfterRestart()).resolves.toBe(1)
+      await expect(runner.list('worker-1')).resolves.toMatchObject([{ subagent_id: 'agent-worker-child', status: 'interrupted' }])
+      await expect(registry.get('agent-other-owner')).resolves.toMatchObject({ status: 'running' })
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/crabot-agent/tests/workers/builtin-subagent-runner.test.ts
+++ b/crabot-agent/tests/workers/builtin-subagent-runner.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { promises as fs } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -6,6 +6,112 @@ import { BuiltinSubagentRunner } from '../../src/workers/builtin/subagent-runner
 import { BgEntityRegistry } from '../../src/engine/bg-entities/registry.js'
 import type { TraceStore } from '../../src/core/trace-store.js'
 import type { LSPManager } from '../../src/lsp/lsp-manager.js'
+import type { SubAgentConfig } from '../../src/types.js'
+import { BUILTIN_WORKER_PERMISSIONS } from '../../src/workers/builtin/runtime.js'
+
+const { createAdapter, forkEngine, spawnPersistentAgent } = vi.hoisted(() => ({
+  createAdapter: vi.fn(),
+  forkEngine: vi.fn(),
+  spawnPersistentAgent: vi.fn(),
+}))
+
+vi.mock('../../src/engine/llm-adapter.js', () => ({ createAdapter }))
+vi.mock('../../src/engine/sub-agent.js', () => ({ forkEngine }))
+vi.mock('../../src/engine/bg-entities/bg-agent.js', () => ({ spawnPersistentAgent }))
+
+function testSubagent(): SubAgentConfig {
+  return {
+    id: 'code-writer',
+    name: 'code_writer',
+    description: '编写代码',
+    when_to_use: '需要实现时使用',
+    model: { endpoint: 'https://example.test', apikey: 'test', model_id: 'test-model', format: 'openai' },
+    max_turns: 3,
+    builtin_capabilities: { file_system: true, shell: true, task_intel: false, crab_memory: false, crab_messaging: false },
+    allowed_mcp_server_ids: [],
+    allowed_skill_ids: [],
+    hook_preset: 'lsp_diagnostics',
+  } as SubAgentConfig
+}
+
+function executionContext() {
+  return {
+    permissionConfig: { mode: 'bypass' as const },
+    resolvedPermissions: BUILTIN_WORKER_PERMISSIONS,
+  }
+}
+
+describe('BuiltinSubagentRunner execution boundary', () => {
+  let dir: string
+  let registry: BgEntityRegistry
+  const lspManager = {} as LSPManager
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    dir = await fs.mkdtemp(join(tmpdir(), 'builtin-subagent-runner-'))
+    process.env.DATA_DIR = dir
+    registry = new BgEntityRegistry(join(dir, 'registry.json'))
+    createAdapter.mockReturnValue({})
+  })
+
+  afterEach(async () => {
+    delete process.env.DATA_DIR
+    await fs.rm(dir, { recursive: true, force: true })
+  })
+
+  it('拒绝在 AgentHandler 注入共享 registry 前运行', async () => {
+    const runner = new BuiltinSubagentRunner({} as TraceStore, lspManager)
+    await expect(runner.recoverAfterRestart()).rejects.toThrow('registry is unavailable')
+  })
+
+  it('异步 child 继承 Worker 权限和完整执行 hooks', async () => {
+    spawnPersistentAgent.mockResolvedValue('agent-child')
+    const runner = new BuiltinSubagentRunner({} as TraceStore, lspManager, undefined, registry)
+
+    await runner.run(
+      testSubagent(),
+      { task: '运行测试' },
+      { worker_subagent: { worker_id: 'worker-1', parent_trace_id: 'trace-parent' } },
+      [],
+      executionContext(),
+    )
+
+    const options = spawnPersistentAgent.mock.calls[0][0]
+    expect(options.permissionConfig).toEqual(executionContext().permissionConfig)
+    expect(options.resolvedPermissions).toEqual(BUILTIN_WORKER_PERMISSIONS)
+    expect(options.senderIsMaster).toBe(false)
+    expect(options.lspManager).toBe(lspManager)
+    expect(options.hookRegistry.getMatching('PreToolUse', { toolName: 'Bash', toolInput: { command: 'crabot config get' } })).toHaveLength(1)
+    expect(options.hookRegistry.getMatching('PreToolUse', { toolName: 'Write', toolInput: {} })).toHaveLength(1)
+    expect(options.hookRegistry.getMatching('PostToolUse', { toolName: 'Write', toolInput: {} })).toHaveLength(1)
+  })
+
+  it('同步 child 同样继承 Worker 权限和完整执行 hooks', async () => {
+    forkEngine.mockResolvedValue({ outcome: 'completed', output: '完成', usage: { inputTokens: 1, outputTokens: 1 }, totalTurns: 1 })
+    const traceStore = {
+      startTrace: vi.fn(() => ({ trace_id: 'trace-child' })),
+      endTrace: vi.fn(),
+    } as unknown as TraceStore
+    const runner = new BuiltinSubagentRunner(traceStore, lspManager, undefined, registry)
+
+    await runner.run(
+      testSubagent(),
+      { task: '运行测试', sync: true },
+      { worker_subagent: { worker_id: 'worker-1', parent_trace_id: 'trace-parent' } },
+      [],
+      executionContext(),
+    )
+
+    const options = forkEngine.mock.calls[0][0]
+    expect(options.permissionConfig).toEqual(executionContext().permissionConfig)
+    expect(options.resolvedPermissions).toEqual(BUILTIN_WORKER_PERMISSIONS)
+    expect(options.senderIsMaster).toBe(false)
+    expect(options.lspManager).toBe(lspManager)
+    expect(options.hookRegistry.getMatching('PreToolUse', { toolName: 'Bash', toolInput: { command: 'crabot config get' } })).toHaveLength(1)
+    expect(options.hookRegistry.getMatching('PreToolUse', { toolName: 'Write', toolInput: {} })).toHaveLength(1)
+    expect(options.hookRegistry.getMatching('PostToolUse', { toolName: 'Write', toolInput: {} })).toHaveLength(1)
+  })
+})
 
 describe('BuiltinSubagentRunner restart recovery', () => {
   it('marks only Worker-owned running children as interrupted after an Agent restart', async () => {

--- a/crabot-agent/tests/workers/claude-code-adapter.test.ts
+++ b/crabot-agent/tests/workers/claude-code-adapter.test.ts
@@ -1115,6 +1115,66 @@ describe('ClaudeCodeAdapter.detect', () => {
   })
 })
 
+describe('ClaudeCodeAdapter subagent observability', () => {
+  let dataDir: string
+  let workspaceRoot: string
+  let projectsDir: string
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'cc-subagent-data-'))
+    workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'cc-subagent-workspace-'))
+    projectsDir = await fs.mkdtemp(path.join(os.tmpdir(), 'cc-subagent-projects-'))
+  })
+
+  afterEach(async () => {
+    await fs.rm(dataDir, { recursive: true, force: true }).catch(() => {})
+    await fs.rm(workspaceRoot, { recursive: true, force: true }).catch(() => {})
+    await fs.rm(projectsDir, { recursive: true, force: true }).catch(() => {})
+  })
+
+  it('只从已完成的原生 child JSONL 行读取 child 与独立 trace', async () => {
+    const workerId = `cctest-${randomUUID().slice(0, 8)}`
+    const sessionId = randomUUID()
+    const childId = 'agent-childabc'
+    const slug = workspaceRoot.replace(/[/.]/g, '-')
+    const childDir = path.join(projectsDir, slug, sessionId, 'subagents')
+    await fs.mkdir(childDir, { recursive: true })
+    await fs.mkdir(path.join(dataDir, workerId), { recursive: true })
+    await fs.writeFile(path.join(dataDir, workerId, 'meta-1.json'), JSON.stringify({
+      seq: 1, state: 'idle', session_id: sessionId, workspace_root: workspaceRoot,
+    }))
+    await fs.writeFile(path.join(childDir, `${childId}.jsonl`), [
+      JSON.stringify({ agentId: childId, agentType: 'Explore', timestamp: '2026-08-22T00:00:00.000Z', type: 'user', message: { content: '检查原生记录' } }),
+      JSON.stringify({ agentId: childId, timestamp: '2026-08-22T00:00:03.000Z', type: 'assistant', message: { content: '已经完成', stop_reason: 'end_turn' } }),
+      '{"agentId":"agent-childabc"',
+    ].join('\n'), 'utf8')
+
+    class OfflineTmux extends TmuxDriver {
+      override async isAlive(): Promise<boolean> { return false }
+      override async killSession(): Promise<void> {}
+    }
+    const adapter = new ClaudeCodeAdapter({
+      dataDir,
+      claudeConfigPath: fakeClaudeConfig(dataDir),
+      claudeProjectsDir: projectsDir,
+      claudeBin: 'unused',
+      tmux: new OfflineTmux(),
+    })
+    const parent = { worker_id: workerId, seq: 1, impl: 'claude-code' as const, session_ref: sessionId }
+
+    await expect(adapter.listSubagents(parent)).resolves.toMatchObject([{
+      subagent_id: childId, executor_impl: 'claude-code', type: 'Explore', name: 'Explore', task: '检查原生记录', status: 'completed',
+    }])
+    await expect(adapter.readSubagentTrace(parent, childId)).resolves.toMatchObject({
+      events: [
+        { kind: 'message', role: 'user', summary: '检查原生记录', source_offset: 0 },
+        { kind: 'message', role: 'assistant', summary: '已经完成', source_offset: 1 },
+      ],
+      nextCursor: { offset: 2 },
+    })
+  })
+})
+
 describe('ClaudeCodeAdapter — session_ref UUID 边界校验', () => {
   let dataDir: string
   let workspaceRoot: string

--- a/crabot-agent/tests/workers/claude-code-adapter.test.ts
+++ b/crabot-agent/tests/workers/claude-code-adapter.test.ts
@@ -1173,6 +1173,44 @@ describe('ClaudeCodeAdapter subagent observability', () => {
       nextCursor: { offset: 2 },
     })
   })
+
+  it('原生 child 仍在 tool_use 时不写 ended_at', async () => {
+    const workerId = `cctest-${randomUUID().slice(0, 8)}`
+    const sessionId = randomUUID()
+    const childId = 'agent-running'
+    const slug = workspaceRoot.replace(/[/.]/g, '-')
+    const childDir = path.join(projectsDir, slug, sessionId, 'subagents')
+    await fs.mkdir(childDir, { recursive: true })
+    await fs.mkdir(path.join(dataDir, workerId), { recursive: true })
+    await fs.writeFile(path.join(dataDir, workerId, 'meta-1.json'), JSON.stringify({
+      seq: 1, state: 'idle', session_id: sessionId, workspace_root: workspaceRoot,
+    }))
+    await fs.writeFile(path.join(childDir, `${childId}.jsonl`), [
+      JSON.stringify({ agentId: childId, agentType: 'Explore', timestamp: '2026-08-22T00:00:00.000Z', type: 'user', message: { content: '继续检查' } }),
+      JSON.stringify({ agentId: childId, timestamp: '2026-08-22T00:00:03.000Z', type: 'assistant', message: { content: '正在调用工具', stop_reason: 'tool_use' } }),
+      '',
+    ].join('\n'), 'utf8')
+
+    class OfflineTmux extends TmuxDriver {
+      override async isAlive(): Promise<boolean> { return false }
+      override async killSession(): Promise<void> {}
+    }
+    const adapter = new ClaudeCodeAdapter({
+      dataDir,
+      claudeConfigPath: fakeClaudeConfig(dataDir),
+      claudeProjectsDir: projectsDir,
+      claudeBin: 'unused',
+      tmux: new OfflineTmux(),
+    })
+    const parent = { worker_id: workerId, seq: 1, impl: 'claude-code' as const, session_ref: sessionId }
+
+    await expect(adapter.listSubagents(parent)).resolves.toMatchObject([{
+      subagent_id: childId,
+      status: 'running',
+    }])
+    const [subagent] = await adapter.listSubagents(parent)
+    expect(subagent).not.toHaveProperty('ended_at')
+  })
 })
 
 describe('ClaudeCodeAdapter — session_ref UUID 边界校验', () => {

--- a/crabot-agent/tests/workers/codex-adapter.test.ts
+++ b/crabot-agent/tests/workers/codex-adapter.test.ts
@@ -1592,7 +1592,7 @@ describe('CodexWorkerAdapter.fork — app-server', () => {
     expect(supported.capabilities().subagent).toBe(true)
   })
 
-  it('读取 app-server 标记为 parentThreadId 的原生 child thread 与其独立 items', async () => {
+  it('读取 app-server 标记为 parentThreadId 的原生 child thread 与其独立 items，时间戳稳定', async () => {
     const childThreadId = randomUUID()
     const adapter = new CodexWorkerAdapter({
       dataDir,
@@ -1606,14 +1606,17 @@ describe('CodexWorkerAdapter.fork — app-server', () => {
     await expect(adapter.listSubagents(parent)).resolves.toMatchObject([{
       subagent_id: childThreadId, executor_impl: 'codex', type: 'research', name: '研究助手', task: '原生子 Agent 任务', status: 'completed',
     }])
-    await expect(adapter.readSubagentTrace(parent, childThreadId)).resolves.toMatchObject({
+    const first = await adapter.readSubagentTrace(parent, childThreadId)
+    const replay = await adapter.readSubagentTrace(parent, childThreadId)
+    expect(first).toMatchObject({
       events: [
-        { kind: 'message', role: 'user', summary: '检查原生记录', source_offset: 0 },
-        { kind: 'tool_call', summary: 'exec_command(pwd)', source_offset: 1 },
-        { kind: 'message', role: 'assistant', summary: '原生子 Agent 已完成', source_offset: 2 },
+        { ts: '2026-02-02T02:40:10.000Z', kind: 'message', role: 'user', summary: '检查原生记录', source_offset: 0 },
+        { ts: '2026-02-02T02:40:10.000Z', kind: 'tool_call', summary: 'exec_command(pwd)', source_offset: 1 },
+        { ts: '2026-02-02T02:40:10.000Z', kind: 'message', role: 'assistant', summary: '原生子 Agent 已完成', source_offset: 2 },
       ],
       nextCursor: { offset: 3 },
     })
+    expect(replay).toEqual(first)
   })
 
   it('detect 切换到同版本的另一 binary 时重新探测 fork capability', async () => {

--- a/crabot-agent/tests/workers/codex-adapter.test.ts
+++ b/crabot-agent/tests/workers/codex-adapter.test.ts
@@ -1589,6 +1589,31 @@ describe('CodexWorkerAdapter.fork — app-server', () => {
     })
     await supported.detect()
     expect(supported.capabilities().fork).toBe(true)
+    expect(supported.capabilities().subagent).toBe(true)
+  })
+
+  it('读取 app-server 标记为 parentThreadId 的原生 child thread 与其独立 items', async () => {
+    const childThreadId = randomUUID()
+    const adapter = new CodexWorkerAdapter({
+      dataDir,
+      codexHomeSource: codexHome,
+      tmux: new NoopTmux(),
+      codexBin: appServerBin('children', `FAKE_CHILD_THREAD_ID=${childThreadId}`),
+    })
+    await adapter.detect()
+    const parent = { worker_id: workerId, seq: 1, impl: 'codex' as const, session_ref: parentSessionId }
+
+    await expect(adapter.listSubagents(parent)).resolves.toMatchObject([{
+      subagent_id: childThreadId, executor_impl: 'codex', type: 'research', name: '研究助手', task: '原生子 Agent 任务', status: 'completed',
+    }])
+    await expect(adapter.readSubagentTrace(parent, childThreadId)).resolves.toMatchObject({
+      events: [
+        { kind: 'message', role: 'user', summary: '检查原生记录', source_offset: 0 },
+        { kind: 'tool_call', summary: 'exec_command(pwd)', source_offset: 1 },
+        { kind: 'message', role: 'assistant', summary: '原生子 Agent 已完成', source_offset: 2 },
+      ],
+      nextCursor: { offset: 3 },
+    })
   })
 
   it('detect 切换到同版本的另一 binary 时重新探测 fork capability', async () => {

--- a/crabot-agent/tests/workers/codex-app-server-client.test.ts
+++ b/crabot-agent/tests/workers/codex-app-server-client.test.ts
@@ -7,6 +7,7 @@ import {
   CodexAppServerClient,
   CodexAppServerRpcError,
   probeCodexAppServerFork,
+  probeCodexAppServerSubagents,
 } from '../../src/workers/codex/app-server-client.js'
 
 const FIXTURE = resolve(__dirname, 'fixtures/fake-codex-app-server.mjs')
@@ -67,6 +68,20 @@ describe('CodexAppServerClient', () => {
     })).resolves.toBe(true)
 
     await expect(probeCodexAppServerFork({
+      command: `env FAKE_APP_SERVER_MODE=unsupported node ${quote(FIXTURE)} app-server --stdio`,
+      cwd: dir,
+      env: { PATH: process.env.PATH ?? '', CODEX_HOME: dir },
+    })).resolves.toBe(false)
+  })
+
+  it('subagent capability probe requires native child thread listing support', async () => {
+    await expect(probeCodexAppServerSubagents({
+      command: `node ${quote(FIXTURE)} app-server --stdio`,
+      cwd: dir,
+      env: { PATH: process.env.PATH ?? '', CODEX_HOME: dir },
+    })).resolves.toBe(true)
+
+    await expect(probeCodexAppServerSubagents({
       command: `env FAKE_APP_SERVER_MODE=unsupported node ${quote(FIXTURE)} app-server --stdio`,
       cwd: dir,
       env: { PATH: process.env.PATH ?? '', CODEX_HOME: dir },

--- a/crabot-agent/tests/workers/composite-trace.test.ts
+++ b/crabot-agent/tests/workers/composite-trace.test.ts
@@ -397,4 +397,29 @@ describe('readCompositeWorkerTrace', () => {
       events: [{ summary: 'other' }],
     })
   })
+
+  it('只枚举待补齐的 child，并保留父化身归属', async () => {
+    const pendingChild = {
+      subagent_id: 'child-pending', worker_id: WORKER_ID, executor_impl: 'codex' as const,
+      name: 'Pending child', status: 'completed' as const,
+      started_at: '2026-08-01T00:00:00.000Z', ended_at: '2026-08-01T00:01:00.000Z',
+    }
+    const completeChild = {
+      ...pendingChild, subagent_id: 'child-complete',
+    }
+    await nativeCopy.beginSubagentCapture(
+      WORKER_ID, INCARNATION_ID, pendingChild, 'pending-fingerprint', (text) => text,
+    )
+    await nativeCopy.completeSubagentCapture(
+      WORKER_ID, INCARNATION_ID, completeChild, 'complete-fingerprint', [], 0, (text) => text,
+    )
+
+    await expect(nativeCopy.listPendingSubagentCaptures()).resolves.toEqual([{
+      worker_id: WORKER_ID,
+      parent_incarnation_id: INCARNATION_ID,
+      subagent_id: 'child-pending',
+      subagent_fingerprint: 'pending-fingerprint',
+      summary: pendingChild,
+    }])
+  })
 })

--- a/crabot-agent/tests/workers/composite-trace.test.ts
+++ b/crabot-agent/tests/workers/composite-trace.test.ts
@@ -371,4 +371,30 @@ describe('readCompositeWorkerTrace', () => {
     expect(result.events.filter((event) => event.source === 'native')).toHaveLength(0)
     expect(result.unavailable_reason).toContain('native unavailable')
   })
+
+  it('删除 Worker 的副本时同时删除其 child trace，且不影响其他 Worker', async () => {
+    const fingerprint = incarnationFingerprint({
+      incarnation_id: INCARNATION_ID,
+      impl: 'claude-code',
+      seq: 1,
+      started_at: '2026-08-01T00:00:00.000Z',
+    })
+    const child = {
+      subagent_id: 'child-1', worker_id: WORKER_ID, executor_impl: 'claude-code' as const,
+      name: 'Child', status: 'completed' as const, started_at: '2026-08-01T00:00:00.000Z',
+    }
+    await nativeCopy.append(WORKER_ID, 1, fingerprint, [nativeEventAt('parent', '2026-08-01T00:00:01.000Z', 0)], (text) => text)
+    await nativeCopy.completeSubagentCapture(WORKER_ID, INCARNATION_ID, child, 'child-fingerprint', [
+      nativeEventAt('child', '2026-08-01T00:00:01.000Z', 0),
+    ], 1, (text) => text)
+    await nativeCopy.append('w-comp-other', 1, 'other-fingerprint', [nativeEventAt('other', '2026-08-01T00:00:01.000Z', 0)], (text) => text)
+
+    await nativeCopy.removeWorker(WORKER_ID)
+
+    await expect(nativeCopy.read(WORKER_ID, 1, fingerprint)).resolves.toBeNull()
+    await expect(nativeCopy.readSubagent(WORKER_ID, 'child-1', 'child-fingerprint')).resolves.toBeNull()
+    await expect(nativeCopy.read('w-comp-other', 1, 'other-fingerprint')).resolves.toMatchObject({
+      events: [{ summary: 'other' }],
+    })
+  })
 })

--- a/crabot-agent/tests/workers/fixtures/fake-codex-app-server.mjs
+++ b/crabot-agent/tests/workers/fixtures/fake-codex-app-server.mjs
@@ -52,6 +52,49 @@ rl.on('line', (line) => {
     send({ method: 'unrelated/notification', params: { ignored: true } })
     return
   }
+  if (message.method === 'thread/list') {
+    if (mode === 'unsupported') {
+      error(message.id, 'method not found', -32601)
+      return
+    }
+    const parentThreadId = message.params?.parentThreadId
+    send({
+      id: message.id,
+      result: {
+        data: mode === 'children' && typeof parentThreadId === 'string' ? [{
+          id: process.env.FAKE_CHILD_THREAD_ID ?? '019d0000-0000-7000-8000-000000000003',
+          parentThreadId,
+          preview: '原生子 Agent 任务',
+          status: { type: 'idle' },
+          agentNickname: '研究助手',
+          agentRole: 'research',
+          createdAt: 1_770_000_000,
+          updatedAt: 1_770_000_060,
+        }] : [],
+        nextCursor: null,
+      },
+    })
+    return
+  }
+  if (message.method === 'thread/items/list') {
+    if (mode === 'unsupported') {
+      error(message.id, 'method not found', -32601)
+      return
+    }
+    const childThreadId = process.env.FAKE_CHILD_THREAD_ID ?? '019d0000-0000-7000-8000-000000000003'
+    send({
+      id: message.id,
+      result: {
+        data: mode === 'children' && message.params?.threadId === childThreadId ? [
+          { turnId: 'turn-child', item: { type: 'userMessage', content: [{ text: '检查原生记录' }] } },
+          { turnId: 'turn-child', item: { type: 'commandExecution', command: 'pwd' } },
+          { turnId: 'turn-child', item: { type: 'agentMessage', text: '原生子 Agent 已完成' } },
+        ] : [],
+        nextCursor: null,
+      },
+    })
+    return
+  }
   if (message.method === 'thread/fork') {
     if (mode === 'unsupported') {
       error(message.id, 'method not found', -32601)

--- a/crabot-agent/tests/workers/fixtures/fake-codex-app-server.mjs
+++ b/crabot-agent/tests/workers/fixtures/fake-codex-app-server.mjs
@@ -95,6 +95,32 @@ rl.on('line', (line) => {
     })
     return
   }
+  if (message.method === 'thread/read') {
+    const childThreadId = process.env.FAKE_CHILD_THREAD_ID ?? '019d0000-0000-7000-8000-000000000003'
+    send({
+      id: message.id,
+      result: {
+        thread: {
+          id: childThreadId,
+          parentThreadId: 'parent-thread',
+          preview: '原生子 Agent 任务',
+          status: { type: 'idle' },
+          agentNickname: '研究助手',
+          agentRole: 'research',
+          createdAt: 1_770_000_000,
+          updatedAt: 1_770_000_060,
+          turns: message.params?.includeTurns ? [{
+            id: 'turn-child',
+            startedAt: 1_770_000_010,
+            completedAt: 1_770_000_020,
+            status: 'completed',
+            items: [],
+          }] : [],
+        },
+      },
+    })
+    return
+  }
   if (message.method === 'thread/fork') {
     if (mode === 'unsupported') {
       error(message.id, 'method not found', -32601)

--- a/crabot-agent/tests/workers/harness/harness-lifecycle.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-lifecycle.test.ts
@@ -247,7 +247,7 @@ async function makeHarness(
   fakeOpts: FakeAdapterOpts = {},
   depsOverrides: Partial<Pick<
     HarnessDeps,
-    'hasRunningBg' | 'capabilityBundle' | 'onOperationNotification' | 'admitWorkerConnection' | 'redactFailureReason'
+    'hasRunningBg' | 'capabilityBundle' | 'onOperationNotification' | 'onNativeActivityCollected' | 'admitWorkerConnection' | 'redactFailureReason'
   >> = {},
 ): Promise<{
   harness: WorkerHarness
@@ -738,6 +738,38 @@ describe('WorkerHarness.spawnWorker', () => {
 })
 
 describe('WorkerHarness.handleStateChange', () => {
+  it('原生 activity 落盘后才通知 child trace 收割回调', async () => {
+    let workersDir!: string
+    let observed: Promise<unknown> | undefined
+    const onNativeActivityCollected = vi.fn((handle: IncarnationHandle) => {
+      observed = fs.readFile(join(workersDir, handle.worker_id, 'native-activity.json'), 'utf8')
+        .then((raw) => JSON.parse(raw))
+    })
+    const assembled = await makeHarness({
+      nativeTrace: [
+        { ts: '2026-08-20T00:00:00.000Z', kind: 'message', role: 'assistant', summary: '已完成子步骤' },
+      ],
+    }, { onNativeActivityCollected })
+    const { harness, workersDir: actualWorkersDir } = assembled
+    workersDir = actualWorkersDir
+    const worker = await harness.spawnWorker(spawnParams())
+    const incarnation = worker.incarnations[0]
+    const handle = {
+      worker_id: worker.worker_id,
+      incarnation_id: incarnation.incarnation_id,
+      seq: incarnation.seq,
+      impl: 'builtin' as const,
+      session_ref: incarnation.session_ref,
+    }
+
+    harness.handleNativeActivity(handle)
+    await waitUntil(() => onNativeActivityCollected.mock.calls.length === 1)
+
+    await expect(observed).resolves.toMatchObject({
+      cursors: [{ incarnation_id: incarnation.incarnation_id, offset: 1 }],
+    })
+  })
+
   it('assistant 原生 trace 只创建一条可重放 activity_available', async () => {
     const route = vi.fn(async () => ({ consumed: true }))
     const { harness, workersDir } = await makeHarness({


### PR DESCRIPTION
## 改动

- 恢复 builtin Worker 已配置的 `delegate_task`，每个 child 保留独立 trace；停止 Worker 会停止未结束 child，Agent 重启后如实标为已中断。
- 为 builtin、Claude Code、Codex 统一提供直接 child 的列表、详情和分页 trace；CLI 仅读取原生 child 记录，不从父工具文本伪造 child trace。
- Worker 详情展示直接启动的子 Agent，父 trace 中已确认 child 可直接跳转；新增子 Agent 详情页，显示实际执行器、实际类型、任务、状态和分页 trace。

## 边界与失败收口

- child 查询严格限定在所属 Worker 内，跨 Worker 查询返回 404。
- CLI 原生 child 记录不可读时保留 child 详情并返回脱敏不可用原因。

## 验证

- Agent 定向测试：`205 passed, 83 skipped`
- Admin API：`70 passed`
- Web Trace 页面：`16 passed`
- Agent/Admin/Web TypeScript 无产物检查通过；Web production build 通过。
- 浏览器验收：Worker 列表和父 Trace 都可进入 child 详情，builtin child 文本可读，child trace 可加载下一批并翻到第 2 页。