### PR TITLE
feat: 模型槽位收敛为两槽 + 槽位思考强度配置 + 上下文窗口配置

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5,6 +5,27 @@
 
 ## 当前状态
 
+### 模型槽位收敛 + 上下文/思考强度配置：实现完成，待 PR review（PR #127）
+
+- spec 与协议先行发布 crabot-docs main：spec `e4bc1da`（含 thinking 存储形态修正——ModelSlotRef
+  保持纯引用，thinking 独立 map）；协议 `eeba0c8`（base-protocol 0.2.3、protocol-admin 0.2.6、
+  protocol-agent-v3 3.1.2）。
+- **槽位收敛**（用户决策）：`CoreAgentModelRole` 4→2（powerful/cost_effective）；Manager loop 直接用
+  powerful（原"manager 槽 + 内部回退"按用户定性为多余设计移除）；vision 场景（research_collector）归
+  cost_effective。存量迁移：槽位引用丢弃+warn（不搬运，防隐式改写保留槽解析）；subagent model_role
+  角色引用归一化 vision→cost_effective / manager→powerful（幂等，经既有 seedBuiltin flush 落盘）。
+  backup import preflight 收敛 2 key（旧备份含 legacy key fail-loud）。
+- **思考强度配置**：`AgentInstanceConfig.thinking`（独立 map，level/custom 互斥；自定义值原样透传，
+  数字仅 anthropic）；解析时"强度跟 slot 走"（回落全局默认仍生效）；三 adapter 映射
+  （anthropic effort/disabled/budget_tokens、openai+gemini 兼容层 reasoning_effort、responses；
+  **Codex 跟随默认保持 medium 现状**）；不做运行时降级，档位不匹配由 Provider 400、用户改档自愈。
+- **上下文窗口配置**：`ModelInfo.context_window` 协议本就有字段，补 UI——详情抽屉"上下文"列内联
+  编辑（清空=回退默认 200K），驱动 compaction 阈值。
+- 分支 `worktree-slot-convergence-thinking-config`（PR #127，3 commits）；新增单测 41 例全绿；
+  worktree 全量测试中 main 既有失败与负载 flaky 已逐个甄别标注。
+- **待做**：spec §9 手工验收三项（真实 provider effort 生效 / 128K compaction 提前 / 存量迁移演练）
+  需起实例验证；@claude review 跟踪。
+
 ### wechat 群聊门控（@ + 引用放行）：已合并（PR #124 → `ffd32e55`）
 
 - 已确认 spec 与计划发布到 `crabot-docs` main（`2631a13` / `d4d9560`）：`protocol-channel.md` 0.1.2

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -23,8 +23,11 @@
   编辑（清空=回退默认 200K），驱动 compaction 阈值。
 - 分支 `worktree-slot-convergence-thinking-config`（PR #127，3 commits）；新增单测 41 例全绿；
   worktree 全量测试中 main 既有失败与负载 flaky 已逐个甄别标注。
+- @claude review（2026-08-28）两条真实风险已修（`f5f430c6`）：①thinking 加进
+  readCoreAgentSemanticSnapshot 投影（否则 thinking-only 保存被判 noop 400）；②AgentConfig
+  的 getGlobalConfig 拆分容错（placeholder 级失败不再打空表单）。
 - **待做**：spec §9 手工验收三项（真实 provider effort 生效 / 128K compaction 提前 / 存量迁移演练）
-  需起实例验证；@claude review 跟踪。
+  需起实例验证；协议注释"四个 slots"修正待推 docs（worktree 隔离，会话收尾补）。
 
 ### wechat 群聊门控（@ + 引用放行）：已合并（PR #124 → `ffd32e55`）
 
@@ -191,6 +194,15 @@
 
 ### 技术债与既有 follow-up（P6 后或并行确认）
 
+- **槽位思考强度 PR #127 review follow-up（2026-08-28）**：① anthropic 数字 budget 档位
+  （`thinking:{type:'enabled',budget_tokens:N}`）会开启经典 extended thinking，但
+  anthropic-adapter 流处理只消费 text/input_json delta，thinking block 与 signature 既不产出
+  也不回传——≤4.5 老模型 tool loop 第二轮大概率 400；触发需「anthropic + 老模型 + 主动填数字」
+  组合且 fail-loud，改 UI placeholder 措辞或做 block 回传属后续 spec。② 数字 thinking_custom 的
+  format 校验是保存时一次性判定：槽位无模型引用时事后换全局默认 Provider 不会重校验，
+  `thinkingEffortValue` 对 number 返回 undefined → 静默退化为跟随默认（协议已知边界）。
+  ③ backup import 对 legacy 槽位 key fail-loud 拒绝 vs 启动迁移丢弃+warn 的恢复体验不一致
+  （有意为之，灾难恢复场景用户需手改归档 JSON，观察是否值得放宽）。
 - **核心配置 revision 启动自检 fail-open：已合并**（PR #126 → `edab960a`）。PR #122 投影变更
   撞上一次性 rebaseline 申报通道锁死生产后，按 spec（crabot-docs
   `2026-08-28-config-revision-startup-fail-open-design.md`、protocol-admin 0.2.5）把启动漂移

--- a/crabot-admin/src/agent-config-thinking.ts
+++ b/crabot-admin/src/agent-config-thinking.ts
@@ -1,0 +1,53 @@
+/**
+ * 槽位 thinking 配置校验（2026-08，protocol-admin §3.19.6；spec §4.4）。
+ * 纯函数便于单测；AdminModule 侧负责组装 roleKeys 与 provider format 解析回调。
+ */
+import type { ModelSlotRef, SlotThinkingConfig } from './types.js'
+
+const VALID_THINKING_LEVELS = ['off', 'low', 'medium', 'high'] as const
+
+/**
+ * 校验 update_agent_config 请求中的槽位 thinking 配置。
+ *
+ * @param roleKeys 当前 CoreAgentModelRole 集合（{powerful, cost_effective}）
+ * @param resolveProviderFormat 给定 slot key，返回其**生效引用**（槽位覆盖的 provider，
+ *   否则全局默认 provider）的 format；查不到返回 undefined。
+ *   数字 thinking_custom 仅 anthropic 支持在此判定。
+ * @throws Error 带明确原因（REST 层映射 400 / RPC 直接上抛）
+ */
+export function validateAgentSlotThinking(
+  modelConfig: Record<string, ModelSlotRef> | undefined,
+  thinking: Record<string, SlotThinkingConfig> | undefined,
+  roleKeys: ReadonlySet<string>,
+  resolveProviderFormat: (roleKey: string) => string | undefined,
+): void {
+  for (const key of Object.keys(modelConfig ?? {})) {
+    if (!roleKeys.has(key)) throw new Error(`Unknown core Agent model slot key: ${key}`)
+  }
+  if (!thinking) return
+  for (const [key, cfg] of Object.entries(thinking)) {
+    if (!roleKeys.has(key)) throw new Error(`Unknown core Agent thinking slot key: ${key}`)
+    const thinkingLevel = cfg?.thinking_level
+    const thinkingCustom = cfg?.thinking_custom
+    if (thinkingLevel !== undefined && !VALID_THINKING_LEVELS.includes(thinkingLevel)) {
+      throw new Error(`Slot "${key}": invalid thinking_level: ${JSON.stringify(thinkingLevel)}`)
+    }
+    if (thinkingCustom !== undefined) {
+      const isNonEmptyString = typeof thinkingCustom === 'string' && thinkingCustom.trim().length > 0
+      const isPositiveInt = typeof thinkingCustom === 'number' && Number.isInteger(thinkingCustom) && thinkingCustom > 0
+      if (!isNonEmptyString && !isPositiveInt) {
+        throw new Error(`Slot "${key}": thinking_custom 必须为非空白字符串或正整数`)
+      }
+    }
+    if (thinkingLevel !== undefined && thinkingCustom !== undefined) {
+      throw new Error(`Slot "${key}": thinking_level 与 thinking_custom 互斥，只能配一个`)
+    }
+    if (typeof thinkingCustom === 'number') {
+      // 数字 budget 参数只有 Anthropic 老模型存在；format 在编辑抽屉不可变，保存时判定一次
+      const format = resolveProviderFormat(key)
+      if (format !== 'anthropic') {
+        throw new Error(`Slot "${key}": 数字 thinking_custom 仅 anthropic 格式的模型支持`)
+      }
+    }
+  }
+}

--- a/crabot-admin/src/agent-manager.test.ts
+++ b/crabot-admin/src/agent-manager.test.ts
@@ -166,12 +166,13 @@ describe('AgentManager (P6-D core-config-only)', () => {
     })
   })
 
