### PR TITLE
fix(worker): finish_task 终态守卫——名下仍有 running bg entity 时打回续 burst

### DIFF
--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -320,6 +320,8 @@ function buildBuiltinWorkerContractPrompt(workspaceRoot: string): string {
     + '你会停下来等待下一条输入。',
     '- 任务完成或确认失败时调用 `finish_task`（`outcome` 取 `completed` 或 `failed`，`summary` 一句话）。'
     + '这是你唯一的终态信号——不调用它，你只是停下来等下一条输入。',
+    '- 还有后台命令或子 Agent 在运行时，任务没有结束——直接结束本轮等它们的完成通知，'
+    + '不要调用 `finish_task`；等全部结束后再收尾。',
   ].join('\n')
 }
 
@@ -3906,6 +3908,9 @@ export class UnifiedAgent extends ModuleBase {
           console.warn(`[${this.config.moduleId}] builtin subagent stop failed for ${workerId}:`, error)
         })
       },
+      // finish_task 终态守卫(拆分 spec 2026-08-28 修订)的查询口径与 harness deps 的
+      // hasRunningBg 相同:bg-shell 与 subagent 都注册在 bg registry、按 owner.worker_id 归属。
+      hasRunningBgEntities: (workerId) => this.agentHandler?.hasRunningBgForWorker(workerId) ?? Promise.resolve(false),
     }
   }
 

--- a/crabot-agent/src/workers/builtin/adapter.ts
+++ b/crabot-agent/src/workers/builtin/adapter.ts
@@ -168,6 +168,12 @@ const FINISH_TASK_TOOL: ToolDefinition = {
   exitsLoop: true,
 }
 
