### PR TITLE
fix(agent): make worker input delivery synchronous and bounded

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -12,7 +12,7 @@
 - `send_to_worker` 在一次有界同步尝试内只返回 `delivered | failed`，不再把 `pending` 暴露给 Manager；输入面不安全、提交确认不确定和超时分别返回稳定原因码与确定性。
 - Manager 活跃 episode 期间到达的 Worker hook/状态通知直接进入当前 mailbox，下一次 LLM 调用批量读取；同一 Worker 的同步投递计数按引用计数维护，避免并发调用提前关闭通知等待。
 - 投递 deadline 收紧为 120 秒；Harness 增加 wall-clock 兜底并隔离迟到 adapter 结果，tmux `execFile`、`load-buffer` 与版本探测均有 15 秒命令上限。
-- 相关协议与设计记录已同步到 `crabot-docs`，待文档仓直推和主仓非 Draft PR review。
+- 相关协议与设计记录已同步到 `crabot-docs`（main `12f52b6`）；待主仓非 Draft PR review。
 
 ### 运行态立即改向：实现完成
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5,7 +5,14 @@
 
 ## 当前状态
 
-### P6 已完成；Manager -> Worker 输入与侧问可靠交付待 PR review
+### P6 已完成；Manager -> Worker 同步输入投递待 PR review
+
+### Manager -> Worker 同步输入投递：实现完成
+
+- `send_to_worker` 在一次有界同步尝试内只返回 `delivered | failed`，不再把 `pending` 暴露给 Manager；输入面不安全、提交确认不确定和超时分别返回稳定原因码与确定性。
+- Manager 活跃 episode 期间到达的 Worker hook/状态通知直接进入当前 mailbox，下一次 LLM 调用批量读取；同一 Worker 的同步投递计数按引用计数维护，避免并发调用提前关闭通知等待。
+- 投递 deadline 收紧为 120 秒；Harness 增加 wall-clock 兜底并隔离迟到 adapter 结果，tmux `execFile`、`load-buffer` 与版本探测均有 15 秒命令上限。
+- 相关协议与设计记录已同步到 `crabot-docs`，待文档仓直推和主仓非 Draft PR review。
 
 ### 运行态立即改向：实现完成
 
@@ -53,7 +60,7 @@
   - Management-only cutover + durable config revision（seqlock 一致性读、HMAC fingerprint、Skill journal binding、publish 失败退避 drain 自愈）。
 - **部署约束**：pre-P6 存量生产不得部署 Slice 0/A/B 中间态；首次 rollout 至少包含 Slice 0 + P6-B grandfather bootstrap + P6-C 最终选择语义。
 
-### Manager -> Worker 输入与侧问可靠交付（实现完成，待 PR review）
+### Manager -> Worker 输入与侧问可靠交付（历史基线）
 
 - 已确认并发布设计、计划和 `protocol-agent-v3` 3.2.1 契约（crabot-docs `d4b4e50`）：`send_to_worker` 使用持久 receipt 返回 `delivered / pending / failed`，5 分钟内有限收口；失败及 pending 后终态只有被原 Manager episode 以 `consumedEvents=true` 消费后才确认完成，Agent 重启不自动重发输入。
 - `query_worker` 改为同步建立 fork 和提交首问、异步生成回答，不进入主 TUI 排队；builtin、Claude Code、Codex 统一“fork + 首问接受后返回”契约，Codex 使用 app-server `thread/fork + turn/start`。

