### PR TITLE
perf(workers): 启动对账冷探测轻量化（重启恢复 ~3min → 秒级）

### DIFF
--- a/crabot-agent/src/workers/claude-code/adapter.ts
+++ b/crabot-agent/src/workers/claude-code/adapter.ts
@@ -2081,13 +2081,15 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
   /**
    * 冷重建懒化的交互重检消费点:ensureInteractionInspected 在首个本来就会 capture 的入口
    * (sendInput/readTerminal)补做一次 ensureRuntime 挂起的交互探测,只消费一次;失败只留
-   * 日志,后续 hook 路径(inspectTerminalInteractionAfterHook)仍会重探。调用方必须不持有
-   * per-worker 锁(内部自取)。
+   * 日志,后续 hook 路径(inspectTerminalInteractionAfterHook)仍会重探。走
+   * inspectTerminalInteraction(自带 per-worker 锁)——原 ensureRuntime 冷重建是在锁内跑
+   * 这段探测的,懒化后调用点都在锁外,锁由这里自取(PR#125 review 修正);调用方不得已持有
+   * 该锁,否则自死锁。
    */
   private async ensureInteractionInspected(runtime: Runtime, h: IncarnationHandle): Promise<void> {
     if (!runtime.pendingInteractionInspect) return
     runtime.pendingInteractionInspect = undefined
-    await this.inspectTerminalInteractionLocked(runtime, h).catch((error) => {
+    await this.inspectTerminalInteraction(runtime, h).catch((error) => {
       console.error(`[ClaudeCodeAdapter] deferred interaction check failed for ${h.worker_id}#${h.seq}:`, error)
     })
   }

--- a/crabot-agent/src/workers/claude-code/adapter.ts
+++ b/crabot-agent/src/workers/claude-code/adapter.ts
@@ -252,6 +252,12 @@ interface Runtime {
   /** 是否已经被 resume 过一次。resume() 锁内检测"对同一 prev 的重复 resume"(先到先得,
    * 后来者报错),对齐 builtin 同款语义(P2 review #2)。fork 不受此限制。 */
   resumed?: boolean
+  /**
+   * 冷重建懒化的交互重检标记:ensureRuntime 恢复活会话现场时不再自动 capture 判交互
+   * (启动对账冷探测要最小化,spec `2026-08-28-startup-reconcile-fast-probe`),改由首个
+   * 本来就会 capture 的入口(sendInput/readTerminal)经 ensureInteractionInspected 消费。
+   */
+  pendingInteractionInspect?: boolean
   /** Present only for a headless query fork; mainline incarnations are owned by tmux. */
   headlessChild?: ChildProcess
 }
@@ -1353,6 +1359,7 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
 
     const { state: current } = await this.syncState(runtime, h)
     if (current === 'exited') throw new WorkerExitedError(h.worker_id, h.seq, runtime.ended_reason)
+    await this.ensureInteractionInspected(runtime, h)
 
     return this.getMutex(h.worker_id).run(async () => {
       if (runtime.controlState.kind === 'exited') throw new WorkerExitedError(h.worker_id, h.seq, runtime.ended_reason)
@@ -1422,6 +1429,7 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
       return chunk ? { kind: 'headless_text', text: chunk } : { kind: 'unavailable', unavailable_reason: 'headless_without_text' }
     }
     if (await this.tmux.isAlive(runtime.sessionName)) {
+      await this.ensureInteractionInspected(runtime, h)
       try {
         const snapshot = await this.capture(runtime)
         if (snapshot.dead) {
@@ -1469,10 +1477,55 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
    * 与旧实现"tmux 会话不存在则返回 exited"的兜底语义一致,直接判 exited。
    */
   async state(h: IncarnationHandle): Promise<WorkerContractState> {
-    const runtime = await this.ensureRuntime(h)
-    if (!runtime) return 'exited'
-    if (runtime.headlessChild) return contractState(runtime.controlState)
-    return (await this.syncState(runtime, h)).state
+    const existing = this.runtimes.get(instanceKey(h))
+    if (existing) {
+      if (existing.headlessChild) return contractState(existing.controlState)
+      return (await this.syncState(existing, h)).state
+    }
+    return this.coldProbeState(h)
+  }
+
+  /**
+   * 冷探测快路径(无常驻 runtime 时的 state()):meta 读盘 + 一次 tmux isAlive 组成最小
+   * 证据链(spec `2026-08-28-startup-reconcile-fast-probe`)。
+   *
+   * 判死:reason 三级推导——meta.ended_reason 已落终态 → 沿用;活视角控制态为
+   * waiting_action → 保守取 'crashed'(无法证明有新 Stop);否则 'completed'(协议 §6.3
+   * 的推断语义,与 syncState 缺省一致)。随后做最小版 transitionExited——残影固化
+   * (final_terminal,tmux server 已不在时 capture 失败静默)、killSession、meta 落终态;
+   * 不建 runtime、不读 events、不做交互探测,也不触发 onStateChange——调用方(harness
+   * 对账 markCrashed)独家落账与事件。
+   *
+   * 判活:走 buildColdRuntimeLocked 轻核重建(装事件监视=协议 §5.5.3 重连原会话),返回
+   * meta 恢复的控制态。不 capture、不做交互恢复——node 死后 CLI 的新进展要等
+   * ensureInteractionInspected 的消费入口或 syncState 才可见(已确认的取舍)。
+   */
+  private async coldProbeState(h: IncarnationHandle): Promise<WorkerContractState> {
+    const key = instanceKey(h)
+    return this.getMutex(h.worker_id).run(async () => {
+      // 锁内重查:排在前面的另一次 ensureRuntime/coldProbeState 可能已重建。命中时只能
+      // 返回 meta 恢复的控制态——syncState 要拿同一把锁,不能在锁内调(常态的常驻探测
+      // 走 state() 的锁外路径;并发首调撞上重查命中的这一个是已确认可接受的滞后)。
+      const resident = this.runtimes.get(key)
+      if (resident) return contractState(resident.controlState)
+      const dir = join(this.deps.dataDir, h.worker_id)
+      const meta = await this.readMetaFile(dir, h.seq)
+      if (!meta) return 'exited'
+      const sessionName = `crabot-w-${h.worker_id}-${h.seq}`
+      if (!(await this.tmux.isAlive(sessionName))) {
+        const reason: IncarnationEndReason = meta.ended_reason
+          ?? (controlFromMeta(meta, true).kind === 'waiting_action' ? 'crashed' : 'completed')
+        try {
+          const snapshot = await this.tmux.capturePane(sessionName)
+          if (!snapshot.dead) await writeFinalTerminalSnapshot(dir, h.seq, snapshot.text, new Date().toISOString())
+        } catch { /* 残影拿不到(如 tmux server 已随整机重启消失)就放弃 */ }
+        await this.tmux.killSession(sessionName)
+        await writeMetaAtomic(dir, h.seq, { ...meta, seq: h.seq, state: 'exited', ended_reason: reason })
+        return 'exited'
+      }
+      const runtime = await this.buildColdRuntimeLocked(h, meta, true)
+      return contractState(runtime.controlState)
+    })
   }
 
   async readTrace(h: IncarnationHandle, cursor?: TraceCursor): Promise<{
@@ -1780,53 +1833,60 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
       const sessionName = `crabot-w-${ref.worker_id}-${ref.seq}`
       const alive = await this.tmux.isAlive(sessionName)
       if (!alive) await this.tmux.killSession(sessionName)
-      const workspaceRoot = meta.workspace_root ?? ''
-      const sessionId = meta.session_id ?? ref.session_ref ?? ''
-      const eventsPath = workspaceRoot ? eventsFilePath({ root: workspaceRoot }) : join(dir, `.no-workspace-events-${ref.seq}.jsonl`)
-      const eventChannel = new CliEventChannel(eventsPath)
-      const eventWatchOffset = await eventChannel.endOffset()
-
-      let stopBaseline = 0
-      if (workspaceRoot) {
-        const events = await eventChannel.readAll()
-        stopBaseline = events.filter((e) => e.kind === 'stop').length
-      }
-
-      const runtime: Runtime = {
-        worker_id: ref.worker_id,
-        incarnation_id: ref.incarnation_id,
-        seq: ref.seq,
-        dir,
-        workspaceRoot,
-        sessionName,
-        controlEndpoint: meta.control_socket && meta.control_monitor_id
-          ? { socket_path: meta.control_socket, monitor_id: meta.control_monitor_id }
-          : undefined,
-        sessionId,
-        eventChannel,
-        eventWatchOffset,
-        controlState: controlFromMeta(meta, alive),
-        ended_reason: alive ? undefined : meta.ended_reason,
-        stopBaseline,
-        killed: false,
-      }
-      this.runtimes.set(key, runtime)
-      // 重启后重连接管(§13):会话还活着的化身在这里重新装上文件监视,它之后每一轮 hook
-      // 都能继续推状态给 harness。已终态的化身 startEventWatch 自己会短路掉。
-      this.startEventWatch(runtime, { worker_id: ref.worker_id, incarnation_id: ref.incarnation_id, seq: ref.seq, impl: 'claude-code', session_ref: sessionId })
-      if (alive) {
-        await this.inspectTerminalInteractionLocked(runtime, {
-          worker_id: ref.worker_id,
-          incarnation_id: ref.incarnation_id,
-          seq: ref.seq,
-          impl: 'claude-code',
-          session_ref: sessionId,
-        }).catch((error) => {
-          console.error(`[ClaudeCodeAdapter] recovery interaction check failed for ${ref.worker_id}#${ref.seq}:`, error)
-        })
-      }
-      return runtime
+      return this.buildColdRuntimeLocked(ref, meta, alive)
     })
+  }
+
+  /**
+   * 冷重建的轻核(调用方必须已持有 per-worker 锁):meta 派生字段、events 基线、事件监视
+   * 重连(协议 §5.5.3「重连原会话」)。活会话不再自动做 capture 交互探测——那是对账冷探测
+   * 的最大耗时源(spec `2026-08-28-startup-reconcile-fast-probe`),改为挂
+   * pendingInteractionInspect 标记,由 ensureInteractionInspected 的消费入口补上。
+   */
+  private async buildColdRuntimeLocked(
+    ref: { worker_id: string; incarnation_id?: string; seq: number; session_ref?: string },
+    meta: { session_id?: string; workspace_root?: string; ended_reason?: IncarnationEndReason; state?: WorkerContractState; wait_mode?: 'text' | 'action'; wait_reason?: string; startup_stalled?: boolean; control_socket?: string; control_monitor_id?: string },
+    alive: boolean,
+  ): Promise<Runtime> {
+    const key = instanceKey(ref)
+    const dir = join(this.deps.dataDir, ref.worker_id)
+    const sessionName = `crabot-w-${ref.worker_id}-${ref.seq}`
+    const workspaceRoot = meta.workspace_root ?? ''
+    const sessionId = meta.session_id ?? ref.session_ref ?? ''
+    const eventsPath = workspaceRoot ? eventsFilePath({ root: workspaceRoot }) : join(dir, `.no-workspace-events-${ref.seq}.jsonl`)
+    const eventChannel = new CliEventChannel(eventsPath)
+    const eventWatchOffset = await eventChannel.endOffset()
+
+    let stopBaseline = 0
+    if (workspaceRoot) {
+      const events = await eventChannel.readAll()
+      stopBaseline = events.filter((e) => e.kind === 'stop').length
+    }
+
+    const runtime: Runtime = {
+      worker_id: ref.worker_id,
+      incarnation_id: ref.incarnation_id,
+      seq: ref.seq,
+      dir,
+      workspaceRoot,
+      sessionName,
+      controlEndpoint: meta.control_socket && meta.control_monitor_id
+        ? { socket_path: meta.control_socket, monitor_id: meta.control_monitor_id }
+        : undefined,
+      sessionId,
+      eventChannel,
+      eventWatchOffset,
+      controlState: controlFromMeta(meta, alive),
+      ended_reason: alive ? undefined : meta.ended_reason,
+      stopBaseline,
+      killed: false,
+    }
+    this.runtimes.set(key, runtime)
+    // 重启后重连接管(§13):会话还活着的化身在这里重新装上文件监视,它之后每一轮 hook
+    // 都能继续推状态给 harness。已终态的化身 startEventWatch 自己会短路掉。
+    this.startEventWatch(runtime, { worker_id: ref.worker_id, incarnation_id: ref.incarnation_id, seq: ref.seq, impl: 'claude-code', session_ref: sessionId })
+    if (alive) runtime.pendingInteractionInspect = true
+    return runtime
   }
 
   /** meta-<seq>.json 读取,文件不存在/内容损坏一律返回 undefined(供 ensureRuntime 判定
@@ -2016,6 +2076,20 @@ export class ClaudeCodeAdapter implements WorkerAdapter {
 
   private inspectTerminalInteraction(runtime: Runtime, h: IncarnationHandle): Promise<void> {
     return this.getMutex(h.worker_id).run(() => this.inspectTerminalInteractionLocked(runtime, h))
+  }
+
+  /**
+   * 冷重建懒化的交互重检消费点:ensureInteractionInspected 在首个本来就会 capture 的入口
+   * (sendInput/readTerminal)补做一次 ensureRuntime 挂起的交互探测,只消费一次;失败只留
+   * 日志,后续 hook 路径(inspectTerminalInteractionAfterHook)仍会重探。调用方必须不持有
+   * per-worker 锁(内部自取)。
+   */
+  private async ensureInteractionInspected(runtime: Runtime, h: IncarnationHandle): Promise<void> {
+    if (!runtime.pendingInteractionInspect) return
+    runtime.pendingInteractionInspect = undefined
+    await this.inspectTerminalInteractionLocked(runtime, h).catch((error) => {
+      console.error(`[ClaudeCodeAdapter] deferred interaction check failed for ${h.worker_id}#${h.seq}:`, error)
+    })
   }
 
   private inspectTerminalInteractionAfterHook(runtime: Runtime, h: IncarnationHandle): Promise<void> {

--- a/crabot-agent/src/workers/codex/adapter.ts
+++ b/crabot-agent/src/workers/codex/adapter.ts
@@ -1916,18 +1916,6 @@ export class CodexWorkerAdapter implements WorkerAdapter {
     }
 
     if (!runtime.rolloutPath) {
-      // 懒查找回填(spec 2026-08-28-startup-reconcile-fast-probe):轻核重建不再扫 sessions
-      // 目录,首次读 trace 时补一次定位。占位 session(无 session_id)或找不到时走下面的
-      // 已知限制降级,cursor 原样透传。
-      if (runtime.sessionDiscoveryStatus === 'discovered' && runtime.codexHome && runtime.sessionId) {
-        try {
-          runtime.rolloutPath = await findRolloutFileBySessionId(join(runtime.codexHome, 'sessions'), runtime.sessionId)
-        } catch (err) {
-          console.warn(`[CodexWorkerAdapter] deferred rollout discovery failed for ${h.worker_id}#${h.seq}:`, err)
-        }
-      }
-    }
-    if (!runtime.rolloutPath) {
       // spawn 时没能发现 rollout 文件(占位 session_id,已知限制)——没有路径可读,退化为空
       // 数组,cursor 原样透传。
       return { sourceAvailable: false, events: [], nextCursor: cursor ?? { offset: 0 } }
@@ -2169,13 +2157,14 @@ export class CodexWorkerAdapter implements WorkerAdapter {
 
   /**
    * 冷重建的轻核(调用方必须已持有 per-worker 锁):meta 派生字段、events 基线、事件监视
-   * 重连(协议 §5.5.3「重连原会话」)。与 cc adapter 的同名拆分一致:
-   * - 活会话不再自动做 capture 交互探测(启动对账冷探测的最大耗时源,spec
-   *   `2026-08-28-startup-reconcile-fast-probe`),改为挂 pendingInteractionInspect 标记,
-   *   由 ensureInteractionInspected 的消费入口补上;
-   * - rollout 文件定位从轻核移出(目录扫描在 sessions 量大时不可忽略),rolloutPath 留空,
-   *   由 readTraceWindow 首次读 trace 时懒查找回填;lastActivityAt 本就有无 runtime 的
-   *   懒查找,不受影响。
+   * 重连(协议 §5.5.3「重连原会话」)。与 cc adapter 的同名拆分一致——活会话不再自动做
+   * capture 交互探测(启动对账冷探测的最大耗时源,spec
+   * `2026-08-28-startup-reconcile-fast-probe`),改为挂 pendingInteractionInspect 标记,
+   * 由 ensureInteractionInspected 的消费入口补上。
+   *
+   * rollout 定位保留在轻核(PR#125 review 修正):rolloutPath 是 resume 门槛(§5.4)、
+   * native trace watch(startNativeTraceWatch)与 lastActivityAt 的共同前置,懒化会在
+   * "重启 → 接续 codex worker"主路径上断掉这三处;它只是本地目录遍历,非对账耗时大头。
    */
   private async buildColdRuntimeLocked(
     ref: { worker_id: string; incarnation_id?: string; seq: number; session_ref?: string },
@@ -2191,6 +2180,8 @@ export class CodexWorkerAdapter implements WorkerAdapter {
     // meta.codex_home）；老 meta 没有该字段才回退 workspace 推导（existing_host 语义）。
     const codexHome = meta.codex_home ?? (workspaceRoot ? join(workspaceRoot, '.codex') : '')
     const sessionDiscoveryStatus: 'discovered' | 'placeholder' = meta.session_discovery ?? 'placeholder'
+    const rolloutPath =
+      sessionDiscoveryStatus === 'discovered' && codexHome ? await findRolloutFileBySessionId(join(codexHome, 'sessions'), sessionId) : undefined
     const eventsPath = workspaceRoot ? eventsFilePath({ root: workspaceRoot }) : join(dir, `.no-workspace-events-${ref.seq}.jsonl`)
     const eventChannel = new CliEventChannel(eventsPath)
     const eventWatchOffset = await eventChannel.endOffset()
@@ -2213,7 +2204,7 @@ export class CodexWorkerAdapter implements WorkerAdapter {
         ? { socket_path: meta.control_socket, monitor_id: meta.control_monitor_id }
         : undefined,
       sessionId,
-      rolloutPath: undefined,
+      rolloutPath,
       eventChannel,
       eventWatchOffset,
       sessionDiscoveryStatus,
@@ -2418,13 +2409,15 @@ export class CodexWorkerAdapter implements WorkerAdapter {
   /**
    * 冷重建懒化的交互重检消费点:在首个本来就会 capture 的入口(sendInput/readTerminal)
    * 补做一次 ensureRuntime 挂起的交互探测,只消费一次;失败只留日志,后续 hook 路径
-   * (inspectTerminalInteractionAfterHook)仍会重探。调用方必须不持有 per-worker 锁
-   * (内部自取)。语义与 cc adapter 的同名方法一致。
+   * (inspectTerminalInteractionAfterHook)仍会重探。走 inspectTerminalInteraction(自带
+   * per-worker 锁)——原 ensureRuntime 冷重建是在锁内跑这段探测的,懒化后调用点都在锁外,
+   * 锁由这里自取(PR#125 review 修正);调用方不得已持有该锁,否则自死锁。语义与 cc adapter
+   * 的同名方法一致。
    */
   private async ensureInteractionInspected(runtime: Runtime, h: IncarnationHandle): Promise<void> {
     if (!runtime.pendingInteractionInspect) return
     runtime.pendingInteractionInspect = undefined
-    await this.inspectTerminalInteractionLocked(runtime, h).catch((error) => {
+    await this.inspectTerminalInteraction(runtime, h).catch((error) => {
       console.error(`[CodexWorkerAdapter] deferred interaction check failed for ${h.worker_id}#${h.seq}:`, error)
     })
   }

--- a/crabot-agent/src/workers/codex/adapter.ts
+++ b/crabot-agent/src/workers/codex/adapter.ts
@@ -297,6 +297,13 @@ interface Runtime {
   /** 是否已经被 resume 过一次。resume() 锁内检测"对同一 prev 的重复 resume"(先到先得,
    * 后来者报错),对齐 builtin/cc 同款语义(P2 review #2)。 */
   resumed?: boolean
+  /**
+   * 冷重建懒化的交互重检标记:ensureRuntime 恢复活会话现场时不再自动 capture 判交互
+   * (启动对账冷探测要最小化,spec `2026-08-28-startup-reconcile-fast-probe`),改由首个
+   * 本来就会 capture 的入口(sendInput/readTerminal)经 ensureInteractionInspected 消费。
+   * 语义与 cc adapter 的同名字段完全一致。
+   */
+  pendingInteractionInspect?: boolean
   /** Present only for a headless query fork; mainline incarnations are owned by tmux. */
   headlessClient?: CodexAppServerClient
 }
@@ -1674,6 +1681,7 @@ export class CodexWorkerAdapter implements WorkerAdapter {
     if (!runtime) throw new WorkerExitedError(h.worker_id, h.seq)
     const { state: current } = await this.syncState(runtime, h)
     if (current === 'exited') throw new WorkerExitedError(h.worker_id, h.seq, runtime.ended_reason)
+    await this.ensureInteractionInspected(runtime, h)
 
     return this.getMutex(h.worker_id).run(async () => {
       if (runtime.controlState.kind === 'exited') throw new WorkerExitedError(h.worker_id, h.seq, runtime.ended_reason)
@@ -1751,6 +1759,7 @@ export class CodexWorkerAdapter implements WorkerAdapter {
       return chunk ? { kind: 'headless_text', text: chunk } : { kind: 'unavailable', unavailable_reason: 'headless_without_text' }
     }
     if (await this.tmux.isAlive(runtime.sessionName)) {
+      await this.ensureInteractionInspected(runtime, h)
       try {
         const snapshot = await this.capture(runtime)
         if (snapshot.dead) {
@@ -1803,10 +1812,49 @@ export class CodexWorkerAdapter implements WorkerAdapter {
    * 不存在则返回 exited"的兜底语义一致,直接判 exited。
    */
   async state(h: IncarnationHandle): Promise<WorkerContractState> {
-    const runtime = await this.ensureRuntime(h)
-    if (!runtime) return 'exited'
-    if (runtime.headlessClient) return contractState(runtime.controlState)
-    return (await this.syncState(runtime, h)).state
+    const existing = this.runtimes.get(instanceKey(h))
+    if (existing) {
+      if (existing.headlessClient) return contractState(existing.controlState)
+      return (await this.syncState(existing, h)).state
+    }
+    return this.coldProbeState(h)
+  }
+
+  /**
+   * 冷探测快路径(无常驻 runtime 时的 state()):meta 读盘 + 一次 tmux isAlive 组成最小
+   * 证据链(spec `2026-08-28-startup-reconcile-fast-probe`),语义与 cc adapter 的
+   * coldProbeState 逐条一致:判死做最小版 transitionExited(残影固化、killSession、meta
+   * 落终态),reason 三级推导(meta.ended_reason → 活视角 waiting_action 保守 'crashed' →
+   * 否则 'completed' 推断),不建 runtime、不读 events、不触发 onStateChange;判活走
+   * buildColdRuntimeLocked 轻核重建(装事件监视=协议 §5.5.3 重连原会话),返回 meta 恢复的
+   * 控制态。
+   */
+  private async coldProbeState(h: IncarnationHandle): Promise<WorkerContractState> {
+    const key = instanceKey(h)
+    return this.getMutex(h.worker_id).run(async () => {
+      // 锁内重查:排在前面的另一次 ensureRuntime/coldProbeState 可能已重建。命中时只能
+      // 返回 meta 恢复的控制态——syncState 要拿同一把锁,不能在锁内调(常态的常驻探测
+      // 走 state() 的锁外路径;并发首调撞上重查命中的这一个是已确认可接受的滞后)。
+      const resident = this.runtimes.get(key)
+      if (resident) return contractState(resident.controlState)
+      const dir = join(this.deps.dataDir, h.worker_id)
+      const meta = await this.readMetaFile(dir, h.seq)
+      if (!meta) return 'exited'
+      const sessionName = `crabot-w-${h.worker_id}-${h.seq}`
+      if (!(await this.tmux.isAlive(sessionName))) {
+        const reason: IncarnationEndReason = meta.ended_reason
+          ?? (controlFromMeta(meta, true).kind === 'waiting_action' ? 'crashed' : 'completed')
+        try {
+          const snapshot = await this.tmux.capturePane(sessionName)
+          if (!snapshot.dead) await writeFinalTerminalSnapshot(dir, h.seq, snapshot.text, new Date().toISOString())
+        } catch { /* 残影拿不到(如 tmux server 已随整机重启消失)就放弃 */ }
+        await this.tmux.killSession(sessionName)
+        await writeMetaAtomic(dir, h.seq, { ...meta, seq: h.seq, state: 'exited', ended_reason: reason })
+        return 'exited'
+      }
+      const runtime = await this.buildColdRuntimeLocked(h, meta, true)
+      return contractState(runtime.controlState)
+    })
   }
 
   async readTrace(h: IncarnationHandle, cursor?: TraceCursor): Promise<{
@@ -1867,6 +1915,18 @@ export class CodexWorkerAdapter implements WorkerAdapter {
       throw new Error(`CodexWorkerAdapter.readTrace: no such incarnation ${h.worker_id}#${h.seq} resident in this process`)
     }
 
+    if (!runtime.rolloutPath) {
+      // 懒查找回填(spec 2026-08-28-startup-reconcile-fast-probe):轻核重建不再扫 sessions
+      // 目录,首次读 trace 时补一次定位。占位 session(无 session_id)或找不到时走下面的
+      // 已知限制降级,cursor 原样透传。
+      if (runtime.sessionDiscoveryStatus === 'discovered' && runtime.codexHome && runtime.sessionId) {
+        try {
+          runtime.rolloutPath = await findRolloutFileBySessionId(join(runtime.codexHome, 'sessions'), runtime.sessionId)
+        } catch (err) {
+          console.warn(`[CodexWorkerAdapter] deferred rollout discovery failed for ${h.worker_id}#${h.seq}:`, err)
+        }
+      }
+    }
     if (!runtime.rolloutPath) {
       // spawn 时没能发现 rollout 文件(占位 session_id,已知限制)——没有路径可读,退化为空
       // 数组,cursor 原样透传。
@@ -2103,63 +2163,72 @@ export class CodexWorkerAdapter implements WorkerAdapter {
       const sessionName = `crabot-w-${ref.worker_id}-${ref.seq}`
       const alive = await this.tmux.isAlive(sessionName)
       if (!alive) await this.tmux.killSession(sessionName)
-      const workspaceRoot = meta.workspace_root ?? ''
-      const sessionId = meta.session_id ?? ref.session_ref ?? ''
-      // P6-B：admin_provider 的 CODEX_HOME 在 worker 级 runtime 目录（spawn/resume 时落了
-      // meta.codex_home）；老 meta 没有该字段才回退 workspace 推导（existing_host 语义）。
-      const codexHome = meta.codex_home ?? (workspaceRoot ? join(workspaceRoot, '.codex') : '')
-      const sessionDiscoveryStatus: 'discovered' | 'placeholder' = meta.session_discovery ?? 'placeholder'
-      const rolloutPath =
-        sessionDiscoveryStatus === 'discovered' && codexHome ? await findRolloutFileBySessionId(join(codexHome, 'sessions'), sessionId) : undefined
-      const eventsPath = workspaceRoot ? eventsFilePath({ root: workspaceRoot }) : join(dir, `.no-workspace-events-${ref.seq}.jsonl`)
-      const eventChannel = new CliEventChannel(eventsPath)
-      const eventWatchOffset = await eventChannel.endOffset()
-
-      let stopBaseline = 0
-      if (workspaceRoot) {
-        const events = await eventChannel.readAll()
-        stopBaseline = events.filter((e) => e.kind === 'stop').length
-      }
-
-      const runtime: Runtime = {
-        worker_id: ref.worker_id,
-        incarnation_id: ref.incarnation_id,
-        seq: ref.seq,
-        dir,
-        workspaceRoot,
-        codexHome,
-        sessionName,
-        controlEndpoint: meta.control_socket && meta.control_monitor_id
-          ? { socket_path: meta.control_socket, monitor_id: meta.control_monitor_id }
-          : undefined,
-        sessionId,
-        rolloutPath,
-        eventChannel,
-        eventWatchOffset,
-        sessionDiscoveryStatus,
-        discoveryStartedAt: Date.now(),
-        controlState: controlFromMeta(meta, alive),
-        ended_reason: alive ? undefined : meta.ended_reason,
-        stopBaseline,
-        killed: false,
-      }
-      this.runtimes.set(key, runtime)
-      // 重启后重连接管(§13):会话还活着的化身在这里重新装上文件监视。已终态的化身
-      // startEventWatch 自己会短路掉。
-      this.startEventWatch(runtime, { worker_id: ref.worker_id, incarnation_id: ref.incarnation_id, seq: ref.seq, impl: 'codex', session_ref: sessionId })
-      if (alive) {
-        await this.inspectTerminalInteractionLocked(runtime, {
-          worker_id: ref.worker_id,
-          incarnation_id: ref.incarnation_id,
-          seq: ref.seq,
-          impl: 'codex',
-          session_ref: sessionId,
-        }).catch((error) => {
-          console.error(`[CodexWorkerAdapter] recovery interaction check failed for ${ref.worker_id}#${ref.seq}:`, error)
-        })
-      }
-      return runtime
+      return this.buildColdRuntimeLocked(ref, meta, alive)
     })
+  }
+
+  /**
+   * 冷重建的轻核(调用方必须已持有 per-worker 锁):meta 派生字段、events 基线、事件监视
+   * 重连(协议 §5.5.3「重连原会话」)。与 cc adapter 的同名拆分一致:
+   * - 活会话不再自动做 capture 交互探测(启动对账冷探测的最大耗时源,spec
+   *   `2026-08-28-startup-reconcile-fast-probe`),改为挂 pendingInteractionInspect 标记,
+   *   由 ensureInteractionInspected 的消费入口补上;
+   * - rollout 文件定位从轻核移出(目录扫描在 sessions 量大时不可忽略),rolloutPath 留空,
+   *   由 readTraceWindow 首次读 trace 时懒查找回填;lastActivityAt 本就有无 runtime 的
+   *   懒查找,不受影响。
+   */
+  private async buildColdRuntimeLocked(
+    ref: { worker_id: string; incarnation_id?: string; seq: number; session_ref?: string },
+    meta: { session_id?: string; workspace_root?: string; ended_reason?: IncarnationEndReason; session_discovery?: 'discovered' | 'placeholder'; codex_home?: string; state?: WorkerContractState; wait_mode?: 'text' | 'action'; wait_reason?: string; startup_stalled?: boolean; control_socket?: string; control_monitor_id?: string },
+    alive: boolean,
+  ): Promise<Runtime> {
+    const key = instanceKey(ref)
+    const dir = join(this.deps.dataDir, ref.worker_id)
+    const sessionName = `crabot-w-${ref.worker_id}-${ref.seq}`
+    const workspaceRoot = meta.workspace_root ?? ''
+    const sessionId = meta.session_id ?? ref.session_ref ?? ''
+    // P6-B：admin_provider 的 CODEX_HOME 在 worker 级 runtime 目录（spawn/resume 时落了
+    // meta.codex_home）；老 meta 没有该字段才回退 workspace 推导（existing_host 语义）。
+    const codexHome = meta.codex_home ?? (workspaceRoot ? join(workspaceRoot, '.codex') : '')
+    const sessionDiscoveryStatus: 'discovered' | 'placeholder' = meta.session_discovery ?? 'placeholder'
+    const eventsPath = workspaceRoot ? eventsFilePath({ root: workspaceRoot }) : join(dir, `.no-workspace-events-${ref.seq}.jsonl`)
+    const eventChannel = new CliEventChannel(eventsPath)
+    const eventWatchOffset = await eventChannel.endOffset()
+
+    let stopBaseline = 0
+    if (workspaceRoot) {
+      const events = await eventChannel.readAll()
+      stopBaseline = events.filter((e) => e.kind === 'stop').length
+    }
+
+    const runtime: Runtime = {
+      worker_id: ref.worker_id,
+      incarnation_id: ref.incarnation_id,
+      seq: ref.seq,
+      dir,
+      workspaceRoot,
+      codexHome,
+      sessionName,
+      controlEndpoint: meta.control_socket && meta.control_monitor_id
+        ? { socket_path: meta.control_socket, monitor_id: meta.control_monitor_id }
+        : undefined,
+      sessionId,
+      rolloutPath: undefined,
+      eventChannel,
+      eventWatchOffset,
+      sessionDiscoveryStatus,
+      discoveryStartedAt: Date.now(),
+      controlState: controlFromMeta(meta, alive),
+      ended_reason: alive ? undefined : meta.ended_reason,
+      stopBaseline,
+      killed: false,
+    }
+    this.runtimes.set(key, runtime)
+    // 重启后重连接管(§13):会话还活着的化身在这里重新装上文件监视。已终态的化身
+    // startEventWatch 自己会短路掉。
+    this.startEventWatch(runtime, { worker_id: ref.worker_id, incarnation_id: ref.incarnation_id, seq: ref.seq, impl: 'codex', session_ref: sessionId })
+    if (alive) runtime.pendingInteractionInspect = true
+    return runtime
   }
 
   /** meta-<seq>.json 读取,文件不存在/内容损坏一律返回 undefined(供 ensureRuntime 判定
@@ -2344,6 +2413,20 @@ export class CodexWorkerAdapter implements WorkerAdapter {
 
   private inspectTerminalInteraction(runtime: Runtime, h: IncarnationHandle): Promise<void> {
     return this.getMutex(h.worker_id).run(() => this.inspectTerminalInteractionLocked(runtime, h))
+  }
+
+  /**
+   * 冷重建懒化的交互重检消费点:在首个本来就会 capture 的入口(sendInput/readTerminal)
+   * 补做一次 ensureRuntime 挂起的交互探测,只消费一次;失败只留日志,后续 hook 路径
+   * (inspectTerminalInteractionAfterHook)仍会重探。调用方必须不持有 per-worker 锁
+   * (内部自取)。语义与 cc adapter 的同名方法一致。
+   */
+  private async ensureInteractionInspected(runtime: Runtime, h: IncarnationHandle): Promise<void> {
+    if (!runtime.pendingInteractionInspect) return
+    runtime.pendingInteractionInspect = undefined
+    await this.inspectTerminalInteractionLocked(runtime, h).catch((error) => {
+      console.error(`[CodexWorkerAdapter] deferred interaction check failed for ${h.worker_id}#${h.seq}:`, error)
+    })
   }
 
   private inspectTerminalInteractionAfterHook(runtime: Runtime, h: IncarnationHandle): Promise<void> {

--- a/crabot-agent/src/workers/harness/harness.ts
+++ b/crabot-agent/src/workers/harness/harness.ts
@@ -4447,10 +4447,10 @@ export class WorkerHarness {
    *   到的同步/异步异常,一个 worker 出问题不影响其它 worker 被处理)。
    * - 返回 `exited`:台账仍非终态却已经不在跑了,判死,ended_reason='crashed'。
    * - 返回 `running`/`idle`:台账保持(不判死)——tmux worker 独立于 agent 进程,重启后
-   *   往往仍活着;按这次实际观察到的 contractState 用 taskStatusFromIncarnation 把
-   *   task.status 对齐到真实值(可能一步都不用走,也可能需要更新化身的 state 字段),
-   *   发 state_changed 事件(detail.source='reconcile',与被动回调路径区分)通知 P4 manager
-   *   接管这个 worker 的后续监护;归 revived。
+   *   往往仍活着;存活分支不用观察值覆盖台账状态(agent 停机期间 CLI 可能又推进了,冷
+   *   探测看到的是滞后控制态,spec `2026-08-28-startup-reconcile-fast-probe`),只修复
+   *   "台账化身已标 exited 而探测判活"的内部矛盾并发 state_changed
+   *   (detail.source='reconcile',与被动回调路径区分);归 revived。
    */
   async reconcileOnStartup(): Promise<ReconcileReport> {
     const revived: string[] = []
@@ -5080,7 +5080,7 @@ export class WorkerHarness {
         return 'failed'
       }
 
-      await this.realignAliveIncarnation(managerKey, worker, mainline, observed)
+      await this.realignAliveIncarnation(managerKey, worker, mainline)
       return 'revived'
     })
   }
@@ -5156,51 +5156,38 @@ export class WorkerHarness {
   }
 
   /**
-   * reconcileOnStartup 存活分支:台账不判死,只按这次实际观察到的 contractState 对齐
-   * incarnation.state 与 task.status(taskStatusFromIncarnation 同一套映射,与
-   * processStateChange 的被动回调路径共用规则)。若观察结果与台账现状完全一致(既没有
-   * 化身 state 差异也没有 task 状态差异),不做任何写入、不发事件——避免每次巡检都产生
-   * 噪声写盘/事件。
+   * reconcileOnStartup 存活分支(冷探测语义,spec `2026-08-28-startup-reconcile-fast-probe`):
+   * 对账只确认"化身还活着",不用冷探测观察值覆盖台账状态——agent 停机期间 CLI 可能又推进了
+   * (turn 跑完、弹出确认框),冷探测看到的是滞后控制态,把滞后值写进台账不如不写;真实状态由
+   * 保留的 hook watcher 被动回调、manager 首次交互的 syncState、liveness sweep 逐步对齐。
+   *
+   * 唯一例外:台账化身 state='exited' 而探测判活的内部矛盾(死而复生只可能来自上一进程的
+   * 判死与实际不符),修复为 running 并发 state_changed(source='reconcile') 事件;无矛盾则
+   * 不写盘、不发事件。
    */
   private async realignAliveIncarnation(
     managerKey: ManagerKey,
     worker: LedgerWorker,
     mainline: ExecutableIncarnation,
-    observed: WorkerContractState
   ): Promise<void> {
-    const waitingInput = observed === 'idle' ? true : undefined
-    const nextStatus =
-      observed === 'idle' && (this.hasPendingBgNotification(worker.worker_id) || await this.deps.hasRunningBg?.(worker.worker_id))
-        ? 'running'
-        : taskStatusFromIncarnation(observed, undefined, waitingInput)
-    const stateChanged = mainline.state !== observed
-    const statusChanged = worker.task.status !== nextStatus
-    if (!stateChanged && !statusChanged) return
-
+    if (mainline.state !== 'exited') return
     const now = this.deps.now()
     const realigned = await this.deps.ledger.upsertWorker(managerKey, worker.worker_id, (prev) => {
       if (!prev) return undefined
-      const nextTask = statusChanged ? transitionTaskTo(prev.task, nextStatus, { now }) : prev.task
-      const incarnations = stateChanged
-        ? patchIncarnationBySeq(prev.incarnations, mainline.impl, mainline.seq, { state: observed })
-        : prev.incarnations
-      const supervision = supervisionAfterMainlineTransition(
-        prev.supervision,
-        nextTask.status,
-        observed,
-        mainline.seq,
-        now,
-      )
-      return { ...prev, task: nextTask, incarnations, ...(supervision ? { supervision } : {}), updated_at: now }
+      // 锁内重读后矛盾可能已被并发动作收尾,不再成立就不动。
+      const current = findIncarnation(prev, mainline.impl, mainline.seq)
+      if (!current || current.state !== 'exited') return undefined
+      const incarnations = patchIncarnationBySeq(prev.incarnations, mainline.impl, mainline.seq, { state: 'running' })
+      const supervision = supervisionAfterMainlineTransition(prev.supervision, prev.task.status, 'running', mainline.seq, now)
+      return { ...prev, incarnations, ...(supervision ? { supervision } : {}), updated_at: now }
     })
-    // 这条事件可能只改了化身 state 而没动 task.status(stateChanged 单独成立);带上落账后的
-    // 状态是无害的——订阅方拿它与上次已知状态比对,相同即静默。
+    if (!realigned) return
     await this.appendEvent(
       worker.worker_id,
       mainline.seq,
       'state_changed',
-      { to: observed, source: 'reconcile' },
-      realigned?.task.status
+      { to: 'running', source: 'reconcile' },
+      realigned.task.status
     )
   }
 

--- a/crabot-agent/tests/workers/claude-code-adapter.test.ts
+++ b/crabot-agent/tests/workers/claude-code-adapter.test.ts
@@ -2892,7 +2892,13 @@ describe('ClaudeCodeAdapter — CLI hook 事件文件监视(被动 push)', () =>
       claudeProjectsDir,
     })
 
+    // 冷探测只判活,不自动做交互探测(spec 2026-08-28-startup-reconcile-fast-probe):
+    // 已可见的 exit-plan modal 要等首个会 capture 的入口消费懒化重检时才被发现。
+    // keyCalls 含首个 spawn 首投提交的历史按键,以 dispose 后为基线比较。
+    const keysBeforeRestart = tmux.keyCalls.length
     expect(await restarted.state(h)).toBe('running')
+    expect(tmux.keyCalls.slice(keysBeforeRestart)).toHaveLength(0)
+    await restarted.readTerminal(h)
     await waitFor(() => tmux.keyCalls.some((keys) => keys.join(',') === '1,Enter'))
     expect(tmux.keyCalls.filter((keys) => keys.join(',') === '1,Enter')).toHaveLength(1)
     await restarted.kill(h)
@@ -3815,4 +3821,168 @@ describe.skipIf(!tmuxAvailable)('ClaudeCodeAdapter — 启动期就绪握手(\\e
     },
     30000,
   )
+})
+
+/**
+ * 冷探测快路径(spec `2026-08-28-startup-reconcile-fast-probe`):无常驻 runtime 时的
+ * state() = meta 读盘 + 一次 tmux isAlive 的最小证据链。判定矩阵、判死 reason 三级推导、
+ * 残影固化、以及"不 capture / 不交互探测 / 判死不建 runtime"的负面断言。
+ * 全程用 mock tmux,不依赖真实 tmux 环境。
+ */
+describe('ClaudeCodeAdapter.state 冷探测快路径(无常驻 runtime)', () => {
+  let dataDir = ''
+  let workspaceRoot = ''
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'cc-cold-probe-data-'))
+    workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'cc-cold-probe-ws-'))
+  })
+
+  afterEach(async () => {
+    await fs.rm(dataDir, { recursive: true, force: true })
+    await fs.rm(workspaceRoot, { recursive: true, force: true })
+  })
+
+  class ProbeTmux extends NoopTmux {
+    alive = true
+    killCalls: string[] = []
+    captureCalls = 0
+
+    override async capturePane(name: string) {
+      this.captureCalls += 1
+      if (!this.alive) throw new Error(`tmux session gone: ${name}`)
+      return { text: this.paneText, dead: !this.alive }
+    }
+
+    override async isAlive(_name: string): Promise<boolean> {
+      return this.alive
+    }
+
+    override async killSession(name: string): Promise<void> {
+      this.killCalls.push(name)
+      this.alive = false
+    }
+  }
+
+  async function seedMeta(workerId: string, meta: Record<string, unknown>): Promise<void> {
+    await fs.mkdir(path.join(dataDir, workerId), { recursive: true })
+    await fs.writeFile(path.join(dataDir, workerId, 'meta-1.json'), JSON.stringify(meta), 'utf-8')
+  }
+
+  function makeAdapter(tmux: ProbeTmux): ClaudeCodeAdapter {
+    return new ClaudeCodeAdapter({
+      dataDir,
+      claudeConfigPath: fakeClaudeConfig(dataDir),
+      tmux,
+      claudeBin: 'unused',
+      claudeProjectsDir: path.join(dataDir, 'claude-projects'),
+    })
+  }
+
+  const h = (workerId: string) => ({ worker_id: workerId, seq: 1, impl: 'claude-code' as const })
+
+  it('meta 缺失 → exited,不 capture', async () => {
+    const tmux = new ProbeTmux()
+    const adapter = makeAdapter(tmux)
+    expect(await adapter.state(h('w-nometa'))).toBe('exited')
+    expect(tmux.captureCalls).toBe(0)
+  })
+
+  it('会话已死 + meta.ended_reason 已落终态 → 沿用该 reason,meta 终态化,killSession,不建 runtime', async () => {
+    const workerId = `w-dead-reason-${randomUUID().slice(0, 8)}`
+    await seedMeta(workerId, { seq: 1, state: 'running', session_id: 's1', workspace_root: workspaceRoot, ended_reason: 'killed' })
+    const tmux = new ProbeTmux()
+    tmux.alive = false
+    const adapter = makeAdapter(tmux)
+
+    expect(await adapter.state(h(workerId))).toBe('exited')
+
+    const meta = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8'))
+    expect(meta.state).toBe('exited')
+    expect(meta.ended_reason).toBe('killed')
+    expect(tmux.killCalls).toEqual([`crabot-w-${workerId}-1`])
+    expect(((adapter as unknown as { runtimes: Map<string, unknown> }).runtimes).size).toBe(0)
+  })
+
+  it('会话已死 + 活视角控制态 waiting_action(startup_stalled) → 保守记 crashed', async () => {
+    const workerId = `w-dead-stall-${randomUUID().slice(0, 8)}`
+    await seedMeta(workerId, { seq: 1, state: 'idle', session_id: 's1', workspace_root: workspaceRoot, startup_stalled: true, wait_mode: 'action' })
+    const tmux = new ProbeTmux()
+    tmux.alive = false
+    const adapter = makeAdapter(tmux)
+
+    expect(await adapter.state(h(workerId))).toBe('exited')
+
+    const meta = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8'))
+    expect(meta.ended_reason).toBe('crashed')
+  })
+
+  it('会话已死 + running 控制态 → completed 推断(协议 §6.3)', async () => {
+    const workerId = `w-dead-run-${randomUUID().slice(0, 8)}`
+    await seedMeta(workerId, { seq: 1, state: 'running', session_id: 's1', workspace_root: workspaceRoot })
+    const tmux = new ProbeTmux()
+    tmux.alive = false
+    const adapter = makeAdapter(tmux)
+
+    expect(await adapter.state(h(workerId))).toBe('exited')
+
+    const meta = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8'))
+    expect(meta.ended_reason).toBe('completed')
+  })
+
+  it('会话存活 → 返回 meta 控制态并重建轻核(装事件监视),不 capture、不做交互探测', async () => {
+    const workerId = `w-alive-${randomUUID().slice(0, 8)}`
+    await seedMeta(workerId, { seq: 1, state: 'running', session_id: 's1', workspace_root: workspaceRoot })
+    const tmux = new ProbeTmux()
+    const adapter = makeAdapter(tmux)
+
+    expect(await adapter.state(h(workerId))).toBe('running')
+
+    expect(tmux.captureCalls).toBe(0)
+    const runtimes = (adapter as unknown as { runtimes: Map<string, { stopEventWatch?: unknown; pendingInteractionInspect?: boolean }> }).runtimes
+    expect(runtimes.size).toBe(1)
+    const runtime = runtimes.get(`${workerId}#1`)
+    expect(runtime?.stopEventWatch).toBeTruthy() // 协议 §5.5.3 重连原会话
+    expect(runtime?.pendingInteractionInspect).toBe(true) // 懒化重检待消费
+  })
+
+  it('会话存活 + meta.startup_stalled → 返回 idle(等待动作),不 capture', async () => {
+    const workerId = `w-alive-stall-${randomUUID().slice(0, 8)}`
+    await seedMeta(workerId, { seq: 1, state: 'idle', session_id: 's1', workspace_root: workspaceRoot, startup_stalled: true, wait_mode: 'action' })
+    const tmux = new ProbeTmux()
+    const adapter = makeAdapter(tmux)
+
+    expect(await adapter.state(h(workerId))).toBe('idle')
+    expect(tmux.captureCalls).toBe(0)
+  })
+
+  it('判死残影固化:活残影写入 final snapshot;dead 残影与 tmux 不可达时静默放弃', async () => {
+    const workerIdA = `w-dead-cap-${randomUUID().slice(0, 8)}`
+    await seedMeta(workerIdA, { seq: 1, state: 'running', session_id: 's1', workspace_root: workspaceRoot })
+    const tmuxA = new ProbeTmux()
+    tmuxA.alive = false
+    const adapterA = makeAdapter(tmuxA)
+    // isAlive=false 但 capture 仍能拿到残影(会话刚死的窗口);dead 残影不写。
+    tmuxA.capturePane = async () => ({ text: '最后的画面', dead: true })
+    await adapterA.state(h(workerIdA))
+    await expect(fs.readFile(path.join(dataDir, workerIdA, 'terminal-final-1.json'), 'utf-8')).rejects.toMatchObject({ code: 'ENOENT' })
+
+    const workerIdB = `w-dead-cap2-${randomUUID().slice(0, 8)}`
+    await seedMeta(workerIdB, { seq: 1, state: 'running', session_id: 's1', workspace_root: workspaceRoot })
+    const tmuxB = new ProbeTmux()
+    tmuxB.alive = false
+    const adapterB = makeAdapter(tmuxB)
+    tmuxB.capturePane = async () => ({ text: '最后的画面', dead: false })
+    await adapterB.state(h(workerIdB))
+    expect(await fs.readFile(path.join(dataDir, workerIdB, 'terminal-final-1.json'), 'utf-8')).toContain('最后的画面')
+
+    const workerIdC = `w-dead-cap3-${randomUUID().slice(0, 8)}`
+    await seedMeta(workerIdC, { seq: 1, state: 'running', session_id: 's1', workspace_root: workspaceRoot })
+    const tmuxC = new ProbeTmux()
+    tmuxC.alive = false
+    const adapterC = makeAdapter(tmuxC)
+    tmuxC.capturePane = async () => { throw new Error('tmux server gone') }
+    expect(await adapterC.state(h(workerIdC))).toBe('exited')
+    await expect(fs.readFile(path.join(dataDir, workerIdC, 'terminal-final-1.json'), 'utf-8')).rejects.toMatchObject({ code: 'ENOENT' })
+  })
 })

--- a/crabot-agent/tests/workers/codex-adapter.test.ts
+++ b/crabot-agent/tests/workers/codex-adapter.test.ts
@@ -3193,8 +3193,8 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter — 启动期就绪握手(\\
 
 /**
  * 冷探测快路径(spec `2026-08-28-startup-reconcile-fast-probe`)的 codex 侧对称覆盖:
- * 判定矩阵、判死 reason 三级推导、rollout 扫描移出冷重建(轻核 rolloutPath 留空,
- * readTrace 懒查找回填)、以及"不 capture / 判死不建 runtime"的负面断言。
+ * 判定矩阵、判死 reason 三级推导、轻核 rollout 定位(resume/trace watch 前置,PR#125
+ * review 修正后保留在冷核)、以及"不 capture / 判死不建 runtime"的负面断言。
  * 全程用 mock tmux,不依赖真实 tmux 环境。
  */
 describe('CodexWorkerAdapter.state 冷探测快路径(无常驻 runtime)', () => {
@@ -3283,9 +3283,17 @@ describe('CodexWorkerAdapter.state 冷探测快路径(无常驻 runtime)', () =>
     expect(meta.ended_reason).toBe('crashed')
   })
 
-  it('会话存活 → 返回 meta 控制态并重建轻核(装事件监视),不 capture;轻核不做 rollout 扫描', async () => {
+  it('会话存活 → 返回 meta 控制态并重建轻核(装事件监视),不 capture;轻核定位 rollout(resume/trace watch 前置,PR#125 review 修正)', async () => {
     const workerId = `w-alive-${randomUUID().slice(0, 8)}`
-    await seedMeta(workerId, { seq: 1, state: 'running', session_id: 's1', workspace_root: workspaceRoot, codex_home: path.join(workspaceRoot, '.codex'), session_discovery: 'discovered' })
+    const sessionId = randomUUID()
+    const codexHome = path.join(workspaceRoot, '.codex')
+    // rollout 按文件名内嵌 uuid 精确匹配:构造可被 findRolloutFileBySessionId 命中的文件
+    const day = new Date().toISOString().slice(0, 10).replaceAll('-', '/')
+    const rolloutDir = path.join(codexHome, 'sessions', day)
+    await fs.mkdir(rolloutDir, { recursive: true })
+    const rolloutFile = path.join(rolloutDir, `rollout-${new Date().toISOString().slice(0, 19).replaceAll(':', '-')}-${sessionId}.jsonl`)
+    await fs.writeFile(rolloutFile, '{}\n', 'utf-8')
+    await seedMeta(workerId, { seq: 1, state: 'running', session_id: sessionId, workspace_root: workspaceRoot, codex_home: codexHome, session_discovery: 'discovered' })
     const tmux = new ProbeTmux()
     const adapter = makeAdapter(tmux)
 
@@ -3297,7 +3305,7 @@ describe('CodexWorkerAdapter.state 冷探测快路径(无常驻 runtime)', () =>
     const runtime = runtimes.get(`${workerId}#1`)
     expect(runtime?.stopEventWatch).toBeTruthy() // 协议 §5.5.3 重连原会话
     expect(runtime?.pendingInteractionInspect).toBe(true) // 懒化重检待消费
-    expect(runtime?.rolloutPath).toBeUndefined() // rollout 定位已移出冷重建
-    expect(runtime?.sessionId).toBe('s1')
+    expect(runtime?.rolloutPath).toBe(rolloutFile) // resume 门槛/native trace watch 前置在冷核即满足
+    expect(runtime?.sessionId).toBe(sessionId)
   })
 })

--- a/crabot-agent/tests/workers/codex-adapter.test.ts
+++ b/crabot-agent/tests/workers/codex-adapter.test.ts
@@ -3190,3 +3190,114 @@ describe.skipIf(!tmuxAvailable)('CodexWorkerAdapter — 启动期就绪握手(\\
     30000,
   )
 })
+
+/**
+ * 冷探测快路径(spec `2026-08-28-startup-reconcile-fast-probe`)的 codex 侧对称覆盖:
+ * 判定矩阵、判死 reason 三级推导、rollout 扫描移出冷重建(轻核 rolloutPath 留空,
+ * readTrace 懒查找回填)、以及"不 capture / 判死不建 runtime"的负面断言。
+ * 全程用 mock tmux,不依赖真实 tmux 环境。
+ */
+describe('CodexWorkerAdapter.state 冷探测快路径(无常驻 runtime)', () => {
+  let dataDir = ''
+  let workspaceRoot = ''
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'cx-cold-probe-data-'))
+    workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'cx-cold-probe-ws-'))
+  })
+
+  afterEach(async () => {
+    await fs.rm(dataDir, { recursive: true, force: true })
+    await fs.rm(workspaceRoot, { recursive: true, force: true })
+  })
+
+  class ProbeTmux extends NoopTmux {
+    alive = true
+    killCalls: string[] = []
+    captureCalls = 0
+
+    override async capturePane(name: string) {
+      this.captureCalls += 1
+      if (!this.alive) throw new Error(`tmux session gone: ${name}`)
+      return { text: this.paneText, dead: !this.alive }
+    }
+
+    override async isAlive(_name: string): Promise<boolean> {
+      return this.alive
+    }
+
+    override async killSession(name: string): Promise<void> {
+      this.killCalls.push(name)
+      this.alive = false
+    }
+  }
+
+  async function seedMeta(workerId: string, meta: Record<string, unknown>): Promise<void> {
+    await fs.mkdir(path.join(dataDir, workerId), { recursive: true })
+    await fs.writeFile(path.join(dataDir, workerId, 'meta-1.json'), JSON.stringify(meta), 'utf-8')
+  }
+
+  function makeAdapter(tmux: ProbeTmux): CodexWorkerAdapter {
+    return new CodexWorkerAdapter({
+      dataDir,
+      tmux,
+      codexBin: 'unused',
+    })
+  }
+
+  const h = (workerId: string) => ({ worker_id: workerId, seq: 1, impl: 'codex' as const })
+
+  it('meta 缺失 → exited,不 capture', async () => {
+    const tmux = new ProbeTmux()
+    const adapter = makeAdapter(tmux)
+    expect(await adapter.state(h('w-nometa'))).toBe('exited')
+    expect(tmux.captureCalls).toBe(0)
+  })
+
+  it('会话已死 + meta.ended_reason 已落终态 → 沿用该 reason,meta 终态化,killSession,不建 runtime', async () => {
+    const workerId = `w-dead-reason-${randomUUID().slice(0, 8)}`
+    await seedMeta(workerId, { seq: 1, state: 'running', session_id: 's1', workspace_root: workspaceRoot, ended_reason: 'killed', session_discovery: 'placeholder' })
+    const tmux = new ProbeTmux()
+    tmux.alive = false
+    const adapter = makeAdapter(tmux)
+
+    expect(await adapter.state(h(workerId))).toBe('exited')
+
+    const meta = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8'))
+    expect(meta.state).toBe('exited')
+    expect(meta.ended_reason).toBe('killed')
+    expect(tmux.killCalls).toEqual([`crabot-w-${workerId}-1`])
+    expect(((adapter as unknown as { runtimes: Map<string, unknown> }).runtimes).size).toBe(0)
+  })
+
+  it('会话已死 + 活视角控制态 waiting_action(startup_stalled) → 保守记 crashed', async () => {
+    const workerId = `w-dead-stall-${randomUUID().slice(0, 8)}`
+    await seedMeta(workerId, { seq: 1, state: 'idle', session_id: 's1', workspace_root: workspaceRoot, startup_stalled: true, wait_mode: 'action' })
+    const tmux = new ProbeTmux()
+    tmux.alive = false
+    const adapter = makeAdapter(tmux)
+
+    expect(await adapter.state(h(workerId))).toBe('exited')
+
+    const meta = JSON.parse(await fs.readFile(path.join(dataDir, workerId, 'meta-1.json'), 'utf-8'))
+    expect(meta.ended_reason).toBe('crashed')
+  })
+
+  it('会话存活 → 返回 meta 控制态并重建轻核(装事件监视),不 capture;轻核不做 rollout 扫描', async () => {
+    const workerId = `w-alive-${randomUUID().slice(0, 8)}`
+    await seedMeta(workerId, { seq: 1, state: 'running', session_id: 's1', workspace_root: workspaceRoot, codex_home: path.join(workspaceRoot, '.codex'), session_discovery: 'discovered' })
+    const tmux = new ProbeTmux()
+    const adapter = makeAdapter(tmux)
+
+    expect(await adapter.state(h(workerId))).toBe('running')
+
+    expect(tmux.captureCalls).toBe(0)
+    const runtimes = (adapter as unknown as { runtimes: Map<string, { stopEventWatch?: unknown; pendingInteractionInspect?: boolean; rolloutPath?: string; sessionId: string }> }).runtimes
+    expect(runtimes.size).toBe(1)
+    const runtime = runtimes.get(`${workerId}#1`)
+    expect(runtime?.stopEventWatch).toBeTruthy() // 协议 §5.5.3 重连原会话
+    expect(runtime?.pendingInteractionInspect).toBe(true) // 懒化重检待消费
+    expect(runtime?.rolloutPath).toBeUndefined() // rollout 定位已移出冷重建
+    expect(runtime?.sessionId).toBe('s1')
+  })
+})

--- a/crabot-agent/tests/workers/harness/harness-recovery.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-recovery.test.ts
@@ -298,7 +298,7 @@ describe('WorkerHarness.reconcileOnStartup — 三态判定', () => {
     })
   })
 
-  it('adapter 报 idle 且台账仍是 running → 对齐 incarnation.state=idle + task.status=waiting_input，发 state_changed(source=reconcile)，归 revived', async () => {
+  it('adapter 报 idle 且台账化身 state=running(无矛盾) → 台账保持不动、不发事件(冷探测观察值不覆盖台账)，归 revived', async () => {
     const { harness, ledger, adaptersMap } = await makeHarness()
     const fake = new FakeAdapter('builtin')
     adaptersMap.set('builtin', fake)
@@ -310,12 +310,32 @@ describe('WorkerHarness.reconcileOnStartup — 三态判定', () => {
 
     expect(report).toEqual<ReconcileReport>({ revived: ['w-idle'], failed: [], unchanged: [] })
     const after = await getWorker(ledger, 'w-idle')
-    expect(after.task.status).toBe('waiting_input')
-    expect(after.incarnations[0].state).toBe('idle')
+    expect(after.task.status).toBe('running')
+    expect(after.incarnations[0].state).toBe('running')
 
-    const stateEvents = events.filter((e) => e.kind === 'state_changed' && e.worker_id === 'w-idle')
+    expect(events.filter((e) => e.worker_id === 'w-idle')).toHaveLength(0)
+  })
+
+  it('台账化身 state=exited 但 adapter 报活(内部矛盾) → 矛盾修复为 running，发 state_changed(source=reconcile)，归 revived', async () => {
+    const { harness, ledger, adaptersMap } = await makeHarness()
+    const fake = new FakeAdapter('builtin')
+    adaptersMap.set('builtin', fake)
+    const worker = makeWorker('w-resurrected', {
+      incarnations: [{ seq: 1, impl: 'builtin', state: 'exited', workspace: '/tmp/ws', session_ref: 'ref-w-resurrected#1', started_at: now() }],
+    })
+    await seed(ledger, DIALOG, worker)
+    fake.setState({ worker_id: 'w-resurrected', seq: 1 }, 'running')
+
+    const report = await harness.reconcileOnStartup()
+
+    expect(report).toEqual<ReconcileReport>({ revived: ['w-resurrected'], failed: [], unchanged: [] })
+    const after = await getWorker(ledger, 'w-resurrected')
+    expect(after.task.status).toBe('running') // task.status 保持，只修复化身 state 的矛盾
+    expect(after.incarnations[0].state).toBe('running')
+
+    const stateEvents = events.filter((e) => e.kind === 'state_changed' && e.worker_id === 'w-resurrected')
     expect(stateEvents).toHaveLength(1)
-    expect(stateEvents[0].detail).toEqual({ to: 'idle', source: 'reconcile' })
+    expect(stateEvents[0].detail).toEqual({ to: 'running', source: 'reconcile' })
   })
 
   it('主线化身的 impl 没有注册 adapter(已禁用/未安装) → 落 failed(crashed)，detail 记原因，不调用任何 adapter.state()', async () => {
@@ -687,7 +707,7 @@ describe('HarnessEvent.task_status —— reconcileOnStartup 的迁移点', () =
     expect(exited[0].task_status).toBe((await getWorker(ledger, 'w-crash')).task.status)
   })
 
-  it('存活对齐(realignAliveIncarnation)的 state_changed 事件带 waiting_input', async () => {
+  it('矛盾修复(realignAliveIncarnation)的 state_changed 事件带落账后的 task 状态；无矛盾时不发事件', async () => {
     const { harness, ledger, adaptersMap } = await makeHarness()
     const fake = new FakeAdapter('builtin')
     adaptersMap.set('builtin', fake)
@@ -696,8 +716,7 @@ describe('HarnessEvent.task_status —— reconcileOnStartup 的迁移点', () =
 
     await harness.reconcileOnStartup()
 
-    const stateEvents = events.filter((e) => e.kind === 'state_changed' && e.worker_id === 'w-realign')
-    expect(stateEvents).toHaveLength(1)
-    expect(stateEvents[0].task_status).toBe('waiting_input')
+    // 台账化身 state=running 与 idle 无矛盾 → 存活分支不再写台账、不发事件。
+    expect(events.filter((e) => e.kind === 'state_changed' && e.worker_id === 'w-realign')).toHaveLength(0)
   })
 })


### PR DESCRIPTION
## 背景

2026-08-27 重启实测：88 个非终态 worker 的启动对账耗时约 3 分钟（每批并发 8 × CLI worker 冷探测要做 ensureRuntime 全量重建：capture 交互探测、events 读取、rollout 扫描等），而 recovery notice 投递排在对账完成之后，manager 获知 worker crashed 的延迟被拉长到停机窗口 + 3 分钟。

## 方案（spec 已确认）

spec：`crabot-docs/superpowers/specs/2026-08-28-startup-reconcile-fast-probe-design.md`

1. **adapter 冷探测快路径**（claude-code/codex 对称）：`state()` 无常驻 runtime 时 = meta 读盘 + 一次 tmux `isAlive` 最小证据链。
   - 判死：最小版 transitionExited（残影固化 + killSession + meta 终态化），reason 三级推导（`ended_reason` → waiting_action 保守 crashed → completed 推断），不建 runtime/不读 events/不触发 onStateChange（markCrashed 独家落账）。
   - 判活：轻核重建（meta 派生 + events 基线 + 事件监视重连，满足协议 §5.5.3"重连原会话"），返回 meta 控制态。
   - capture 交互探测从冷重建移出，挂 `pendingInteractionInspect`，由 sendInput/readTerminal（本来就 capture 的入口）一次性消费；codex rollout 扫描懒化到 readTrace。
2. **对账存活分支收窄**：`realignAliveIncarnation` 不再用冷探测观察值覆盖台账状态（滞后信息不落账），仅保留"台账 exited 而探测判活"的矛盾修复；无矛盾不写盘不发事件。

## 已确认的取舍

- 冷探测不读屏幕：agent 停机期间 CLI 的新进展（turn 跑完/新弹确认框）推迟到下一次交互或 5 分钟 sweep 才可见；
- 判死 reason 放弃 stopCount 精确检查：极端场景把"刚跑完就死"保守记 crashed（多一次续办查询），不会反向漏报；
- 判死保留残影固化与 meta 终态化（用户确认）。

## 新引入的失败路径及收口

- 残影 capture 失败（tmux server 已消失）→ try/catch 静默，判死不受影响；
- killSession 对已消失会话 → driver 内幂等吞错；
- meta 终态写盘失败 → 冒泡到 reconcileOneWorker 既有 try/catch（判死 + 错误进事件 detail），不中断整轮；
- 判死不发 onStateChange → 避免与 markCrashed 双事件双落账。

## 验证

- 新增 claude-code 7 例 / codex 4 例冷探测判定矩阵（mock tmux，含负面断言：判活不 capture、判死不建 runtime、rollout 不扫描）+ 残影固化三态；harness-recovery 更新为收窄后语义 + 矛盾修复新用例；
- 全量回归 2814 passed；13 个失败逐一核对为预存失败（workspace-manager×3、inbound×6、assemble-agent×1、runtime-config×1，主仓基线同样失败）或并行 flake（单跑全过），与本 PR 无关；
- **实测计时**（真实 harness + 真实 CLI adapter + tmux 会话全灭的整机重启形态）：88 个非终态 worker 对账 **820ms** 全部正确判死（基线 ~3 分钟，验收目标 <15s）。