### PR TITLE
fix: harden real Claude/Codex tmux TUI interactions

### DIFF
--- a/crabot-agent/src/workers/claude-code/adapter.ts
+++ b/crabot-agent/src/workers/claude-code/adapter.ts
@@ -50,10 +50,12 @@ import {
   probeClaudeInput,
   acceptedClaudeInput,
   hasClaudeExecutionOrComposer,
+  claudePrimaryComposerText,
   hasClaudeInteraction,
   classifyClaudeTerminalInteraction,
   managerActionsForClaudeAutomaticInteraction,
 } from './input-surface.js'
+
 import { assertInputDeliveryActive } from '../input-delivery-control.js'
 import { assertWorkspaceFilesUntracked, materializeSkills, renderMcpJson, writeSensitiveFileAtomic, type ProvisionSources } from '../provision/materialize.js'
 import type {
@@ -82,6 +84,7 @@ import { classifySupervisionActivity } from '../types.js'
 import type { SupervisionObservation } from '../types.js'
 
 const execFileAsync = promisify(execFile)
+const INTERACTION_PROBE_DELAYS_MS = [100, 200, 400, 800, 1600] as const
 
 /** POSIX shell 单引号转义,与 tmux/driver.ts 的私有 shQuote 同款用法(独立复制一份)。 */
 function shQuote(s: string): string {
@@ -237,6 +240,7 @@ interface Runtime {
   eventWatchDrain?: Promise<void>
   stopTraceWatch?: () => void
   interactionFingerprint?: string
+  interactionProbe?: Promise<void>
   /** 是否已经被 resume 过一次。resume() 锁内检测"对同一 prev 的重复 resume"(先到先得,
    * 后来者报错),对齐 builtin 同款语义(P2 review #2)。fork 不受此限制。 */
   resumed?: boolean
@@ -704,7 +708,7 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
             await this.tmux.pasteText(runtime.sessionName, value)
             pasted = true
           },
-          sendEnter: () => this.tmux.sendKeys(runtime.sessionName, ['Enter']),
+          submit: () => this.tmux.sendKeys(runtime.sessionName, ['Enter']),
           capture: () => this.capture(runtime),
         },
         (snapshot, phase) => probeClaudeInput(snapshot, mode, phase === 'after_paste' ? text : undefined, phase === 'before_paste'),
@@ -1400,7 +1404,11 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
     this.assertActive()
     const runtime = await this.ensureRuntime(h)
     if (!runtime || runtime.controlState.kind === 'exited') return
-    await this.tmux.sendKeys(runtime.sessionName, ['C-c'])
+    await this.getMutex(h.worker_id).run(async () => {
+      if (runtime.controlState.kind === 'exited') return
+      await this.tmux.sendKeys(runtime.sessionName, ['C-c'])
+      await this.confirmInterrupt(runtime, h)
+    })
   }
 
   async stop(h: IncarnationHandle): Promise<void> {
@@ -1677,7 +1685,7 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
         const raw = event.raw as { notification_type?: unknown; message?: unknown; title?: unknown } | null
         const type = typeof raw?.notification_type === 'string' ? raw.notification_type : undefined
         if (!type || !['permission_prompt', 'elicitation_dialog', 'agent_needs_input'].includes(type)) return
-        return this.inspectTerminalInteraction(runtime, h).catch((err) => {
+        return this.inspectTerminalInteractionAfterHook(runtime, h).catch((err) => {
           console.error(`[ClaudeCodeAdapter] notification interaction check failed for ${h.worker_id}#${h.seq}:`, err)
         })
       }
@@ -1722,15 +1730,63 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
     return this.getMutex(h.worker_id).run(() => this.inspectTerminalInteractionLocked(runtime, h))
   }
 
-  private async inspectTerminalInteractionLocked(runtime: Runtime, h: IncarnationHandle): Promise<void> {
+  private inspectTerminalInteractionAfterHook(runtime: Runtime, h: IncarnationHandle): Promise<void> {
+    if (runtime.interactionProbe) return runtime.interactionProbe
+    const probe = this.getMutex(h.worker_id).run(() => this.inspectTerminalInteractionLocked(runtime, h, true))
+    runtime.interactionProbe = probe
+    void probe.then(
+      () => { if (runtime.interactionProbe === probe) runtime.interactionProbe = undefined },
+      () => { if (runtime.interactionProbe === probe) runtime.interactionProbe = undefined },
+    )
+    return probe
+  }
+
+  private async inspectTerminalInteractionLocked(runtime: Runtime, h: IncarnationHandle, retryUnknown = false): Promise<void> {
     if (this.closing || runtime.controlState.kind === 'exited') return
-    let snapshot: CapturedPane
-    try {
-      snapshot = await this.capture(runtime)
-    } catch {
-      return
+    for (let attempt = 0; ; attempt++) {
+      if (attempt > 0) {
+        if (runtime.controlState.kind !== 'running') return
+        await new Promise((resolve) => setTimeout(resolve, INTERACTION_PROBE_DELAYS_MS[attempt - 1]))
+        if (this.closing || runtime.controlState.kind !== 'running' || !(await this.tmux.isAlive(runtime.sessionName))) return
+      }
+      let snapshot: CapturedPane
+      try {
+        snapshot = await this.capture(runtime)
+      } catch {
+        return
+      }
+      const interaction = classifyClaudeTerminalInteraction(snapshot)
+      if (interaction.kind !== 'none') {
+        await this.handleTerminalInteraction(runtime, h, interaction, snapshot)
+        return
+      }
+      runtime.interactionFingerprint = undefined
+      if (!retryUnknown || attempt === INTERACTION_PROBE_DELAYS_MS.length) return
     }
-    await this.handleTerminalInteraction(runtime, h, classifyClaudeTerminalInteraction(snapshot), snapshot)
+  }
+
+  private async confirmInterrupt(runtime: Runtime, h: IncarnationHandle): Promise<void> {
+    let clearRequested = false
+    for (let attempt = 0; ; attempt++) {
+      if (!(await this.tmux.isAlive(runtime.sessionName))) return
+      const snapshot = await this.capture(runtime).catch(() => undefined)
+      if (!snapshot) return
+      const composer = claudePrimaryComposerText(snapshot)
+      if (composer !== undefined && composer.length === 0) {
+        runtime.interactionFingerprint = undefined
+        await this.transitionControlState(runtime, h, { kind: 'waiting_text' })
+        return
+      }
+      if (composer !== undefined && !clearRequested) {
+        // Claude retains the interrupted request in the primary composer. A
+        // second Ctrl-C clears that known residual without changing unknown UI.
+        await this.tmux.sendKeys(runtime.sessionName, ['C-c'])
+        clearRequested = true
+      }
+      if (attempt === INTERACTION_PROBE_DELAYS_MS.length) return
+      await new Promise((resolve) => setTimeout(resolve, INTERACTION_PROBE_DELAYS_MS[attempt]))
+      if (this.closing || runtime.controlState.kind === 'exited') return
+    }
   }
 
   private async handleTerminalInteraction(

--- a/crabot-agent/src/workers/claude-code/input-surface.ts
+++ b/crabot-agent/src/workers/claude-code/input-surface.ts
@@ -36,22 +36,25 @@ export function acceptedClaudeInput(snapshot: PaneSnapshot, mode: InputMode, tex
 
 export function classifyClaudeTerminalInteraction(snapshot: PaneSnapshot): TerminalInteraction {
   const pane = snapshot.text
+  // A real ready-to-code confirmation can render its highlighted option with
+  // the composer marker. Recognize the complete approval shape before the
+  // generic composer parser, without changing ordinary numbered input text.
+  const tailLines = pane.split('\n')
+  const tail = tailLines.join('\n')
+  const readyToCode = /Claude has written up a plan and is ready to execute\./i.test(tail) &&
+    /Would you like to\s+proceed\?/i.test(tail) &&
+    /^\s*(?:❯\s*)?1[.)]\s+Yes, and use auto mode\b/im.test(tail)
+  if (readyToCode) return { kind: 'automatic', family: 'claude_exit_plan', fingerprint: 'claude_exit_plan:ready-to-code-auto' }
   // A footer-anchored ordinary composer means a previously rendered selector in
   // the transcript is no longer the active surface.
   if (claudeComposerText(snapshot) !== undefined) return { kind: 'none' }
   // capture-pane returns only the current viewport. A real plan approval can
   // wrap its body far enough that the heading is near the viewport's top.
-  const tailLines = pane.split('\n')
-  const tail = tailLines.join('\n')
   const exitPlan = /Exit plan mode\?/i.test(tail) &&
     /Claude wants to exit plan mode/i.test(tail) &&
     /^\s*1[.)]\s+\S/m.test(tail) &&
     /^\s*2[.)]\s+\S/m.test(tail)
   if (exitPlan) return { kind: 'automatic', family: 'claude_exit_plan', fingerprint: 'claude_exit_plan:1-2' }
-  const readyToCode = /Claude has written up a plan and is ready to execute\./i.test(tail) &&
-    /Would you like to\s+proceed\?/i.test(tail) &&
-    /^\s*(?:❯\s*)?1[.)]\s+Yes, and use auto mode\b/im.test(tail)
-  if (readyToCode) return { kind: 'automatic', family: 'claude_exit_plan', fingerprint: 'claude_exit_plan:ready-to-code-auto' }
   const hasOption = tailLines.some((line) => /^\s*(?:❯|[○◉☐☑]|\d+[.)])\s+\S/.test(line))
   const hasYes = /(?:^|\n)\s*(?:❯\s*)?(?:\d+[.)]\s*)?Yes\b/i.test(tail)
   const hasNo = /(?:^|\n)\s*(?:❯\s*)?(?:\d+[.)]\s*)?No\b/i.test(tail)