--- a/crabot-agent/src/manager/bootstrap.ts
+++ b/crabot-agent/src/manager/bootstrap.ts
@@ -390,7 +390,13 @@ export function buildManagerStack(deps: BootstrapDeps): ManagerStack {
           // A set/clear/expiry/terminal transition can invalidate a due while it was queued, or
           // during its Manager episode. It remains in trace/events.jsonl but must not affect the
           // replacement rule. `undefined` from the narrow route is the before-wake stale case.
-          if (event.kind === 'supervision_due' && (result === undefined || !await harness.isSupervisionDueCurrent(event))) {
+          if (event.kind === 'supervision_due' && result === undefined) {
+            // `undefined` is either a stale due (safe to consume) or an active Manager
+            // defer (keep the durable due for retry). The current-state check distinguishes
+            // those two cases without inventing a completed EpisodeResult.
+            return { consumed: !await harness.isSupervisionDueCurrent(event) }
+          }
+          if (event.kind === 'supervision_due' && !await harness.isSupervisionDueCurrent(event)) {
             return { consumed: true }
           }
           // fail-loud 的判据必须双管:`.catch` 只抓得到 F2(中途抛错),而最常见的 F1(LLM 挂 /

--- a/crabot-agent/src/manager/prompt.ts
+++ b/crabot-agent/src/manager/prompt.ts
@@ -64,7 +64,7 @@ Crabot 把"对话"和"干活"拆成了两层：
 
 **等待即 end_turn**：你的 loop 里没有阻塞等待原语。需要等任何事时直接结束回合，结果会唤醒你——不管等的是执行器干活、侧问答案还是人类回复，都不要空转、不要反复查询。
 
-**慢工具是异步的**：\`spawn_worker\` / \`send_to_worker\` / \`query_worker\` 发起后立即返回，只代表编排动作已落地，不代表事情做完了。\`send_to_worker\` 只有返回 \`delivered\` 才能对人类说输入已送达；\`pending\` 只表示已登记、正在等待安全输入面，不能说成已送达或任务已启动，应结束回合等待带同一 \`delivery_id\` 的终态事件；\`failed\` 必须按给出的原因和确定性如实处理。执行器每跑完一轮（转 idle）或结束时会有事件唤醒你；事件给出状态和待处置回合，不把终端画面当作常规进度。先用 \`get_worker_turn\` 与 \`get_worker_activity\` 读取原生会话（缺省只看 assistant text，诊断时才传 \`view=all\`）；只有收到 \`interaction_required\` 时才用 \`get_worker_terminal\` 看一次诊断画面，再用事件里的 \`snapshot_id\` 调 \`respond_to_worker_ui\`，不得经普通输入原样敲终端。
+**慢工具是异步的**：\`spawn_worker\` / \`send_to_worker\` / \`query_worker\` 只等待编排动作本身，不等待执行器完成任务。\`send_to_worker\` 只有返回 \`delivered\` 才能对人类说输入已送达；\`failed\` 必须按给出的原因和确定性如实处理。执行器每跑完一轮（转 idle）或结束时会有事件唤醒你；事件给出状态和待处置回合，不把终端画面当作常规进度。先用 \`get_worker_turn\` 与 \`get_worker_activity\` 读取原生会话（缺省只看 assistant text，诊断时才传 \`view=all\`）；只有收到 \`interaction_required\` 时才用 \`get_worker_terminal\` 看一次诊断画面，再用事件里的 \`snapshot_id\` 调 \`respond_to_worker_ui\`，不得经普通输入原样敲终端。
 
 **执行器回合的交付闭环**：收到带 \`turn_pending=true\` 的事件，必须先读该回合及其活动，再决定续办、转述还是提问。向人类报告结果或提问后，在同一 manager 回合中先成功调用 \`send_message\` 到该执行器的 \`report_to\`，再用 \`resolve_worker_turn\` 标为 \`reported\` 或 \`asked_human\`；已用 \`send_to_worker\` 实际续办才标 \`continued\`；无需打扰人类时标 \`suppressed\` 并写明原因。没有成功发送消息时绝不能把回合标为已交付。
 

--- a/crabot-agent/src/manager/registry.ts
+++ b/crabot-agent/src/manager/registry.ts
@@ -354,25 +354,7 @@ export class ManagerRegistry {
    * 不同的对话对象(同一 friend 跨 channel 共享台账)——这是设计意图,不是需要修正的不一致。
    */
   async routeWorkerEvent(event: HarnessEvent): Promise<EpisodeResult | undefined> {
-    const capture = this.captureIngress()
-    const found = await this.deps.ledger.findWorker(event.worker_id)
-    const eventWithOrigin: HarnessEvent = found
-      ? {
-          ...event,
-          detail: {
-            ...(event.detail ?? {}),
-            ...(event.task_status ? { outcome: event.task_status } : {}),
-            trigger_type: found.worker.origin.trigger_type,
-            task_id: found.worker.task.id,
-          },
-        }
-      : event
-    const envelope = this.makeEnvelope(
-      capture,
-      { kind: 'worker_event', event: eventWithOrigin },
-      typeof event.ts === 'string' ? event.ts : undefined,
-    )
-    const key = found?.worker.manager_key ?? SYSTEM_TASKS_MANAGER_KEY
+    const { key, envelope } = await this.prepareWorkerEventRoute(event)
     const loop = this.getOrCreate(key)
     if (this.isEpisodeActive(key)) {
       // A hook raised while a Manager tool is running belongs to the current episode.
@@ -398,7 +380,21 @@ export class ManagerRegistry {
   async routeSupervisionDue(event: HarnessEvent): Promise<EpisodeResult | undefined> {
     if (event.kind !== 'supervision_due') throw new Error('routeSupervisionDue requires supervision_due')
     if (!await this.deps.harness.isSupervisionDueCurrent(event)) return undefined
-    return this.routeWorkerEvent(event)
+    const { key, envelope } = await this.prepareWorkerEventRoute(event)
+    // A periodic/default supervision due needs a real episode result to decide whether its
+    // persistent due can be consumed. Do not enqueue it into an unrelated active episode
+    // and then fabricate that result: the Harness will retain and retry this due instead.
+    // Route preparation reads the ledger asynchronously, so the due can be cleared or
+    // replaced after the first check. Revalidate immediately before episode admission.
+    if (!await this.deps.harness.isSupervisionDueCurrent(event)) return undefined
+    if (this.isEpisodeActive(key)) return undefined
+    return this.runWake(
+      key,
+      envelope,
+      0,
+      undefined,
+      () => this.deps.harness.isSupervisionDueCurrent(event),
+    )
   }
 
   /** Operation notifications join an active episode mailbox; idle Managers get a fresh wake. */
@@ -534,6 +530,33 @@ export class ManagerRegistry {
     return { now, timezone, received_at: formatOffsetIso(now, timezone) }
   }
 
+  private async prepareWorkerEventRoute(event: HarnessEvent): Promise<{
+    key: ManagerKey
+    envelope: TimedWakeEnvelope
+  }> {
+    const capture = this.captureIngress()
+    const found = await this.deps.ledger.findWorker(event.worker_id)
+    const eventWithOrigin: HarnessEvent = found
+      ? {
+          ...event,
+          detail: {
+            ...(event.detail ?? {}),
+            ...(event.task_status ? { outcome: event.task_status } : {}),
+            trigger_type: found.worker.origin.trigger_type,
+            task_id: found.worker.task.id,
+          },
+        }
+      : event
+    return {
+      key: found?.worker.manager_key ?? SYSTEM_TASKS_MANAGER_KEY,
+      envelope: this.makeEnvelope(
+        capture,
+        { kind: 'worker_event', event: eventWithOrigin },
+        typeof event.ts === 'string' ? event.ts : undefined,
+      ),
+    }
+  }
+
   private makeEnvelope(
     capture: IngressCapture,
     wake: WakeEvent,
@@ -577,15 +600,30 @@ export class ManagerRegistry {
    * 自唤醒都走这里。`event === undefined` ⇒ 自唤醒(只处理 mailbox 残留,见
    * `ManagerLoop.drainMailbox`);`selfWakeChain` 是当前连锁自唤醒的深度,真实唤醒恒为 0。
    */
+  private runWake(
+    key: ManagerKey,
+    envelope: TimedWakeEnvelope | undefined,
+    selfWakeChain?: number,
+    onHumanInputCommitted?: (lastCommittedMessageId: string) => Promise<void>,
+  ): Promise<EpisodeResult>
+  private runWake(
+    key: ManagerKey,
+    envelope: TimedWakeEnvelope | undefined,
+    selfWakeChain: number,
+    onHumanInputCommitted: ((lastCommittedMessageId: string) => Promise<void>) | undefined,
+    shouldAdmit: () => Promise<boolean>,
+  ): Promise<EpisodeResult | undefined>
   private async runWake(
     key: ManagerKey,
     envelope: TimedWakeEnvelope | undefined,
     selfWakeChain = 0,
     onHumanInputCommitted?: (lastCommittedMessageId: string) => Promise<void>,
-  ): Promise<EpisodeResult> {
+    shouldAdmit?: () => Promise<boolean>,
+  ): Promise<EpisodeResult | undefined> {
     this.assertWakeAdmission()
     if (this.deps.beforeWake) await this.deps.beforeWake(key, envelope)
     this.assertWakeAdmission()
+    if (shouldAdmit && !await shouldAdmit()) return undefined
     const loop = this.getOrCreate(key)
     this.activeEpisodes.set(key, (this.activeEpisodes.get(key) ?? 0) + 1)
     let result: EpisodeResult | undefined

--- a/crabot-agent/src/manager/registry.ts
+++ b/crabot-agent/src/manager/registry.ts
@@ -373,6 +373,21 @@ export class ManagerRegistry {
       typeof event.ts === 'string' ? event.ts : undefined,
     )
     const key = found?.worker.manager_key ?? SYSTEM_TASKS_MANAGER_KEY
+    const loop = this.getOrCreate(key)
+    if (this.isEpisodeActive(key)) {
+      // A hook raised while a Manager tool is running belongs to the current episode.
+      // Enqueue synchronously so the next engine turn sees the whole mailbox batch; never
+      // wait for (or recursively start) another Manager episode here.
+      loop.enqueueDuringEpisode(envelope)
+      return {
+        episodeId: '',
+        outcome: 'completed',
+        turns: 0,
+        consumedEvents: true,
+        repliedToHuman: false,
+        successfulSendMessageTargets: [],
+      }
+    }
     return this.runWake(key, envelope)
   }
 
@@ -386,14 +401,18 @@ export class ManagerRegistry {
     return this.routeWorkerEvent(event)
   }
 
-  /** Durable operation notifications never join an already-running episode's in-memory mailbox. */
+  /** Operation notifications join an active episode mailbox; idle Managers get a fresh wake. */
   async routeOperationNotification(
     key: ManagerKey,
     event: HarnessEvent,
   ): Promise<HarnessEventDelivery> {
-    if (this.isEpisodeActive(key)) return { consumed: false }
     const capture = this.captureIngress()
     const envelope = this.makeEnvelope(capture, { kind: 'worker_event', event }, event.ts)
+    const loop = this.getOrCreate(key)
+    if (this.isEpisodeActive(key)) {
+      loop.enqueueDuringEpisode(envelope)
+      return { consumed: true }
+    }
     const result = await this.runWake(key, envelope)
     return { consumed: result.consumedEvents === true }
   }

--- a/crabot-agent/src/manager/tools/worker-tools.ts
+++ b/crabot-agent/src/manager/tools/worker-tools.ts
@@ -34,7 +34,7 @@
 
 import { defineTool } from '../../engine/index.js'
 import type { ToolDefinition, ToolCallResult } from '../../engine/index.js'
-import type { WorkerHarness } from '../../workers/harness/harness'
+import { INPUT_DELIVERY_TIMEOUT_MS, type WorkerHarness } from '../../workers/harness/harness'
 import type { ManagerKey, LedgerWorker, TaskStatus } from '../../workers/harness/ledger-types'
 import { isDecisionVisibleWorker } from '../../workers/harness/task-status.js'
 import type { MasterAuthorization } from '../principal.js'
@@ -196,6 +196,31 @@ function normalizePagination(page: unknown, pageSize: unknown): { page: number; 
 }
 
 const ACCESS_DENIED = 'worker 不存在或当前会话无权访问'
+
+class SendToWorkerDeadlineError extends Error {
+  constructor() {
+    super('input delivery setup exceeded the 120 second synchronous deadline')
+    this.name = 'SendToWorkerDeadlineError'
+  }
+}
+
+async function awaitWithinSendToWorkerDeadline<T>(
+  deadlineAt: number,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const remainingMs = deadlineAt - Date.now()
+  if (remainingMs <= 0) throw new SendToWorkerDeadlineError()
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new SendToWorkerDeadlineError()), remainingMs)
+    timer.unref?.()
+  })
+  try {
+    return await Promise.race([Promise.resolve().then(operation), timeout])
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
+}
 
 async function workerState(harness: WorkerHarness, worker: LedgerWorker) {
   const mainline = worker.incarnations.filter((inc) => inc.forked_from === undefined).at(-1)
@@ -365,11 +390,13 @@ export function buildWorkerTools(deps: WorkerToolsDeps): ToolDefinition[] {
         return invalid('send_to_worker: immediate_redirect 必须为布尔值')
       }
 
+      const deadlineAt = Date.now() + INPUT_DELIVERY_TIMEOUT_MS
       try {
-        const worker = await authorizeWorker(worker_id)
+        const worker = await awaitWithinSendToWorkerDeadline(deadlineAt, () => authorizeWorker(worker_id))
         const legacyContinuationAuth = capturedLegacyContinuationAuth?.(worker.manager_key)
         const result = await harness.sendToWorker(worker_id, text, {
           managerKey: context().managerKey,
+          deadline_at: new Date(deadlineAt).toISOString(),
           ...(immediate_redirect !== undefined ? { immediate_redirect } : {}),
           ...(legacyContinuationAuth ? { legacyContinuationAuth } : {}),
         })

--- a/crabot-agent/src/manager/tools/worker-tools.ts
+++ b/crabot-agent/src/manager/tools/worker-tools.ts
@@ -327,15 +327,14 @@ export function buildWorkerTools(deps: WorkerToolsDeps): ToolDefinition[] {
     },
   })
 
-  // --- send_to_worker(异步:投递即返回,worker 的回应由事件唤醒) ---
+  // --- send_to_worker(同步完成一次投递尝试,worker 的回应仍由事件唤醒) ---
   const sendToWorker = defineTool({
     name: 'send_to_worker',
     description:
-      '向指定 worker 投递一条输入。返回 delivered 才表示 worker adapter 已确认接受；pending ' +
-      '表示尚未送达，系统会在 5 分钟内结算并用事件通知你；failed 会给出原因与送达确定性。' +
+      '向指定 worker 投递一条输入。返回 delivered 才表示 worker adapter 已确认接受；failed 会立即给出简要原因与送达确定性。' +
       'worker 处于什么状态都能投:在跑/空闲的排进信箱,' +
       '已结束(completed/failed)的会自动复活它原来的会话接着干、上下文完整保留——所以延续、' +
-      '补充、返工一个老任务都走这里,不必先判断它死活,也不必为此新开 worker。异步语义:本工具' +
+      '补充、返工一个老任务都走这里,不必先判断它死活,也不必为此新开 worker。同步投递只等待一次有界尝试，' +
       '不等 worker 处理完这条消息;worker 每跑完一轮或结束时' +
       '会作为事件唤醒你,事件带状态和待处置回合；用 get_worker_activity 读取原生会话。命中已 cancelled 的任务会被拒绝。' +
       '未知交互界面必须使用 respond_to_worker_ui，普通输入不提供 raw 终端旁路。' +
@@ -374,7 +373,7 @@ export function buildWorkerTools(deps: WorkerToolsDeps): ToolDefinition[] {
           ...(immediate_redirect !== undefined ? { immediate_redirect } : {}),
           ...(legacyContinuationAuth ? { legacyContinuationAuth } : {}),
         })
-        if (result.status === 'delivered' || result.status === 'pending') deps.onWorkerContinuation?.(worker_id)
+        if (result.status === 'delivered') deps.onWorkerContinuation?.(worker_id)
         return ok(result)
       } catch (error) {
         return mapError(`send_to_worker(${worker_id})`, error)

--- a/crabot-agent/src/workers/harness/harness.ts
+++ b/crabot-agent/src/workers/harness/harness.ts
@@ -180,7 +180,7 @@ import {
  */
 const WAKE_TEXT_MAX_CHARS = 2000
 
-export const INPUT_DELIVERY_TIMEOUT_MS = 5 * 60_000
+export const INPUT_DELIVERY_TIMEOUT_MS = 120_000
 export const QUERY_ESTABLISHMENT_TIMEOUT_MS = 30_000
 
 const INPUT_DELIVERY_FAILURE_CODES = new Set<InputDeliveryFailureCode>([
@@ -193,6 +193,13 @@ const INPUT_DELIVERY_FAILURE_CODES = new Set<InputDeliveryFailureCode>([
   'abandoned_by_control_input',
   'confirmation_lost_after_restart',
 ])
+
+class InputDeliveryDeadlineError extends Error {
+  constructor(readonly delivery_id: string) {
+    super(`input delivery ${delivery_id} exceeded the synchronous attempt deadline`)
+    this.name = 'InputDeliveryDeadlineError'
+  }
+}
 
 function isInputDeliveryFailureCode(value: string | undefined): value is InputDeliveryFailureCode {
   return value !== undefined && INPUT_DELIVERY_FAILURE_CODES.has(value as InputDeliveryFailureCode)
@@ -829,6 +836,12 @@ export class WorkerHarness {
   private readonly stallReports = new Map<string, StallReportMark>()
   /** Adapter state callbacks observed per incarnation; used to order harness-owned CLI input settlement. */
   private readonly stateChangeRevisions = new Map<string, number>()
+  /** Serializes state callbacks and lets synchronous input wait for its hook publication. */
+  private readonly stateChangeTails = new Map<string, Promise<void>>()
+  /** Manager-originated deliveries are allowed to await active-episode mailbox publication. */
+  private readonly synchronousDeliveryWorkers = new Map<string, number>()
+  /** Retains the adapter disposition when a phase update itself cannot be persisted. */
+  private readonly deliveryStallDispositions = new Map<string, 'not_pasted' | 'pending_in_ui'>()
   /** Synchronous generation of the pane that currently owns input for each logical worker. */
   private readonly inputOwnershipRevisions = new Map<string, number>()
   private sweepInFlight = false
@@ -886,11 +899,26 @@ export class WorkerHarness {
     }
     const revisionKey = `${h.worker_id}#${h.impl}#${h.seq}`
     this.stateChangeRevisions.set(revisionKey, (this.stateChangeRevisions.get(revisionKey) ?? 0) + 1)
-    this.processStateChange(h, state, report)
+    const prior = this.stateChangeTails.get(revisionKey)
+    const processing = prior
+      ? prior.then(() => this.processStateChange(h, state, report))
+      : this.processStateChange(h, state, report)
+    const tail = processing
       .then(() => this.verifyControlOperationsForStateChange(h))
       .catch((err) => {
         console.error(`[WorkerHarness] handleStateChange failed for ${h.worker_id}#${h.seq}:`, err)
       })
+    this.stateChangeTails.set(revisionKey, tail)
+  }
+
+  private async waitForStateChanges(workerId: string, before: ReadonlyMap<string, number>): Promise<void> {
+    const pending: Promise<void>[] = []
+    for (const [key, tail] of this.stateChangeTails) {
+      if (!key.startsWith(`${workerId}#`)) continue
+      const current = this.stateChangeRevisions.get(key) ?? 0
+      if (current > (before.get(key) ?? 0)) pending.push(tail)
+    }
+    await Promise.all(pending)
   }
 
   /**
@@ -1175,6 +1203,7 @@ export class WorkerHarness {
     let redirectTarget: ExecutableIncarnation | undefined
     let redirectHeld = false
     let redirectItem: InboxItem | undefined
+    let synchronousDeadlineAt: number | undefined
 
     // "读台账状态 → 判断 cancelled/化身 → 入信箱"在同一临界区完成,不允许 check-then-act 跨 await。
     try {
@@ -1221,6 +1250,7 @@ export class WorkerHarness {
           )}`)
         }
         this.inputDeliveryControllers.set(deliveryId, new AbortController())
+        synchronousDeadlineAt = Date.now() + INPUT_DELIVERY_TIMEOUT_MS
       }
 
       const durableReceipt = receipt
@@ -1233,13 +1263,16 @@ export class WorkerHarness {
         ...(durableReceipt
           ? {
               delivery_id: durableReceipt.delivery_id,
-              onPending: (reason: InboxDeliveryResult['reason']) =>
-                this.inputDeliveryStore.updatePendingPhase(
+              onPending: (reason: InboxDeliveryResult['reason']) => {
+                const disposition = reason === 'input_pending' ? 'pending_in_ui' : 'not_pasted'
+                this.deliveryStallDispositions.set(durableReceipt.delivery_id, disposition)
+                return this.inputDeliveryStore.updatePendingPhase(
                   workerId,
                   durableReceipt.delivery_id,
-                  reason === 'input_pending' ? 'pending_in_ui' : 'waiting_for_safe_input',
+                  disposition === 'pending_in_ui' ? 'pending_in_ui' : 'waiting_for_safe_input',
                   this.deps.now(),
-                ).then(() => undefined),
+                ).then(() => undefined)
+              },
               shouldDeliver: async () =>
                 (await this.inputDeliveryStore.get(workerId, durableReceipt.delivery_id))?.state === 'pending',
               onSettled: async (settlement, detail) => {
@@ -1266,53 +1299,169 @@ export class WorkerHarness {
     }
 
     if (!enqueued) opts?.onDeduplicated?.()
+    const stateChangesBefore = new Map(
+      [...this.stateChangeRevisions.entries()].filter(([key]) => key.startsWith(`${workerId}#`)),
+    )
+    if (receipt) {
+      this.synchronousDeliveryWorkers.set(
+        workerId,
+        (this.synchronousDeliveryWorkers.get(workerId) ?? 0) + 1,
+      )
+    }
     let redirectError: unknown
     if (redirectTarget) {
       try {
-        await this.interruptForImmediateRedirect(workerId, redirectTarget)
+        const operation = this.interruptForImmediateRedirect(workerId, redirectTarget)
+        if (receipt && synchronousDeadlineAt !== undefined) {
+          await this.awaitWithinDeadline(operation, synchronousDeadlineAt, receipt.delivery_id)
+        } else {
+          await operation
+        }
       } catch (error) {
         redirectError = error
-        if (receipt) await this.failDurableInputAttempt(receipt, inbox, error, text)
+        if (receipt) {
+          if (error instanceof InputDeliveryDeadlineError) await this.settleTimedOutInput(receipt, inbox)
+          else await this.failDurableInputAttempt(receipt, inbox, error, text)
+        }
         else if (redirectItem) await inbox.cancelItem(redirectItem)
         else throw error
       } finally {
         inbox.release('immediate_redirect')
       }
     }
-    if (!redirectError) {
-      try {
-        await this.flushInbox(workerId)
-      } catch (error) {
-        if (!receipt) throw error
-        await this.failDurableInputAttempt(receipt, inbox, error, text)
-      }
-    }
-
-    if (!receipt) return
-    let current: WorkerInputDeliveryReceipt
     try {
-      current = await this.inputDeliveryStore.readForToolResult(
-        workerId,
-        receipt.delivery_id,
-        this.deps.now(),
-      )
-    } catch (error) {
-      this.inputDeliveryControllers.get(receipt.delivery_id)?.abort()
-      try {
-        await this.failDurableInputAttempt(receipt, inbox, error, text)
-      } catch (settlementError) {
-        throw new Error(`delivery receipt unavailable after acceptance: ${sanitizeOperationFailureReason(
-          settlementError,
-          this.deps.redactFailureReason,
-          text,
-          'receipt store failed',
-        )}`)
+      if (!redirectError) {
+        try {
+          if (receipt && synchronousDeadlineAt !== undefined) {
+            await this.flushInboxWithDeadline(workerId, receipt, synchronousDeadlineAt)
+          }
+          else await this.flushInbox(workerId)
+        } catch (error) {
+          if (!receipt) throw error
+          if (error instanceof InputDeliveryDeadlineError) {
+            await this.settleTimedOutInput(receipt, inbox)
+          } else {
+            await this.failDurableInputAttempt(receipt, inbox, error, text)
+          }
+        }
       }
-      const settled = await this.inputDeliveryStore.get(workerId, receipt.delivery_id)
-      if (!settled) throw error
-      current = settled
+
+      if (receipt) {
+        await this.waitForStateChanges(workerId, stateChangesBefore)
+      }
+
+      if (!receipt) return
+      let current: WorkerInputDeliveryReceipt
+      try {
+        current = await this.inputDeliveryStore.readForToolResult(
+          workerId,
+          receipt.delivery_id,
+          this.deps.now(),
+        )
+      } catch (error) {
+        this.inputDeliveryControllers.get(receipt.delivery_id)?.abort()
+        try {
+          await this.failDurableInputAttempt(receipt, inbox, error, text)
+        } catch (settlementError) {
+          throw new Error(`delivery receipt unavailable after acceptance: ${sanitizeOperationFailureReason(
+            settlementError,
+            this.deps.redactFailureReason,
+            text,
+            'receipt store failed',
+          )}`)
+        }
+        const settled = await this.inputDeliveryStore.get(workerId, receipt.delivery_id)
+        if (!settled) throw error
+        current = settled
+      }
+      if (current.state === 'pending') {
+        const cancellation = await inbox.cancelDelivery(receipt.delivery_id)
+        const disposition = this.deliveryStallDispositions.get(receipt.delivery_id)
+        let failed: InputDeliveryFailure
+        if (disposition === 'pending_in_ui' || current.phase === 'pending_in_ui' || cancellation === 'unsafe') {
+          failed = {
+            reason_code: 'submission_unconfirmed_timeout',
+            reason: 'input was placed in the CLI composer but acceptance could not be confirmed',
+            certainty: 'unknown',
+          }
+        } else if (current.phase === 'waiting_for_safe_input' || current.phase === 'queued') {
+          failed = {
+            reason_code: 'input_surface_timeout',
+            reason: 'CLI input surface was unavailable for this delivery attempt',
+            certainty: 'not_delivered',
+          }
+        } else {
+          failed = {
+            reason_code: 'delivery_attempt_failed',
+            reason: 'input delivery did not settle during the synchronous attempt',
+            certainty: 'unknown',
+          }
+        }
+        await this.settlePendingInputFailure(current, failed, true)
+        const settled = await this.inputDeliveryStore.get(workerId, receipt.delivery_id)
+        if (!settled) throw new Error(`delivery receipt disappeared: ${receipt.delivery_id}`)
+        current = settled
+      }
+      return this.toSendToWorkerResult(current)
+    } finally {
+      if (receipt) {
+        const active = (this.synchronousDeliveryWorkers.get(workerId) ?? 1) - 1
+        if (active > 0) this.synchronousDeliveryWorkers.set(workerId, active)
+        else this.synchronousDeliveryWorkers.delete(workerId)
+        this.deliveryStallDispositions.delete(receipt.delivery_id)
+      }
     }
-    return this.toSendToWorkerResult(current)
+  }
+
+  private async flushInboxWithDeadline(
+    workerId: string,
+    receipt: WorkerInputDeliveryReceipt,
+    deadlineAt: number,
+  ): Promise<void> {
+    const operation = this.flushInbox(workerId)
+    await this.awaitWithinDeadline(operation, deadlineAt, receipt.delivery_id)
+  }
+
+  private async awaitWithinDeadline<T>(
+    operation: Promise<T>,
+    deadlineAt: number,
+    deliveryId: string,
+  ): Promise<T> {
+    const remainingMs = deadlineAt - Date.now()
+    if (remainingMs <= 0) throw new InputDeliveryDeadlineError(deliveryId)
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const timeout = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => reject(new InputDeliveryDeadlineError(deliveryId)), remainingMs)
+      timer.unref?.()
+    })
+    try {
+      return await Promise.race([operation, timeout])
+    } finally {
+      if (timer) clearTimeout(timer)
+    }
+  }
+
+  private async settleTimedOutInput(
+    receipt: WorkerInputDeliveryReceipt,
+    inbox: WorkerInbox,
+  ): Promise<void> {
+    this.inputDeliveryControllers.get(receipt.delivery_id)?.abort()
+    const cancellation = await inbox.cancelDelivery(receipt.delivery_id)
+    const current = await this.inputDeliveryStore.get(receipt.worker_id, receipt.delivery_id)
+    if (!current || current.state !== 'pending') return
+    const failure: InputDeliveryFailure = cancellation === 'cancelled'
+      ? {
+          reason_code: 'input_surface_timeout',
+          reason: 'CLI input surface was unavailable before the synchronous delivery deadline',
+          certainty: 'not_delivered',
+        }
+      : {
+          reason_code: 'submission_unconfirmed_timeout',
+          reason: 'input acceptance could not be confirmed before the synchronous delivery deadline',
+          certainty: 'unknown',
+    }
+    await this.settlePendingInputFailure(current, failure, true)
+    this.inputDeliveryControllers.delete(receipt.delivery_id)
   }
 
   private async settleDurableInput(
@@ -1378,14 +1527,9 @@ export class WorkerHarness {
       certainty,
     }
     this.inputDeliveryControllers.delete(receipt.delivery_id)
-    await this.inputDeliveryStore.settleFailed(receipt.worker_id, receipt.delivery_id, failure, this.deps.now())
-    const found = await this.deps.ledger.findWorker(receipt.worker_id)
-    await this.appendAuditEvent(
-      receipt.worker_id,
-      found ? requireMainlineIncarnation(found.worker).seq : 0,
-      'input_delivery_failed',
-      { delivery_id: receipt.delivery_id, ...failure },
-    )
+    // The synchronous tool is about to return this failure in the Manager context;
+    // do not leave the same terminal result queued for a duplicate wake.
+    await this.settlePendingInputFailure(receipt, failure, true)
   }
 
   private toSendToWorkerResult(receipt: WorkerInputDeliveryReceipt): SendToWorkerResult {
@@ -1401,15 +1545,7 @@ export class WorkerHarness {
         ...receipt.failure,
       }
     }
-    return {
-      status: 'pending',
-      delivery_id: receipt.delivery_id,
-      worker_id: receipt.worker_id,
-      pending_reason: receipt.phase === 'queued' || receipt.phase === 'waiting_for_safe_input'
-        ? 'waiting_for_safe_input'
-        : 'submission_unconfirmed',
-      deadline_at: receipt.deadline_at,
-    }
+    throw new Error(`delivery ${receipt.delivery_id} remained pending after synchronous attempt`)
   }
 
   private async inputAttemptOptions(
@@ -3493,12 +3629,12 @@ export class WorkerHarness {
       const failure: InputDeliveryFailure = safelyWithdrawn
         ? {
             reason_code: 'input_surface_timeout',
-            reason: 'input did not reach a safe input surface before the 5 minute deadline',
+            reason: 'input did not reach a safe input surface before the 120 second deadline',
             certainty: 'not_delivered',
           }
         : {
             reason_code: 'submission_unconfirmed_timeout',
-            reason: 'input acceptance could not be confirmed before the 5 minute deadline',
+            reason: 'input acceptance could not be confirmed before the 120 second deadline',
             certainty: 'unknown',
           }
       this.inputDeliveryControllers.delete(receipt.delivery_id)
@@ -3510,6 +3646,7 @@ export class WorkerHarness {
   private async settlePendingInputFailure(
     receipt: WorkerInputDeliveryReceipt,
     failure: InputDeliveryFailure,
+    managerContextDelivered = false,
   ): Promise<void> {
     const settled = await this.inputDeliveryStore.settleFailed(
       receipt.worker_id,
@@ -3517,6 +3654,13 @@ export class WorkerHarness {
       failure,
       this.deps.now(),
     )
+    if (managerContextDelivered && settled.manager_notification.status === 'pending') {
+      await this.inputDeliveryStore.markNotificationConsumed(
+        receipt.worker_id,
+        receipt.delivery_id,
+        this.deps.now(),
+      )
+    }
     const found = await this.deps.ledger.findWorker(receipt.worker_id)
     const seq = found ? requireMainlineIncarnation(found.worker).seq : 0
     await this.appendAuditEvent(receipt.worker_id, seq, 'input_delivery_failed', {
@@ -5486,9 +5630,9 @@ export class WorkerHarness {
   ): Promise<void> {
     const event = this.buildEvent(workerId, seq, kind, detail, taskStatus)
     await this.getEventLog(workerId).append(event)
-    // fire-and-forget:本方法的调用点几乎都在 per-worker 锁内,而一次唤醒是一整个 manager
-    // episode(见 HarnessDeps.onEvent)。返回值只有活性巡检看,走下面那条专用出口。
-    void this.deps.onEvent?.(event)
+    const delivery = this.deps.onEvent?.(event)
+    if ((this.synchronousDeliveryWorkers.get(workerId) ?? 0) > 0) await delivery
+    else void delivery
   }
 
   /**

--- a/crabot-agent/src/workers/harness/harness.ts
+++ b/crabot-agent/src/workers/harness/harness.ts
@@ -702,6 +702,8 @@ export interface HarnessSendToWorkerOptions {
   /** Interrupt a non-builtin mainline before delivering this direction change. */
   readonly immediate_redirect?: boolean
   readonly managerKey?: ManagerKey
+  /** Absolute deadline created by the Manager tool before authorization starts. */
+  readonly deadline_at?: string
   readonly onSettled?: InboxItem['onSettled']
   readonly dedupeKey?: string
   readonly onDeduplicated?: () => void
@@ -842,6 +844,8 @@ export class WorkerHarness {
   private readonly synchronousDeliveryWorkers = new Map<string, number>()
   /** Retains the adapter disposition when a phase update itself cannot be persisted. */
   private readonly deliveryStallDispositions = new Map<string, 'not_pasted' | 'pending_in_ui'>()
+  /** Preserves one conservative timeout outcome while its nonblocking receipt cleanup runs. */
+  private readonly inputTimeoutFailures = new Map<string, InputDeliveryFailure>()
   /** Synchronous generation of the pane that currently owns input for each logical worker. */
   private readonly inputOwnershipRevisions = new Map<string, number>()
   private sweepInFlight = false
@@ -1203,12 +1207,21 @@ export class WorkerHarness {
     let redirectTarget: ExecutableIncarnation | undefined
     let redirectHeld = false
     let redirectItem: InboxItem | undefined
-    let synchronousDeadlineAt: number | undefined
+    let inputEnqueued = false
+    const deliveryId = opts?.managerKey ? randomUUID() : undefined
+    const synchronousDeadlineAt = opts?.managerKey
+      ? this.resolveSynchronousInputDeadline(opts.deadline_at)
+      : undefined
+    let awaitOwnerStateHooks = false
 
     // "读台账状态 → 判断 cancelled/化身 → 入信箱"在同一临界区完成,不允许 check-then-act 跨 await。
     try {
-      await this.withLock(workerId, async () => {
+      const prepare = () => this.withLock(workerId, async () => {
+      this.assertSynchronousInputDeadline(synchronousDeadlineAt, deliveryId)
       const found = await this.deps.ledger.findWorker(workerId)
+      // A queued worker lock or ledger read may have crossed the caller's deadline. Do not
+      // create a redirect hold, receipt, or inbox item after the tool has timed out.
+      this.assertSynchronousInputDeadline(synchronousDeadlineAt, deliveryId)
       if (!found) throw new WorkerNotFoundError(workerId)
       if (found.worker.task.status === 'cancelled') throw new TaskCancelledError(workerId)
       const mainline = requireMainlineIncarnation(found.worker)
@@ -1226,17 +1239,16 @@ export class WorkerHarness {
 
       if (opts?.managerKey) {
         const createdAt = this.deps.now()
-        const deliveryId = randomUUID()
         try {
           receipt = await this.inputDeliveryStore.create({
-            delivery_id: deliveryId,
+            delivery_id: deliveryId!,
             worker_id: workerId,
             manager_key: opts.managerKey,
             raw: opts.raw ?? false,
             text_preview: text,
             created_at: createdAt,
             updated_at: createdAt,
-            deadline_at: new Date(Date.parse(createdAt) + INPUT_DELIVERY_TIMEOUT_MS).toISOString(),
+            deadline_at: new Date(synchronousDeadlineAt!).toISOString(),
             state: 'pending',
             phase: 'queued',
             manager_notification: { status: 'not_required' },
@@ -1249,8 +1261,16 @@ export class WorkerHarness {
             'receipt store failed',
           )}`)
         }
-        this.inputDeliveryControllers.set(deliveryId, new AbortController())
-        synchronousDeadlineAt = Date.now() + INPUT_DELIVERY_TIMEOUT_MS
+        if (receipt.state !== 'pending') {
+          this.recordExpiredReceiptFailure(receipt, requireMainlineIncarnation(found.worker).seq)
+          return
+        }
+        if (this.isSynchronousInputDeadlineExpired(synchronousDeadlineAt)) {
+          this.scheduleTimedOutInputSettlement(receipt, inbox, 'cancelled')
+          throw new InputDeliveryDeadlineError(deliveryId!)
+        }
+        this.inputDeliveryControllers.set(deliveryId!, new AbortController())
+        awaitOwnerStateHooks = opts.managerKey === found.managerKey
       }
 
       const durableReceipt = receipt
@@ -1263,6 +1283,7 @@ export class WorkerHarness {
         ...(durableReceipt
           ? {
               delivery_id: durableReceipt.delivery_id,
+              deadline_at: durableReceipt.deadline_at,
               onPending: (reason: InboxDeliveryResult['reason']) => {
                 const disposition = reason === 'input_pending' ? 'pending_in_ui' : 'not_pasted'
                 this.deliveryStallDispositions.set(durableReceipt.delivery_id, disposition)
@@ -1274,6 +1295,7 @@ export class WorkerHarness {
                 ).then(() => undefined)
               },
               shouldDeliver: async () =>
+                !this.isSynchronousInputDeadlineExpired(Date.parse(durableReceipt.deadline_at)) &&
                 (await this.inputDeliveryStore.get(workerId, durableReceipt.delivery_id))?.state === 'pending',
               onSettled: async (settlement, detail) => {
                 await this.settleDurableInput(durableReceipt, text, settlement, detail)
@@ -1284,6 +1306,7 @@ export class WorkerHarness {
         ...(opts?.dedupeKey ? { dedupe_key: opts.dedupeKey } : {}),
         ...(opts?.legacyContinuationAuth ? { legacy_continuation_auth: opts.legacyContinuationAuth } : {}),
       }
+      this.assertSynchronousInputDeadline(synchronousDeadlineAt, deliveryId)
       if (redirectTarget) redirectItem = item
       if (opts?.dedupeKey && !durableReceipt) {
         enqueued = inbox.enqueueUnique(item)
@@ -1291,45 +1314,94 @@ export class WorkerHarness {
         if (opts?.immediate_redirect === true) inbox.enqueuePriority(item)
         else inbox.enqueue(item)
         enqueued = true
+        inputEnqueued = durableReceipt !== undefined
       }
       })
+      if (synchronousDeadlineAt !== undefined && deliveryId !== undefined) {
+        await this.awaitWithinDeadline(prepare, synchronousDeadlineAt, deliveryId)
+      } else {
+        await prepare()
+      }
     } catch (error) {
       if (redirectHeld) inbox.release('immediate_redirect')
+      if (error instanceof InputDeliveryDeadlineError && deliveryId !== undefined) {
+        return this.finishSynchronousInputDeadline(
+          workerId,
+          deliveryId,
+          receipt,
+          inbox,
+          receipt && !inputEnqueued ? 'cancelled' : undefined,
+        )
+      }
       throw error
+    }
+
+    if (receipt && receipt.state !== 'pending') {
+      if (redirectHeld) inbox.release('immediate_redirect')
+      return this.toSendToWorkerResult(receipt)
     }
 
     if (!enqueued) opts?.onDeduplicated?.()
     const stateChangesBefore = new Map(
       [...this.stateChangeRevisions.entries()].filter(([key]) => key.startsWith(`${workerId}#`)),
     )
-    if (receipt) {
+    if (receipt && awaitOwnerStateHooks) {
       this.synchronousDeliveryWorkers.set(
         workerId,
         (this.synchronousDeliveryWorkers.get(workerId) ?? 0) + 1,
       )
     }
-    let redirectError: unknown
-    if (redirectTarget) {
-      try {
-        const operation = this.interruptForImmediateRedirect(workerId, redirectTarget)
-        if (receipt && synchronousDeadlineAt !== undefined) {
-          await this.awaitWithinDeadline(operation, synchronousDeadlineAt, receipt.delivery_id)
-        } else {
-          await operation
-        }
-      } catch (error) {
-        redirectError = error
-        if (receipt) {
-          if (error instanceof InputDeliveryDeadlineError) await this.settleTimedOutInput(receipt, inbox)
-          else await this.failDurableInputAttempt(receipt, inbox, error, text)
-        }
-        else if (redirectItem) await inbox.cancelItem(redirectItem)
-        else throw error
-      } finally {
-        inbox.release('immediate_redirect')
-      }
-    }
     try {
+      let redirectError: unknown
+      if (redirectTarget) {
+        try {
+          if (receipt && synchronousDeadlineAt !== undefined) {
+            const activeReceipt = receipt
+            await this.awaitWithinDeadline(
+              () => this.interruptForImmediateRedirect(
+                workerId,
+                redirectTarget!,
+                synchronousDeadlineAt,
+                activeReceipt.delivery_id,
+              ),
+              synchronousDeadlineAt,
+              activeReceipt.delivery_id,
+            )
+          } else {
+            await this.interruptForImmediateRedirect(workerId, redirectTarget)
+          }
+        } catch (error) {
+          redirectError = error
+          if (receipt) {
+            if (error instanceof InputDeliveryDeadlineError) {
+              return this.finishSynchronousInputDeadline(workerId, receipt.delivery_id, receipt, inbox)
+            }
+            try {
+              const settled = await this.awaitWithinDeadline(
+                () => this.failDurableInputAttempt(receipt!, inbox, error, text),
+                synchronousDeadlineAt!,
+                receipt.delivery_id,
+              )
+              return this.toSendToWorkerResult(settled)
+            } catch (settlementError) {
+              if (settlementError instanceof InputDeliveryDeadlineError) {
+                return this.finishSynchronousInputDeadline(workerId, receipt.delivery_id, receipt, inbox)
+              }
+              throw new Error(`delivery receipt unavailable after redirect failure: ${sanitizeOperationFailureReason(
+                settlementError,
+                this.deps.redactFailureReason,
+                text,
+                'receipt store failed',
+              )}`)
+            }
+          }
+          else if (redirectItem) await inbox.cancelItem(redirectItem)
+          else throw error
+        } finally {
+          inbox.release('immediate_redirect')
+        }
+      }
+
       if (!redirectError) {
         try {
           if (receipt && synchronousDeadlineAt !== undefined) {
@@ -1339,30 +1411,70 @@ export class WorkerHarness {
         } catch (error) {
           if (!receipt) throw error
           if (error instanceof InputDeliveryDeadlineError) {
-            await this.settleTimedOutInput(receipt, inbox)
-          } else {
-            await this.failDurableInputAttempt(receipt, inbox, error, text)
+            return this.finishSynchronousInputDeadline(workerId, receipt.delivery_id, receipt, inbox)
+          }
+          try {
+            const settled = await this.awaitWithinDeadline(
+              () => this.failDurableInputAttempt(receipt!, inbox, error, text),
+              synchronousDeadlineAt!,
+              receipt.delivery_id,
+            )
+            return this.toSendToWorkerResult(settled)
+          } catch (settlementError) {
+            if (settlementError instanceof InputDeliveryDeadlineError) {
+              return this.finishSynchronousInputDeadline(workerId, receipt.delivery_id, receipt, inbox)
+            }
+            throw new Error(`delivery receipt unavailable after input failure: ${sanitizeOperationFailureReason(
+              settlementError,
+              this.deps.redactFailureReason,
+              text,
+              'receipt store failed',
+            )}`)
           }
         }
       }
 
-      if (receipt) {
-        await this.waitForStateChanges(workerId, stateChangesBefore)
+      if (receipt && awaitOwnerStateHooks && synchronousDeadlineAt !== undefined) {
+        try {
+          await this.awaitWithinDeadline(
+            () => this.waitForStateChanges(workerId, stateChangesBefore),
+            synchronousDeadlineAt,
+            receipt.delivery_id,
+          )
+        } catch (error) {
+          if (!(error instanceof InputDeliveryDeadlineError)) throw error
+          return this.finishSynchronousInputDeadline(workerId, receipt.delivery_id, receipt, inbox)
+        }
       }
 
       if (!receipt) return
       let current: WorkerInputDeliveryReceipt
       try {
-        current = await this.inputDeliveryStore.readForToolResult(
-          workerId,
+        current = await this.awaitWithinDeadline(
+          () => this.inputDeliveryStore.readForToolResult(
+            workerId,
+            receipt!.delivery_id,
+            this.deps.now(),
+          ),
+          synchronousDeadlineAt!,
           receipt.delivery_id,
-          this.deps.now(),
         )
       } catch (error) {
+        if (error instanceof InputDeliveryDeadlineError) {
+          return this.finishSynchronousInputDeadline(workerId, receipt.delivery_id, receipt, inbox)
+        }
         this.inputDeliveryControllers.get(receipt.delivery_id)?.abort()
         try {
-          await this.failDurableInputAttempt(receipt, inbox, error, text)
+          const settled = await this.awaitWithinDeadline(
+            () => this.failDurableInputAttempt(receipt!, inbox, error, text),
+            synchronousDeadlineAt!,
+            receipt.delivery_id,
+          )
+          return this.toSendToWorkerResult(settled)
         } catch (settlementError) {
+          if (settlementError instanceof InputDeliveryDeadlineError) {
+            return this.finishSynchronousInputDeadline(workerId, receipt.delivery_id, receipt, inbox)
+          }
           throw new Error(`delivery receipt unavailable after acceptance: ${sanitizeOperationFailureReason(
             settlementError,
             this.deps.redactFailureReason,
@@ -1370,15 +1482,16 @@ export class WorkerHarness {
             'receipt store failed',
           )}`)
         }
-        const settled = await this.inputDeliveryStore.get(workerId, receipt.delivery_id)
-        if (!settled) throw error
-        current = settled
       }
       if (current.state === 'pending') {
-        const cancellation = await inbox.cancelDelivery(receipt.delivery_id)
+        const cancellation = inbox.cancelDeliveryImmediately(receipt.delivery_id)
         const disposition = this.deliveryStallDispositions.get(receipt.delivery_id)
         let failed: InputDeliveryFailure
-        if (disposition === 'pending_in_ui' || current.phase === 'pending_in_ui' || cancellation === 'unsafe') {
+        if (
+          disposition === 'pending_in_ui' ||
+          current.phase === 'pending_in_ui' ||
+          cancellation !== 'cancelled'
+        ) {
           failed = {
             reason_code: 'submission_unconfirmed_timeout',
             reason: 'input was placed in the CLI composer but acceptance could not be confirmed',
@@ -1397,14 +1510,22 @@ export class WorkerHarness {
             certainty: 'unknown',
           }
         }
-        await this.settlePendingInputFailure(current, failed, true)
-        const settled = await this.inputDeliveryStore.get(workerId, receipt.delivery_id)
-        if (!settled) throw new Error(`delivery receipt disappeared: ${receipt.delivery_id}`)
-        current = settled
+        try {
+          current = await this.awaitWithinDeadline(
+            () => this.settlePendingInputFailure(current, failed, true),
+            synchronousDeadlineAt!,
+            receipt.delivery_id,
+          )
+        } catch (error) {
+          if (error instanceof InputDeliveryDeadlineError) {
+            return this.finishSynchronousInputDeadline(workerId, receipt.delivery_id, receipt, inbox, cancellation)
+          }
+          throw error
+        }
       }
       return this.toSendToWorkerResult(current)
     } finally {
-      if (receipt) {
+      if (receipt && awaitOwnerStateHooks) {
         const active = (this.synchronousDeliveryWorkers.get(workerId) ?? 1) - 1
         if (active > 0) this.synchronousDeliveryWorkers.set(workerId, active)
         else this.synchronousDeliveryWorkers.delete(workerId)
@@ -1418,12 +1539,11 @@ export class WorkerHarness {
     receipt: WorkerInputDeliveryReceipt,
     deadlineAt: number,
   ): Promise<void> {
-    const operation = this.flushInbox(workerId)
-    await this.awaitWithinDeadline(operation, deadlineAt, receipt.delivery_id)
+    await this.awaitWithinDeadline(() => this.flushInbox(workerId), deadlineAt, receipt.delivery_id)
   }
 
   private async awaitWithinDeadline<T>(
-    operation: Promise<T>,
+    operation: () => Promise<T>,
     deadlineAt: number,
     deliveryId: string,
   ): Promise<T> {
@@ -1435,21 +1555,41 @@ export class WorkerHarness {
       timer.unref?.()
     })
     try {
-      return await Promise.race([operation, timeout])
+      return await Promise.race([Promise.resolve().then(operation), timeout])
     } finally {
       if (timer) clearTimeout(timer)
     }
   }
 
-  private async settleTimedOutInput(
-    receipt: WorkerInputDeliveryReceipt,
-    inbox: WorkerInbox,
-  ): Promise<void> {
-    this.inputDeliveryControllers.get(receipt.delivery_id)?.abort()
-    const cancellation = await inbox.cancelDelivery(receipt.delivery_id)
-    const current = await this.inputDeliveryStore.get(receipt.worker_id, receipt.delivery_id)
-    if (!current || current.state !== 'pending') return
-    const failure: InputDeliveryFailure = cancellation === 'cancelled'
+  private assertSynchronousInputDeadline(deadlineAt: number | undefined, deliveryId: string | undefined): void {
+    if (deliveryId !== undefined && this.isSynchronousInputDeadlineExpired(deadlineAt)) {
+      throw new InputDeliveryDeadlineError(deliveryId)
+    }
+  }
+
+  private isSynchronousInputDeadlineExpired(deadlineAt: number | undefined): boolean {
+    return deadlineAt !== undefined && deadlineAt <= Date.now()
+  }
+
+  private expiredInboxDelivery(item: InboxItem | undefined, seq: number): InboxSettledResult | undefined {
+    if (!item?.delivery_id || !item.deadline_at || !this.isSynchronousInputDeadlineExpired(Date.parse(item.deadline_at))) {
+      return undefined
+    }
+    return {
+      action: 'settled',
+      settlement: 'dead_letter',
+      detail: {
+        seq,
+        reason: 'input_surface_timeout',
+        certainty: 'not_delivered',
+      },
+    }
+  }
+
+  private timeoutFailureFor(
+    cancellation: ReturnType<WorkerInbox['cancelDeliveryImmediately']>,
+  ): InputDeliveryFailure {
+    return cancellation === 'cancelled'
       ? {
           reason_code: 'input_surface_timeout',
           reason: 'CLI input surface was unavailable before the synchronous delivery deadline',
@@ -1459,9 +1599,75 @@ export class WorkerHarness {
           reason_code: 'submission_unconfirmed_timeout',
           reason: 'input acceptance could not be confirmed before the synchronous delivery deadline',
           certainty: 'unknown',
+        }
+  }
+
+  /**
+   * Never await persistence from the deadline path. A queued item can be removed synchronously;
+   * anything in flight, settling, or absent is conservatively unknown and reconciled later.
+   */
+  private finishSynchronousInputDeadline(
+    workerId: string,
+    deliveryId: string,
+    receipt: WorkerInputDeliveryReceipt | undefined,
+    inbox: WorkerInbox,
+    knownCancellation?: ReturnType<WorkerInbox['cancelDeliveryImmediately']>,
+  ): SendToWorkerResult {
+    if (!receipt) {
+      return {
+        status: 'failed',
+        delivery_id: deliveryId,
+        worker_id: workerId,
+        reason_code: 'input_surface_timeout',
+        reason: 'input delivery setup exceeded the synchronous delivery deadline',
+        certainty: 'not_delivered',
+      }
     }
-    await this.settlePendingInputFailure(current, failure, true)
-    this.inputDeliveryControllers.delete(receipt.delivery_id)
+    const cancellation = knownCancellation ?? inbox.cancelDeliveryImmediately(receipt.delivery_id)
+    const failure = this.timeoutFailureFor(cancellation)
+    this.scheduleTimedOutInputSettlement(receipt, inbox, cancellation)
+    return {
+      status: 'failed',
+      delivery_id: receipt.delivery_id,
+      worker_id: receipt.worker_id,
+      ...failure,
+    }
+  }
+
+  private scheduleTimedOutInputSettlement(
+    receipt: WorkerInputDeliveryReceipt,
+    inbox: WorkerInbox,
+    cancellation = inbox.cancelDeliveryImmediately(receipt.delivery_id),
+  ): void {
+    this.inputDeliveryControllers.get(receipt.delivery_id)?.abort()
+    const failure = this.inputTimeoutFailures.get(receipt.delivery_id) ?? this.timeoutFailureFor(cancellation)
+    if (this.inputTimeoutFailures.has(receipt.delivery_id)) return
+    this.inputTimeoutFailures.set(receipt.delivery_id, failure)
+    void this.settlePendingInputFailure(receipt, failure, true)
+      .catch((error) => {
+        console.error(`[WorkerHarness] timed out input settlement failed for ${receipt.delivery_id}:`, error)
+      })
+      .finally(() => {
+        this.inputTimeoutFailures.delete(receipt.delivery_id)
+        this.inputDeliveryControllers.delete(receipt.delivery_id)
+      })
+  }
+
+  private recordExpiredReceiptFailure(receipt: WorkerInputDeliveryReceipt, seq: number): void {
+    if (receipt.state !== 'failed' || !receipt.failure) return
+    void this.appendAuditEvent(receipt.worker_id, seq, 'input_delivery_failed', {
+      delivery_id: receipt.delivery_id,
+      ...receipt.failure,
+    }).catch((error) => {
+      console.error(`[WorkerHarness] failed to record expired input receipt ${receipt.delivery_id}:`, error)
+    })
+  }
+
+  private resolveSynchronousInputDeadline(deadlineAt: string | undefined): number {
+    if (deadlineAt === undefined) return Date.now() + INPUT_DELIVERY_TIMEOUT_MS
+    const parsed = Date.parse(deadlineAt)
+    if (!Number.isFinite(parsed)) throw new Error(`invalid input delivery deadline: ${deadlineAt}`)
+    return parsed
   }
 
   private async settleDurableInput(
@@ -1472,11 +1678,21 @@ export class WorkerHarness {
   ): Promise<void> {
     this.inputDeliveryControllers.delete(receipt.delivery_id)
     if (settlement === 'delivered') {
-      const settled = await this.inputDeliveryStore.settleDelivered(receipt.worker_id, receipt.delivery_id, this.deps.now())
-      await this.appendAuditEvent(receipt.worker_id, detail?.seq ?? 0, 'input_sent', {
+      const result = await this.inputDeliveryStore.settleDelivered(receipt.worker_id, receipt.delivery_id, this.deps.now())
+      if (!result.transitioned) return
+      const settled = result.receipt
+      if (settled.state === 'delivered') {
+        await this.appendAuditEvent(receipt.worker_id, detail?.seq ?? 0, 'input_sent', {
+          delivery_id: receipt.delivery_id,
+          text_preview: settled.text_preview,
+          text_len: text.length,
+        })
+        return
+      }
+      if (!settled.failure) throw new Error(`failed delivery ${receipt.delivery_id} has no failure detail`)
+      await this.appendAuditEvent(receipt.worker_id, detail?.seq ?? 0, 'input_delivery_failed', {
         delivery_id: receipt.delivery_id,
-        text_preview: settled.text_preview,
-        text_len: text.length,
+        ...settled.failure,
       })
       return
     }
@@ -1489,11 +1705,7 @@ export class WorkerHarness {
       reason: describeInputDeliveryFailure(reasonCode),
       certainty: detail?.certainty ?? 'unknown',
     }
-    await this.inputDeliveryStore.settleFailed(receipt.worker_id, receipt.delivery_id, failure, this.deps.now())
-    await this.appendAuditEvent(receipt.worker_id, detail?.seq ?? 0, 'input_delivery_failed', {
-      delivery_id: receipt.delivery_id,
-      ...failure,
-    })
+    await this.settlePendingInputFailure(receipt, failure, true)
   }
 
   private async failDurableInputAttempt(
@@ -1501,10 +1713,11 @@ export class WorkerHarness {
     inbox: WorkerInbox,
     error: unknown,
     text: string,
-  ): Promise<void> {
-    const cancellation = await inbox.cancelDelivery(receipt.delivery_id)
+  ): Promise<WorkerInputDeliveryReceipt> {
+    const cancellation = inbox.cancelDeliveryImmediately(receipt.delivery_id)
     const current = await this.inputDeliveryStore.get(receipt.worker_id, receipt.delivery_id)
-    if (!current || current.state !== 'pending') return
+    if (!current) throw new Error(`delivery receipt disappeared: ${receipt.delivery_id}`)
+    if (current.state !== 'pending') return current
 
     const reasonCode: InputDeliveryFailureCode = current.phase === 'continuing'
       ? 'continuation_failed'
@@ -1529,7 +1742,7 @@ export class WorkerHarness {
     this.inputDeliveryControllers.delete(receipt.delivery_id)
     // The synchronous tool is about to return this failure in the Manager context;
     // do not leave the same terminal result queued for a duplicate wake.
-    await this.settlePendingInputFailure(receipt, failure, true)
+    return this.settlePendingInputFailure(receipt, failure, true)
   }
 
   private toSendToWorkerResult(receipt: WorkerInputDeliveryReceipt): SendToWorkerResult {
@@ -1695,6 +1908,8 @@ export class WorkerHarness {
       // 主线化身,不能用"数组最后一个"——fork 之后数组末尾是侧问分支,投递必须仍然打到
       // 主线(protocol-agent-v3 §5.3:fork 不影响主线)。
       const incarnation = requireMainlineIncarnation(found.worker)
+      const expired = this.expiredInboxDelivery(item, incarnation.seq)
+      if (expired) return expired
 
       if (isLegacyIncarnation(incarnation)) {
         if (item.allow_terminal_continuation === false) return 'delivered'
@@ -1748,6 +1963,8 @@ export class WorkerHarness {
           signal: this.inputDeliveryControllers.get(item.delivery_id)?.signal,
         }
       }
+      const expiredBeforeAttempt = this.expiredInboxDelivery(item, incarnation.seq)
+      if (expiredBeforeAttempt) return expiredBeforeAttempt
       const attempt = await this.attemptInput(adapter, handle, item.text, item.raw, {
         ...deliveryOptions,
         ...(item.immediate_redirect ? { immediate_redirect: true } : {}),
@@ -1798,6 +2015,8 @@ export class WorkerHarness {
       if (!isLegacyIncarnation(legacy)) {
         throw new Error('WorkerHarness.legacyContinuation: mainline changed before continuation')
       }
+      const expired = this.expiredInboxDelivery(item, legacy.seq)
+      if (expired) return expired
       if (
         (worker.task.status !== 'completed' && worker.task.status !== 'failed') ||
         !['completed', 'failed', 'pre_migration'].includes(legacy.ended_reason)
@@ -1832,6 +2051,10 @@ export class WorkerHarness {
         worker.worker_id,
         material.workspaceCandidate,
       )
+      // Source reads may have waited past the synchronous deadline. Do not begin a new
+      // provision/handoff after the caller has already received its timeout.
+      const expiredAfterPreparation = this.expiredInboxDelivery(item, legacy.seq)
+      if (expiredAfterPreparation) return expiredAfterPreparation
       // P6-C：目标选择来自 registry（排除该 worker 已用过的实现）；无 selector 的旧测试
       // 路径保留 pickUnusedImpl。
       const usedImpls = new Set(worker.incarnations.map((inc) => inc.impl).filter((impl): impl is WorkerImplId => impl !== 'legacy'))
@@ -1841,7 +2064,14 @@ export class WorkerHarness {
       // P6-B §6.5：legacy 接续的 spawn 同样过 registry gate + connection admission——
       // 不得绕过 ready 校验，admin_provider 形态不得回落宿主凭证。
       await this.deps.assertWorkerImplReady?.(targetImpl)
+      const expiredAfterReady = this.expiredInboxDelivery(item, legacy.seq)
+      if (expiredAfterReady) return expiredAfterReady
       const admission = await this.deps.admitWorkerConnection?.(targetImpl, worker.worker_id)
+      const expiredAfterAdmission = this.expiredInboxDelivery(item, legacy.seq)
+      if (expiredAfterAdmission) {
+        if (admission) void admission.dispose().catch(() => {})
+        return expiredAfterAdmission
+      }
       const targetAdapter = this.deps.adapters.get(targetImpl)
       if (!targetAdapter) {
         if (admission) await admission.dispose()
@@ -1857,11 +2087,21 @@ export class WorkerHarness {
             principal_permissions: auth.principal_permissions,
           })
         : EMPTY_CAPABILITY_BUNDLE
+      const expiredAfterCapabilities = this.expiredInboxDelivery(item, legacy.seq)
+      if (expiredAfterCapabilities) {
+        if (admission) void admission.dispose().catch(() => {})
+        return expiredAfterCapabilities
+      }
       if (targetImpl === 'builtin' && !this.deps.builtinSpawnDefaults) {
         throw new Error('WorkerHarness.legacyContinuation: builtin target requires builtinSpawnDefaults')
       }
       // No context, HANDOFF, ledger, provision or spawn side effect precedes target preflight.
       await targetAdapter.preflightProvision?.(workspace, caps)
+      const expiredAfterPreflight = this.expiredInboxDelivery(item, legacy.seq)
+      if (expiredAfterPreflight) {
+        if (admission) void admission.dispose().catch(() => {})
+        return expiredAfterPreflight
+      }
 
       const handoffAt = this.deps.now()
       const incarnationId = randomUUID()
@@ -1872,6 +2112,11 @@ export class WorkerHarness {
         workspaceRoot: workspace.root,
         capturedAt: handoffAt,
       })
+      const expiredAfterInstructions = this.expiredInboxDelivery(item, legacy.seq)
+      if (expiredAfterInstructions) {
+        if (admission) void admission.dispose().catch(() => {})
+        return expiredAfterInstructions
+      }
       const builtin = targetImpl === 'builtin'
         ? this.deps.builtinSpawnDefaults?.({
             worker_id: worker.worker_id,
@@ -1894,10 +2139,31 @@ export class WorkerHarness {
             instructions,
           })
         : undefined
+      const discardPreparedLegacyContinuation = (): void => {
+        if (claudeBridge?.managed) {
+          void cleanupClaudeWorkspaceBridge({
+            workersDir: this.deps.workersDir,
+            workerId: worker.worker_id,
+            incarnationId,
+            workspaceRoot: workspace.root,
+          }).catch(() => {})
+        }
+        if (admission) void admission.dispose().catch(() => {})
+      }
+      const expiredAfterBridge = this.expiredInboxDelivery(item, legacy.seq)
+      if (expiredAfterBridge) {
+        discardPreparedLegacyContinuation()
+        return expiredAfterBridge
+      }
       const legacyIncarnationId = requireStableIncarnationId(legacy, worker.worker_id)
       const persistedActivity = worker.legacy_source?.kind === 'ambiguous_v3_ledger'
         ? await this.nativeActivityStore.activities(worker.worker_id, legacyIncarnationId)
         : material.events
+      const expiredAfterActivityRead = this.expiredInboxDelivery(item, legacy.seq)
+      if (expiredAfterActivityRead) {
+        discardPreparedLegacyContinuation()
+        return expiredAfterActivityRead
+      }
       const handoff = await writeHandoffPackage({
         workersDir: this.deps.workersDir,
         workerId: worker.worker_id,
@@ -1909,9 +2175,19 @@ export class WorkerHarness {
           ...traceHandoffEvidence('persisted_activity', legacyIncarnationId, persistedActivity),
         ],
       })
+      const expiredAfterHandoff = this.expiredInboxDelivery(item, legacy.seq)
+      if (expiredAfterHandoff) {
+        discardPreparedLegacyContinuation()
+        return expiredAfterHandoff
+      }
       await this.contextStore.write(worker.worker_id, {
         principal_permissions: auth.principal_permissions,
       })
+      const expiredAfterContextWrite = this.expiredInboxDelivery(item, legacy.seq)
+      if (expiredAfterContextWrite) {
+        discardPreparedLegacyContinuation()
+        return expiredAfterContextWrite
+      }
       await this.appendEvent(worker.worker_id, legacy.seq, 'handoff_started', {
         target_impl: targetImpl,
         legacy: true,
@@ -1919,9 +2195,35 @@ export class WorkerHarness {
       })
 
       const prompt = renderHandoffPrompt(handoff, item.text)
+      const expiredBeforeSpawn = this.expiredInboxDelivery(item, legacy.seq)
+      if (expiredBeforeSpawn) {
+        if (claudeBridge?.managed) {
+          void cleanupClaudeWorkspaceBridge({
+            workersDir: this.deps.workersDir,
+            workerId: worker.worker_id,
+            incarnationId,
+            workspaceRoot: workspace.root,
+          }).catch(() => {})
+        }
+        if (admission) void admission.dispose().catch(() => {})
+        return expiredBeforeSpawn
+      }
       let handle
       try {
         await targetAdapter.provision(workspace, caps)
+        const expiredAfterProvision = this.expiredInboxDelivery(item, legacy.seq)
+        if (expiredAfterProvision) {
+          if (claudeBridge?.managed) {
+            void cleanupClaudeWorkspaceBridge({
+              workersDir: this.deps.workersDir,
+              workerId: worker.worker_id,
+              incarnationId,
+              workspaceRoot: workspace.root,
+            }).catch(() => {})
+          }
+          if (admission) void admission.dispose().catch(() => {})
+          return expiredAfterProvision
+        }
         handle = await targetAdapter.spawn({
           worker_id: worker.worker_id,
           incarnation_id: incarnationId,
@@ -2249,6 +2551,8 @@ export class WorkerHarness {
         const found = await this.deps.ledger.findWorker(workerId)
         if (!found) throw new WorkerNotFoundError(workerId)
         const { worker, managerKey } = found
+        const expired = this.expiredInboxDelivery(item, curSeq)
+        if (expired) return expired
 
         // task 在锁外投递期间被 killWorker 打断(如 send 卡在 tmux 投递期间调 kill,这条
         // 消息在拿到这把锁之前就已经确定要走接续路径了):§5.5"唯一硬拒绝:cancelled"只
@@ -2302,17 +2606,20 @@ export class WorkerHarness {
             impl: mainline.impl,
             session_ref: mainline.session_ref,
           }
+          const deliveryOptions = item?.delivery_id
+            ? {
+                ...(await this.inputAttemptOptions(workerId, item.delivery_id)),
+                ...(item.immediate_redirect ? { immediate_redirect: true } : {}),
+              }
+            : item?.immediate_redirect ? { immediate_redirect: true } : undefined
+          const expiredBeforeAttempt = this.expiredInboxDelivery(item, mainline.seq)
+          if (expiredBeforeAttempt) return expiredBeforeAttempt
           const attempt = await this.attemptInput(
             adapter,
             handle,
             text,
             raw,
-            item?.delivery_id
-              ? {
-                  ...(await this.inputAttemptOptions(workerId, item.delivery_id)),
-                  ...(item.immediate_redirect ? { immediate_redirect: true } : {}),
-                }
-              : item?.immediate_redirect ? { immediate_redirect: true } : undefined,
+            deliveryOptions,
           )
           if (attempt.kind === 'exited') {
             // adapter 侧权威判定这个"看起来存活"的新主线其实也已经终态(台账的异步状态
@@ -2334,6 +2641,8 @@ export class WorkerHarness {
         }
 
         if (adapter.capabilities().revive) {
+          const expiredBeforeRevive = this.expiredInboxDelivery(item, mainline.seq)
+          if (expiredBeforeRevive) return expiredBeforeRevive
           const delivery = await this.reviveIncarnation(
             managerKey,
             worker,
@@ -2341,6 +2650,7 @@ export class WorkerHarness {
             adapter,
             text,
             curEndReason,
+            item,
           )
           if (isContinuationRetry(delivery)) {
             curImpl = delivery.impl
@@ -2362,6 +2672,8 @@ export class WorkerHarness {
           const targetImpl = this.deps.selectWorkerImpl
             ? this.deps.selectWorkerImpl(undefined, usedImpls2)
             : pickUnusedImpl(worker, this.deps.adapters, this.deps.defaultImpl)
+          const expiredBeforeHandoff = this.expiredInboxDelivery(item, mainline.seq)
+          if (expiredBeforeHandoff) return expiredBeforeHandoff
           const handoff = await this.handoffIncarnation(
             managerKey,
             worker,
@@ -2370,6 +2682,7 @@ export class WorkerHarness {
             text,
             true,
             raw,
+            item,
           )
           if (isContinuationRetry(handoff.delivery)) {
             curImpl = handoff.delivery.impl
@@ -2415,10 +2728,13 @@ export class WorkerHarness {
     text: string,
     /** adapter 经 WorkerExitedError 报上来的源化身终止原因(见下面回填段的注释)。 */
     sourceEndReason?: IncarnationEndReason,
+    item?: InboxItem,
   ): Promise<ContinuationDelivery> {
     this.deps.assertExecutionAdmission?.()
     // P6-B：resume 重验 ready（「已有 running incarnation 不杀，新 resume/handoff 重验」）。
     await this.deps.assertWorkerImplReady?.(mainline.impl)
+    const expiredAfterReady = this.expiredInboxDelivery(item, mainline.seq)
+    if (expiredAfterReady) return expiredAfterReady
     const incarnationId = randomUUID()
     const instructions = await captureWorkspaceInstructions({
       workersDir: this.deps.workersDir,
@@ -2427,6 +2743,8 @@ export class WorkerHarness {
       workspaceRoot: mainline.workspace,
       capturedAt: this.deps.now(),
     })
+    const expiredAfterInstructions = this.expiredInboxDelivery(item, mainline.seq)
+    if (expiredAfterInstructions) return expiredAfterInstructions
     const claudeBridge = mainline.impl === 'claude-code'
       ? await prepareClaudeWorkspaceBridge({
         workersDir: this.deps.workersDir,
@@ -2436,8 +2754,33 @@ export class WorkerHarness {
         instructions,
       })
       : undefined
+    const expiredAfterBridge = this.expiredInboxDelivery(item, mainline.seq)
+    if (expiredAfterBridge) {
+      if (claudeBridge?.managed) {
+        void cleanupClaudeWorkspaceBridge({
+          workersDir: this.deps.workersDir,
+          workerId: worker.worker_id,
+          incarnationId,
+          workspaceRoot: mainline.workspace,
+        }).catch(() => {})
+      }
+      return expiredAfterBridge
+    }
     // P6-B §6.5：resume 同样 operation-time 解析连接（revision 变化即拒绝）。
     const admission = await this.deps.admitWorkerConnection?.(mainline.impl, worker.worker_id)
+    const expiredAfterAdmission = this.expiredInboxDelivery(item, mainline.seq)
+    if (expiredAfterAdmission) {
+      if (claudeBridge?.managed) {
+        void cleanupClaudeWorkspaceBridge({
+          workersDir: this.deps.workersDir,
+          workerId: worker.worker_id,
+          incarnationId,
+          workspaceRoot: mainline.workspace,
+        }).catch(() => {})
+      }
+      if (admission) void admission.dispose().catch(() => {})
+      return expiredAfterAdmission
+    }
     const prevRef: IncarnationRef = { worker_id: worker.worker_id, incarnation_id: mainline.incarnation_id, seq: mainline.seq, session_ref: mainline.session_ref }
     // resume 直接把 text 作为 wakeInput 传入——接续就是这次输入的投递方式,不需要在
     // resume 成功之后再补一次 adapter.sendInput。
@@ -2447,6 +2790,19 @@ export class WorkerHarness {
     } catch (error) {
       // 原生 session 不可读时不伪造 activity；接续本身仍可继续，后续读取再按既有降级处理。
       console.error(`[WorkerHarness] failed to establish native activity baseline for revived worker ${worker.worker_id}#${mainline.seq}:`, error)
+    }
+    const expiredBeforeResume = this.expiredInboxDelivery(item, mainline.seq)
+    if (expiredBeforeResume) {
+      if (claudeBridge?.managed) {
+        void cleanupClaudeWorkspaceBridge({
+          workersDir: this.deps.workersDir,
+          workerId: worker.worker_id,
+          incarnationId,
+          workspaceRoot: mainline.workspace,
+        }).catch(() => {})
+      }
+      if (admission) void admission.dispose().catch(() => {})
+      return expiredBeforeResume
     }
     let newHandle
     try {
@@ -2571,8 +2927,11 @@ export class WorkerHarness {
     input: string,
     inputOwnedByInbox = false,
     inboxRaw = false,
+    deadlineItem?: InboxItem,
   ): Promise<HandoffResult> {
     this.deps.assertExecutionAdmission?.()
+    const expiredBeforePreparation = this.expiredInboxDelivery(deadlineItem, source.seq)
+    if (expiredBeforePreparation) return { restoredDurableReceipt: false, delivery: expiredBeforePreparation }
     const sourceAdapter = this.deps.adapters.get(source.impl)
     const sourceHandle: IncarnationHandle = {
       worker_id: worker.worker_id,
@@ -2602,9 +2961,16 @@ export class WorkerHarness {
     // 保持可重试。
     // P6-B：目标 impl 重验 ready（配置可能在 source 运行期间已失效）。
     await this.deps.assertWorkerImplReady?.(targetImpl)
+    const expiredAfterReady = this.expiredInboxDelivery(deadlineItem, source.seq)
+    if (expiredAfterReady) return { restoredDurableReceipt: false, delivery: expiredAfterReady }
     // P6-B §6.5：handoff 同样过 connection admission——早于 package 生成与 source stop；
     // admin_provider 形态下目标 CLI 不得静默回落宿主原生凭证。
     const admission = await this.deps.admitWorkerConnection?.(targetImpl, worker.worker_id)
+    const expiredAfterAdmission = this.expiredInboxDelivery(deadlineItem, source.seq)
+    if (expiredAfterAdmission) {
+      if (admission) void admission.dispose().catch(() => {})
+      return { restoredDurableReceipt: false, delivery: expiredAfterAdmission }
+    }
     const newAdapter = this.deps.adapters.get(targetImpl)
     if (!newAdapter) {
       if (admission) await admission.dispose()
@@ -2633,9 +2999,19 @@ export class WorkerHarness {
       caps = this.deps.capabilityBundle
         ? await this.deps.capabilityBundle({ worker_id: worker.worker_id, principal_permissions: principalPermissions })
         : EMPTY_CAPABILITY_BUNDLE
+      const expiredAfterCapabilities = this.expiredInboxDelivery(deadlineItem, source.seq)
+      if (expiredAfterCapabilities) {
+        if (admission) void admission.dispose().catch(() => {})
+        return { restoredDurableReceipt: false, delivery: expiredAfterCapabilities }
+      }
       // tracked credential target 等确定性检查必须在 package / source stop 之前完成；preflightProvision
       // 不得写 workspace。正式 provision 仍在 source teardown 之后执行并重检，避免 TOCTOU 静默越界。
       await newAdapter.preflightProvision?.(workspace, caps)
+      const expiredAfterPreflight = this.expiredInboxDelivery(deadlineItem, source.seq)
+      if (expiredAfterPreflight) {
+        if (admission) void admission.dispose().catch(() => {})
+        return { restoredDurableReceipt: false, delivery: expiredAfterPreflight }
+      }
 
       // The target identity, workspace rules snapshot and the private handoff package all exist
       // before we stop the source. Any failure here leaves the source untouched and retryable.
@@ -2648,6 +3024,11 @@ export class WorkerHarness {
         workspaceRoot: workspace.root,
         capturedAt,
       })
+      const expiredAfterInstructions = this.expiredInboxDelivery(deadlineItem, source.seq)
+      if (expiredAfterInstructions) {
+        if (admission) void admission.dispose().catch(() => {})
+        return { restoredDurableReceipt: false, delivery: expiredAfterInstructions }
+      }
       if (targetImpl === 'builtin') {
         builtinInjection = this.deps.builtinSpawnDefaults?.({
           worker_id: worker.worker_id,
@@ -2673,7 +3054,28 @@ export class WorkerHarness {
             instructions: targetInstructions,
           })
         : undefined
+      const discardPreparedHandoff = (): void => {
+        if (targetClaudeBridge?.managed) {
+          void cleanupClaudeWorkspaceBridge({
+            workersDir: this.deps.workersDir,
+            workerId: worker.worker_id,
+            incarnationId: targetIncarnationId,
+            workspaceRoot: workspace.root,
+          }).catch(() => {})
+        }
+        if (admission) void admission.dispose().catch(() => {})
+      }
+      const expiredAfterBridge = this.expiredInboxDelivery(deadlineItem, source.seq)
+      if (expiredAfterBridge) {
+        discardPreparedHandoff()
+        return { restoredDurableReceipt: false, delivery: expiredAfterBridge }
+      }
       handoff = await this.captureHandoffPackage(worker, source, sourceAdapter, sourceHandle, capturedAt)
+      const expiredAfterHandoff = this.expiredInboxDelivery(deadlineItem, source.seq)
+      if (expiredAfterHandoff) {
+        discardPreparedHandoff()
+        return { restoredDurableReceipt: false, delivery: expiredAfterHandoff }
+      }
     } catch (error) {
       // admission 之后、package/kill 之前的前置失败：dispose admission，source 不动。
       if (admission) await admission.dispose()
@@ -2683,6 +3085,19 @@ export class WorkerHarness {
     // 1. Persist the package before source teardown. Terminal capture is deliberately absent:
     // it is a caller-driven diagnostic viewport, not a handoff or result data source.
     try {
+      const expiredBeforeHandoffEvent = this.expiredInboxDelivery(deadlineItem, source.seq)
+      if (expiredBeforeHandoffEvent) {
+        if (targetClaudeBridge?.managed) {
+          void cleanupClaudeWorkspaceBridge({
+            workersDir: this.deps.workersDir,
+            workerId: worker.worker_id,
+            incarnationId: targetIncarnationId,
+            workspaceRoot: workspace.root,
+          }).catch(() => {})
+        }
+        if (admission) void admission.dispose().catch(() => {})
+        return { restoredDurableReceipt: false, delivery: expiredBeforeHandoffEvent }
+      }
       await this.appendEvent(worker.worker_id, source.seq, 'handoff_started', {
         target_impl: targetImpl,
         handoff_id: handoff.package_id,
@@ -2691,6 +3106,19 @@ export class WorkerHarness {
       // 2. A live source crosses the same durable stop-and-verify boundary as the Manager tool.
       // An unknown or failed stop never starts a target, avoiding two simultaneous mainlines.
       if (source.state !== 'exited') {
+        const expiredBeforeSourceStop = this.expiredInboxDelivery(deadlineItem, source.seq)
+        if (expiredBeforeSourceStop) {
+          if (targetClaudeBridge?.managed) {
+            void cleanupClaudeWorkspaceBridge({
+              workersDir: this.deps.workersDir,
+              workerId: worker.worker_id,
+              incarnationId: targetIncarnationId,
+              workspaceRoot: workspace.root,
+            }).catch(() => {})
+          }
+          if (admission) void admission.dispose().catch(() => {})
+          return { restoredDurableReceipt: false, delivery: expiredBeforeSourceStop }
+        }
         const stop = await this.stopSourceForHandoffLocked(managerKey, worker, source)
         if (stop.status !== 'succeeded') {
           throw new Error(`WorkerHarness.handoffIncarnation: source stop did not verify (${stop.status})`)
@@ -2706,9 +3134,35 @@ export class WorkerHarness {
     // the package, so workers never need to read a workspace handoff file.
     // newAdapter / builtinInjection / workspace / caps 已在上面的 pre-flight 里取好。
     const prompt = renderHandoffPrompt(handoff, input)
+    const expiredBeforeProvision = this.expiredInboxDelivery(deadlineItem, source.seq)
+    if (expiredBeforeProvision) {
+      if (targetClaudeBridge?.managed) {
+        void cleanupClaudeWorkspaceBridge({
+          workersDir: this.deps.workersDir,
+          workerId: worker.worker_id,
+          incarnationId: targetIncarnationId,
+          workspaceRoot: workspace.root,
+        }).catch(() => {})
+      }
+      if (admission) void admission.dispose().catch(() => {})
+      return { restoredDurableReceipt: false, delivery: expiredBeforeProvision }
+    }
     let newHandle
     try {
       await newAdapter.provision(workspace, caps)
+      const expiredBeforeSpawn = this.expiredInboxDelivery(deadlineItem, source.seq)
+      if (expiredBeforeSpawn) {
+        if (targetClaudeBridge?.managed) {
+          void cleanupClaudeWorkspaceBridge({
+            workersDir: this.deps.workersDir,
+            workerId: worker.worker_id,
+            incarnationId: targetIncarnationId,
+            workspaceRoot: workspace.root,
+          }).catch(() => {})
+        }
+        if (admission) void admission.dispose().catch(() => {})
+        return { restoredDurableReceipt: false, delivery: expiredBeforeSpawn }
+      }
       newHandle = await newAdapter.spawn({
         worker_id: worker.worker_id,
         incarnation_id: targetIncarnationId,
@@ -3617,14 +4071,13 @@ export class WorkerHarness {
   }
 
   private async reconcileInputDeliveryOperations(): Promise<void> {
-    const nowMs = Date.parse(this.deps.now())
+    const nowMs = Date.now()
     for (const receipt of await this.inputDeliveryStore.listPendingDeliveries()) {
       if (Date.parse(receipt.deadline_at) > nowMs) continue
       this.inputDeliveryControllers.get(receipt.delivery_id)?.abort()
       const cancellation = await this.getInbox(receipt.worker_id).cancelDelivery(receipt.delivery_id)
-      const current = await this.inputDeliveryStore.get(receipt.worker_id, receipt.delivery_id)
-      if (!current || current.state !== 'pending') continue
-
+      // `not_found` can mean a late adapter acceptance whose settlement has not reached the
+      // receipt store yet. Only removing an item from the queue proves no input side effect.
       const safelyWithdrawn = cancellation === 'cancelled'
       const failure: InputDeliveryFailure = safelyWithdrawn
         ? {
@@ -3638,7 +4091,7 @@ export class WorkerHarness {
             certainty: 'unknown',
           }
       this.inputDeliveryControllers.delete(receipt.delivery_id)
-      await this.settlePendingInputFailure(current, failure)
+      await this.settlePendingInputFailure(receipt, failure)
     }
     await this.deliverInputOperationNotifications()
   }
@@ -3647,26 +4100,30 @@ export class WorkerHarness {
     receipt: WorkerInputDeliveryReceipt,
     failure: InputDeliveryFailure,
     managerContextDelivered = false,
-  ): Promise<void> {
-    const settled = await this.inputDeliveryStore.settleFailed(
+  ): Promise<WorkerInputDeliveryReceipt> {
+    const result = await this.inputDeliveryStore.settleFailed(
       receipt.worker_id,
       receipt.delivery_id,
       failure,
       this.deps.now(),
     )
+    let settled = result.receipt
     if (managerContextDelivered && settled.manager_notification.status === 'pending') {
-      await this.inputDeliveryStore.markNotificationConsumed(
+      settled = await this.inputDeliveryStore.markNotificationConsumed(
         receipt.worker_id,
         receipt.delivery_id,
         this.deps.now(),
       )
     }
+    if (!result.transitioned) return settled
     const found = await this.deps.ledger.findWorker(receipt.worker_id)
     const seq = found ? requireMainlineIncarnation(found.worker).seq : 0
+    if (!settled.failure) throw new Error(`failed delivery ${receipt.delivery_id} has no failure detail`)
     await this.appendAuditEvent(receipt.worker_id, seq, 'input_delivery_failed', {
       delivery_id: receipt.delivery_id,
       ...settled.failure,
     })
+    return settled
   }
 
   private async deliverInputOperationNotifications(): Promise<void> {
@@ -4615,8 +5072,12 @@ export class WorkerHarness {
     worker: LedgerWorker,
     incarnation: ExecutableIncarnation,
     kind: WorkerControlOperationKind,
-    options?: { readonly handoffSupersede?: boolean },
+    options?: {
+      readonly handoffSupersede?: boolean
+      readonly inputDeadline?: { readonly deadlineAt: number; readonly deliveryId: string }
+    },
   ): Promise<WorkerControlOperation> {
+    this.assertSynchronousInputDeadline(options?.inputDeadline?.deadlineAt, options?.inputDeadline?.deliveryId)
     if (!incarnation.incarnation_id) throw new Error(`worker ${worker.worker_id} incarnation has no stable identity`)
     const adapter = this.deps.adapters.get(incarnation.impl)
     if (!adapter) throw new Error(`worker adapter unavailable: ${incarnation.impl}`)
@@ -4636,6 +5097,9 @@ export class WorkerHarness {
       this.deps.now(),
     )
     try {
+      // Control persistence may have waited behind I/O. Do not send a late Escape after the
+      // synchronous caller already received its timeout.
+      this.assertSynchronousInputDeadline(options?.inputDeadline?.deadlineAt, options?.inputDeadline?.deliveryId)
       const handle = handleForIncarnation(worker.worker_id, incarnation)
       if (kind === 'interrupt') {
         if (!adapter.interrupt) throw new Error(`worker impl '${incarnation.impl}' does not support interrupt`)
@@ -4660,6 +5124,16 @@ export class WorkerHarness {
       }
       await this.controlOperationStore.transition(worker.worker_id, executing.operation_id, 'verifying', this.deps.now())
     } catch (error) {
+      if (error instanceof InputDeliveryDeadlineError) {
+        void this.settleControlOperation(
+          executing,
+          'unknown',
+          'synchronous input deadline elapsed before control submission',
+        ).catch((settlementError) => {
+          console.error(`[WorkerHarness] failed to settle expired redirect control operation ${executing.operation_id}:`, settlementError)
+        })
+        throw error
+      }
       return this.settleControlOperation(
         executing,
         'failed',
@@ -4677,9 +5151,14 @@ export class WorkerHarness {
   private async interruptForImmediateRedirect(
     workerId: string,
     target: ExecutableIncarnation,
+    deadlineAt?: number,
+    deliveryId?: string,
   ): Promise<void> {
     const operation = await this.withLock(workerId, async () => {
+      this.assertSynchronousInputDeadline(deadlineAt, deliveryId)
       const found = await this.deps.ledger.findWorker(workerId)
+      // Waiting for the worker lock or ledger must never turn into a late redirect.
+      this.assertSynchronousInputDeadline(deadlineAt, deliveryId)
       if (!found) throw new WorkerNotFoundError(workerId)
       if (found.worker.task.status === 'cancelled') throw new TaskCancelledError(workerId)
       const current = requireMainlineIncarnation(found.worker)
@@ -4691,7 +5170,12 @@ export class WorkerHarness {
       ) {
         throw new Error(`worker ${workerId} mainline changed before immediate redirect interrupt`)
       }
-      return this.executeControlOperationLocked(found.managerKey, found.worker, current, 'interrupt')
+      this.assertSynchronousInputDeadline(deadlineAt, deliveryId)
+      return this.executeControlOperationLocked(found.managerKey, found.worker, current, 'interrupt', {
+        ...(deadlineAt !== undefined && deliveryId !== undefined
+          ? { inputDeadline: { deadlineAt, deliveryId } }
+          : {}),
+      })
     })
     if (operation.status !== 'succeeded') {
       throw new Error(

--- a/crabot-agent/src/workers/harness/inbox.ts
+++ b/crabot-agent/src/workers/harness/inbox.ts
@@ -1,9 +1,9 @@
 /**
  * WorkerInbox —— 每 worker 一个信箱(protocol-agent-v3 §5.5)。
  *
- * 语义:`send_to_worker` 投递永不因状态失败(唯一硬拒绝是 task 已 cancelled,由调用方在
- * 投递前把关,不属于本类职责);安全态(running / idle)即投,不安全态(provision 中、
- * 模态弹窗、化身交接间隙、僵尸态)暂扣,恢复后按序补投。
+ * 语义:安全态(running / idle)即投;不安全态(provision 中、模态弹窗、化身交接间隙、僵尸态)
+ * 可暂扣并按序恢复,但 Manager-originated 的调用会在本次同步尝试内把这类 hold 结算为
+ * failed,不会在工具返回后继续隐藏等待。内部非 Manager 输入仍可使用 hold/requeue。
  *
  * hold 使用理由集合：`waiting_action` / `input_pending` 只允许显式 raw 控制键旁路；
  * provision / handoff 等其它理由属于 exclusive hold，连 raw 也阻断。理由可独立置位和释放，
@@ -193,7 +193,7 @@ export class WorkerInbox {
    * 视为"确定未投递"的快照,不会把正在投递、随后可能投递成功的条目也一并当作
    * dead-letter 带走,避免同一条目既真正投递、又混进 dead-letter 批次重复投递。
    *
-   * pending:返回队列中的待投条数。注意:在 await deliver() 期间,该条已从 queue
+   * `pending` 仅是内部队列/诊断计数,不是 `send_to_worker` 的公开状态。注意:在 await deliver() 期间,该条已从 queue
    * 取出(shift),所以 pending 不计入 in-flight 条目。
    */
   async flush(

--- a/crabot-agent/src/workers/harness/inbox.ts
+++ b/crabot-agent/src/workers/harness/inbox.ts
@@ -44,6 +44,8 @@ export interface InboxItem {
   readonly enqueued_at: string
   /** Stable identity for Manager-originated input. */
   readonly delivery_id?: string
+  /** Absolute synchronous deadline carried with a Manager-originated receipt. */
+  readonly deadline_at?: string
   /** False for untrusted wakeups that must never revive a terminal task. */
   readonly allow_terminal_continuation?: boolean
   /** Process-local receipt; durable truth remains with the producer. */
@@ -78,6 +80,8 @@ export class WorkerInbox {
   private inFlight: InboxItem | null = null
   /** Items pasted into a CLI composer: UI owns the text, but durable receipts still need settlement. */
   private consumedPending: InboxItem[] = []
+  /** A receipt callback is settling after adapter acceptance; timeout cannot claim it was safely withdrawn. */
+  private readonly settlingDeliveries = new Set<string>()
   /** Serializes queue state transitions shared by flush and cancellation. */
   private readonly mutex = new AsyncMutex()
   /** Prevents two flush drivers from delivering concurrently without holding the state mutex across adapter IO. */
@@ -153,6 +157,7 @@ export class WorkerInbox {
     return this.mutex.run(async () => {
       if (
         this.inFlight?.delivery_id === deliveryId ||
+        this.settlingDeliveries.has(deliveryId) ||
         this.consumedPending.some((item) => item.delivery_id === deliveryId)
       ) {
         return 'unsafe'
@@ -162,6 +167,25 @@ export class WorkerInbox {
       this.queue.splice(index, 1)
       return 'cancelled'
     })
+  }
+
+  /**
+   * Deadline cleanup cannot wait behind an adapter settlement that is itself blocked on I/O.
+   * JavaScript executes these ownership checks and queue removal atomically; an in-flight or
+   * settling item is conservatively unsafe rather than being claimed as withdrawn.
+   */
+  cancelDeliveryImmediately(deliveryId: string): 'cancelled' | 'unsafe' | 'not_found' {
+    if (
+      this.inFlight?.delivery_id === deliveryId ||
+      this.settlingDeliveries.has(deliveryId) ||
+      this.consumedPending.some((item) => item.delivery_id === deliveryId)
+    ) {
+      return 'unsafe'
+    }
+    const index = this.queue.findIndex((item) => item.delivery_id === deliveryId)
+    if (index < 0) return 'not_found'
+    this.queue.splice(index, 1)
+    return 'cancelled'
   }
 
   /** Remove an undelivered non-durable item by identity (used by control preflight failure). */
@@ -285,6 +309,7 @@ export class WorkerInbox {
 
   private async settle(item: InboxItem, settlement: InboxSettlement, detail?: InboxSettlementDetail): Promise<void> {
     if (!item.onSettled) return
+    if (item.delivery_id) this.settlingDeliveries.add(item.delivery_id)
     try {
       if (detail) await item.onSettled(settlement, detail)
       else await item.onSettled(settlement)
@@ -293,6 +318,8 @@ export class WorkerInbox {
       // would duplicate input; the producer keeps its durable pending receipt and
       // reconciles it without automatically replaying the input.
       console.warn(`[WorkerInbox:${this.workerId}] settlement callback failed:`, error)
+    } finally {
+      if (item.delivery_id) this.settlingDeliveries.delete(item.delivery_id)
     }
   }
 

--- a/crabot-agent/src/workers/harness/input-delivery-store.ts
+++ b/crabot-agent/src/workers/harness/input-delivery-store.ts
@@ -40,13 +40,6 @@ export interface WorkerInputDeliveryReceipt {
 export type SendToWorkerResult =
   | { status: 'delivered'; delivery_id: string; worker_id: string }
   | {
-      status: 'pending'
-      delivery_id: string
-      worker_id: string
-      pending_reason: 'waiting_for_safe_input' | 'submission_unconfirmed'
-      deadline_at: string
-    }
-  | {
       status: 'failed'
       delivery_id: string
       worker_id: string

--- a/crabot-agent/src/workers/harness/input-delivery-store.ts
+++ b/crabot-agent/src/workers/harness/input-delivery-store.ts
@@ -48,6 +48,12 @@ export type SendToWorkerResult =
       certainty: 'not_delivered' | 'unknown'
     }
 
+export interface InputDeliverySettlement {
+  readonly receipt: WorkerInputDeliveryReceipt
+  /** Whether this call changed a pending receipt into a terminal receipt. */
+  readonly transitioned: boolean
+}
+
 const FILENAME = 'input-deliveries.json'
 
 export class InputDeliveryStore {
@@ -66,6 +72,25 @@ export class InputDeliveryStore {
     return this.mutate(receipt.worker_id, (receipts) => {
       if (receipts.some((item) => item.delivery_id === receipt.delivery_id)) {
         throw new Error(`duplicate delivery_id: ${receipt.delivery_id}`)
+      }
+      const nowMs = Date.now()
+      if (Date.parse(normalized.deadline_at) <= nowMs) {
+        const now = new Date(nowMs).toISOString()
+        const expired: WorkerInputDeliveryReceipt = {
+          ...normalized,
+          updated_at: now,
+          state: 'failed',
+          failure: {
+            reason_code: 'input_surface_timeout',
+            reason: 'input delivery setup exceeded the synchronous delivery deadline',
+            certainty: 'not_delivered',
+          },
+          // The synchronous caller has already received this timeout result. A late
+          // receipt write must not manufacture a second Manager notification.
+          manager_notification: { status: 'consumed', consumed_at: now },
+        }
+        receipts.push(expired)
+        return expired
       }
       receipts.push(normalized)
       return normalized
@@ -118,11 +143,11 @@ export class InputDeliveryStore {
       const index = receipts.findIndex((receipt) => receipt.delivery_id === deliveryId)
       if (index < 0) throw new Error(`delivery receipt not found: ${deliveryId}`)
       const receipt = receipts[index]
-      if (receipt.state !== 'pending' || receipt.manager_notification.status !== 'not_required') return receipt
+      if (receipt.state === 'pending' || receipt.manager_notification.status !== 'pending') return receipt
       const next: WorkerInputDeliveryReceipt = {
         ...receipt,
         updated_at: updatedAt,
-        manager_notification: { status: 'pending' },
+        manager_notification: { status: 'consumed', consumed_at: updatedAt },
       }
       receipts[index] = next
       await writeReceiptFile(this.path(workerId), receipts)
@@ -130,10 +155,22 @@ export class InputDeliveryStore {
     })
   }
 
-  async settleDelivered(workerId: string, deliveryId: string, updatedAt: string): Promise<WorkerInputDeliveryReceipt> {
-    return this.mutateReceipt(workerId, deliveryId, (receipt) => {
-      this.assertPending(receipt)
-      return { ...receipt, state: 'delivered', updated_at: updatedAt }
+  async settleDelivered(workerId: string, deliveryId: string, updatedAt: string): Promise<InputDeliverySettlement> {
+    return this.settleIfPending(workerId, deliveryId, (receipt) => {
+      if (Date.parse(receipt.deadline_at) > Date.now()) {
+        return { ...receipt, state: 'delivered', updated_at: updatedAt }
+      }
+      return {
+        ...receipt,
+        state: 'failed',
+        failure: {
+          reason_code: 'submission_unconfirmed_timeout',
+          reason: 'input acceptance could not be confirmed before the synchronous delivery deadline',
+          certainty: 'unknown',
+        },
+        updated_at: updatedAt,
+        manager_notification: { status: 'pending' },
+      }
     })
   }
 
@@ -142,9 +179,8 @@ export class InputDeliveryStore {
     deliveryId: string,
     failure: InputDeliveryFailure,
     updatedAt: string,
-  ): Promise<WorkerInputDeliveryReceipt> {
-    return this.mutateReceipt(workerId, deliveryId, (receipt) => {
-      this.assertPending(receipt)
+  ): Promise<InputDeliverySettlement> {
+    return this.settleIfPending(workerId, deliveryId, (receipt) => {
       return {
         ...receipt,
         state: 'failed',
@@ -161,21 +197,16 @@ export class InputDeliveryStore {
     consumedAt: string,
   ): Promise<WorkerInputDeliveryReceipt> {
     return this.mutateReceipt(workerId, deliveryId, (receipt) => {
-      if (receipt.state === 'pending' || receipt.manager_notification.status !== 'pending') {
+      if (receipt.state === 'pending') {
         throw new Error(`delivery ${deliveryId} has no pending terminal notification`)
       }
+      if (receipt.manager_notification.status !== 'pending') return receipt
       return {
         ...receipt,
         updated_at: consumedAt,
         manager_notification: { status: 'consumed', consumed_at: consumedAt },
       }
     })
-  }
-
-  private assertPending(receipt: WorkerInputDeliveryReceipt): void {
-    if (receipt.state !== 'pending') {
-      throw new Error(`delivery ${receipt.delivery_id} is already terminal (${receipt.state})`)
-    }
   }
 
   private async mutateReceipt(
@@ -189,6 +220,23 @@ export class InputDeliveryStore {
       const next = mutator(receipts[index])
       receipts[index] = next
       return next
+    })
+  }
+
+  private async settleIfPending(
+    workerId: string,
+    deliveryId: string,
+    mutator: (receipt: WorkerInputDeliveryReceipt) => WorkerInputDeliveryReceipt,
+  ): Promise<InputDeliverySettlement> {
+    return this.mutate(workerId, (receipts) => {
+      const index = receipts.findIndex((receipt) => receipt.delivery_id === deliveryId)
+      if (index < 0) throw new Error(`delivery receipt not found: ${deliveryId}`)
+      if (receipts[index].state !== 'pending') {
+        return { receipt: receipts[index], transitioned: false }
+      }
+      const next = mutator(receipts[index])
+      receipts[index] = next
+      return { receipt: next, transitioned: true }
     })
   }
 

--- a/crabot-agent/src/workers/tmux/driver.ts
+++ b/crabot-agent/src/workers/tmux/driver.ts
@@ -26,6 +26,9 @@ import {
 
 const execFileAsync = promisify(execFile)
 
+/** tmux client commands must never hold a Manager tool open indefinitely. */
+export const DEFAULT_TMUX_COMMAND_TIMEOUT_MS = 15_000
+
 function normalizedPaneTerm(value: string | undefined): string {
   const term = value?.trim()
   return term && term.toLowerCase() !== 'dumb' ? term : 'xterm-256color'
@@ -58,14 +61,23 @@ export type TmuxSession = TmuxControlEndpoint & {
 
 export class TmuxDriver {
   private readonly tmuxBin: string
+  private readonly commandTimeoutMs: number
 
-  constructor(opts?: { tmuxBin?: string }) {
+  constructor(opts?: { tmuxBin?: string; commandTimeoutMs?: number }) {
     this.tmuxBin = opts?.tmuxBin ?? 'tmux'
+    this.commandTimeoutMs = opts?.commandTimeoutMs ?? DEFAULT_TMUX_COMMAND_TIMEOUT_MS
+    if (!Number.isFinite(this.commandTimeoutMs) || this.commandTimeoutMs <= 0) {
+      throw new Error('TmuxDriver commandTimeoutMs must be a positive finite number')
+    }
   }
 
   async available(): Promise<boolean> {
     try {
-      await execFileAsync(this.tmuxBin, ['-V'], { env: buildChildEnv() })
+      await execFileAsync(this.tmuxBin, ['-V'], {
+        env: buildChildEnv(),
+        timeout: this.commandTimeoutMs,
+        killSignal: 'SIGKILL',
+      })
       return true
     } catch {
       return false
@@ -264,7 +276,11 @@ exec ${spec.command}
   }
 
   private run(args: string[]): Promise<{ stdout: string; stderr: string }> {
-    return execFileAsync(this.tmuxBin, args, { env: buildChildEnv() })
+    return execFileAsync(this.tmuxBin, args, {
+      env: buildChildEnv(),
+      timeout: this.commandTimeoutMs,
+      killSignal: 'SIGKILL',
+    })
   }
 
   /** `tmux load-buffer -b <name> -` 从 stdin 灌入内容,不把文本经过 shell 参数或临时文件。 */
@@ -272,16 +288,34 @@ exec ${spec.command}
     return new Promise((resolve, reject) => {
       const child = spawn(this.tmuxBin, ['load-buffer', '-b', bufferName, '-'], { env: buildChildEnv() })
       let stderr = ''
+      let settled = false
+      let timer: ReturnType<typeof setTimeout>
+      const finish = (error?: Error) => {
+        if (settled) return
+        settled = true
+        clearTimeout(timer)
+        if (error) reject(error)
+        else resolve()
+      }
+      timer = setTimeout(() => {
+        child.kill('SIGKILL')
+        finish(new Error(`tmux load-buffer timed out after ${this.commandTimeoutMs}ms`))
+      }, this.commandTimeoutMs)
+      timer.unref?.()
       child.stderr.on('data', (chunk: Buffer) => {
         stderr += chunk.toString('utf-8')
       })
-      child.on('error', reject)
+      child.on('error', (error) => finish(error))
       child.on('close', (code) => {
-        if (code === 0) resolve()
-        else reject(new Error(`tmux load-buffer exited with code ${code}: ${stderr}`))
+        if (code === 0) finish()
+        else finish(new Error(`tmux load-buffer exited with code ${code}: ${stderr}`))
       })
-      child.stdin.write(content)
-      child.stdin.end()
+      try {
+        child.stdin.write(content)
+        child.stdin.end()
+      } catch (error) {
+        finish(error instanceof Error ? error : new Error(String(error)))
+      }
     })
   }
 }

--- a/crabot-agent/tests/manager/prompt.test.ts
+++ b/crabot-agent/tests/manager/prompt.test.ts
@@ -79,15 +79,14 @@ describe('MANAGER_IDENTITY 静态段内容', () => {
     expect(MANAGER_IDENTITY).toContain('spawn_worker')
     expect(MANAGER_IDENTITY).toContain('send_to_worker')
     expect(MANAGER_IDENTITY).toContain('query_worker')
-    expect(MANAGER_IDENTITY).toContain('不代表事情做完了')
+    expect(MANAGER_IDENTITY).toContain('只等待编排动作本身')
+    expect(MANAGER_IDENTITY).toContain('不等待执行器完成任务')
   })
 
-  it('含管家纪律：send_to_worker pending 不得冒充已送达', () => {
+  it('含管家纪律：send_to_worker 失败不得冒充已送达', () => {
     expect(MANAGER_IDENTITY).toContain('只有返回 `delivered` 才能对人类说输入已送达')
-    expect(MANAGER_IDENTITY).toContain('`pending` 只表示已登记、正在等待安全输入面')
-    expect(MANAGER_IDENTITY).toContain('不能说成已送达或任务已启动')
-    expect(MANAGER_IDENTITY).toContain('等待带同一 `delivery_id` 的终态事件')
     expect(MANAGER_IDENTITY).toContain('`failed` 必须按给出的原因和确定性如实处理')
+    expect(MANAGER_IDENTITY).not.toContain('`pending` 只表示已登记、正在等待安全输入面')
   })
 
   it('含执行器选择与复用纪律：有效实现选择、等待投递、运行中改向和 fork 侧问', () => {

--- a/crabot-agent/tests/manager/registry.test.ts
+++ b/crabot-agent/tests/manager/registry.test.ts
@@ -481,6 +481,126 @@ describe('ManagerRegistry', () => {
     expect(calls).toHaveLength(0)
   })
 
+  it('routeSupervisionDue: 路由准备期间 due 被 clear 后不创建 Manager episode', async () => {
+    const { adapter, calls } = makeAdapter()
+    const routePreparationEntered = deferred()
+    const releaseRoutePreparation = deferred()
+    const owner = 'wechat::periodic-owner' as ManagerKey
+    let current = true
+    const isCurrent = vi.fn(async () => current)
+    const findWorker = vi.fn(async () => {
+      routePreparationEntered.resolve()
+      await releaseRoutePreparation.promise
+      return { managerKey: owner, worker: makeLedgerWorker('w-periodic', owner) }
+    })
+    const registry = new ManagerRegistry(baseRegistryDeps({
+      adapter,
+      ledger: { findWorker } as unknown as LedgerStore,
+      harness: { ...FAKE_HARNESS, isSupervisionDueCurrent: isCurrent } as unknown as WorkerHarness,
+    }))
+    const event: HarnessEvent = {
+      ts: '2026-01-01T00:00:00.000Z',
+      kind: 'supervision_due',
+      worker_id: 'w-periodic',
+      seq: 1,
+      detail: { mode: 'periodic_report', due_id: 'cleared-due', mainline_seq: 1, observation: 'none' },
+    }
+
+    const routed = registry.routeSupervisionDue(event)
+    await routePreparationEntered.promise
+    current = false
+    releaseRoutePreparation.resolve()
+
+    await expect(routed).resolves.toBeUndefined()
+    expect(isCurrent).toHaveBeenCalledTimes(2)
+    expect(isCurrent).toHaveBeenNthCalledWith(1, event)
+    expect(isCurrent).toHaveBeenNthCalledWith(2, event)
+    expect(calls).toHaveLength(0)
+  })
+
+  it('routeSupervisionDue: pre-wake 异步刷新期间 due 被 clear 后不创建 Manager episode', async () => {
+    const { adapter, calls } = makeAdapter()
+    const beforeWakeEntered = deferred()
+    const releaseBeforeWake = deferred()
+    const owner = 'wechat::periodic-owner' as ManagerKey
+    let current = true
+    const isCurrent = vi.fn(async () => current)
+    const registry = new ManagerRegistry(baseRegistryDeps({
+      adapter,
+      ledger: fakeLedger({ 'w-periodic': makeLedgerWorker('w-periodic', owner) }),
+      harness: { ...FAKE_HARNESS, isSupervisionDueCurrent: isCurrent } as unknown as WorkerHarness,
+      beforeWake: async () => {
+        beforeWakeEntered.resolve()
+        await releaseBeforeWake.promise
+      },
+    }))
+    const event: HarnessEvent = {
+      ts: '2026-01-01T00:00:00.000Z',
+      kind: 'supervision_due',
+      worker_id: 'w-periodic',
+      seq: 1,
+      detail: { mode: 'periodic_report', due_id: 'cleared-at-admission', mainline_seq: 1, observation: 'none' },
+    }
+
+    const routed = registry.routeSupervisionDue(event)
+    await beforeWakeEntered.promise
+    current = false
+    releaseBeforeWake.resolve()
+
+    await expect(routed).resolves.toBeUndefined()
+    expect(isCurrent).toHaveBeenCalledTimes(3)
+    expect(calls).toHaveLength(0)
+  })
+
+  it('routeSupervisionDue: owning Manager 正执行时保留 due，不伪造已消费结果', async () => {
+    const calls: LLMStreamParams[] = []
+    const entered = deferred()
+    const release = deferred()
+    let turn = 0
+    const adapter: LLMAdapter = {
+      async *stream(params) {
+        calls.push({ ...params, messages: [...params.messages] })
+        if (isAssistantTextEndTurnReminder(params)) {
+          yield* chunksFromContent([], 'end_turn', { inputTokens: 1, outputTokens: 1 })
+          return
+        }
+        turn++
+        if (turn === 1) {
+          entered.resolve()
+          await release.promise
+        }
+        yield* chunksFromContent([{ type: 'text', text: '当前 episode 完成' }], 'end_turn', { inputTokens: 1, outputTokens: 1 })
+      },
+      updateConfig: () => {},
+    }
+    const owner = 'wechat::periodic-owner' as ManagerKey
+    const event: HarnessEvent = {
+      ts: '2026-01-01T00:00:00.000Z',
+      kind: 'supervision_due',
+      worker_id: 'w-periodic',
+      seq: 1,
+      detail: { mode: 'periodic_report', due_id: 'due-active', mainline_seq: 1, observation: 'none' },
+    }
+    const isCurrent = vi.fn(async () => true)
+    const registry = new ManagerRegistry(baseRegistryDeps({
+      adapter,
+      ledger: fakeLedger({ 'w-periodic': makeLedgerWorker('w-periodic', owner) }),
+      harness: { ...FAKE_HARNESS, isSupervisionDueCurrent: isCurrent } as unknown as WorkerHarness,
+    }))
+
+    const active = registry.routeHumanMessages('wechat', 'periodic-owner', [makeChannelMessage('先完成这一轮')])
+    await entered.promise
+    await expect(registry.routeSupervisionDue(event)).resolves.toBeUndefined()
+    expect(isCurrent).toHaveBeenCalledWith(event)
+    expect(calls).toHaveLength(1)
+
+    release.resolve()
+    await active
+    for (const call of calls) {
+      expect(JSON.stringify(call.messages)).not.toContain('due-active')
+    }
+  })
+
   it('operation notification 在 owning Manager 正执行时进入当前 mailbox，下一轮 LLM 批量读取', async () => {
     const calls: LLMStreamParams[] = []
     const entered = deferred()

--- a/crabot-agent/tests/manager/registry.test.ts
+++ b/crabot-agent/tests/manager/registry.test.ts
@@ -481,7 +481,7 @@ describe('ManagerRegistry', () => {
     expect(calls).toHaveLength(0)
   })
 
-  it('operation notification 在 owning Manager 正执行时 deferred，不塞进当前 mailbox', async () => {
+  it('operation notification 在 owning Manager 正执行时进入当前 mailbox，下一轮 LLM 批量读取', async () => {
     const calls: LLMStreamParams[] = []
     const entered = deferred()
     const release = deferred()
@@ -511,16 +511,22 @@ describe('ManagerRegistry', () => {
       seq: 1,
       detail: { delivery_id: 'delivery-1' },
     }
+    const secondEvent: HarnessEvent = {
+      ...event,
+      detail: { delivery_id: 'delivery-2', reason_code: 'input_surface_timeout' },
+    }
 
     const active = registry.routeHumanMessages('wechat', 'operation-owner', [makeChannelMessage('先处理这条')])
     await entered.promise
-    await expect(registry.routeOperationNotification(key, event)).resolves.toEqual({ consumed: false })
+    await expect(registry.routeOperationNotification(key, event)).resolves.toEqual({ consumed: true })
+    await expect(registry.routeOperationNotification(key, secondEvent)).resolves.toEqual({ consumed: true })
     expect(calls).toHaveLength(1)
 
     release.resolve()
     await active
-    await expect(registry.routeOperationNotification(key, event)).resolves.toEqual({ consumed: true })
-    expect(calls).toHaveLength(4)
+    expect(calls.length).toBeGreaterThan(1)
+    expect(JSON.stringify(calls[1].messages)).toContain('delivery-1')
+    expect(JSON.stringify(calls[1].messages)).toContain('delivery-2')
   })
 
   // --- routeSchedule ---

--- a/crabot-agent/tests/manager/worker-tools.test.ts
+++ b/crabot-agent/tests/manager/worker-tools.test.ts
@@ -3,7 +3,7 @@ import { promises as fs } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { buildWorkerTools, type WorkerToolsContext } from '../../src/manager/tools/worker-tools'
-import { WorkerHarness, type HarnessDeps, type SpawnWorkerParams } from '../../src/workers/harness/harness'
+import { INPUT_DELIVERY_TIMEOUT_MS, WorkerHarness, type HarnessDeps, type SpawnWorkerParams } from '../../src/workers/harness/harness'
 import { LedgerStore } from '../../src/workers/harness/ledger-store'
 import { WorkspaceManager } from '../../src/workers/harness/workspace-manager'
 import { NativeActivityStore } from '../../src/workers/harness/native-activity-store'
@@ -558,6 +558,28 @@ describe('send_to_worker', () => {
     const result = await sendToWorker.call({ worker_id: 'w-does-not-exist', text: '你好' }, {})
     expect(result.isError).toBe(true)
     expect(result.output).toContain('不存在或当前会话无权访问')
+  })
+
+  it('授权查询永久挂起时仍在同步 deadline 内返回简要失败', async () => {
+    const { harness } = await makeHarness()
+    const findWorker = vi.spyOn(harness, 'findWorker').mockImplementation(() => new Promise<never>(() => {}))
+    const sendWorker = vi.spyOn(harness, 'sendToWorker')
+    const sendToWorker = buildWorkerTools({ harness, context: () => CTX }).find((t) => t.name === 'send_to_worker')!
+
+    try {
+      vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'Date'] })
+      const resultPromise = sendToWorker.call({ worker_id: 'w-authorization-stall', text: '继续' }, {})
+      await Promise.resolve()
+      expect(findWorker).toHaveBeenCalledWith('w-authorization-stall')
+
+      await vi.advanceTimersByTimeAsync(INPUT_DELIVERY_TIMEOUT_MS)
+      const result = await resultPromise
+      expect(result).toMatchObject({ isError: true })
+      expect(result.output).toContain('input delivery setup exceeded the 120 second synchronous deadline')
+      expect(sendWorker).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('task 已 cancelled → TaskCancelledError 转成可读 tool_result（isError:true，不抛出）', async () => {

--- a/crabot-agent/tests/workers/harness/harness-lifecycle.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-lifecycle.test.ts
@@ -245,11 +245,17 @@ function now(): string {
   return new Date(nowValue).toISOString()
 }
 
+function deferred(): { readonly promise: Promise<void>; readonly resolve: () => void } {
+  let resolve!: () => void
+  const promise = new Promise<void>((done) => { resolve = done })
+  return { promise, resolve }
+}
+
 async function makeHarness(
   fakeOpts: FakeAdapterOpts = {},
   depsOverrides: Partial<Pick<
     HarnessDeps,
-    'hasRunningBg' | 'capabilityBundle' | 'onOperationNotification' | 'onNativeActivityCollected' | 'admitWorkerConnection' | 'redactFailureReason'
+    'hasRunningBg' | 'capabilityBundle' | 'onEvent' | 'onOperationNotification' | 'onNativeActivityCollected' | 'admitWorkerConnection' | 'redactFailureReason'
   >> = {},
 ): Promise<{
   harness: WorkerHarness
@@ -2023,53 +2029,67 @@ describe('WorkerHarness.sendToWorker', () => {
     const attempting = new Promise<void>((resolve) => { markAttempting = resolve })
     let releaseAdapter!: () => void
     const adapterGate = new Promise<void>((resolve) => { releaseAdapter = resolve })
-    const { harness, workersDir } = await makeHarness(
-      {
-        sendInputBehavior: async () => {
-          markAttempting()
-          await adapterGate
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => nowValue)
+    try {
+      const { harness, workersDir } = await makeHarness(
+        {
+          sendInputBehavior: async () => {
+            markAttempting()
+            await adapterGate
+          },
         },
-      },
-      {
-        onOperationNotification: async (_managerKey, event) => {
-          notifications.push(event)
-          return { consumed: true }
+        {
+          onOperationNotification: async (_managerKey, event) => {
+            notifications.push(event)
+            return { consumed: true }
+          },
         },
-      },
-    )
-    const worker = await harness.spawnWorker(spawnParams())
-    const send = harness.sendToWorker(worker.worker_id, 'adapter 卡住的输入', {
-      managerKey: `test::friend-1` as ManagerKey,
-    })
-    await attempting
+      )
+      const worker = await harness.spawnWorker(spawnParams())
+      const send = harness.sendToWorker(worker.worker_id, 'adapter 卡住的输入', {
+        managerKey: `test::friend-1` as ManagerKey,
+      })
+      await attempting
 
-    nowValue += 5 * 60_000
-    const sweepResult = await Promise.race([
-      harness.sweepLiveness().then(() => 'completed'),
-      new Promise<string>((resolve) => setTimeout(() => resolve('timed_out'), 100)),
-    ])
-    expect(sweepResult).toBe('completed')
+      nowValue += 5 * 60_000
+      const sweepResult = await Promise.race([
+        harness.sweepLiveness().then(() => 'completed'),
+        new Promise<string>((resolve) => setTimeout(() => resolve('timed_out'), 100)),
+      ])
+      expect(sweepResult).toBe('completed')
 
-    const persisted = JSON.parse(
-      await fs.readFile(join(workersDir, worker.worker_id, 'input-deliveries.json'), 'utf8'),
-    ) as { receipts: Array<Record<string, any>> }
-    expect(persisted.receipts[0]).toMatchObject({
-      state: 'failed',
-      failure: { reason_code: 'submission_unconfirmed_timeout', certainty: 'unknown' },
-      manager_notification: { status: 'consumed' },
-    })
-    expect(notifications).toHaveLength(1)
-    expect(notifications[0]).toMatchObject({
-      kind: 'input_delivery_failed',
-      detail: { reason_code: 'submission_unconfirmed_timeout', certainty: 'unknown' },
-    })
+      const persisted = JSON.parse(
+        await fs.readFile(join(workersDir, worker.worker_id, 'input-deliveries.json'), 'utf8'),
+      ) as { receipts: Array<Record<string, any>> }
+      expect(persisted.receipts[0]).toMatchObject({
+        state: 'failed',
+        failure: { reason_code: 'submission_unconfirmed_timeout', certainty: 'unknown' },
+        manager_notification: { status: 'consumed' },
+      })
+      expect(notifications).toHaveLength(1)
+      expect(notifications[0]).toMatchObject({
+        kind: 'input_delivery_failed',
+        detail: { reason_code: 'submission_unconfirmed_timeout', certainty: 'unknown' },
+      })
 
-    releaseAdapter()
-    await expect(send).resolves.toMatchObject({
-      status: 'failed',
-      reason_code: 'submission_unconfirmed_timeout',
-      certainty: 'unknown',
-    })
+      releaseAdapter()
+      await expect(send).resolves.toMatchObject({
+        status: 'failed',
+        reason_code: 'submission_unconfirmed_timeout',
+        certainty: 'unknown',
+      })
+      expect((await harness.readWorkerEvents(worker.worker_id)).filter((event) => event.kind === 'input_sent')).toEqual([])
+      expect(JSON.parse(
+        await fs.readFile(join(workersDir, worker.worker_id, 'input-deliveries.json'), 'utf8'),
+      )).toMatchObject({
+        receipts: [expect.objectContaining({
+          state: 'failed',
+          failure: expect.objectContaining({ reason_code: 'submission_unconfirmed_timeout' }),
+        })],
+      })
+    } finally {
+      nowSpy.mockRestore()
+    }
   })
 
   it('同步投递确认不确定时立即返回 unknown，且不自动重发', async () => {
@@ -2139,6 +2159,224 @@ describe('WorkerHarness.sendToWorker', () => {
     }
   })
 
+  it('receipt 结果读取永久挂起时仍受同一同步 deadline 约束', async () => {
+    const { harness } = await makeHarness()
+    const worker = await harness.spawnWorker(spawnParams())
+    const receiptStore = (harness as unknown as {
+      inputDeliveryStore: {
+        readForToolResult(workerId: string, deliveryId: string, updatedAt: string): Promise<unknown>
+      }
+    }).inputDeliveryStore
+    const readEntered = deferred()
+    const readForToolResult = vi.spyOn(receiptStore, 'readForToolResult')
+      .mockImplementation(() => {
+        readEntered.resolve()
+        return new Promise<never>(() => {})
+      })
+
+    const send = harness.sendToWorker(worker.worker_id, '结果读取卡住的输入', {
+      managerKey: `test::friend-1` as ManagerKey,
+      deadline_at: new Date(Date.now() + 1_000).toISOString(),
+    })
+    await readEntered.promise
+    expect(readForToolResult).toHaveBeenCalledTimes(1)
+
+    await expect(send).resolves.toMatchObject({
+      status: 'failed',
+      reason_code: 'submission_unconfirmed_timeout',
+      certainty: 'unknown',
+    })
+  })
+
+  it('state hook 持有 worker 锁时，waitForStateChanges 仍受同一同步 deadline 约束', async () => {
+    const stateEventEntered = deferred()
+    const releaseStateEvent = deferred()
+    const onEvent = vi.fn((event: HarnessEvent) => {
+      events.push(event)
+      if (event.kind !== 'state_changed') return undefined
+      stateEventEntered.resolve()
+      return releaseStateEvent.promise
+    })
+    const { harness, fake } = await makeHarness({}, { onEvent })
+    const worker = await harness.spawnWorker(spawnParams())
+    onEvent.mockClear()
+    vi.spyOn(fake, 'sendInput').mockImplementation(async (handle) => {
+      harness.handleStateChange(handle, 'idle')
+    })
+
+    try {
+      vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'Date'] })
+      vi.setSystemTime(new Date(nowValue))
+      const send = harness.sendToWorker(worker.worker_id, 'state hook 卡住的输入', {
+        managerKey: `test::friend-1` as ManagerKey,
+      })
+      await stateEventEntered.promise
+
+      await vi.advanceTimersByTimeAsync(INPUT_DELIVERY_TIMEOUT_MS)
+      await expect(send).resolves.toMatchObject({
+        status: 'failed',
+        reason_code: 'submission_unconfirmed_timeout',
+        certainty: 'unknown',
+      })
+    } finally {
+      releaseStateEvent.resolve()
+      for (let step = 0; step < 5; step++) await Promise.resolve()
+      vi.useRealTimers()
+    }
+  })
+
+  it('跨 Manager 投递不等待永不返回的状态事件路由', async () => {
+    const stateEventEntered = deferred()
+    const releaseStateEvent = deferred()
+    const onEvent = vi.fn((event: HarnessEvent) => {
+      if (event.kind !== 'state_changed') return undefined
+      stateEventEntered.resolve()
+      return releaseStateEvent.promise
+    })
+    const { harness, fake } = await makeHarness({}, { onEvent })
+    const worker = await harness.spawnWorker(spawnParams())
+    onEvent.mockClear()
+    vi.spyOn(fake, 'sendInput').mockImplementation(async (handle) => {
+      harness.handleStateChange(handle, 'idle')
+    })
+
+    try {
+      const send = harness.sendToWorker(worker.worker_id, '跨 manager 的输入', {
+        managerKey: `test::friend-2` as ManagerKey,
+      })
+      await stateEventEntered.promise
+      await expect(send).resolves.toMatchObject({ status: 'delivered' })
+
+      expect(onEvent).toHaveBeenCalledWith(expect.objectContaining({ kind: 'state_changed' }))
+    } finally {
+      releaseStateEvent.resolve()
+    }
+  })
+
+  it('terminal revive 准备跨 deadline 后不再调用 adapter.resume', async () => {
+    const { harness, fake } = await makeHarness({ caps: { revive: true } })
+    const worker = await harness.spawnWorker(spawnParams())
+    fake.emitStateChange({
+      worker_id: worker.worker_id,
+      seq: 1,
+      impl: 'builtin',
+      session_ref: `ref-${worker.worker_id}#1`,
+    }, 'exited', undefined, 'completed')
+    await waitUntil(async () => (await harness.listWorkers(`test::friend-1` as ManagerKey))[0].task.status === 'completed')
+    const reviveHarness = harness as unknown as {
+      establishCliResumeActivityBaseline(workerId: string, source: unknown, adapter: unknown): Promise<number | undefined>
+      settlePendingInputFailure(...args: unknown[]): Promise<unknown>
+    }
+    const baselineEntered = deferred()
+    const releaseBaseline = deferred()
+    const timeoutSettlementDone = deferred()
+    vi.spyOn(reviveHarness, 'establishCliResumeActivityBaseline').mockImplementation(async () => {
+      baselineEntered.resolve()
+      await releaseBaseline.promise
+      return undefined
+    })
+    const settlePendingInputFailure = reviveHarness.settlePendingInputFailure.bind(reviveHarness)
+    vi.spyOn(reviveHarness, 'settlePendingInputFailure').mockImplementation(async (...args) => {
+      const settled = await settlePendingInputFailure(...args)
+      timeoutSettlementDone.resolve()
+      return settled
+    })
+    const resume = vi.spyOn(fake, 'resume').mockImplementation(() => new Promise<never>(() => {}))
+
+    try {
+      vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'Date'] })
+      vi.setSystemTime(new Date(nowValue))
+      const send = harness.sendToWorker(worker.worker_id, '终态后继续，但不能晚到 revive', {
+        managerKey: `test::friend-1` as ManagerKey,
+      })
+      await baselineEntered.promise
+
+      await vi.advanceTimersByTimeAsync(INPUT_DELIVERY_TIMEOUT_MS)
+      const result = await send
+      expect(result).toMatchObject({
+        status: 'failed',
+        reason_code: 'submission_unconfirmed_timeout',
+        certainty: 'unknown',
+      })
+      await timeoutSettlementDone.promise
+
+      releaseBaseline.resolve()
+      for (let step = 0; step < 5; step++) await Promise.resolve()
+      expect(resume).not.toHaveBeenCalled()
+    } finally {
+      releaseBaseline.resolve()
+      vi.useRealTimers()
+    }
+  })
+
+  it('terminal handoff 准备跨 deadline 后不写 handoff_started 或启动目标 adapter', async () => {
+    const { harness, fake, adaptersMap } = await makeHarness({ caps: { revive: false } })
+    const target = new FakeAdapter({
+      implId: 'claude-code',
+      onStateChange: harness.handleStateChange,
+    })
+    adaptersMap.set(target.implId, target)
+    const worker = await harness.spawnWorker(spawnParams())
+    fake.emitStateChange({
+      worker_id: worker.worker_id,
+      seq: 1,
+      impl: 'builtin',
+      session_ref: `ref-${worker.worker_id}#1`,
+    }, 'exited', undefined, 'completed')
+    await waitUntil(async () => (await harness.listWorkers(`test::friend-1` as ManagerKey))[0].task.status === 'completed')
+
+    const handoffHarness = harness as unknown as {
+      captureHandoffPackage(...args: unknown[]): Promise<unknown>
+      settlePendingInputFailure(...args: unknown[]): Promise<unknown>
+    }
+    const captureEntered = deferred()
+    const releaseCapture = deferred()
+    const captureFinished = deferred()
+    const timeoutSettlementDone = deferred()
+    const captureHandoffPackage = handoffHarness.captureHandoffPackage.bind(handoffHarness)
+    vi.spyOn(handoffHarness, 'captureHandoffPackage').mockImplementation(async (...args) => {
+      captureEntered.resolve()
+      await releaseCapture.promise
+      const handoff = await captureHandoffPackage(...args)
+      captureFinished.resolve()
+      return handoff
+    })
+    const settlePendingInputFailure = handoffHarness.settlePendingInputFailure.bind(handoffHarness)
+    vi.spyOn(handoffHarness, 'settlePendingInputFailure').mockImplementation(async (...args) => {
+      const settled = await settlePendingInputFailure(...args)
+      timeoutSettlementDone.resolve()
+      return settled
+    })
+
+    try {
+      vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'Date'] })
+      vi.setSystemTime(new Date(nowValue))
+      const send = harness.sendToWorker(worker.worker_id, '终态后继续，但不能晚到 handoff', {
+        managerKey: `test::friend-1` as ManagerKey,
+      })
+      await captureEntered.promise
+
+      await vi.advanceTimersByTimeAsync(INPUT_DELIVERY_TIMEOUT_MS)
+      await expect(send).resolves.toMatchObject({
+        status: 'failed',
+        reason_code: 'submission_unconfirmed_timeout',
+        certainty: 'unknown',
+      })
+      await timeoutSettlementDone.promise
+
+      releaseCapture.resolve()
+      await captureFinished.promise
+      for (let step = 0; step < 5; step++) await Promise.resolve()
+
+      expect((await harness.readWorkerEvents(worker.worker_id))
+        .filter((event) => event.kind === 'handoff_started')).toEqual([])
+      expect(target.spawnCalls).toEqual([])
+    } finally {
+      releaseCapture.resolve()
+      vi.useRealTimers()
+    }
+  })
+
   it('正常投递:running worker 收到输入,adapter.sendInput 被正确调用,事件 input_sent 外发', async () => {
     const { harness, fake } = await makeHarness()
     const worker = await harness.spawnWorker(spawnParams())
@@ -2177,6 +2415,60 @@ describe('WorkerHarness.sendToWorker', () => {
     expect(fake.interruptCalls).toHaveLength(1)
     expect(fake.sendInputCalls).toHaveLength(1)
     expect(fake.sendInputCalls[0].opts).toMatchObject({ immediate_redirect: true })
+  })
+
+  it('immediate_redirect 等待 worker 锁越过 deadline 时不补发 interrupt', async () => {
+    const { harness, fake } = await makeHarness({ implId: 'claude-code' })
+    const worker = await harness.spawnWorker({ ...spawnParams(), impl: 'claude-code' })
+    const receiptStore = (harness as unknown as {
+      inputDeliveryStore: { create(receipt: unknown): Promise<unknown> }
+    }).inputDeliveryStore
+    const createReceipt = receiptStore.create.bind(receiptStore)
+    const createEntered = deferred()
+    const releaseCreate = deferred()
+    vi.spyOn(receiptStore, 'create').mockImplementation(async (receipt) => {
+      createEntered.resolve()
+      await releaseCreate.promise
+      return createReceipt(receipt)
+    })
+    const blockerEntered = deferred()
+    const releaseBlocker = deferred()
+    const lockedHarness = harness as unknown as {
+      withLock<T>(workerId: string, fn: () => Promise<T>): Promise<T>
+    }
+
+    try {
+      vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'Date'] })
+      vi.setSystemTime(new Date(nowValue))
+      const send = harness.sendToWorker(worker.worker_id, 'deadline 后不可打断旧任务', {
+        managerKey: `test::friend-1` as ManagerKey,
+        immediate_redirect: true,
+      })
+      await createEntered.promise
+      const blocker = lockedHarness.withLock(worker.worker_id, async () => {
+        blockerEntered.resolve()
+        await releaseBlocker.promise
+      })
+      releaseCreate.resolve()
+      await blockerEntered.promise
+
+      await vi.advanceTimersByTimeAsync(INPUT_DELIVERY_TIMEOUT_MS)
+      await expect(send).resolves.toMatchObject({
+        status: 'failed',
+        reason_code: 'input_surface_timeout',
+        certainty: 'not_delivered',
+      })
+      expect(fake.interruptCalls).toEqual([])
+
+      releaseBlocker.resolve()
+      await blocker
+      await new Promise<void>((resolve) => setImmediate(resolve))
+      expect(fake.interruptCalls).toEqual([])
+    } finally {
+      releaseCreate.resolve()
+      releaseBlocker.resolve()
+      vi.useRealTimers()
+    }
   })
 
   it('builtin immediate_redirect 不调用 interrupt', async () => {

--- a/crabot-agent/tests/workers/harness/harness-lifecycle.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-lifecycle.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { promises as fs } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
-import { WorkerHarness, WorkerNotFoundError, TaskCancelledError, type HarnessDeps, type SpawnWorkerParams } from '../../../src/workers/harness/harness'
+import { INPUT_DELIVERY_TIMEOUT_MS, WorkerHarness, WorkerNotFoundError, TaskCancelledError, type HarnessDeps, type SpawnWorkerParams } from '../../../src/workers/harness/harness'
 import { LedgerStore } from '../../../src/workers/harness/ledger-store'
 import { WorkspaceManager } from '../../../src/workers/harness/workspace-manager'
 import { NativeActivityStore } from '../../../src/workers/harness/native-activity-store'
@@ -621,7 +621,7 @@ describe('WorkerHarness.spawnWorker', () => {
   })
 
   it('CLI首投not_pasted先落waiting_action，再由raw解除hold并按FIFO只补投一次原prompt', async () => {
-    const { harness, fake } = await makeHarness({
+    const { harness, fake, workersDir } = await makeHarness({
       implId: 'claude-code',
       spawnInitialInput: {
         control_state: 'waiting_action',
@@ -1782,7 +1782,7 @@ describe('WorkerHarness.sendToWorker', () => {
     ])
   })
 
-  it('输入面暂不可用时返回 pending，而不是伪装成 sent', async () => {
+  it('输入面暂不可用时同步返回 failed，而不是留下 pending', async () => {
     const { harness, workersDir } = await makeHarness({
       implId: 'claude-code',
       sendInputBehavior: () => {
@@ -1796,23 +1796,24 @@ describe('WorkerHarness.sendToWorker', () => {
     })
 
     expect(result).toMatchObject({
-      status: 'pending',
+      status: 'failed',
       worker_id: worker.worker_id,
-      pending_reason: 'waiting_for_safe_input',
+      reason_code: 'input_surface_timeout',
+      certainty: 'not_delivered',
     })
     const persisted = JSON.parse(
       await fs.readFile(join(workersDir, worker.worker_id, 'input-deliveries.json'), 'utf8'),
     ) as { receipts: Array<Record<string, unknown>> }
     expect(persisted.receipts[0]).toMatchObject({
       delivery_id: result.delivery_id,
-      state: 'pending',
+      state: 'failed',
       phase: 'waiting_for_safe_input',
-      manager_notification: { status: 'pending' },
+      manager_notification: { status: 'consumed' },
     })
     expect(events.some((event) => event.kind === 'input_sent')).toBe(false)
   })
 
-  it('adapter 已接手后 phase 写失败时保守返回 submission_unconfirmed', async () => {
+  it('adapter 已接手后 phase 写失败时仍同步返回 submission_unconfirmed', async () => {
     const { harness } = await makeHarness({
       implId: 'claude-code',
       sendInputBehavior: () => {
@@ -1837,8 +1838,9 @@ describe('WorkerHarness.sendToWorker', () => {
     })
 
     expect(result).toMatchObject({
-      status: 'pending',
-      pending_reason: 'submission_unconfirmed',
+      status: 'failed',
+      reason_code: 'submission_unconfirmed_timeout',
+      certainty: 'unknown',
     })
   })
 
@@ -1873,7 +1875,7 @@ describe('WorkerHarness.sendToWorker', () => {
   })
 
   it('adapter 已开始投递后抛普通错误时保守结算 unknown', async () => {
-    const { harness, fake } = await makeHarness({
+    const { harness, fake, workersDir } = await makeHarness({
       sendInputBehavior: () => {
         throw new Error('input transport failed')
       },
@@ -1890,6 +1892,13 @@ describe('WorkerHarness.sendToWorker', () => {
       reason_code: 'delivery_attempt_failed',
       reason: 'input transport failed',
       certainty: 'unknown',
+    })
+    const persisted = JSON.parse(
+      await fs.readFile(join(workersDir, worker.worker_id, 'input-deliveries.json'), 'utf8'),
+    ) as { receipts: Array<Record<string, unknown>> }
+    expect(persisted.receipts[0]).toMatchObject({
+      state: 'failed',
+      manager_notification: { status: 'consumed' },
     })
   })
 
@@ -1920,7 +1929,7 @@ describe('WorkerHarness.sendToWorker', () => {
     expect(result.reason).not.toContain('sk-testcredential')
   })
 
-  it('kill_worker 清空 pending 输入时以 task_cancelled 结算 receipt', async () => {
+  it('不安全的 held inbox 输入在本次调用内失败，不等待 kill_worker 清理', async () => {
     const { harness, workersDir } = await makeHarness()
     const worker = await harness.spawnWorker(spawnParams())
     const inbox = (harness as unknown as {
@@ -1931,7 +1940,11 @@ describe('WorkerHarness.sendToWorker', () => {
     const result = await harness.sendToWorker(worker.worker_id, '尚未进入输入面', {
       managerKey: `test::friend-1` as ManagerKey,
     })
-    expect(result.status).toBe('pending')
+    expect(result).toMatchObject({
+      status: 'failed',
+      reason_code: 'input_surface_timeout',
+      certainty: 'not_delivered',
+    })
 
     await harness.killWorker(worker.worker_id, '用户取消')
 
@@ -1942,10 +1955,10 @@ describe('WorkerHarness.sendToWorker', () => {
       delivery_id: result.delivery_id,
       state: 'failed',
       failure: {
-        reason_code: 'task_cancelled',
-        certainty: 'unknown',
+        reason_code: 'input_surface_timeout',
+        certainty: 'not_delivered',
       },
-      manager_notification: { status: 'pending' },
+      manager_notification: { status: 'consumed' },
     })
   })
 
@@ -1966,9 +1979,8 @@ describe('WorkerHarness.sendToWorker', () => {
       .getInbox(worker.worker_id).pending).toBe(0)
   })
 
-  it('pending 超过 5 分钟后结算失败，通知只有 consumed 后才确认', async () => {
+  it('输入面 stall 在同步调用内结算失败，不依赖后续 sweep 通知', async () => {
     const deliveries: HarnessEvent[] = []
-    let consumed = false
     const { harness, fake, workersDir } = await makeHarness(
       {
         implId: 'claude-code',
@@ -1979,7 +1991,7 @@ describe('WorkerHarness.sendToWorker', () => {
       {
         onOperationNotification: async (_managerKey, event) => {
           deliveries.push(event)
-          return { consumed }
+          return { consumed: true }
         },
       },
     )
@@ -1987,32 +1999,22 @@ describe('WorkerHarness.sendToWorker', () => {
     const result = await harness.sendToWorker(worker.worker_id, '会超时的输入', {
       managerKey: `test::friend-1` as ManagerKey,
     })
-    expect(result.status).toBe('pending')
+    expect(result).toMatchObject({
+      status: 'failed',
+      reason_code: 'input_surface_timeout',
+      certainty: 'not_delivered',
+    })
 
-    nowValue += 5 * 60_000
-    await harness.sweepLiveness()
-    let persisted = JSON.parse(
+    const persisted = JSON.parse(
       await fs.readFile(join(workersDir, worker.worker_id, 'input-deliveries.json'), 'utf8'),
     ) as { receipts: Array<Record<string, any>> }
     expect(persisted.receipts[0]).toMatchObject({
       state: 'failed',
       failure: { reason_code: 'input_surface_timeout', certainty: 'not_delivered' },
-      manager_notification: { status: 'pending' },
+      manager_notification: { status: 'consumed' },
     })
-    expect(deliveries).toHaveLength(1)
-    expect(deliveries[0].detail?.delivery_id).toBe(result.delivery_id)
+    expect(deliveries).toHaveLength(0)
     expect(fake.sendInputCalls).toHaveLength(1)
-
-    consumed = true
-    await harness.sweepLiveness()
-    persisted = JSON.parse(
-      await fs.readFile(join(workersDir, worker.worker_id, 'input-deliveries.json'), 'utf8'),
-    ) as { receipts: Array<Record<string, any>> }
-    expect(persisted.receipts[0].manager_notification.status).toBe('consumed')
-    expect(deliveries).toHaveLength(2)
-
-    await harness.sweepLiveness()
-    expect(deliveries).toHaveLength(2)
   })
 
   it('adapter 永久挂起时仍按 deadline 结算并通知 Manager', async () => {
@@ -2070,7 +2072,7 @@ describe('WorkerHarness.sendToWorker', () => {
     })
   })
 
-  it('启动恢复把未结算输入标为 unknown 失败，且不自动重发', async () => {
+  it('同步投递确认不确定时立即返回 unknown，且不自动重发', async () => {
     const notifications: HarnessEvent[] = []
     const { harness, fake, workersDir } = await makeHarness(
       {
@@ -2090,7 +2092,11 @@ describe('WorkerHarness.sendToWorker', () => {
     const result = await harness.sendToWorker(worker.worker_id, '可能已经 paste', {
       managerKey: `test::friend-1` as ManagerKey,
     })
-    expect(result.status).toBe('pending')
+    expect(result).toMatchObject({
+      status: 'failed',
+      reason_code: 'submission_unconfirmed_timeout',
+      certainty: 'unknown',
+    })
     expect(fake.sendInputCalls).toHaveLength(1)
 
     await harness.reconcileInputDeliveriesOnStartup()
@@ -2101,10 +2107,36 @@ describe('WorkerHarness.sendToWorker', () => {
     ) as { receipts: Array<Record<string, any>> }
     expect(persisted.receipts[0]).toMatchObject({
       state: 'failed',
-      failure: { reason_code: 'confirmation_lost_after_restart', certainty: 'unknown' },
+      failure: { reason_code: 'submission_unconfirmed_timeout', certainty: 'unknown' },
       manager_notification: { status: 'consumed' },
     })
-    expect(notifications[0].detail?.text).toMatch(/禁止盲目重发/)
+    expect(notifications).toHaveLength(0)
+  })
+
+  it('adapter 不响应取消时，Harness wall-clock deadline 仍结算同步投递', async () => {
+    try {
+      const { harness } = await makeHarness()
+      const worker = await harness.spawnWorker(spawnParams())
+      vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+      const flush = vi.spyOn(harness as unknown as { flushInbox: () => Promise<void> }, 'flushInbox')
+        .mockImplementation(() => new Promise<void>(() => {}))
+      const send = harness.sendToWorker(worker.worker_id, '永不返回的输入', {
+        managerKey: `test::friend-1` as ManagerKey,
+      })
+      await new Promise<void>((resolve) => {
+        const check = () => flush.mock.calls.length > 0 ? resolve() : setImmediate(check)
+        check()
+      })
+      await vi.advanceTimersByTimeAsync(INPUT_DELIVERY_TIMEOUT_MS)
+
+      await expect(send).resolves.toMatchObject({
+        status: 'failed',
+        reason_code: 'input_surface_timeout',
+        certainty: 'not_delivered',
+      })
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('正常投递:running worker 收到输入,adapter.sendInput 被正确调用,事件 input_sent 外发', async () => {

--- a/crabot-agent/tests/workers/harness/input-delivery-store.test.ts
+++ b/crabot-agent/tests/workers/harness/input-delivery-store.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { promises as fs } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
@@ -9,6 +9,7 @@ import {
 import type { ManagerKey } from '../../../src/workers/harness/ledger-types'
 
 let root: string
+let nowMs: number
 const workerId = 'w-input-receipt'
 const managerKey = 'wechat::session-1' as ManagerKey
 
@@ -31,9 +32,12 @@ function receipt(overrides: Partial<WorkerInputDeliveryReceipt> = {}): WorkerInp
 
 beforeEach(async () => {
   root = await fs.mkdtemp(join(tmpdir(), 'input-delivery-store-'))
+  nowMs = Date.parse('2026-08-17T00:00:00.000Z')
+  vi.spyOn(Date, 'now').mockImplementation(() => nowMs)
 })
 
 afterEach(async () => {
+  vi.restoreAllMocks()
   await fs.rm(root, { recursive: true, force: true })
 })
 
@@ -63,39 +67,69 @@ describe('InputDeliveryStore', () => {
     }, '2026-08-17T01:01:00.000Z')
 
     expect(failed).toMatchObject({
-      state: 'failed',
-      manager_notification: { status: 'pending' },
+      transitioned: true,
+      receipt: {
+        state: 'failed',
+        manager_notification: { status: 'pending' },
+      },
     })
-    await expect(store.settleDelivered(workerId, 'delivery-1', '2026-08-17T01:02:00.000Z'))
-      .rejects.toThrow('terminal')
+    const lateDelivered = await store.settleDelivered(workerId, 'delivery-1', '2026-08-17T01:02:00.000Z')
+    expect(lateDelivered).toEqual({ receipt: failed.receipt, transitioned: false })
   })
 
-  it('工具返回 pending 前原子挂通知；随后 delivered 保留通知责任直到 consumed', async () => {
+  it('同步工具读取失败终态时消费通知，不把 pending 暴露给 Manager', async () => {
     const store = new InputDeliveryStore(root)
     await store.create(receipt())
 
-    const pending = await store.readForToolResult(workerId, 'delivery-1', '2026-08-17T01:00:01.000Z')
-    expect(pending.manager_notification.status).toBe('pending')
+    await store.settleFailed(workerId, 'delivery-1', {
+      reason_code: 'delivery_attempt_failed',
+      reason: 'tmux command failed',
+      certainty: 'unknown',
+    }, '2026-08-17T01:00:01.000Z')
 
-    const delivered = await store.settleDelivered(workerId, 'delivery-1', '2026-08-17T01:00:02.000Z')
-    expect(delivered.manager_notification.status).toBe('pending')
+    const terminal = await store.readForToolResult(workerId, 'delivery-1', '2026-08-17T01:00:02.000Z')
+    expect(terminal.manager_notification).toEqual({
+      status: 'consumed',
+      consumed_at: '2026-08-17T01:00:02.000Z',
+    })
 
     const consumed = await store.markNotificationConsumed(workerId, 'delivery-1', '2026-08-17T01:00:03.000Z')
-    expect(consumed.manager_notification).toEqual({
-      status: 'consumed',
-      consumed_at: '2026-08-17T01:00:03.000Z',
-    })
+    expect(consumed).toEqual(terminal)
   })
 
   it('同步 delivered 在工具读取终态时不制造重复通知', async () => {
     const store = new InputDeliveryStore(root)
     await store.create(receipt())
-    await store.settleDelivered(workerId, 'delivery-1', '2026-08-17T01:00:01.000Z')
+    const settled = await store.settleDelivered(workerId, 'delivery-1', '2026-08-17T01:00:01.000Z')
+    expect(settled).toMatchObject({ transitioned: true, receipt: { state: 'delivered' } })
     const path = join(root, workerId, 'input-deliveries.json')
     const before = await fs.stat(path)
 
     const delivered = await store.readForToolResult(workerId, 'delivery-1', '2026-08-17T01:00:02.000Z')
     expect(delivered.manager_notification.status).toBe('not_required')
     expect((await fs.stat(path)).ino).toBe(before.ino)
+  })
+
+  it('deadline 后迟到的 accepted 结算 unknown，后续 accepted 不能翻转终态', async () => {
+    const store = new InputDeliveryStore(root)
+    await store.create(receipt())
+    nowMs = Date.parse('2026-08-17T01:06:00.000Z')
+
+    const lateAccepted = await store.settleDelivered(workerId, 'delivery-1', '2026-08-17T01:06:00.000Z')
+    expect(lateAccepted).toMatchObject({
+      transitioned: true,
+      receipt: {
+        state: 'failed',
+        failure: {
+          reason_code: 'submission_unconfirmed_timeout',
+          certainty: 'unknown',
+        },
+        manager_notification: { status: 'pending' },
+      },
+    })
+
+    const duplicateAccepted = await store.settleDelivered(workerId, 'delivery-1', '2026-08-17T01:06:01.000Z')
+    expect(duplicateAccepted).toEqual({ receipt: lateAccepted.receipt, transitioned: false })
+    expect(await store.get(workerId, 'delivery-1')).toEqual(lateAccepted.receipt)
   })
 })

--- a/crabot-agent/tests/workers/tmux-driver.test.ts
+++ b/crabot-agent/tests/workers/tmux-driver.test.ts
@@ -42,6 +42,25 @@ describe('TmuxDriver.capturePane', () => {
   })
 })
 
+describe('TmuxDriver command deadlines', () => {
+  it('bounds both execFile tmux commands and load-buffer stdin processes', async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tmux-driver-timeout-'))
+    const hangingBin = path.join(tempDir, 'tmux-hanging.sh')
+    await fs.writeFile(hangingBin, '#!/bin/sh\nsleep 5\n', { mode: 0o700 })
+    const driver = new TmuxDriver({ tmuxBin: hangingBin, commandTimeoutMs: 25 })
+
+    const commandStartedAt = Date.now()
+    await expect(driver.sendKeys('crabot-w-timeout', ['Enter'])).rejects.toBeTruthy()
+    expect(Date.now() - commandStartedAt).toBeLessThan(1000)
+
+    const bufferStartedAt = Date.now()
+    await expect(driver.pasteText('crabot-w-timeout', 'input')).rejects.toThrow(/timed out|exited|SIGKILL/i)
+    expect(Date.now() - bufferStartedAt).toBeLessThan(1000)
+
+    await fs.rm(tempDir, { recursive: true, force: true })
+  })
+})
+
 describe.skipIf(!detectTmux())('TmuxDriver', () => {
   const driver = new TmuxDriver()
   let tempDir: string


### PR DESCRIPTION
## 变更\n- 将 send_to_worker 收敛为一次有界同步投递，只返回 delivered | failed，失败返回原因码和 certainty。\n- 输入面不安全、提交确认不确定和超时在调用内结算；120 秒 wall-clock deadline，tmux 命令 15 秒上限，迟到结果不翻转 receipt。\n- Manager 活跃 episode 期间的 hook/状态通知进入当前 mailbox，下一次 LLM 调用批量读取；同步工具已返回的失败不再重复排队通知。\n- 补齐 Harness、Manager、Inbox、receipt、tmux driver 及回归测试，更新 PROGRESS.md。\n\n## 验证\n- tsc -p crabot-agent/tsconfig.json --noEmit\n- Agent 定向测试：254 passed, 4 skipped\n- git diff --check\n\n完整测试在当前 macOS 沙箱中受端口监听、tmux socket 权限和既有时序抖动影响，未作为本 PR 的通过依据。\n\n文档仓协议与设计记录已提交并推送：a83c19d。