### PR TITLE
feat(agent): isolate local host tool execution

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -7,6 +7,18 @@
 
 ### P6 已完成；Manager -> Worker 输入与侧问可靠交付待 PR review
 
+### 本地宿主工具大文件安全与进程隔离：实施完成，待非 Draft PR review
+
+- 已确认设计与计划：`crabot-docs/superpowers/specs/2026-08-25-tool-process-isolation-design.md`、
+  `crabot-docs/superpowers/plans/2026-08-25-local-tool-execution-safety.md`。`Read`、`Write`、`Edit`、
+  `Glob`、`Grep`、`Skill` 均改为一调用一 Node helper；Bash 保持现有后台实体所有权，但统一受控启动、
+  有界输出、取消/超时和进程树回收。
+- `Read` 对超长单行只保留前缀并做固定上限的行长探测；`Edit` 为两遍流式匹配和同目录原子替换，保留
+  现有文件 mode 与最终 symlink 语义；`Write` 同样原子替换。父 Agent 仍独占权限、hooks、trace、cwd、
+  read dedup 与 BgEntity 台账，写入 helper 失联后统一报告“执行结果未知”。
+- 分支 `feat/local-tool-process-isolation` 已完成真实 Node helper / shell / `rg` 回归；实机 1.65 GiB
+  单行文件读取返回 51 KB 有界结果（helper 91 ms，无 `RangeError`），待创建非 Draft PR，不自行合并。
+
 ### 统一 Worker Runtime（v3.6.0）：实现完成，待设计型 PR review
 
 - 已确认 `crabot-docs/superpowers/specs/2026-08-20-unified-worker-runtime-design.md`，并同步

--- a/crabot-agent/src/engine/bg-entities/bg-shell.ts
+++ b/crabot-agent/src/engine/bg-entities/bg-shell.ts
@@ -5,7 +5,7 @@
  * Plan: crabot-docs/superpowers/plans/2026-05-01-long-running-agent-plan-2.md  Task 4
  */
 
-import { spawn, execFile, type SpawnOptions, type ChildProcess } from 'node:child_process'
+import { execFile, type SpawnOptions, type ChildProcess } from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
 import { randomBytes } from 'node:crypto'
@@ -16,6 +16,7 @@ import { resolveBashPath, BASH_NOT_FOUND_MESSAGE } from '../../utils/resolve-bas
 import type { BgEntityOwner, BgShellRegistryRecord } from './types.js'
 import type { BgEntityRegistry } from './registry.js'
 import { emitInstantSpan, type BgEntityTraceContext } from './trace.js'
+import { launchHostProcess, terminateHostProcessTree } from '../host-process.js'
 
 const execFileAsync = promisify(execFile)
 const INLINE_TEE_DRAIN_TIMEOUT_SECONDS = 0.5
@@ -34,10 +35,12 @@ function spawnBash(command: string, extraOpts: SpawnOptions = {}): ChildProcess 
   if (bashPath === null) {
     throw new Error(BASH_NOT_FOUND_MESSAGE)
   }
-  return spawn(bashPath, ['-c', command], {
-    detached: process.platform !== 'win32',
-    env: buildChildEnv(),
-    ...extraOpts,
+  return launchHostProcess({
+    argv: [bashPath, '-c', command],
+    ...(typeof extraOpts.cwd === 'string' ? { cwd: extraOpts.cwd } : {}),
+    ...(extraOpts.stdio ? { stdio: extraOpts.stdio } : {}),
+    env: buildChildEnv(extraOpts.env as Record<string, string | undefined> | undefined),
+    detached: extraOpts.detached ?? process.platform !== 'win32',
   })
 }
 
@@ -625,23 +628,5 @@ export async function readProcStartTime(pid: number): Promise<string> {
  * Both forms swallow "already dead" errors silently.
  */
 export function killShellTree(pid: number): void {
-  if (process.platform === 'win32') {
-    execFile('taskkill', ['/F', '/T', '/PID', String(pid)], { env: buildChildEnv() }, () => {
-      // Errors (process already exited, access denied for system-level pids)
-      // are non-actionable here — the registry update already marks status=killed.
-    })
-    return
-  }
-  try {
-    process.kill(-pid, 'SIGTERM')
-  } catch {
-    /* already dead */
-  }
-  setTimeout(() => {
-    try {
-      process.kill(-pid, 'SIGKILL')
-    } catch {
-      /* already dead */
-    }
-  }, 3000).unref()
+  terminateHostProcessTree(pid, 3000)
 }

--- a/crabot-agent/src/engine/host-process.ts
+++ b/crabot-agent/src/engine/host-process.ts
@@ -1,0 +1,298 @@
+import { execFile, spawn, type ChildProcess, type StdioOptions } from 'node:child_process'
+import { buildChildEnv } from '../core/runtime-env'
+
+export interface HostProcessLimits {
+  readonly timeoutMs: number
+  readonly stdoutBytes: number
+  readonly stderrBytes: number
+  readonly killGraceMs?: number
+}
+
+/**
+ * 本地宿主进程唯一的启动描述。将来 sandbox 只能在这里包装 argv/cwd/env，工具调用方
+ * 不应再自行拼 shell 或管理进程树。
+ */
+export interface HostProcessLaunchSpec {
+  readonly argv: readonly [string, ...string[]]
+  readonly cwd?: string
+  readonly env?: Record<string, string>
+  readonly stdio?: StdioOptions
+  readonly detached?: boolean
+  readonly policy?: Readonly<Record<string, never>>
+}
+
+export interface HostProcessRunSpec extends HostProcessLaunchSpec {
+  readonly stdin?: string
+  readonly limits: HostProcessLimits
+  readonly abortSignal?: AbortSignal
+  /** 供流式消费者使用；不会改变有限 collector 的超限判断。 */
+  readonly onStdoutChunk?: (chunk: Buffer) => void
+  readonly onStderrChunk?: (chunk: Buffer) => void
+  /** Glob 等调用只消费 chunk，不把所有 stdout 再存一份。 */
+  readonly captureStdout?: boolean
+}
+
+export type HostProcessOutcomeKind = 'exit' | 'spawn_error' | 'aborted' | 'timed_out' | 'output_limit'
+
+export interface HostProcessOutcome {
+  readonly kind: HostProcessOutcomeKind
+  readonly exitCode: number | null
+  readonly signal: NodeJS.Signals | null
+  readonly stdout: string
+  readonly stderr: string
+  readonly stdoutBytes: number
+  readonly stderrBytes: number
+  readonly message?: string
+}
+
+const DEFAULT_KILL_GRACE_MS = 500
+
+/**
+ * Start a command in its own POSIX process group. A no-op error listener is installed before
+ * returning so a later caller failure can never become an Agent-level uncaught `error` event.
+ */
+export function launchHostProcess(spec: HostProcessLaunchSpec): ChildProcess {
+  const [file, ...args] = spec.argv
+  const child = spawn(file, args, {
+    cwd: spec.cwd,
+    env: spec.env ?? buildChildEnv(),
+    stdio: spec.stdio ?? ['pipe', 'pipe', 'pipe'],
+    detached: spec.detached ?? process.platform !== 'win32',
+  })
+  child.on('error', () => {
+    // runHostProcess / the owning background entity adds its own settlement handler.
+  })
+  return child
+}
+
+/** Terminate the whole controlled process tree. Calling this repeatedly is harmless. */
+export function terminateHostProcessTree(pid: number, graceMs = DEFAULT_KILL_GRACE_MS): void {
+  if (process.platform === 'win32') {
+    execFile('taskkill', ['/F', '/T', '/PID', String(pid)], { env: buildChildEnv() }, () => {
+      // A process can race us to exit; there is no further local recovery action.
+    })
+    return
+  }
+
+  try {
+    process.kill(-pid, 'SIGTERM')
+  } catch {
+    return
+  }
+  setTimeout(() => {
+    try {
+      process.kill(-pid, 'SIGKILL')
+    } catch {
+      // Already reaped.
+    }
+  }, graceMs).unref()
+}
+
+function isProcessTreeAlive(pid: number): boolean {
+  if (process.platform === 'win32') return false
+  try {
+    process.kill(-pid, 0)
+    return true
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'EPERM'
+  }
+}
+
+async function waitForExit(isAlive: () => boolean, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (isAlive() && Date.now() < deadline) {
+    await new Promise<void>((resolve) => setTimeout(resolve, 25))
+  }
+}
+
+async function waitForProcessTreeExit(pid: number, timeoutMs: number): Promise<void> {
+  if (process.platform !== 'win32') await waitForExit(() => isProcessTreeAlive(pid), timeoutMs)
+}
+
+function isDirectProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'EPERM'
+  }
+}
+
+/** Terminate a controlled tree and wait until its process group has gone away. */
+async function terminateHostProcessTreeAndWait(pid: number, graceMs: number): Promise<void> {
+  if (process.platform === 'win32') {
+    await new Promise<void>((resolve) => {
+      execFile('taskkill', ['/F', '/T', '/PID', String(pid)], { env: buildChildEnv() }, () => resolve())
+    })
+    return
+  }
+
+  try {
+    process.kill(-pid, 'SIGTERM')
+  } catch {
+    return
+  }
+  await waitForProcessTreeExit(pid, graceMs)
+  if (!isProcessTreeAlive(pid)) return
+  try {
+    process.kill(-pid, 'SIGKILL')
+  } catch {
+    return
+  }
+  await waitForProcessTreeExit(pid, graceMs)
+}
+
+async function terminateDirectProcessAndWait(pid: number, graceMs: number): Promise<void> {
+  if (process.platform === 'win32') {
+    await new Promise<void>((resolve) => {
+      execFile('taskkill', ['/F', '/T', '/PID', String(pid)], { env: buildChildEnv() }, () => resolve())
+    })
+    return
+  }
+
+  try {
+    process.kill(pid, 'SIGTERM')
+  } catch {
+    return
+  }
+  await waitForExit(() => isDirectProcessAlive(pid), graceMs)
+  if (!isDirectProcessAlive(pid)) return
+  try {
+    process.kill(pid, 'SIGKILL')
+  } catch {
+    return
+  }
+  await waitForExit(() => isDirectProcessAlive(pid), graceMs)
+}
+
+interface BoundedCollector {
+  readonly push: (chunk: Buffer) => boolean
+  readonly finish: () => string
+  readonly bytes: () => number
+}
+
+function createCollector(limit: number, capture: boolean): BoundedCollector {
+  const chunks: Buffer[] = []
+  let retained = 0
+  let bytes = 0
+
+  return {
+    push(chunk): boolean {
+      bytes += chunk.length
+      if (!capture) return bytes <= limit
+      chunks.push(chunk)
+      retained += chunk.length
+      while (retained > limit && chunks.length > 0) {
+        const excess = retained - limit
+        const first = chunks[0]
+        if (first.length <= excess) {
+          chunks.shift()
+          retained -= first.length
+        } else {
+          chunks[0] = first.subarray(excess)
+          retained -= excess
+        }
+      }
+      return bytes <= limit
+    },
+    finish(): string {
+      if (!capture || retained === 0) return ''
+      const output = Buffer.concat(chunks, retained)
+      let start = 0
+      while (start < output.length && (output[start] & 0xc0) === 0x80) start++
+      return output.subarray(start).toString('utf8')
+    },
+    bytes(): number {
+      return bytes
+    },
+  }
+}
+
+/**
+ * Run a short-lived controlled process. Spawn failure is a structured outcome; normal non-zero
+ * exits remain `exit`, so each operation retains its own exit-code contract.
+ */
+export function runHostProcess(spec: HostProcessRunSpec): Promise<HostProcessOutcome> {
+  if (spec.abortSignal?.aborted) {
+    return Promise.resolve({
+      kind: 'aborted', exitCode: null, signal: null, stdout: '', stderr: '', stdoutBytes: 0, stderrBytes: 0,
+    })
+  }
+
+  return new Promise((resolve) => {
+    let child: ChildProcess
+    try {
+      child = launchHostProcess({ ...spec, stdio: ['pipe', 'pipe', 'pipe'] })
+    } catch (error) {
+      resolve({
+        kind: 'spawn_error', exitCode: null, signal: null, stdout: '', stderr: '', stdoutBytes: 0, stderrBytes: 0,
+        message: error instanceof Error ? error.message : String(error),
+      })
+      return
+    }
+
+    const stdout = createCollector(spec.limits.stdoutBytes, spec.captureStdout !== false)
+    const stderr = createCollector(spec.limits.stderrBytes, true)
+    const killGraceMs = spec.limits.killGraceMs ?? DEFAULT_KILL_GRACE_MS
+    let terminal: Exclude<HostProcessOutcomeKind, 'exit' | 'spawn_error'> | undefined
+    let termination: Promise<void> | undefined
+    let settled = false
+
+    const requestTermination = (reason: Exclude<HostProcessOutcomeKind, 'exit' | 'spawn_error'>): void => {
+      if (terminal !== undefined) return
+      terminal = reason
+      if (child.pid !== undefined) {
+        termination = spec.detached === false
+          ? terminateDirectProcessAndWait(child.pid, killGraceMs)
+          : terminateHostProcessTreeAndWait(child.pid, killGraceMs)
+      }
+    }
+
+    const onAbort = (): void => requestTermination('aborted')
+    if (spec.abortSignal) spec.abortSignal.addEventListener('abort', onAbort, { once: true })
+    const timer = setTimeout(() => requestTermination('timed_out'), spec.limits.timeoutMs)
+    timer.unref?.()
+
+    const finish = (outcome: HostProcessOutcome): void => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      if (spec.abortSignal) spec.abortSignal.removeEventListener('abort', onAbort)
+      resolve(outcome)
+    }
+
+    child.stdout?.on('data', (chunk: Buffer) => {
+      spec.onStdoutChunk?.(chunk)
+      if (!stdout.push(chunk)) requestTermination('output_limit')
+    })
+    child.stderr?.on('data', (chunk: Buffer) => {
+      spec.onStderrChunk?.(chunk)
+      if (!stderr.push(chunk)) requestTermination('output_limit')
+    })
+    child.on('error', (error) => {
+      finish({
+        kind: 'spawn_error', exitCode: null, signal: null, stdout: stdout.finish(), stderr: stderr.finish(),
+        stdoutBytes: stdout.bytes(), stderrBytes: stderr.bytes(),
+        message: error instanceof Error ? error.message : String(error),
+      })
+    })
+    child.on('close', (exitCode, signal) => {
+      void (async () => {
+        await termination
+        finish({
+          kind: terminal ?? 'exit', exitCode, signal,
+          stdout: stdout.finish(), stderr: stderr.finish(), stdoutBytes: stdout.bytes(), stderrBytes: stderr.bytes(),
+        })
+      })()
+    })
+
+    if (spec.stdin !== undefined) {
+      child.stdin?.on('error', () => {
+        // EPIPE means the child declined the request. Its close result determines the tool error.
+      })
+      child.stdin?.end(spec.stdin)
+    } else {
+      child.stdin?.end()
+    }
+  })
+}