-  describe('manager model slot（additive，protocol-agent-v3 §11）', () => {
-    it('builtin model_roles 含 manager，required=false', () => {
+  describe('槽位收敛（2026-08，protocol-admin §3.19.11）', () => {
+    it('builtin model_roles 恰为 powerful/cost_effective，不含 vision/manager', () => {
       const impl = agentManager.getImplementation('default')
-      const managerRole = impl?.model_roles.find((r) => r.key === 'manager')
-      expect(managerRole).toBeDefined()
-      expect(managerRole?.required).toBe(false)
+      const keys = (impl?.model_roles ?? []).map((r) => r.key).sort()
+      expect(keys).toEqual(['cost_effective', 'powerful'])
+      const powerful = impl?.model_roles.find((r) => r.key === 'powerful')
+      expect(powerful?.required).toBe(true)
     })
 
     it('既有配置（无 manager 键）启动迁移后仍有效，不报错、不被强行补 manager 键', async () => {
@@ -199,6 +200,41 @@ describe('AgentManager (P6-D core-config-only)', () => {
         expect(config?.model_config).toEqual({ powerful: { provider_id: 'p1', model_id: 'm1' } })
         expect(config?.model_config?.manager).toBeUndefined()
       } finally {
+        await fs.rm(preExistingDataDir, { recursive: true, force: true })
+      }
+    })
+
+    it('存量 vision/manager 槽位引用启动时丢弃，保留槽不受影响', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const preExistingDataDir = path.join(process.cwd(), 'test-data', `agent-manager-converge-${Date.now()}`)
+      await fs.mkdir(path.join(preExistingDataDir, 'agent-configs'), { recursive: true })
+      const legacyConfig = {
+        instance_id: 'crabot-agent',
+        system_prompt: '',
+        model_config: {
+          powerful: { provider_id: 'p1', model_id: 'm1' },
+          cost_effective: { provider_id: 'p2', model_id: 'm2' },
+          vision: { provider_id: 'p3', model_id: 'm3' },
+          manager: { provider_id: 'p4', model_id: 'm4' },
+        },
+      }
+      await fs.writeFile(
+        path.join(preExistingDataDir, 'agent-configs', 'crabot-agent.json'),
+        JSON.stringify(legacyConfig, null, 2)
+      )
+
+      try {
+        const mgr = new AgentManager(preExistingDataDir)
+        await mgr.initialize()
+        await mgr.initializeCoreDefaultsAndMigrations()
+
+        const config = mgr.getConfig('crabot-agent')
+        expect(config?.model_config).toEqual({
+          powerful: { provider_id: 'p1', model_id: 'm1' },
+          cost_effective: { provider_id: 'p2', model_id: 'm2' },
+        })
+      } finally {
+        warnSpy.mockRestore()
         await fs.rm(preExistingDataDir, { recursive: true, force: true })
       }
     })

--- a/crabot-admin/src/agent-manager.ts
+++ b/crabot-admin/src/agent-manager.ts
@@ -353,18 +353,19 @@ const LEGACY_ROLE_MIGRATION: Record<string, ModelRole> = {
   triage: 'cost_effective',
   digest: 'cost_effective',
   fast: 'cost_effective',
-  vision_expert: 'vision',
+  // vision_expert / vision 不迁移：2026-08 槽位收敛移除 vision 槽（protocol-admin §3.19.11），
+  // 视觉场景由 cost_effective 承担；不把存量引用搬到 cost_effective，避免隐式改写其既有解析。
   // coding_expert 不迁移：阶段 2 由 code_planner / code_writer 替代，
   // 各自走 powerful / cost_effective role；现有 coding_expert 配置丢弃即可。
 }
 
-const KNOWN_NEW_KEYS: ReadonlySet<string> = new Set(['powerful', 'cost_effective', 'vision', 'manager'])
+const KNOWN_NEW_KEYS: ReadonlySet<string> = new Set(['powerful', 'cost_effective'])
 
 /**
  * 迁移 model_config 旧 keys 到新 ModelRole。
- * - 已是新 key（powerful/cost_effective/vision）直接保留
+ * - 已是新 key（powerful/cost_effective）直接保留
  * - 旧 key 通过 LEGACY_ROLE_MIGRATION 映射；多个旧 key 映射到同一新 key 时不覆盖（保留先遇到的）
- * - 不识别的 key 丢弃并 console.warn
+ * - 不识别的 key（含收敛移除的 vision/manager/vision_expert）丢弃并 console.warn
  */
 export function migrateModelConfig(
   oldConfig: Record<string, ModelSlotRef>

--- a/crabot-admin/src/agent-manager.ts
+++ b/crabot-admin/src/agent-manager.ts
@@ -137,6 +137,7 @@ export class AgentManager {
       ...existing,
       ...(params.system_prompt !== undefined && { system_prompt: params.system_prompt }),
       ...(params.model_config !== undefined && { model_config: params.model_config }),
+      ...(params.thinking !== undefined && { thinking: params.thinking }),
       ...(params.mcp_server_ids !== undefined && { mcp_server_ids: params.mcp_server_ids }),
       ...(params.skill_ids !== undefined && { skill_ids: params.skill_ids }),
       ...(params.max_iterations !== undefined && { max_iterations: params.max_iterations }),
@@ -150,7 +151,10 @@ export class AgentManager {
       await this.saveConfig(params.instance_id)
     }
     const domains: ConfigDomain[] = [
-      ...(params.model_config !== undefined && canonicalizeJson(existing.model_config) !== canonicalizeJson(updated.model_config) ? ['models' as const] : []),
+      ...((
+        (params.model_config !== undefined && canonicalizeJson(existing.model_config) !== canonicalizeJson(updated.model_config)) ||
+        (params.thinking !== undefined && canonicalizeJson(existing.thinking ?? {}) !== canonicalizeJson(updated.thinking ?? {}))
+      ) ? ['models' as const] : []),
       ...(
         (params.system_prompt !== undefined && existing.system_prompt !== updated.system_prompt) ||
         (params.max_iterations !== undefined && existing.max_iterations !== updated.max_iterations) ||

--- a/crabot-admin/src/builtin-subagents.ts
+++ b/crabot-admin/src/builtin-subagents.ts
@@ -636,7 +636,8 @@ export function getBuiltinSubAgents(): SubAgentRegistryEntry[] {
       verification: RESEARCH_COLLECTOR_VERIFICATION,
       provider_id: null,
       model_id: null,
-      model_role: 'vision',
+      // 2026-08 槽位收敛：原 vision 槽场景（批量消化图片）由 cost_effective 承担（protocol-admin §3.19.11）
+      model_role: 'cost_effective',
       builtin_capabilities: {
         file_system: true,
         shell: true,

--- a/crabot-admin/src/core-agent-definition.ts
+++ b/crabot-admin/src/core-agent-definition.ts
@@ -15,7 +15,7 @@ const CORE_BODY: AgentImplementation = {
   model_roles: [
     {
       key: 'powerful',
-      description: '强力模型，用于主 worker / 复杂推理 / planning',
+      description: '强力模型，用于主 worker / 复杂推理 / planning / Manager loop 对话与决策',
       required: true,
       recommended_capabilities: ['tool_use', 'long_context'],
       used_by: ['front', 'worker'],
@@ -23,32 +23,11 @@ const CORE_BODY: AgentImplementation = {
     },
     {
       key: 'cost_effective',
-      description: '性价比模型，用于简单执行 / 摘要 / 低复杂度调用',
+      description: '性价比模型，用于简单执行 / 摘要 / 低复杂度调用 / 视觉内容消化',
       required: false,
       recommended_capabilities: ['fast'],
       used_by: ['front', 'worker'],
       fallback: 'global_default',
-    },
-    {
-      key: 'vision',
-      description: '视觉模型，用于截图分析 / UI 识别 / 图片内容理解',
-      required: false,
-      recommended_capabilities: ['vision'],
-      used_by: ['worker'],
-      fallback: 'none',
-    },
-    {
-      // protocol-agent-v3.md §11：manager loop 的对话与工具调用决策用模型。
-      // fallback 特意选 'none'（而不是 'global_default'）：未配置时不由 Admin 自动填全局默认，
-      // 而是把"未配置"这个事实原样透传给 agent 侧——agent 按 model_config.manager ?? model_config.powerful
-      // 解析（见 crabot-agent/src/manager/model-slot.ts），这样当用户已显式给 powerful 配了非默认
-      // provider/model 时，manager 会跟着用 powerful 的实际值，而不是被 Admin 全局默认覆盖掉。
-      key: 'manager',
-      description: 'Manager loop 用模型，负责对话与决策；未配置时回退到 powerful',
-      required: false,
-      recommended_capabilities: ['tool_use', 'long_context'],
-      used_by: ['front'],
-      fallback: 'none',
     },
   ],
   extra_schema: [

--- a/crabot-admin/src/index.ts
+++ b/crabot-admin/src/index.ts
@@ -182,6 +182,7 @@ import {
 import { unionResolved } from './permission-resolution.js'
 import { ModelProviderManager, imageResultToConfigFields } from './model-provider-manager.js'
 import { AgentManager } from './agent-manager.js'
+import { validateAgentSlotThinking } from './agent-config-thinking.js'
 import { buildOnboardFinishResponse } from './onboard-finish-response.js'
 import { ChannelManager } from './channel-manager.js'
 import {
@@ -7248,6 +7249,9 @@ export class AdminModule extends ModuleBase {
     for (const key of Object.keys(config.model_config)) {
       if (!modelRoles.some((role) => role.key === key)) throw new Error(`Unknown core Agent model role: ${key}`)
     }
+    for (const key of Object.keys(config.thinking ?? {})) {
+      if (!modelRoles.some((role) => role.key === key)) throw new Error(`Unknown core Agent thinking role: ${key}`)
+    }
 
     // 全局默认 LLM 配置（作为 fallback，未配置时为 null）
     let globalLLM: LLMConnectionInfo | null = null
@@ -7269,6 +7273,7 @@ export class AdminModule extends ModuleBase {
     for (const role of modelRoles) {
       const ref = config.model_config[role.key]
       const fallback = role.fallback ?? 'global_default'
+      const slotThinking = config.thinking?.[role.key]
 
       if (ref) {
         // 用户显式配置了此 slot
@@ -7290,6 +7295,17 @@ export class AdminModule extends ModuleBase {
         resolvedModelConfig[role.key] = globalLLM
       }
       // fallback === 'none' 且未配置 → 不加入 resolvedModelConfig
+
+      // 思考强度跟 slot 走（protocol-admin §3.19.8）：模型来自 slot 覆盖或全局默认都一样附加；
+      // "跟随默认"（槽位无 thinking 配置）时不加任何字段，请求保持现状。
+      const resolved = resolvedModelConfig[role.key]
+      if (resolved && slotThinking) {
+        resolvedModelConfig[role.key] = {
+          ...resolved,
+          ...(slotThinking.thinking_level !== undefined && { thinking_level: slotThinking.thinking_level }),
+          ...(slotThinking.thinking_custom !== undefined && { thinking_custom: slotThinking.thinking_custom }),
+        }
+      }
     }
 
     if (!resolvedModelConfig.powerful) {
@@ -7366,10 +7382,32 @@ export class AdminModule extends ModuleBase {
       worker_implementations: await this.buildWorkerImplementationRuntimeConfig(),
     }
     delete runtimeConfig.agent_config.extra
+    // thinking 是 Admin 侧存储格式（槽位引用语义），下发的是已附加到 model_config 的解析结果
+    delete runtimeConfig.agent_config.thinking
     return {
       config_revision: epoch.revision,
       config: runtimeConfig,
     }
+  }
+
+  /**
+   * 槽位 thinking 配置校验（2026-08，protocol-admin §3.19.6）。
+   * 纯校验逻辑见 agent-config-thinking.ts；这里组装 roleKeys 与 provider format 解析回调。
+   */
+  private validateAgentSlotThinking(params: UpdateAgentConfigParams): void {
+    const roleKeys = new Set((CORE_AGENT_DEFINITION.model_roles ?? []).map((r) => r.key))
+    validateAgentSlotThinking(
+      params.model_config,
+      params.thinking,
+      roleKeys,
+      (roleKey) => {
+        const ref = params.model_config?.[roleKey]
+        const globalCfg = this.modelProviderManager.getGlobalConfig()
+        const providerId = ref?.provider_id ?? globalCfg.default_llm_provider_id
+        const provider = providerId ? this.modelProviderManager.getProvider(providerId) : undefined
+        return provider?.format
+      },
+    )
   }
 
   private async handleUpdateAgentConfig(params: UpdateAgentConfigParams): Promise<{
@@ -7378,6 +7416,7 @@ export class AdminModule extends ModuleBase {
     if (params.instance_id !== 'crabot-agent') {
       throw new RpcError('ADMIN_HOTPLUG_NOT_ALLOWED', 'Legacy Agent configuration is read-only')
     }
+    this.validateAgentSlotThinking(params)
     const config = await this.agentManager.updateConfig(params)
     this.publishAdminEvent('admin.agent_instance_config_updated', {
       instance_id: params.instance_id,
@@ -10629,6 +10668,20 @@ export class AdminModule extends ModuleBase {
         }
         sanitizedBody.model_config = sanitized
       }
+      // 防御性提取 thinking：只保留两个已知字段（语义校验见 validateAgentSlotThinking）
+      if (body.thinking !== undefined) {
+        const sanitizedThinking: Record<string, import('./types.js').SlotThinkingConfig> = {}
+        for (const [key, cfg] of Object.entries(body.thinking ?? {})) {
+          if (!cfg || typeof cfg !== 'object') continue
+          const { thinking_level, thinking_custom } = cfg
+          sanitizedThinking[key] = {
+            ...(thinking_level !== undefined && { thinking_level }),
+            ...(thinking_custom !== undefined && { thinking_custom }),
+          }
+        }
+        sanitizedBody.thinking = sanitizedThinking
+      }
+      this.validateAgentSlotThinking(sanitizedBody)
 
       const config = await this.agentManager.updateConfig(sanitizedBody)
       this.publishAdminEvent('admin.agent_instance_config_updated', {

--- a/crabot-admin/src/index.ts
+++ b/crabot-admin/src/index.ts
@@ -8740,6 +8740,9 @@ export class AdminModule extends ModuleBase {
     return {
       core_agent: core ? {
         model_config: core.model_config,
+        // thinking 必须进语义投影：thinking-only 变更也要产生不同 fingerprint，
+        // 否则 mutateComputed 判 noop 直接 400（PR #127 review 意见 1）
+        thinking: core.thinking ?? {},
         system_prompt: core.system_prompt,
         max_iterations: core.max_iterations,
         tools_readonly: core.tools_readonly,

--- a/crabot-admin/src/index.ts
+++ b/crabot-admin/src/index.ts
@@ -11031,7 +11031,9 @@ export class AdminModule extends ModuleBase {
       if (raw.instance_id !== 'crabot-agent') {
         throw new ImportPreflightRejected('ADMIN_BACKUP_NON_CORE_AGENT_UNSUPPORTED', 'agent-configs/crabot-agent.json 的 instance_id 不是 crabot-agent')
       }
-      const allowed = new Set(['powerful', 'cost_effective', 'vision', 'manager'])
+      // 2026-08 槽位收敛：旧备份含 vision/manager key 时 fail-loud 拒绝导入（与 update REST 400 契约一致），
+      // 用户需手动清理归档中的 model_config 后重试。
+      const allowed = new Set(['powerful', 'cost_effective'])
       const badKey = Object.keys((raw.model_config ?? {}) as Record<string, unknown>).find((k) => !allowed.has(k))
       if (badKey) {
         throw new ImportPreflightRejected('ADMIN_BACKUP_NON_CORE_AGENT_UNSUPPORTED', `core config 含未知 model slot key: ${badKey}`)

--- a/crabot-admin/src/subagent-manager.ts
+++ b/crabot-admin/src/subagent-manager.ts
@@ -260,6 +260,19 @@ export class SubAgentManager {
       }
     }
 
+    // 2026-08 槽位收敛（protocol-admin §3.19.10）：存量 model_role 角色引用归一化到代替槽位。
+    // model_role 是角色引用而非模型快照，归一化无损；builtin 的 stored state 会覆盖 codeDefault，
+    // 所以仅改 seed 不够，这里对已持久化记录（builtin + 自建）统一收敛。
+    for (const [id, entry] of this.entries) {
+      // model_role 从磁盘 JSON 读入，可能是收敛前的 legacy 值（类型已不含），按字符串比较
+      const legacyRole = entry.model_role as unknown as string | null
+      if (legacyRole === 'vision' || legacyRole === 'manager') {
+        entry.model_role = legacyRole === 'vision' ? 'cost_effective' : 'powerful'
+        needsRewrite = true
+        console.warn(`[SubAgentManager] model_role 收敛：${id} 的 model_role "${legacyRole}" → "${entry.model_role}"`)
+      }
+    }
+
     if (needsRewrite) {
       // Startup recovery must observe the persisted source before legacy normalization. The caller
       // performs the post-recovery write through coordinator-owned seed/reconciliation.

--- a/crabot-admin/src/types.ts
+++ b/crabot-admin/src/types.ts
@@ -2140,10 +2140,10 @@ export interface MemoryStats {
 // ============================================================================
 
 /** Subagent 抽象模型 role。Admin push 时按当前 agent 实例的 model_config[role] 解析为 LLMConnectionInfo。
- *  - powerful: 主 worker / 复杂推理 / planning（如 Claude Sonnet, GPT-5）
- *  - cost_effective: 简单执行 / 摘要 / 高频低成本调用（如 DeepSeek, Haiku）
- *  - vision: 截图 / UI 识别 / 多模态图像理解 */
-export type ModelRole = 'powerful' | 'cost_effective' | 'vision' | 'manager'
+ *  - powerful: 主 worker / 复杂推理 / planning / Manager loop（如 Claude Sonnet, GPT-5）
+ *  - cost_effective: 简单执行 / 摘要 / 高频低成本调用 / 视觉内容消化（如 DeepSeek, Haiku）
+ *  2026-08 槽位收敛：vision/manager 槽位移除（protocol-admin §3.19.11），存量配置启动时丢弃。 */
+export type ModelRole = 'powerful' | 'cost_effective'
 
 /** Subagent 内置能力组配置。file_system/shell/task_intel 控制工具注入；两个 crab_* 字段只兼容旧存储，运行时固定 false。
  *  详见 subagent-tool-filter.ts 的 classifyTool 映射。

--- a/crabot-admin/src/types.ts
+++ b/crabot-admin/src/types.ts
@@ -1311,6 +1311,10 @@ export interface LLMConnectionInfo extends ModelConnectionInfo {
   supports_vision?: boolean
   /** 模型上下文窗口（token 数）；agent 侧用于 compaction 触发阈值，缺失时回退内置默认 */
   context_window?: number
+  /** 思考强度档位（槽位配置附加，base-protocol §5.14）；与 thinking_custom 互斥，缺省 = 跟随模型默认 */
+  thinking_level?: 'off' | 'low' | 'medium' | 'high'
+  /** 自定义思考参数原样透传值；字符串 → 枚举型参数，数字 → budget 型参数。与 thinking_level 互斥 */
+  thinking_custom?: string | number
 }
 
 // Model Provider API 参数类型
@@ -1574,6 +1578,14 @@ export interface ModelSlotRef {
   model_id: string
 }
 
+/** 槽位思考强度配置（2026-08 起，protocol-admin §3.19.2）；与 models 独立——槽位未配模型引用时仍可配思考。 */
+export interface SlotThinkingConfig {
+  /** 思考强度档位；与 thinking_custom 互斥，两者均缺省 = 跟随模型默认（不下发任何思考参数） */
+  thinking_level?: 'off' | 'low' | 'medium' | 'high'
+  /** 自定义思考参数原样透传值；字符串 → 枚举型参数，数字 → budget 型参数。与 thinking_level 互斥 */
+  thinking_custom?: string | number
+}
+
 /** Agent 实例配置（存储格式：引用注册表 ID） */
 export interface AgentInstanceConfig {
   /** 实例 ID */
@@ -1582,6 +1594,8 @@ export interface AgentInstanceConfig {
   system_prompt: string
   /** 模型配置（按角色键索引，值为 ModelSlotRef 引用） */
   model_config: Record<string, ModelSlotRef>
+  /** 各槽位思考强度配置（可选，key 与 model_config 一致；缺省键 = 跟随默认） */
+  thinking?: Record<string, SlotThinkingConfig>
   /** @deprecated as of 2026-04-27. MCP enable/disable 已移到 MCPServerRegistryEntry.enabled 全局字段。运行时忽略此字段；前端不再写入此字段。保留兼容期不破坏老数据。 */
   mcp_server_ids?: string[]
   /** @deprecated as of 2026-04-27. Skill enable/disable 已移到 SkillRegistryEntry.enabled 全局字段。运行时忽略此字段；前端不再写入此字段。保留兼容期不破坏老数据。 */
@@ -1716,6 +1730,8 @@ export interface UpdateAgentConfigParams {
   instance_id: string
   system_prompt?: string
   model_config?: Record<string, ModelSlotRef>
+  /** 各槽位思考强度配置（2026-08 起）；语义见 SlotThinkingConfig */
+  thinking?: Record<string, SlotThinkingConfig>
   /** @deprecated as of 2026-04-27. MCP enable/disable 已移到 MCPServerRegistryEntry.enabled 全局字段。运行时忽略此字段；前端不再写入此字段。保留兼容期不破坏老数据。 */
   mcp_server_ids?: string[]
   /** @deprecated as of 2026-04-27. Skill enable/disable 已移到 SkillRegistryEntry.enabled 全局字段。运行时忽略此字段；前端不再写入此字段。保留兼容期不破坏老数据。 */

--- a/crabot-admin/tests/agent-config-thinking.test.ts
+++ b/crabot-admin/tests/agent-config-thinking.test.ts
@@ -1,0 +1,69 @@
+/**
+ * 槽位 thinking 配置校验（spec 2026-08 §4.4 / §9.3）。
+ */
+import { describe, it, expect } from 'vitest'
+import { validateAgentSlotThinking } from '../src/agent-config-thinking.js'
+
+const ROLE_KEYS = new Set(['powerful', 'cost_effective'])
+
+/** 默认所有 slot 生效 format=anthropic；个别用例覆写（显式 undefined 表示 provider 查不到） */
+function formatsBy(overrides: Record<string, string | undefined> = {}) {
+  return (roleKey: string) => (roleKey in overrides ? overrides[roleKey] : 'anthropic')
+}
+
+describe('validateAgentSlotThinking', () => {
+  it('合法配置通过（level / custom 字符串 / custom 数字×anthropic）', () => {
+    expect(() => validateAgentSlotThinking(undefined, undefined, ROLE_KEYS, formatsBy())).not.toThrow()
+    expect(() => validateAgentSlotThinking(undefined, {
+      powerful: { thinking_level: 'high' },
+      cost_effective: { thinking_level: 'off' },
+    }, ROLE_KEYS, formatsBy())).not.toThrow()
+    expect(() => validateAgentSlotThinking(undefined, {
+      powerful: { thinking_custom: 'xhigh' },
+    }, ROLE_KEYS, formatsBy())).not.toThrow()
+    expect(() => validateAgentSlotThinking({
+      powerful: { provider_id: 'p', model_id: 'm' },
+    }, {
+      powerful: { thinking_custom: 8192 },
+    }, ROLE_KEYS, formatsBy())).not.toThrow()
+  })
+
+  it('slot key 不在 CoreAgentModelRole 内拒绝（含 thinking 独立校验）', () => {
+    expect(() => validateAgentSlotThinking({ vision: { provider_id: 'p', model_id: 'm' } }, undefined, ROLE_KEYS, formatsBy()))
+      .toThrow(/Unknown core Agent model slot key: vision/)
+    expect(() => validateAgentSlotThinking(undefined, { manager: { thinking_level: 'high' } }, ROLE_KEYS, formatsBy()))
+      .toThrow(/Unknown core Agent thinking slot key: manager/)
+  })
+
+  it('thinking_level 枚举外拒绝', () => {
+    expect(() => validateAgentSlotThinking(undefined, { powerful: { thinking_level: 'max' as never } }, ROLE_KEYS, formatsBy()))
+      .toThrow(/invalid thinking_level/)
+  })
+
+  it('thinking_custom 非空白字符串/正整数拒绝', () => {
+    expect(() => validateAgentSlotThinking(undefined, { powerful: { thinking_custom: '   ' } }, ROLE_KEYS, formatsBy()))
+      .toThrow(/非空白字符串或正整数/)
+    expect(() => validateAgentSlotThinking(undefined, { powerful: { thinking_custom: -1 } }, ROLE_KEYS, formatsBy()))
+      .toThrow(/非空白字符串或正整数/)
+    expect(() => validateAgentSlotThinking(undefined, { powerful: { thinking_custom: 1.5 } }, ROLE_KEYS, formatsBy()))
+      .toThrow(/非空白字符串或正整数/)
+  })
+
+  it('thinking_level 与 thinking_custom 互斥', () => {
+    expect(() => validateAgentSlotThinking(undefined, { powerful: { thinking_level: 'high', thinking_custom: 'xhigh' } }, ROLE_KEYS, formatsBy()))
+      .toThrow(/互斥/)
+  })
+
+  it('数字 thinking_custom × 非 anthropic format 拒绝', () => {
+    expect(() => validateAgentSlotThinking(undefined, { powerful: { thinking_custom: 8192 } }, ROLE_KEYS, formatsBy({ powerful: 'openai' })))
+      .toThrow(/仅 anthropic/)
+    expect(() => validateAgentSlotThinking(undefined, { cost_effective: { thinking_custom: 8192 } }, ROLE_KEYS, formatsBy({ cost_effective: 'gemini' })))
+      .toThrow(/仅 anthropic/)
+    // 生效 provider 查不到（undefined）时同样拒绝
+    expect(() => validateAgentSlotThinking(undefined, { powerful: { thinking_custom: 8192 } }, ROLE_KEYS, formatsBy({ powerful: undefined })))
+      .toThrow(/仅 anthropic/)
+    // 字符串自定义不受 format 限制
+    expect(() => validateAgentSlotThinking(undefined, { powerful: { thinking_custom: 'xhigh' } }, ROLE_KEYS, formatsBy({ powerful: 'openai' })))
+      .not.toThrow()
+  })
+})

--- a/crabot-admin/tests/agent-manager-migration.test.ts
+++ b/crabot-admin/tests/agent-manager-migration.test.ts
@@ -20,9 +20,20 @@ describe('migrateModelConfig', () => {
       .toEqual({ cost_effective: { provider_id: 'p3', model_id: 'm3' } })
   })
 
-  it('vision_expert → vision', () => {
+  it('vision_expert / vision / manager 丢弃（2026-08 槽位收敛，不搬运到保留槽）', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     expect(migrateModelConfig({ vision_expert: { provider_id: 'p', model_id: 'm' } }))
-      .toEqual({ vision: { provider_id: 'p', model_id: 'm' } })
+      .toEqual({})
+    expect(migrateModelConfig({ vision: { provider_id: 'p', model_id: 'm' } }))
+      .toEqual({})
+    expect(migrateModelConfig({ manager: { provider_id: 'p', model_id: 'm' } }))
+      .toEqual({})
+    // 收敛不隐式改写保留槽的既有解析结果
+    expect(migrateModelConfig({
+      powerful: { provider_id: 'p1', model_id: 'm1' },
+      manager: { provider_id: 'p2', model_id: 'm2' },
+    })).toEqual({ powerful: { provider_id: 'p1', model_id: 'm1' } })
+    spy.mockRestore()
   })
 
   it('coding_expert 丢弃', () => {
@@ -35,7 +46,7 @@ describe('migrateModelConfig', () => {
   it('已是新 key 保持不变', () => {
     const input = {
       powerful: { provider_id: 'p1', model_id: 'm1' },
-      vision: { provider_id: 'p2', model_id: 'm2' },
+      cost_effective: { provider_id: 'p2', model_id: 'm2' },
     }
     expect(migrateModelConfig(input)).toEqual(input)
   })

--- a/crabot-admin/tests/builtin-seeding.test.ts
+++ b/crabot-admin/tests/builtin-seeding.test.ts
@@ -241,9 +241,9 @@ describe('getBuiltinSubAgents', () => {
     expect(quality.workflow).not.toContain('spec_reviewer 已 APPROVED')
   })
 
-  it('research_collector 使用 vision role，保留调查能力但不持有 Memory', () => {
+  it('research_collector 使用 cost_effective role（2026-08 槽位收敛），保留调查能力但不持有 Memory', () => {
     const r = getBuiltinSubAgents().find((s) => s.name === 'research_collector')!
-    expect(r.model_role).toBe('vision')
+    expect(r.model_role).toBe('cost_effective')
     expect(r.builtin_capabilities.file_system).toBe(true)
     expect(r.builtin_capabilities.crab_memory).toBe(false)
     const prompt = [r.when_to_use, r.role, r.workflow, r.deliverables, r.verification].join('\n')

--- a/crabot-admin/tests/handle-get-agent-config.test.ts
+++ b/crabot-admin/tests/handle-get-agent-config.test.ts
@@ -223,3 +223,40 @@ describe('handleGetAgentConfig — 槽位 thinking 附加', () => {
     expect(result.config.agent_config.model_config.powerful.thinking_level).toBe('off')
   })
 })
+
+// PR #127 review 意见 1 的回归：thinking 必须进 core_agent 语义投影。
+// 否则 thinking-only 变更的 before/after fingerprint 相同，mutateComputed 判 noop
+// 抛 'Config mutation did not change semantic snapshot'（400 且不落盘，主用例必现）。
+describe('readCoreAgentSemanticSnapshot — thinking 进语义投影', () => {
+  function buildSnapshotAdmin(config: Record<string, unknown>): unknown {
+    const admin = Object.create(AdminModule.prototype) as Record<string, unknown>
+    admin.agentManager = { getSemanticCoreConfig: () => config }
+    admin.modelProviderManager = { getGlobalConfig: () => ({}), listProviders: () => [] }
+    admin.mcpServerManager = { runtimeSemanticEntries: () => [] }
+    admin.subAgentManager = { runtimeSemanticEntries: () => [], semanticMigrationState: () => ({ storage_version: 2, legacy_rewrite_pending: false }) }
+    admin.skillManager = { runtimeSemanticEntries: () => [], semanticMigrationState: () => ({ storage_version: 2, legacy_rewrite_pending: false }) }
+    admin.workerImplementationStore = { runtimeSemanticEntries: () => ({}) }
+    return admin
+  }
+
+  function snapshotOf(config: Record<string, unknown>): string {
+    return JSON.stringify((buildSnapshotAdmin(config) as {
+      readCoreAgentSemanticSnapshot: () => unknown
+    }).readCoreAgentSemanticSnapshot())
+  }
+
+  it('仅 thinking 不同的两份配置产生不同语义快照', () => {
+    const base = {
+      model_config: { powerful: { provider_id: 'p1', model_id: 'm1' } },
+      system_prompt: 'x',
+    }
+    const withThinking = { ...base, thinking: { powerful: { thinking_level: 'high' } } }
+    expect(snapshotOf(base)).not.toBe(snapshotOf(withThinking))
+  })
+
+  it('thinking 缺省与空对象在投影中归一化为相同快照（语义等价，不误判 noop 的前提）', () => {
+    const base = { model_config: {}, system_prompt: 'x' }
+    const withEmpty = { ...base, thinking: {} }
+    expect(snapshotOf(base)).toBe(snapshotOf(withEmpty))
+  })
+})

--- a/crabot-admin/tests/handle-get-agent-config.test.ts
+++ b/crabot-admin/tests/handle-get-agent-config.test.ts
@@ -163,3 +163,63 @@ describe('handleGetAgentConfig — global enable layer', () => {
     expect(result.config.agent_config.skills).toEqual([])
   })
 })
+
+// 槽位 thinking 附加（2026-08，spec §4.3/§9.2）：强度跟 slot 走，模型来源无关。
+describe('handleGetAgentConfig — 槽位 thinking 附加', () => {
+  function buildAdminForThinking(deps: { agentConfig?: Record<string, unknown> }): unknown {
+    const admin = buildAdmin({ agentConfig: deps.agentConfig }) as Record<string, unknown>
+    // buildConnectionInfo 返回可断言的连接信息（默认 stub 返回 null）
+    ;(admin.modelProviderManager as Record<string, unknown>).buildConnectionInfo = async (pid: string, mid: string) => ({
+      endpoint: 'https://ref.test', apikey: 'ref-key', model_id: mid,
+      format: 'openai', provider_id: pid,
+    })
+    return admin
+  }
+
+  async function pullModelConfig(admin: unknown): Promise<Record<string, Record<string, unknown>>> {
+    const result = await (admin as {
+      handleGetAgentConfig: (p: unknown, context: unknown) => Promise<{ config: { agent_config: Record<string, unknown> } }>
+    }).handleGetAgentConfig({ instance_id: 'crabot-agent' }, { authorizationBearer: 'runtime' })
+    return result.config.agent_config.model_config as Record<string, Record<string, unknown>>
+  }
+
+  it('slot 配 thinking + 覆盖模型：附加到该 slot 解析结果', async () => {
+    const admin = buildAdminForThinking({
+      agentConfig: {
+        model_config: { powerful: { provider_id: 'p1', model_id: 'm1' } },
+        thinking: { powerful: { thinking_level: 'high' } },
+      },
+    })
+    const modelConfig = await pullModelConfig(admin)
+    expect(modelConfig.powerful.thinking_level).toBe('high')
+    expect(modelConfig.powerful.thinking_custom).toBeUndefined()
+  })
+
+  it('slot 配 thinking + 回落全局默认：仍附加（强度跟 slot 走）', async () => {
+    const admin = buildAdminForThinking({
+      agentConfig: {
+        model_config: {},
+        thinking: { cost_effective: { thinking_custom: 'xhigh' } },
+      },
+    })
+    const modelConfig = await pullModelConfig(admin)
+    expect(modelConfig.cost_effective.thinking_custom).toBe('xhigh')
+    // powerful 无 thinking 配置 → 不加字段（跟随默认）
+    expect(modelConfig.powerful.thinking_level).toBeUndefined()
+    expect(modelConfig.powerful.thinking_custom).toBeUndefined()
+  })
+
+  it('原始 thinking map 不随 runtime config 下发', async () => {
+    const admin = buildAdminForThinking({
+      agentConfig: {
+        model_config: { powerful: { provider_id: 'p1', model_id: 'm1' } },
+        thinking: { powerful: { thinking_level: 'off' } },
+      },
+    })
+    const result = await (admin as {
+      handleGetAgentConfig: (p: unknown, context: unknown) => Promise<{ config: { agent_config: Record<string, unknown> } }>
+    }).handleGetAgentConfig({ instance_id: 'crabot-agent' }, { authorizationBearer: 'runtime' })
+    expect(result.config.agent_config.thinking).toBeUndefined()
+    expect(result.config.agent_config.model_config.powerful.thinking_level).toBe('off')
+  })
+})

--- a/crabot-admin/tests/subagent-manager.test.ts
+++ b/crabot-admin/tests/subagent-manager.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { mkdtempSync, rmSync } from 'fs'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { SubAgentManager, resolveSubAgentModel } from '../src/subagent-manager.js'
@@ -167,5 +167,75 @@ describe('resolveSubAgentModel', () => {
   it('都缺则抛错', () => {
     const entry = { provider_id: null, model_id: null, model_role: null }
     expect(() => resolveSubAgentModel(entry)).toThrow(/缺失/)
+  })
+})
+
+describe('SubAgentManager model_role 收敛（2026-08，protocol-admin §3.19.10）', () => {
+  let tmpDir: string
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'subagent-role-conv-'))
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  function seedLegacyStore(): void {
+    mkdirSync(tmpDir, { recursive: true })
+    const file = {
+      version: 2,
+      entries: [
+        {
+          id: 'research_collector', is_builtin: true, enabled: true,
+          provider_id: null, model_id: null, model_role: 'vision',
+          created_at: 't', updated_at: 't',
+        },
+        {
+          id: 'custom-1', is_builtin: false, enabled: true, name: 'c', description: '',
+          when_to_use: '', role: '', workflow: '', deliverables: '',
+          provider_id: null, model_id: null, model_role: 'manager',
+          builtin_capabilities: { file_system: false, shell: false, task_intel: false, crab_memory: false, crab_messaging: false },
+          allowed_mcp_server_ids: [], allowed_skill_ids: [], max_turns: 10,
+          created_at: 't', updated_at: 't',
+        },
+      ],
+    }
+    writeFileSync(join(tmpDir, 'subagents.json'), JSON.stringify(file, null, 2))
+  }
+
+  it('启动加载时 vision→cost_effective、manager→powerful 并落盘', async () => {
+    seedLegacyStore()
+    const mgr = new SubAgentManager(tmpDir, () => [])
+    await mgr.initialize()
+    // 生产启动序列中 seedBuiltin 在 coordinator recovery 后触发 pending rewrite 落盘（index.ts:945）
+    await mgr.seedBuiltin([])
+
+    expect(mgr.get('research_collector')?.model_role).toBe('cost_effective')
+    expect(mgr.get('custom-1')?.model_role).toBe('powerful')
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('model_role 收敛'))
+
+    // 归一化已持久化
+    const persisted = JSON.parse(readFileSync(join(tmpDir, 'subagents.json'), 'utf-8'))
+    const roles = Object.fromEntries(persisted.entries.map((e: { id: string; model_role: string }) => [e.id, e.model_role]))
+    expect(roles.research_collector).toBe('cost_effective')
+    expect(roles['custom-1']).toBe('powerful')
+  })
+
+  it('二次启动幂等（无 warn、无改写）', async () => {
+    seedLegacyStore()
+    const mgr = new SubAgentManager(tmpDir, () => [])
+    await mgr.initialize()
+    await mgr.seedBuiltin([])
+    warnSpy.mockClear()
+
+    const mgr2 = new SubAgentManager(tmpDir, () => [])
+    await mgr2.initialize()
+    await mgr2.seedBuiltin([])
+    expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('model_role 收敛'))
+    expect(mgr2.get('research_collector')?.model_role).toBe('cost_effective')
   })
 })

--- a/crabot-admin/web/src/App.css
+++ b/crabot-admin/web/src/App.css
@@ -3916,6 +3916,7 @@ input[type="radio"]:disabled {
 
 .model-table-col-id { flex: 2; }
 .model-table-col-type { flex: 1; }
+.model-table-col-ctx { flex: 1; }
 .model-table-col-test { width: 80px; text-align: right; }
 
 /* ============================================================================

--- a/crabot-admin/web/src/pages/Agents/AgentConfig.thinking.test.tsx
+++ b/crabot-admin/web/src/pages/Agents/AgentConfig.thinking.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * 槽位思考强度 UI（2026-08 spec §7.2/§9.6）：
+ * 下拉默认"跟随默认"；选档位/自定义后保存 payload 携带正确 thinking 字段；
+ * 自定义纯数字 + 非 anthropic format 的弱提示。
+ */
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { AgentConfig } from './AgentConfig'
+
+vi.mock('../../components/Layout/MainLayout', () => ({
+  MainLayout: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+const toastError = vi.fn()
+vi.mock('../../contexts/ToastContext', () => ({
+  useToast: () => ({ success: vi.fn(), error: toastError, info: vi.fn() }),
+}))
+
+vi.mock('../../services/mcp', () => ({
+  mcpService: { list: vi.fn().mockResolvedValue([]) },
+}))
+vi.mock('../../services/skill', () => ({
+  skillService: { list: vi.fn().mockResolvedValue([]) },
+}))
+
+const updateConfig = vi.fn().mockResolvedValue({})
+vi.mock('../../services/agent', () => ({
+  agentService: {
+    getConfig: vi.fn().mockResolvedValue({
+      instance_id: 'inst-1',
+      system_prompt: '',
+      model_config: {},
+      thinking: {},
+      extra: {},
+    }),
+    updateConfig: (...args: unknown[]) => updateConfig(...args),
+    getLLMRequirements: vi.fn().mockResolvedValue({
+      requirements: [
+        { key: 'powerful', required: true, description: '', recommended_capabilities: [] },
+        { key: 'cost_effective', required: false, description: '', recommended_capabilities: [] },
+      ],
+      extra_schema: [],
+    }),
+  },
+}))
+
+const listProviders = vi.fn()
+const getGlobalConfig = vi.fn()
+vi.mock('../../services/provider', () => ({
+  providerService: {
+    listProviders: (...args: unknown[]) => listProviders(...args),
+    getGlobalConfig: (...args: unknown[]) => getGlobalConfig(...args),
+  },
+}))
+
+function mockProviders(format: string): void {
+  listProviders.mockResolvedValue({
+    items: [{
+      id: 'p1',
+      name: `Prov (${format})`,
+      format,
+      type: 'manual',
+      endpoint: 'https://x.test',
+      models: [{ model_id: 'm-1', display_name: 'Model 1', type: 'llm' }],
+    }],
+  })
+  getGlobalConfig.mockResolvedValue({ default_llm_provider_id: 'p1' })
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <AgentConfig />
+    </MemoryRouter>,
+  )
+}
+
+function thinkingSelects(): HTMLSelectElement[] {
+  return screen.getAllByDisplayValue('思考：跟随默认') as HTMLSelectElement[]
+}
+
+describe('AgentConfig — 槽位思考强度', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    updateConfig.mockClear()
+    toastError.mockClear()
+  })
+
+  it('每个槽位有思考下拉且默认跟随默认；选"高"后保存 payload 携带 thinking_level', async () => {
+    mockProviders('anthropic')
+    renderPage()
+    // 等待角色行渲染（powerful + cost_effective 各一个思考下拉）
+    const thinking = await vi.waitFor(() => {
+      const found = thinkingSelects()
+      expect(found.length).toBe(2)
+      return found
+    })
+    expect((thinking[0].selectedOptions[0] as HTMLOptionElement).text).toBe('思考：跟随默认')
+
+    fireEvent.change(thinking[0], { target: { value: 'high' } })
+    fireEvent.click(screen.getByRole('button', { name: '保存配置' }))
+    await vi.waitFor(() => {
+      expect(updateConfig).toHaveBeenCalledWith(expect.objectContaining({
+        thinking: { powerful: { thinking_level: 'high' } },
+      }))
+    })
+  })
+
+  it('选"自定义…"出现输入框（placeholder 按 anthropic 提示），保存透传 thinking_custom', async () => {
+    mockProviders('anthropic')
+    renderPage()
+    const thinking = await vi.waitFor(() => {
+      const found = thinkingSelects()
+      expect(found.length).toBe(2)
+      return found
+    })
+    fireEvent.change(thinking[0], { target: { value: 'custom' } })
+    const input = await screen.findByPlaceholderText('如 xhigh / max；老模型可填 budget 数字如 8192')
+    fireEvent.change(input, { target: { value: 'xhigh' } })
+    fireEvent.click(screen.getByRole('button', { name: '保存配置' }))
+    await vi.waitFor(() => {
+      expect(updateConfig).toHaveBeenCalledWith(expect.objectContaining({
+        thinking: { powerful: { thinking_custom: 'xhigh' } },
+      }))
+    })
+  })
+
+  it('自定义纯数字在非 anthropic format 下显示弱提示', async () => {
+    mockProviders('openai')
+    renderPage()
+    const thinking = await vi.waitFor(() => {
+      const found = thinkingSelects()
+      expect(found.length).toBe(2)
+      return found
+    })
+    fireEvent.change(thinking[0], { target: { value: 'custom' } })
+    await screen.findByPlaceholderText('如 minimal / xhigh / max')
+    const input = screen.getByPlaceholderText('如 minimal / xhigh / max')
+    fireEvent.change(input, { target: { value: '8192' } })
+    expect(screen.getByText(/数字 budget 仅 anthropic 格式支持/)).toBeDefined()
+  })
+})

--- a/crabot-admin/web/src/pages/Agents/AgentConfig.thinking.test.tsx
+++ b/crabot-admin/web/src/pages/Agents/AgentConfig.thinking.test.tsx
@@ -8,6 +8,7 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { AgentConfig } from './AgentConfig'
+import { agentService } from '../../services/agent'
 
 vi.mock('../../components/Layout/MainLayout', () => ({
   MainLayout: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
@@ -140,5 +141,18 @@ describe('AgentConfig — 槽位思考强度', () => {
     const input = screen.getByPlaceholderText('如 minimal / xhigh / max')
     fireEvent.change(input, { target: { value: '8192' } })
     expect(screen.getByText(/数字 budget 仅 anthropic 格式支持/)).toBeDefined()
+  })
+
+  it('getGlobalConfig 失败不影响 agent 配置装载（review 意见 2 回归：表单不得被打回空）', async () => {
+    getGlobalConfig.mockRejectedValueOnce(new Error('boom'))
+    ;(agentService.getConfig as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      instance_id: 'inst-1',
+      system_prompt: 'persona-x',
+      model_config: {},
+      thinking: {},
+      extra: {},
+    })
+    renderPage()
+    expect(await screen.findByDisplayValue('persona-x')).toBeDefined()
   })
 })

--- a/crabot-admin/web/src/pages/Agents/AgentConfig.tsx
+++ b/crabot-admin/web/src/pages/Agents/AgentConfig.tsx
@@ -12,6 +12,7 @@ import type {
   ModelProvider,
   LLMRoleRequirement,
   ModelSlotRef,
+  SlotThinkingConfig,
   MCPServerRegistryEntry,
   SkillRegistryEntry,
   ExtraConfigSchema,
@@ -86,7 +87,23 @@ interface AgentUnifiedConfig {
   system_prompt: string
   timezone: string
   model_roles: Record<string, ModelSlotRef>
+  /** 槽位思考强度（2026-08）；与 model_roles 独立，key 一致 */
+  thinking: Record<string, SlotThinkingConfig>
   extra: Record<string, unknown>
+}
+
+/** 思考下拉选项值：'' 跟随默认；off~high 常用档；custom 自定义透传 */
+type ThinkingSelectValue = '' | 'off' | 'low' | 'medium' | 'high' | 'custom'
+
+/** 自定义值归一化：纯数字串 → number（数字 budget 仅 anthropic 支持，后端校验为准） */
+function normalizeCustomThinking(raw: string): string | number {
+  return /^\d+$/.test(raw) ? parseInt(raw, 10) : raw
+}
+
+function thinkingSelectValue(t: SlotThinkingConfig | undefined): ThinkingSelectValue {
+  if (!t) return ''
+  if (t.thinking_level) return t.thinking_level
+  return 'custom'
 }
 
 export const AgentConfig: React.FC = () => {
@@ -102,8 +119,11 @@ export const AgentConfig: React.FC = () => {
     system_prompt: '',
     timezone: '',
     model_roles: {},
+    thinking: {},
     extra: {},
   })
+  /** 全局默认 LLM provider id：slot 未覆盖模型时，思考下拉的 placeholder 按全局默认 format 提示 */
+  const [globalDefaultProviderId, setGlobalDefaultProviderId] = useState<string | undefined>(undefined)
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState('')
@@ -129,13 +149,18 @@ export const AgentConfig: React.FC = () => {
       setAllSkills(skills)
 
       try {
-        const existingConfig = await agentService.getConfig()
+        const [existingConfig, globalConfig] = await Promise.all([
+          agentService.getConfig(),
+          providerService.getGlobalConfig(),
+        ])
         setConfig({
           system_prompt: existingConfig.system_prompt || '',
           timezone: existingConfig.timezone || '',
           model_roles: existingConfig.model_config || {},
+          thinking: existingConfig.thinking || {},
           extra: existingConfig.extra || {},
         })
+        setGlobalDefaultProviderId(globalConfig.default_llm_provider_id)
       } catch {
         // Agent config not available yet, use defaults
       }
@@ -149,10 +174,27 @@ export const AgentConfig: React.FC = () => {
   const handleSave = async () => {
     try {
       setSaving(true)
+      // 自定义思考值归一化 + 空值拦截（后端校验为准，这里只挡明显笔误）
+      for (const [key, t] of Object.entries(config.thinking)) {
+        if (t.thinking_custom !== undefined && typeof t.thinking_custom === 'string' && t.thinking_custom.trim() === '') {
+          toast.error(`槽位 "${key}" 的自定义思考强度不能为空`)
+          setSaving(false)
+          return
+        }
+      }
+      const thinking = Object.fromEntries(
+        Object.entries(config.thinking).map(([key, t]) => [
+          key,
+          t.thinking_custom !== undefined && typeof t.thinking_custom === 'string'
+            ? { thinking_custom: normalizeCustomThinking(t.thinking_custom.trim()) }
+            : t,
+        ])
+      )
       await agentService.updateConfig({
         system_prompt: config.system_prompt,
         timezone: config.timezone || undefined,
         model_config: config.model_roles,
+        thinking,
         extra: Object.keys(config.extra).length > 0 ? config.extra : undefined,
       })
       toast.success('Agent 配置保存成功')
@@ -197,6 +239,45 @@ export const AgentConfig: React.FC = () => {
     const roleConfig = config.model_roles[roleKey]
     if (!roleConfig) return undefined
     return providers.find((p) => p.id === roleConfig.provider_id)
+  }
+
+  // --- 槽位思考强度（2026-08） ---
+
+  /** 该槽位生效 provider 的 format：槽位覆盖优先，回落全局默认；用于 placeholder/弱提示 */
+  const effectiveFormat = (roleKey: string): string | undefined => {
+    return getSelectedProvider(roleKey)?.format
+      ?? providers.find((p) => p.id === globalDefaultProviderId)?.format
+  }
+
+  const thinkingPlaceholder = (roleKey: string): string => {
+    switch (effectiveFormat(roleKey)) {
+      case 'anthropic': return '如 xhigh / max；老模型可填 budget 数字如 8192'
+      case 'openai': return '如 minimal / xhigh / max'
+      case 'openai-responses': return '如 minimal / xhigh / max'
+      case 'gemini': return '如 low / high（兼容层映射 thinking level）'
+      default: return '原生枚举值或 budget 数字'
+    }
+  }
+
+  const handleThinkingChange = (roleKey: string, value: ThinkingSelectValue) => {
+    setConfig((prev) => {
+      const next = { ...prev.thinking }
+      if (value === '') {
+        delete next[roleKey]
+      } else if (value === 'custom') {
+        next[roleKey] = { thinking_custom: prev.thinking[roleKey]?.thinking_custom ?? '' }
+      } else {
+        next[roleKey] = { thinking_level: value }
+      }
+      return { ...prev, thinking: next }
+    })
+  }
+
+  const handleCustomThinkingInput = (roleKey: string, raw: string) => {
+    setConfig((prev) => ({
+      ...prev,
+      thinking: { ...prev.thinking, [roleKey]: { thinking_custom: raw } },
+    }))
   }
 
   const configurableRoles = llmRequirements
@@ -297,7 +378,7 @@ export const AgentConfig: React.FC = () => {
                     {role.description && (
                       <p style={{ color: 'var(--text-secondary)', fontSize: '0.75rem', marginBottom: '0.5rem', lineHeight: 1.4 }}>{role.description}</p>
                     )}
-                    <div style={{ display: 'grid', gridTemplateColumns: llmModels.length > 0 ? '1fr 1fr' : '1fr', gap: '0.5rem' }}>
+                    <div style={{ display: 'grid', gridTemplateColumns: llmModels.length > 0 ? '1fr 1fr 1fr' : '1fr 1fr', gap: '0.5rem' }}>
                       <div className="form-group" style={{ marginBottom: 0 }}>
                         <select
                           className="select"
@@ -320,7 +401,7 @@ export const AgentConfig: React.FC = () => {
                           ))}
                         </select>
                       </div>
-                      {llmModels.length > 0 && (
+                      {llmModels.length > 0 ? (
                         <div className="form-group" style={{ marginBottom: 0 }}>
                           <select
                             className="select"
@@ -334,8 +415,43 @@ export const AgentConfig: React.FC = () => {
                             ))}
                           </select>
                         </div>
-                      )}
+                      ) : null}
+                      <div className="form-group" style={{ marginBottom: 0 }}>
+                        <select
+                          className="select"
+                          value={thinkingSelectValue(config.thinking[role.key])}
+                          onChange={(e) => handleThinkingChange(role.key, e.target.value as ThinkingSelectValue)}
+                        >
+                          <option value="">思考：跟随默认</option>
+                          <option value="off">思考：关闭</option>
+                          <option value="low">思考：低</option>
+                          <option value="medium">思考：中</option>
+                          <option value="high">思考：高</option>
+                          <option value="custom">思考：自定义…</option>
+                        </select>
+                      </div>
                     </div>
+                    {thinkingSelectValue(config.thinking[role.key]) === 'custom' && (
+                      <div style={{ marginTop: '0.5rem' }}>
+                        <input
+                          className="input"
+                          value={typeof config.thinking[role.key]?.thinking_custom === 'string'
+                            ? (config.thinking[role.key].thinking_custom as string)
+                            : config.thinking[role.key]?.thinking_custom !== undefined
+                              ? String(config.thinking[role.key].thinking_custom)
+                              : ''}
+                          onChange={(e) => handleCustomThinkingInput(role.key, e.target.value)}
+                          placeholder={thinkingPlaceholder(role.key)}
+                        />
+                        {typeof config.thinking[role.key]?.thinking_custom === 'string'
+                          && /^\d+$/.test(config.thinking[role.key].thinking_custom as string)
+                          && effectiveFormat(role.key) !== 'anthropic' && (
+                          <div style={{ color: 'var(--warning)', fontSize: '0.6875rem', marginTop: '0.25rem' }}>
+                            数字 budget 仅 anthropic 格式支持，其他格式请填原生枚举值
+                          </div>
+                        )}
+                      </div>
+                    )}
                   </div>
                 )
               })}

--- a/crabot-admin/web/src/pages/Agents/AgentConfig.tsx
+++ b/crabot-admin/web/src/pages/Agents/AgentConfig.tsx
@@ -148,11 +148,14 @@ export const AgentConfig: React.FC = () => {
       setAllMCPServers(mcpServers)
       setAllSkills(skills)
 
+      // 全局默认仅用于思考下拉的 placeholder 提示：单独容错。它和 agent 配置共用 catch
+      // 会让 placeholder 级失败把整个表单打回空初始值，此时点保存会把线上配置抹成空
+      // （PR #127 review 意见 2）。
+      providerService.getGlobalConfig()
+        .then((globalConfig) => setGlobalDefaultProviderId(globalConfig.default_llm_provider_id))
+        .catch(() => { /* placeholder 退化为通用提示 */ })
       try {
-        const [existingConfig, globalConfig] = await Promise.all([
-          agentService.getConfig(),
-          providerService.getGlobalConfig(),
-        ])
+        const existingConfig = await agentService.getConfig()
         setConfig({
           system_prompt: existingConfig.system_prompt || '',
           timezone: existingConfig.timezone || '',
@@ -160,7 +163,6 @@ export const AgentConfig: React.FC = () => {
           thinking: existingConfig.thinking || {},
           extra: existingConfig.extra || {},
         })
-        setGlobalDefaultProviderId(globalConfig.default_llm_provider_id)
       } catch {
         // Agent config not available yet, use defaults
       }

--- a/crabot-admin/web/src/pages/Providers/ProviderDrawerDetail.ctx.test.tsx
+++ b/crabot-admin/web/src/pages/Providers/ProviderDrawerDetail.ctx.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * 详情抽屉"上下文"列编辑（2026-08 spec §7.1/§9.6）：
+ * 未设置显示"默认 200K"；点击内联编辑；非法输入不保存；清空 = 删除字段。
+ */
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import type { ModelProvider } from '../../types'
+import { ProviderDrawerDetail } from './ProviderDrawerDetail'
+import { providerService } from '../../services/provider'
+
+vi.mock('../../contexts/ToastContext', () => ({
+  useToast: () => ({ success: vi.fn(), error: vi.fn() }),
+}))
+
+vi.mock('../../services/provider', () => ({
+  providerService: {
+    updateProvider: vi.fn().mockResolvedValue({}),
+  },
+}))
+
+const updateProvider = providerService.updateProvider as ReturnType<typeof vi.fn>
+
+function makeProvider(models: ModelProvider['models']): ModelProvider {
+  return {
+    id: 'provider-1',
+    name: 'Prov',
+    type: 'manual',
+    format: 'anthropic',
+    endpoint: 'https://example.com',
+    api_key: 'test-api-key',
+    models,
+    status: 'active',
+    created_at: '2026-08-28T00:00:00.000Z',
+    updated_at: '2026-08-28T00:00:00.000Z',
+  }
+}
+
+function renderDrawer(provider: ModelProvider) {
+  return render(
+    <ProviderDrawerDetail
+      provider={provider}
+      onEdit={vi.fn()}
+      onDelete={vi.fn()}
+      onRefresh={vi.fn()}
+    />,
+  )
+}
+
+describe('ProviderDrawerDetail — 上下文列', () => {
+  beforeEach(() => {
+    updateProvider.mockClear()
+  })
+
+  it('未设置显示"默认 200K"，已设置显示 K 格式化值', () => {
+    renderDrawer(makeProvider([
+      { model_id: 'm-unset', display_name: 'u', type: 'llm' },
+      { model_id: 'm-set', display_name: 's', type: 'llm', context_window: 128000 },
+    ]))
+    expect(screen.getByText('默认 200K')).toBeInTheDocument()
+    expect(screen.getByText('128K')).toBeInTheDocument()
+  })
+
+  it('点击进入内联编辑，保存合法值 → PATCH 全量 models 携带 context_window', async () => {
+    const { rerender } = renderDrawer(makeProvider([
+      { model_id: 'm-unset', display_name: 'u', type: 'llm' },
+    ]))
+    fireEvent.click(screen.getByText('默认 200K'))
+    const input = screen.getByPlaceholderText('token 数')
+    fireEvent.change(input, { target: { value: '128000' } })
+    fireEvent.blur(input)
+
+    await waitFor(() => {
+      expect(updateProvider).toHaveBeenCalledWith('provider-1', {
+        models: [expect.objectContaining({ model_id: 'm-unset', context_window: 128000 })],
+      })
+    })
+    // onRefresh 触发后父组件会换新 provider；这里手动重渲染验证格式化显示
+    rerender(
+      <ProviderDrawerDetail
+        provider={makeProvider([{ model_id: 'm-unset', display_name: 'u', type: 'llm', context_window: 128000 }])}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onRefresh={vi.fn()}
+      />,
+    )
+    expect(screen.getByText('128K')).toBeInTheDocument()
+  })
+
+  it('清空输入保存 = 删除字段（context_window undefined）', async () => {
+    renderDrawer(makeProvider([
+      { model_id: 'm-set', display_name: 's', type: 'llm', context_window: 128000 },
+    ]))
+    fireEvent.click(screen.getByText('128K'))
+    const input = screen.getByPlaceholderText('token 数')
+    fireEvent.change(input, { target: { value: '' } })
+    fireEvent.blur(input)
+
+    await waitFor(() => {
+      const call = updateProvider.mock.calls[0]
+      const models = (call[1] as { models: Array<{ model_id: string; context_window?: number }> }).models
+      expect(models[0].model_id).toBe('m-set')
+      expect(models[0].context_window).toBeUndefined()
+    })
+  })
+
+  it('非法输入（非正整数）不保存并提示', async () => {
+    renderDrawer(makeProvider([
+      { model_id: 'm-unset', display_name: 'u', type: 'llm' },
+    ]))
+    fireEvent.click(screen.getByText('默认 200K'))
+    const input = screen.getByPlaceholderText('token 数')
+    fireEvent.change(input, { target: { value: 'abc' } })
+    fireEvent.blur(input)
+
+    await waitFor(() => {
+      expect(updateProvider).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/crabot-admin/web/src/pages/Providers/ProviderDrawerDetail.tsx
+++ b/crabot-admin/web/src/pages/Providers/ProviderDrawerDetail.tsx
@@ -24,6 +24,9 @@ export const ProviderDrawerDetail: React.FC<ProviderDrawerDetailProps> = ({
   const [refreshing, setRefreshing] = useState(false)
   const [togglingVision, setTogglingVision] = useState<string | null>(null)
   const [modelTestResults, setModelTestResults] = useState<Record<string, ProviderTestState>>({})
+  // 上下文列内联编辑：editingCtx 记录正在编辑的 model_id，ctxInput 为输入框原始值
+  const [editingCtx, setEditingCtx] = useState<string | null>(null)
+  const [ctxInput, setCtxInput] = useState('')
 
   const handleRefreshModels = async () => {
     try {
@@ -82,6 +85,32 @@ export const ProviderDrawerDetail: React.FC<ProviderDrawerDetailProps> = ({
       toast.error(err instanceof Error ? err.message : '更新失败')
     } finally {
       setTogglingVision(null)
+    }
+  }
+
+  const formatContext = (n: number) => `${Math.round(n / 1000)}K`
+
+  // 保存上下文：空输入 = 清除配置（回退默认 200K）；Enter/失焦触发，Esc 取消
+  const handleSaveContext = async (modelId: string) => {
+    const raw = ctxInput.trim()
+    if (raw !== '' && (!/^\d+$/.test(raw) || parseInt(raw, 10) <= 0)) {
+      toast.error('上下文必须为正整数 token 数')
+      return
+    }
+    try {
+      const updatedModels = provider.models.map(m =>
+        m.model_id === modelId
+          ? (raw === '' ? { ...m, context_window: undefined } : { ...m, context_window: parseInt(raw, 10) })
+          : m
+      )
+      await providerService.updateProvider(provider.id, { models: updatedModels })
+      toast.success(raw === ''
+        ? `已清除 ${modelId} 的上下文配置（回退默认 200K）`
+        : `已保存 ${modelId} 上下文为 ${formatContext(parseInt(raw, 10))}`)
+      setEditingCtx(null)
+      onRefresh()
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : '更新失败')
     }
   }
 
@@ -164,6 +193,9 @@ export const ProviderDrawerDetail: React.FC<ProviderDrawerDetailProps> = ({
           <div className="model-table-header">
             <span className="model-table-col-id">模型 ID</span>
             <span className="model-table-col-type">类型</span>
+            <Tooltip content="模型上下文窗口 token 数；用于 Agent 上下文压缩触发阈值（约 80% 时压缩），缺省按 200000 处理" size="lg">
+              <span className="model-table-col-ctx">上下文</span>
+            </Tooltip>
             <Tooltip content="实战测速：和 Agent/Memory 实际调用一致的 payload 形态（带 system + tools + 真实 max_tokens）+ stream 拉首字节，能复现「中转不吃 tools / 大 max_tokens」等典型坑" size="lg">
               <span className="model-table-col-test">首字</span>
             </Tooltip>
@@ -193,6 +225,39 @@ export const ProviderDrawerDetail: React.FC<ProviderDrawerDetailProps> = ({
                         </span>
                       </Tooltip>
                     </>
+                  )}
+                </span>
+                <span className="model-table-col-ctx">
+                  {model.type === 'image' ? (
+                    <span style={{ color: 'var(--text-secondary)' }}>—</span>
+                  ) : editingCtx === model.model_id ? (
+                    <input
+                      className="input"
+                      style={{ width: '96px', padding: '0.1rem 0.4rem', fontSize: '0.8rem' }}
+                      autoFocus
+                      value={ctxInput}
+                      placeholder="token 数"
+                      onChange={(e) => setCtxInput(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') (e.target as HTMLInputElement).blur()
+                        if (e.key === 'Escape') setEditingCtx(null)
+                      }}
+                      onBlur={() => void handleSaveContext(model.model_id)}
+                    />
+                  ) : (
+                    <Tooltip content={model.context_window
+                      ? `已设置 ${formatContext(model.context_window)}（点击修改，清空即回退默认）`
+                      : '未设置；Agent 按 200000 处理（点击设置）'}>
+                      <span
+                        style={{ cursor: 'pointer', color: model.context_window ? undefined : 'var(--text-secondary)' }}
+                        onClick={() => {
+                          setCtxInput(model.context_window ? String(model.context_window) : '')
+                          setEditingCtx(model.model_id)
+                        }}
+                      >
+                        {model.context_window ? formatContext(model.context_window) : '默认 200K'}
+                      </span>
+                    </Tooltip>
                   )}
                 </span>
                 <span className="model-table-col-test">

--- a/crabot-admin/web/src/pages/Subagents/SubagentEditor.test.tsx
+++ b/crabot-admin/web/src/pages/Subagents/SubagentEditor.test.tsx
@@ -116,6 +116,19 @@ describe('SubagentEditor', () => {
     })
   })
 
+  it('model_role 下拉不再提供 vision 选项（2026-08 槽位收敛）', async () => {
+    renderEditor({
+      mode: 'edit',
+      entry: makeEntry({ provider_id: null, model_id: null, model_role: 'powerful' }),
+    })
+    fireEvent.click(screen.getByText('模型'))
+    fireEvent.click(screen.getByLabelText('使用 role 默认'))
+    const roleSelect = screen.getByLabelText('model_role') as HTMLSelectElement
+    const options = Array.from(roleSelect.options).map((o) => o.value)
+    expect(options).toEqual(['powerful', 'cost_effective'])
+    expect(options).not.toContain('vision')
+  })
+
   it('Tab 5 内置能力默认值：工作能力 on，Memory 与 messaging 协议固定 off', async () => {
     renderEditor()
     fireEvent.click(screen.getByText('内置能力'))

--- a/crabot-admin/web/src/pages/Subagents/SubagentEditor.tsx
+++ b/crabot-admin/web/src/pages/Subagents/SubagentEditor.tsx
@@ -390,7 +390,6 @@ const ModelTab: React.FC<{
             >
               <option value="powerful">powerful（强力）</option>
               <option value="cost_effective">cost_effective（性价比）</option>
-              <option value="vision">vision（视觉）</option>
             </select>
             <span style={{ color: 'var(--text-muted)', marginLeft: 12, fontSize: 12 }}>
               实际指向取决于该 agent 实例的 model_config[role]

--- a/crabot-admin/web/src/types/index.ts
+++ b/crabot-admin/web/src/types/index.ts
@@ -213,10 +213,18 @@ export interface ModelSlotRef {
   model_id: string
 }
 
+/** 槽位思考强度配置（2026-08）；与 models 独立，缺省 = 跟随模型默认 */
+export interface SlotThinkingConfig {
+  thinking_level?: 'off' | 'low' | 'medium' | 'high'
+  thinking_custom?: string | number
+}
+
 export interface AgentInstanceConfig {
   instance_id: string
   system_prompt: string
   model_config: Record<string, ModelSlotRef>
+  /** 各槽位思考强度配置；key 与 model_config 一致 */
+  thinking?: Record<string, SlotThinkingConfig>
   mcp_server_ids?: string[]
   skill_ids?: string[]
   max_iterations?: number

--- a/crabot-admin/web/src/types/index.ts
+++ b/crabot-admin/web/src/types/index.ts
@@ -663,7 +663,7 @@ export interface Schedule {
 // SubAgent（与 crabot-admin/src/types.ts 镜像；保持字段名 100% 一致）
 // ============================================================================
 
-export type ModelRole = 'powerful' | 'cost_effective' | 'vision' | 'manager'
+export type ModelRole = 'powerful' | 'cost_effective'
 
 export interface BuiltinCapabilities {
   file_system: boolean

--- a/crabot-agent/src/agent/agent-handler.ts
+++ b/crabot-agent/src/agent/agent-handler.ts
@@ -335,6 +335,8 @@ export interface AgentHandlerDeps {
 }
 
 import type { LLMFormat } from '../engine/llm-adapter'
+import type { LLMThinkingConfig } from '../engine/llm-adapter-types.js'
+import { thinkingParam } from '../engine/llm-adapter-types.js'
 
 export interface WorkerTraceContext {
   traceStore: import('../core/trace-store').TraceStore
@@ -387,6 +389,8 @@ export interface SdkEnvConfig {
   maxTokens?: number
   /** Provider 模型配置的 context_window；未配置时 engine 回退内置默认 200000 */
   contextWindow?: number
+  /** 槽位思考强度；未配置 = 跟随模型默认（请求中不出现任何思考参数） */
+  thinking?: LLMThinkingConfig
   env: Record<string, string>
 }
 
@@ -1766,6 +1770,7 @@ export class AgentHandler {
             adapter,
             modelId: this.sdkEnv.modelId,
             ...(this.sdkEnv.maxTokens !== undefined ? { maxTokens: this.sdkEnv.maxTokens } : {}),
+            ...(this.sdkEnv.thinking !== undefined ? { thinking: this.sdkEnv.thinking } : {}),
             messagesRef,
           }
 
@@ -1829,6 +1834,7 @@ export class AgentHandler {
           model: this.sdkEnv.modelId,
           ...(this.sdkEnv.maxTokens !== undefined ? { maxTokens: this.sdkEnv.maxTokens } : {}),
           ...(this.sdkEnv.contextWindow !== undefined ? { contextWindowTokens: this.sdkEnv.contextWindow } : {}),
+          ...(this.sdkEnv.thinking !== undefined ? { thinking: this.sdkEnv.thinking } : {}),
           maxTurns: 2000,
           supportsVision: this.sdkEnv.supportsVision,
           permissionConfig: initialPermissionConfig,
@@ -3514,6 +3520,10 @@ export class AgentHandler {
         tools: subTools,
         maxTurns: subagent.max_turns,
         ...(subagent.model.max_tokens !== undefined ? { maxTokens: subagent.model.max_tokens } : {}),
+        // role fallback 解析的 subagent 连接信息自带槽位 thinking（spec §6.4）；直连引用不带 → undefined
+        ...(thinkingParam(subagent.model.thinking_level, subagent.model.thinking_custom) !== undefined
+          ? { thinking: thinkingParam(subagent.model.thinking_level, subagent.model.thinking_custom) }
+          : {}),
         ...(input.context ? { parentContext: input.context } : {}),
         abortSignal: ctx.abortSignal,
         onTurn: subTraceCallback,
@@ -3722,6 +3732,9 @@ export class AgentHandler {
       systemPrompt: finalSystemPrompt,
       model: subModel.model_id,
       ...(subModel.max_tokens !== undefined ? { maxTokens: subModel.max_tokens } : {}),
+      ...(thinkingParam(subModel.thinking_level, subModel.thinking_custom) !== undefined
+        ? { thinking: thinkingParam(subModel.thinking_level, subModel.thinking_custom) }
+        : {}),
       adapter: subAdapter,
       owner: asyncCtx.owner,
       spawned_by_task_id: deps.parentTaskId,

--- a/crabot-agent/src/engine/anthropic-adapter.ts
+++ b/crabot-agent/src/engine/anthropic-adapter.ts
@@ -12,7 +12,7 @@ import type {
   ToolResultBlockParam,
 } from '@anthropic-ai/sdk/resources/messages'
 import { proxyManager } from 'crabot-shared'
-import type { LLMAdapter, LLMAdapterConfig, LLMStreamParams } from './llm-adapter-types.js'
+import type { LLMAdapter, LLMAdapterConfig, LLMStreamParams, LLMThinkingConfig } from './llm-adapter-types.js'
 import { streamWithTimeoutAndRetry } from './stream-timeout.js'
 import { isToolResultMessage, mergeConsecutiveUserMessages, capToolResultForLLM } from './llm-adapter-types.js'
 import type {
@@ -34,6 +34,25 @@ function defaultAnthropicMaxTokens(model: string): number {
   // claude-4 / claude-opus-4 / claude-sonnet-4 / claude-haiku-4 起，上限 32K-64K
   // 32K 是各档位都能接受的安全值（够 reasoning + 长响应）；想跑更长由用户在 admin 上调
   return 32768
+}
+
+// --- 槽位思考强度 → Anthropic 请求字段（spec 2026-08 §5.2）---
+// 跟随默认（undefined）不发任何字段；off → thinking:{type:'disabled'}（4.6+ 必须显式发才能关，
+// 老模型默认即不思考，发 disabled 同样合法）；low/medium/high → output_config:{effort}；
+// 自定义字符串 → output_config:{effort:原样透传}（如 xhigh/max）；自定义数字 → budget_tokens
+// （仅 ≤4.5 老模型接受，新模型 400 由用户改档，不做运行时降级）。
+// SDK 0.30 的类型不含 output_config，故整体以 Params 投影透传。
+function anthropicThinkingFields(thinking: LLMThinkingConfig | undefined): Record<string, unknown> {
+  if (!thinking) return {}
+  if (thinking.custom !== undefined) {
+    if (typeof thinking.custom === 'number') {
+      return { thinking: { type: 'enabled', budget_tokens: thinking.custom } }
+    }
+    return { output_config: { effort: thinking.custom } }
+  }
+  if (thinking.level === 'off') return { thinking: { type: 'disabled' } }
+  if (thinking.level !== undefined) return { output_config: { effort: thinking.level } }
+  return {}
 }
 
 // --- Anthropic Message Normalization ---
@@ -294,7 +313,8 @@ export class AnthropicAdapter implements LLMAdapter {
       ...(system ? { system } : {}),
       messages: cachedMessages,
       ...(cachedTools.length > 0 ? { tools: cachedTools } : {}),
-    })
+      ...anthropicThinkingFields(params.thinking),
+    } as Parameters<typeof this.client.messages.stream>[0])
 
     // signal 通常是 task 级长寿命的（一个 task 内每个 turn 都共用）。如果只 addEventListener
     // 不 removeEventListener，每次 LLM call 都会在 signal 上挂一个 onAbort 闭包，闭包又

--- a/crabot-agent/src/engine/bg-entities/bg-agent.ts
+++ b/crabot-agent/src/engine/bg-entities/bg-agent.ts
@@ -41,6 +41,8 @@ export interface SpawnPersistentAgentOpts {
   readonly model: string
   /** Per-call max output tokens；缺省时让 adapter 走默认行为 */
   readonly maxTokens?: number
+  /** 槽位思考强度；缺省 = 跟随模型默认 */
+  readonly thinking?: import('../llm-adapter-types.js').LLMThinkingConfig
   readonly adapter: LLMAdapter
   /**
    * 工具权限配置——透传给 runEngine。不传时 checkToolPermission 对 dangerous 级
@@ -185,6 +187,7 @@ export async function spawnPersistentAgent(opts: SpawnPersistentAgentOpts): Prom
           tools: [...opts.tools],
           model: opts.model,
           ...(opts.maxTokens !== undefined ? { maxTokens: opts.maxTokens } : {}),
+          ...(opts.thinking !== undefined ? { thinking: opts.thinking } : {}),
           ...(opts.permissionConfig ? { permissionConfig: opts.permissionConfig } : {}),
           hookRegistry: opts.hookRegistry,
           lspManager: opts.lspManager,

--- a/crabot-agent/src/engine/llm-adapter-types.ts
+++ b/crabot-agent/src/engine/llm-adapter-types.ts
@@ -43,12 +43,49 @@ export function wrapOnRetry(
   return (e) => cb({ ...e, source })
 }
 
+/** 槽位思考强度（base-protocol §5.14 thinking_level/thinking_custom 的运行时形态）。 */
+export interface LLMThinkingConfig {
+  readonly level?: 'off' | 'low' | 'medium' | 'high'
+  readonly custom?: string | number
+}
+
+/**
+ * LLMConnectionInfo.thinking_level/custom → LLMThinkingConfig。
+ * 两字段均缺省（跟随默认）时返回 undefined，调用方据此不下发任何思考参数。
+ */
+export function thinkingParam(
+  level: LLMThinkingConfig['level'],
+  custom: LLMThinkingConfig['custom'],
+): LLMThinkingConfig | undefined {
+  if (level === undefined && custom === undefined) return undefined
+  return {
+    ...(level !== undefined ? { level } : {}),
+    ...(custom !== undefined ? { custom } : {}),
+  }
+}
+
+/**
+ * 思考强度 → 枚举型参数值（OpenAI `reasoning_effort` / Responses `reasoning.effort`；
+ * Gemini 经 OpenAI 兼容层映射 thinking level）。
+ * off → 'none'；low/medium/high 字面量透传；自定义字符串原样透传；
+ * 自定义数字是 budget 型参数（仅 anthropic），此处返回 undefined 表示不适用。
+ */
+export function thinkingEffortValue(thinking: LLMThinkingConfig | undefined): string | undefined {
+  if (!thinking) return undefined
+  if (thinking.custom !== undefined) {
+    return typeof thinking.custom === 'string' ? thinking.custom : undefined
+  }
+  return thinking.level === 'off' ? 'none' : thinking.level
+}
+
 export interface LLMStreamParams {
   readonly messages: EngineMessage[]
   readonly systemPrompt: string
   readonly tools: ToolDefinition[]
   readonly model: string
   readonly maxTokens?: number
+  /** 思考强度；undefined = 跟随模型默认（请求中不出现任何思考参数） */
+  readonly thinking?: LLMThinkingConfig
   readonly signal?: AbortSignal
   /** 可观测性回调：retry 发生时触发；用于 worker → admin web 实时显示"LLM 正在重试" */
   readonly onRetry?: (event: LLMRetryEvent) => void

--- a/crabot-agent/src/engine/openai-adapter.ts
+++ b/crabot-agent/src/engine/openai-adapter.ts
@@ -3,7 +3,7 @@
  */
 
 import type { LLMAdapter, LLMAdapterConfig, LLMStreamParams } from './llm-adapter-types.js'
-import { isToolResultMessage, extractText, buildImageUrl, readSSELines, mergeConsecutiveUserMessages, capToolResultForLLM } from './llm-adapter-types.js'
+import { isToolResultMessage, extractText, buildImageUrl, readSSELines, mergeConsecutiveUserMessages, capToolResultForLLM, thinkingEffortValue } from './llm-adapter-types.js'
 import type { EngineMessage, ToolDefinition, StreamChunk, ContentBlock, LLMTokenUsage } from './types.js'
 import { HttpResponseError, StreamProtocolError } from './retry-utils.js'
 import { streamWithTimeoutAndRetry } from './stream-timeout.js'
@@ -178,6 +178,11 @@ export class OpenAIAdapter implements LLMAdapter {
       stream: true,
       stream_options: { include_usage: true },
     }
+
+    // 思考强度（spec 2026-08 §5.2）：跟随默认不发；off→'none'；low/medium/high/自定义字符串
+    // 字面量透传。gemini format 复用本 adapter（OpenAI 兼容层），同样经 reasoning_effort 映射。
+    const reasoningEffort = thinkingEffortValue(params.thinking)
+    if (reasoningEffort !== undefined) body.reasoning_effort = reasoningEffort
 
     if (tools.length > 0) {
       body.tools = tools

--- a/crabot-agent/src/engine/openai-responses-adapter.ts
+++ b/crabot-agent/src/engine/openai-responses-adapter.ts
@@ -5,7 +5,7 @@
  */
 
 import type { LLMAdapter, LLMAdapterConfig, LLMStreamParams } from './llm-adapter-types.js'
-import { isToolResultMessage, extractText, buildImageUrl, readSSEEvents, capToolResultForLLM } from './llm-adapter-types.js'
+import { isToolResultMessage, extractText, buildImageUrl, readSSEEvents, capToolResultForLLM, thinkingEffortValue } from './llm-adapter-types.js'
 import type { EngineMessage, ToolDefinition, StreamChunk, ContentBlock, LLMTokenUsage } from './types.js'
 import { HttpResponseError, StreamProtocolError } from './retry-utils.js'
 import { streamWithTimeoutAndRetry } from './stream-timeout.js'
@@ -173,9 +173,14 @@ export class OpenAIResponsesAdapter implements LLMAdapter {
     }
 
     // Codex 特有字段：reasoning 控制和 include（传递加密的 reasoning 上下文）
+    // 思考强度（spec 2026-08 §5.2）：Codex 跟随默认保持现状 effort='medium'；槽位配置覆盖。
+    // OpenAI 官方 Responses 跟随默认不发 reasoning；配置了才发。
     if (isCodexBackend) {
-      body.reasoning = { effort: 'medium', summary: 'auto' }
+      body.reasoning = { effort: thinkingEffortValue(params.thinking) ?? 'medium', summary: 'auto' }
       body.include = ['reasoning.encrypted_content']
+    } else {
+      const reasoningEffort = thinkingEffortValue(params.thinking)
+      if (reasoningEffort !== undefined) body.reasoning = { effort: reasoningEffort }
     }
 
     // max_output_tokens 对 Codex 无效，仅 OpenAI 官方 Responses API 支持

--- a/crabot-agent/src/engine/progress-digest.ts
+++ b/crabot-agent/src/engine/progress-digest.ts
@@ -1,5 +1,6 @@
 import type { LLMAdapter } from './llm-adapter'
 import { callNonStreaming } from './llm-adapter'
+import type { LLMThinkingConfig } from './llm-adapter-types'
 import type { EngineMessage, EngineMessagesRef, EngineTurnEvent } from './types'
 import { createUserMessage } from './types'
 import { hasDanglingToolUse } from './tool-message-integrity.js'
@@ -52,6 +53,8 @@ export interface ProgressDigestDeps {
   readonly modelId: string
   /** 主 loop 的 maxTokens；不传则走 adapter 默认 */
   readonly maxTokens?: number
+  /** 主 loop 的思考强度（spec §6.5 辅助调用继承）；不传 = 跟随模型默认 */
+  readonly thinking?: LLMThinkingConfig
   /**
    * 主 loop 对话状态的只读 holder。engine 在每个 turn 完成时浅拷贝刷新
    * `current`，每次 LLM 调用前快照 systemPrompt/tools。doFlush 时拿当前
@@ -196,6 +199,7 @@ export class ProgressDigest {
       tools: [...tools],
       model: this.deps.modelId,
       ...(this.deps.maxTokens !== undefined ? { maxTokens: this.deps.maxTokens } : {}),
+      ...(this.deps.thinking !== undefined ? { thinking: this.deps.thinking } : {}),
     }
     const response = await callNonStreaming(this.deps.adapter, params)
 

--- a/crabot-agent/src/engine/query-loop.ts
+++ b/crabot-agent/src/engine/query-loop.ts
@@ -177,6 +177,7 @@ export async function runEngine(params: RunEngineParams): Promise<EngineResult> 
         tools: [...currentTools],
         model: options.model,
         maxTokens: options.maxTokens,
+        thinking: options.thinking,
         signal: abortSignal,
         onRetry: (event) => {
           if (options.onLiveProgress) {

--- a/crabot-agent/src/engine/sub-agent.ts
+++ b/crabot-agent/src/engine/sub-agent.ts
@@ -1,4 +1,5 @@
 import type { LLMAdapter } from './llm-adapter'
+import type { LLMThinkingConfig } from './llm-adapter-types'
 import type { ToolDefinition, EngineTurnEvent, EngineResult, ContentBlock, HumanMessageQueueLike, ToolPermissionConfig } from './types'
 import type { ResolvedPermissions } from '../types'
 import type { TraceStore } from '../core/trace-store'
@@ -21,6 +22,8 @@ export interface ForkEngineParams {
   readonly maxTurns?: number
   /** Per-call max output tokens；缺省时让 adapter 走默认行为 */
   readonly maxTokens?: number
+  /** 槽位思考强度；缺省 = 跟随模型默认（请求中不出现任何思考参数） */
+  readonly thinking?: LLMThinkingConfig
   /** Optional: parent context to share (recent messages summary) */
   readonly parentContext?: string
   /** Abort signal (linked to parent) */
@@ -89,6 +92,7 @@ export async function forkEngine(params: ForkEngineParams): Promise<ForkEngineRe
       model: params.model,
       maxTurns: params.maxTurns ?? DEFAULT_SUB_AGENT_MAX_TURNS,
       ...(params.maxTokens !== undefined ? { maxTokens: params.maxTokens } : {}),
+      ...(params.thinking !== undefined ? { thinking: params.thinking } : {}),
       abortSignal: params.abortSignal,
       onTurn: params.onTurn,
       supportsVision: params.supportsVision,

--- a/crabot-agent/src/engine/types.ts
+++ b/crabot-agent/src/engine/types.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'crypto'
+import type { LLMThinkingConfig } from './llm-adapter-types.js'
 
 // --- Content Blocks ---
 
@@ -410,6 +411,12 @@ export interface EngineOptions {
    * 缺失时 engine 回退到内置默认 200000。仅影响 compaction 触发阈值，不影响请求参数。
    */
   readonly contextWindowTokens?: number
+
+  /**
+   * 槽位思考强度（2026-08）；undefined = 跟随模型默认（请求中不出现任何思考参数）。
+   * 来自 provider 槽位配置的 thinking_level/thinking_custom，随 LLMStreamParams 进 adapter。
+   */
+  readonly thinking?: LLMThinkingConfig
 }
 
 export interface HumanMessageQueueLike {

--- a/crabot-agent/src/manager/bootstrap.ts
+++ b/crabot-agent/src/manager/bootstrap.ts
@@ -131,9 +131,11 @@ export interface BootstrapDeps {
    * `agent_config.timezone` 不必重建整个栈。不注入则退回 `resolveTimezone(undefined)`。
    */
   readonly timezone?: () => string
-  /** manager 的 LLM 来源(model_config.manager ?? powerful),thunk 以支持热更 */
+  /** manager 的 LLM 来源(2026-08 收敛后即 powerful slot),thunk 以支持热更 */
   readonly managerAdapter: () => LLMAdapter
   readonly managerModel: () => string
+  /** manager 的槽位思考强度(随 powerful slot),thunk 以支持热更;返回 undefined = 跟随默认 */
+  readonly managerThinking?: () => import('../engine/llm-adapter-types.js').LLMThinkingConfig | undefined
   readonly messagingDeps: CrabMessagingDeps
   /**
    * crab-memory server **工厂**(P7 J:原本是一个建好的 `McpServer` 定值)。
@@ -504,6 +506,7 @@ export function buildManagerStack(deps: BootstrapDeps): ManagerStack {
     ledger,
     adapter: deps.managerAdapter,
     model: deps.managerModel,
+    thinking: deps.managerThinking,
     now: () => new Date(deps.now()),
     isClosing: deps.isClosing,
     timezone: deps.timezone,

--- a/crabot-agent/src/manager/loop.ts
+++ b/crabot-agent/src/manager/loop.ts
@@ -210,6 +210,8 @@ export interface ManagerLoopDeps {
   readonly model: () => string
   readonly maxTurns?: number
   readonly contextWindowTokens?: number
+  /** manager 的槽位思考强度(thunk,episode 内与 adapter/model 同点解析);undefined = 跟随默认 */
+  readonly thinking?: () => import('../engine/llm-adapter-types.js').LLMThinkingConfig | undefined
   /**
    * 工具面提供者(thunk):每轮重算,由调用方决定要不要按最新状态重建。
    *
@@ -615,6 +617,7 @@ export class ManagerLoop {
     // model,固定用这份快照——即使两次解析之间 admin config 已经变了,当前 episode 也不换。
     const adapter = this.deps.adapter()
     const model = this.deps.model()
+    const thinking = this.deps.thinking?.()
 
     let state = initialState
     let historyState = withoutProtectedTail(state, committedHumanMessages.length)
@@ -645,6 +648,7 @@ export class ManagerLoop {
     ]
 
     let attempt = await this.runAttempt(episodeId, state, tailMessages, adapter, model, {
+      thinking,
       contextEnvelopes: currentInputEnvelopes,
     })
     let totalTurnsUsed = attempt.result.totalTurns
@@ -693,6 +697,7 @@ export class ManagerLoop {
           ...retryInjectedEnvelopes.map((item) => createUserMessage(this.renderEnvelope(item))),
         ]
         const retryAttempt = await this.runAttempt(episodeId, state, retryTailMessages, adapter, model, {
+          thinking,
           contextEnvelopes: [...retryCurrentEnvelopes, ...retryInjectedEnvelopes],
         })
         totalTurnsUsed += retryAttempt.result.totalTurns
@@ -733,7 +738,7 @@ export class ManagerLoop {
         [],
         adapter,
         model,
-        { initialMessages: continuationInitial },
+        { thinking, initialMessages: continuationInitial },
       )
       totalTurnsUsed += continuation.result.totalTurns
       if (continuation.result.outcome === 'completed' || continuation.result.outcome === 'max_turns') {
@@ -1136,6 +1141,8 @@ export class ManagerLoop {
     overrides?: {
       readonly initialMessages?: ReadonlyArray<EngineMessage>
       readonly contextEnvelopes?: ReadonlyArray<TimedWakeEnvelope>
+      /** 本 episode 的槽位思考强度快照（与 adapter/model 同点解析，episode 内固定） */
+      readonly thinking?: import('../engine/llm-adapter-types.js').LLMThinkingConfig
     },
   ): Promise<{ readonly result: EngineResult; readonly hasSummaryMarker: boolean; readonly initialMessageCount: number }> {
     this.attemptCounter += 1
@@ -1171,6 +1178,7 @@ export class ManagerLoop {
       model,
       maxTurns: this.deps.maxTurns,
       contextWindowTokens: this.deps.contextWindowTokens,
+      ...(overrides?.thinking !== undefined ? { thinking: overrides.thinking } : {}),
       disableCompaction: true,
       humanMessageQueue: this.mailbox,
       onBeforeLlmCall: () => {

--- a/crabot-agent/src/manager/model-slot.ts
+++ b/crabot-agent/src/manager/model-slot.ts
@@ -1,12 +1,8 @@
 /**
  * manager model slot 解析(protocol-agent-v3.md §11)。
  *
- * `model_config` 新增的 `'manager'` slot 是 admin 侧 additive 可选项(见
- * `crabot-admin/src/agent-manager.ts` builtin `model_roles`,`fallback: 'none'`)——
- * 未显式配置时 Admin 不会自动拿全局默认去填充它,而是原样不下发该键。真正的回退语义在
- * agent 这一侧完成:`model_config.manager ?? model_config.powerful`,两者都缺才报错。
- * 这样当用户已经给 `powerful` 配了非默认的 provider/model 时,manager 会跟着用 `powerful`
- * 的实际值,而不是被 Admin 的全局默认覆盖掉。
+ * 2026-08 槽位收敛(protocol-admin §3.19.11)：`'manager'` slot 已移除，
+ * Manager loop 直接使用 `model_config.powerful`。
  *
  * @see crabot-docs/protocols/protocol-agent-v3.md §11
  */
@@ -15,16 +11,16 @@ import type { LLMConnectionInfo } from '../types.js'
 
 /**
  * 解析 manager loop 应使用的 LLM 连接信息。
- * 回退链:`model_config.manager` → `model_config.powerful`;两者都未配置则抛出明确错误
+ * 2026-08 槽位收敛后即 `model_config.powerful`；缺失则抛出明确错误
  * (manager loop 没有"跳过不跑"这条路,必须有一个可用的连接信息)。
  */
 export function resolveManagerModelConfig(
   modelConfig: Record<string, LLMConnectionInfo> | undefined
 ): LLMConnectionInfo {
-  const resolved = modelConfig?.manager ?? modelConfig?.powerful
+  const resolved = modelConfig?.powerful
   if (!resolved) {
     throw new Error(
-      "[ManagerLoop] model_config 缺少 'manager' 与 'powerful' 两个 slot，manager loop 无法解析可用的 LLM 连接信息"
+      "[ManagerLoop] model_config 缺少 'powerful' slot，manager loop 无法解析可用的 LLM 连接信息"
     )
   }
   return resolved

--- a/crabot-agent/src/manager/registry.ts
+++ b/crabot-agent/src/manager/registry.ts
@@ -94,6 +94,8 @@ export interface ManagerRegistryDeps {
   readonly model: () => string
   readonly maxTurns?: number
   readonly contextWindowTokens?: number
+  /** manager 的槽位思考强度(随 powerful slot,thunk 支持 hot-reload);undefined = 跟随默认 */
+  readonly thinking?: () => import('../engine/llm-adapter-types.js').LLMThinkingConfig | undefined
   readonly now: () => Date
   /** Once true, no new wake may create or enqueue work for a Manager episode. */
   readonly isClosing?: () => boolean
@@ -227,6 +229,9 @@ export class ManagerRegistry {
       model: this.deps.model,
       maxTurns: this.deps.maxTurns,
       contextWindowTokens: this.deps.contextWindowTokens,
+      // thunk 原样下传：thinking 的解析在 episode 内与 adapter/model 同点发生（同样的
+      // fail-loud 语义），不能在 getOrCreate 急切调用——缺 powerful 会让唤醒路径直接抛错。
+      thinking: this.deps.thinking,
       // 唤醒事件由 ManagerLoop 按 episode 传入(见 ManagerLoopDeps.toolFace);schedule 之外
       // 的唤醒不带身份,工具面照旧。
       toolFace: (wakeEvent) =>

--- a/crabot-agent/src/manager/registry.ts
+++ b/crabot-agent/src/manager/registry.ts
@@ -83,12 +83,11 @@ export interface ManagerRegistryDeps {
   /** routeWorkerEvent 的 origin 归属查找用(harness 未公开 findWorker,直接持有台账存储)。 */
   readonly ledger: LedgerStore
   /**
-   * manager model slot 解析器(protocol-agent-v3.md §11):调用方在此按最新 admin config
-   * 解析 `model_config.manager ?? model_config.powerful`(见 `model-slot.ts`
-   * `resolveManagerModelConfig`)、用 `createAdapter` 建出 `LLMAdapter`。做成 thunk 而非
-   * 字面量是为了让"下一个 episode 生效"的热更语义成立——`getOrCreate` 只在 key 首次建
-   * `ManagerLoop` 时把这两个 thunk 原样转给 `ManagerLoopDeps`(见下),`ManagerLoop` 自己
-   * 按 episode 边界调用,本 registry 不缓存解析结果。
+   * manager model 解析器(protocol-agent-v3.md §11;2026-08 收敛后即 `model_config.powerful`,
+   * 见 `model-slot.ts` `resolveManagerModelConfig`)、用 `createAdapter` 建出 `LLMAdapter`。
+   * 做成 thunk 而非字面量是为了让"下一个 episode 生效"的热更语义成立——`getOrCreate` 只在
+   * key 首次建 `ManagerLoop` 时把这两个 thunk 原样转给 `ManagerLoopDeps`(见下),`ManagerLoop`
+   * 自己按 episode 边界调用,本 registry 不缓存解析结果。
    */
   readonly adapter: () => LLMAdapter
   readonly model: () => string

--- a/crabot-agent/src/types.ts
+++ b/crabot-agent/src/types.ts
@@ -704,6 +704,10 @@ export interface LLMConnectionInfo {
   supports_vision?: boolean
   /** 模型上下文窗口（token 数）；用于 compaction 触发阈值，缺失时 engine 回退内置默认 200000 */
   context_window?: number
+  /** 思考强度档位（槽位配置附加，base-protocol §5.14）；与 thinking_custom 互斥，缺省 = 跟随模型默认 */
+  thinking_level?: 'off' | 'low' | 'medium' | 'high'
+  /** 自定义思考参数原样透传值；字符串 → 枚举型参数，数字 → budget 型参数。与 thinking_level 互斥 */
+  thinking_custom?: string | number
   /** ChatGPT OAuth 账号 ID（仅 openai-responses + ChatGPT 订阅需要） */
   account_id?: string
 }

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -46,6 +46,7 @@ import { MemoryWriter } from './orchestration/memory-writer.js'
 import { AttentionScheduler, type AttentionConfig, type BufferedMessage } from './orchestration/attention-scheduler.js'
 import { SessionLaneRegistry } from './orchestration/session-lane.js'
 import { AgentHandler, type SdkEnvConfig, type ExecuteTriggerMessageParams, type ExecuteTriggerMessageResult, adapterFromSdkEnv } from './agent/agent-handler.js'
+import { thinkingParam } from './engine/llm-adapter-types.js'
 import type { ToolPermissionConfig, ToolDefinition as EngineToolDefinition } from './engine/types.js'
 import { filterToolsByPermission } from './engine/index.js'
 import { getConfiguredBuiltinTools, filterMcpToolsByConfig } from './engine/tools/index.js'
@@ -901,10 +902,17 @@ export class UnifiedAgent extends ModuleBase {
       // 人类消息渲染的时区（`formatChannelMessageLine` 的 ts 属性）。与 worker 侧
       // `buildBuiltinWorkerRuntime` 取同一个来源，避免 manager 与 worker 看到的时间对不上。
       timezone: () => resolveTimezone(this.agentConfig?.timezone),
-      // §11：manager slot → 回退 powerful。两个 thunk 每个 episode 各解析一次，
-      // 未配置时抛出的错误信息由 model-slot.ts 给出（明确指出缺哪两个 slot）。
+      // §11：2026-08 收敛后 manager 直接用 powerful slot。thunk 每个 episode 各解析一次，
+      // 未配置时抛出的错误信息由 model-slot.ts 给出。
       managerAdapter: () => adapterFromSdkEnv(this.buildSdkEnv(resolveManagerModelConfig(this.agentConfig?.model_config))),
       managerModel: () => resolveManagerModelConfig(this.agentConfig?.model_config).model_id,
+      managerThinking: () => {
+        const thinking = thinkingParam(
+          resolveManagerModelConfig(this.agentConfig?.model_config).thinking_level,
+          resolveManagerModelConfig(this.agentConfig?.model_config).thinking_custom,
+        )
+        return thinking
+      },
       // crab-messaging：与 `createMcpConfigs` 同款依赖，但不传 `getTaskContext`——manager 不是
       // task，且 tool-face 已把 `send_message` 的 intent 去掉，ask_human 路径对 manager 不存在。
       messagingDeps: {
@@ -1062,6 +1070,7 @@ export class UnifiedAgent extends ModuleBase {
       ...(sdkEnv.supportsVision !== undefined ? { supportsVision: sdkEnv.supportsVision } : {}),
       ...(sdkEnv.maxTokens !== undefined ? { maxTokens: sdkEnv.maxTokens } : {}),
       ...(sdkEnv.contextWindow !== undefined ? { contextWindowTokens: sdkEnv.contextWindow } : {}),
+      ...(sdkEnv.thinking !== undefined ? { thinking: sdkEnv.thinking } : {}),
     }
   }
 
@@ -1334,6 +1343,9 @@ export class UnifiedAgent extends ModuleBase {
       supportsVision: connInfo.supports_vision,
       ...(connInfo.max_tokens !== undefined ? { maxTokens: connInfo.max_tokens } : {}),
       ...(connInfo.context_window !== undefined ? { contextWindow: connInfo.context_window } : {}),
+      ...(thinkingParam(connInfo.thinking_level, connInfo.thinking_custom) !== undefined
+        ? { thinking: thinkingParam(connInfo.thinking_level, connInfo.thinking_custom) }
+        : {}),
       env: {
         LLM_BASE_URL: connInfo.endpoint,
         LLM_API_KEY: connInfo.apikey || 'dummy-key',

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -907,11 +907,8 @@ export class UnifiedAgent extends ModuleBase {
       managerAdapter: () => adapterFromSdkEnv(this.buildSdkEnv(resolveManagerModelConfig(this.agentConfig?.model_config))),
       managerModel: () => resolveManagerModelConfig(this.agentConfig?.model_config).model_id,
       managerThinking: () => {
-        const thinking = thinkingParam(
-          resolveManagerModelConfig(this.agentConfig?.model_config).thinking_level,
-          resolveManagerModelConfig(this.agentConfig?.model_config).thinking_custom,
-        )
-        return thinking
+        const conn = resolveManagerModelConfig(this.agentConfig?.model_config)
+        return thinkingParam(conn.thinking_level, conn.thinking_custom)
       },
       // crab-messaging：与 `createMcpConfigs` 同款依赖，但不传 `getTaskContext`——manager 不是
       // task，且 tool-face 已把 `send_message` 的 intent 去掉，ask_human 路径对 manager 不存在。

--- a/crabot-agent/src/workers/builtin/adapter.ts
+++ b/crabot-agent/src/workers/builtin/adapter.ts
@@ -55,6 +55,7 @@ import { isDeepStrictEqual } from 'node:util'
 import { runEngine, defineTool, createUserMessage } from '../../engine/index.js'
 import type { EngineMessage, EngineMessagesRef, EngineResult, ToolDefinition } from '../../engine/index.js'
 import type { Resolvable } from '../../engine/types.js'
+import type { LLMThinkingConfig } from '../../engine/llm-adapter-types.js'
 import { SessionTree } from '../session-tree.js'
 import { OutputLog } from '../output-log.js'
 import { AsyncMutex } from '../async-mutex.js'
@@ -1574,6 +1575,7 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     maxTokens?: number
     contextWindowTokens?: number
     supportsVision?: boolean
+    thinking?: LLMThinkingConfig
     timezone?: string
   } {
     return {
@@ -1586,6 +1588,7 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
       ...(builtin.maxTokens !== undefined ? { maxTokens: builtin.maxTokens } : {}),
       ...(builtin.contextWindowTokens !== undefined ? { contextWindowTokens: builtin.contextWindowTokens } : {}),
       ...(builtin.supportsVision !== undefined ? { supportsVision: builtin.supportsVision } : {}),
+      ...(builtin.thinking !== undefined ? { thinking: builtin.thinking } : {}),
       ...(builtin.timezone !== undefined ? { timezone: builtin.timezone } : {}),
     }
   }

--- a/crabot-agent/src/workers/builtin/subagent-runner.ts
+++ b/crabot-agent/src/workers/builtin/subagent-runner.ts
@@ -2,6 +2,7 @@ import { randomBytes } from 'node:crypto'
 import { promises as fs } from 'node:fs'
 import path from 'node:path'
 import { createAdapter } from '../../engine/llm-adapter.js'
+import { thinkingParam } from '../../engine/llm-adapter-types.js'
 import { forkEngine } from '../../engine/sub-agent.js'
 import { recordSubAgentTurn } from '../../engine/sub-agent-trace.js'
 import { spawnPersistentAgent } from '../../engine/bg-entities/bg-agent.js'
@@ -142,6 +143,9 @@ export class BuiltinSubagentRunner {
       systemPrompt: childPrompt,
       model: subagent.model.model_id,
       ...(subagent.model.max_tokens !== undefined ? { maxTokens: subagent.model.max_tokens } : {}),
+      ...(thinkingParam(subagent.model.thinking_level, subagent.model.thinking_custom) !== undefined
+        ? { thinking: thinkingParam(subagent.model.thinking_level, subagent.model.thinking_custom) }
+        : {}),
       adapter: createAdapter({
         endpoint: subagent.model.endpoint,
         apikey: subagent.model.apikey,
@@ -282,6 +286,9 @@ export class BuiltinSubagentRunner {
         tools: childTools,
         maxTurns: subagent.max_turns,
         ...(subagent.model.max_tokens !== undefined ? { maxTokens: subagent.model.max_tokens } : {}),
+        ...(thinkingParam(subagent.model.thinking_level, subagent.model.thinking_custom) !== undefined
+          ? { thinking: thinkingParam(subagent.model.thinking_level, subagent.model.thinking_custom) }
+          : {}),
         ...(input.context ? { parentContext: input.context } : {}),
         abortSignal: controller.signal,
         onTurn: (event) => recordSubAgentTurn(this.traceStore, trace.trace_id, event, this.redactText),

--- a/crabot-agent/src/workers/types.ts
+++ b/crabot-agent/src/workers/types.ts
@@ -1,5 +1,6 @@
 import type { ModelFormat } from 'crabot-shared'
 import type { ToolDefinition, LLMAdapter } from '../engine/index.js'
+import type { LLMThinkingConfig } from '../engine/llm-adapter-types.js'
 import type { Resolvable } from '../engine/types.js'
 // 纯类型引用(两侧都是 `import type`,编译后无运行时依赖,不构成模块环)。
 import type { LedgerWorker } from './harness/ledger-types.js'
@@ -297,6 +298,8 @@ export interface SpawnSpec {
     readonly maxTokens?: number
     readonly contextWindowTokens?: number
     readonly supportsVision?: boolean
+    /** 槽位思考强度（2026-08）；缺省 = 跟随模型默认 */
+    readonly thinking?: LLMThinkingConfig
     /** IANA 时区名,用于 tool_result 时间戳渲染 */
     readonly timezone?: string
   }

--- a/crabot-agent/tests/engine/thinking-mapping.test.ts
+++ b/crabot-agent/tests/engine/thinking-mapping.test.ts
@@ -1,0 +1,195 @@
+/**
+ * 槽位思考强度 → 各 adapter 请求参数映射（spec 2026-08 §5.2 映射表逐格断言）。
+ *
+ * 契约：跟随默认（无 thinking）时请求与现状逐字节等价（不发任何思考参数；
+ * Codex 保持硬编码 effort='medium'）；off/低中高/自定义按 format 映射；
+ * 不支持档位由 Provider 400 兜底，adapter 不做运行时降级。
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { AnthropicAdapter } from '../../src/engine/anthropic-adapter'
+import { OpenAIAdapter } from '../../src/engine/openai-adapter'
+import { OpenAIResponsesAdapter } from '../../src/engine/openai-responses-adapter'
+import { thinkingParam, thinkingEffortValue, type LLMThinkingConfig } from '../../src/engine/llm-adapter-types'
+
+// --- helpers ---
+
+function sseResponse(text: string): Response {
+  const encoder = new TextEncoder()
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode(text))
+      controller.close()
+    },
+  })
+  return new Response(body, { status: 200 })
+}
+
+/** mock 全局 fetch，跑一次 streamOnce，返回发出的 JSON 请求体 */
+async function captureBody(
+  adapter: { streamOnce: (p: unknown) => AsyncGenerator<unknown> },
+  params: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const fetchMock = vi.fn(async (_url: unknown, init?: { body?: string }) =>
+    sseResponse('data: [DONE]\n\n'),
+  )
+  vi.stubGlobal('fetch', fetchMock)
+  try {
+    for await (const _ of adapter.streamOnce(params)) {
+      // drain
+    }
+  } catch {
+    // 空流的收尾处理差异不影响请求体断言
+  }
+  expect(fetchMock).toHaveBeenCalledTimes(1)
+  const init = fetchMock.mock.calls[0][1] as { body: string }
+  return JSON.parse(init.body)
+}
+
+// --- 共享 helper 单测 ---
+
+describe('thinking helpers', () => {
+  it('thinkingParam：两字段缺省返回 undefined（跟随默认）', () => {
+    expect(thinkingParam(undefined, undefined)).toBeUndefined()
+    expect(thinkingParam('high', undefined)).toEqual({ level: 'high' })
+    expect(thinkingParam(undefined, 8192)).toEqual({ custom: 8192 })
+  })
+
+  it('thinkingEffortValue：off→none、档位字面量、自定义字符串透传、数字不适用', () => {
+    expect(thinkingEffortValue(undefined)).toBeUndefined()
+    expect(thinkingEffortValue({ level: 'off' })).toBe('none')
+    expect(thinkingEffortValue({ level: 'medium' })).toBe('medium')
+    expect(thinkingEffortValue({ custom: 'xhigh' })).toBe('xhigh')
+    expect(thinkingEffortValue({ custom: 8192 })).toBeUndefined()
+  })
+})
+
+// --- anthropic 映射 ---
+
+describe('anthropic adapter thinking mapping', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  async function capture(thinking: LLMThinkingConfig | undefined): Promise<Record<string, unknown>> {
+    const adapter = new AnthropicAdapter({ endpoint: 'https://example.test', apikey: 'k' })
+    const fakeStream = {
+      abort: vi.fn(),
+      finalMessage: vi.fn().mockResolvedValue({ stop_reason: 'end_turn', usage: {} }),
+      [Symbol.asyncIterator]: async function* () {
+        yield { type: 'message_start', message: { id: 'm' } }
+      },
+    }
+    vi.spyOn((adapter as unknown as { client: { messages: { stream: unknown } } }).client.messages, 'stream')
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .mockReturnValue(fakeStream as any)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const gen = (adapter as unknown as { streamOnce: (p: unknown) => AsyncGenerator<unknown> }).streamOnce({
+      messages: [],
+      systemPrompt: 's',
+      tools: [],
+      model: 'claude-x',
+      thinking,
+    })
+    for await (const _ of gen) { /* drain */ }
+    const streamSpy = (adapter as unknown as { client: { messages: { stream: ReturnType<typeof vi.fn> } } }).client.messages.stream
+    return (streamSpy.mock.calls[0][0]) as Record<string, unknown>
+  }
+
+  it('跟随默认：不发 thinking / output_config', async () => {
+    const body = await capture(undefined)
+    expect(body.thinking).toBeUndefined()
+    expect(body.output_config).toBeUndefined()
+  })
+
+  it('off → thinking:{type:"disabled"}', async () => {
+    const body = await capture({ level: 'off' })
+    expect(body.thinking).toEqual({ type: 'disabled' })
+  })
+
+  it('low/medium/high → output_config:{effort}', async () => {
+    expect((await capture({ level: 'low' })).output_config).toEqual({ effort: 'low' })
+    expect((await capture({ level: 'medium' })).output_config).toEqual({ effort: 'medium' })
+    expect((await capture({ level: 'high' })).output_config).toEqual({ effort: 'high' })
+  })
+
+  it('自定义字符串 → output_config:{effort:原样透传}', async () => {
+    expect((await capture({ custom: 'xhigh' })).output_config).toEqual({ effort: 'xhigh' })
+  })
+
+  it('自定义数字 → thinking:{type:"enabled",budget_tokens}', async () => {
+    const body = await capture({ custom: 8192 })
+    expect(body.thinking).toEqual({ type: 'enabled', budget_tokens: 8192 })
+  })
+})
+
+// --- openai (chat) 映射 ---
+
+describe('openai adapter thinking mapping', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  async function capture(thinking: LLMThinkingConfig | undefined): Promise<Record<string, unknown>> {
+    const adapter = new OpenAIAdapter({ endpoint: 'https://api.example.test/v1', apikey: 'k' })
+    return captureBody(
+      adapter as unknown as { streamOnce: (p: unknown) => AsyncGenerator<unknown> },
+      { messages: [], systemPrompt: 's', tools: [], model: 'gpt-x', thinking },
+    )
+  }
+
+  it('跟随默认：不发 reasoning_effort', async () => {
+    expect((await capture(undefined)).reasoning_effort).toBeUndefined()
+  })
+
+  it('off → reasoning_effort:"none"；low/medium/high 字面量', async () => {
+    expect((await capture({ level: 'off' })).reasoning_effort).toBe('none')
+    expect((await capture({ level: 'low' })).reasoning_effort).toBe('low')
+    expect((await capture({ level: 'high' })).reasoning_effort).toBe('high')
+  })
+
+  it('自定义字符串原样透传（如 minimal / xhigh）', async () => {
+    expect((await capture({ custom: 'minimal' })).reasoning_effort).toBe('minimal')
+    expect((await capture({ custom: 'xhigh' })).reasoning_effort).toBe('xhigh')
+  })
+})
+
+// --- openai-responses 映射 ---
+
+describe('openai-responses adapter thinking mapping', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  async function capture(thinking: LLMThinkingConfig | undefined, codex = false): Promise<Record<string, unknown>> {
+    const endpoint = codex
+      ? 'https://chatgpt.com/backend-api/codex'
+      : 'https://api.openai.com/v1'
+    const adapter = new OpenAIResponsesAdapter({ endpoint, apikey: 'k' })
+    return captureBody(
+      adapter as unknown as { streamOnce: (p: unknown) => AsyncGenerator<unknown> },
+      { messages: [], systemPrompt: 's', tools: [], model: 'gpt-x', thinking },
+    )
+  }
+
+  it('Codex 跟随默认：保持现状 effort=medium', async () => {
+    const body = await capture(undefined, true)
+    expect(body.reasoning).toEqual({ effort: 'medium', summary: 'auto' })
+  })
+
+  it('Codex 配置档位：覆盖 effort，summary 保持 auto', async () => {
+    expect((await capture({ level: 'high' }, true)).reasoning).toEqual({ effort: 'high', summary: 'auto' })
+    expect((await capture({ level: 'off' }, true)).reasoning).toEqual({ effort: 'none', summary: 'auto' })
+  })
+
+  it('官方 Responses 跟随默认：不发 reasoning', async () => {
+    expect((await capture(undefined)).reasoning).toBeUndefined()
+  })
+
+  it('官方 Responses 配置档位：reasoning:{effort}', async () => {
+    expect((await capture({ level: 'low' })).reasoning).toEqual({ effort: 'low' })
+    expect((await capture({ custom: 'max' })).reasoning).toEqual({ effort: 'max' })
+  })
+})

--- a/crabot-agent/tests/manager/model-slot.test.ts
+++ b/crabot-agent/tests/manager/model-slot.test.ts
@@ -6,26 +6,19 @@ function makeConnInfo(model_id: string): LLMConnectionInfo {
   return { endpoint: 'https://example.test', apikey: 'k', model_id, format: 'anthropic' }
 }
 
-describe('resolveManagerModelConfig（protocol-agent-v3.md §11）', () => {
-  it('有 manager slot：直接用它，不看 powerful', () => {
-    const managerConn = makeConnInfo('manager-model')
-    const powerfulConn = makeConnInfo('powerful-model')
-    const resolved = resolveManagerModelConfig({ manager: managerConn, powerful: powerfulConn })
-    expect(resolved).toBe(managerConn)
-  })
-
-  it('只有 powerful：回退用它', () => {
+describe('resolveManagerModelConfig（protocol-agent-v3.md §11；2026-08 槽位收敛）', () => {
+  it('manager 直接使用 powerful slot（manager 槽位已移除）', () => {
     const powerfulConn = makeConnInfo('powerful-model')
     const resolved = resolveManagerModelConfig({ powerful: powerfulConn })
     expect(resolved).toBe(powerfulConn)
   })
 
-  it('manager 和 powerful 都没有：报明确错误', () => {
-    expect(() => resolveManagerModelConfig({})).toThrow(/manager/)
+  it('powerful 和 vision 都没有：报明确错误', () => {
+    expect(() => resolveManagerModelConfig({})).toThrow(/powerful/)
     expect(() => resolveManagerModelConfig({ vision: makeConnInfo('v') })).toThrow(/powerful/)
   })
 
   it('model_config 整体为 undefined：同样报明确错误，不抛无关的 TypeError', () => {
-    expect(() => resolveManagerModelConfig(undefined)).toThrow(/manager/)
+    expect(() => resolveManagerModelConfig(undefined)).toThrow(/powerful/)
   })
 })

--- a/crabot-agent/tests/manager/p5-integration.test.ts
+++ b/crabot-agent/tests/manager/p5-integration.test.ts
@@ -201,7 +201,6 @@ describe('P5 集成：manager 栈启动接线（Task 6）', () => {
 
   function boot(modelConfig: Record<string, LLMConnectionInfo> = {
     powerful: connInfo('powerful-model-x'),
-    manager: connInfo('manager-model-x'),
   }): void {
     agent = new UnifiedAgent(makeConfig(modelConfig))
     internals = agent as unknown as AgentInternals
@@ -316,26 +315,22 @@ describe('P5 集成：manager 栈启动接线（Task 6）', () => {
     expect(after).not.toContain('send_master_private')
   })
 
-  // --- ⑤ §11 manager slot 与降级路径 ---
+  // --- ⑤ §11 manager 模型解析与降级路径（2026-08 收敛：manager 直接用 powerful） ---
 
-  it('§11 manager slot：manager 优先，缺失回退 powerful', () => {
-    boot({ manager: connInfo('manager-model-x'), powerful: connInfo('powerful-model-y') })
-    const withManager = internals.managerStack as unknown as { registry: { deps: { model: () => string } } }
-    expect(withManager.registry.deps.model()).toBe('manager-model-x')
-
+  it('manager 直接使用 powerful slot（manager 槽位已移除）', () => {
     boot({ powerful: connInfo('powerful-model-y') })
-    const fallback = internals.managerStack as unknown as { registry: { deps: { model: () => string } } }
-    expect(fallback.registry.deps.model()).toBe('powerful-model-y')
+    const stack = internals.managerStack as unknown as { registry: { deps: { model: () => string } } }
+    expect(stack.registry.deps.model()).toBe('powerful-model-y')
   })
 
-  it('降级：两个 slot 都没配（现网此刻的状态）时 agent 照常构造，读模型四件套照常可用，只有 LLM 解析在被用到时才抛', async () => {
+  it('降级：powerful 也没配时 agent 照常构造，读模型四件套照常可用，只有 LLM 解析在被用到时才抛', async () => {
     boot({})
 
     expect(internals.managerStack).toBeDefined()
     await expect(rpc('list_workers_admin', {})).resolves.toBeDefined()
 
     const deps = (internals.managerStack as unknown as { registry: { deps: { model: () => string } } }).registry.deps
-    expect(() => deps.model()).toThrow(/model_config 缺少 'manager' 与 'powerful'/)
+    expect(() => deps.model()).toThrow(/model_config 缺少 'powerful'/)
   })
 
   // --- ② trigger_schedule → 系统线程 manager ---


### PR DESCRIPTION
## 概要

实现 [spec：模型槽位收敛 + 上下文窗口配置 + 槽位思考强度配置](https://github.com/smilefufu/crabot-docs/blob/main/superpowers/specs/2026-08-28-model-context-thinking-config-design.md)（已确认，crabot-docs commit e4bc1da）。协议文档先行更新（base-protocol 0.2.3 / protocol-admin 0.2.6 / protocol-agent-v3 3.1.2，crabot-docs commit eeba0c8）。

三个 commit，各自独立可审：

| Commit | 内容 | spec 依据 |
|---|---|---|
| bb2d8695 | 槽位收敛：ModelRole 4→2（vision/manager 移除），Manager loop 直接用 powerful，research_collector 归 cost_effective，存量引用丢弃 + subagent model_role 归一化（幂等） | §3 |
| 57dbf5db | 思考强度全链路：AgentInstanceConfig.thinking（独立 map）→ 保存校验 → handleGetAgentConfig 附加（强度跟 slot 走）→ agent 透传链 → 三 adapter 请求映射 | §4/§5 |
| 834b3bf3 | Web UI：详情抽屉上下文列内联编辑；Agent 配置页思考下拉（跟随默认/关闭/低/中/高/自定义透传，placeholder 按 format）；SubagentEditor 删 vision 选项 | §6/§7 |

## 关键语义（review 重点）

- **跟随默认 = 零变化**：两 thinking 字段均缺省时请求与现状逐字节等价；Codex 硬编码 `effort:'medium'` 保留为该 backend 默认行为，配置档位才覆盖（spec §5.2）。
- **强度跟 slot 走**：thinking 与 models 两 map 独立，槽位未配模型（回落全局默认）时 thinking 仍生效；`handleGetAgentConfig` 附加、原始 map 剥离不下发。
- **不做运行时降级**：档位与模型不匹配 → Provider 400 上抛，用户改档自愈（已确认的产品契约）。
- **manager thinking 与 model 同点解析**：episode 内 `runEpisodeBody` 与 adapter/model 同步解析（§11 热更快照语义），不在 `getOrCreate` 急切求值——缺 powerful 时不在唤醒路径抛错（首次实现踩了这点，已修正并有测试覆盖对应场景）。

## 新增失败路径及收口（CLAUDE.md 要求逐条声明）

1. **档位×模型不匹配（Provider 400）**：不可重试错误照常上抛失败，不静默降级；trace 可见，用户回 Admin 改档即恢复。
2. **backup import preflight 白名单收敛为 2 key**：旧备份含 vision/manager key 时 fail-loud 拒绝（报错指明 key），与 update REST 400 契约一致；Phase 5 legacy key 当时同样处理。
3. **subagent model_role 归一化的落盘**：只置既有 `needsLegacyRewrite` 标记，由生产启动序列 `index.ts:945 seedBuiltin`（既有 flush 点）写入，无新写路径；幂等有测试。
4. **前端拦截**：自定义思考值为空、上下文非正整数在前端拦截，不打到后端。

## 验证

- 新增单测 41 例：thinking-mapping 14（映射表逐格 + Codex 默认保持）、agent-config-thinking 6、handle-get-agent-config 附加/剥离 3、ProviderDrawerDetail.ctx 4、AgentConfig.thinking 3、SubagentEditor 1、迁移/归一化 10。
- 构建：shared/core/channels/admin/agent/web 全绿。
- 测试说明：worktree 全量并行下 admin/agent 有若干失败，逐个甄别后全部为 **main 既有失败**（v1-cleanup、load-data-repair、cutover-ingress、WorkersView 等，主仓复现）或**负载 flaky**（manager-integration 场景一、harness-lifecycle、builtin-injection、coherent-read 等，单跑稳定通过）。

## 待办（不阻塞合并前 review，合并后跟进）

- spec §9 手工验收三项（真实 provider effort 生效 / 128K compaction 提前 / 存量迁移演练）需在跑起来的实例上验证。
- follow-up 候选见 spec §12（Reasoning badge 防呆、max_tokens UI、subagent 独立 thinking、Gemini 2.5 数字 budget 通道）。