@@ -119,9 +122,6 @@ function claudeComposerText(snapshot: PaneSnapshot, preservePlaceholderText = fa
   for (let i = lines.length - 1; i >= 0; i--) {
     const match = lines[i].match(/^\s*❯(?:\s?(.*))?$/)
     if (!match) continue
-    // Claude uses the same marker to highlight a numbered selector option;
-    // that is an interaction surface, never the primary composer.
-    if (/^[1-9][.)]\s+/.test(match[1] ?? '')) continue
     const anchored = lines.slice(i + 1).some((line) => CLAUDE_FOOTER.test(line))
     if (!anchored) return undefined
     const content = [match[1] ?? '']

--- a/crabot-agent/src/workers/claude-code/input-surface.ts
+++ b/crabot-agent/src/workers/claude-code/input-surface.ts
@@ -39,16 +39,17 @@ export function classifyClaudeTerminalInteraction(snapshot: PaneSnapshot): Termi
   // A footer-anchored ordinary composer means a previously rendered selector in
   // the transcript is no longer the active surface.
   if (claudeComposerText(snapshot) !== undefined) return { kind: 'none' }
-  const tailLines = pane.split('\n').slice(-24)
+  // capture-pane returns only the current viewport. A real plan approval can
+  // wrap its body far enough that the heading is near the viewport's top.
+  const tailLines = pane.split('\n')
   const tail = tailLines.join('\n')
   const exitPlan = /Exit plan mode\?/i.test(tail) &&
     /Claude wants to exit plan mode/i.test(tail) &&
     /^\s*1[.)]\s+\S/m.test(tail) &&
     /^\s*2[.)]\s+\S/m.test(tail)
   if (exitPlan) return { kind: 'automatic', family: 'claude_exit_plan', fingerprint: 'claude_exit_plan:1-2' }
-  const readyToCode = /Ready to code\?/i.test(tail) &&
-    /Claude has written up a plan and is ready to execute\./i.test(tail) &&
-    /Would you like to proceed\?/i.test(tail) &&
+  const readyToCode = /Claude has written up a plan and is ready to execute\./i.test(tail) &&
+    /Would you like to\s+proceed\?/i.test(tail) &&
     /^\s*(?:❯\s*)?1[.)]\s+Yes, and use auto mode\b/im.test(tail)
   if (readyToCode) return { kind: 'automatic', family: 'claude_exit_plan', fingerprint: 'claude_exit_plan:ready-to-code-auto' }
   const hasOption = tailLines.some((line) => /^\s*(?:❯|[○◉☐☑]|\d+[.)])\s+\S/.test(line))
@@ -107,11 +108,20 @@ export function hasClaudeExecutionOrComposer(snapshot: PaneSnapshot): boolean {
   return claudeComposerText(snapshot) !== undefined || /esc to interrupt/i.test(snapshot.text)
 }
 
