### PR TITLE
feat: restore user-level worker CLI installation

### DIFF
--- a/crabot-admin/src/index.ts
+++ b/crabot-admin/src/index.ts
@@ -2442,9 +2442,9 @@ export class AdminModule extends ModuleBase {
       }
 
       // Worker operation（§3.19.12.1）：per-action 端点。builtin 一律 400。
-      const workerActionMatch = pathname.match(/^\/api\/agent\/worker-implementations\/([^/]+)\/(verify)$/)
+      const workerActionMatch = pathname.match(/^\/api\/agent\/worker-implementations\/([^/]+)\/(install|verify)$/)
       if (workerActionMatch && req.method === 'POST') {
-        await this.handleWorkerActionApi(req, res, decodeURIComponent(workerActionMatch[1]), 'verify')
+        await this.handleWorkerActionApi(req, res, decodeURIComponent(workerActionMatch[1]), workerActionMatch[2] as 'install' | 'verify')
         return
       }
       const workerOpGetMatch = pathname.match(/^\/api\/agent\/worker-implementations\/([^/]+)\/operations\/([^/]+)$/)
@@ -9886,7 +9886,7 @@ export class AdminModule extends ModuleBase {
   private async admitWorkerOperation(
     res: ServerResponse,
     impl: string,
-    action: 'verify' | 'cancel',
+    action: 'install' | 'verify',
     expectedRevision: unknown,
   ): Promise<{ operationId: string; assertion: string; agentPort: number; revision: number; mode: string } | null> {
     if (impl === 'builtin') {
@@ -9907,7 +9907,7 @@ export class AdminModule extends ModuleBase {
       return null
     }
     const policy = desired.implementations[impl]
-    if (!policy.enabled) {
+    if (action !== 'install' && !policy.enabled) {
       sendJson(res, 409, { error: `${impl} is not enabled`, code: 'ADMIN_WORKER_IMPL_INVALID' })
       return null
     }
@@ -9916,7 +9916,7 @@ export class AdminModule extends ModuleBase {
       sendJson(res, 503, { error: 'Agent not available', code: 'ADMIN_CORE_AGENT_UNAVAILABLE' })
       return null
     }
-    const mode = policy.connection?.mode ?? 'native_account'
+    const mode = action === 'install' ? 'install' : (policy.connection?.mode ?? 'native_account')
     const operationId = generateId()
     const assertion = this.workerOperationAssertions.issue({
       action, operation_id: operationId, impl: impl as 'claude-code' | 'codex', mode, policy_revision: desired.revision,
@@ -9925,9 +9925,14 @@ export class AdminModule extends ModuleBase {
   }
 
   /** POST /:impl/install|verify（§3.19.12.1）：assertion 不出服务端。 */
-  private async handleWorkerActionApi(req: IncomingMessage, res: ServerResponse, impl: string, action: 'verify'): Promise<void> {
-    const body = await this.readJsonBody<{ expected_revision?: unknown }>(req)
-    const admission = await this.admitWorkerOperation(res, impl, action, body.expected_revision)
+  private async handleWorkerActionApi(req: IncomingMessage, res: ServerResponse, impl: string, action: 'install' | 'verify'): Promise<void> {
+    const body = await this.readJsonBody<unknown>(req)
+    if (!body || Array.isArray(body) || typeof body !== 'object' || Object.keys(body).some((key) => key !== 'expected_revision')) {
+      sendJson(res, 400, { error: 'only expected_revision is accepted', code: 'ADMIN_WORKER_IMPL_INVALID' })
+      return
+    }
+    const expectedRevision = (body as { expected_revision?: unknown }).expected_revision
+    const admission = await this.admitWorkerOperation(res, impl, action, expectedRevision)
     if (!admission) return
     try {
       const result = await this.rpcClient.callSensitive<
@@ -9998,7 +10003,20 @@ export class AdminModule extends ModuleBase {
     }
     // cancel 同样签发/核销 assertion（§3.19.12.1），绑定的是被操作的既有 operation_id。
     const policy = desired.implementations[impl]
-    const mode = policy.connection?.mode ?? 'native_account'
+    let mode: string = policy.connection?.mode ?? 'native_account'
+    try {
+      const target = await this.rpcClient.call<Record<string, unknown>, { operation?: { kind?: unknown } }>(
+        agentPort, 'get_worker_implementation_operation', { operation_id: operationId }, this.config.moduleId,
+      )
+      if (!target.operation) {
+        sendJson(res, 404, { error: 'operation not found', code: 'ADMIN_WORKER_OPERATION_NOT_FOUND' })
+        return
+      }
+      if (target.operation.kind === 'install') mode = 'install'
+    } catch (error) {
+      sendJson(res, 502, { error: (error instanceof Error ? error.message : String(error)).slice(0, 300) })
+      return
+    }
     const assertion = this.workerOperationAssertions.issue({
       action: 'cancel', operation_id: operationId, impl, mode, policy_revision: desired.revision,
     })

--- a/crabot-admin/src/worker-management-api.test.ts
+++ b/crabot-admin/src/worker-management-api.test.ts
@@ -52,6 +52,11 @@ describe('Worker implementation management API（P6-B §5）', () => {
       method: 'PUT', headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
       body: JSON.stringify(body),
     })
+  const startOperation = (impl: string, action: 'install' | 'verify', body: Record<string, unknown>) =>
+    fetch(`http://localhost:${TEST_WEB_PORT}/api/agent/worker-implementations/${impl}/${action}`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify(body),
+    })
 
   it('GET 返回协议合并 shape（config + agent_status + statuses），revision 1 安全初始配置', async () => {
     const res = await get()
@@ -140,5 +145,40 @@ describe('Worker implementation management API（P6-B §5）', () => {
       codex: { enabled: false },
     } } })
     expect(res.status).toBe(400)
+  })
+
+  it('disabled 且未配置的 CLI 也可安装，拒绝浏览器额外字段', async () => {
+    const current = await get()
+    const revision = ((await current.json()) as { config: { revision: number } }).config.revision
+    const calls: Array<{ method: string; params: Record<string, unknown> }> = []
+    ;(admin as unknown as { ensureAgentPort: () => Promise<number> }).ensureAgentPort = async () => 19999
+    ;(admin as unknown as { rpcClient: { callSensitive: (port: number, method: string, params: Record<string, unknown>) => Promise<unknown> } }).rpcClient.callSensitive = async (_port, method, params) => {
+      calls.push({ method, params })
+      const expected = params.expected as { action: 'install'; operation_id: string; impl: 'codex'; mode: 'install'; policy_revision: number }
+      await (admin as unknown as { workerOperationAssertions: { consume: (assertion: string, claims: typeof expected) => Promise<unknown> } })
+        .workerOperationAssertions.consume(params.assertion as string, expected)
+      return { operation_id: params.operation_id, state: 'completed', version: '0.1.2' }
+    }
+
+    const invalid = await startOperation('codex', 'install', {
+      expected_revision: revision,
+      package: 'attacker-controlled-package',
+      args: ['--unsafe'],
+    })
+    expect(invalid.status).toBe(400)
+    expect(calls).toHaveLength(0)
+
+    const res = await startOperation('codex', 'install', { expected_revision: revision })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ operation: expect.objectContaining({ state: 'completed', version: '0.1.2' }) })
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toMatchObject({
+      method: 'install_worker_implementation',
+      params: {
+        impl: 'codex',
+        expected: { action: 'install', impl: 'codex', mode: 'install', policy_revision: revision },
+      },
+    })
   })
 })

--- a/crabot-admin/src/worker-operation-assertions.test.ts
+++ b/crabot-admin/src/worker-operation-assertions.test.ts
@@ -23,6 +23,14 @@ describe('WorkerOperationAssertions（P6-B §9）', () => {
     await expect(assertions.consume(token, base)).rejects.toThrow(/already consumed/)
   })
 
+  it('install assertion 固定绑定 install mode，不能换成 verify', async () => {
+    const install = { action: 'install' as const, operation_id: 'op-install', impl: 'codex' as const, mode: 'install', policy_revision: 3 }
+    const token = assertions.issue(install)
+    await expect(assertions.consume(token, { ...install, action: 'verify' })).rejects.toThrow(/mismatch/)
+    await expect(assertions.consume(token, { ...install, mode: 'existing_host' })).rejects.toThrow(/mismatch/)
+    await expect(assertions.consume(token, install)).resolves.toMatchObject({ consumed: true })
+  })
+
   it('claim 不匹配（action/impl/revision/mode）逐个拒绝', async () => {
     await expect(assertions.consume(assertions.issue(base), { ...base, action: 'cancel' })).rejects.toThrow(/mismatch/)
     await expect(assertions.consume(assertions.issue(base), { ...base, impl: 'codex' })).rejects.toThrow(/mismatch/)

--- a/crabot-admin/src/worker-operation-assertions.ts
+++ b/crabot-admin/src/worker-operation-assertions.ts
@@ -19,7 +19,7 @@ const ISSUER = 'admin-web'
 const TTL_SECONDS = 120
 const CLAIM_KEYS = ['assertion_id', 'issuer_module_id', 'audience', 'purpose', 'action', 'operation_id', 'impl', 'mode', 'policy_revision', 'nonce', 'issued_at', 'expires_at'] as const
 
-export type WorkerOperationAction = 'verify' | 'cancel'
+export type WorkerOperationAction = 'install' | 'verify' | 'cancel'
 
 export interface WorkerOperationClaims {
   assertion_id: string
@@ -53,7 +53,7 @@ function validClaims(value: unknown): value is WorkerOperationClaims {
   const claims = value as Record<string, unknown>
   return typeof claims.assertion_id === 'string' && claims.assertion_id.length > 0
     && claims.issuer_module_id === ISSUER && claims.audience === AUDIENCE && claims.purpose === PURPOSE
-    && ['verify', 'cancel'].includes(claims.action as string)
+    && ['install', 'verify', 'cancel'].includes(claims.action as string)
     && typeof claims.operation_id === 'string' && claims.operation_id.length > 0
     && (claims.impl === 'claude-code' || claims.impl === 'codex')
     && typeof claims.mode === 'string' && claims.mode.length > 0

--- a/crabot-admin/web/src/pages/Workers/WorkersPage.test.tsx
+++ b/crabot-admin/web/src/pages/Workers/WorkersPage.test.tsx
@@ -7,6 +7,7 @@ vi.mock('../../services/worker-management', () => ({
   workerManagementService: {
     getAll: vi.fn(),
     putConfig: vi.fn(),
+    startInstall: vi.fn(),
     startVerify: vi.fn(),
   },
 }))
@@ -20,6 +21,7 @@ vi.mock('../../components/Layout/MainLayout', () => ({
 const svc = workerManagementService as unknown as {
   getAll: ReturnType<typeof vi.fn>
   putConfig: ReturnType<typeof vi.fn>
+  startInstall: ReturnType<typeof vi.fn>
   startVerify: ReturnType<typeof vi.fn>
 }
 
@@ -103,6 +105,39 @@ describe('WorkersPage（P6-B §13）', () => {
     expect(svc.startVerify).not.toHaveBeenCalled()
     fireEvent.click(screen.getByText('开始验证'))
     await waitFor(() => expect(svc.startVerify).toHaveBeenCalledWith('codex', 1))
+  })
+
+  it('用户级 CLI 缺失时 Claude Code 与 Codex 都在确认后发起安装', async () => {
+    const missing = {
+      ...readyStatus,
+      installed: false,
+      ready: false,
+      verification: 'never',
+    }
+    svc.getAll.mockResolvedValue(mergedResult(baseConfig, [
+      { ...missing, impl: 'claude-code' },
+      { ...missing, impl: 'codex' },
+    ]))
+    svc.startInstall.mockResolvedValue({ state: 'completed', version: '0.1.2' })
+    render(<WorkersPage />)
+    await waitFor(() => screen.getByRole('button', { name: '安装 Claude Code' }))
+    expect(screen.getByRole('button', { name: '安装 Codex' })).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: '安装 Codex' }))
+    expect(svc.startInstall).not.toHaveBeenCalled()
+    fireEvent.click(screen.getByRole('button', { name: '开始安装' }))
+    await waitFor(() => expect(svc.startInstall).toHaveBeenCalledWith('codex', 1))
+  })
+
+  it('安装失败后保留脱敏错误与重试入口', async () => {
+    const missing = { ...readyStatus, impl: 'codex', installed: false, ready: false, verification: 'never' }
+    svc.getAll.mockResolvedValue(mergedResult(baseConfig, [missing]))
+    svc.startInstall.mockRejectedValue(new Error('registry unavailable'))
+    render(<WorkersPage />)
+    await waitFor(() => screen.getByRole('button', { name: '安装 Codex' }))
+    fireEvent.click(screen.getByRole('button', { name: '安装 Codex' }))
+    fireEvent.click(screen.getByRole('button', { name: '开始安装' }))
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('安装失败: registry unavailable'))
+    expect(screen.getByRole('button', { name: '安装 Codex' })).toBeTruthy()
   })
 
   it('未验证的 ready 实现仍标记为可派用', async () => {

--- a/crabot-admin/web/src/pages/Workers/index.tsx
+++ b/crabot-admin/web/src/pages/Workers/index.tsx
@@ -118,6 +118,7 @@ export const WorkersPage: React.FC = () => {
   const [error, setError] = useState<string | null>(null)
   const [notice, setNotice] = useState<string | null>(null)
   const [dialog, setDialog] = useState<DialogState | null>(null)
+  const [installImpl, setInstallImpl] = useState<CLIWorkerImplId | null>(null)
   const [verifyImpl, setVerifyImpl] = useState<CLIWorkerImplId | null>(null)
   const [preferenceDrafts, setPreferenceDrafts] = useState<Record<CLIWorkerImplId, string>>({
     'claude-code': '',
@@ -239,6 +240,23 @@ export const WorkersPage: React.FC = () => {
     }
   }
 
+  const runInstallation = async (impl: CLIWorkerImplId) => {
+    if (!config) return
+    setBusy(true)
+    setError(null)
+    try {
+      const result = await workerManagementService.startInstall(impl, config.revision)
+      if (result.state === 'completed') setNotice(`已安装 ${IMPL_LABEL[impl]}${result.version ? ` · ${result.version}` : ''}`)
+      else setError(`安装未完成: ${result.detail ?? '未返回原因'}`)
+      await refresh()
+    } catch (err) {
+      setError(`安装失败: ${err instanceof Error ? err.message : String(err)}`)
+    } finally {
+      setBusy(false)
+      setInstallImpl(null)
+    }
+  }
+
   const savePreference = async (impl: CLIWorkerImplId, policy: WorkerImplementationPolicy) => {
     const value = preferenceDrafts[impl].trim()
     if (value === (policy.preference ?? '')) {
@@ -257,6 +275,7 @@ export const WorkersPage: React.FC = () => {
     const status = statusOf(impl)
     const policy = config?.implementations[impl]
     const isBuiltin = impl === 'builtin'
+    const installable = !isBuiltin && agentStatus === 'available' && !!status && !status.installed
     const readiness = readinessView(policy, status, agentStatus)
     const verification = verificationLabel(status)
     return (
@@ -311,6 +330,11 @@ export const WorkersPage: React.FC = () => {
                 })}>
                   配置连接
                 </Button>
+                {installable && (
+                  <Button size="sm" disabled={busy} onClick={() => setInstallImpl(impl as CLIWorkerImplId)}>
+                    {busy && installImpl === impl ? '安装中...' : `安装 ${IMPL_LABEL[impl]}`}
+                  </Button>
+                )}
                 {policy.enabled && (
                   <Button size="sm" disabled={busy} onClick={() => setVerifyImpl(impl as CLIWorkerImplId)}>验证</Button>
                 )}
@@ -370,6 +394,22 @@ export const WorkersPage: React.FC = () => {
           {IMPLEMENTATIONS.map(renderCard)}
         </section>
 
+        <Modal
+          open={installImpl !== null}
+          onClose={() => { if (!busy) setInstallImpl(null) }}
+          title={installImpl ? `安装 ${IMPL_LABEL[installImpl]}` : ''}
+          footer={(
+            <>
+              <Button variant="secondary" disabled={busy} onClick={() => setInstallImpl(null)}>取消</Button>
+              <Button
+                disabled={busy || installImpl === null}
+                onClick={() => { if (installImpl) void runInstallation(installImpl) }}
+              >{busy ? '安装中...' : '开始安装'}</Button>
+            </>
+          )}
+        >
+          <p>将为当前用户安装官方 {installImpl ? IMPL_LABEL[installImpl] : 'CLI'}。</p>
+        </Modal>
         <Modal
           open={dialog !== null}
           onClose={() => setDialog(null)}

--- a/crabot-admin/web/src/services/worker-management.ts
+++ b/crabot-admin/web/src/services/worker-management.ts
@@ -97,4 +97,11 @@ export const workerManagementService = {
     })
     return result.operation
   },
+
+  async startInstall(impl: CLIWorkerImplId, expectedRevision: number): Promise<WorkerOperationView> {
+    const result = await api.post<{ operation: WorkerOperationView }>(`/agent/worker-implementations/${impl}/install`, {
+      expected_revision: expectedRevision,
+    })
+    return result.operation
+  },
 }

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -75,7 +75,15 @@ import { selectWorkerImplementation } from './workers/implementation-selection.j
 import { admitWorkerConnection } from './workers/connections/admission.js'
 import { WorkerOperationStore } from './workers/operations/store.js'
 import { resolveUserLevelBinary } from './workers/cli-binary.js'
+import { UserLevelInstaller } from './workers/install/user-level-installer.js'
 import { GrandfatherBootstrapStore } from './workers/operations/bootstrap.js'
+
+function sanitizeWorkerOperationError(error: unknown): string {
+  return (error instanceof Error ? error.message : String(error))
+    .replace(/\/[^\s]+/g, '<path>')
+    .replace(/[A-Za-z0-9_-]{24,}/g, '<redacted>')
+    .slice(0, 200)
+}
 
 /** 新部署安全初始 worker implementation 配置（与 Admin store revision-1 语义一致）。 */
 const DEFAULT_SAFE_WORKER_IMPLS: import('./workers/types.js').WorkerImplementationRuntimeConfig = {
@@ -553,11 +561,25 @@ export class UnifiedAgent extends ModuleBase {
   private managerStack?: ManagerStack
   private activationRegistry!: ActivationRegistry
   private workerOperationStore!: WorkerOperationStore
+  private userLevelInstaller!: UserLevelInstaller
+  /** 覆盖 assertion 核销前的异步窗口；持久 store 负责跨重启的 active state。 */
+  private readonly workerOperationReservations = new Set<import('./workers/types.js').CLIWorkerImplId>()
   private grandfatherBootstrapStore!: GrandfatherBootstrapStore
   private managerEventPublisher?: AgentEventPublisher
   /** True after startup reconciliation has settled, even when it failed. */
   private managerReconciliationSettled = false
   private runtimeClosing = false
+
+  private reserveWorkerOperation(impl: import('./workers/types.js').CLIWorkerImplId): void {
+    if (this.workerOperationReservations.has(impl) || this.workerOperationStore.hasActiveFor(impl)) {
+      throw new Error(`another mutating operation is active for ${impl}`)
+    }
+    this.workerOperationReservations.add(impl)
+  }
+
+  private releaseWorkerOperation(impl: import('./workers/types.js').CLIWorkerImplId): void {
+    this.workerOperationReservations.delete(impl)
+  }
 
   // Trace 存储
   private traceStore: TraceStore
@@ -798,6 +820,7 @@ export class UnifiedAgent extends ModuleBase {
     this.managerEventPublisher = publishEvent
     this.activationRegistry = new ActivationRegistry(getAgentDataDir())
     this.workerOperationStore = new WorkerOperationStore(getAgentDataDir())
+    this.userLevelInstaller = new UserLevelInstaller({ dataRoot: getDataRootDir() })
     this.grandfatherBootstrapStore = new GrandfatherBootstrapStore(getAgentDataDir())
 
     this.managerStack = buildManagerStack({
@@ -1372,6 +1395,7 @@ export class UnifiedAgent extends ModuleBase {
     this.registerMethod('list_workers_admin', this.handleListWorkersAdmin.bind(this))
     this.registerMethod('list_managers_admin', this.handleListManagersAdmin.bind(this))
     this.registerMethod('list_worker_implementation_status', this.handleListWorkerImplementationStatus.bind(this))
+    this.registerMethod('install_worker_implementation', this.handleInstallWorkerImplementation.bind(this))
     this.registerMethod('verify_worker_implementation', this.handleVerifyWorkerImplementation.bind(this))
     this.registerMethod('get_worker_implementation_operation', this.handleGetWorkerOperation.bind(this))
     this.registerMethod('cancel_worker_implementation_operation', this.handleCancelWorkerOperation.bind(this))
@@ -3111,6 +3135,79 @@ export class UnifiedAgent extends ModuleBase {
     return result
   }
 
+  /** §3.19.12 install_worker_implementation：用户显式授权的固定用户级 CLI 安装。 */
+  private async handleInstallWorkerImplementation(params: {
+    impl?: unknown
+    operation_id?: unknown
+    assertion?: unknown
+    expected?: Record<string, unknown>
+  }): Promise<{ operation_id: string; state: string; version?: string; detail?: string }> {
+    const impl = params.impl
+    if (impl !== 'claude-code' && impl !== 'codex') throw new Error('impl must be claude-code or codex')
+    if (typeof params.operation_id !== 'string' || typeof params.assertion !== 'string' || !params.expected) {
+      throw new Error('operation_id, assertion and expected are required')
+    }
+    if (
+      params.expected.action !== 'install'
+      || params.expected.impl !== impl
+      || params.expected.operation_id !== params.operation_id
+      || params.expected.mode !== 'install'
+      || typeof params.expected.policy_revision !== 'number'
+    ) {
+      throw new Error('assertion binding mismatch with requested operation')
+    }
+    this.reserveWorkerOperation(impl)
+    const operationId = params.operation_id
+    const operation: import('./workers/operations/store.js').WorkerOperationRecord = {
+      operation_id: operationId, kind: 'install' as const, impl, state: 'accepted' as const,
+      created_at: new Date().toISOString(), updated_at: new Date().toISOString(),
+    }
+    try {
+      // 先持久 reservation，取消可以在探测、assertion 核销或 npm 启动前稳定地找到 operation。
+      await this.workerOperationStore.upsert(operation)
+      const status = await this.activationRegistry.refreshImpl(impl)
+      if (status.installed) throw new Error(`${impl} already has a working user-level installation`)
+      if (this.workerOperationStore.get(operationId)?.state === 'cancelled') {
+        return { operation_id: operationId, state: 'cancelled', detail: 'installation cancelled' }
+      }
+      const adminPort = this.adminPort
+      if (!adminPort) throw new Error('Admin module is unavailable for assertion consumption')
+      await this.rpcClient.callSensitive(
+        adminPort,
+        'consume_worker_operation_assertion',
+        { assertion: params.assertion, expected: params.expected },
+        this.config.moduleId,
+        { authorizationBearer: ConfigLoader.getRuntimeBearer() },
+      )
+      if (this.workerOperationStore.get(operationId)?.state === 'cancelled') {
+        return { operation_id: operationId, state: 'cancelled', detail: 'installation cancelled' }
+      }
+      await this.workerOperationStore.upsert({ ...operation, state: 'running' })
+      const result = await this.userLevelInstaller.install(impl)
+      await this.activationRegistry.refresh()
+      if (this.workerOperationStore.get(operationId)?.state === 'cancelled') {
+        return { operation_id: operationId, state: 'cancelled', detail: 'installation cancelled' }
+      }
+      await this.workerOperationStore.upsert({
+        ...operation, state: 'completed', detail: `installed ${result.version}`.slice(0, 200),
+      })
+      return { operation_id: operationId, state: 'completed', version: result.version }
+    } catch (error) {
+      const existing = this.workerOperationStore.get(operationId)
+      if (existing?.state === 'cancelled') {
+        return { operation_id: operationId, state: 'cancelled', detail: 'installation cancelled' }
+      }
+      const sanitized = sanitizeWorkerOperationError(error)
+      await this.workerOperationStore.upsert({
+        ...operation, state: 'failed',
+        detail: sanitized,
+      })
+      throw new Error(`install failed: ${sanitized}`)
+    } finally {
+      this.releaseWorkerOperation(impl)
+    }
+  }
+
   /**
    * §3.19.12 verify_worker_implementation：assertion 核销 → 隔离临时 workspace 最小真实
    * turn（不是 --version）。结果写 registry verification binding（passed/failed 都记）。
@@ -3129,48 +3226,50 @@ export class UnifiedAgent extends ModuleBase {
     if (params.expected.action !== 'verify' || params.expected.impl !== impl || params.expected.operation_id !== params.operation_id) {
       throw new Error('assertion binding mismatch with requested operation')
     }
-    if (this.workerOperationStore.hasActiveFor(impl)) {
-      throw new Error(`another mutating operation is active for ${impl}`)
-    }
-    const adminPort = this.adminPort
-    if (!adminPort) throw new Error('Admin module is unavailable for assertion consumption')
-    await this.rpcClient.callSensitive(
-      adminPort,
-      'consume_worker_operation_assertion',
-      { assertion: params.assertion, expected: params.expected },
-      this.config.moduleId,
-      { authorizationBearer: ConfigLoader.getRuntimeBearer() },
-    )
-    const operationId = params.operation_id
-    await this.workerOperationStore.upsert({
-      operation_id: operationId, kind: 'verify', impl, state: 'running',
-      created_at: new Date().toISOString(), updated_at: new Date().toISOString(),
-    })
-    const { runWorkerVerification, commitVerification } = await import('./workers/verify/verifier.js')
+    this.reserveWorkerOperation(impl)
     try {
-      const outcome = await runWorkerVerification(this.activationRegistry, impl, {
-        resolveAdminProviderConnection: (cliImpl, rev) => this.resolveWorkerConnectionAdminProvider(cliImpl, rev),
-        runtimeRoot: path.join(getAgentDataDir(), 'worker-impls', 'runtime'),
-        dataRoot: getDataRootDir(),
-      })
-      await commitVerification(this.activationRegistry, impl, outcome)
+      const adminPort = this.adminPort
+      if (!adminPort) throw new Error('Admin module is unavailable for assertion consumption')
+      await this.rpcClient.callSensitive(
+        adminPort,
+        'consume_worker_operation_assertion',
+        { assertion: params.assertion, expected: params.expected },
+        this.config.moduleId,
+        { authorizationBearer: ConfigLoader.getRuntimeBearer() },
+      )
+      const operationId = params.operation_id
       await this.workerOperationStore.upsert({
-        operation_id: operationId, kind: 'verify', impl,
-        state: outcome.passed ? 'completed' : 'failed',
-        detail: outcome.detail.slice(0, 200),
+        operation_id: operationId, kind: 'verify', impl, state: 'running',
         created_at: new Date().toISOString(), updated_at: new Date().toISOString(),
       })
-      return { operation_id: operationId, state: outcome.passed ? 'completed' : 'failed', passed: outcome.passed, detail: outcome.detail }
-    } catch (error) {
-      // 抛错必须收口 operation failed——否则卡在 running，互斥门把该 impl 后续
-      // install/verify 永久挡死（只能重启 Agent 恢复）。
-      const sanitized = (error instanceof Error ? error.message : String(error)).replace(/\/[^\s]+/g, '<path>').replace(/[A-Za-z0-9_-]{24,}/g, '<redacted>').slice(0, 200)
-      await this.workerOperationStore.upsert({
-        operation_id: operationId, kind: 'verify', impl, state: 'failed',
-        detail: sanitized,
-        created_at: new Date().toISOString(), updated_at: new Date().toISOString(),
-      })
-      throw new Error(`verify failed: ${sanitized}`)
+      const { runWorkerVerification, commitVerification } = await import('./workers/verify/verifier.js')
+      try {
+        const outcome = await runWorkerVerification(this.activationRegistry, impl, {
+          resolveAdminProviderConnection: (cliImpl, rev) => this.resolveWorkerConnectionAdminProvider(cliImpl, rev),
+          runtimeRoot: path.join(getAgentDataDir(), 'worker-impls', 'runtime'),
+          dataRoot: getDataRootDir(),
+        })
+        await commitVerification(this.activationRegistry, impl, outcome)
+        await this.workerOperationStore.upsert({
+          operation_id: operationId, kind: 'verify', impl,
+          state: outcome.passed ? 'completed' : 'failed',
+          detail: outcome.detail.slice(0, 200),
+          created_at: new Date().toISOString(), updated_at: new Date().toISOString(),
+        })
+        return { operation_id: operationId, state: outcome.passed ? 'completed' : 'failed', passed: outcome.passed, detail: outcome.detail }
+      } catch (error) {
+        // 抛错必须收口 operation failed——否则卡在 running，互斥门把该 impl 后续
+        // install/verify 永久挡死（只能重启 Agent 恢复）。
+        const sanitized = sanitizeWorkerOperationError(error)
+        await this.workerOperationStore.upsert({
+          operation_id: operationId, kind: 'verify', impl, state: 'failed',
+          detail: sanitized,
+          created_at: new Date().toISOString(), updated_at: new Date().toISOString(),
+        })
+        throw new Error(`verify failed: ${sanitized}`)
+      }
+    } finally {
+      this.releaseWorkerOperation(impl)
     }
   }
 
@@ -3328,6 +3427,7 @@ export class UnifiedAgent extends ModuleBase {
     const record = this.workerOperationStore.get(params.operation_id)
     if (!record) return { operation: null }
     if (record.state === 'running' || record.state === 'accepted') {
+      if (record.kind === 'install') this.userLevelInstaller.cancelInFlight(record.impl)
       await this.workerOperationStore.upsert({ ...record, state: 'cancelled' })
     }
     return { operation: this.workerOperationStore.get(params.operation_id) ?? null }

--- a/crabot-agent/src/workers/cli-binary.ts
+++ b/crabot-agent/src/workers/cli-binary.ts
@@ -19,15 +19,37 @@ export interface CliBinaryResolution {
   global_detected: boolean
 }
 
-export async function resolveUserLevelBinary(name: string, dataRoot: string): Promise<CliBinaryResolution> {
+export interface ResolveUserLevelBinaryOptions {
+  /** 测试可注入；生产始终使用当前运行用户 home。 */
+  homeDir?: string
+  /** 测试可注入；生产从 scrubbed child env 读取。 */
+  pathEnv?: string
+}
+
+export async function resolveUserLevelBinary(
+  name: string,
+  dataRoot: string,
+  options: ResolveUserLevelBinaryOptions = {},
+): Promise<CliBinaryResolution> {
   // 枚举 PATH 全部候选（command -v 只给首命中——全局排在前面时会把已存在的用户级
   // 安装整段漏掉并误报 global；必须看全）。
-  const pathEnv = buildScrubbedChildEnv().PATH ?? process.env.PATH ?? ''
-  const home = path.resolve(os.homedir())
-  const data = path.resolve(dataRoot)
+  const pathEnv = options.pathEnv ?? buildScrubbedChildEnv().PATH ?? process.env.PATH ?? ''
+  const resolvedHome = path.resolve(options.homeDir ?? os.homedir())
+  const resolvedData = path.resolve(dataRoot)
+  // macOS 的 /var -> /private/var alias 会让 realpath(candidate) 与 path.resolve($HOME)
+  // 前缀不同；比较时两端都尽量 realpath，缺失 data root 则保留解析后的目标。
+  const home = await fs.realpath(resolvedHome).catch(() => resolvedHome)
+  const data = await fs.realpath(resolvedData).catch(() => resolvedData)
   let globalFound = false
-  for (const dir of pathEnv.split(path.delimiter)) {
+  // Crabot 页面安装固定使用 npm 的标准用户级 prefix，但不得持久修改 PATH；把该 bin
+  // 目录作为显式候选，保证安装后 Worker 能解析到同一 binary。
+  const directories = [path.join(home, '.local', 'bin'), ...pathEnv.split(path.delimiter)]
+  const visited = new Set<string>()
+  for (const dir of directories) {
     if (!dir) continue
+    const normalizedDir = path.resolve(dir)
+    if (visited.has(normalizedDir)) continue
+    visited.add(normalizedDir)
     const candidate = path.join(dir, name)
     let real: string
     try {

--- a/crabot-agent/src/workers/install/user-level-installer.ts
+++ b/crabot-agent/src/workers/install/user-level-installer.ts
@@ -1,0 +1,173 @@
+/**
+ * 固定官方 package 的用户级 CLI 安装器。
+ *
+ * 这里不维护 Crabot private runtime：npm 只写当前用户 ~/.local，成功后仍以
+ * resolveUserLevelBinary() 作为唯一 binary 真相。
+ */
+
+import { execFile, type ExecFileOptions } from 'node:child_process'
+import { promises as fs } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { buildScrubbedChildEnv } from '../connections/secret-env.js'
+import { resolveUserLevelBinary, type CliBinaryResolution } from '../cli-binary.js'
+import type { CLIWorkerImplId } from '../types.js'
+
+export interface UserLevelInstallManifest {
+  readonly impl: CLIWorkerImplId
+  readonly packageId: string
+  readonly binaryName: string
+}
+
+const MANIFESTS: Record<CLIWorkerImplId, UserLevelInstallManifest> = {
+  'claude-code': {
+    impl: 'claude-code',
+    packageId: '@anthropic-ai/claude-code',
+    binaryName: 'claude',
+  },
+  codex: {
+    impl: 'codex',
+    packageId: '@openai/codex',
+    binaryName: 'codex',
+  },
+}
+
+export function userLevelInstallManifestFor(impl: CLIWorkerImplId): UserLevelInstallManifest {
+  return MANIFESTS[impl]
+}
+
+export function userLevelNpmPrefix(homeDir = os.homedir()): string {
+  return path.join(homeDir, '.local')
+}
+
+export interface InstallCommandOptions {
+  env: NodeJS.ProcessEnv
+  signal: AbortSignal
+  timeout: number
+  maxBuffer: number
+}
+
+export type InstallCommandRunner = (
+  file: string,
+  args: readonly string[],
+  options: InstallCommandOptions,
+) => Promise<{ stdout: string; stderr: string }>
+
+export interface UserLevelInstallerDeps {
+  dataRoot: string
+  homeDir?: string
+  resolveNpmCli?: (env: NodeJS.ProcessEnv) => Promise<string>
+  resolveBinary?: (name: string, dataRoot: string, options: { homeDir: string }) => Promise<CliBinaryResolution>
+  runCommand?: InstallCommandRunner
+}
+
+export interface UserLevelInstallResult {
+  impl: CLIWorkerImplId
+  version: string
+  binaryPath: string
+}
+
+const INSTALL_TIMEOUT_MS = 5 * 60_000
+const VERSION_TIMEOUT_MS = 30_000
+const NPM_REGISTRY = 'https://registry.npmjs.org/'
+
+export class UserLevelInstaller {
+  private readonly homeDir: string
+  private readonly resolveNpmCli: (env: NodeJS.ProcessEnv) => Promise<string>
+  private readonly resolveBinary: NonNullable<UserLevelInstallerDeps['resolveBinary']>
+  private readonly runCommand: InstallCommandRunner
+  private readonly inFlight = new Map<CLIWorkerImplId, AbortController>()
+
+  constructor(private readonly deps: UserLevelInstallerDeps) {
+    this.homeDir = path.resolve(deps.homeDir ?? os.homedir())
+    this.resolveNpmCli = deps.resolveNpmCli ?? resolveNpmCli
+    this.resolveBinary = deps.resolveBinary ?? ((name, dataRoot, options) => resolveUserLevelBinary(name, dataRoot, options))
+    this.runCommand = deps.runCommand ?? runCommand
+  }
+
+  async install(impl: CLIWorkerImplId): Promise<UserLevelInstallResult> {
+    if (this.inFlight.has(impl)) {
+      const error = new Error(`install already in flight for ${impl}`)
+      ;(error as Error & { code?: string }).code = 'WORKER_OPERATION_CONFLICT'
+      throw error
+    }
+    const controller = new AbortController()
+    this.inFlight.set(impl, controller)
+    try {
+      return await this.installInternal(impl, controller.signal)
+    } finally {
+      this.inFlight.delete(impl)
+    }
+  }
+
+  cancelInFlight(impl: CLIWorkerImplId): void {
+    this.inFlight.get(impl)?.abort()
+  }
+
+  private async installInternal(impl: CLIWorkerImplId, signal: AbortSignal): Promise<UserLevelInstallResult> {
+    const manifest = userLevelInstallManifestFor(impl)
+    const env = buildScrubbedChildEnv()
+    const npmCli = await this.resolveNpmCli(env)
+    const prefix = userLevelNpmPrefix(this.homeDir)
+    await this.runCommand(process.execPath, [
+      npmCli,
+      'install',
+      '--global',
+      '--prefix', prefix,
+      '--registry', NPM_REGISTRY,
+      manifest.packageId,
+    ], { env, signal, timeout: INSTALL_TIMEOUT_MS, maxBuffer: 4 * 1024 * 1024 })
+
+    const resolved = await this.resolveBinary(manifest.binaryName, this.deps.dataRoot, { homeDir: this.homeDir })
+    if (!resolved.binary) {
+      throw new Error(`installed ${manifest.impl} but no user-level binary was resolved`)
+    }
+    const version = await this.runCommand(resolved.binary, ['--version'], {
+      env,
+      signal,
+      timeout: VERSION_TIMEOUT_MS,
+      maxBuffer: 64 * 1024,
+    })
+    const value = version.stdout.trim()
+    if (!value) throw new Error(`installed ${manifest.impl} produced no version output`)
+    return { impl, version: value, binaryPath: resolved.binary }
+  }
+}
+
+async function resolveNpmCli(env: NodeJS.ProcessEnv): Promise<string> {
+  const pathEnv = env.PATH ?? ''
+  for (const dir of pathEnv.split(path.delimiter)) {
+    if (!dir) continue
+    const candidate = path.join(dir, 'npm')
+    try {
+      const stat = await fs.stat(candidate)
+      if (!stat.isFile()) continue
+      await fs.access(candidate, fs.constants.X_OK)
+      return await fs.realpath(candidate)
+    } catch {
+      // 继续枚举，避免 `command -v` 只看 PATH 首项。
+    }
+  }
+  throw new Error('npm not found on PATH')
+}
+
+const runCommand: InstallCommandRunner = (file, args, options) => new Promise((resolve, reject) => {
+  const execOptions: ExecFileOptions = {
+    env: options.env,
+    timeout: options.timeout,
+    maxBuffer: options.maxBuffer,
+    killSignal: 'SIGKILL',
+  }
+  let abort = () => {}
+  const child = execFile(file, [...args], execOptions, (error, stdout, stderr) => {
+    options.signal.removeEventListener('abort', abort)
+    if (error) {
+      reject(error)
+      return
+    }
+    resolve({ stdout: String(stdout), stderr: String(stderr) })
+  })
+  abort = () => child.kill('SIGKILL')
+  if (options.signal.aborted) abort()
+  else options.signal.addEventListener('abort', abort, { once: true })
+})

--- a/crabot-agent/tests/workers/user-level-installer.test.ts
+++ b/crabot-agent/tests/workers/user-level-installer.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest'
+import { promises as fs } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  UserLevelInstaller,
+  userLevelInstallManifestFor,
+  userLevelNpmPrefix,
+  type InstallCommandRunner,
+} from '../../src/workers/install/user-level-installer.js'
+import { resolveUserLevelBinary } from '../../src/workers/cli-binary.js'
+
+describe('UserLevelInstaller', () => {
+  it('Claude Code 与 Codex 都使用固定官方 package', () => {
+    expect(userLevelInstallManifestFor('claude-code')).toMatchObject({
+      packageId: '@anthropic-ai/claude-code', binaryName: 'claude',
+    })
+    expect(userLevelInstallManifestFor('codex')).toMatchObject({
+      packageId: '@openai/codex', binaryName: 'codex',
+    })
+  })
+
+  it('只向固定用户级 prefix 安装，并以 resolver + --version 收口', async () => {
+    const homeDir = path.join(os.tmpdir(), 'crabot-user-install-home')
+    const calls: Array<{ file: string; args: readonly string[] }> = []
+    const runner: InstallCommandRunner = async (file, args) => {
+      calls.push({ file, args })
+      return { stdout: args[0] === '--version' ? '0.1.2\n' : '', stderr: '' }
+    }
+    const installer = new UserLevelInstaller({
+      dataRoot: '/tmp/crabot-data',
+      homeDir,
+      resolveNpmCli: async () => '/fixed/npm-cli.js',
+      resolveBinary: async (name) => ({ binary: path.join(homeDir, '.local', 'bin', name), global_detected: false }),
+      runCommand: runner,
+    })
+
+    await expect(installer.install('codex')).resolves.toEqual({
+      impl: 'codex', version: '0.1.2', binaryPath: path.join(homeDir, '.local', 'bin', 'codex'),
+    })
+    expect(calls).toEqual([
+      {
+        file: process.execPath,
+        args: [
+          '/fixed/npm-cli.js', 'install', '--global', '--prefix', userLevelNpmPrefix(homeDir),
+          '--registry', 'https://registry.npmjs.org/', '@openai/codex',
+        ],
+      },
+      { file: path.join(homeDir, '.local', 'bin', 'codex'), args: ['--version'] },
+    ])
+  })
+
+  it('resolver 或 version probe 未通过时不报告安装成功', async () => {
+    const installer = new UserLevelInstaller({
+      dataRoot: '/tmp/crabot-data',
+      homeDir: '/tmp/crabot-user-install-home',
+      resolveNpmCli: async () => '/fixed/npm-cli.js',
+      resolveBinary: async () => ({ global_detected: true }),
+      runCommand: async () => ({ stdout: '', stderr: '' }),
+    })
+
+    await expect(installer.install('claude-code')).rejects.toThrow(/no user-level binary/)
+  })
+
+  it('同 implementation 的安装互斥，并可取消在途命令', async () => {
+    let started!: () => void
+    const commandStarted = new Promise<void>((resolve) => { started = resolve })
+    const runner: InstallCommandRunner = async (_file, _args, options) => {
+      started()
+      return new Promise((_, reject) => {
+        options.signal.addEventListener('abort', () => reject(new Error('cancelled')), { once: true })
+      })
+    }
+    const installer = new UserLevelInstaller({
+      dataRoot: '/tmp/crabot-data',
+      homeDir: '/tmp/crabot-user-install-home',
+      resolveNpmCli: async () => '/fixed/npm-cli.js',
+      resolveBinary: async () => ({ binary: '/tmp/crabot-user-install-home/.local/bin/codex', global_detected: false }),
+      runCommand: runner,
+    })
+
+    const first = installer.install('codex')
+    await commandStarted
+    await expect(installer.install('codex')).rejects.toThrow(/in flight/)
+    installer.cancelInFlight('codex')
+    await expect(first).rejects.toThrow('cancelled')
+  })
+})
+
+describe('resolveUserLevelBinary', () => {
+  it('无需修改 PATH 也会发现标准用户级 npm bin', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'crabot-user-level-resolver-'))
+    const homeDir = path.join(root, 'home')
+    const dataRoot = path.join(root, 'data')
+    const binDir = path.join(homeDir, '.local', 'bin')
+    const binary = path.join(binDir, 'fake-cli')
+    await fs.mkdir(binDir, { recursive: true })
+    await fs.writeFile(binary, '#!/bin/sh\necho fake\n', { mode: 0o755 })
+    try {
+      await expect(resolveUserLevelBinary('fake-cli', dataRoot, { homeDir, pathEnv: '/usr/bin' })).resolves.toEqual({
+        binary: await fs.realpath(binary),
+        global_detected: false,
+      })
+    } finally {
+      await fs.rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('仍拒绝位于 Crabot data 目录的伪用户级 binary', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'crabot-user-level-data-'))
+    const homeDir = path.join(root, 'home')
+    const dataRoot = path.join(homeDir, '.crabot', 'data')
+    const binDir = path.join(dataRoot, 'bin')
+    await fs.mkdir(binDir, { recursive: true })
+    await fs.writeFile(path.join(binDir, 'fake-cli'), '#!/bin/sh\necho fake\n', { mode: 0o755 })
+    try {
+      await expect(resolveUserLevelBinary('fake-cli', dataRoot, { homeDir, pathEnv: binDir })).resolves.toEqual({
+        global_detected: true,
+      })
+    } finally {
+      await fs.rm(root, { recursive: true, force: true })
+    }
+  })
+})

--- a/crabot-agent/tests/workers/worker-implementation-install-operation.test.ts
+++ b/crabot-agent/tests/workers/worker-implementation-install-operation.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { promises as fs } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { UnifiedAgent } from '../../src/unified-agent.js'
+import { WorkerOperationStore } from '../../src/workers/operations/store.js'
+import type { UnifiedAgentConfig } from '../../src/types.js'
+
+function config(): UnifiedAgentConfig {
+  return {
+    module_id: 'worker-install-test-agent', module_type: 'agent', version: '0.1.0', protocol_version: '3.6.0', port: 19999,
+    orchestration: { front_context_recent_messages_window_hours: 1, front_context_recent_messages_max_cap: 1, front_context_short_term_memory_window_hours: 1, front_context_short_term_memory_max_cap: 1, worker_recent_messages_window_hours: 1, worker_recent_messages_max_cap: 1, worker_short_term_memory_window_hours: 1, worker_short_term_memory_max_cap: 1, worker_long_term_memory_limit: 1, front_agent_timeout: 1, session_state_ttl: 1, worker_config_refresh_interval: 1, front_agent_queue_max_length: 1, front_agent_queue_timeout: 1 },
+    agent_config: { instance_id: 'worker-install-test-agent', roles: [], system_prompt: 'test', model_config: {} },
+  }
+}
+
+function installParams(operationId = 'op-install') {
+  return {
+    impl: 'codex' as const,
+    operation_id: operationId,
+    assertion: 'one-time-assertion',
+    expected: { action: 'install', operation_id: operationId, impl: 'codex', mode: 'install', policy_revision: 1 },
+  }
+}
+
+describe('UnifiedAgent install_worker_implementation', () => {
+  let dataDir: string
+  let agent: any
+  let operations: WorkerOperationStore
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'crabot-worker-install-operation-'))
+    operations = new WorkerOperationStore(dataDir)
+    await operations.load()
+    agent = new UnifiedAgent(config()) as any
+    agent.adminPort = 19998
+    agent.workerOperationStore = operations
+    agent.activationRegistry = {
+      refreshImpl: vi.fn().mockResolvedValue({ installed: false }),
+      refresh: vi.fn().mockResolvedValue(undefined),
+    }
+    agent.userLevelInstaller = {
+      install: vi.fn().mockResolvedValue({ impl: 'codex', version: '0.1.2', binaryPath: '/home/test/.local/bin/codex' }),
+      cancelInFlight: vi.fn(),
+    }
+    agent.rpcClient = { callSensitive: vi.fn().mockResolvedValue({ consumed: true }) }
+  })
+
+  afterEach(async () => {
+    await fs.rm(dataDir, { recursive: true, force: true })
+  })
+
+  it('核销精确 install assertion 后安装、刷新 activation registry 并收口 operation', async () => {
+    await expect(agent.handleInstallWorkerImplementation(installParams())).resolves.toEqual({
+      operation_id: 'op-install', state: 'completed', version: '0.1.2',
+    })
+
+    expect(agent.rpcClient.callSensitive).toHaveBeenCalledWith(
+      19998,
+      'consume_worker_operation_assertion',
+      { assertion: 'one-time-assertion', expected: installParams().expected },
+      'worker-install-test-agent',
+      expect.any(Object),
+    )
+    expect(agent.userLevelInstaller.install).toHaveBeenCalledWith('codex')
+    expect(agent.activationRegistry.refresh).toHaveBeenCalledOnce()
+    expect(operations.get('op-install')).toMatchObject({ kind: 'install', state: 'completed', impl: 'codex' })
+  })
+
+  it('在核销前拒绝 action、mode 或 revision 绑定错误', async () => {
+    const params = installParams()
+    params.expected.mode = 'existing_host'
+    await expect(agent.handleInstallWorkerImplementation(params)).rejects.toThrow(/assertion binding mismatch/)
+    expect(agent.rpcClient.callSensitive).not.toHaveBeenCalled()
+    expect(operations.get('op-install')).toBeUndefined()
+  })
+
+  it('在首次异步探测期间保留同 implementation 的互斥', async () => {
+    let releaseProbe!: (value: { installed: boolean }) => void
+    const probeStarted = new Promise<void>((resolve) => {
+      agent.activationRegistry.refreshImpl.mockImplementationOnce(() => {
+        resolve()
+        return new Promise((done) => { releaseProbe = done })
+      })
+    })
+
+    const first = agent.handleInstallWorkerImplementation(installParams('op-first'))
+    await probeStarted
+    await expect(agent.handleInstallWorkerImplementation(installParams('op-second'))).rejects.toThrow(/another mutating operation/)
+    releaseProbe({ installed: false })
+    await expect(first).resolves.toMatchObject({ operation_id: 'op-first', state: 'completed' })
+  })
+
+  it('取消在途安装后保持 cancelled，不被安装器失败改写', async () => {
+    let rejectInstall!: (error: Error) => void
+    const installStarted = new Promise<void>((resolve) => {
+      agent.userLevelInstaller.install.mockImplementationOnce(() => new Promise((_, reject) => {
+        rejectInstall = reject
+        resolve()
+      }))
+    })
+    agent.userLevelInstaller.cancelInFlight.mockImplementation(() => rejectInstall(new Error('cancelled')))
+
+    const running = agent.handleInstallWorkerImplementation(installParams())
+    await installStarted
+    const cancelled = await agent.handleCancelWorkerOperation({
+      operation_id: 'op-install',
+      assertion: 'cancel-assertion',
+      expected: { action: 'cancel', operation_id: 'op-install', impl: 'codex', mode: 'install', policy_revision: 1 },
+    })
+
+    expect(cancelled.operation).toMatchObject({ state: 'cancelled' })
+    await expect(running).resolves.toMatchObject({ state: 'cancelled' })
+    expect(operations.get('op-install')).toMatchObject({ state: 'cancelled' })
+  })
+})


### PR DESCRIPTION
## Summary

Restores the user-level managed-worker CLI installation flow at `/agents/workers`.

- Installs only the official CLI packages (`@anthropic-ai/claude-code` or `@openai/codex`) under `$HOME/.local`, then verifies resolution and `--version`.
- Restores the Admin assertion and REST boundary plus Agent operation, cancellation, and same-implementation concurrency handling.
- Adds the worker-page confirmation, failed-install retry, and tests for the end-to-end UI state.

## Validation

- `crabot-agent`: 21/21 tests
- `crabot-admin`: 13/13 tests
- `crabot-admin/web`: 9/9 tests
- Production builds: `crabot-agent`, `crabot-admin`, `crabot-admin/web`
- `git diff --check`