+/** finish_task 被终态守卫打回时注入会话的系统提醒(拆分 spec 2026-08-28 修订)。 */
+const FINISH_TASK_REJECTED_NOTICE = [
+  '[finish_task 未生效] 仍有正在运行的后台命令或子 Agent，任务此刻不能结束。',
+  '请继续等待它们的完成通知；若确认某个子任务不再需要，先用 Kill 结束它，再重新调用 finish_task。',
+].join('')
+
 interface WorkerInstance {
   readonly worker_id: string
   readonly incarnation_id?: string
@@ -281,6 +287,11 @@ export interface BuiltinTraceHooks {
   appendTurn(traceId: string, event: import('../../engine/types.js').EngineTurnEvent): void
   finishIncarnationTrace(traceId: string, patch: { status: 'completed' | 'failed'; summary: string }): void
   stopWorkerSubagents?(workerId: string): void
+  /**
+   * 该 worker 名下是否仍有 running 的 bg entity(bg-shell / subagent),供 finish_task
+   * 终态守卫查询(拆分 spec 2026-08-28 修订)。缺省视为无,守卫静默关闭。
+   */
+  hasRunningBgEntities?(workerId: string): Promise<boolean>
 }
 
 export interface BuiltinTraceReader {
@@ -1142,6 +1153,20 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
       }
 
       if (result.exitToolCall?.name === 'finish_task') {
+        // 终态守卫(拆分 spec 2026-08-28 修订):名下仍有 running bg entity(bg-shell /
+        // subagent)时 finish_task 不落终态——否则化身 exited 会连带终止还在跑的 subagent,
+        // 其完成通知又被 killed 状态静默丢弃,worker 以 end_turn 等待结果的那条路就被这条
+        // 终态出口整体绕过。此处以系统提醒打回并原地续 burst;fork 化身不装配 finish_task,
+        // 查询条件与 transitionExited 的杀因条件(query_id === undefined)保持一致。
+        const bgEntityRunning = handle.query_id === undefined &&
+          (await this.deps.traceHooks?.hasRunningBgEntities?.(instance.worker_id)) === true
+        if (bgEntityRunning) {
+          const notice = createUserMessage(FINISH_TASK_REJECTED_NOTICE)
+          const noticeTip = await instance.sessionTree.append(instance.tip, notice)
+          instance.tip = noticeTip
+          this.setEngineMessagesSnapshot(instance, [...result.finalMessages, notice], noticeTip)
+          return true
+        }
         const rawOutcome = result.exitToolCall.input.outcome
         const outcome: 'completed' | 'failed' = rawOutcome === 'failed' ? 'failed' : 'completed'
         // summary 是 finish_task 的**必填**入参（见 FINISH_TASK_TOOL 的 inputSchema.required），

--- a/crabot-agent/src/workers/builtin/adapter.ts
+++ b/crabot-agent/src/workers/builtin/adapter.ts
@@ -53,7 +53,7 @@ import { join } from 'path'
 import { randomUUID } from 'crypto'
 import { isDeepStrictEqual } from 'node:util'
 import { runEngine, defineTool, createUserMessage } from '../../engine/index.js'
-import type { EngineMessage, EngineMessagesRef, EngineResult, ToolDefinition } from '../../engine/index.js'
+import type { EngineMessage, EngineMessagesRef, EngineResult, EngineToolResultMessage, ToolDefinition } from '../../engine/index.js'
 import type { Resolvable } from '../../engine/types.js'
 import type { LLMThinkingConfig } from '../../engine/llm-adapter-types.js'
 import { SessionTree } from '../session-tree.js'
@@ -168,11 +168,10 @@ const FINISH_TASK_TOOL: ToolDefinition = {
   exitsLoop: true,
 }
 
-/** finish_task 被终态守卫打回时注入会话的系统提醒(拆分 spec 2026-08-28 修订)。 */
-const FINISH_TASK_REJECTED_NOTICE = [
-  '[finish_task 未生效] 仍有正在运行的后台命令或子 Agent，任务此刻不能结束。',
-  '请继续等待它们的完成通知；若确认某个子任务不再需要，先用 Kill 结束它，再重新调用 finish_task。',
-].join('')
+/** finish_task 被终态守卫打回时,作为失败 tool_result 内容回给 worker 的提醒(拆分 spec 2026-08-28 修订)。 */
+const FINISH_TASK_REJECTED_NOTICE =
+  '[finish_task 未生效] 仍有正在运行的后台命令或子 Agent，任务此刻不能结束。' +
+  '请继续等待它们的完成通知；若确认某个子任务不再需要，先用 Kill 结束它，再重新调用 finish_task。'
 
 interface WorkerInstance {
   readonly worker_id: string
@@ -1078,7 +1077,7 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     // 用 `result.finalText` 不行：finish_task 这类早退工具收场时它可能为空串，而那恰恰是
     // manager 最需要看到的一轮。
     let lastAssistantText = ''
-    const result: EngineResult = await runEngine({
+    let result: EngineResult = await runEngine({
       prompt: '',
       adapter: builtin.adapter,
       initialMessages,
@@ -1138,6 +1137,23 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     // 期间新 sendInput 插队"的窗口——判定与状态落定必须是同一个不可分割的临界区。
     // 续 burst 的递归调用放在锁外触发（见下），不然会把 runEngine 的执行时长堵在锁里。
     const continueBurst = await mutex.run(async () => {
+      // finish_task 终态守卫(拆分 spec 2026-08-28 修订):名下仍有 running bg entity
+      // (bg-shell / subagent)时 finish_task 不落终态——否则化身 exited 会连带终止还在跑的
+      // subagent,其完成通知又被 killed 状态静默丢弃,worker 以 end_turn 等待结果的那条路
+      // 就被这条终态出口整体绕过。判定必须在 writeBack 之前:打回时要先把 engine 为
+      // exitsLoop 合成的成功 tool_result 改写成"失败 + 提醒"(协议 §5.1/§6.4),树和下一轮
+      // 上下文都从 finalMessages 落。fork 化身不装配 finish_task,查询条件与 transitionExited
+      // 的杀因条件(query_id === undefined)一致;aborted/failed 优先级更高,与下方分支顺序一致。
+      let finishTaskRejected = false
+      if (
+        result.outcome !== 'aborted' && result.outcome !== 'failed' &&
+        result.exitToolCall?.name === 'finish_task' && handle.query_id === undefined
+      ) {
+        finishTaskRejected =
+          (await this.deps.traceHooks?.hasRunningBgEntities?.(instance.worker_id)) === true
+        if (finishTaskRejected) result = this.markFinishTaskRejected(result)
+      }
+
       await this.writeBack(instance, tip, result, initialMessages.length, compactedThisBurst)
 
       if (result.outcome === 'aborted' && instance.interruptRequested && !instance.killRequested) {
@@ -1153,18 +1169,12 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
       }
 
       if (result.exitToolCall?.name === 'finish_task') {
-        // 终态守卫(拆分 spec 2026-08-28 修订):名下仍有 running bg entity(bg-shell /
-        // subagent)时 finish_task 不落终态——否则化身 exited 会连带终止还在跑的 subagent,
-        // 其完成通知又被 killed 状态静默丢弃,worker 以 end_turn 等待结果的那条路就被这条
-        // 终态出口整体绕过。此处以系统提醒打回并原地续 burst;fork 化身不装配 finish_task,
-        // 查询条件与 transitionExited 的杀因条件(query_id === undefined)保持一致。
-        const bgEntityRunning = handle.query_id === undefined &&
-          (await this.deps.traceHooks?.hasRunningBgEntities?.(instance.worker_id)) === true
-        if (bgEntityRunning) {
-          const notice = createUserMessage(FINISH_TASK_REJECTED_NOTICE)
-          const noticeTip = await instance.sessionTree.append(instance.tip, notice)
-          instance.tip = noticeTip
-          this.setEngineMessagesSnapshot(instance, [...result.finalMessages, notice], noticeTip)
+        // 守卫打回:先排空本 burst 收尾期间排队的输入(bg 完成通知恰恰是让 worker 停止
+        // 重试 finish_task 的信息;immediate_redirect 不走 interrupt(builtin 例外),全靠
+        // 这个收尾排空点投递),无论队列空不空都必须续 burst——worker 要对上一条"失败的
+        // finish_task tool_result"重新作出决策。
+        if (finishTaskRejected) {
+          await this.drainQueuedInputs(instance)
           return true
         }
         const rawOutcome = result.exitToolCall.input.outcome
@@ -1205,19 +1215,7 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
       // end_turn（或 max_turns 耗尽）→ 若 sendInput 排了队，逐条 append 后原地续 burst
       // （不经过可见的 idle 态）；否则转 idle，等待下一次 resume/sendInput 唤醒。
       if (instance.pendingImmediateInputs.length > 0 || instance.pendingInputs.length > 0) {
-        const queued = [
-          ...instance.pendingImmediateInputs.splice(0, instance.pendingImmediateInputs.length),
-          ...instance.pendingInputs.splice(0, instance.pendingInputs.length),
-        ]
-        const queuedMessages = this.messagesAtTip(instance, instance.tip)
-        let queueParent = instance.tip
-        for (const text of queued) {
-          const queuedMessage = createUserMessage(text)
-          queueParent = await instance.sessionTree.append(queueParent, queuedMessage)
-          queuedMessages.push(queuedMessage)
-        }
-        instance.tip = queueParent
-        this.setEngineMessagesSnapshot(instance, queuedMessages, queueParent)
+        await this.drainQueuedInputs(instance)
         return true
       }
 
@@ -1481,6 +1479,49 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     const messages = instance.sessionTree.pathTo(tip)
     this.setEngineMessagesSnapshot(instance, messages, tip)
     return messages
+  }
+
+  /**
+   * 把 sendInput 在 burst 运行期间排队的输入（immediate_redirect 优先，然后普通队列）append
+   * 进会话树并刷新 snapshot，供收尾段续 burst 时消费；队列全空时 no-op。返回排空的条数。
+   */
+  private async drainQueuedInputs(instance: WorkerInstance): Promise<number> {
+    if (instance.pendingImmediateInputs.length === 0 && instance.pendingInputs.length === 0) return 0
+    const queued = [
+      ...instance.pendingImmediateInputs.splice(0, instance.pendingImmediateInputs.length),
+      ...instance.pendingInputs.splice(0, instance.pendingInputs.length),
+    ]
+    const queuedMessages = this.messagesAtTip(instance, instance.tip)
+    let queueParent = instance.tip
+    for (const text of queued) {
+      const queuedMessage = createUserMessage(text)
+      queueParent = await instance.sessionTree.append(queueParent, queuedMessage)
+      queuedMessages.push(queuedMessage)
+    }
+    instance.tip = queueParent
+    this.setEngineMessagesSnapshot(instance, queuedMessages, queueParent)
+    return queued.length
+  }
+
+  /**
+   * 守卫打回 finish_task 时,把 engine 为 exitsLoop 合成的成功 tool_result（`[exit_tool]`,
+   * is_error=false）改写为"失败 + 提醒文案"（协议 §5.1/§6.4:调用方收到失败 tool_result 与
+   * 提醒）。树和下一轮上下文都从 finalMessages 落,所以收尾段必须在 writeBack 前调用它。
+   * 只改写 exitsLoop 工具的条目(content === '[exit_tool]');同轮其他工具是 [skipped...],不动。
+   */
+  private markFinishTaskRejected(result: EngineResult): EngineResult {
+    const last = result.finalMessages[result.finalMessages.length - 1]
+    if (last === undefined || !('toolResults' in last)) return result
+    const rewrittenLast: EngineToolResultMessage = {
+      ...last,
+      toolResults: last.toolResults.map((r) =>
+        r.content === '[exit_tool]' ? { ...r, content: FINISH_TASK_REJECTED_NOTICE, is_error: true } : r,
+      ),
+    }
+    return {
+      ...result,
+      finalMessages: [...result.finalMessages.slice(0, -1), rewrittenLast],
+    }
   }
 
   private setEngineMessagesSnapshot(

--- a/crabot-agent/tests/workers/builtin-adapter.test.ts
+++ b/crabot-agent/tests/workers/builtin-adapter.test.ts
@@ -892,6 +892,77 @@ describe('BuiltinWorkerAdapter', () => {
     expect(exited!.report?.endReason).toBe('completed')
   })
 
+  it('finish_task 终态守卫:名下仍有 running bg entity → 打回续 burst,等待后 idle(拆分 spec 2026-08-28 修订)', async () => {
+    const seen: Array<{ state: WorkerContractState; report?: StateChangeReport }> = []
+    const stopWorkerSubagents = vi.fn()
+    // 第一次查询(收尾段):subagent 还在跑 → 拒绝;之后返回 false(模拟 subagent 完成)。
+    let bgRunning = true
+    const adapter = new BuiltinWorkerAdapter({
+      dataDir: tmp,
+      onStateChange: (_h, state, report) => {
+        seen.push({ state, ...(report ? { report } : {}) })
+      },
+      traceHooks: {
+        startIncarnationTrace: () => 'trace-1',
+        appendTurn: () => {},
+        finishIncarnationTrace: () => {},
+        stopWorkerSubagents,
+        hasRunningBgEntities: async () => bgRunning,
+      },
+    })
+    const s = spec({
+      adapter: makeAdapter([
+        // 第一轮:subagent 还在跑时 worker 就调 finish_task → 守卫打回。
+        { toolCalls: [{ name: 'finish_task', id: 'call_1', input: { outcome: 'completed', summary: '提前收尾' } }], stopReason: 'tool_use' },
+        // 第二轮:bg entity 已结束,end_turn 正常等待/收尾。
+        { text: '子任务完成,验证通过', stopReason: 'end_turn' },
+      ]),
+    })
+
+    const h = await adapter.spawn(s)
+    await waitState(adapter, h, 'idle')
+    bgRunning = false
+    // 打回后必须续过第二轮 burst:第二轮 end_turn 落 idle,证明第一轮没有按 finish_task 终态化。
+    await adapter.sendInput(h, '继续')
+    await waitState(adapter, h, 'idle')
+
+    const metaRaw = await fs.readFile(join(tmp, s.worker_id, 'meta-1.json'), 'utf-8')
+    const meta = JSON.parse(metaRaw)
+    expect(meta.state).toBe('idle')
+    expect(meta.ended_reason).toBeUndefined()
+    // 从未 exited:没有终态上报,也没有连带杀 subagent。
+    expect(seen.some((e) => e.state === 'exited')).toBe(false)
+    expect(stopWorkerSubagents).not.toHaveBeenCalled()
+    // 会话树里有打回提醒,worker 下一轮能看到。
+    const treeRaw = await fs.readFile(join(tmp, s.worker_id, 'session.jsonl'), 'utf-8')
+    expect(treeRaw).toContain('finish_task 未生效')
+  })
+
+  it('finish_task 终态守卫:bg entity 全部结束后调用 → 正常 exited(completed)', async () => {
+    const adapter = new BuiltinWorkerAdapter({
+      dataDir: tmp,
+      traceHooks: {
+        startIncarnationTrace: () => 'trace-1',
+        appendTurn: () => {},
+        finishIncarnationTrace: () => {},
+        hasRunningBgEntities: async () => false,
+      },
+    })
+    const s = spec({
+      adapter: makeAdapter([
+        { toolCalls: [{ name: 'finish_task', id: 'call_1', input: { outcome: 'completed', summary: '搞定了' } }], stopReason: 'tool_use' },
+      ]),
+    })
+
+    const h = await adapter.spawn(s)
+    await waitState(adapter, h, 'exited')
+
+    const metaRaw = await fs.readFile(join(tmp, s.worker_id, 'meta-1.json'), 'utf-8')
+    const meta = JSON.parse(metaRaw)
+    expect(meta.state).toBe('exited')
+    expect(meta.outcome).toBe('completed')
+  })
+
   it('engine 抛错 → exited(crashed)', async () => {
     const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
     const s = spec({ adapter: throwingAdapter() })

--- a/crabot-agent/tests/workers/builtin-adapter.test.ts
+++ b/crabot-agent/tests/workers/builtin-adapter.test.ts
@@ -963,6 +963,97 @@ describe('BuiltinWorkerAdapter', () => {
     expect(meta.outcome).toBe('completed')
   })
 
+  it('守卫打回时以失败 tool_result 回给 worker(engine 合成的 [exit_tool] 被改写)', async () => {
+    const gate = deferred<void>()
+    let callNumber = 0
+    const adapter = new BuiltinWorkerAdapter({
+      dataDir: tmp,
+      traceHooks: {
+        startIncarnationTrace: () => 'trace-1',
+        appendTurn: () => {},
+        finishIncarnationTrace: () => {},
+        hasRunningBgEntities: async () => true,
+      },
+    })
+    const s = spec({
+      adapter: {
+        stream: vi.fn((_params: LLMStreamParams) => {
+          const currentCall = callNumber++
+          return (async function* () {
+            if (currentCall === 0) await gate
+            const r = currentCall === 0
+              ? { toolCalls: [{ name: 'finish_task', id: 'call_1', input: { outcome: 'completed', summary: '收尾' } }], stopReason: 'tool_use' as const }
+              : { text: '继续等待', stopReason: 'end_turn' as const }
+            const content: unknown[] = []
+            if ('text' in r && r.text) content.push({ type: 'text', text: r.text })
+            for (const tc of r.toolCalls ?? []) content.push({ type: 'tool_use', id: tc.id, name: tc.name, input: tc.input })
+            yield* chunksFromContent(content, r.stopReason, { inputTokens: 10, outputTokens: 5 })
+          })()
+        }),
+        updateConfig: () => {},
+      } as unknown as LLMAdapter,
+    })
+
+    const h = await adapter.spawn(s)
+    gate.resolve()
+    await waitState(adapter, h, 'idle')
+
+    // 落树的是 finish_task 的失败 tool_result(含提醒文案),不再是成功的 [exit_tool]。
+    const treeRaw = await fs.readFile(join(tmp, s.worker_id, 'session.jsonl'), 'utf-8')
+    expect(treeRaw).toContain('finish_task 未生效')
+    expect(treeRaw).toContain('"is_error":true')
+    expect(treeRaw).not.toContain('[exit_tool]')
+  })
+
+  it('守卫打回时排空收尾期间排队的输入:immediate_redirect 先于普通输入进下一轮上下文', async () => {
+    const gate = deferred<void>()
+    let callNumber = 0
+    const messageSnapshots: LLMStreamParams[] = []
+    const adapter = new BuiltinWorkerAdapter({
+      dataDir: tmp,
+      traceHooks: {
+        startIncarnationTrace: () => 'trace-1',
+        appendTurn: () => {},
+        finishIncarnationTrace: () => {},
+        hasRunningBgEntities: async () => true,
+      },
+    })
+    const s = spec({
+      adapter: {
+        stream: vi.fn((_params: LLMStreamParams) => {
+          messageSnapshots.push({ ..._params, messages: [..._params.messages], tools: [..._params.tools] })
+          const currentCall = callNumber++
+          return (async function* () {
+            if (currentCall === 0) await gate
+            const r = currentCall === 0
+              ? { toolCalls: [{ name: 'finish_task', id: 'call_1', input: { outcome: 'completed', summary: '收尾' } }], stopReason: 'tool_use' as const }
+              : { text: '收到,继续', stopReason: 'end_turn' as const }
+            const content: unknown[] = []
+            if ('text' in r && r.text) content.push({ type: 'text', text: r.text })
+            for (const tc of r.toolCalls ?? []) content.push({ type: 'tool_use', id: tc.id, name: tc.name, input: tc.input })
+            yield* chunksFromContent(content, r.stopReason, { inputTokens: 10, outputTokens: 5 })
+          })()
+        }),
+        updateConfig: () => {},
+      } as unknown as LLMAdapter,
+    })
+
+    const h = await adapter.spawn(s)
+    // 第一轮 LLM 挂起期间(worker running)排队:immediate_redirect 必须先于普通输入被消费。
+    await adapter.sendInput(h, '普通排队输入')
+    await adapter.sendInput(h, '立即改向输入', { immediate_redirect: true })
+    gate.resolve()
+    await waitState(adapter, h, 'idle')
+
+    const second = messageSnapshots[1]
+    expect(second).toBeDefined()
+    const joined = JSON.stringify(second!.messages)
+    expect(joined).toContain('finish_task 未生效')
+    expect(joined).toContain('普通排队输入')
+    expect(joined).toContain('立即改向输入')
+    expect(joined.indexOf('立即改向输入')).toBeLessThan(joined.indexOf('普通排队输入'))
+  })
+
   it('engine 抛错 → exited(crashed)', async () => {
     const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
     const s = spec({ adapter: throwingAdapter() })


### PR DESCRIPTION
## 背景

现网事故(2026-08-28,manager `feishu-fengyan::2mpxa9jb`,worker `w-8168481b` seq 7):

1. worker 用 `delegate_task` 派出 code_writer subagent 改 `build_assets.py`;
2. build_assets 后台 shell 失败(exit_code=1),subagent 还在修;
3. worker 此时调 `finish_task(outcome=completed)` → 化身 `exited`,`transitionExited` 首行 `stopWorkerSubagents` 连带终止 subagent,其完成通知又因 registry `killed` 状态被 `onExit` 静默丢弃(`subagent-runner.ts:166-172`);
4. manager 收到 `turn_completed` 后按"等联合验证后再通知" suppress,但 worker 已终态、subagent 已死、巡检对终态 task 跳过——**系统里再无任何事件能唤醒 manager,汇报永久落空**。

根因:finish_task 的终态语义当初只定义了"任务完成或确认失败时调用",未定义与 bg-shell / subagent 共存的行为——worker 以 end_turn 等待 subagent 完成通知的正当路径被这条终态出口整体绕过。

## 设计依据

- 拆分 spec 修订:crabot-docs `2026-07-28-manager-worker-agent-split-design.md` §7.5"2026-08-28 实现遗漏修订"(已提交 docs main b5f7ed1)
- 协议:protocol-agent-v3 **3.1.3**(§5.1 / §6.4 结构化 finalize 守卫)

## 改动

- `adapter.ts` runBurst 收尾段 finish_task 分支:名下仍有 running bg entity(bg-shell / subagent,复用 `hasRunningBgForWorker` 查询口径)时**不落终态**,注入系统提醒并原地续 burst;fork 化身不装配 finish_task,查询条件与 `transitionExited` 杀因条件(`query_id === undefined`)一致。
- `unified-agent.ts`:`BuiltinTraceHooks` 新增可选 `hasRunningBgEntities` 并接线;worker 契约尾巴补"有后台命令/子 Agent 在跑时不要 finish_task"指导(不暴露 harness 机制术语)。
- 语义不变:人工停止(`killed`)的连带终止与完成通知抑制不变(防通知经透明接续复活刚被人工停止的 worker);`crashed` 路径维持现状,是否留活自愈列 follow-up。

## 验证

- `tests/workers/builtin-adapter.test.ts` 新增 2 用例:有 running bg entity 时打回续 burst(断言从未 exited、未调用 `stopWorkerSubagents`、会话树含提醒)、bg entity 全部结束后正常 `exited(completed)`;该文件 62/62 通过。
- `tests/workers/` 全量:870 passed;4 个失败(`workspace-manager`×3、`builtin-injection` tmp 清理 ENOTEMPTY)在**未改动的主仓基线**同样复现,为既有失败,与本 PR 无关。
- `tsc --noEmit` 干净。

## 新增失败路径说明

- 守卫打回的续 burst 与既有 `pendingInputs` 续 burst 同路径,不新增状态机,打回不产生 `onStateChange` 噪音;
- 钩子缺省(旧测试/旧部署)时守卫静默关闭;
- 反复打回的打转风险:提醒文案给出明确出路(等待完成通知 / 先 Kill 再收尾),暂不设次数上限,现网出现打转再收紧。

🤖 Generated with [Claude Code](https://claude.com/claude-code)