+/** Only explicit interrupt confirmation may use this visual state transition. */
+export function claudePrimaryComposerText(snapshot: PaneSnapshot): string | undefined {
+  if (/esc to interrupt/i.test(snapshot.text)) return undefined
+  return claudeComposerText(snapshot)
+}
+
 function claudeComposerText(snapshot: PaneSnapshot, preservePlaceholderText = false): string | undefined {
   const lines = snapshot.text.split('\n')
   for (let i = lines.length - 1; i >= 0; i--) {
     const match = lines[i].match(/^\s*❯(?:\s?(.*))?$/)
     if (!match) continue
+    // Claude uses the same marker to highlight a numbered selector option;
+    // that is an interaction surface, never the primary composer.
+    if (/^[1-9][.)]\s+/.test(match[1] ?? '')) continue
     const anchored = lines.slice(i + 1).some((line) => CLAUDE_FOOTER.test(line))
     if (!anchored) return undefined
     const content = [match[1] ?? '']

--- a/crabot-agent/src/workers/codex/adapter.ts
+++ b/crabot-agent/src/workers/codex/adapter.ts
@@ -4,8 +4,8 @@
  * Interactive incarnations run in tmux with approve-for-me (which selects the workspace-write
  * sandbox), and
  * workspace network access. spawn/resume wait for bracketed-paste readiness and submit opening
- * input through the guarded `empty -> one paste -> pending -> Enter` transaction (one Enter retry,
- * never a second paste). `initial_input` on the returned handle gives the harness explicit state
+ * input through the guarded `empty -> one paste -> pending -> submit` transaction (the adapter
+ * repeats the same native submission key once, never a second paste). `initial_input` on the returned handle gives the harness explicit state
  * and text ownership for accepted, not_pasted, and pending_in_ui outcomes.
  *
  * Runtime truth is one `CliControlState`: running, waiting_text, waiting_action, or exited.
@@ -41,7 +41,8 @@ import type { TerminalInteraction } from '../tmux/terminal-interaction.js'
 import { AsyncMutex } from '../async-mutex.js'
 import { writeMetaAtomic, maxSeqOnDisk, latestModifiedMs } from '../meta-store.js'
 import { WorkerExitedError, CapabilityNotSupportedError, CliInputStallError, WorkerImplUnavailableError, ForkEstablishmentError } from '../errors.js'
-import { probeCodexInput, acceptedCodexInput, classifyCodexTerminalInteraction } from './input-surface.js'
+import { probeCodexInput, acceptedCodexInput, classifyCodexTerminalInteraction, codexPrimaryComposerText } from './input-surface.js'
+
 import { assertInputDeliveryActive } from '../input-delivery-control.js'
 import { buildScrubbedChildEnv } from '../connections/secret-env.js'
 import {
@@ -80,6 +81,7 @@ import { classifySupervisionActivity } from '../types.js'
 import type { SupervisionObservation } from '../types.js'
 
 const execFileAsync = promisify(execFile)
+const INTERACTION_PROBE_DELAYS_MS = [100, 200, 400, 800, 1600] as const
 
 /** spawn/resume 都要带的主命令级选项:放行 workspace-write 沙箱的出网。见文件头
  * "spawn/resume 启动参数"节。取值只含 `[A-Za-z_.=]`,不含 shell 元字符,拼进经 `sh -c`
@@ -286,6 +288,7 @@ interface Runtime {
   eventWatchDrain?: Promise<void>
   stopTraceWatch?: () => void
   interactionFingerprint?: string
+  interactionProbe?: Promise<void>
   /** 是否已经被 resume 过一次。resume() 锁内检测"对同一 prev 的重复 resume"(先到先得,
    * 后来者报错),对齐 builtin/cc 同款语义(P2 review #2)。 */
   resumed?: boolean
@@ -1028,7 +1031,7 @@ export class CodexWorkerAdapter implements WorkerAdapter {
             await this.tmux.pasteText(runtime.sessionName, value)
             pasted = true
           },
-          sendEnter: () => this.tmux.sendKeys(runtime.sessionName, ['Enter']),
+          submit: () => this.tmux.sendKeys(runtime.sessionName, [mode === 'steering' ? 'Tab' : 'Enter']),
           capture: () => this.capture(runtime),
         },
         (snapshot, phase) => probeCodexInput(snapshot, mode, phase === 'after_paste' ? text : undefined, phase === 'before_paste'),
@@ -1807,7 +1810,11 @@ export class CodexWorkerAdapter implements WorkerAdapter {
     this.assertActive()
     const runtime = await this.ensureRuntime(h)
     if (!runtime || runtime.controlState.kind === 'exited') return
-    await this.tmux.sendKeys(runtime.sessionName, ['C-c'])
+    await this.getMutex(h.worker_id).run(async () => {
+      if (runtime.controlState.kind === 'exited') return
+      await this.tmux.sendKeys(runtime.sessionName, ['C-c'])
+      await this.confirmInterrupt(runtime, h)
+    })
   }
 
   async stop(h: IncarnationHandle): Promise<void> {
@@ -2094,7 +2101,7 @@ export class CodexWorkerAdapter implements WorkerAdapter {
     if (runtime.stopEventWatch) return // 幂等:同一 runtime 只装一个
     runtime.stopEventWatch = runtime.eventChannel.watch((event) => {
       if (event.kind === 'permission_request') {
-        return this.inspectTerminalInteraction(runtime, h).catch((err) => {
+        return this.inspectTerminalInteractionAfterHook(runtime, h).catch((err) => {
           console.error(`[CodexWorkerAdapter] permission-request interaction check failed for ${h.worker_id}#${h.seq}:`, err)
         })
       }
@@ -2137,28 +2144,65 @@ export class CodexWorkerAdapter implements WorkerAdapter {
     return this.getMutex(h.worker_id).run(() => this.inspectTerminalInteractionLocked(runtime, h))
   }
 
-  private async inspectTerminalInteractionLocked(runtime: Runtime, h: IncarnationHandle): Promise<void> {
+  private inspectTerminalInteractionAfterHook(runtime: Runtime, h: IncarnationHandle): Promise<void> {
+    if (runtime.interactionProbe) return runtime.interactionProbe
+    const probe = this.getMutex(h.worker_id).run(() => this.inspectTerminalInteractionLocked(runtime, h, true))
+    runtime.interactionProbe = probe
+    void probe.then(
+      () => { if (runtime.interactionProbe === probe) runtime.interactionProbe = undefined },
+      () => { if (runtime.interactionProbe === probe) runtime.interactionProbe = undefined },
+    )
+    return probe
+  }
+
+  private async inspectTerminalInteractionLocked(runtime: Runtime, h: IncarnationHandle, retryUnknown = false): Promise<void> {
     if (this.closing || runtime.controlState.kind === 'exited') return
-    let snapshot: CapturedPane
-    try {
-      snapshot = await this.capture(runtime)
-    } catch {
+    for (let attempt = 0; ; attempt++) {
+      if (attempt > 0) {
+        if (runtime.controlState.kind !== 'running') return
+        await new Promise((resolve) => setTimeout(resolve, INTERACTION_PROBE_DELAYS_MS[attempt - 1]))
+        if (this.closing || runtime.controlState.kind !== 'running' || !(await this.tmux.isAlive(runtime.sessionName))) return
+      }
+      let snapshot: CapturedPane
+      try {
+        snapshot = await this.capture(runtime)
+      } catch {
+        return
+      }
+      const interaction: TerminalInteraction = classifyCodexTerminalInteraction(snapshot)
+      if (interaction.kind === 'none') {
+        runtime.interactionFingerprint = undefined
+        if (!retryUnknown || attempt === INTERACTION_PROBE_DELAYS_MS.length) return
+        continue
+      }
+      if (interaction.kind !== 'manager_required') return
+      if (runtime.interactionFingerprint === interaction.fingerprint) return
+      runtime.interactionFingerprint = interaction.fingerprint
+      await this.transitionControlState(runtime, h, { kind: 'waiting_action', reason: 'interaction_required' }, {
+        terminal: this.liveTerminal(snapshot),
+        waitReason: 'interaction_required',
+        ui: { fingerprint: interaction.fingerprint, actions: interaction.actions },
+        notification: { type: 'terminal_interaction' },
+      }, true, true)
       return
     }
-    const interaction: TerminalInteraction = classifyCodexTerminalInteraction(snapshot)
-    if (interaction.kind === 'none') {
-      runtime.interactionFingerprint = undefined
-      return
+  }
+
+  private async confirmInterrupt(runtime: Runtime, h: IncarnationHandle): Promise<void> {
+    for (let attempt = 0; ; attempt++) {
+      if (!(await this.tmux.isAlive(runtime.sessionName))) return
+      const snapshot = await this.capture(runtime).catch(() => undefined)
+      if (!snapshot) return
+      const composer = codexPrimaryComposerText(snapshot)
+      if (composer !== undefined && composer.length === 0) {
+        runtime.interactionFingerprint = undefined
+        await this.transitionControlState(runtime, h, { kind: 'waiting_text' })
+        return
+      }
+      if (attempt === INTERACTION_PROBE_DELAYS_MS.length) return
+      await new Promise((resolve) => setTimeout(resolve, INTERACTION_PROBE_DELAYS_MS[attempt]))
+      if (this.closing || runtime.controlState.kind === 'exited') return
     }
-    if (interaction.kind !== 'manager_required') return
-    if (runtime.interactionFingerprint === interaction.fingerprint) return
-    runtime.interactionFingerprint = interaction.fingerprint
-    await this.transitionControlState(runtime, h, { kind: 'waiting_action', reason: 'interaction_required' }, {
-      terminal: this.liveTerminal(snapshot),
-      waitReason: 'interaction_required',
-      ui: { fingerprint: interaction.fingerprint, actions: interaction.actions },
-      notification: { type: 'terminal_interaction' },
-    }, true, true)
   }
 
   private assertActive(): void {

--- a/crabot-agent/src/workers/codex/input-surface.ts
+++ b/crabot-agent/src/workers/codex/input-surface.ts
@@ -5,8 +5,8 @@ import type { WorkerUiActionDescriptor } from '../types.js'
 
 // codex 0.146 实测页脚：`gpt-5.6-sol xhigh · ~/.crabot/...`——home 缩写是 `~/` 不是 `/`，
 // 旧正则 `·\s\/` 在它上面失配会让 composer 探测整体失败（输入永远 stalled）。
-const CODEX_FOOTER = /^\s*(?:Working\b|esc to interrupt|(?:\?\s*)?for shortcuts|\d+% context|context left|.*\s·\s[~\/])/i
-const CODEX_COMPOSER_BOUNDARY = /^\s*(?:[─━-]{3,}|Working\b|esc to interrupt|(?:\?\s*)?for shortcuts|\d+% context|context left|.*\s·\s[~\/])/i
+const CODEX_FOOTER = /^\s*(?:Working\b|esc to interrupt|tab to queue message|(?:\?\s*)?for shortcuts|\d+% context|context left|.*\s·\s[~\/])/i
+const CODEX_COMPOSER_BOUNDARY = /^\s*(?:[─━-]{3,}|Working\b|esc to interrupt|tab to queue message|(?:\?\s*)?for shortcuts|\d+% context|context left|.*\s·\s[~\/])/i
 const CODEX_PLACEHOLDERS = [
   'Ask Codex to do anything',
   'Explain this codebase',
@@ -49,8 +49,12 @@ export function acceptedCodexInput(snapshot: PaneSnapshot, mode: InputMode, text
 export function classifyCodexTerminalInteraction(snapshot: PaneSnapshot): TerminalInteraction {
   if (codexComposerText(snapshot) !== undefined) return { kind: 'none' }
   const pane = snapshot.text
-  const tail = pane.split('\n').slice(-14).join('\n')
-  if (/(?:Would you like to|Do you want to|Allow Codex to|approval required)[\s\S]{0,600}(?:\bYes\b[\s\S]{0,120}\bNo\b|\bapprove\b[\s/|]+\bdeny\b)/i.test(tail)) {
+  // Real Codex command approvals can wrap an option across several lines and
+  // leave a trailing blank line; retain the prompt heading as well as footer.
+  const tail = pane.split('\n').slice(-24).join('\n')
+  const yesNoApproval = /(?:Would you like to|Do you want to|Allow Codex to|approval required)[\s\S]{0,600}(?:\bYes\b[\s\S]{0,120}\bNo\b|\bapprove\b[\s/|]+\bdeny\b)/i.test(tail)
+  const commandApproval = /Would you like to run the following command\?[\s\S]{0,600}Press enter to confirm or esc to cancel/i.test(tail)
+  if (yesNoApproval || commandApproval) {
     return {
       kind: 'manager_required',
       family: 'codex_approval',
@@ -70,6 +74,12 @@ function boundedUiActions(): WorkerUiActionDescriptor[] {
 
 function hasCodexInteraction(pane: string): boolean {
   return classifyCodexTerminalInteraction({ text: pane }).kind !== 'none'
+}
+
+/** Only explicit interrupt confirmation may use this visual state transition. */
+export function codexPrimaryComposerText(snapshot: PaneSnapshot): string | undefined {
+  if (codexIsWorking(snapshot)) return undefined
+  return codexComposerText(snapshot)
 }
 
 function codexIsWorking(snapshot: PaneSnapshot): boolean {

--- a/crabot-agent/src/workers/tmux/input-commit.ts
+++ b/crabot-agent/src/workers/tmux/input-commit.ts
@@ -7,7 +7,10 @@ export type InputProbePhase = 'before_paste' | 'after_paste'
 
 export interface InputCommitDriver {
   pasteText(text: string): Promise<void>
-  sendEnter(): Promise<void>
+  /** Adapter-owned submission action for the currently probed input surface. */
+  submit?(): Promise<void>
+  /** @deprecated Test-only compatibility for the old fixed-Enter transaction. */
+  sendEnter?(): Promise<void>
   capture(): Promise<PaneSnapshot>
 }
 
@@ -53,7 +56,7 @@ export async function commitInput(
   if (currentProbe !== 'pending') return { disposition: 'pending_in_ui', snapshot }
 
   opts.beforeSideEffect?.('enter')
-  await driver.sendEnter()
+  await submit(driver)
   snapshot = await waitUntil(
     driver,
     timeoutMs,
@@ -65,7 +68,7 @@ export async function commitInput(
   currentProbe = probe(snapshot, 'after_paste')
   if (currentProbe === 'pending') {
     opts.beforeSideEffect?.('enter')
-    await driver.sendEnter()
+    await submit(driver)
     snapshot = await waitUntil(
       driver,
       timeoutMs,
@@ -75,6 +78,12 @@ export async function commitInput(
     if (accepted(snapshot)) return { disposition: 'accepted', snapshot }
   }
   return { disposition: 'pending_in_ui', snapshot }
+}
+
+async function submit(driver: InputCommitDriver): Promise<void> {
+  const action = driver.submit ?? driver.sendEnter
+  if (!action) throw new Error('input commit driver has no submission action')
+  await action()
 }
 
 export async function waitForPaneChange(

--- a/crabot-agent/tests/workers/real-cli-tmux.e2e.test.ts
+++ b/crabot-agent/tests/workers/real-cli-tmux.e2e.test.ts
@@ -1,0 +1,507 @@
+/**
+ * Opt-in black-box coverage for the real interactive CLIs.
+ *
+ * This intentionally does not use mock-cli. It costs real model calls, so it
+ * is skipped unless CRABOT_REAL_CLI_E2E=1 is set explicitly.
+ */
+import { afterEach, describe, expect, it } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
+import * as fs from 'node:fs/promises'
+import os from 'node:os'
+import { join } from 'node:path'
+
+import { ClaudeCodeAdapter } from '../../src/workers/claude-code/adapter.js'
+import { CodexWorkerAdapter } from '../../src/workers/codex/adapter.js'
+import { WorkerHarness, type HarnessDeps } from '../../src/workers/harness/harness.js'
+import { LedgerStore } from '../../src/workers/harness/ledger-store.js'
+import type { ManagerKey } from '../../src/workers/harness/ledger-types.js'
+import { WorkspaceManager } from '../../src/workers/harness/workspace-manager.js'
+import type { HarnessEvent } from '../../src/workers/harness/worker-events.js'
+import { TmuxDriver } from '../../src/workers/tmux/driver.js'
+import type { IncarnationHandle, WorkerAdapter, WorkerContractState, WorkerImplId } from '../../src/workers/types.js'
+
+const enabled = process.env.CRABOT_REAL_CLI_E2E === '1'
+const tmux = new TmuxDriver()
+const sessionPrefix = 'crabot-w-real-tui-e2e-'
+const CLAUDE_BIN = process.env.CLAUDE_BIN ?? 'claude'
+const CODEX_BIN = process.env.CODEX_BIN ?? 'codex'
+
+type CliAdapter = ClaudeCodeAdapter | CodexWorkerAdapter
+
+type RealCliSetupOptions = {
+  prompt?: string
+  claudeBinFactory?: (root: string) => Promise<string>
+}
+
+type HarnessCliSetupOptions = {
+  forcePermission?: boolean
+  prompt?: string
+}
+
+async function waitFor(
+  predicate: () => Promise<boolean>,
+  description: string,
+  timeoutMs = 45_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (await predicate()) return
+    await new Promise((resolve) => setTimeout(resolve, 250))
+  }
+  throw new Error(`timed out waiting for ${description}`)
+}
+
+async function waitForState(
+  adapter: CliAdapter,
+  handle: IncarnationHandle,
+  state: WorkerContractState,
+  timeoutMs = 45_000,
+): Promise<void> {
+  try {
+    await waitFor(async () => (await adapter.state(handle)) === state, `state=${state}`, timeoutMs)
+  } catch (error) {
+    throw new Error(`${error instanceof Error ? error.message : String(error)}:\n${await paneText(adapter, handle)}`)
+  }
+}
+
+async function paneText(adapter: CliAdapter, handle: IncarnationHandle): Promise<string> {
+  const terminal = await adapter.readTerminal(handle)
+  return terminal.kind === 'unavailable' ? '' : terminal.text
+}
+
+async function waitForPane(adapter: CliAdapter, handle: IncarnationHandle, text: string, timeoutMs = 45_000): Promise<void> {
+  try {
+    await waitFor(async () => (await paneText(adapter, handle)).includes(text), `pane text ${text}`, timeoutMs)
+  } catch (error) {
+    throw new Error(`${error instanceof Error ? error.message : String(error)}:\n${await paneText(adapter, handle)}`)
+  }
+}
+
+function cleanupOwnedTmuxSessions(): void {
+  try {
+    const output = execFileSync('tmux', ['list-sessions', '-F', '#{session_name}'], { encoding: 'utf-8' })
+    for (const session of output.split('\n').map((item) => item.trim()).filter((item) => item.startsWith(sessionPrefix))) {
+      execFileSync('tmux', ['kill-session', '-t', session], { stdio: 'ignore' })
+    }
+  } catch {
+    // No sessions or tmux exiting concurrently is fine during cleanup.
+  }
+}
+
+async function setup(kind: 'claude' | 'codex', options: RealCliSetupOptions = {}): Promise<{
+  adapter: CliAdapter
+  workspace: string
+  dataDir: string
+  handle: IncarnationHandle
+}> {
+  const root = await fs.mkdtemp(join(os.tmpdir(), `crabot-real-tui-${kind}-`))
+  const workspace = join(root, 'workspace')
+  const dataDir = join(root, 'adapter-data')
+  await fs.mkdir(workspace, { recursive: true })
+  await fs.writeFile(join(workspace, 'AGENTS.md'), 'Work only in this temporary E2E workspace.\n', 'utf-8')
+
+  const workerId = `real-tui-e2e-${kind}-${randomUUID().slice(0, 8)}`
+  const claudeBin = kind === 'claude' && options.claudeBinFactory
+    ? await options.claudeBinFactory(root)
+    : CLAUDE_BIN
+  const adapter: CliAdapter = kind === 'claude'
+    ? new ClaudeCodeAdapter({
+      dataDir,
+      claudeBin,
+      pasteReadyTimeoutMs: 20_000,
+    })
+    : new CodexWorkerAdapter({
+      dataDir,
+      codexBin: CODEX_BIN,
+      codexHomeSource: join(os.homedir(), '.codex'),
+      pasteReadyTimeoutMs: 20_000,
+      sessionDiscoveryTimeoutMs: 20_000,
+    })
+
+  await adapter.provision({ root: workspace }, { skills: [], mcp_servers: [] })
+  const padding = 'input-verification-padding '.repeat(80)
+  const handle = await adapter.spawn({
+    worker_id: workerId,
+    prompt: options.prompt ?? `Reply with exactly E2E_${kind.toUpperCase()}_INITIAL_OK. Do not edit files. Ignore this padding: ${padding}`,
+    workspace: { root: workspace },
+  })
+  return { adapter, workspace, dataDir: root, handle }
+}
+
+async function clearClaudeTestTrust(workspace: string): Promise<void> {
+  const configPath = join(os.homedir(), '.claude.json')
+  let raw: string
+  try {
+    raw = await fs.readFile(configPath, 'utf-8')
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return
+    throw error
+  }
+  const config = JSON.parse(raw) as { projects?: Record<string, unknown> }
+  const realWorkspace = await fs.realpath(workspace)
+  if (!config.projects?.[realWorkspace]) return
+  delete config.projects[realWorkspace]
+  await fs.writeFile(configPath, JSON.stringify(config, null, 2) + '\n', 'utf-8')
+}
+
+async function finish(adapter: CliAdapter, handle: IncarnationHandle, root: string): Promise<void> {
+  await adapter.stop(handle).catch(() => {})
+  await adapter.dispose().catch(() => {})
+  const workspace = join(root, 'workspace')
+  await clearClaudeTestTrust(workspace)
+  await fs.rm(root, { recursive: true, force: true })
+}
+
+function recreateAdapter(kind: 'claude' | 'codex', root: string): CliAdapter {
+  return kind === 'claude'
+    ? new ClaudeCodeAdapter({
+      dataDir: join(root, 'adapter-data'),
+      claudeBin: CLAUDE_BIN,
+      pasteReadyTimeoutMs: 20_000,
+    })
+    : new CodexWorkerAdapter({
+      dataDir: join(root, 'adapter-data'),
+      codexBin: CODEX_BIN,
+      codexHomeSource: join(os.homedir(), '.codex'),
+      pasteReadyTimeoutMs: 20_000,
+      sessionDiscoveryTimeoutMs: 20_000,
+    })
+}
+
+function binaryPath(command: string): string {
+  return execFileSync('/bin/sh', ['-lc', `command -v ${command}`], { encoding: 'utf-8' }).trim()
+}
+
+async function writePermissionWrapper(root: string, kind: 'claude' | 'codex'): Promise<string> {
+  const target = kind === 'claude' ? binaryPath(CLAUDE_BIN) : binaryPath(CODEX_BIN)
+  const file = join(root, `${kind}-permission-wrapper.sh`)
+  const filter = kind === 'claude'
+    ? 'if [[ "$1" == "--permission-mode" ]]; then shift 2; continue; fi'
+    : 'if [[ "$1" == "--approve-for-me" ]]; then shift; continue; fi\n  if [[ "$1" == "--ask-for-approval" ]]; then shift 2; continue; fi'
+  const prefix = kind === 'claude'
+    ? 'exec ' + JSON.stringify(target) + ' --permission-mode manual'
+    : 'exec ' + JSON.stringify(target) + ' --ask-for-approval untrusted'
+  await fs.writeFile(file, `#!/usr/bin/env bash\nset -euo pipefail\nargs=()\nwhile (( $# )); do\n  ${filter}\n  args+=("$1")\n  shift\ndone\n${prefix} "${'${args[@]}'}"\n`, { mode: 0o700 })
+  return file
+}
+
+async function writeClaudePlanWrapper(root: string): Promise<string> {
+  const target = binaryPath(CLAUDE_BIN)
+  const file = join(root, 'claude-plan-wrapper.sh')
+  await fs.writeFile(file, `#!/usr/bin/env bash\nset -euo pipefail\nargs=()\nwhile (( $# )); do\n  if [[ "$1" == "--permission-mode" ]]; then shift 2; continue; fi\n  args+=("$1")\n  shift\ndone\nexec ${JSON.stringify(target)} --permission-mode plan "${'${args[@]}'}"\n`, { mode: 0o700 })
+  return file
+}
+
+async function cliEventsText(workspace: string, kind: 'claude' | 'codex'): Promise<string> {
+  const dir = kind === 'claude' ? '.claude' : '.codex'
+  return fs.readFile(join(workspace, dir, 'events-cli.jsonl'), 'utf-8').catch(() => '<no hook events file>')
+}
+
+async function terminalContains(harness: WorkerHarness, workerId: string, text: string): Promise<boolean> {
+  const terminal = await harness.getWorkerTerminal(workerId)
+  return terminal.kind !== 'unavailable' && terminal.text.includes(text)
+}
+
+async function setupHarnessWorker(kind: 'claude' | 'codex', options: HarnessCliSetupOptions = {}): Promise<{
+  root: string
+  workspace: string
+  adapter: CliAdapter
+  harness: WorkerHarness
+  workerId: string
+  events: HarnessEvent[]
+  managerKey: ManagerKey
+  permissionFile?: string
+}> {
+  const root = await fs.mkdtemp(join(os.tmpdir(), `crabot-real-ui-${kind}-`))
+  const workspace = join(root, 'workspace')
+  const workerRoot = join(root, 'workers')
+  const permissionFile = options.forcePermission ? join(root, `${kind}-permission.txt`) : undefined
+  await fs.mkdir(workspace, { recursive: true })
+  const adapters = new Map<WorkerImplId, WorkerAdapter>()
+  const events: HarnessEvent[] = []
+  const managerKey = `wechat::real-tui-${kind}-${randomUUID()}` as ManagerKey
+  const harness = new WorkerHarness({
+    adapters,
+    defaultImpl: kind === 'claude' ? 'claude-code' : 'codex',
+    ledger: new LedgerStore(join(root, 'ledgers')),
+    workspaces: new WorkspaceManager(join(root, 'workspaces')),
+    workersDir: workerRoot,
+    now: () => new Date().toISOString(),
+    onEvent: (event) => { events.push(event) },
+  } satisfies HarnessDeps)
+  const cliBin = options.forcePermission ? await writePermissionWrapper(root, kind) : undefined
+  const adapter: CliAdapter = kind === 'claude'
+    ? new ClaudeCodeAdapter({ dataDir: join(root, 'adapter-data'), claudeBin: cliBin ?? CLAUDE_BIN, onStateChange: harness.handleStateChange })
+    : new CodexWorkerAdapter({
+      dataDir: join(root, 'adapter-data'),
+      codexBin: cliBin ?? CODEX_BIN,
+      codexHomeSource: join(os.homedir(), '.codex'),
+      onStateChange: harness.handleStateChange,
+      sessionDiscoveryTimeoutMs: 20_000,
+    })
+  adapters.set(adapter.implId, adapter)
+  const worker = await harness.spawnWorker({
+    managerKey,
+    title: `real ${kind} CLI worker`,
+    prompt: options.prompt ?? (permissionFile
+      ? `Use the shell command printf approved > ${permissionFile} to create that file outside the workspace. Do not use an editor or patch tool. Do not do anything else.`
+      : `Reply with exactly E2E_${kind.toUpperCase()}_HARNESS_INITIAL_OK. Do not edit files.`),
+    origin: { trigger_type: 'message' },
+    report_to: { channel_id: 'wechat', session_id: 'real-tui-e2e' },
+    impl: adapter.implId,
+    workspace,
+  })
+  return { root, workspace, adapter, harness, workerId: worker.worker_id, events, managerKey, permissionFile }
+}
+
+function setupHarnessPermissionWorker(kind: 'claude' | 'codex') {
+  return setupHarnessWorker(kind, { forcePermission: true })
+}
+
+async function cleanupHarnessPermissionWorker(test: Awaited<ReturnType<typeof setupHarnessPermissionWorker>>): Promise<void> {
+  await test.harness.requestWorkerStop(test.workerId).catch(() => {})
+  await test.adapter.dispose().catch(() => {})
+  await clearClaudeTestTrust(test.workspace)
+  await fs.rm(test.root, { recursive: true, force: true })
+}
+
+describe.skipIf(!enabled)('real CLI tmux E2E', () => {
+  afterEach(() => cleanupOwnedTmuxSessions())
+
+  for (const kind of ['claude', 'codex'] as const) {
+    it(`${kind}: initial input, idle follow-up, steering, interrupt, restart reattach, and stop`, async () => {
+      const { adapter, workspace, dataDir, handle } = await setup(kind)
+      let currentAdapter = adapter
+      let currentHandle = handle
+      const runningMarker = kind === 'claude' ? 'esc to interrupt' : 'Working'
+      try {
+        if (currentHandle.initial_input?.disposition !== 'accepted') {
+          throw new Error(
+            `initial input was ${currentHandle.initial_input?.disposition ?? 'missing'}:\n` +
+            await paneText(currentAdapter, currentHandle),
+          )
+        }
+        await waitForState(currentAdapter, currentHandle, 'idle')
+        await waitForPane(currentAdapter, currentHandle, `E2E_${kind.toUpperCase()}_INITIAL_OK`)
+
+        await currentAdapter.sendInput(currentHandle, `Reply with exactly E2E_${kind.toUpperCase()}_FOLLOWUP_OK. Do not edit files.`)
+        await waitForState(currentAdapter, currentHandle, 'idle')
+        await waitForPane(currentAdapter, currentHandle, `E2E_${kind.toUpperCase()}_FOLLOWUP_OK`)
+
+        await currentAdapter.sendInput(
+          currentHandle,
+          `Immediately run the shell command sleep 20. When it finishes, reply with exactly E2E_${kind.toUpperCase()}_STEERING_BASE_OK.`,
+        )
+        await waitForPane(currentAdapter, currentHandle, runningMarker, 25_000)
+        await currentAdapter.sendInput(
+          currentHandle,
+          `After the current command, also include exactly E2E_${kind.toUpperCase()}_STEERING_OK in your response.`,
+        )
+        await waitForState(currentAdapter, currentHandle, 'idle', 60_000)
+        await waitForPane(currentAdapter, currentHandle, `E2E_${kind.toUpperCase()}_STEERING_OK`, 60_000)
+
+        // Recreate only the adapter process. The tmux pane and its native session stay alive.
+        await currentAdapter.dispose()
+        currentAdapter = kind === 'claude'
+          ? new ClaudeCodeAdapter({
+            dataDir: join(dataDir, 'adapter-data'),
+            claudeBin: CLAUDE_BIN,
+            pasteReadyTimeoutMs: 20_000,
+          })
+          : new CodexWorkerAdapter({
+            dataDir: join(dataDir, 'adapter-data'),
+            codexBin: CODEX_BIN,
+            codexHomeSource: join(os.homedir(), '.codex'),
+            pasteReadyTimeoutMs: 20_000,
+            sessionDiscoveryTimeoutMs: 20_000,
+          })
+        expect(await currentAdapter.state(currentHandle)).toBe('idle')
+        await currentAdapter.sendInput(currentHandle, `Reply with exactly E2E_${kind.toUpperCase()}_REATTACH_OK. Do not edit files.`)
+        await waitForState(currentAdapter, currentHandle, 'idle')
+        await waitForPane(currentAdapter, currentHandle, `E2E_${kind.toUpperCase()}_REATTACH_OK`)
+
+        await currentAdapter.sendInput(
+          currentHandle,
+          `Immediately run the shell command sleep 45. Do not respond before the command ends.`,
+        )
+        await waitForPane(currentAdapter, currentHandle, runningMarker, 25_000)
+        const interruptedAt = Date.now()
+        await currentAdapter.interrupt(currentHandle)
+        await waitForState(currentAdapter, currentHandle, 'idle', 10_000)
+        expect(Date.now() - interruptedAt).toBeLessThan(10_000)
+
+        await currentAdapter.sendInput(
+          currentHandle,
+          `Immediately run the shell command sleep 60. Do not respond before the command ends.`,
+        )
+        await waitForPane(currentAdapter, currentHandle, runningMarker, 25_000)
+        await currentAdapter.stop(currentHandle)
+        await waitForState(currentAdapter, currentHandle, 'exited', 10_000)
+        expect(await tmux.isAlive(`crabot-w-${currentHandle.worker_id}-${currentHandle.seq}`)).toBe(false)
+      } finally {
+        await finish(currentAdapter, currentHandle, dataDir)
+        await fs.rm(workspace, { recursive: true, force: true }).catch(() => {})
+      }
+    }, 240_000)
+
+    it(`${kind}: adapter restart reattaches the real tmux pane`, async () => {
+      const { adapter, dataDir, handle } = await setup(kind)
+      let active = adapter
+      try {
+        expect(handle.initial_input?.disposition).toBe('accepted')
+        await waitForState(active, handle, 'idle', 90_000)
+        await active.dispose()
+        active = recreateAdapter(kind, dataDir)
+        expect(await active.state(handle)).toBe('idle')
+        await active.sendInput(handle, `Reply with exactly E2E_${kind.toUpperCase()}_REATTACH_ONLY_OK. Do not edit files.`)
+        await waitForState(active, handle, 'idle', 90_000)
+        await waitForPane(active, handle, `E2E_${kind.toUpperCase()}_REATTACH_ONLY_OK`, 90_000)
+      } finally {
+        await finish(active, handle, dataDir)
+      }
+    }, 120_000)
+
+    it(`${kind}: resume sends a real primary input to the native session`, async () => {
+      const { adapter, dataDir, handle } = await setup(kind)
+      let active = adapter
+      let resumed = handle
+      try {
+        expect(handle.initial_input?.disposition).toBe('accepted')
+        await waitForState(active, handle, 'idle')
+        await active.stop(handle)
+        await waitForState(active, handle, 'exited')
+        resumed = await active.resume(handle, `Reply with exactly E2E_${kind.toUpperCase()}_RESUME_OK. Do not edit files.`)
+        expect(resumed.initial_input?.disposition).toBe('accepted')
+        await waitForState(active, resumed, 'idle', 60_000)
+        await waitForPane(active, resumed, `E2E_${kind.toUpperCase()}_RESUME_OK`, 60_000)
+      } finally {
+        await finish(active, resumed, dataDir)
+      }
+    }, 180_000)
+
+    it(`${kind}: stop closes a real running tmux worker`, async () => {
+      const { adapter, dataDir, handle } = await setup(kind)
+      const runningMarker = kind === 'claude' ? 'esc to interrupt' : 'Working'
+      try {
+        expect(handle.initial_input?.disposition).toBe('accepted')
+        await waitForState(adapter, handle, 'idle')
+        await adapter.sendInput(handle, 'Immediately run the shell command sleep 60. Do not respond before it ends.')
+        await waitForPane(adapter, handle, runningMarker, 25_000)
+        await adapter.stop(handle)
+        await waitForState(adapter, handle, 'exited', 10_000)
+        expect(await tmux.isAlive(`crabot-w-${handle.worker_id}-${handle.seq}`)).toBe(false)
+      } finally {
+        await finish(adapter, handle, dataDir)
+      }
+    }, 120_000)
+
+    it(`${kind}: interrupt settles a real running worker`, async () => {
+      const { adapter, dataDir, handle } = await setup(kind)
+      const runningMarker = kind === 'claude' ? 'esc to interrupt' : 'Working'
+      try {
+        expect(handle.initial_input?.disposition).toBe('accepted')
+        await waitForState(adapter, handle, 'idle')
+        await adapter.sendInput(handle, 'Immediately run the shell command sleep 45. Do not respond before it ends.')
+        await waitForPane(adapter, handle, runningMarker, 25_000)
+        const started = Date.now()
+        await adapter.interrupt(handle)
+        await waitForState(adapter, handle, 'idle', 10_000)
+        expect(Date.now() - started).toBeLessThan(10_000)
+      } finally {
+        await finish(adapter, handle, dataDir)
+      }
+    }, 120_000)
+  }
+
+  it('claude: real plan mode automatically switches to auto and executes', async () => {
+    const { adapter, workspace, dataDir, handle } = await setup('claude', {
+      claudeBinFactory: writeClaudePlanWrapper,
+      prompt: 'Create a concise plan to write plan-mode-result.txt containing exactly plan_mode_done. When the plan is ready, proceed with the file creation.',
+    })
+    try {
+      expect(handle.initial_input?.disposition).toBe('accepted')
+      try {
+        await waitFor(
+          async () => (await fs.readFile(join(workspace, 'plan-mode-result.txt'), 'utf-8').catch(() => '')) === 'plan_mode_done',
+          'Claude plan-mode execution',
+          90_000,
+        )
+      } catch (error) {
+        throw new Error(
+          `${error instanceof Error ? error.message : String(error)}\n` +
+          `--- terminal ---\n${await paneText(adapter, handle)}\n` +
+          `--- hook events ---\n${await cliEventsText(workspace, 'claude')}`,
+        )
+      }
+      await waitForState(adapter, handle, 'idle', 60_000)
+      await waitForPane(adapter, handle, 'auto mode on', 30_000)
+    } finally {
+      await finish(adapter, handle, dataDir)
+    }
+  }, 180_000)
+
+  for (const kind of ['claude', 'codex'] as const) {
+    it(`${kind}: harness interrupt settles and permits a follow-up`, async () => {
+      const test = await setupHarnessWorker(kind)
+      const runningMarker = kind === 'claude' ? 'esc to interrupt' : 'Working'
+      try {
+        await waitFor(async () => (await test.harness.findWorker(test.workerId))?.worker.incarnations[0]?.state === 'idle', 'initial worker idle', 60_000)
+        await test.harness.sendToWorker(test.workerId, 'Immediately run the shell command sleep 45. Do not respond before it ends.')
+        await waitFor(async () => terminalContains(test.harness, test.workerId, runningMarker), 'running worker pane', 25_000)
+        const operation = await test.harness.requestWorkerInterrupt(test.workerId)
+        expect(operation.status).toBe('succeeded')
+        await waitFor(async () => {
+          const events = await test.harness.readWorkerEvents(test.workerId)
+          return events.some((event) => event.kind === 'operation_settled' && event.detail?.operation_id === operation.operation_id && event.detail?.status === 'succeeded')
+        }, 'interrupt settlement event', 10_000)
+        await test.harness.sendToWorker(test.workerId, `Reply with exactly E2E_${kind.toUpperCase()}_INTERRUPT_FOLLOWUP_OK. Do not edit files.`)
+        try {
+          await waitFor(
+            async () => terminalContains(test.harness, test.workerId, `E2E_${kind.toUpperCase()}_INTERRUPT_FOLLOWUP_OK`),
+            'interrupt follow-up',
+            60_000,
+          )
+        } catch (error) {
+          const terminal = await test.harness.getWorkerTerminal(test.workerId)
+          throw new Error(
+            `${error instanceof Error ? error.message : String(error)}\n` +
+            `--- terminal ---\n${terminal.kind === 'unavailable' ? terminal.unavailable_reason : terminal.text}\n` +
+            `--- hook events ---\n${await cliEventsText(test.workspace, kind)}\n` +
+            `--- harness events ---\n${JSON.stringify(test.events, null, 2)}`,
+          )
+        }
+      } finally {
+        await cleanupHarnessPermissionWorker(test)
+      }
+    }, 180_000)
+
+    it(`${kind}: real permission UI is answered through one snapshot action`, async () => {
+      const test = await setupHarnessPermissionWorker(kind)
+      try {
+        let snapshotId: string | undefined
+        try {
+          await waitFor(async () => {
+            const event = test.events.find((candidate) => typeof candidate.detail?.snapshot_id === 'string')
+            snapshotId = event?.detail?.snapshot_id as string | undefined
+            return snapshotId !== undefined
+          }, 'permission snapshot', 60_000)
+        } catch (error) {
+          const terminal = await test.harness.getWorkerTerminal(test.workerId)
+          throw new Error(
+            `${error instanceof Error ? error.message : String(error)}\n` +
+            `--- terminal ---\n${terminal.kind === 'unavailable' ? terminal.unavailable_reason : terminal.text}\n` +
+            `--- hook events ---\n${await cliEventsText(test.workspace, kind)}\n` +
+            `--- harness events ---\n${JSON.stringify(test.events, null, 2)}`,
+          )
+        }
+        const result = await test.harness.respondToWorkerUi(test.workerId, snapshotId!, 'confirm')
+        expect(result.status).toBe('submitted')
+        await waitFor(async () => (await fs.readFile(test.permissionFile!, 'utf-8').catch(() => '')) === 'approved', 'approved file', 60_000)
+        expect((await test.harness.requestWorkerStop(test.workerId)).status).toBe('succeeded')
+      } finally {
+        await cleanupHarnessPermissionWorker(test)
+      }
+    }, 180_000)
+  }
+})

--- a/crabot-agent/tests/workers/terminal-interaction.test.ts
+++ b/crabot-agent/tests/workers/terminal-interaction.test.ts
@@ -55,6 +55,15 @@ describe('current terminal interaction classification', () => {
     }, 'primary')).toBe('empty')
   })
 
+  it('keeps an ordinary numbered Claude message usable as a composer', () => {
+    expect(probeClaudeInput({
+      text: [
+        '❯ 1. fix the bug, then add a regression test',
+        '? for shortcuts',
+      ].join('\n'),
+    }, 'primary', '1. fix the bug, then add a regression test')).toBe('pending')
+  })
+
   it('classifies the visible Claude plan confirmation when its heading is above the viewport', () => {
     expect(classifyClaudeTerminalInteraction({
       text: [

--- a/crabot-agent/tests/workers/terminal-interaction.test.ts
+++ b/crabot-agent/tests/workers/terminal-interaction.test.ts
@@ -25,6 +25,7 @@ describe('current terminal interaction classification', () => {
       '  2. Yes, manually approve edits',
       '  3. Tell Claude what to change',
       '    shift+tab to approve with this feedback',
+      '⏸ plan mode on (shift+tab to cycle)',
       'ctrl+g to edit in Vim',
       '~/.claude/plans/create-a-minimal-plan.md',
     ].join('\n'),
@@ -52,6 +53,21 @@ describe('current terminal interaction classification', () => {
         '⏸ manual mode on (shift+tab to cycle)',
       ].join('\n'),
     }, 'primary')).toBe('empty')
+  })
+
+  it('classifies the visible Claude plan confirmation when its heading is above the viewport', () => {
+    expect(classifyClaudeTerminalInteraction({
+      text: [
+        'Claude has written up a plan and is ready to execute. Would you like to',
+        'proceed?',
+        '❯ 1. Yes, and use auto mode',
+        '  2. Yes, manually approve edits',
+        '  3. Tell Claude what to change',
+        '    shift+tab to approve with this feedback',
+        'ctrl+g to edit in Vim ·',
+        '~/.claude/plans/create-a-plan.md',
+      ].join('\n'),
+    })).toEqual({ kind: 'automatic', family: 'claude_exit_plan', fingerprint: 'claude_exit_plan:ready-to-code-auto' })
   })
 
   it('keeps a current Claude permission dialog manager-owned', () => {


### PR DESCRIPTION
## 变更内容\n\n修复 Claude Code / Codex 在真实 tmux TUI 下的输入提交、中断确认与交互界面识别问题。\n\n## 根因\n\n- 共享输入事务把所有提交动作写死为 Enter，Codex running steering 实际要求 Tab 才会排队。\n- 中断只发送 Ctrl-C，不确认 TUI 是否已回到可接收输入的 composer，可能把未完成状态错误结算为成功。\n- 交互 hook 的首帧 capture 可能早于 TUI 渲染完成；Claude 计划确认标题可能滚出当前 viewport，且高亮编号选项会被误识别为 composer。\n\n## 修复\n\n- 由 adapter 提供原生提交动作，Codex steering 使用 Tab。\n- Claude/Codex interrupt 增加有界 pane 确认；Claude 仅对已确认的中断残留输入发送一次第二个 Ctrl-C 并复验。\n- 交互 hook 仅在当前事件内做有限指数退避复查，按 fingerprint 去重，不增加后台 pane scanner 或周期性 capture。\n- 修正 Codex footer/composer、Claude 计划 viewport 与高亮选项识别。\n- 补充真实 CLI tmux E2E 和回归覆盖。\n\n## 验证\n\n- 真实 tmux + 真实 Claude/Codex CLI：15/15 E2E 通过。\n- TypeScript 编译通过。\n- adapter/交互回归：126 passed / 83 skipped。\n- git diff --check 通过。\n- 协议版本保持 3.6.9；对应协议、spec、plan 已发布到 crabot-docs/main。\n\n失败路径均有界：输入/中断确认失败不会伪造成功；未知交互只在当前事件内有限复查，随后按既有 waiting/Manager 通知语义收口。