--- a/crabot-agent/src/engine/local-host-tool-executor.ts
+++ b/crabot-agent/src/engine/local-host-tool-executor.ts
@@ -1,0 +1,134 @@
+import { existsSync } from 'node:fs'
+import path from 'node:path'
+import { randomUUID } from 'node:crypto'
+import type { ToolCallContext, ToolCallResult } from './types'
+import { runHostProcess } from './host-process'
+import { buildChildEnv } from '../core/runtime-env'
+import {
+  LOCAL_HOST_PROTOCOL_VERSION,
+  isReadObservation,
+  type LocalHostOperation,
+  type LocalHostResponse,
+  type ReadObservation,
+} from './tools/local-host-protocol'
+
+const HELPER_STDOUT_LIMIT = 32 * 1024 * 1024 // Read image transport keeps its existing 20 MiB contract.
+const HELPER_STDERR_LIMIT = 64 * 1024
+
+export interface LocalHostExecution {
+  readonly result: ToolCallResult
+  readonly effect?: ReadObservation
+}
+
+function helperLaunch(): { readonly argv: readonly [string, ...string[]]; readonly env?: Record<string, string> } {
+  const compiled = path.join(__dirname, 'tools', 'local-host-helper.js')
+  if (existsSync(compiled)) return { argv: [process.execPath, compiled] }
+
+  const source = path.join(__dirname, 'tools', 'local-host-helper.ts')
+  if (existsSync(source)) {
+    return {
+      argv: [process.execPath, '-r', require.resolve('ts-node/register/transpile-only'), source],
+      // The tool cwd is intentionally the caller's workspace, so ts-node must not discover an
+      // unrelated parent tsconfig from that directory.
+      env: buildChildEnv({
+        TS_NODE_PROJECT: path.resolve(__dirname, '..', '..', 'tsconfig.json'),
+        TS_NODE_EXPERIMENTAL_RESOLVER: 'true',
+      }),
+    }
+  }
+  throw new Error('local host helper entrypoint is missing')
+}
+
+function protocolFailure(operation: LocalHostOperation, message: string): LocalHostExecution {
+  if (operation === 'write' || operation === 'edit') return uncertainFailure(operation, `helper protocol error: ${message}`)
+  return { result: { output: `Local tool helper protocol error: ${message}`, isError: true } }
+}
+
+function uncertainFailure(operation: LocalHostOperation, reason: string): LocalHostExecution {
+  const sideEffect = operation === 'write' || operation === 'edit'
+  const prefix = sideEffect ? 'Local tool execution result is unknown' : 'Local tool execution failed'
+  return { result: { output: `${prefix} (${operation}): ${reason}`, isError: true } }
+}
+
+function parseResponse(stdout: string, callId: string, operation: LocalHostOperation): LocalHostExecution {
+  const lines = stdout.split(/\r?\n/).filter((line) => line.length > 0)
+  if (lines.length !== 1) return protocolFailure(operation, `expected one response line, received ${lines.length}`)
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(lines[0])
+  } catch {
+    return protocolFailure(operation, 'response is not valid JSON')
+  }
+  if (parsed === null || typeof parsed !== 'object') return protocolFailure(operation, 'response is not an object')
+  const response = parsed as Partial<LocalHostResponse>
+  if (response.protocol_version !== LOCAL_HOST_PROTOCOL_VERSION || response.call_id !== callId || response.ok !== true) {
+    return protocolFailure(operation, 'response version, call id, or status does not match the request')
+  }
+  if (response.result === undefined || typeof response.result.output !== 'string' || typeof response.result.isError !== 'boolean') {
+    return protocolFailure(operation, 'response result has an invalid shape')
+  }
+  if (response.result.images !== undefined && !Array.isArray(response.result.images)) {
+    return protocolFailure(operation, 'response images has an invalid shape')
+  }
+  if (operation === 'read' && response.effect !== undefined && !isReadObservation(response.effect)) {
+    return protocolFailure(operation, 'read observation has an invalid shape')
+  }
+  if (operation !== 'read' && response.effect !== undefined) return protocolFailure(operation, 'unexpected operation effect')
+
+  return {
+    result: response.result,
+    ...(isReadObservation(response.effect) ? { effect: response.effect } : {}),
+  }
+}
+
+/** Parent-side helper boundary. Permission/hooks/tracing remain outside this class. */
+export class LocalHostToolExecutor {
+  constructor(private readonly getHelperLaunch: () => ReturnType<typeof helperLaunch> = helperLaunch) {}
+
+  async execute(
+    operation: LocalHostOperation,
+    input: Record<string, unknown>,
+    cwd: string,
+    context: ToolCallContext,
+  ): Promise<LocalHostExecution> {
+    const callId = randomUUID()
+    let launch: { readonly argv: readonly [string, ...string[]]; readonly env?: Record<string, string> }
+    try {
+      launch = this.getHelperLaunch()
+    } catch (error) {
+      return uncertainFailure(operation, error instanceof Error ? error.message : String(error))
+    }
+
+    const request = JSON.stringify({
+      protocol_version: LOCAL_HOST_PROTOCOL_VERSION,
+      call_id: callId,
+      operation,
+      input,
+      context: { cwd, timezone: Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC' },
+    }) + '\n'
+    const outcome = await runHostProcess({
+      argv: launch.argv,
+      cwd,
+      ...(launch.env ? { env: launch.env } : {}),
+      stdin: request,
+      abortSignal: context.abortSignal,
+      limits: {
+        timeoutMs: operation === 'grep' || operation === 'glob' ? 70_000 : 130_000,
+        stdoutBytes: HELPER_STDOUT_LIMIT,
+        stderrBytes: HELPER_STDERR_LIMIT,
+      },
+    })
+
+    if (outcome.kind !== 'exit' || outcome.exitCode !== 0) {
+      const detail = outcome.kind === 'exit'
+        ? `helper exited with code ${outcome.exitCode ?? 'null'}${outcome.signal ? ` (${outcome.signal})` : ''}`
+        : outcome.kind
+      if (outcome.stderr) console.error(`[local-host-tool] ${operation} ${callId}: ${detail}: ${outcome.stderr}`)
+      return uncertainFailure(operation, detail)
+    }
+    return parseResponse(outcome.stdout, callId, operation)
+  }
+}
+
+export const localHostToolExecutor = new LocalHostToolExecutor()

--- a/crabot-agent/src/engine/tools/bash-tool.ts
+++ b/crabot-agent/src/engine/tools/bash-tool.ts
@@ -1,4 +1,3 @@
-import { execFile } from 'child_process'
 import { randomUUID } from 'crypto'
 import * as fsp from 'fs/promises'
 import * as path from 'path'
@@ -10,8 +9,8 @@ import type { BgEntityTraceContext } from '../bg-entities/trace.js'
 import { runShellWithGrace } from '../bg-entities/bg-shell.js'
 import { resolveBashPath, BASH_NOT_FOUND_MESSAGE } from '../../utils/resolve-bash-path.js'
 import { getAgentDataDir } from '../../core/data-paths.js'
-import { buildChildEnv } from '../../core/runtime-env.js'
 import { byteLength, truncateUtf8Tail } from '../byte-cap.js'
+import { runHostProcess } from '../host-process.js'
 
 /** 截断阈值（UTF-8 字节）：自截产物恒 < 编排层 100KB 兜底，尾部 hint 不会被再截掉。 */
 const MAX_OUTPUT_BYTES = 50000
@@ -156,11 +155,7 @@ async function formatBashToolExecutionError(
   return `${header}\n${truncated}`.trim()
 }
 
-function extractExitCode(error: { code?: string | number | null }): number | null {
-  return typeof error.code === 'number' ? error.code : null
-}
-
-function execCommand(
+async function execCommand(
   command: string,
   cwd: string,
   timeoutMs: number,
@@ -168,74 +163,32 @@ function execCommand(
 ): Promise<ToolCallResult> {
   const bashPath = resolveBashPath()
   if (bashPath === null) {
-    return Promise.resolve({ output: BASH_NOT_FOUND_MESSAGE, isError: true })
+    return { output: BASH_NOT_FOUND_MESSAGE, isError: true }
   }
-  return new Promise((resolve) => {
-    const child = execFile(
-      bashPath,
-      ['-c', command],
-      {
-        cwd,
-        timeout: timeoutMs,
-        signal,
-        maxBuffer: 10 * 1024 * 1024,
-        // 显式透传父进程 env，确保 CRABOT_TOKEN / DATA_DIR 等环境变量进入子 shell。
-        // execFile 默认 inherit 但显式传更稳定。
-        env: buildChildEnv(),
-      },
-      (error, stdout, stderr) => {
-        void (async () => {
-          const stdoutText = stdout ?? ''
-          const stderrText = stderr ?? ''
-
-          if (error !== null) {
-            // Timeout
-            if (error.killed && (error as NodeJS.ErrnoException).code === undefined) {
-              resolve({
-                output: `Command timed out after ${timeoutMs}ms`,
-                isError: true,
-              })
-              return
-            }
-
-            // Abort
-            if (error.name === 'AbortError' || signal?.aborted === true) {
-              resolve({
-                output: 'Command aborted',
-                isError: true,
-              })
-              return
-            }
-
-            const exitCode = extractExitCode(error)
-            if (exitCode === null) {
-              resolve({
-                output: await formatBashToolExecutionError(error.message, stdoutText, stderrText),
-                isError: true,
-              })
-              return
-            }
-
-            resolve({
-              output: await formatBashToolOutput(exitCode, stdoutText, stderrText),
-              isError: false,
-            })
-            return
-          }
-
-          resolve({
-            output: await formatBashToolOutput(0, stdoutText, stderrText),
-            isError: false,
-          })
-        })()
-      },
-    )
-
-    // If signal is already aborted, kill the child
-    if (signal?.aborted === true) {
-      child.kill()
-    }
+  const outcome = await runHostProcess({
+    argv: [bashPath, '-c', command],
+    cwd,
+    ...(signal ? { abortSignal: signal } : {}),
+    limits: { timeoutMs, stdoutBytes: 1024 * 1024, stderrBytes: 1024 * 1024 },
   })
+  if (outcome.kind === 'timed_out') return { output: `Command execution result is unknown: timed out after ${timeoutMs}ms`, isError: true }
+  if (outcome.kind === 'aborted') return { output: 'Command execution result is unknown: command aborted', isError: true }
+  if (outcome.kind === 'output_limit') {
+    return {
+      output: await formatBashToolExecutionError('command execution result is unknown: output exceeded the 1 MiB limit', outcome.stdout, outcome.stderr),
+      isError: true,
+    }
+  }
+  if (outcome.kind === 'spawn_error') {
+    return { output: await formatBashToolExecutionError(outcome.message ?? 'spawn failed', outcome.stdout, outcome.stderr), isError: true }
+  }
+  if (outcome.exitCode === null) {
+    return {
+      output: await formatBashToolExecutionError(`command execution result is unknown: terminated by ${outcome.signal ?? 'signal'}`, outcome.stdout, outcome.stderr),
+      isError: true,
+    }
+  }
+  return { output: await formatBashToolOutput(outcome.exitCode, outcome.stdout, outcome.stderr), isError: false }
 }
 
 /**
@@ -266,7 +219,7 @@ async function runForegroundWithGrace(
 
   switch (result.kind) {
     case 'aborted':
-      return { output: 'Command aborted', isError: true }
+      return { output: 'Command execution result is unknown: command aborted', isError: true }
     case 'spawn_error':
       return { output: result.message, isError: true }
     case 'background': {

--- a/crabot-agent/src/engine/tools/edit-tool.ts
+++ b/crabot-agent/src/engine/tools/edit-tool.ts
@@ -1,19 +1,7 @@
-import { readFileSync, writeFileSync } from 'fs'
 import { defineTool } from '../tool-framework'
+import { localHostToolExecutor } from '../local-host-tool-executor'
 import type { ToolDefinition } from '../types'
 import { resolvePath } from './utils'
-
-function findOccurrenceLines(content: string, search: string): ReadonlyArray<number> {
-  const collect = (from: number, acc: ReadonlyArray<number>): ReadonlyArray<number> => {
-    const index = content.indexOf(search, from)
-    if (index === -1) {
-      return acc
-    }
-    const lineNumber = content.substring(0, index).split('\n').length
-    return collect(index + search.length, [...acc, lineNumber])
-  }
-  return collect(0, [])
-}
 
 export function createEditTool(getCwd: () => string): ToolDefinition {
   return defineTool({
@@ -33,56 +21,13 @@ export function createEditTool(getCwd: () => string): ToolDefinition {
     },
     isReadOnly: false,
     permissionLevel: 'normal',
-    call: async (input) => {
-      const rawPath = input.file_path as string
-      const oldString = input.old_string as string
-      const newString = input.new_string as string
-      const replaceAll = input.replace_all === true
-
-      if (oldString === newString) {
-        return { output: 'old_string must differ from new_string', isError: true }
-      }
-
-      const filePath = resolvePath(getCwd(), rawPath)
-
-      let content: string
-      try {
-        content = readFileSync(filePath, 'utf-8')
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error)
-        return { output: `Failed to read file: ${message}`, isError: true }
-      }
-
-      const occurrenceLines = findOccurrenceLines(content, oldString)
-      const count = occurrenceLines.length
-
-      if (count === 0) {
-        return { output: 'old_string not found in file', isError: true }
-      }
-
-      if (count > 1 && !replaceAll) {
-        return {
-          output: `old_string found ${count} times, use replace_all or provide more context`,
-          isError: true,
-        }
-      }
-
-      const modified = replaceAll
-        ? content.split(oldString).join(newString)
-        : content.replace(oldString, newString)
-
-      try {
-        writeFileSync(filePath, modified, 'utf-8')
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error)
-        return { output: `Failed to write file: ${message}`, isError: true }
-      }
-
-      const lineList = occurrenceLines.join(', ')
-      return {
-        output: `Edited ${filePath}: replaced ${count} occurrence(s) at line(s) ${lineList}`,
-        isError: false,
-      }
+    async call(input, context) {
+      return (await localHostToolExecutor.execute('edit', {
+        file_path: resolvePath(getCwd(), input.file_path as string),
+        old_string: input.old_string,
+        new_string: input.new_string,
+        replace_all: input.replace_all === true,
+      }, getCwd(), context)).result
     },
   })
 }

--- a/crabot-agent/src/engine/tools/fda-check.ts
+++ b/crabot-agent/src/engine/tools/fda-check.ts
@@ -19,7 +19,7 @@ import { accessSync, constants } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { spawn } from 'node:child_process'
-import { buildChildEnv } from '../../core/runtime-env.js'
+import { buildChildEnv } from '../../core/runtime-env'
 
 /** 直达「完全磁盘访问权限」面板的深链（macOS 13+ System Settings 同样支持）。 */
 const FDA_SETTINGS_URL =

--- a/crabot-agent/src/engine/tools/glob-tool.ts
+++ b/crabot-agent/src/engine/tools/glob-tool.ts
@@ -1,18 +1,8 @@
-import { relative } from 'path'
 import { defineTool } from '../tool-framework'
+import { localHostToolExecutor } from '../local-host-tool-executor'
 import type { ToolDefinition } from '../types'
 import { resolvePath } from './utils'
-import { runRipgrep, DEFAULT_EXCLUDE_GLOBS, getProtectedExcludeGlobs } from './ripgrep-helper'
 
-const MAX_RESULTS = 200
-
-/**
- * Glob tool — 走 ripgrep `--files --glob`，把目录扫描丢给 rg 子进程。
- *
- * 旧实现用 fast-glob (纯 JS 全 walk)，跟旧 grep-tool 的 walkDirectory 同款隐患——
- * 大仓里可能把几万个文件路径全拉进 JS 堆。rg --files 把扫描留在 rg 进程内部，
- * 流式吐出来 + 应用层 MAX_RESULTS 截断，agent 堆只承担最多 200 个路径字符串。
- */
 export function createGlobTool(getCwd: () => string): ToolDefinition {
   return defineTool({
     name: 'Glob',
@@ -28,79 +18,12 @@ export function createGlobTool(getCwd: () => string): ToolDefinition {
     },
     isReadOnly: true,
     permissionLevel: 'safe',
-    call: async (input) => {
-      const pattern = input.pattern as string
-      const pathInput = input.path as string | undefined
-
-      const resolvedPath = pathInput ? resolvePath(getCwd(), pathInput) : getCwd()
-
-      const args: string[] = [
-        '--no-config',
-        '--no-ignore',
-        '--hidden',
-        '--files',
-        '--no-messages',
-      ]
-      // ripgrep glob 按顺序应用、**最后匹配胜出**：用户 pattern 必须在排除 glob
-      // 之前 push，否则像 `**/*` 这种广模式会把 !node_modules / !.git 反向包含进来。
-      args.push('--glob', pattern)
-      for (const g of DEFAULT_EXCLUDE_GLOBS) {
-        args.push('--glob', g)
-      }
-      // macOS 受保护目录（~/Library 等）：默认排除以避开 TCC 弹窗 / EPERM，
-      // 仅当用户开启 CRABOT_ENABLE_FDA 且真持有 FDA 时才放开。
-      for (const g of getProtectedExcludeGlobs(resolvedPath)) {
-        args.push('--glob', g)
-      }
-      args.push(resolvedPath)
-
-      let rg
-      try {
-        rg = await runRipgrep(args)
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err)
-        return { output: `Glob error: ${message}`, isError: true }
-      }
-
-      // 退出码 2 且没有任何 stdout = 真错误（路径不存在 / 参数非法）。
-      // 有 stdout 时（如某子目录权限被拒 EPERM，其它目录已列出文件）→ 当 partial
-      // 处理，不丢弃已搜到的结果（--no-messages 已抑制 stderr 噪音）。
-      if (rg.exitCode === 2 && !rg.stdout) {
-        const msg = (rg.stderr || '').trim() || 'ripgrep exited with code 2'
-        return { output: `Glob error: ${msg}`, isError: true }
-      }
-
-      // rg --files 输出绝对路径（因为传了绝对路径作为 search root），
-      // 旧契约（fast-glob）返回的是相对 resolvedPath 的路径，这里 normalize 回去。
-      const allEntries: string[] = []
-      for (const line of rg.stdout.split('\n')) {
-        if (!line) continue
-        const rel = relative(resolvedPath, line)
-        // relative 可能输出空字符串（path === resolvedPath，理论不会出现在 --files 输出里），跳过
-        if (rel) allEntries.push(rel)
-      }
-
-      const sorted = [...allEntries].sort()
-
-      // 超时提示：rg 被墙钟超时 kill，结果可能不完整，引导收窄范围。
-      const timeoutHint = rg.timedOut
-        ? `\n[搜索超时，结果可能不完整。请用更具体的 path 缩小目录、或收窄 pattern。]`
-        : ''
-
-      if (sorted.length === 0) {
-        if (rg.timedOut) {
-          return { output: `Glob 搜索超时，未在时限内列出任何文件。请缩小 path 或收窄 pattern。`, isError: false }
-        }
-        return { output: `No files found matching pattern: ${pattern}`, isError: false }
-      }
-
-      const truncated = sorted.length > MAX_RESULTS
-      const displayed = truncated ? sorted.slice(0, MAX_RESULTS) : sorted
-      const lines = truncated
-        ? [...displayed, `[...${sorted.length - MAX_RESULTS} more results truncated]`]
-        : displayed
-
-      return { output: lines.join('\n') + timeoutHint, isError: false }
+    async call(input, context) {
+      const cwd = getCwd()
+      return (await localHostToolExecutor.execute('glob', {
+        pattern: input.pattern,
+        path: typeof input.path === 'string' ? resolvePath(cwd, input.path) : cwd,
+      }, cwd, context)).result
     },
   })
 }

--- a/crabot-agent/src/engine/tools/grep-tool.ts
+++ b/crabot-agent/src/engine/tools/grep-tool.ts
@@ -1,63 +1,7 @@
-import { existsSync } from 'node:fs'
 import { defineTool } from '../tool-framework'
+import { localHostToolExecutor } from '../local-host-tool-executor'
 import type { ToolDefinition } from '../types'
-import { byteLength } from '../byte-cap'
 import { resolvePath } from './utils'
-import { runRipgrep, DEFAULT_EXCLUDE_GLOBS, getProtectedExcludeGlobs } from './ripgrep-helper'
-
-// Grep 输出按 UTF-8 字节累加上限。命中行内容很长（K 线 / CSV / JSON 单行数 KB～MB）时，
-// 仅靠 head_limit（行数）无法兜住——必须按字节裁剪，否则会塞 N MB 进 toolResult。
-// 必须低于编排层兜底（tool-orchestration 100KB）并留包装余量，否则自截 hint 会被兜底硬切替换。
-const MAX_OUTPUT_BYTES = 95_000
-
-// 单行最大列数。base64 / minified 单行能到几 MB，rg 默认无上限会把这种行
-// 完整吐出来撑爆 stdout 缓冲；500 列已经足够人读、超出截断显示 "[...]"。
-const MAX_COLUMNS = 500
-
-function truncationHint(): string {
-  return (
-    `\n[truncated: hit ${MAX_OUTPUT_BYTES} byte cap. ` +
-    `用 glob 收窄文件类型 / 用 path 缩小搜索目录 / 降低 head_limit / 改用 count 模式。]`
-  )
-}
-
-/**
- * 按 UTF-8 字节累加把 lines 收集成单字符串，超出 MAX_OUTPUT_BYTES / headLimit 即停。
- * 三个 output_mode formatter 共用，确保截断行为一致。
- */
-function joinWithCap(lines: Iterable<string>, headLimit: number): string {
-  const collected: string[] = []
-  let bytes = 0
-  let truncated = false
-
-  for (const line of lines) {
-    if (collected.length >= headLimit) break
-    const lineBytes = byteLength(line) + 1 // +1 for join newline
-    if (bytes + lineBytes > MAX_OUTPUT_BYTES) {
-      truncated = true
-      break
-    }
-    collected.push(line)
-    bytes += lineBytes
-  }
-
-  if (collected.length === 0) return 'No matches found'
-  const joined = collected.join('\n')
-  return truncated ? joined + truncationHint() : joined
-}
-
-/** rg stdout 按 \n 切，去掉空尾行。 */
-function* splitLines(stdout: string): Generator<string> {
-  if (!stdout) return
-  let start = 0
-  for (let i = 0; i < stdout.length; i++) {
-    if (stdout.charCodeAt(i) === 0x0a) {
-      if (i > start) yield stdout.slice(start, i)
-      start = i + 1
-    }
-  }
-  if (start < stdout.length) yield stdout.slice(start)
-}
 
 export function createGrepTool(getCwd: () => string): ToolDefinition {
   return defineTool({
@@ -67,145 +11,28 @@ export function createGrepTool(getCwd: () => string): ToolDefinition {
     inputSchema: {
       type: 'object',
       properties: {
-        pattern: {
-          type: 'string',
-          description: 'Regex pattern to search for',
-        },
-        path: {
-          type: 'string',
-          description: 'Directory to search in (default: working directory)',
-        },
-        glob: {
-          type: 'string',
-          description: 'File filter pattern (e.g., "*.ts")',
-        },
-        output_mode: {
-          type: 'string',
-          enum: ['files_with_matches', 'content', 'count'],
-          description: 'Output format (default: files_with_matches)',
-        },
-        context: {
-          type: 'number',
-          description: 'Lines of context before/after match (content mode only)',
-        },
-        head_limit: {
-          type: 'number',
-          description: 'Maximum number of results (default: 250)',
-        },
+        pattern: { type: 'string', description: 'Regex pattern to search for' },
+        path: { type: 'string', description: 'Directory to search in (default: working directory)' },
+        glob: { type: 'string', description: 'File filter pattern (e.g., "*.ts")' },
+        output_mode: { type: 'string', enum: ['files_with_matches', 'content', 'count'], description: 'Output format (default: files_with_matches)' },
+        context: { type: 'number', description: 'Lines of context before/after match (content mode only)' },
+        head_limit: { type: 'number', description: 'Maximum number of results (default: 250)' },
       },
       required: ['pattern'],
     },
     isReadOnly: true,
     permissionLevel: 'safe',
-    call: async (input) => {
-      const pattern = input.pattern as string
-      const searchPath = (input.path as string | undefined) ?? getCwd()
-      const glob = input.glob as string | undefined
-      const outputMode = (input.output_mode as string | undefined) ?? 'files_with_matches'
-      const contextLines = (input.context as number | undefined) ?? 0
-      const headLimit = (input.head_limit as number | undefined) ?? 250
-
-      // 前置 regex 校验：避免起进程再炸（rg 错误信息没 JS 友好，且工具
-      // 之前的契约就是返回 "Invalid regex pattern: ..."，不破坏调用方）。
-      try {
-        new RegExp(pattern)
-      } catch (err) {
-        return {
-          output: `Invalid regex pattern: ${err instanceof Error ? err.message : String(err)}`,
-          isError: true,
-        }
-      }
-
-      const args: string[] = [
-        '--no-config',
-        '--no-ignore',          // 测试 / 用户场景不一定有 .gitignore，保留显式排除（DEFAULT_EXCLUDE_GLOBS）
-        '--hidden',             // 默认搜 hidden 文件，VCS 目录靠下面 glob 排除
-        `--max-columns=${MAX_COLUMNS}`,
-        // 不加 --no-messages：runRipgrep 把 stdout/stderr 分开收集，给 agent 的结果只用
-        // rg.stdout，stderr 噪音本就不会污染输出；而 --no-messages 会把 code-2 时的真实
-        // 错误（哪个文件 / 什么原因）一并吞掉，导致事后无法定位。stderr 改为单独处理：
-        // 正常路径只记日志、不给 agent；判错路径用作错误原因（见下）。
-      ]
-
-      // ripgrep glob 顺序敏感：**最后匹配胜出**。用户 include glob（如 `*.ts`）
-      // 必须先 push，排除 glob（`!node_modules` 等）放在后面，否则用户的 include
-      // 会反向把 node_modules 等目录拉回来。
-      if (glob) {
-        args.push('--glob', glob)
-      }
-
-      for (const g of DEFAULT_EXCLUDE_GLOBS) {
-        args.push('--glob', g)
-      }
-      // macOS 受保护目录（~/Library / ~/Documents 等）：搜索根落在家目录或其祖先时
-      // 默认排除以避开 TCC 弹窗 / EPERM，仅当用户开启 CRABOT_ENABLE_FDA 且真持有 FDA 时放开。
-      const searchRoot = resolvePath(getCwd(), searchPath)
-      for (const g of getProtectedExcludeGlobs(searchRoot)) {
-        args.push('--glob', g)
-      }
-
-      // 模式输出参数
-      if (outputMode === 'files_with_matches') {
-        args.push('--files-with-matches')
-      } else if (outputMode === 'count') {
-        args.push('--count')      // path:N（每文件总匹配数）
-      } else {
-        // content mode: rg 默认输出 path:line:content，加 -n 显式带行号
-        args.push('--line-number', '--with-filename')
-        if (contextLines > 0) args.push('--context', String(contextLines))
-      }
-
-      // pattern 必须放 args 最后第二（path 在最后），且用 -e 防止以 `-` 起头被当成 flag
-      args.push('-e', pattern, searchPath)
-
-      let rg
-      try {
-        rg = await runRipgrep(args)
-      } catch (err) {
-        return {
-          output: `Grep error: ${err instanceof Error ? err.message : String(err)}`,
-          isError: true,
-        }
-      }
-
-      // stderr 拆开走：不混进给 agent 的结果，但有内容就记日志（agent 子进程 stderr
-      // 落到 data/logs/<agent>.log），便于事后排查到底是哪个文件 / 什么原因出的错。
-      const stderr = (rg.stderr || '').trim()
-      if (stderr) {
-        console.error(
-          `[Grep] ripgrep stderr (exit=${rg.exitCode}) pattern=${JSON.stringify(pattern)} path=${searchRoot}:\n${stderr}`,
-        )
-      }
-
-      // exitCode 1 = 无匹配（合法，对外 "No matches found"）。
-      // exitCode 2 = 错误，但仅当没有任何 stdout 时才判错（路径不存在 / 真正异常）；
-      // 有 stdout 时（如某子目录权限被拒 EPERM，其它文件已命中）→ 当 partial 返回，
-      // 不丢弃已搜到的结果（stderr 噪音上面已记日志、不进 agent 输出）。
-      if (rg.exitCode === 2 && !rg.stdout) {
-        // code-2 + 无 stdout = 真错误。stderr 此时带具体原因（如某文件 Permission denied），
-        // 直接当错误返回给 agent，使其能自纠、且 trace 可追溯。
-        const msg = stderr || 'ripgrep exited with code 2'
-        // code-2 最常见的真因：searchPath 相对当前 cwd 不存在（cwd 没锚定到项目）。
-        // 补结构化提示：点明解析后的绝对路径不存在 + 当前 cwd，引导用绝对路径或先 set_cwd。
-        const hint = !existsSync(searchRoot)
-          ? `\n搜索路径不存在：${searchRoot}（当前 cwd=${getCwd()}）。`
-            + `若目标在别的项目目录，请先用 set_cwd 锚定到该项目，或给 path 传绝对路径。`
-          : ''
-        return { output: `Grep error: ${msg}${hint}`, isError: true }
-      }
-
-      const output = joinWithCap(splitLines(rg.stdout), headLimit)
-
-      // rg stdout 自己被 ripgrep-helper 截断时，附带提示——优先于无字节超限的情况。
-      let finalOutput = rg.truncated && !rg.timedOut && !output.endsWith(truncationHint())
-        ? output + truncationHint()
-        : output
-      // 超时单独提示：墙钟超时被 kill，结果可能不完整，引导收窄范围。
-      if (rg.timedOut) {
-        finalOutput += `\n[搜索超时，结果可能不完整。请用更具体的 path / glob 缩小范围。]`
-      }
-
-      return { output: finalOutput, isError: false }
+    async call(input, context) {
+      const cwd = getCwd()
+      return (await localHostToolExecutor.execute('grep', {
+        pattern: input.pattern,
+        path: typeof input.path === 'string' ? resolvePath(cwd, input.path) : cwd,
+        glob: input.glob,
+        output_mode: input.output_mode,
+        context: input.context,
+        head_limit: input.head_limit,
+        calling_cwd: cwd,
+      }, cwd, context)).result
     },
   })
 }

--- a/crabot-agent/src/engine/tools/index.ts
+++ b/crabot-agent/src/engine/tools/index.ts
@@ -50,7 +50,7 @@ function buildBaseTools(
     createGrepTool(getCwd),
   ]
   if (availableSkills && availableSkills.length > 0) {
-    tools.push(createSkillTool({ availableSkills }))
+    tools.push(createSkillTool({ availableSkills, getCwd }))
   }
   if (bgToolDeps) {
     tools.push(createOutputTool(bgToolDeps))

--- a/crabot-agent/src/engine/tools/local-host-helper.ts
+++ b/crabot-agent/src/engine/tools/local-host-helper.ts
@@ -1,0 +1,36 @@
+import { createInterface } from 'node:readline'
+import { executeLocalHostOperation } from './local-host-operations'
+import { LOCAL_HOST_PROTOCOL_VERSION, isLocalHostOperation, type LocalHostRequest, type LocalHostResponse } from './local-host-protocol'
+
+function writeResponse(response: LocalHostResponse): void {
+  process.stdout.write(`${JSON.stringify(response)}\n`)
+}
+
+async function main(): Promise<void> {
+  const lines: string[] = []
+  const reader = createInterface({ input: process.stdin, crlfDelay: Infinity })
+  for await (const line of reader) {
+    lines.push(line)
+    if (lines.length > 1) throw new Error('expected exactly one request line')
+  }
+  if (lines.length !== 1) throw new Error('expected one request line')
+  const request = JSON.parse(lines[0]) as Partial<LocalHostRequest>
+  if (request.protocol_version !== LOCAL_HOST_PROTOCOL_VERSION || typeof request.call_id !== 'string' || !isLocalHostOperation(request.operation)
+    || request.input === null || typeof request.input !== 'object' || request.context === null || typeof request.context !== 'object'
+    || typeof request.context.cwd !== 'string' || typeof request.context.timezone !== 'string') {
+    throw new Error('invalid helper request')
+  }
+  const outcome = await executeLocalHostOperation(request.operation, request.input as Record<string, unknown>)
+  writeResponse({
+    protocol_version: LOCAL_HOST_PROTOCOL_VERSION,
+    call_id: request.call_id,
+    ok: true,
+    result: outcome.result,
+    ...(outcome.effect ? { effect: outcome.effect } : {}),
+  })
+}
+
+void main().catch((error: unknown) => {
+  process.stderr.write(`[local-host-helper] ${error instanceof Error ? error.message : String(error)}\n`)
+  process.exitCode = 1
+})

--- a/crabot-agent/src/engine/tools/local-host-helper.ts
+++ b/crabot-agent/src/engine/tools/local-host-helper.ts
@@ -1,10 +1,18 @@
 import { createInterface } from 'node:readline'
-import { executeLocalHostOperation } from './local-host-operations'
+import { cleanUpInFlightTemporaryFiles, executeLocalHostOperation } from './local-host-operations'
 import { LOCAL_HOST_PROTOCOL_VERSION, isLocalHostOperation, type LocalHostRequest, type LocalHostResponse } from './local-host-protocol'
 
 function writeResponse(response: LocalHostResponse): void {
   process.stdout.write(`${JSON.stringify(response)}\n`)
 }
+
+function exitAfterCleaningTemporaryFiles(exitCode: number): void {
+  cleanUpInFlightTemporaryFiles()
+  process.exit(exitCode)
+}
+
+process.once('SIGTERM', () => exitAfterCleaningTemporaryFiles(143))
+process.once('SIGINT', () => exitAfterCleaningTemporaryFiles(130))
 
 async function main(): Promise<void> {
   const lines: string[] = []

--- a/crabot-agent/src/engine/tools/local-host-operations.ts
+++ b/crabot-agent/src/engine/tools/local-host-operations.ts
@@ -134,6 +134,13 @@ async function readTextWindow(filePath: string, offset: number, limit: number): 
     reachedEof = false
     stream.destroy()
   }
+  const stopAtOversizedLine = (lineLength: LineLength): void => {
+    if (lines.length === 0) {
+      lines.push(oversizedLine(current, lineIndex + 1, String(lineIndex + 2).length, filePath, lineLength))
+    }
+    truncated = true
+    stop()
+  }
   const consumeLine = (): void => {
     if (lineIndex >= offset && lines.length < limit) {
       const normalized = current.endsWith('\r') ? current.slice(0, -1) : current
@@ -171,12 +178,10 @@ async function readTextWindow(filePath: string, offset: number, limit: number): 
             const nextLineBytes = oversizedLineBytes + partBytes
             const probeLimit = MAX_READ_OUTPUT_BYTES + MAX_LINE_LENGTH_PROBE_BYTES
             if ((newline !== -1 && nextLineBytes <= probeLimit) || nextLineBytes >= probeLimit) {
-              lines.push(oversizedLine(current, lineIndex + 1, String(lineIndex + 2).length, filePath, {
+              stopAtOversizedLine({
                 bytes: newline !== -1 && nextLineBytes <= probeLimit ? nextLineBytes : probeLimit,
                 exact: newline !== -1 && nextLineBytes <= probeLimit,
-              }))
-              truncated = true
-              stop()
+              })
               break
             }
             oversizedLineBytes = nextLineBytes
@@ -186,12 +191,10 @@ async function readTextWindow(filePath: string, offset: number, limit: number): 
             const observedLineBytes = currentBytes + partBytes
             const probeLimit = MAX_READ_OUTPUT_BYTES + MAX_LINE_LENGTH_PROBE_BYTES
             if (newline !== -1 || observedLineBytes >= probeLimit) {
-              lines.push(oversizedLine(current, lineIndex + 1, String(lineIndex + 2).length, filePath, {
+              stopAtOversizedLine({
                 bytes: newline !== -1 ? observedLineBytes : probeLimit,
                 exact: newline !== -1,
-              }))
-              truncated = true
-              stop()
+              })
               break
             }
             oversizedLineBytes = observedLineBytes
@@ -213,19 +216,17 @@ async function readTextWindow(filePath: string, offset: number, limit: number): 
           if (oversizedLineBytes !== undefined) {
             const probeLimit = MAX_READ_OUTPUT_BYTES + MAX_LINE_LENGTH_PROBE_BYTES
             const exactLineBytes = oversizedLineBytes + tailBytes
-            lines.push(oversizedLine(current, lineIndex + 1, String(lineIndex + 2).length, filePath, {
+            stopAtOversizedLine({
               bytes: Math.min(exactLineBytes, probeLimit),
               exact: exactLineBytes <= probeLimit,
-            }))
-            truncated = true
+            })
           } else if (currentBytes + tailBytes > MAX_READ_OUTPUT_BYTES) {
             const remaining = Math.max(0, MAX_READ_OUTPUT_BYTES - currentBytes)
             if (remaining > 0) current += truncateUtf8(tail, remaining)
-            lines.push(oversizedLine(current, lineIndex + 1, String(lineIndex + 2).length, filePath, {
+            stopAtOversizedLine({
               bytes: currentBytes + tailBytes,
               exact: true,
-            }))
-            truncated = true
+            })
           } else {
             current += tail
             currentBytes += tailBytes
@@ -524,7 +525,6 @@ async function globOperation(input: Record<string, unknown>): Promise<LocalOpera
   }
   const outcome = await runHostProcess({
     argv: [rgPath, '--max-filesize=10M', '--threads=1', ...args],
-    cwd: searchRoot,
     // The outer helper owns the process group and must reap rg if it times out or dies.
     detached: false,
     captureStdout: false,
@@ -605,7 +605,7 @@ async function grepOperation(input: Record<string, unknown>): Promise<LocalOpera
   args.push('-e', pattern, searchRoot)
   let result
   try {
-    result = await runRipgrep(args, { cwd: searchRoot, maxBytes: 2 * 1024 * 1024, timeoutMs: 60_000, detached: false })
+    result = await runRipgrep(args, { maxBytes: 2 * 1024 * 1024, timeoutMs: 60_000, detached: false })
   } catch (error) {
     return { result: { output: `Grep error: ${error instanceof Error ? error.message : String(error)}`, isError: true } }
   }

--- a/crabot-agent/src/engine/tools/local-host-operations.ts
+++ b/crabot-agent/src/engine/tools/local-host-operations.ts
@@ -234,7 +234,9 @@ async function readTextWindow(filePath: string, offset: number, limit: number): 
         }
       }
       if (!truncated && oversizedLineBytes !== undefined) {
-        lines.push(oversizedLine(current, lineIndex + 1, String(lineIndex + 2).length, filePath, { bytes: oversizedLineBytes, exact: true }))
+        if (lines.length === 0) {
+          lines.push(oversizedLine(current, lineIndex + 1, String(lineIndex + 2).length, filePath, { bytes: oversizedLineBytes, exact: true }))
+        }
         truncated = true
       }
       if (!truncated && current.length > 0 && lineIndex >= offset && lines.length < limit) consumeLine()

--- a/crabot-agent/src/engine/tools/local-host-operations.ts
+++ b/crabot-agent/src/engine/tools/local-host-operations.ts
@@ -23,6 +23,7 @@ const MAX_SKILL_DEPTH = 8
 const MAX_GLOB_RESULTS = 200
 const MAX_GREP_OUTPUT_BYTES = 95_000
 const MAX_GREP_COLUMNS = 500
+const MAX_GREP_DIAGNOSTIC_BYTES = 8 * 1024
 
 const IMAGE_EXTENSIONS = new Set(['jpg', 'jpeg', 'png', 'gif', 'webp'])
 const inFlightTemporaryFiles = new Set<string>()
@@ -387,8 +388,10 @@ async function scanOccurrences(filePath: string, oldString: string, stopAfterTwo
           if (lines.length < 200) lines.push(lineBase + countNewlines(content.slice(0, found)))
           nextAllowed = absolute + oldString.length
           if (stopAfterTwo && count > 1) return
+          index = found + Math.max(1, oldString.length)
+        } else {
+          index = Math.max(found + 1, nextAllowed - globalBase)
         }
-        index = found + Math.max(1, oldString.length)
       }
     }
     lineBase += countNewlines(content.slice(0, advance))
@@ -556,6 +559,15 @@ function grepTruncationHint(): string {
   return `\n[truncated: hit ${MAX_GREP_OUTPUT_BYTES} byte cap. 用 glob 收窄文件类型 / 用 path 缩小搜索目录 / 降低 head_limit / 改用 count 模式。]`
 }
 
+function logGrepStderr(stderr: string, exitCode: number, pattern: string, searchRoot: string): void {
+  const message = `[Grep] ripgrep stderr (exit=${exitCode}) pattern=${JSON.stringify(pattern)} path=${searchRoot}:\n${stderr}`
+  const marker = '\n[...diagnostic truncated]'
+  const output = byteLength(message) > MAX_GREP_DIAGNOSTIC_BYTES
+    ? `${truncateUtf8(message, MAX_GREP_DIAGNOSTIC_BYTES - byteLength(marker))}${marker}`
+    : message
+  console.error(output)
+}
+
 function formatGrepOutput(stdout: string, headLimit: number): string {
   const lines = stdout.split('\n').filter(Boolean)
   const selected: string[] = []
@@ -612,7 +624,7 @@ async function grepOperation(input: Record<string, unknown>): Promise<LocalOpera
     return { result: { output: `Grep error: ${error instanceof Error ? error.message : String(error)}`, isError: true } }
   }
   const stderr = result.stderr.trim()
-  if (stderr) console.error(`[Grep] ripgrep stderr (exit=${result.exitCode}) pattern=${JSON.stringify(pattern)} path=${searchRoot}:\n${stderr}`)
+  if (stderr) logGrepStderr(stderr, result.exitCode, pattern, searchRoot)
   if (result.exitCode === 2 && !result.stdout) {
     return { result: { output: `Grep error: ${stderr || 'ripgrep exited with code 2'}`, isError: true } }
   }

--- a/crabot-agent/src/engine/tools/local-host-operations.ts
+++ b/crabot-agent/src/engine/tools/local-host-operations.ts
@@ -1,4 +1,4 @@
-import { createReadStream, existsSync } from 'node:fs'
+import { createReadStream, existsSync, unlinkSync } from 'node:fs'
 import * as fs from 'node:fs/promises'
 import path from 'node:path'
 import { randomUUID } from 'node:crypto'
@@ -25,6 +25,27 @@ const MAX_GREP_OUTPUT_BYTES = 95_000
 const MAX_GREP_COLUMNS = 500
 
 const IMAGE_EXTENSIONS = new Set(['jpg', 'jpeg', 'png', 'gif', 'webp'])
+const inFlightTemporaryFiles = new Set<string>()
+
+/** The helper calls this synchronously before exiting from SIGTERM/SIGINT. */
+export function cleanUpInFlightTemporaryFiles(): void {
+  for (const filePath of inFlightTemporaryFiles) {
+    try {
+      unlinkSync(filePath)
+    } catch {
+      // The temporary file may not have been created yet or was already renamed.
+    }
+  }
+  inFlightTemporaryFiles.clear()
+}
+
+function trackTemporaryFile(filePath: string): void {
+  inFlightTemporaryFiles.add(filePath)
+}
+
+function releaseTemporaryFile(filePath: string): void {
+  inFlightTemporaryFiles.delete(filePath)
+}
 
 export interface LocalOperationResult {
   readonly result: ToolCallResult
@@ -294,6 +315,7 @@ async function atomicWrite(filePath: string, content: string): Promise<void> {
       throw error
     })
   const tempPath = path.join(path.dirname(targetPath), `.${path.basename(targetPath)}.${randomUUID()}.tmp`)
+  trackTemporaryFile(tempPath)
   try {
     const handle = await fs.open(tempPath, 'wx')
     try {
@@ -307,6 +329,8 @@ async function atomicWrite(filePath: string, content: string): Promise<void> {
   } catch (error) {
     await fs.unlink(tempPath).catch(() => undefined)
     throw error
+  } finally {
+    releaseTemporaryFile(tempPath)
   }
 }
 
@@ -389,6 +413,7 @@ async function transformFile(filePath: string, oldString: string, newString: str
   const decoder = new StringDecoder('utf8')
   let carry = ''
   const carryLength = Math.max(0, oldString.length - 1)
+  trackTemporaryFile(tempPath)
   try {
     const handle = await fs.open(tempPath, 'wx')
     try {
@@ -422,6 +447,7 @@ async function transformFile(filePath: string, oldString: string, newString: str
     await fs.unlink(tempPath).catch(() => undefined)
     throw error
   } finally {
+    releaseTemporaryFile(tempPath)
     stream.destroy()
   }
 }
@@ -631,7 +657,8 @@ async function enumerateResources(skillDir: string): Promise<ReadonlyArray<strin
     try {
       const dir = await fs.opendir(directory)
       for await (const entry of dir) {
-        if (result.length >= MAX_SKILL_RESOURCES || entry.name.startsWith('.')) break
+        if (result.length >= MAX_SKILL_RESOURCES) break
+        if (entry.name.startsWith('.')) continue
         const fullPath = path.join(directory, entry.name)
         if (entry.isDirectory()) await walk(fullPath, depth + 1)
         else if (entry.name !== 'SKILL.md' && entry.name !== 'skill.md') result.push(relative(skillDir, fullPath))

--- a/crabot-agent/src/engine/tools/local-host-operations.ts
+++ b/crabot-agent/src/engine/tools/local-host-operations.ts
@@ -1,0 +1,694 @@
+import { createReadStream, existsSync } from 'node:fs'
+import * as fs from 'node:fs/promises'
+import path from 'node:path'
+import { randomUUID } from 'node:crypto'
+import { StringDecoder } from 'node:string_decoder'
+import { relative } from 'node:path'
+import { rgPath } from '@vscode/ripgrep'
+import { compressImage } from '../image-utils'
+import { inferMediaType } from '../../agent/media-resolver'
+import { truncateUtf8, byteLength } from '../byte-cap'
+import { FILE_UNCHANGED_STUB } from './file-read-state'
+import type { ToolCallResult } from '../types'
+import type { LocalHostOperation, ReadObservation } from './local-host-protocol'
+
+const MAX_READ_OUTPUT_BYTES = 50 * 1024
+const MAX_LINE_LENGTH_PROBE_BYTES = 256 * 1024
+const DEFAULT_READ_LIMIT = 2000
+const BINARY_CHECK_SIZE = 8192
+const MAX_IMAGE_SIZE = 20 * 1024 * 1024
+const MAX_SKILL_BYTES = 256 * 1024
+const MAX_SKILL_RESOURCES = 500
+const MAX_SKILL_DEPTH = 8
+const MAX_GLOB_RESULTS = 200
+const MAX_GREP_OUTPUT_BYTES = 95_000
+const MAX_GREP_COLUMNS = 500
+
+const IMAGE_EXTENSIONS = new Set(['jpg', 'jpeg', 'png', 'gif', 'webp'])
+
+export interface LocalOperationResult {
+  readonly result: ToolCallResult
+  readonly effect?: ReadObservation
+}
+
+function asString(input: Record<string, unknown>, key: string): string | undefined {
+  const value = input[key]
+  return typeof value === 'string' ? value : undefined
+}
+
+function asFiniteInteger(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? Math.max(0, Math.floor(value)) : fallback
+}
+
+function isImageFile(filePath: string): boolean {
+  return IMAGE_EXTENSIONS.has(path.extname(filePath).slice(1).toLowerCase())
+}
+
+function containsNullBytes(buffer: Buffer): boolean {
+  const length = Math.min(buffer.length, BINARY_CHECK_SIZE)
+  for (let index = 0; index < length; index++) {
+    if (buffer[index] === 0) return true
+  }
+  return false
+}
+
+async function readHeadBytes(filePath: string, size: number): Promise<Buffer> {
+  const handle = await fs.open(filePath, 'r')
+  try {
+    const buffer = Buffer.alloc(size)
+    const { bytesRead } = await handle.read(buffer, 0, size, 0)
+    return buffer.subarray(0, bytesRead)
+  } finally {
+    await handle.close()
+  }
+}
+
+function formatLineNumber(line: number, width: number): string {
+  return String(line).padStart(width, ' ')
+}
+
+interface LineLength {
+  readonly bytes: number
+  readonly exact: boolean
+}
+
+function oversizedLine(line: string, lineNumber: number, width: number, filePath: string, lineLength: LineLength): string {
+  const shown = truncateUtf8(line, MAX_READ_OUTPUT_BYTES - 256)
+  const shownBytes = byteLength(shown)
+  const total = lineLength.exact
+    ? `a ${lineLength.bytes}-byte line`
+    : `at least ${lineLength.bytes} bytes of the line before its end`
+  return `${formatLineNumber(lineNumber, width)}\t${shown}` +
+    `[...line truncated: showing first ${shownBytes} bytes of ${total}. ` +
+    `Use Bash: sed -n '${lineNumber}p' '${filePath}' | tail -c +${shownBytes + 1} | head -c ${MAX_READ_OUTPUT_BYTES} to read more.]`
+}
+
+function readMarker(fileSize: number): string {
+  return `\n[...truncated: output capped at ${MAX_READ_OUTPUT_BYTES} bytes (file is ${fileSize} bytes total). Use offset to continue reading.]`
+}
+
+interface StreamedLines {
+  readonly lines: ReadonlyArray<string>
+  readonly truncated: boolean
+  readonly reachedEof: boolean
+}
+
+/** Reads only a bounded view. It never holds an arbitrary physical line in memory. */
+async function readTextWindow(filePath: string, offset: number, limit: number): Promise<StreamedLines> {
+  if (limit === 0) return { lines: [], truncated: false, reachedEof: false }
+  const decoder = new StringDecoder('utf8')
+  const stream = createReadStream(filePath, { highWaterMark: 64 * 1024 })
+  const lines: string[] = []
+  let current = ''
+  let currentBytes = 0
+  let oversizedLineBytes: number | undefined
+  let lineIndex = 0
+  let outputBytes = 0
+  let truncated = false
+  let reachedEof = true
+  let stopped = false
+
+  const stop = (): void => {
+    stopped = true
+    reachedEof = false
+    stream.destroy()
+  }
+  const consumeLine = (): void => {
+    if (lineIndex >= offset && lines.length < limit) {
+      const normalized = current.endsWith('\r') ? current.slice(0, -1) : current
+      const candidateBytes = byteLength(normalized) + 16
+      if (outputBytes + candidateBytes > MAX_READ_OUTPUT_BYTES) {
+        if (lines.length === 0) {
+          lines.push(oversizedLine(normalized, lineIndex + 1, String(lineIndex + 2).length, filePath, { bytes: currentBytes, exact: true }))
+        }
+        truncated = true
+        stop()
+        return
+      }
+      lines.push(normalized)
+      outputBytes += candidateBytes
+      if (lines.length >= limit) {
+        stop()
+        return
+      }
+    }
+    lineIndex++
+    current = ''
+    currentBytes = 0
+    oversizedLineBytes = undefined
+  }
+
+  try {
+    for await (const chunk of stream) {
+      let text = decoder.write(chunk as Buffer)
+      while (text.length > 0 && !stopped) {
+        const newline = text.indexOf('\n')
+        const part = newline === -1 ? text : text.slice(0, newline)
+        if (lineIndex >= offset && lines.length < limit) {
+          const partBytes = byteLength(part)
+          if (oversizedLineBytes !== undefined) {
+            const nextLineBytes = oversizedLineBytes + partBytes
+            const probeLimit = MAX_READ_OUTPUT_BYTES + MAX_LINE_LENGTH_PROBE_BYTES
+            if ((newline !== -1 && nextLineBytes <= probeLimit) || nextLineBytes >= probeLimit) {
+              lines.push(oversizedLine(current, lineIndex + 1, String(lineIndex + 2).length, filePath, {
+                bytes: newline !== -1 && nextLineBytes <= probeLimit ? nextLineBytes : probeLimit,
+                exact: newline !== -1 && nextLineBytes <= probeLimit,
+              }))
+              truncated = true
+              stop()
+              break
+            }
+            oversizedLineBytes = nextLineBytes
+          } else if (currentBytes + partBytes > MAX_READ_OUTPUT_BYTES) {
+            const remaining = Math.max(0, MAX_READ_OUTPUT_BYTES - currentBytes)
+            if (remaining > 0) current += truncateUtf8(part, remaining)
+            const observedLineBytes = currentBytes + partBytes
+            const probeLimit = MAX_READ_OUTPUT_BYTES + MAX_LINE_LENGTH_PROBE_BYTES
+            if (newline !== -1 || observedLineBytes >= probeLimit) {
+              lines.push(oversizedLine(current, lineIndex + 1, String(lineIndex + 2).length, filePath, {
+                bytes: newline !== -1 ? observedLineBytes : probeLimit,
+                exact: newline !== -1,
+              }))
+              truncated = true
+              stop()
+              break
+            }
+            oversizedLineBytes = observedLineBytes
+          } else {
+            current += part
+            currentBytes += partBytes
+          }
+        }
+        if (newline === -1) break
+        consumeLine()
+        text = text.slice(newline + 1)
+      }
+    }
+    if (!stopped) {
+      const tail = decoder.end()
+      if (tail) {
+        if (lineIndex >= offset && lines.length < limit) {
+          const tailBytes = byteLength(tail)
+          if (oversizedLineBytes !== undefined) {
+            const probeLimit = MAX_READ_OUTPUT_BYTES + MAX_LINE_LENGTH_PROBE_BYTES
+            const exactLineBytes = oversizedLineBytes + tailBytes
+            lines.push(oversizedLine(current, lineIndex + 1, String(lineIndex + 2).length, filePath, {
+              bytes: Math.min(exactLineBytes, probeLimit),
+              exact: exactLineBytes <= probeLimit,
+            }))
+            truncated = true
+          } else if (currentBytes + tailBytes > MAX_READ_OUTPUT_BYTES) {
+            const remaining = Math.max(0, MAX_READ_OUTPUT_BYTES - currentBytes)
+            if (remaining > 0) current += truncateUtf8(tail, remaining)
+            lines.push(oversizedLine(current, lineIndex + 1, String(lineIndex + 2).length, filePath, {
+              bytes: currentBytes + tailBytes,
+              exact: true,
+            }))
+            truncated = true
+          } else {
+            current += tail
+            currentBytes += tailBytes
+          }
+        }
+      }
+      if (!truncated && oversizedLineBytes !== undefined) {
+        lines.push(oversizedLine(current, lineIndex + 1, String(lineIndex + 2).length, filePath, { bytes: oversizedLineBytes, exact: true }))
+        truncated = true
+      }
+      if (!truncated && current.length > 0 && lineIndex >= offset && lines.length < limit) consumeLine()
+    }
+  } catch (error) {
+    // Destroying a stream after a complete bounded window causes Node to surface
+    // ERR_STREAM_PREMATURE_CLOSE through async iteration; that is our success path.
+    if (!stopped) throw error
+  } finally {
+    stream.destroy()
+  }
+
+  return { lines, truncated, reachedEof }
+}
+
+async function readOperation(input: Record<string, unknown>): Promise<LocalOperationResult> {
+  const filePath = asString(input, 'file_path')
+  if (!filePath) return { result: { output: 'Error reading file: file_path is required', isError: true } }
+  const offset = asFiniteInteger(input.offset, 0)
+  const limit = asFiniteInteger(input.limit, DEFAULT_READ_LIMIT)
+
+  try {
+    const stat = await fs.stat(filePath)
+    if (stat.size === 0) return { result: { output: '', isError: false } }
+
+    const previous = input.previous_read
+    if (previous !== null && typeof previous === 'object') {
+      const read = previous as Record<string, unknown>
+      if (read.mtime_ms === stat.mtimeMs && read.offset === offset && read.limit === limit) {
+        return { result: { output: FILE_UNCHANGED_STUB, isError: false } }
+      }
+    }
+
+    if (isImageFile(filePath)) {
+      if (stat.size > MAX_IMAGE_SIZE) return { result: { output: `[Image too large: ${filePath}, ${stat.size} bytes]`, isError: false } }
+      const image = await fs.readFile(filePath)
+      const compressed = await compressImage({ media_type: inferMediaType(undefined, filePath), data: image.toString('base64') })
+      return {
+        result: { output: `[Image: ${filePath}, ${stat.size} bytes]`, isError: false, images: [compressed] },
+      }
+    }
+
+    const head = await readHeadBytes(filePath, BINARY_CHECK_SIZE)
+    if (containsNullBytes(head)) return { result: { output: 'Binary file, cannot display', isError: false } }
+    const window = await readTextWindow(filePath, offset, limit)
+    const startLine = offset + 1
+    const width = String(startLine + window.lines.length).length
+    const text = window.lines.map((line, index) => {
+      if (/^\s*\d+\t/.test(line) && line.includes('[...line truncated:')) return line
+      return `${formatLineNumber(startLine + index, width)}\t${line}`
+    }).join('\n')
+    const output = window.truncated ? `${text}${readMarker(stat.size)}` : text
+    const complete = !window.truncated && (window.reachedEof || window.lines.length >= limit)
+    return {
+      result: { output, isError: false },
+      ...(complete ? { effect: { kind: 'read_observation' as const, path: filePath, mtime_ms: stat.mtimeMs, offset, limit } } : {}),
+    }
+  } catch (error) {
+    return { result: { output: `Error reading file: ${error instanceof Error ? error.message : String(error)}`, isError: true } }
+  }
+}
+
+async function replacementPath(filePath: string): Promise<string> {
+  const stat = await fs.lstat(filePath)
+    .catch((error: NodeJS.ErrnoException) => {
+      if (error.code === 'ENOENT') return undefined
+      throw error
+    })
+  return stat?.isSymbolicLink() ? fs.realpath(filePath) : filePath
+}
+
+async function atomicWrite(filePath: string, content: string): Promise<void> {
+  const targetPath = await replacementPath(filePath)
+  await fs.mkdir(path.dirname(targetPath), { recursive: true })
+  const existingMode = await fs.stat(targetPath)
+    .then((stat) => stat.mode & 0o777)
+    .catch((error: NodeJS.ErrnoException) => {
+      if (error.code === 'ENOENT') return undefined
+      throw error
+    })
+  const tempPath = path.join(path.dirname(targetPath), `.${path.basename(targetPath)}.${randomUUID()}.tmp`)
+  try {
+    const handle = await fs.open(tempPath, 'wx')
+    try {
+      if (existingMode !== undefined) await handle.chmod(existingMode)
+      await handle.writeFile(content, 'utf8')
+      await handle.sync()
+    } finally {
+      await handle.close()
+    }
+    await fs.rename(tempPath, targetPath)
+  } catch (error) {
+    await fs.unlink(tempPath).catch(() => undefined)
+    throw error
+  }
+}
+
+async function writeOperation(input: Record<string, unknown>): Promise<LocalOperationResult> {
+  const filePath = asString(input, 'file_path')
+  const content = asString(input, 'content')
+  if (!filePath || content === undefined) return { result: { output: 'Failed to write file: file_path and content are required', isError: true } }
+  try {
+    await atomicWrite(filePath, content)
+    return { result: { output: `Successfully wrote ${byteLength(content)} bytes to ${filePath}`, isError: false } }
+  } catch (error) {
+    return { result: { output: `Failed to write file: ${error instanceof Error ? error.message : String(error)}`, isError: true } }
+  }
+}
+
+interface ScanResult {
+  readonly count: number
+  readonly lines: ReadonlyArray<number>
+}
+
+function countNewlines(value: string): number {
+  let count = 0
+  for (let index = 0; index < value.length; index++) if (value.charCodeAt(index) === 10) count++
+  return count
+}
+
+/** First pass uses at most `oldString.length - 1` carry bytes from the file stream. */
+async function scanOccurrences(filePath: string, oldString: string, stopAfterTwo: boolean): Promise<ScanResult> {
+  const stream = createReadStream(filePath)
+  const decoder = new StringDecoder('utf8')
+  const carryLength = Math.max(0, oldString.length - 1)
+  let carry = ''
+  let globalBase = 0
+  let lineBase = 1
+  let nextAllowed = 0
+  let count = 0
+  const lines: number[] = []
+
+  const process = (chunk: string, final: boolean): void => {
+    const content = carry + chunk
+    const maxStart = content.length - oldString.length
+    const advance = final ? content.length : Math.max(0, maxStart + 1)
+    if (maxStart >= 0) {
+      let index = 0
+      while (index <= maxStart) {
+        const found = content.indexOf(oldString, index)
+        if (found === -1 || found > maxStart) break
+        const absolute = globalBase + found
+        if (absolute >= nextAllowed) {
+          count++
+          if (lines.length < 200) lines.push(lineBase + countNewlines(content.slice(0, found)))
+          nextAllowed = absolute + oldString.length
+          if (stopAfterTwo && count > 1) return
+        }
+        index = found + Math.max(1, oldString.length)
+      }
+    }
+    lineBase += countNewlines(content.slice(0, advance))
+    globalBase += advance
+    carry = final ? '' : content.slice(advance)
+    if (!final && carry.length > carryLength) carry = carry.slice(-carryLength)
+  }
+
+  try {
+    for await (const buffer of stream) {
+      process(decoder.write(buffer as Buffer), false)
+      if (stopAfterTwo && count > 1) break
+    }
+    if (!(stopAfterTwo && count > 1)) process(decoder.end(), true)
+  } finally {
+    stream.destroy()
+  }
+  return { count, lines }
+}
+
+async function transformFile(filePath: string, oldString: string, newString: string): Promise<void> {
+  const targetPath = await replacementPath(filePath)
+  const tempPath = path.join(path.dirname(targetPath), `.${path.basename(targetPath)}.${randomUUID()}.tmp`)
+  const stream = createReadStream(targetPath)
+  const decoder = new StringDecoder('utf8')
+  let carry = ''
+  const carryLength = Math.max(0, oldString.length - 1)
+  try {
+    const handle = await fs.open(tempPath, 'wx')
+    try {
+      await handle.chmod((await fs.stat(targetPath)).mode & 0o777)
+      const emit = async (chunk: string, final: boolean): Promise<void> => {
+        const content = carry + chunk
+        const maxStart = content.length - oldString.length
+        const advance = final ? content.length : Math.max(0, maxStart + 1)
+        let cursor = 0
+        if (maxStart >= 0) {
+          while (cursor <= maxStart) {
+            const found = content.indexOf(oldString, cursor)
+            if (found === -1 || found > maxStart) break
+            await handle.writeFile(content.slice(cursor, found), 'utf8')
+            await handle.writeFile(newString, 'utf8')
+            cursor = found + oldString.length
+          }
+        }
+        if (cursor < advance) await handle.writeFile(content.slice(cursor, advance), 'utf8')
+        carry = final ? '' : content.slice(Math.max(advance, cursor))
+        if (!final && carry.length > carryLength) carry = carry.slice(-carryLength)
+      }
+      for await (const buffer of stream) await emit(decoder.write(buffer as Buffer), false)
+      await emit(decoder.end(), true)
+      await handle.sync()
+    } finally {
+      await handle.close()
+    }
+    await fs.rename(tempPath, targetPath)
+  } catch (error) {
+    await fs.unlink(tempPath).catch(() => undefined)
+    throw error
+  } finally {
+    stream.destroy()
+  }
+}
+
+async function editOperation(input: Record<string, unknown>): Promise<LocalOperationResult> {
+  const filePath = asString(input, 'file_path')
+  const oldString = asString(input, 'old_string')
+  const newString = asString(input, 'new_string')
+  const replaceAll = input.replace_all === true
+  if (!filePath || oldString === undefined || newString === undefined) return { result: { output: 'Failed to read file: file_path, old_string and new_string are required', isError: true } }
+  if (oldString.length === 0) return { result: { output: 'old_string must not be empty', isError: true } }
+  if (oldString === newString) return { result: { output: 'old_string must differ from new_string', isError: true } }
+
+  let scan: ScanResult
+  try {
+    scan = await scanOccurrences(filePath, oldString, false)
+  } catch (error) {
+    return { result: { output: `Failed to read file: ${error instanceof Error ? error.message : String(error)}`, isError: true } }
+  }
+  if (scan.count === 0) return { result: { output: 'old_string not found in file', isError: true } }
+  if (scan.count > 1 && !replaceAll) {
+    return { result: { output: `old_string found ${scan.count} times, use replace_all or provide more context`, isError: true } }
+  }
+  try {
+    await transformFile(filePath, oldString, newString)
+  } catch (error) {
+    return { result: { output: `Failed to write file: ${error instanceof Error ? error.message : String(error)}`, isError: true } }
+  }
+  const lineList = scan.lines.join(', ')
+  const suffix = scan.lines.length < scan.count ? ` (first ${scan.lines.length} shown)` : ''
+  return { result: { output: `Edited ${filePath}: replaced ${scan.count} occurrence(s) at line(s) ${lineList}${suffix}`, isError: false } }
+}
+
+function addGlobCandidate(candidates: string[], value: string): void {
+  if (candidates.length < MAX_GLOB_RESULTS) {
+    candidates.push(value)
+    candidates.sort()
+    return
+  }
+  if (value < candidates[candidates.length - 1]) {
+    candidates.push(value)
+    candidates.sort()
+    candidates.pop()
+  }
+}
+
+async function globOperation(input: Record<string, unknown>): Promise<LocalOperationResult> {
+  const pattern = asString(input, 'pattern')
+  const searchRoot = asString(input, 'path')
+  if (!pattern || !searchRoot) return { result: { output: 'Glob error: pattern and path are required', isError: true } }
+  const { DEFAULT_EXCLUDE_GLOBS, getProtectedExcludeGlobs } = await import('./ripgrep-helper')
+  const { runHostProcess } = await import('../host-process')
+  const args = ['--no-config', '--no-ignore', '--hidden', '--files', '--no-messages', '--glob', pattern]
+  for (const glob of DEFAULT_EXCLUDE_GLOBS) args.push('--glob', glob)
+  for (const glob of getProtectedExcludeGlobs(searchRoot)) args.push('--glob', glob)
+  args.push(searchRoot)
+
+  const candidates: string[] = []
+  let count = 0
+  let pending = ''
+  const consume = (chunk: Buffer): void => {
+    pending += chunk.toString('utf8')
+    let newline = pending.indexOf('\n')
+    while (newline !== -1) {
+      const full = pending.slice(0, newline)
+      pending = pending.slice(newline + 1)
+      if (full) {
+        count++
+        addGlobCandidate(candidates, relative(searchRoot, full))
+      }
+      newline = pending.indexOf('\n')
+    }
+    if (pending.length > 16 * 1024) pending = '' // filesystem path components are bounded; never retain malformed giant output.
+  }
+  const outcome = await runHostProcess({
+    argv: [rgPath, '--max-filesize=10M', '--threads=1', ...args],
+    cwd: searchRoot,
+    // The outer helper owns the process group and must reap rg if it times out or dies.
+    detached: false,
+    captureStdout: false,
+    onStdoutChunk: consume,
+    limits: { timeoutMs: 60_000, stdoutBytes: 64 * 1024 * 1024, stderrBytes: 64 * 1024 },
+  })
+  if (pending) {
+    count++
+    addGlobCandidate(candidates, relative(searchRoot, pending))
+  }
+  if (outcome.kind === 'spawn_error') return { result: { output: `Glob error: ${outcome.message ?? 'ripgrep spawn failed'}`, isError: true } }
+  if (outcome.kind === 'timed_out') {
+    const content = candidates.length === 0
+      ? 'Glob 搜索超时，未在时限内列出任何文件。请缩小 path 或收窄 pattern。'
+      : `${candidates.join('\n')}\n[搜索超时，结果可能不完整。请用更具体的 path 缩小目录、或收窄 pattern。]`
+    return { result: { output: content, isError: false } }
+  }
+  if (outcome.kind !== 'exit' || (outcome.exitCode === 2 && count === 0)) {
+    return { result: { output: `Glob error: ${outcome.stderr.trim() || 'ripgrep exited with code 2'}`, isError: true } }
+  }
+  if (count === 0) return { result: { output: `No files found matching pattern: ${pattern}`, isError: false } }
+  const suffix = count > MAX_GLOB_RESULTS ? `\n[...${count - MAX_GLOB_RESULTS} more results truncated]` : ''
+  return { result: { output: candidates.join('\n') + suffix, isError: false } }
+}
+
+function grepTruncationHint(): string {
+  return `\n[truncated: hit ${MAX_GREP_OUTPUT_BYTES} byte cap. 用 glob 收窄文件类型 / 用 path 缩小搜索目录 / 降低 head_limit / 改用 count 模式。]`
+}
+
+function formatGrepOutput(stdout: string, headLimit: number): string {
+  const lines = stdout.split('\n').filter(Boolean)
+  const selected: string[] = []
+  let used = 0
+  for (const line of lines) {
+    if (selected.length >= headLimit) break
+    const bytes = byteLength(line) + 1
+    if (used + bytes > MAX_GREP_OUTPUT_BYTES) return selected.length === 0 ? 'No matches found' : selected.join('\n') + grepTruncationHint()
+    selected.push(line)
+    used += bytes
+  }
+  return selected.length === 0 ? 'No matches found' : selected.join('\n')
+}
+
+async function grepOperation(input: Record<string, unknown>): Promise<LocalOperationResult> {
+  const pattern = asString(input, 'pattern')
+  const searchRoot = asString(input, 'path')
+  if (!pattern || !searchRoot) return { result: { output: 'Grep error: pattern and path are required', isError: true } }
+  if (!existsSync(searchRoot)) {
+    const cwd = asString(input, 'calling_cwd') ?? searchRoot
+    return {
+      result: {
+        output: `Grep error: 搜索路径不存在：${searchRoot}（当前 cwd=${cwd}）。` +
+          '若目标在别的项目目录，请先用 set_cwd 锚定到该项目，或给 path 传绝对路径。',
+        isError: true,
+      },
+    }
+  }
+  try {
+    new RegExp(pattern)
+  } catch (error) {
+    return { result: { output: `Invalid regex pattern: ${error instanceof Error ? error.message : String(error)}`, isError: true } }
+  }
+  const { DEFAULT_EXCLUDE_GLOBS, getProtectedExcludeGlobs, runRipgrep } = await import('./ripgrep-helper')
+  const glob = asString(input, 'glob')
+  const outputMode = asString(input, 'output_mode') ?? 'files_with_matches'
+  const contextLines = asFiniteInteger(input.context, 0)
+  const headLimit = asFiniteInteger(input.head_limit, 250)
+  const args = ['--no-config', '--no-ignore', '--hidden', `--max-columns=${MAX_GREP_COLUMNS}`]
+  if (glob) args.push('--glob', glob)
+  for (const excluded of DEFAULT_EXCLUDE_GLOBS) args.push('--glob', excluded)
+  for (const excluded of getProtectedExcludeGlobs(searchRoot)) args.push('--glob', excluded)
+  if (outputMode === 'files_with_matches') args.push('--files-with-matches')
+  else if (outputMode === 'count') args.push('--count')
+  else {
+    args.push('--line-number', '--with-filename')
+    if (contextLines > 0) args.push('--context', String(contextLines))
+  }
+  args.push('-e', pattern, searchRoot)
+  let result
+  try {
+    result = await runRipgrep(args, { cwd: searchRoot, maxBytes: 2 * 1024 * 1024, timeoutMs: 60_000, detached: false })
+  } catch (error) {
+    return { result: { output: `Grep error: ${error instanceof Error ? error.message : String(error)}`, isError: true } }
+  }
+  const stderr = result.stderr.trim()
+  if (stderr) console.error(`[Grep] ripgrep stderr (exit=${result.exitCode}) pattern=${JSON.stringify(pattern)} path=${searchRoot}:\n${stderr}`)
+  if (result.exitCode === 2 && !result.stdout) {
+    return { result: { output: `Grep error: ${stderr || 'ripgrep exited with code 2'}`, isError: true } }
+  }
+  let output = formatGrepOutput(result.stdout, headLimit)
+  if (result.truncated && !result.timedOut && !output.endsWith(grepTruncationHint())) output += grepTruncationHint()
+  if (result.timedOut) output += '\n[搜索超时，结果可能不完整。请用更具体的 path / glob 缩小范围。]'
+  return { result: { output, isError: false } }
+}
+
+async function readUtf8Prefix(filePath: string, limit: number): Promise<{ text: string; truncated: boolean }> {
+  const handle = await fs.open(filePath, 'r')
+  const decoder = new StringDecoder('utf8')
+  const parts: string[] = []
+  let remaining = limit
+  let position = 0
+  try {
+    while (remaining > 0) {
+      const buffer = Buffer.alloc(Math.min(64 * 1024, remaining + 4))
+      const { bytesRead } = await handle.read(buffer, 0, buffer.length, position)
+      if (bytesRead === 0) return { text: parts.join('') + decoder.end(), truncated: false }
+      position += bytesRead
+      const allowed = Math.min(bytesRead, remaining)
+      parts.push(decoder.write(buffer.subarray(0, allowed)))
+      remaining -= allowed
+      if (bytesRead > allowed) return { text: parts.join('') + decoder.end(), truncated: true }
+    }
+    const extra = Buffer.alloc(1)
+    const { bytesRead } = await handle.read(extra, 0, 1, position)
+    return { text: parts.join('') + decoder.end(), truncated: bytesRead > 0 }
+  } finally {
+    await handle.close()
+  }
+}
+
+function stripFrontmatter(content: string): string {
+  const match = content.match(/^---\s*\n[\s\S]*?\n---\s*\n([\s\S]*)$/)
+  return match ? match[1] : content
+}
+
+async function enumerateResources(skillDir: string): Promise<ReadonlyArray<string>> {
+  const result: string[] = []
+  const walk = async (directory: string, depth: number): Promise<void> => {
+    if (depth > MAX_SKILL_DEPTH || result.length >= MAX_SKILL_RESOURCES) return
+    try {
+      const dir = await fs.opendir(directory)
+      for await (const entry of dir) {
+        if (result.length >= MAX_SKILL_RESOURCES || entry.name.startsWith('.')) break
+        const fullPath = path.join(directory, entry.name)
+        if (entry.isDirectory()) await walk(fullPath, depth + 1)
+        else if (entry.name !== 'SKILL.md' && entry.name !== 'skill.md') result.push(relative(skillDir, fullPath))
+      }
+    } catch {
+      // A disappearing optional resource does not invalidate its skill content.
+    }
+  }
+  await walk(skillDir, 0)
+  return result.sort()
+}
+
+interface SkillSnapshot {
+  readonly name: string
+  readonly skill_dir: string
+}
+
+async function skillOperation(input: Record<string, unknown>): Promise<LocalOperationResult> {
+  const raw = asString(input, 'skill') ?? ''
+  const skills = Array.isArray(input.available_skills)
+    ? input.available_skills.filter((value): value is SkillSnapshot => value !== null && typeof value === 'object'
+      && typeof (value as Record<string, unknown>).name === 'string'
+      && typeof (value as Record<string, unknown>).skill_dir === 'string')
+    : []
+  const names = skills.map((skill) => skill.name).sort()
+  if (raw.trim() === '' || raw.trim() === 'list') {
+    return { result: { output: names.length === 0 ? 'No skills available.' : `Available skills:\n${names.map((name) => `- ${name}`).join('\n')}`, isError: false } }
+  }
+  const requested = raw.trim().toLowerCase()
+  const selected = skills.find((skill) => skill.name.toLowerCase() === requested)
+  if (!selected) {
+    const hint = names.length === 0 ? '' : `\nAvailable skills: ${names.join(', ')}`
+    return { result: { output: `Skill not found: ${raw.trim()}${hint}`, isError: true } }
+  }
+  try {
+    const content = await readUtf8Prefix(path.join(selected.skill_dir, 'SKILL.md'), MAX_SKILL_BYTES)
+    const resources = await enumerateResources(selected.skill_dir)
+    const resourceXml = resources.length === 0 ? '' : `\n<skill_resources>\n${resources.map((resource) => `  <file>${resource}</file>`).join('\n')}\n</skill_resources>`
+    const truncated = content.truncated ? `\n\n[skill content truncated at ${MAX_SKILL_BYTES} bytes]` : ''
+    return {
+      result: {
+        output: `<skill_content name="${selected.name}">\n${stripFrontmatter(content.text)}${truncated}\n\nSkill directory: ${selected.skill_dir}\nRelative paths in this skill are relative to the skill directory.${resourceXml}\n</skill_content>`,
+        isError: false,
+      },
+    }
+  } catch {
+    return { result: { output: `Failed to read skill: ${selected.name}`, isError: true } }
+  }
+}
+
+export async function executeLocalHostOperation(operation: LocalHostOperation, input: Record<string, unknown>): Promise<LocalOperationResult> {
+  switch (operation) {
+    case 'read': return readOperation(input)
+    case 'write': return writeOperation(input)
+    case 'edit': return editOperation(input)
+    case 'glob': return globOperation(input)
+    case 'grep': return grepOperation(input)
+    case 'skill': return skillOperation(input)
+  }
+}

--- a/crabot-agent/src/engine/tools/local-host-protocol.ts
+++ b/crabot-agent/src/engine/tools/local-host-protocol.ts
@@ -1,0 +1,45 @@
+import type { ToolCallResult } from '../types'
+
+export const LOCAL_HOST_PROTOCOL_VERSION = 1 as const
+
+export const LOCAL_HOST_OPERATIONS = ['read', 'write', 'edit', 'glob', 'grep', 'skill'] as const
+export type LocalHostOperation = typeof LOCAL_HOST_OPERATIONS[number]
+
+export interface ReadObservation {
+  readonly kind: 'read_observation'
+  readonly path: string
+  readonly mtime_ms: number
+  readonly offset: number
+  readonly limit: number
+}
+
+export interface LocalHostRequest {
+  readonly protocol_version: typeof LOCAL_HOST_PROTOCOL_VERSION
+  readonly call_id: string
+  readonly operation: LocalHostOperation
+  readonly input: Record<string, unknown>
+  readonly context: { readonly cwd: string; readonly timezone: string }
+}
+
+export interface LocalHostResponse {
+  readonly protocol_version: typeof LOCAL_HOST_PROTOCOL_VERSION
+  readonly call_id: string
+  readonly ok: true
+  readonly result: ToolCallResult
+  readonly effect?: ReadObservation
+}
+
+export function isLocalHostOperation(value: unknown): value is LocalHostOperation {
+  return typeof value === 'string' && (LOCAL_HOST_OPERATIONS as readonly string[]).includes(value)
+}
+
+export function isReadObservation(value: unknown): value is ReadObservation {
+  if (value === undefined) return false
+  if (value === null || typeof value !== 'object') return false
+  const effect = value as Record<string, unknown>
+  return effect.kind === 'read_observation'
+    && typeof effect.path === 'string'
+    && typeof effect.mtime_ms === 'number'
+    && typeof effect.offset === 'number'
+    && typeof effect.limit === 'number'
+}

--- a/crabot-agent/src/engine/tools/read-tool.ts
+++ b/crabot-agent/src/engine/tools/read-tool.ts
@@ -1,130 +1,20 @@
-import * as fs from 'fs/promises'
-import { createReadStream } from 'fs'
-import * as readline from 'readline'
 import { defineTool } from '../tool-framework'
+import { localHostToolExecutor } from '../local-host-tool-executor'
 import type { ToolDefinition } from '../types'
-import { compressImage } from '../image-utils'
-import { truncateUtf8 } from '../byte-cap'
 import { resolvePath } from './utils'
-import { inferMediaType } from '../../agent/media-resolver'
-import { FILE_UNCHANGED_STUB } from './file-read-state'
 import type { FileReadState } from './file-read-state'
 
-/** 单次返回字节上限（与 2000 行上限先到先截），超出部分用 offset 分页续读。 */
-const MAX_OUTPUT_BYTES = 50 * 1024
-/** 超过该大小的文件流式按行定位读取，不整文件入内存。 */
-const STREAM_READ_THRESHOLD = 10 * 1024 * 1024
-const IMAGE_EXTENSIONS = new Set(['jpg', 'jpeg', 'png', 'gif', 'webp'])
-const MAX_IMAGE_SIZE = 20 * 1024 * 1024 // 20MB
-
-function isImageFile(filePath: string): boolean {
-  const ext = filePath.split('.').pop()?.toLowerCase() ?? ''
-  return IMAGE_EXTENSIONS.has(ext)
-}
 const DEFAULT_LIMIT = 2000
-const BINARY_CHECK_SIZE = 8192
-
-function formatLineNumber(lineNum: number, totalDigits: number): string {
-  return String(lineNum).padStart(totalDigits, ' ')
-}
-
-function formatLinesWithNumbers(lines: ReadonlyArray<string>, startLine: number): string {
-  if (lines.length === 0) {
-    return ''
-  }
-  const lastLineNum = startLine + lines.length
-  const totalDigits = String(lastLineNum).length
-  return lines
-    .map((line, i) => `${formatLineNumber(startLine + i, totalDigits)}\t${line}`)
-    .join('\n')
-}
-
-/**
- * 单行自身超 MAX_OUTPUT_BYTES 时的降级格式化：返回该行前 ~50KB + 行内续读提示。
- * 整行丢弃返回空内容会让该行用任何 offset 都读不到（minified JS / 单行大 JSON 常见）。
- */
-function formatOversizedLine(line: string, lineNo: number, totalDigits: number, filePath: string): string {
-  const lineBytes = Buffer.byteLength(line, 'utf8')
-  const head = truncateUtf8(line, MAX_OUTPUT_BYTES - 32) // 留行号前缀 + 提示的预算
-  const shownBytes = Buffer.byteLength(head, 'utf8')
-  return (
-    `${formatLineNumber(lineNo, totalDigits)}\t${head}` +
-    `[...line truncated: showing first ${shownBytes} bytes of a ${lineBytes}-byte line. ` +
-    `Use Bash: sed -n '${lineNo}p' '${filePath}' | tail -c +${shownBytes + 1} | head -c ${MAX_OUTPUT_BYTES} to read more.]`
-  )
-}
-
-/**
- * 逐行累加格式化，累计字节超 MAX_OUTPUT_BYTES 即截断（不切断行）。
- * 未截断时产物与 formatLinesWithNumbers 完全一致。
- */
-function formatLinesWithByteCap(
-  lines: ReadonlyArray<string>,
-  startLine: number,
-  filePath: string,
-): { text: string; truncated: boolean } {
-  if (lines.length === 0) {
-    return { text: '', truncated: false }
-  }
-  const totalDigits = String(startLine + lines.length).length
-  const parts: string[] = []
-  let bytes = 0
-  for (let i = 0; i < lines.length; i++) {
-    const part = `${formatLineNumber(startLine + i, totalDigits)}\t${lines[i]}`
-    const partBytes = Buffer.byteLength(part, 'utf8') + 1 // + '\n'
-    if (bytes + partBytes > MAX_OUTPUT_BYTES) {
-      if (parts.length === 0) {
-        // 第一行就超限：降级为行内截断，保证该行内容仍可（部分）读到
-        parts.push(formatOversizedLine(lines[i], startLine + i, totalDigits, filePath))
-      }
-      return { text: parts.join('\n'), truncated: true }
-    }
-    parts.push(part)
-    bytes += partBytes
-  }
-  return { text: parts.join('\n'), truncated: false }
-}
-
-/** 字节截断提示：引导用 offset 分页续读。 */
-function byteCapTruncatedMarker(fileSize: number): string {
-  return `\n[...truncated: output capped at ${MAX_OUTPUT_BYTES} bytes (file is ${fileSize} bytes total). Use offset to continue reading.]`
-}
-
-/** 读取文件头部 n 字节（用于大文件的 binary 探测，不整文件入内存）。 */
-async function readHeadBytes(filePath: string, n: number): Promise<Buffer> {
-  const fileHandle = await fs.open(filePath, 'r')
-  try {
-    const buffer = Buffer.alloc(n)
-    const { bytesRead } = await fileHandle.read(buffer, 0, n, 0)
-    return buffer.subarray(0, bytesRead)
-  } finally {
-    await fileHandle.close()
-  }
-}
-
-function containsNullBytes(buffer: Buffer): boolean {
-  const checkLength = Math.min(buffer.length, BINARY_CHECK_SIZE)
-  for (let i = 0; i < checkLength; i++) {
-    if (buffer[i] === 0x00) {
-      return true
-    }
-  }
-  return false
-}
-
 const SENSITIVE_PATH_PATTERNS = [
   /[/\\]data[/\\]admin[/\\]channel-configs[/\\]/,
   /[/\\]data[/\\]admin[/\\]model_providers[/\\]/,
 ]
 
 function isSensitivePath(filePath: string): boolean {
-  return SENSITIVE_PATH_PATTERNS.some(p => p.test(filePath))
+  return SENSITIVE_PATH_PATTERNS.some((pattern) => pattern.test(filePath))
 }
 
-/**
- * @param fileReadState 可选的 task 级去重缓存。提供时启用 read dedup（见 file-read-state.ts）；
- *   不提供时退化为普通无状态 Read。仅 main worker 传入，subagent 不传。
- */
+/** Parent-side Read only owns the task-local dedup ledger. */
 export function createReadTool(getCwd: () => string, fileReadState?: FileReadState): ToolDefinition {
   return defineTool({
     name: 'Read',
@@ -135,161 +25,42 @@ export function createReadTool(getCwd: () => string, fileReadState?: FileReadSta
     inputSchema: {
       type: 'object',
       properties: {
-        file_path: {
-          type: 'string',
-          description: 'Absolute or relative file path to read',
-        },
-        offset: {
-          type: 'number',
-          description: 'Start line (0-based, default 0)',
-        },
-        limit: {
-          type: 'number',
-          description: 'Max lines to read (default 2000)',
-        },
+        file_path: { type: 'string', description: 'Absolute or relative file path to read' },
+        offset: { type: 'number', description: 'Start line (0-based, default 0)' },
+        limit: { type: 'number', description: 'Max lines to read (default 2000)' },
       },
       required: ['file_path'],
     },
     isReadOnly: true,
     permissionLevel: 'safe',
-
-    async call(input) {
+    async call(input, context) {
       const filePath = resolvePath(getCwd(), input.file_path as string)
-
-      // 敏感路徑守衛：禁止直接讀取渠道憑證文件
       if (isSensitivePath(filePath)) {
         return {
           output: '此路徑包含渠道憑證，禁止直接讀取。要讀取飛書文檔請使用 read_feishu_document 工具；要查看 channel 配置請通過 Admin Web 或 crabot CLI。',
           isError: true,
         }
       }
-
-      // offset 归一化为非负整数：负数/小数/NaN 在流式（lineIdx < offset）与非流式
-      //（lines.slice(offset)）两条路径下行为不一致（slice 负数会从尾部数），统一在入口收敛。
       const rawOffset = typeof input.offset === 'number' ? input.offset : 0
       const offset = Number.isFinite(rawOffset) ? Math.max(0, Math.floor(rawOffset)) : 0
-      const limit = typeof input.limit === 'number' ? input.limit : DEFAULT_LIMIT
-
-      try {
-        const stat = await fs.stat(filePath)
-        const fileSize = stat.size
-
-        if (fileSize === 0) {
-          return { output: '', isError: false }
-        }
-
-        // Image file detection — return as ImageBlock before text processing
-        if (isImageFile(filePath)) {
-          if (fileSize > MAX_IMAGE_SIZE) {
-            return {
-              output: `[Image too large: ${filePath}, ${fileSize} bytes]`,
-              isError: false,
-            }
-          }
-          const imageBuffer = await fs.readFile(filePath)
-          const rawImageData = {
-            media_type: inferMediaType(undefined, filePath),
-            data: imageBuffer.toString('base64'),
-          }
-          const compressed = await compressImage(rawImageData)
-          return {
-            output: `[Image: ${filePath}, ${fileSize} bytes]`,
-            isError: false,
-            images: [compressed],
-          }
-        }
-
-        // >10MB 大文件：流式按行定位读取，不整文件入内存。
-        // 大文件必为部分视图（50KB 上限），不参与 read dedup。
-        if (fileSize > STREAM_READ_THRESHOLD) {
-          const head = await readHeadBytes(filePath, BINARY_CHECK_SIZE)
-          if (containsNullBytes(head)) {
-            return { output: 'Binary file, cannot display', isError: false }
-          }
-
-          const stream = createReadStream(filePath)
-          const rl = readline.createInterface({ input: stream, crlfDelay: Infinity })
-          const collected: string[] = []
-          let bytes = 0
-          let lineIdx = 0
-          let byteTruncated = false
-          try {
-            for await (const line of rl) {
-              if (lineIdx < offset) {
-                lineIdx++
-                continue
-              }
-              if (collected.length >= limit) {
-                break
-              }
-              const lineBytes = Buffer.byteLength(line, 'utf8') + 16 // 行号前缀 + 换行余量
-              if (bytes + lineBytes > MAX_OUTPUT_BYTES) {
-                if (collected.length === 0) {
-                  // 单行超限：行内截断降级（同非流式路径），不让该行完全不可读
-                  const lineNo = lineIdx + 1
-                  const oversized =
-                    formatOversizedLine(line, lineNo, String(lineNo + 1).length, filePath)
-                  return { output: `${oversized}${byteCapTruncatedMarker(fileSize)}`, isError: false }
-                }
-                byteTruncated = true
-                break
-              }
-              collected.push(line)
-              bytes += lineBytes
-              lineIdx++
-            }
-          } finally {
-            rl.close()
-            stream.destroy()
-          }
-
-          const formatted = formatLinesWithNumbers(collected, offset + 1)
-          if (byteTruncated) {
-            return { output: `${formatted}${byteCapTruncatedMarker(fileSize)}`, isError: false }
-          }
-          return { output: formatted, isError: false }
-        }
-
-        // Read dedup：相同范围 + 磁盘 mtime 未变 → 返回 stub，不把整文件重复回灌进 context。
-        // mtime 为准，文件被改过会自动失效。字节截断读是部分视图，不进缓存（下方 set 处判断）。
-        if (fileReadState) {
-          const prev = fileReadState.get(filePath)
-          if (prev && prev.offset === offset && prev.limit === limit && prev.mtimeMs === stat.mtimeMs) {
-            return { output: FILE_UNCHANGED_STUB, isError: false }
-          }
-        }
-
-        const fileHandle = await fs.open(filePath, 'r')
-        try {
-          const buffer = Buffer.alloc(fileSize)
-          await fileHandle.read(buffer, 0, fileSize, 0)
-
-          if (containsNullBytes(buffer)) {
-            return { output: 'Binary file, cannot display', isError: false }
-          }
-
-          const text = buffer.toString('utf-8')
-          const allLines = text.split('\n')
-          const endsWithNewline =
-            allLines.length > 0 && allLines[allLines.length - 1] === '' && text.endsWith('\n')
-          const lines = endsWithNewline ? allLines.slice(0, -1) : allLines
-          const selected = lines.slice(offset, offset + limit)
-          const { text: formatted, truncated: byteTruncated } = formatLinesWithByteCap(selected, offset + 1, filePath)
-
-          if (byteTruncated) {
-            return { output: `${formatted}${byteCapTruncatedMarker(fileSize)}`, isError: false }
-          }
-          if (endsWithNewline) {
-            fileReadState?.set(filePath, { mtimeMs: stat.mtimeMs, offset, limit })
-          }
-          return { output: formatted, isError: false }
-        } finally {
-          await fileHandle.close()
-        }
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error)
-        return { output: `Error reading file: ${message}`, isError: true }
+      const limit = typeof input.limit === 'number' && Number.isFinite(input.limit)
+        ? Math.max(0, Math.floor(input.limit))
+        : DEFAULT_LIMIT
+      const previous = fileReadState?.get(filePath)
+      const execution = await localHostToolExecutor.execute('read', {
+        file_path: filePath,
+        offset,
+        limit,
+        previous_read: previous ? { mtime_ms: previous.mtimeMs, offset: previous.offset, limit: previous.limit } : null,
+      }, getCwd(), context)
+      if (execution.effect) {
+        fileReadState?.set(filePath, {
+          mtimeMs: execution.effect.mtime_ms,
+          offset: execution.effect.offset,
+          limit: execution.effect.limit,
+        })
       }
+      return execution.result
     },
   })
 }

--- a/crabot-agent/src/engine/tools/ripgrep-helper.ts
+++ b/crabot-agent/src/engine/tools/ripgrep-helper.ts
@@ -9,12 +9,11 @@
  * 二进制由 @vscode/ripgrep 提供，npm install 时自动下载平台对应的 rg。
  */
 
-import { spawn } from 'node:child_process'
 import { homedir } from 'node:os'
 import { relative, isAbsolute } from 'node:path'
 import { rgPath } from '@vscode/ripgrep'
 import { shouldScanProtectedDirs } from './fda-check'
-import { buildChildEnv } from '../../core/runtime-env.js'
+import { runHostProcess } from '../host-process'
 
 export interface RipgrepResult {
   /** rg 进程的 stdout 全文（已按 maxBytes 截断）。 */
@@ -30,7 +29,6 @@ export interface RipgrepResult {
 }
 
 const DEFAULT_MAX_BYTES = 16 * 1024 * 1024 // 16MB stdout 上限——再多上层也消化不了
-const KILL_GRACE_MS = 500
 // 墙钟超时上限。rg 卡在巨型目录遍历（网络盘 / FUSE / 海量缓存）或 macOS TCC 权限
 // 弹窗时会无限挂起，把 agent 主循环一起拖死（实测挂过 144 分钟）。源码工程的合理
 // glob/grep 远用不到 60s，超出即 kill 返回 partial，让上层提示缩小范围。
@@ -75,89 +73,29 @@ export function runRipgrep(
     maxBytes?: number
     timeoutMs?: number
     signal?: AbortSignal
+    /** A helper-owned rg must stay in the helper group so outer termination reaps both. */
+    detached?: boolean
   } = {},
 ): Promise<RipgrepResult> {
   const maxBytes = opts.maxBytes ?? DEFAULT_MAX_BYTES
   const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS
 
-  return new Promise((resolve, reject) => {
-    const proc = spawn(rgPath, [...FORCED_LIMITS, ...args], {
-      cwd: opts.cwd,
-      stdio: ['ignore', 'pipe', 'pipe'],
-      env: buildChildEnv(),
-    })
-
-    let stdout = ''
-    let stderr = ''
-    let stdoutBytes = 0
-    let truncated = false
-    let timedOut = false
-    let killed = false
-    let timer: ReturnType<typeof setTimeout> | undefined
-
-    const killProc = () => {
-      if (killed) return
-      killed = true
-      try {
-        proc.kill('SIGTERM')
-        setTimeout(() => {
-          if (proc.exitCode === null && proc.signalCode === null) {
-            try { proc.kill('SIGKILL') } catch { /* already dead */ }
-          }
-        }, KILL_GRACE_MS).unref()
-      } catch { /* already dead */ }
+  return runHostProcess({
+    argv: [rgPath, ...FORCED_LIMITS, ...args],
+    ...(opts.cwd ? { cwd: opts.cwd } : {}),
+    ...(opts.signal ? { abortSignal: opts.signal } : {}),
+    ...(opts.detached === false ? { detached: false } : {}),
+    limits: { timeoutMs, stdoutBytes: maxBytes, stderrBytes: 64 * 1024 },
+  }).then((outcome) => {
+    if (outcome.kind === 'spawn_error') throw new Error(`ripgrep spawn failed: ${outcome.message ?? 'unknown error'}`)
+    const signalCode = outcome.signal ? 128 + (signalNumber(outcome.signal) ?? 0) : 0
+    return {
+      stdout: outcome.stdout,
+      stderr: outcome.stderr,
+      truncated: outcome.kind === 'output_limit' || outcome.kind === 'aborted' || outcome.kind === 'timed_out',
+      timedOut: outcome.kind === 'timed_out',
+      exitCode: outcome.exitCode ?? (outcome.kind === 'aborted' ? 130 : signalCode),
     }
-
-    const onAbort = () => {
-      truncated = true
-      killProc()
-    }
-    if (opts.signal) {
-      if (opts.signal.aborted) {
-        onAbort()
-        return resolve({ stdout: '', stderr: '', truncated: true, timedOut: false, exitCode: 130 })
-      }
-      opts.signal.addEventListener('abort', onAbort, { once: true })
-    }
-
-    // 墙钟超时：到点 kill rg 并标 timedOut，已收到的 stdout 作为 partial 返回。
-    timer = setTimeout(() => {
-      timedOut = true
-      truncated = true
-      killProc()
-    }, timeoutMs)
-    timer.unref()
-
-    proc.stdout.on('data', (chunk: Buffer) => {
-      if (truncated) return
-      stdoutBytes += chunk.length
-      if (stdoutBytes > maxBytes) {
-        // 超额：取到上限为止，丢弃 stream 后续，kill 进程。
-        const allowed = maxBytes - (stdoutBytes - chunk.length)
-        if (allowed > 0) stdout += chunk.subarray(0, allowed).toString('utf-8')
-        truncated = true
-        killProc()
-        return
-      }
-      stdout += chunk.toString('utf-8')
-    })
-
-    proc.stderr.on('data', (chunk: Buffer) => {
-      stderr += chunk.toString('utf-8')
-    })
-
-    proc.on('error', (err) => {
-      if (timer) clearTimeout(timer)
-      if (opts.signal) opts.signal.removeEventListener('abort', onAbort)
-      reject(new Error(`ripgrep spawn failed: ${err.message}`))
-    })
-
-    proc.on('close', (code, signal) => {
-      if (timer) clearTimeout(timer)
-      if (opts.signal) opts.signal.removeEventListener('abort', onAbort)
-      const exitCode = code ?? (signal ? 128 + (signalNumber(signal) ?? 0) : 0)
-      resolve({ stdout, stderr, truncated, timedOut, exitCode })
-    })
   })
 }
 

--- a/crabot-agent/src/engine/tools/ripgrep-helper.ts
+++ b/crabot-agent/src/engine/tools/ripgrep-helper.ts
@@ -16,7 +16,7 @@ import { shouldScanProtectedDirs } from './fda-check'
 import { runHostProcess } from '../host-process'
 
 export interface RipgrepResult {
-  /** rg 进程的 stdout 全文（已按 maxBytes 截断）。 */
+  /** rg 进程 stdout 的前缀（已按 maxBytes 截断）。 */
   stdout: string
   /** rg 进程的 stderr 全文。 */
   stderr: string
@@ -33,6 +33,22 @@ const DEFAULT_MAX_BYTES = 16 * 1024 * 1024 // 16MB stdout 上限——再多上�
 // 弹窗时会无限挂起，把 agent 主循环一起拖死（实测挂过 144 分钟）。源码工程的合理
 // glob/grep 远用不到 60s，超出即 kill 返回 partial，让上层提示缩小范围。
 const DEFAULT_TIMEOUT_MS = 60_000
+
+function createStdoutPrefixCollector(maxBytes: number): { push(chunk: Buffer): void; finish(): string } {
+  const chunks: Buffer[] = []
+  let retained = 0
+  return {
+    push(chunk): void {
+      if (retained >= maxBytes) return
+      const allowed = Math.min(chunk.length, maxBytes - retained)
+      chunks.push(chunk.subarray(0, allowed))
+      retained += allowed
+    },
+    finish(): string {
+      return Buffer.concat(chunks, retained).toString('utf8')
+    },
+  }
+}
 
 /**
  * 强制注入到每次 rg 调用的硬限制。这些 flag 不可让上层覆盖：
@@ -79,18 +95,21 @@ export function runRipgrep(
 ): Promise<RipgrepResult> {
   const maxBytes = opts.maxBytes ?? DEFAULT_MAX_BYTES
   const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  const stdoutPrefix = createStdoutPrefixCollector(maxBytes)
 
   return runHostProcess({
     argv: [rgPath, ...FORCED_LIMITS, ...args],
     ...(opts.cwd ? { cwd: opts.cwd } : {}),
     ...(opts.signal ? { abortSignal: opts.signal } : {}),
     ...(opts.detached === false ? { detached: false } : {}),
+    captureStdout: false,
+    onStdoutChunk: (chunk) => stdoutPrefix.push(chunk),
     limits: { timeoutMs, stdoutBytes: maxBytes, stderrBytes: 64 * 1024 },
   }).then((outcome) => {
     if (outcome.kind === 'spawn_error') throw new Error(`ripgrep spawn failed: ${outcome.message ?? 'unknown error'}`)
     const signalCode = outcome.signal ? 128 + (signalNumber(outcome.signal) ?? 0) : 0
     return {
-      stdout: outcome.stdout,
+      stdout: stdoutPrefix.finish(),
       stderr: outcome.stderr,
       truncated: outcome.kind === 'output_limit' || outcome.kind === 'aborted' || outcome.kind === 'timed_out',
       timedOut: outcome.kind === 'timed_out',

--- a/crabot-agent/src/engine/tools/skill-tool.ts
+++ b/crabot-agent/src/engine/tools/skill-tool.ts
@@ -1,53 +1,15 @@
-import { readdir, readFile } from 'fs/promises'
-import { join, relative } from 'path'
 import { defineTool } from '../tool-framework'
+import { localHostToolExecutor } from '../local-host-tool-executor'
 import type { ToolDefinition } from '../types'
 import type { SkillConfig } from '../../types.js'
 
-const FRONTMATTER_RE = /^---\s*\n[\s\S]*?\n---\s*\n([\s\S]*)$/
-
-function stripFrontmatter(content: string): string {
-  const match = content.match(FRONTMATTER_RE)
-  return match ? match[1] : content
-}
-
-const SKILL_MD_FILES = new Set(['SKILL.md', 'skill.md'])
-
-async function enumerateResources(skillDir: string): Promise<ReadonlyArray<string>> {
-  const resources: string[] = []
-  async function walk(dir: string): Promise<void> {
-    let entries
-    try {
-      entries = await readdir(dir, { withFileTypes: true })
-    } catch {
-      return
-    }
-    for (const entry of entries) {
-      if (entry.name.startsWith('.')) continue
-      const fullPath = join(dir, entry.name)
-      if (entry.isDirectory()) {
-        await walk(fullPath)
-      } else if (!SKILL_MD_FILES.has(entry.name)) {
-        resources.push(relative(skillDir, fullPath))
-      }
-    }
-  }
-  await walk(skillDir)
-  return resources.sort()
-}
-
 export interface SkillToolOptions {
   readonly availableSkills: ReadonlyArray<SkillConfig>
+  readonly getCwd?: () => string
 }
 
 export function createSkillTool(options: SkillToolOptions): ToolDefinition {
-  // 把 name → skill_dir 映射拍快照，工具内只读这个 map，不再扫盘列目录。
-  // admin 在 updateSkills 时会重建 tool（同 task 内通过 buildToolsDynamic callback），
-  // 所以 map 不需要在工具内热刷新。
-  const skillDirByName = new Map<string, string>(
-    options.availableSkills.map((s) => [s.name, s.skill_dir]),
-  )
-
+  const skills = options.availableSkills.map((skill) => ({ name: skill.name, skill_dir: skill.skill_dir }))
   return defineTool({
     name: 'Skill',
     category: 'mcp_skill',
@@ -58,72 +20,16 @@ export function createSkillTool(options: SkillToolOptions): ToolDefinition {
       'Use "list" to see available skills.',
     inputSchema: {
       type: 'object',
-      properties: {
-        skill: {
-          type: 'string',
-          description: 'Skill name to activate, or "list" to see available skills.',
-        },
-      },
+      properties: { skill: { type: 'string', description: 'Skill name to activate, or "list" to see available skills.' } },
       required: ['skill'],
     },
     isReadOnly: true,
     permissionLevel: 'safe',
-    call: async (input) => {
-      const skillInput = (input.skill as string).trim()
-      const names = [...skillDirByName.keys()].sort()
-
-      if (skillInput === 'list' || skillInput === '') {
-        if (names.length === 0) {
-          return { output: 'No skills available.', isError: false }
-        }
-        return {
-          output: `Available skills:\n${names.map((name) => `- ${name}`).join('\n')}`,
-          isError: false,
-        }
-      }
-
-      const lowerInput = skillInput.toLowerCase()
-      const matchedName = names.find((n) => n.toLowerCase() === lowerInput)
-
-      if (!matchedName) {
-        const availableHint = names.length > 0
-          ? `\nAvailable skills: ${names.join(', ')}`
-          : ''
-        return {
-          output: `Skill not found: ${skillInput}${availableHint}`,
-          isError: true,
-        }
-      }
-
-      // admin 传来的 skill_dir 是绝对路径，agent 子进程同主机直接读
-      const skillDir = skillDirByName.get(matchedName)!
-      const filePath = join(skillDir, 'SKILL.md')
-
-      let content: string
-      try {
-        content = await readFile(filePath, 'utf-8')
-      } catch {
-        return { output: `Failed to read skill: ${matchedName}`, isError: true }
-      }
-
-      // Strip frontmatter — body only per Agent Skills standard
-      const body = stripFrontmatter(content)
-
-      // Enumerate bundled resources
-      const resources = await enumerateResources(skillDir)
-      const resourcesXml = resources.length > 0
-        ? `\n<skill_resources>\n${resources.map((r) => `  <file>${r}</file>`).join('\n')}\n</skill_resources>`
-        : ''
-
-      const output =
-        `<skill_content name="${matchedName}">\n` +
-        `${body}\n\n` +
-        `Skill directory: ${skillDir}\n` +
-        `Relative paths in this skill are relative to the skill directory.` +
-        `${resourcesXml}\n` +
-        `</skill_content>`
-
-      return { output, isError: false }
+    async call(input, context) {
+      return (await localHostToolExecutor.execute('skill', {
+        skill: input.skill,
+        available_skills: skills,
+      }, options.getCwd?.() ?? process.cwd(), context)).result
     },
   })
 }

--- a/crabot-agent/src/engine/tools/write-tool.ts
+++ b/crabot-agent/src/engine/tools/write-tool.ts
@@ -1,6 +1,5 @@
-import * as fs from 'fs/promises'
-import * as path from 'path'
 import { defineTool } from '../tool-framework'
+import { localHostToolExecutor } from '../local-host-tool-executor'
 import type { ToolDefinition } from '../types'
 import { resolvePath } from './utils'
 
@@ -19,28 +18,11 @@ export function createWriteTool(getCwd: () => string): ToolDefinition {
     },
     isReadOnly: false,
     permissionLevel: 'normal',
-    call: async (input) => {
-      const filePath = input.file_path as string
-      const content = input.content as string
-
-      const resolvedPath = resolvePath(getCwd(), filePath)
-
-      try {
-        await fs.mkdir(path.dirname(resolvedPath), { recursive: true })
-        await fs.writeFile(resolvedPath, content, 'utf-8')
-
-        const byteCount = Buffer.byteLength(content, 'utf-8')
-        return {
-          output: `Successfully wrote ${byteCount} bytes to ${resolvedPath}`,
-          isError: false,
-        }
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error)
-        return {
-          output: `Failed to write file: ${message}`,
-          isError: true,
-        }
-      }
+    async call(input, context) {
+      return (await localHostToolExecutor.execute('write', {
+        file_path: resolvePath(getCwd(), input.file_path as string),
+        content: input.content,
+      }, getCwd(), context)).result
     },
   })
 }

--- a/crabot-agent/tests/engine/host-process.test.ts
+++ b/crabot-agent/tests/engine/host-process.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import * as fs from 'node:fs/promises'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { runHostProcess } from '../../src/engine/host-process'
+import { resolveBashPath } from '../../src/utils/resolve-bash-path'
+
+const bashPath = resolveBashPath()
+
+function shell(command: string, overrides: Partial<Parameters<typeof runHostProcess>[0]> = {}) {
+  if (bashPath === null) throw new Error('bash is required for host-process integration tests')
+  return runHostProcess({
+    argv: [bashPath, '-c', command],
+    limits: { timeoutMs: 2_000, stdoutBytes: 64 * 1024, stderrBytes: 64 * 1024, killGraceMs: 25 },
+    ...overrides,
+  })
+}
+
+describe('runHostProcess', () => {
+  const temporaryPaths: string[] = []
+
+  afterEach(async () => {
+    await Promise.all(temporaryPaths.splice(0).map((filePath) => fs.rm(filePath, { recursive: true, force: true })))
+  })
+
+  it('captures normal and non-zero shell exits without involving the Agent process', async () => {
+    const normal = await shell('printf out; printf err >&2')
+    expect(normal).toMatchObject({ kind: 'exit', exitCode: 0, stdout: 'out', stderr: 'err' })
+
+    const nonzero = await shell('exit 7')
+    expect(nonzero).toMatchObject({ kind: 'exit', exitCode: 7 })
+  })
+
+  it('terminates the entire process group on timeout and leaves later calls usable', async () => {
+    const pidFile = path.join(await fs.mkdtemp(path.join(os.tmpdir(), 'host-process-tree-')), 'grandchild.pid')
+    temporaryPaths.push(path.dirname(pidFile))
+    const childProgram = `require('node:fs').writeFileSync(${JSON.stringify(pidFile)}, String(process.pid)); setInterval(() => {}, 1000)`
+    const timedOut = await shell(
+      `${JSON.stringify(process.execPath)} -e ${JSON.stringify(childProgram)} & wait`,
+      { limits: { timeoutMs: 500, stdoutBytes: 64 * 1024, stderrBytes: 64 * 1024, killGraceMs: 100 } },
+    )
+
+    expect(timedOut.kind).toBe('timed_out')
+    const grandchildPid = Number(await fs.readFile(pidFile, 'utf8'))
+    expect(Number.isInteger(grandchildPid)).toBe(true)
+    expect(() => process.kill(grandchildPid, 0)).toThrow()
+
+    const later = await shell('printf still-running')
+    expect(later).toMatchObject({ kind: 'exit', exitCode: 0, stdout: 'still-running' })
+  })
+
+  it('reports abort and bounded-output failures while retaining the collected tail', async () => {
+    const controller = new AbortController()
+    const abortTimer = setTimeout(() => controller.abort(), 25)
+    const aborted = await shell('sleep 5', { abortSignal: controller.signal })
+    clearTimeout(abortTimer)
+    expect(aborted.kind).toBe('aborted')
+
+    const limited = await shell(
+      "printf 'HEAD_MARKER\\n'; printf 'a%.0s' {1..120000}; printf 'END_MARKER\\n'",
+      { limits: { timeoutMs: 2_000, stdoutBytes: 64 * 1024, stderrBytes: 64 * 1024, killGraceMs: 25 } },
+    )
+    expect(limited.kind).toBe('output_limit')
+    expect(limited.stdout).not.toContain('HEAD_MARKER')
+    expect(Buffer.byteLength(limited.stdout, 'utf8')).toBeLessThanOrEqual(64 * 1024)
+  })
+})

--- a/crabot-agent/tests/engine/local-host-tool-executor.test.ts
+++ b/crabot-agent/tests/engine/local-host-tool-executor.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import * as fs from 'node:fs/promises'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { LocalHostToolExecutor } from '../../src/engine/local-host-tool-executor'
+
+describe('LocalHostToolExecutor', () => {
+  let tempDir: string
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'local-host-executor-'))
+  })
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true })
+  })
+
+  async function fixture(source: string): Promise<LocalHostToolExecutor> {
+    const filePath = path.join(tempDir, `fixture-${Math.random().toString(16).slice(2)}.cjs`)
+    await fs.writeFile(filePath, source)
+    return new LocalHostToolExecutor(() => ({ argv: [process.execPath, filePath] }))
+  }
+
+  it('runs the actual local helper and accepts its verified response', async () => {
+    const filePath = path.join(tempDir, 'written.txt')
+    const execution = await new LocalHostToolExecutor().execute('write', {
+      file_path: filePath,
+      content: 'written by helper',
+    }, tempDir, {})
+
+    expect(execution.result).toMatchObject({ isError: false })
+    expect(await fs.readFile(filePath, 'utf8')).toBe('written by helper')
+  })
+
+  it.each([
+    ['invalid JSON', "process.stdin.resume(); process.stdin.on('end', () => process.stdout.write('not json\\n'))"],
+    ['empty stdout', "process.stdin.resume()"],
+    ['multiple responses', "process.stdin.resume(); process.stdin.on('end', () => process.stdout.write('{}\\n{}\\n'))"],
+  ])('rejects a real helper process with %s', async (_name, source) => {
+    const executor = await fixture(source)
+    const execution = await executor.execute('read', { file_path: path.join(tempDir, 'missing.txt') }, tempDir, {})
+
+    expect(execution.result.isError).toBe(true)
+    expect(execution.result.output).toContain('Local tool helper protocol error')
+  })
+
+  it.each([
+    ['write', { content: 'requested value' }],
+    ['edit', { old_string: 'old', new_string: 'new', replace_all: false }],
+  ] as const)('marks %s result unknown when a launched helper commits but cannot return a response', async (operation, input) => {
+    const executor = await fixture([
+      "let body = ''",
+      "process.stdin.on('data', (chunk) => { body += chunk })",
+      "process.stdin.on('end', () => {",
+      '  const request = JSON.parse(body)',
+      "  require('node:fs').writeFileSync(request.input.file_path, 'committed')",
+      '})',
+    ].join('\n'))
+    const filePath = path.join(tempDir, 'unknown-result.txt')
+
+    const execution = await executor.execute(operation, { file_path: filePath, ...input }, tempDir, {})
+
+    expect(execution.result).toMatchObject({ isError: true })
+    expect(execution.result.output).toContain(`Local tool execution result is unknown (${operation})`)
+    expect(await fs.readFile(filePath, 'utf8')).toBe('committed')
+  })
+})

--- a/crabot-agent/tests/engine/local-host-tool-executor.test.ts
+++ b/crabot-agent/tests/engine/local-host-tool-executor.test.ts
@@ -2,7 +2,12 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import * as fs from 'node:fs/promises'
 import * as os from 'node:os'
 import * as path from 'node:path'
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
 import { LocalHostToolExecutor } from '../../src/engine/local-host-tool-executor'
+
+const execFileAsync = promisify(execFile)
+const itPosix = process.platform === 'win32' ? it.skip : it
 
 describe('LocalHostToolExecutor', () => {
   let tempDir: string
@@ -64,4 +69,31 @@ describe('LocalHostToolExecutor', () => {
     expect(execution.result.output).toContain(`Local tool execution result is unknown (${operation})`)
     expect(await fs.readFile(filePath, 'utf8')).toBe('committed')
   })
+
+  itPosix('cleans the actual helper temporary file when an Edit is aborted', async () => {
+    const pipePath = path.join(tempDir, 'blocked-input')
+    await execFileAsync('mkfifo', [pipePath])
+    const controller = new AbortController()
+    const execution = new LocalHostToolExecutor().execute('edit', {
+      file_path: pipePath,
+      old_string: 'old',
+      new_string: 'new',
+    }, tempDir, { abortSignal: controller.signal })
+
+    // The first pass consumes this writer. The helper then opens the FIFO for its second pass,
+    // after its same-directory temporary file exists, and blocks waiting for another writer.
+    await fs.writeFile(pipePath, 'old')
+    const temporaryPrefix = `.${path.basename(pipePath)}.`
+    const deadline = Date.now() + 5_000
+    while (!(await fs.readdir(tempDir)).some((name) => name.startsWith(temporaryPrefix) && name.endsWith('.tmp'))) {
+      if (Date.now() >= deadline) throw new Error('helper did not create its temporary file')
+      await new Promise((resolve) => setTimeout(resolve, 10))
+    }
+
+    controller.abort()
+    const result = await execution
+
+    expect(result.result.output).toContain('Local tool execution result is unknown (edit)')
+    expect((await fs.readdir(tempDir)).some((name) => name.startsWith(temporaryPrefix) && name.endsWith('.tmp'))).toBe(false)
+  }, 10_000)
 })

--- a/crabot-agent/tests/engine/tools/edit-tool.test.ts
+++ b/crabot-agent/tests/engine/tools/edit-tool.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'fs'
+import { mkdtempSync, writeFileSync, readFileSync, rmSync, chmodSync, statSync, lstatSync, symlinkSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { createEditTool } from '../../../src/engine/tools/edit-tool'
@@ -123,6 +123,38 @@ describe('createEditTool', () => {
 
     expect(result.isError).toBe(false)
     expect(result.output).toContain('line(s) 3, 6')
+  })
+
+  it('replaces a unique string that spans real stream chunks', async () => {
+    const filePath = writeTestFile('cross-chunk.txt', `${'x'.repeat(64 * 1024 - 3)}TARGET\n`)
+    const tool = createEditTool(() => tempDir)
+
+    const result = await tool.call(
+      { file_path: filePath, old_string: 'TARGET', new_string: 'REPLACED' },
+      context,
+    )
+
+    expect(result.isError).toBe(false)
+    expect(result.output).toContain('1 occurrence')
+    expect(readFileSync(filePath, 'utf-8')).toBe(`${'x'.repeat(64 * 1024 - 3)}REPLACED\n`)
+  })
+
+  it('preserves the existing file mode after atomic replacement', async () => {
+    const targetPath = writeTestFile('executable.txt', 'replace me\n')
+    const linkPath = join(tempDir, 'executable-link.txt')
+    chmodSync(targetPath, 0o755)
+    symlinkSync(targetPath, linkPath)
+    const tool = createEditTool(() => tempDir)
+
+    const result = await tool.call(
+      { file_path: linkPath, old_string: 'replace me', new_string: 'replaced' },
+      context,
+    )
+
+    expect(result.isError).toBe(false)
+    expect(lstatSync(linkPath).isSymbolicLink()).toBe(true)
+    expect(readFileSync(targetPath, 'utf-8')).toBe('replaced\n')
+    expect(statSync(targetPath).mode & 0o777).toBe(0o755)
   })
 
   it('resolves relative file paths against cwd', async () => {

--- a/crabot-agent/tests/engine/tools/edit-tool.test.ts
+++ b/crabot-agent/tests/engine/tools/edit-tool.test.ts
@@ -139,6 +139,21 @@ describe('createEditTool', () => {
     expect(readFileSync(filePath, 'utf-8')).toBe(`${'x'.repeat(64 * 1024 - 3)}REPLACED\n`)
   })
 
+  it('rejects overlapping matches that cross a stream boundary without writing', async () => {
+    const original = `${'x'.repeat(64 * 1024 - 4)}aaaaaa`
+    const filePath = writeTestFile('overlapping-cross-chunk.txt', original)
+    const tool = createEditTool(() => tempDir)
+
+    const result = await tool.call(
+      { file_path: filePath, old_string: 'aaa', new_string: 'replaced' },
+      context,
+    )
+
+    expect(result.isError).toBe(true)
+    expect(result.output).toContain('2 times')
+    expect(readFileSync(filePath, 'utf-8')).toBe(original)
+  })
+
   it('preserves the existing file mode after atomic replacement', async () => {
     const targetPath = writeTestFile('executable.txt', 'replace me\n')
     const linkPath = join(tempDir, 'executable-link.txt')

--- a/crabot-agent/tests/engine/tools/grep-tool.test.ts
+++ b/crabot-agent/tests/engine/tools/grep-tool.test.ts
@@ -170,6 +170,19 @@ describe('createGrepTool', () => {
     expect(result.output).toContain('data.txt')
   })
 
+  it('searches a single file supplied as path', async () => {
+    const filePath = path.join(tmpDir, 'src', 'hello.ts')
+
+    const result = await tool.call(
+      { pattern: 'greeting', path: filePath, output_mode: 'content' },
+      {},
+    )
+
+    expect(result.isError).toBe(false)
+    expect(result.output).toContain('greeting')
+    expect(result.output).toContain('hello.ts')
+  })
+
   it('returns error for invalid regex pattern', async () => {
     const result = await tool.call({ pattern: '[invalid' }, {})
 

--- a/crabot-agent/tests/engine/tools/grep-tool.test.ts
+++ b/crabot-agent/tests/engine/tools/grep-tool.test.ts
@@ -5,6 +5,8 @@ import * as fs from 'fs'
 import * as path from 'path'
 import * as os from 'os'
 
+const itPosix = process.platform === 'win32' ? it.skip : it
+
 describe('createGrepTool', () => {
   let tmpDir: string
   let tool: ToolDefinition
@@ -181,6 +183,21 @@ describe('createGrepTool', () => {
     expect(result.isError).toBe(false)
     expect(result.output).toContain('greeting')
     expect(result.output).toContain('hello.ts')
+  })
+
+  itPosix('returns a partial result when ripgrep diagnostics reach the helper stderr limit', async () => {
+    for (let index = 0; index < 1200; index++) {
+      const filePath = path.join(tmpDir, `denied-${index}.txt`)
+      fs.writeFileSync(filePath, 'no match\n')
+      fs.chmodSync(filePath, 0)
+    }
+    const matchPath = path.join(tmpDir, 'match.txt')
+    fs.writeFileSync(matchPath, 'MATCH\n')
+
+    const result = await tool.call({ pattern: 'MATCH', path: tmpDir }, {})
+
+    expect(result.isError).toBe(false)
+    expect(result.output).toContain('[truncated: hit')
   })
 
   it('returns error for invalid regex pattern', async () => {

--- a/crabot-agent/tests/engine/tools/read-tool.test.ts
+++ b/crabot-agent/tests/engine/tools/read-tool.test.ts
@@ -176,6 +176,35 @@ describe('createReadTool', () => {
     expect(result.output).toContain(`sed -n '1p' '${filePath}'`)
   })
 
+  it('为探测窗口内的超长单行报告精确长度', async () => {
+    const filePath = path.join(tmpDir, 'probed-longline.log')
+    const bigLine = 'c'.repeat(192 * 1024)
+    await fs.writeFile(filePath, bigLine + '\nnext line\n')
+
+    const result = await tool.call({ file_path: filePath }, {})
+
+    expect(result.isError).toBe(false)
+    expect(result.output).toContain('196608-byte line')
+    expect(result.output).not.toContain('at least')
+  })
+
+  it('对 128 MiB 无换行文件只做有界长度探测', async () => {
+    const filePath = path.join(tmpDir, 'single-128m-line.log')
+    const handle = await fs.open(filePath, 'w')
+    try {
+      const chunk = Buffer.alloc(1024 * 1024, 'x')
+      for (let index = 0; index < 128; index++) await handle.write(chunk)
+    } finally {
+      await handle.close()
+    }
+
+    const result = await tool.call({ file_path: filePath }, {})
+
+    expect(result.isError).toBe(false)
+    expect(result.output).toContain('at least 313344 bytes of the line before its end')
+    expect(Buffer.byteLength(result.output, 'utf8')).toBeLessThanOrEqual(52 * 1024)
+  })
+
   it('streams >10MB files line-by-line and can reach the tail via offset', async () => {
     const filePath = path.join(tmpDir, 'huge.txt')
     // 150000 行 × ~90B ≈ 13MB，走流式按行定位路径

--- a/crabot-agent/tests/engine/tools/read-tool.test.ts
+++ b/crabot-agent/tests/engine/tools/read-tool.test.ts
@@ -148,6 +148,21 @@ describe('createReadTool', () => {
     expect(Buffer.byteLength(result.output, 'utf8')).toBeLessThanOrEqual(52 * 1024)
   })
 
+  it('keeps the 50KB budget when the final oversized line has no newline', async () => {
+    const filePath = path.join(tmpDir, 'normal-then-eof-oversized.txt')
+    const prefix = Array.from({ length: 5 }, (_, index) => `row-${index}-${'x'.repeat(10_000)}`)
+    const oversized = 'y'.repeat(60 * 1024)
+    await fs.writeFile(filePath, `${prefix.join('\n')}\n${oversized}`)
+
+    const result = await tool.call({ file_path: filePath }, {})
+
+    expect(result.isError).toBe(false)
+    expect(result.output).toContain('1\trow-0-')
+    expect(result.output).not.toContain('y'.repeat(100))
+    expect(result.output).toContain('[...truncated')
+    expect(Buffer.byteLength(result.output, 'utf8')).toBeLessThanOrEqual(52 * 1024)
+  })
+
   it('reads the tail of a >500KB file via offset (no more 500KB hard cap)', async () => {
     const filePath = path.join(tmpDir, 'paged.txt')
     // 8000 行 × ~90B ≈ 700KB，超过旧的 500KB 硬上限

--- a/crabot-agent/tests/engine/tools/read-tool.test.ts
+++ b/crabot-agent/tests/engine/tools/read-tool.test.ts
@@ -133,6 +133,21 @@ describe('createReadTool', () => {
     expect(result.output).toContain('offset')
   })
 
+  it('keeps the 50KB budget when an oversized line follows normal output', async () => {
+    const filePath = path.join(tmpDir, 'normal-then-oversized.txt')
+    const prefix = Array.from({ length: 350 }, (_, index) => `row-${index}-${'x'.repeat(120)}`)
+    const oversized = 'y'.repeat(60 * 1024)
+    await fs.writeFile(filePath, [...prefix, oversized, 'afterwards'].join('\n'))
+
+    const result = await tool.call({ file_path: filePath }, {})
+
+    expect(result.isError).toBe(false)
+    expect(result.output).toContain('1\trow-0-')
+    expect(result.output).not.toContain('y'.repeat(100))
+    expect(result.output).toContain('[...truncated')
+    expect(Buffer.byteLength(result.output, 'utf8')).toBeLessThanOrEqual(52 * 1024)
+  })
+
   it('reads the tail of a >500KB file via offset (no more 500KB hard cap)', async () => {
     const filePath = path.join(tmpDir, 'paged.txt')
     // 8000 行 × ~90B ≈ 700KB，超过旧的 500KB 硬上限

--- a/crabot-agent/tests/engine/tools/ripgrep-helper.test.ts
+++ b/crabot-agent/tests/engine/tools/ripgrep-helper.test.ts
@@ -48,7 +48,7 @@ describe('runRipgrep', () => {
     expect(r.exitCode).toBe(2)
   })
 
-  it('caps stdout by maxBytes and kills the rg process', async () => {
+  it('caps stdout by maxBytes, retaining the first matches, and kills the rg process', async () => {
     // 写一个会产生大量 stdout 的场景：1000 行匹配，每行 ~50 字节，~50KB 总输出
     const big = Array.from({ length: 1000 }, (_, i) => `line-${i}: MATCH_ME some content here`).join('\n')
     writeFileSync(join(tmp, 'big.txt'), big)
@@ -59,9 +59,11 @@ describe('runRipgrep', () => {
     )
 
     expect(r.truncated).toBe(true)
-    // 截断时 stdout 应该接近但不超过 maxBytes
+    // Grep 的契约是前 N 个匹配；截断时必须保留 stdout 头部，而不是滑动窗口的尾部。
     expect(r.stdout.length).toBeLessThanOrEqual(4096)
     expect(r.stdout.length).toBeGreaterThan(0)
+    expect(r.stdout).toContain('line-0: MATCH_ME')
+    expect(r.stdout).not.toContain('line-999: MATCH_ME')
   })
 
   it('respects AbortSignal pre-aborted state', async () => {

--- a/crabot-agent/tests/engine/tools/skill-tool.test.ts
+++ b/crabot-agent/tests/engine/tools/skill-tool.test.ts
@@ -115,6 +115,26 @@ describe('createSkillTool', () => {
     expect(result.output).toContain('</skill_resources>')
   })
 
+  it('skips hidden resources without stopping sibling resource enumeration', async () => {
+    const dir = writeSkillWithResources(
+      'hidden-resource',
+      '# Skill',
+      {
+        '.DS_Store': 'ignored',
+        'references/guide.md': '# Guide',
+        'scripts/run.py': 'print("hello")',
+      },
+    )
+    const tool = createSkillTool({ availableSkills: [makeSkillConfig('hidden-resource', dir)] })
+
+    const result = await tool.call({ skill: 'hidden-resource' }, {})
+
+    expect(result.isError).toBe(false)
+    expect(result.output).not.toContain('.DS_Store')
+    expect(result.output).toContain('<file>references/guide.md</file>')
+    expect(result.output).toContain('<file>scripts/run.py</file>')
+  })
+
   it('omits <skill_resources> when no resources exist', async () => {
     const dir = writeSkill('no-resources', '---\nname: no-resources\ndescription: test\n---\n# Skill')
     const tool = createSkillTool({ availableSkills: [makeSkillConfig('no-resources', dir)] })

--- a/crabot-agent/tests/engine/tools/write-tool.test.ts
+++ b/crabot-agent/tests/engine/tools/write-tool.test.ts
@@ -62,6 +62,22 @@ describe('createWriteTool', () => {
     expect(written).toBe('new content')
   })
 
+  it('preserves the existing file mode and follows its final symlink', async () => {
+    const targetPath = path.join(tmpDir, 'target.txt')
+    const linkPath = path.join(tmpDir, 'link.txt')
+    await fs.writeFile(targetPath, 'old content', 'utf-8')
+    await fs.chmod(targetPath, 0o755)
+    await fs.symlink(targetPath, linkPath)
+
+    const tool = createWriteTool(() => tmpDir)
+    const result = await tool.call({ file_path: linkPath, content: 'new content' }, {})
+
+    expect(result.isError).toBe(false)
+    expect((await fs.lstat(linkPath)).isSymbolicLink()).toBe(true)
+    expect(await fs.readFile(targetPath, 'utf8')).toBe('new content')
+    expect((await fs.stat(targetPath)).mode & 0o777).toBe(0o755)
+  })
+
   it('creates parent directories automatically', async () => {
     const tool = createWriteTool(() => tmpDir)
     const filePath = path.join(tmpDir, 'a', 'b', 'c', 'deep.txt')


### PR DESCRIPTION
## 背景

超大单行文件会在 Agent 进程内经 `readline` 累积为完整字符串，曾触发 `RangeError: Invalid string length`；其他本地文件工具和 shell/ripgrep 也没有统一的进程级故障边界。

## 改动

- `Read`、`Write`、`Edit`、`Glob`、`Grep`、`Skill` 改为每次调用一个 JSONL Node helper；父 Agent 保留权限、hooks、trace、cwd、read dedup 和 BgEntity 所有权。
- 新增统一 host-process runner：有界 stdout/stderr、超时、AbortSignal、POSIX 进程组/Windows `/T` 回收；Bash 复用它但不改变既有后台实体、re-adopt、Output/Kill 语义。
- `Read` 使用有界 UTF-8 流扫描与固定行长探测；`Edit` 两遍流式匹配并同目录原子替换；`Write` 同样原子替换，并保留已有 mode 和最终 symlink 语义。
- 已启动但没有可信回包的 Write/Edit 统一返回“执行结果未知”，不自动重试。

## 验证

- 真实 Node helper / shell / `rg` 定向回归：12 文件、134 tests passed。
- `crabot-agent` TypeScript build 通过；编译后的 helper 直跑写入通过。
- 真实 128 MiB 无换行文件测试通过。
- 发布前实机 1,772,093,440 字节单行读取：helper 92 ms 返回 51 KB 有界结果，无 stderr、无 `RangeError`。

## 范围外

本 PR 只建立进程隔离与未来 sandbox 的启动接入点；不实现容器/资源配额 sandbox，不修改 Worker/Manager 生命周期、权限协议或持久化模型。