### PR TITLE
[codex] preserve full builtin subagent text traces

### DIFF
--- a/crabot-agent/src/engine/bg-entities/bg-agent.ts
+++ b/crabot-agent/src/engine/bg-entities/bg-agent.ts
@@ -82,6 +82,8 @@ export interface SpawnPersistentAgentOpts {
     readonly taskType?: string
     /** summary 前缀，如 '[goal_audit]'。缺省直接用 task_description。 */
     readonly summaryPrefix?: string
+    /** 在 TraceStore 写入前脱敏子 Agent 的 assistant text。 */
+    readonly redactText?: (text: string) => string
   }
   /**
    * Async exit hook —— sub-agent loop 自然结束 / 失败时调用（killed 由 Kill 工具发出，不走这里）。
@@ -195,7 +197,7 @@ export async function spawnPersistentAgent(opts: SpawnPersistentAgentOpts): Prom
           ...(subTrace && subTraceStore
             ? {
                 onTurn: (event) =>
-                  recordSubAgentTurn(subTraceStore, subTrace.trace_id, event),
+                  recordSubAgentTurn(subTraceStore, subTrace.trace_id, event, opts.subTrace?.redactText),
               }
             : {}),
           onLiveProgress: (event) => {

--- a/crabot-agent/src/engine/sub-agent-trace.ts
+++ b/crabot-agent/src/engine/sub-agent-trace.ts
@@ -12,11 +12,15 @@
 import type { TraceStore } from '../core/trace-store.js'
 import type { EngineTurnEvent } from './types.js'
 
+export type TraceTextRedactor = (text: string) => string
+
 export function recordSubAgentTurn(
   traceStore: TraceStore,
   traceId: string,
   event: EngineTurnEvent,
+  redact: TraceTextRedactor = (text) => text,
 ): void {
+  const assistantText = redact(event.assistantText)
   const llmEndedAtMs =
     event.llmStartedAtMs !== undefined && event.llmCallMs !== undefined
       ? event.llmStartedAtMs + event.llmCallMs
@@ -64,7 +68,7 @@ export function recordSubAgentTurn(
     'completed',
     {
       stop_reason: event.stopReason ?? undefined,
-      output_summary: event.assistantText.slice(0, 200) || undefined,
+      ...(assistantText.trim() ? { assistant_text: assistantText } : {}),
       tool_calls_count: event.toolCalls.length > 0 ? event.toolCalls.length : undefined,
     },
     llmEndedAtMs,

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -614,6 +614,7 @@ export class UnifiedAgent extends ModuleBase {
         await this.requireManagerStack().harness.sendToWorker(workerId, text)
       },
       this.builtinBgRegistry,
+      (text) => redactSecrets(text, [...this.knownSecrets]),
     )
 
     this.promptManager = new PromptManager()

--- a/crabot-agent/src/workers/builtin/subagent-runner.ts
+++ b/crabot-agent/src/workers/builtin/subagent-runner.ts
@@ -56,14 +56,17 @@ function summaryOf(workerId: string, record: BgAgentRegistryRecord): WorkerSubag
 export class BuiltinSubagentRunner {
   private readonly abortControllers = new Map<string, AbortController>()
   private registry?: BgEntityRegistry
+  private readonly redactText: (text: string) => string
 
   constructor(
     private readonly traceStore: TraceStore,
     private readonly lspManager: import('../../lsp/lsp-manager.js').LSPManager,
     private readonly deliverCompletion?: (workerId: string, text: string) => Promise<void>,
     registry?: BgEntityRegistry,
+    redactText: (text: string) => string = (text) => text,
   ) {
     this.registry = registry
+    this.redactText = redactText
   }
 
   setRegistry(registry: BgEntityRegistry): void {
@@ -130,6 +133,7 @@ export class BuiltinSubagentRunner {
         traceStore: this.traceStore,
         parentTraceId: worker.parent_trace_id,
         summaryPrefix: `[${subagent.name}]`,
+        redactText: this.redactText,
       },
       onExit: async (info) => {
         const current = await registry.get(info.entity_id)
@@ -251,7 +255,7 @@ export class BuiltinSubagentRunner {
         ...(subagent.model.max_tokens !== undefined ? { maxTokens: subagent.model.max_tokens } : {}),
         ...(input.context ? { parentContext: input.context } : {}),
         abortSignal: controller.signal,
-        onTurn: (event) => recordSubAgentTurn(this.traceStore, trace.trace_id, event),
+        onTurn: (event) => recordSubAgentTurn(this.traceStore, trace.trace_id, event, this.redactText),
         supportsVision: subagent.model.supports_vision,
         ...(subagent.model.context_window !== undefined ? { contextWindowTokens: subagent.model.context_window } : {}),
         permissionConfig: execution.permissionConfig,
@@ -308,8 +312,11 @@ export class BuiltinSubagentRunner {
 function normalizeTraceSpan(span: import('../../types.js').AgentSpan): NormalizedTraceEvent[] {
   const details = (span.details ?? {}) as Record<string, unknown>
   if (span.type === 'llm_call') {
-    const assistantText = typeof details.output_summary === 'string' ? details.output_summary : undefined
-    return [{ ts: span.started_at, kind: 'llm_call', summary: typeof details.stop_reason === 'string' ? `llm ${details.stop_reason}` : 'llm call', detail: details }, ...(assistantText ? [{ ts: span.started_at, kind: 'message' as const, role: 'assistant' as const, summary: assistantText.slice(0, 200), detail: { content: assistantText } }] : [])]
+    const { assistant_text: recordedAssistantText, ...technicalDetails } = details
+    const assistantText = typeof recordedAssistantText === 'string'
+      ? recordedAssistantText
+      : typeof details.output_summary === 'string' ? details.output_summary : undefined
+    return [{ ts: span.started_at, kind: 'llm_call', summary: typeof details.stop_reason === 'string' ? `llm ${details.stop_reason}` : 'llm call', detail: technicalDetails }, ...(assistantText ? [{ ts: span.started_at, kind: 'message' as const, role: 'assistant' as const, summary: assistantText.replace(/\s+/g, ' ').trim().slice(0, 200), detail: { content: assistantText } }] : [])]
   }
   if (span.type === 'tool_call') {
     const name = typeof details.tool_name === 'string' ? details.tool_name : 'tool call'

--- a/crabot-agent/tests/engine/sub-agent-trace.test.ts
+++ b/crabot-agent/tests/engine/sub-agent-trace.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest'
+import { recordSubAgentTurn } from '../../src/engine/sub-agent-trace.js'
+import type { TraceStore } from '../../src/core/trace-store.js'
+
+describe('recordSubAgentTurn', () => {
+  it('persists the complete redacted assistant text for child trace projection', () => {
+    const traceStore = {
+      startSpan: vi.fn(() => ({ span_id: 'llm-1' })),
+      endSpan: vi.fn(),
+    } as unknown as TraceStore
+    const assistantText = `标题\n${'完整内容。'.repeat(80)}`
+
+    recordSubAgentTurn(traceStore, 'trace-1', {
+      turnNumber: 1,
+      assistantText: `${assistantText} secret-value`,
+      toolCalls: [],
+      stopReason: 'end_turn',
+    }, (text) => text.replace('secret-value', '[REDACTED]'))
+
+    const endDetails = traceStore.endSpan.mock.calls[0][3] as Record<string, unknown>
+    expect(endDetails).toMatchObject({ stop_reason: 'end_turn', assistant_text: `${assistantText} [REDACTED]` })
+    expect(String(endDetails.assistant_text)).toHaveLength(assistantText.length + 11)
+    expect(endDetails).not.toHaveProperty('output_summary')
+  })
+
+  it('does not persist an assistant text field for whitespace-only turns', () => {
+    const traceStore = {
+      startSpan: vi.fn(() => ({ span_id: 'llm-1' })),
+      endSpan: vi.fn(),
+    } as unknown as TraceStore
+
+    recordSubAgentTurn(traceStore, 'trace-1', {
+      turnNumber: 1,
+      assistantText: ' \n\t',
+      toolCalls: [],
+    })
+
+    expect(traceStore.endSpan.mock.calls[0][3]).not.toHaveProperty('assistant_text')
+  })
+})

--- a/crabot-agent/tests/workers/builtin-adapter.test.ts
+++ b/crabot-agent/tests/workers/builtin-adapter.test.ts
@@ -355,12 +355,13 @@ describe('BuiltinWorkerAdapter', () => {
   })
 
   it('llm span 分开投影模型调用与 assistant 文本，且 cursor 按 span 推进一次', async () => {
+    const longAssistantText = `先检查当前配置。\n${'这是完整的子 Agent 输出。'.repeat(40)}`
     const trace = {
       spans: [
         {
           type: 'llm_call',
           started_at: '2026-08-20T01:00:00.000Z',
-          details: { stop_reason: 'tool_use', assistant_text: '先检查当前配置。\n然后读取日志。', usage: { input_tokens: 10, output_tokens: 5 } },
+          details: { stop_reason: 'tool_use', assistant_text: longAssistantText, usage: { input_tokens: 10, output_tokens: 5 } },
         },
         {
           span_id: 'tool-1',
@@ -392,7 +393,7 @@ describe('BuiltinWorkerAdapter', () => {
 
     expect(first.events).toMatchObject([
       { kind: 'llm_call', summary: 'llm tool_use', source_offset: 0, detail: { stop_reason: 'tool_use' } },
-      { kind: 'message', role: 'assistant', summary: '先检查当前配置。 然后读取日志。', source_offset: 0, detail: { content: '先检查当前配置。\n然后读取日志。' } },
+      { kind: 'message', role: 'assistant', summary: longAssistantText.replace(/\s+/g, ' ').trim().slice(0, 200), source_offset: 0, detail: { content: longAssistantText } },
       { kind: 'tool_call', summary: 'shell', source_offset: 1, detail: { call_id: 'tool-1', name: 'shell', input: 'pwd' } },
       { kind: 'tool_result', source_offset: 1, detail: { call_id: 'tool-1', output: '/workspace' } },
       { kind: 'llm_call', summary: 'llm tool_use', source_offset: 2 },


### PR DESCRIPTION
## 问题

builtin 子 Agent 的 trace 写入将每轮 assistantText 固定截为 200 字符。详情页的 detail.content 因而也是 200 字符，长结果在句中截断。已复现：agent_75cee91057ce 的 RPC 返回 content_length=200，尾部为截图中的 U；同一任务的 Worker 输出保留完整报告。

## 修复

- 同步和异步 builtin 子 Agent 都在 llm_call span 保存脱敏后的完整 assistant_text。
- 子 Agent trace 投影读取 assistant_text；旧 trace 的 output_summary 继续可读，避免历史记录报错。
- 列表摘要仍限制为 200 字符；展开后展示完整 trace 正文。
- 将 UnifiedAgent 的既有 secret redaction 注入子 Agent trace 写入点。

## 验证

- TypeScript 编译：通过。
- 6 个定向测试文件，80 个用例通过。

## 历史记录

已截断的 trace 不回填：完整内容不属于 trace 的可验证持久化数据，不能从 output log 或父 Worker 推断重建。修复对新产生的 builtin 子 Agent 生效。