### PR TITLE
fix(admin): 核心配置 revision 启动自检改为 fail-open 重记账

### DIFF
--- a/crabot-admin/src/core-agent-config-revision-store.test.ts
+++ b/crabot-admin/src/core-agent-config-revision-store.test.ts
@@ -100,15 +100,21 @@ describe('CoreAgentConfigMutationCoordinator', () => {
     } finally { await cleanup(f.dir) }
   })
 
-  it('fails closed when a committed no-outbox source fingerprint no longer matches', async () => {
+  it('re-baselines a drifted no-outbox source fingerprint (fail-open) and stays idempotent on restart', async () => {
     const f = await fixture()
     try {
       f.state.provider = 'tampered-after-commit'
+      const snapshot = () => ({ provider: f.state.provider, secret: f.state.secret })
       const restarted = new CoreAgentConfigMutationCoordinator(f.dir, {
-        readSemanticSnapshot: () => ({ provider: f.state.provider, secret: f.state.secret }),
+        readSemanticSnapshot: snapshot,
         publishInvalidation: () => {},
       })
-      await expect(restarted.initialize()).rejects.toThrow('semantic fingerprint does not match committed revision')
+      await expect(restarted.initialize()).resolves.toMatchObject({ revision: 2 })
+      const second = new CoreAgentConfigMutationCoordinator(f.dir, {
+        readSemanticSnapshot: snapshot,
+        publishInvalidation: () => {},
+      })
+      await expect(second.initialize()).resolves.toMatchObject({ revision: 2 })
     } finally { await cleanup(f.dir) }
   })
 

--- a/crabot-admin/src/core-agent-config-revision-store.ts
+++ b/crabot-admin/src/core-agent-config-revision-store.ts
@@ -118,7 +118,6 @@ export class CoreAgentConfigMutationCoordinator {
   private readonly recordPath: string
   private readonly outboxPath: string
   private readonly receiptPath: string
-  private rebaselineMarkerPath: string
   private readonly options: CoreAgentConfigMutationCoordinatorOptions
   private key: Buffer | null = null
   private record: CoreAgentConfigRevisionRecord | null = null
@@ -128,7 +127,6 @@ export class CoreAgentConfigMutationCoordinator {
 
   constructor(dataDir: string, options: CoreAgentConfigMutationCoordinatorOptions) {
     this.configDir = path.join(dataDir, 'config')
-    this.rebaselineMarkerPath = path.join(dataDir, 'migrations', 'core-config-projection-rebaseline.json')
     this.keyPath = path.join(this.configDir, 'core-agent-config-hmac-key')
     this.recordPath = path.join(this.configDir, 'core-agent-config-revision.json')
     this.outboxPath = path.join(this.configDir, 'core-agent-config-mutation-outbox.json')
@@ -166,29 +164,18 @@ export class CoreAgentConfigMutationCoordinator {
       if (outbox) await this.recoverOutbox(outbox, false)
       const liveFingerprint = await this.fingerprint()
       if (!this.equal(liveFingerprint, this.record!.semantic_fingerprint_hmac)) {
-        // 投影扩展一次性 rebaseline：仅当升级代码显式预埋 marker 且无在途 mutation 时，
-        // 以 live fingerprint 提交 revision+1（语义等价于「runtime config 新增字段」的
-        // 一次合法变更，Agent 会经 invalidation 拉到新字段）。无 marker 维持 fail closed。
-        const rebaselineMarker = await readJson<{ projection: string; prepared_at: string }>(this.rebaselineMarkerPath)
-        if (!rebaselineMarker || typeof rebaselineMarker.projection !== 'string') {
-          throw new Error('Core Agent config semantic fingerprint does not match committed revision')
-        }
-        if (this.recoveredMutation) {
-          throw new Error('Core Agent config projection rebaseline blocked by in-flight mutation')
-        }
+        // fail-open（protocol-admin 0.2.5 §3.19.8.1）：无 pending outbox 时的投影漂移不再拒绝
+        // 启动——记警告并以 live 指纹重记账后继续。不回写域源数据；改变投影的启动期源写入
+        // 必须在 recoverOutbox 之后经 durable mutation 收敛落盘（见 Admin 启动 seeding）。
+        const previousRevision = this.record!.revision
         this.record = {
           schema_version: 1,
-          revision: this.record!.revision + 1,
+          revision: previousRevision + 1,
           semantic_fingerprint_hmac: liveFingerprint,
           updated_at: new Date().toISOString(),
         }
         await atomicWrite(this.recordPath, this.record)
-        await fs.rm(this.rebaselineMarkerPath, { force: true })
-        console.warn(`[CoreAgentConfig] projection rebaselined to revision ${this.record.revision} (${rebaselineMarker.projection})`)
-      } else {
-        // fingerprint 一致时 marker 是残留（上次预埋后未发生 mismatch）——立即清掉，
-        // 否则它会纵容未来某次真正的数据漂移被误认为合法 rebaseline。
-        await fs.rm(this.rebaselineMarkerPath, { force: true }).catch(() => {})
+        console.warn(`[CoreAgentConfig] live config projection drifted from committed revision ${previousRevision}; accepted and re-baselined to revision ${this.record.revision} (fail-open)`)
       }
       return this.record!
     })
@@ -402,12 +389,6 @@ export class CoreAgentConfigMutationCoordinator {
     if (outbox) { this.assertOutbox(outbox); return outbox }
     this.assertReceipt(receipt!)
     return receipt
-  }
-
-  async verifyCommittedFingerprint(): Promise<void> {
-    await this.current()
-    const live = await this.fingerprint()
-    if (!this.equal(live, this.record!.semantic_fingerprint_hmac)) throw new Error('Core Agent config semantic fingerprint does not match committed revision')
   }
 
   async pendingMutation(): Promise<CoreAgentConfigMutationOutboxRecord | null> {

--- a/crabot-admin/src/index.ts
+++ b/crabot-admin/src/index.ts
@@ -496,7 +496,6 @@ export class AdminModule extends ModuleBase {
   // Agent 管理器
   private workerImplementationStore!: WorkerImplementationStore
   private workerConnectionRevisionSigner!: WorkerConnectionRevisionSigner
-  private pendingRebaselineDoneMarker?: string
   private workerOperationAssertions!: WorkerOperationAssertions
   private agentManager: AgentManager
 
@@ -879,37 +878,11 @@ export class AdminModule extends ModuleBase {
     //（新部署在此原子落 revision 1 安全初始配置）。
     await this.workerImplementationStore.load()
 
-    // P6-B：worker_implementations 首次进入 semantic 投影时，存量实例的 committed
-    // fingerprint 与 live 不一致——预埋一次性 rebaseline marker，让 coordinator initialize
-    // 以 revision+1 合法扩展（而不是 fail closed）。fresh deploy 无 committed record，
-    // 不需要 marker（initialize 直接以新投影建 revision 1）。
-    {
-      // 一次性化：done marker 存在（无论当年是否真发生 mismatch）就不再预埋——否则每次
-      // 启动都预埋会让 coordinator 的防漂移 fail-closed 永久失效（review R2）。
-      const markerDir = path.join(this.adminConfig.data_dir, 'migrations')
-      const donePath = path.join(markerDir, 'core-config-projection-rebaseline.done.json')
-      const done = await fs.access(donePath).then(() => true).catch(() => false)
-      const recordExists = await fs.access(path.join(this.adminConfig.data_dir, 'config', 'core-agent-config-revision.json')).then(() => true).catch(() => false)
-      if (recordExists && !done) {
-        await fs.mkdir(markerDir, { recursive: true, mode: 0o700 })
-        const markerPath = path.join(markerDir, 'core-config-projection-rebaseline.json')
-        await fs.writeFile(markerPath, JSON.stringify({ projection: 'worker_implementations', prepared_at: new Date().toISOString() }), { mode: 0o600 })
-        // done marker 在 initialize 消费/清理后由下方补写（本轮启动内即可收口）。
-        this.pendingRebaselineDoneMarker = donePath
-      }
-    }
-
     // Recover durable revision/outbox against fully loaded source state before any mutation.
     // Verify any Skill source journal binding before coordinator initialization/recovery trusts source projection.
     await this.skillManager.verifySourceJournalBinding(this.configMutationCoordinator)
     await this.configMutationCoordinator.initialize()
-    if (this.pendingRebaselineDoneMarker) {
-      // coordinator initialize 已消费/清理预埋 marker；写持久 done，之后启动不再预埋。
-      await fs.writeFile(this.pendingRebaselineDoneMarker, JSON.stringify({ completed_at: new Date().toISOString() }), { mode: 0o600 })
-      this.pendingRebaselineDoneMarker = undefined
-    }
     await this.skillManager.recoverSourceJournal(this.configMutationCoordinator)
-    await this.configMutationCoordinator.verifyCommittedFingerprint()
     if (!this.managementOnly) {
       // Normal mode is already eligible to publish; clear a committed startup outbox before
       // builtin seeding attempts another mutation. Management-only deliberately retains it

--- a/crabot-admin/src/mcp-subagent-config-mutation.test.ts
+++ b/crabot-admin/src/mcp-subagent-config-mutation.test.ts
@@ -98,7 +98,14 @@ describe('MCP and SubAgent coordinator mutations', () => {
       readSemanticSnapshot: () => ({ mcp: [{ id: 'tampered' }], subagents: agents.runtimeSemanticEntries() }),
       publishInvalidation: () => {},
     })
-    await expect(restarted.initialize()).rejects.toThrow('semantic fingerprint does not match committed revision')
+    // fail-open（protocol-admin 0.2.5 §3.19.8.1）：无 outbox 的源漂移不再拒绝启动，
+    // 以 live 投影重记账 revision+1；再次重启指纹一致，revision 不再前进。
+    await expect(restarted.initialize()).resolves.toMatchObject({ revision: changedRevision + 1 })
+    const second = new CoreAgentConfigMutationCoordinator(dir, {
+      readSemanticSnapshot: () => ({ mcp: [{ id: 'tampered' }], subagents: agents.runtimeSemanticEntries() }),
+      publishInvalidation: () => {},
+    })
+    await expect(second.initialize()).resolves.toMatchObject({ revision: changedRevision + 1 })
   })
 
   it('rewrites legacy v1 storage only inside a coordinator mutation', async () => {

--- a/crabot-admin/src/skill-config-mutation.test.ts
+++ b/crabot-admin/src/skill-config-mutation.test.ts
@@ -155,7 +155,13 @@ describe('Skill source mutation journal', () => {
       await coordinator.initialize(); const entry = await manager.create({ name: 'tamper', description: 'tamper', content: skill('tamper') })
       await fs.appendFile(path.join(entry.skill_dir, 'SKILL.md'), ' altered')
       const restarted = new SkillManager(dir); await restarted.initializeLoadOnly()
-      await expect(new CoreAgentConfigMutationCoordinator(dir, { readSemanticSnapshot: () => ({ skills: restarted.runtimeSemanticEntries(), storage: restarted.semanticMigrationState() }), publishInvalidation: () => {} }).initialize()).rejects.toThrow('semantic fingerprint does not match committed revision')
+      // fail-open（protocol-admin 0.2.5 §3.19.8.1）：无 outbox 的源漂移不再拒绝启动，
+      // 以 live 投影重记账 revision+1；再次重启指纹一致，revision 不再前进。
+      const tamperedSnapshot = () => ({ skills: restarted.runtimeSemanticEntries(), storage: restarted.semanticMigrationState() })
+      const first = new CoreAgentConfigMutationCoordinator(dir, { readSemanticSnapshot: tamperedSnapshot, publishInvalidation: () => {} })
+      await expect(first.initialize()).resolves.toMatchObject({ revision: 3 })
+      const second = new CoreAgentConfigMutationCoordinator(dir, { readSemanticSnapshot: tamperedSnapshot, publishInvalidation: () => {} })
+      await expect(second.initialize()).resolves.toMatchObject({ revision: 3 })
     } finally { await fs.rm(dir, { recursive: true, force: true }) }
   })
 

--- a/crabot-admin/tests/builtin-seeding.test.ts
+++ b/crabot-admin/tests/builtin-seeding.test.ts
@@ -590,3 +590,96 @@ describe('getBuiltinSubAgents > goal_auditor', () => {
     expect(g.when_to_use).toContain('system_only')
   })
 })
+
+describe('启动序列收敛（fail-open 启动自检，protocol-admin 0.2.5 §3.19.8.1）', () => {
+  it('存量禁用必备 skill：首轮 seeding 记账落盘，二轮启动 revision 稳定', async () => {
+    const { CoreAgentConfigMutationCoordinator } = await import('../src/core-agent-config-revision-store.js')
+    const tmpDir = mkdtempSync(join(tmpdir(), 'skill-fail-open-'))
+    try {
+      // 存量旧形态 registry：必备 skill 被禁用（PR #122 归一化前的持久状态）
+      const workspaceSkill = getBuiltinSkills().find(
+        (entry) => entry.id === BUILTIN_SKILL_IDS.workspaceContextMaintenance,
+      )!
+      writeFileSync(join(tmpDir, 'skills.json'), JSON.stringify([{
+        ...workspaceSkill,
+        enabled: false,
+        can_disable: true,
+      }]))
+
+      const manager = new SkillManager(tmpDir)
+      const snapshot = () => ({ skills: manager.runtimeSemanticEntries(), storage: manager.semanticMigrationState() })
+      let revision = 0
+      const coordinator = new CoreAgentConfigMutationCoordinator(tmpDir, {
+        readSemanticSnapshot: snapshot,
+        publishInvalidation: () => {},
+      })
+      manager.setSemanticSnapshotProvider(snapshot)
+      manager.setMutationRunner((domains, preview, apply) =>
+        coordinator.mutateComputed(domains, preview, apply).then((r) => { revision = r.revision; return undefined }))
+
+      // 第一轮启动：load-only → initialize → seeding 归一化经 mutation 记账落盘
+      await manager.initializeLoadOnly()
+      const firstRecord = await coordinator.initialize()
+      expect(firstRecord.revision).toBe(1)
+      await manager.seedBuiltinSkills(getBuiltinSkills())
+      const revisionAfterFirstBoot = revision
+      expect(revisionAfterFirstBoot).toBe(2)
+
+      // 第二轮启动：投影已收敛，revision 不再前进（无重复重记账）
+      const manager2 = new SkillManager(tmpDir)
+      await manager2.initializeLoadOnly()
+      const coordinator2 = new CoreAgentConfigMutationCoordinator(tmpDir, {
+        readSemanticSnapshot: () => ({ skills: manager2.runtimeSemanticEntries(), storage: manager2.semanticMigrationState() }),
+        publishInvalidation: () => {},
+      })
+      const secondRecord = await coordinator2.initialize()
+      expect(secondRecord.revision).toBe(revisionAfterFirstBoot)
+      expect(manager2.get(BUILTIN_SKILL_IDS.workspaceContextMaintenance)).toMatchObject({ enabled: true, can_disable: false })
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  it('磁盘漂移（绕过 mutation 的手工改动）：首轮 fail-open 重记账，二轮安静通过', async () => {
+    const { CoreAgentConfigMutationCoordinator } = await import('../src/core-agent-config-revision-store.js')
+    const tmpDir = mkdtempSync(join(tmpdir(), 'skill-fail-open-drift-'))
+    try {
+      const manager = new SkillManager(tmpDir)
+      const snapshot = () => ({ skills: manager.runtimeSemanticEntries(), storage: manager.semanticMigrationState() })
+      const coordinator = new CoreAgentConfigMutationCoordinator(tmpDir, {
+        readSemanticSnapshot: snapshot,
+        publishInvalidation: () => {},
+      })
+      manager.setSemanticSnapshotProvider(snapshot)
+      manager.setMutationRunner((domains, preview, apply) => coordinator.mutateComputed(domains, preview, apply).then(() => undefined))
+      await manager.initializeLoadOnly()
+      await coordinator.initialize()
+      await manager.create({ name: 'user-skill', description: 'd', content: '# x' })
+      const revisionBeforeDrift = (await coordinator.current()).revision
+
+      // 绕过 mutation 直接改磁盘（模拟手工漂移）
+      const raw = JSON.parse(readFileSync(join(tmpDir, 'skills.json'), 'utf-8')) as Array<Record<string, unknown>>
+      raw[0]!['description'] = 'hand-edited'
+      writeFileSync(join(tmpDir, 'skills.json'), JSON.stringify(raw))
+
+      const driftedSnapshot = async () => {
+        const m = new SkillManager(tmpDir)
+        await m.initializeLoadOnly()
+        return { skills: m.runtimeSemanticEntries(), storage: m.semanticMigrationState() }
+      }
+      const drifted = new CoreAgentConfigMutationCoordinator(tmpDir, {
+        readSemanticSnapshot: driftedSnapshot,
+        publishInvalidation: () => {},
+      })
+      await expect(drifted.initialize()).resolves.toMatchObject({ revision: revisionBeforeDrift + 1 })
+
+      const quiet = new CoreAgentConfigMutationCoordinator(tmpDir, {
+        readSemanticSnapshot: driftedSnapshot,
+        publishInvalidation: () => {},
+      })
+      await expect(quiet.initialize()).resolves.toMatchObject({ revision: revisionBeforeDrift + 1 })
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## 背景

PR #122 改变语义投影输出，撞上核心配置账本的启动 fail-closed 自检，且 rebaseline marker 申报通道为全局一次性（8-15 已用）→ 生产实例启动锁死。当时手工预埋 marker 临时解除。

## 方案

按已确认 spec（crabot-docs `483dccd`）与 protocol-admin 0.2.5（`60f6221`）：

- **initialize fail-open**：无 pending outbox 时投影漂移 → 警告 + 以 live 指纹重记账 revision+1 → 继续启动（不再拒绝）
- **退役 marker 申报机制全链路**：store 消费分支、index.ts P6-B 预埋块/done 补写、verifyCommittedFingerprint 启动调用
- **不动**：outbox 两阶段恢复（before/after 判别与 fail-loud 原样）、seqlock、invalidation、cutover gate

## 归因说明

revision 52 记账时的代码形态不可考（很可能是 #122 开发中间态），按 spec 设计收敛验证不依赖归因：builtin-seeding 新增两个集成用例证明"旧值+新代码"首轮启动收敛落盘、二次启动安静通过。

## 新增失败路径与收口

- fail-open 重记账的 record 写盘失败 → 沿用既有 initialize 写盘失败路径（向上抛、启动失败），无新增静默路径
- 漂移不再拦截启动 → spec 记录的语义取舍（单实例自托管，用户拍板）

## 验证

- Admin `tsc --noEmit` 通过
- 定向测试全绿：core-agent-config-revision-store（20）、skill-config-mutation（17）、mcp-subagent-config-mutation（原 7）、builtin-seeding（39，含 2 个新增收敛用例）
- admin 全量与 main 干净基线对比：无新增失败（基线存在全量并发 flaky 与 v1-cleanup 既有失败，单跑均绿/与本改动无关）

## 实证

生产实例（事故现场）当前已在手工 marker 下运行于 revision 53；本 PR 合并后该实例升级将无需任何手工步骤。