### PR TITLE
feat(worker): builtin 输入投递消费点从 burst 边界前移到 turn 边界

### DIFF
--- a/crabot-agent/src/engine/query-loop.ts
+++ b/crabot-agent/src/engine/query-loop.ts
@@ -577,6 +577,7 @@ export async function runEngine(params: RunEngineParams): Promise<EngineResult> 
     const toolResults = await executeToolBatches(batches, currentTools, {
       abortSignal,
       ...(options.timezone ? { timezone: options.timezone } : {}),
+      ...(options.hasPendingExternalInputs ? { hasPendingExternalInput: options.hasPendingExternalInputs } : {}),
     }, options.permissionConfig, hooks)
     // Live progress: tools finished
     if (options.onLiveProgress) {
@@ -663,6 +664,31 @@ export async function runEngine(params: RunEngineParams): Promise<EngineResult> 
         options.onSystemInjection?.({
           type: 'supplement',
           text: typeof content === 'string' ? content : '[ContentBlock[] supplement]',
+          turnNumber: totalTurns,
+          injectedAtMs: Date.now(),
+        })
+      }
+    }
+
+    // ── External input injection (turn boundary) ──
+    // worker inbox 等外部输入源在 turn 边界消费：工具执行完成后、下一轮 LLM 调用前，
+    // drain 回调返回的每条输入作为 user message 注入（取出即从源队列移除，FIFO/优先级/
+    // receipt 结算由 caller 负责）。仅在有剩余 turn 时 drain（最后一轮注入无人消费）。
+    // 回调抛错只跳过本轮（输入保留在源队列，下一轮重试），不影响 burst——与上方
+    // supplement 同序，先于下一轮 LLM 调用的 abort 响应。
+    if (hasRemainingTurn && options.drainExternalInputs) {
+      let externalInputs: ReadonlyArray<string> = []
+      try {
+        externalInputs = await options.drainExternalInputs()
+      } catch (error) {
+        console.error(`[engine] drainExternalInputs failed (turn ${totalTurns}), inputs kept in source queue:`,
+          error instanceof Error ? error.message : String(error))
+      }
+      for (const text of externalInputs) {
+        messages.push(createUserMessage(text))
+        options.onSystemInjection?.({
+          type: 'external_input',
+          text,
           turnNumber: totalTurns,
           injectedAtMs: Date.now(),
         })

--- a/crabot-agent/src/engine/tools/output-tool.ts
+++ b/crabot-agent/src/engine/tools/output-tool.ts
@@ -152,6 +152,10 @@ export function createOutputTool(deps: BgToolDeps): ToolDefinition {
       const requestedTimeout = typeof input.timeout_ms === 'number' ? input.timeout_ms : BLOCK_DEFAULT_TIMEOUT_MS
       const timeoutMs = Math.min(Math.max(0, requestedTimeout), BLOCK_MAX_TIMEOUT_MS)
       const abortSignal = context.abortSignal
+      // 外部输入 pending 探针（spec 2026-08-29-worker-input-turn-boundary-delivery）：
+      // block 等待期间 worker inbox 有排队输入时立即返回让位——本工具返回后就是 turn
+      // 边界，输入在下一轮 LLM 调用前注入。engine 从 options 透传，未接线的调用方为 undefined。
+      const hasPendingExternalInput = context.hasPendingExternalInput
 
       const readOnce = async (): Promise<ReadResult> => {
         if (entityId.startsWith('shell_')) {
@@ -175,7 +179,7 @@ export function createOutputTool(deps: BgToolDeps): ToolDefinition {
         return toResult(first)
       }
 
-      // 进入 poll loop：每 2s 重读，等到有新内容 / 状态变化 / 超时 / abort
+      // 进入 poll loop：每 2s 重读，等到有新内容 / 状态变化 / 超时 / abort / 外部输入 pending
       const startMs = Date.now()
       let last = first
       while (Date.now() - startMs < timeoutMs) {
@@ -184,6 +188,9 @@ export function createOutputTool(deps: BgToolDeps): ToolDefinition {
         } catch {
           break  // abort
         }
+        // 外部输入（如 manager 投递）已排队：立即返回让位——本工具返回后就是 turn 边界，
+        // 输入会在下一轮 LLM 调用前注入，LLM 优先处理新输入。
+        if (hasPendingExternalInput?.()) break
         last = await readOnce()
         if (last.isError || !last.isRunning || !last.output.includes(NO_NEW_OUTPUT_MARKER)) break
       }

--- a/crabot-agent/src/engine/types.ts
+++ b/crabot-agent/src/engine/types.ts
@@ -132,6 +132,12 @@ export interface ToolCallContext {
     readonly worker_id: string
     readonly parent_trace_id?: string
   }
+  /**
+   * 外部输入 pending 探针（spec 2026-08-29-worker-input-turn-boundary-delivery）：
+   * 长等待工具（Output block=true 的 poll loop）每次睡醒后查询——源队列有排队输入时
+   * 提前返回，让输入在紧接着的 turn 边界被注入。非消费性查询。未接线时为 undefined。
+   */
+  readonly hasPendingExternalInput?: () => boolean
 }
 
 export interface ToolCallResult {
@@ -293,6 +299,24 @@ export interface EngineOptions {
   readonly permissionConfig?: ToolPermissionConfig
   readonly supportsVision?: boolean
   readonly humanMessageQueue?: HumanMessageQueueLike
+  /**
+   * turn 边界外部输入源（spec 2026-08-29-worker-input-turn-boundary-delivery）。
+   *
+   * 每轮「工具执行完成后、下一轮 LLM 调用前」调用一次，返回待注入的外部输入文本；
+   * 取出即从源队列移除（由 caller 负责其 FIFO / 优先级 / receipt 结算）。返回的每条
+   * 文本作为 user message 注入当前 burst（worker inbox 的 manager 投递由此在 turn
+   * 边界可见，不再等 burst 结束）。
+   *
+   * 仅在仍有剩余 turn 时调用（最后一轮注入无人消费）；回调抛错时 engine 跳过本轮
+   * 注入（输入保留在源队列，下一轮重试），不影响 burst。不传时行为与现状一致。
+   */
+  readonly drainExternalInputs?: () => ReadonlyArray<string> | Promise<ReadonlyArray<string>>
+  /**
+   * 外部输入 pending 探针（与 drainExternalInputs 同源，非消费性）：engine 经
+   * ToolCallContext.hasPendingExternalInput 透传给长等待工具（Output block），让它在
+   * 源队列有排队输入时提前返回。不传时工具行为与现状一致。
+   */
+  readonly hasPendingExternalInputs?: () => boolean
   readonly hookRegistry?: import('../hooks/hook-registry').HookRegistry
   readonly lspManager?: import('../hooks/types').LspManagerLike
   /** IANA 时区名（如 "Asia/Shanghai"），用于 tool_result 时间戳渲染 */
@@ -331,8 +355,9 @@ export interface EngineOptions {
   /**
    * 引擎层主动向 loop 注入 user message 时触发（trace 可见性钩子）。
    *
-   * 当前 4 类注入：
+   * 当前 5 类注入：
    * - `supplement` —— humanMessageQueue 实时纠偏注入
+   * - `external_input` —— drainExternalInputs 在 turn 边界消费的外部输入（worker inbox）
    * - `forced_summary` —— silent end_turn 兜底要求模型重说
    * - `stop_hook` —— Stop hook block 后注入的引导文本
    * - `assistant_text_end_turn` —— 非空 assistant text + end_turn 走错通道纠偏提醒
@@ -436,11 +461,12 @@ export interface SystemInjectionEvent {
   /**
    * 注入类型：
    * - `supplement`：humanMessageQueue 实时纠偏注入
+   * - `external_input`：drainExternalInputs 在 turn 边界消费的外部输入（如 worker inbox 的 manager 投递）
    * - `forced_summary`：silent end_turn 兜底要求模型重说
    * - `stop_hook`：Stop hook block 后注入的引导文本
    * - `assistant_text_end_turn`：非空 assistant text + end_turn 走错通道纠偏提醒
    */
-  readonly type: 'supplement' | 'forced_summary' | 'stop_hook' | 'assistant_text_end_turn'
+  readonly type: 'supplement' | 'external_input' | 'forced_summary' | 'stop_hook' | 'assistant_text_end_turn'
   /** 注入的文本内容（不含 ContentBlock[] 形态——supplement 的 ContentBlock 注入退化为 type 字符串描述） */
   readonly text: string
   /** 注入发生时的 turn 序号（与 EngineTurnEvent.turnNumber 同口径） */

--- a/crabot-agent/src/manager/tools/worker-tools.ts
+++ b/crabot-agent/src/manager/tools/worker-tools.ts
@@ -364,7 +364,7 @@ export function buildWorkerTools(deps: WorkerToolsDeps): ToolDefinition[] {
       '会作为事件唤醒你,事件带状态和待处置回合；用 get_worker_activity 读取原生会话。命中已 cancelled 的任务会被拒绝。' +
       '未知交互界面必须使用 respond_to_worker_ui，普通输入不提供 raw 终端旁路。' +
       '如果这条消息代表立即改变当前任务方向，设置 immediate_redirect=true；非 builtin worker 会先由 Harness 中断当前回合，' +
-      '确认中断完成后再投递，builtin worker 不 abort 而是在下一轮 LLM 调用前优先消费。',
+      '确认中断完成后再投递；builtin worker 不 abort，投递会在它当前执行步骤结束后的下一步之前注入（无论其当前回合多长）。',
     inputSchema: {
       type: 'object',
       properties: {

--- a/crabot-agent/src/prompts/agent-sections.ts
+++ b/crabot-agent/src/prompts/agent-sections.ts
@@ -562,6 +562,8 @@ list_groups / list_contacts 的返回是**分页结果**——看到 \`paginatio
 
 **反 pattern（明令禁止）**：在 agent 主循环里反复调 \`Output(id)\`（不带 block）等同一个 entity——每次调用都污染上下文（tool_call + tool_result 对），且没新内容时纯空跑。**同一 entity 连续 ≥2 次 Output 都返回 \`(no new output)\`，下一次必须 block=true 或干别的事**。
 
+**连续 block 有上限**：不要无限连续 \`block=true\` 盯同一个 entity——连续 3 次 block 超时都没等到新内容，就换方式：\`end_turn\` 转 idle 等通知唤醒、先去做别的、或收窄等待（缩短 timeout / 改 snapshot 抽查）。监控类任务靠「睡醒看一眼」无限循环是最差形态。
+
 **时长分级**：
 - 1min - 1h：转后台 shell；交给它跑、干别的事，等 push notification
 - 1h - 数天：转后台 shell；**转后台的命令跨 task / worker 重启都不被杀（持久）**，由你显式 Kill 或进程自己 exit

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -3900,6 +3900,23 @@ export class UnifiedAgent extends ModuleBase {
             toolCall.startedAtMs !== undefined && toolCall.durationMs !== undefined ? toolCall.startedAtMs + toolCall.durationMs : undefined)
         }
       },
+      // turn 边界注入的 manager 输入（spec 2026-08-29-worker-input-turn-boundary-delivery）：
+      // 与 spawn 初始输入同款 context_assembly + message_batch(manager) span——
+      // normalizeBuiltinSpan 会把它转成 message/user 事件，get_worker_activity 可见。
+      appendManagerInput: (traceId, text) => {
+        const span = this.traceStore.startSpan(traceId, {
+          type: 'context_assembly',
+          details: {
+            context_type: 'worker',
+            message_batch: [{
+              sender: 'manager',
+              text: redact(text),
+              is_mention_crab: false,
+            }],
+          },
+        })
+        this.traceStore.endSpan(traceId, span.span_id, 'completed')
+      },
       finishIncarnationTrace: (traceId, patch) => {
         this.traceStore.endTrace(traceId, patch.status, { summary: redact(patch.summary) })
       },

--- a/crabot-agent/src/workers/builtin/adapter.ts
+++ b/crabot-agent/src/workers/builtin/adapter.ts
@@ -284,6 +284,12 @@ export interface BuiltinTraceHooks {
     initial_input?: string
   }): string
   appendTurn(traceId: string, event: import('../../engine/types.js').EngineTurnEvent): void
+  /**
+   * turn 边界注入的 manager 输入落 trace（spec 2026-08-29-worker-input-turn-boundary-delivery）：
+   * 落成 context_assembly + message_batch(manager) span，与 spawn 初始输入同款表达，
+   * get_worker_activity(view=assistant) 里以 message/user 事件可见。
+   */
+  appendManagerInput?(traceId: string, text: string): void
   finishIncarnationTrace(traceId: string, patch: { status: 'completed' | 'failed'; summary: string }): void
   stopWorkerSubagents?(workerId: string): void
   /**
@@ -1086,6 +1092,18 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
         tools: this.combineTools(builtin.tools, instance),
         model: builtin.model,
         ...(builtin.maxTurnsPerBurst !== undefined ? { maxTurns: builtin.maxTurnsPerBurst } : {}),
+        // turn 边界外部输入注入（spec 2026-08-29-worker-input-turn-boundary-delivery）：
+        // 主线 burst 把 inbox 排队输入（immediate 优先）接到 engine——工具执行完成后、
+        // 下一轮 LLM 调用前注入为 user message，manager 投递不再等 burst（end_turn）结束。
+        // fork 侧问（runForkBurst）不接，不被主线输入打断。
+        drainExternalInputs: () => this.takeQueuedInputsAsExternal(instance),
+        hasPendingExternalInputs: () =>
+          instance.pendingImmediateInputs.length > 0 || instance.pendingInputs.length > 0,
+        onSystemInjection: (event) => {
+          if (event.type === 'external_input' && instance.traceId) {
+            this.deps.traceHooks?.appendManagerInput?.(instance.traceId, event.text)
+          }
+        },
         ...this.safetyOptions(builtin),
         // 长活 worker 的窗口是在**一次 burst 内部**被跑满的（maxTurns 默认 200），
         // burst 边界折叠够不着，只有 engine 的 per-turn 阈值压缩 + max_tokens 强压重试
@@ -1501,6 +1519,24 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     instance.tip = queueParent
     this.setEngineMessagesSnapshot(instance, queuedMessages, queueParent)
     return queued.length
+  }
+
+  /**
+   * turn 边界外部输入 drain（spec 2026-08-29-worker-input-turn-boundary-delivery）：
+   * 取出 pendingImmediateInputs（immediate 优先）+ pendingInputs，包装 `[manager input]`
+   * 来源标记后交给 engine 注入当前 burst。取出即移除——收尾段 drainQueuedInputs 只会
+   * 看到之后新到的输入，不重复注入。receipt 不在此结算：builtin 投递在 attemptInput
+   * 成功时已 settle（delivered = 已接受并排队），本方法保证「delivered ⇒ 至多一个执行
+   * 步骤后注入」。注入随 writeBack 落 sessionTree；trace 可见性由 onSystemInjection 经
+   * traceHooks.appendManagerInput 落 message/user 事件。
+   */
+  private takeQueuedInputsAsExternal(instance: WorkerInstance): ReadonlyArray<string> {
+    if (instance.pendingImmediateInputs.length === 0 && instance.pendingInputs.length === 0) return []
+    const queued = [
+      ...instance.pendingImmediateInputs.splice(0, instance.pendingImmediateInputs.length),
+      ...instance.pendingInputs.splice(0, instance.pendingInputs.length),
+    ]
+    return queued.map((text) => `[manager input]\n${text}`)
   }
 
   /**

--- a/crabot-agent/src/workers/builtin/adapter.ts
+++ b/crabot-agent/src/workers/builtin/adapter.ts
@@ -310,6 +310,20 @@ export interface BuiltinTraceReader {
   }>
 }
 
+/**
+ * 系统通知信封（PR #130 复审识别的真实风险）：bg shell 退出（unified-agent renderShellExitNotification）
+ * 与 subagent 完成（subagent-runner deliverCompletion）的通知经同一 inbox 通道（sendToWorker →
+ * sendInput → pendingInputs）投递，自带信封标记。turn 边界 drain 时它们**不是** manager 输入——
+ * 不得加 `[manager input]` 前缀（否则 worker 会把 shell 退出通知当 manager 指令执行），也不得以
+ * manager 名义落 trace（否则 get_worker_activity 出现 manager 从未发过的 message/user 事件）。
+ * 彻底方案（inbox item 带 source 字段透传）属跨模块契约变更，记 spec §8 follow-up。
+ */
+const SYSTEM_NOTIFICATION_ENVELOPES: readonly string[] = ['<bg-notification>', '<sub_agent_notification>']
+
+function isSystemNotificationEnvelope(text: string): boolean {
+  return SYSTEM_NOTIFICATION_ENVELOPES.some((envelope) => text.includes(envelope))
+}
+
 
 export class BuiltinWorkerAdapter implements WorkerAdapter {
   readonly implId = 'builtin' as const
@@ -1100,7 +1114,8 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
         hasPendingExternalInputs: () =>
           instance.pendingImmediateInputs.length > 0 || instance.pendingInputs.length > 0,
         onSystemInjection: (event) => {
-          if (event.type === 'external_input' && instance.traceId) {
+          // 系统通知（bg 退出 / subagent 完成）不落 manager 名义的 trace 事件
+          if (event.type === 'external_input' && instance.traceId && !isSystemNotificationEnvelope(event.text)) {
             this.deps.traceHooks?.appendManagerInput?.(instance.traceId, event.text)
           }
         },
@@ -1536,7 +1551,8 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
       ...instance.pendingImmediateInputs.splice(0, instance.pendingImmediateInputs.length),
       ...instance.pendingInputs.splice(0, instance.pendingInputs.length),
     ]
-    return queued.map((text) => `[manager input]\n${text}`)
+    // 系统通知（bg 退出 / subagent 完成）保持裸信封——只区分 manager 人工投递
+    return queued.map((text) => isSystemNotificationEnvelope(text) ? text : `[manager input]\n${text}`)
   }
 
   /**

--- a/crabot-agent/tests/engine/output-tool-pending-probe.test.ts
+++ b/crabot-agent/tests/engine/output-tool-pending-probe.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi } from 'vitest'
+import { promises as fs } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { createOutputTool } from '../../src/engine/tools/output-tool.js'
+import type { BgEntityRegistry } from '../../src/engine/bg-entities/registry.js'
+import type { ToolCallContext } from '../../src/engine/types.js'
+
+/** 事故复现（spec 2026-08-29 §7.3/§7.7）：worker 卡在 Output(block=true) 的 poll loop 里
+ * 时 manager 投递到达——探针让 Output 提前返回，不等满 timeout。 */
+function shellRegistry(logFile: string): BgEntityRegistry {
+  return {
+    get: async () => ({
+      entity_id: 'shell_test',
+      type: 'shell',
+      status: 'running',
+      exit_code: null,
+      command: 'tail -f runner.log',
+      log_file: logFile,
+      pid: 1,
+      pgid: 1,
+      process_started_at: new Date().toISOString(),
+      spawned_at: new Date().toISOString(),
+      last_activity_at: new Date().toISOString(),
+      owner_friend_id: '__system_w1',
+      worker_id: 'w1',
+    }),
+    update: async () => {},
+  } as unknown as BgEntityRegistry
+}
+
+function makeContext(probe?: () => boolean): ToolCallContext {
+  return { ...(probe ? { hasPendingExternalInput: probe } : {}) }
+}
+
+describe('Output block=true 的外部输入 pending 探针', () => {
+  it('探针为 true 时立即返回,不等满 timeout(默认未接线时行为不变)', async () => {
+    const dir = await fs.mkdtemp(join(tmpdir(), 'output-probe-'))
+    const logFile = join(dir, 'shell.log')
+    await fs.writeFile(logFile, '') // 空日志 → 无新输出 → 正常情况下会 block 到超时
+
+    const tool = createOutputTool({
+      registry: shellRegistry(logFile),
+      cursorMap: new Map(),
+      taskId: 'w1',
+    })
+
+    // 探针恒 true:第一次 poll 睡醒(2s)前就该返回
+    const start = Date.now()
+    const result = await tool.call({ entity_id: 'shell_test', block: true, timeout_ms: 60_000 }, makeContext(() => true))
+    const elapsed = Date.now() - start
+
+    expect(result.output).toContain('(no new output)')
+    expect(elapsed).toBeLessThan(5_000) // 未修复时会等满 60s
+    await fs.rm(dir, { recursive: true, force: true })
+  })
+
+  it('探针始终 false 时不提前返回,行为与现状一致(等到超时)', { timeout: 15_000 }, async () => {
+    const dir = await fs.mkdtemp(join(tmpdir(), 'output-probe-'))
+    const logFile = join(dir, 'shell.log')
+    await fs.writeFile(logFile, '')
+
+    const tool = createOutputTool({
+      registry: shellRegistry(logFile),
+      cursorMap: new Map(),
+      taskId: 'w1',
+    })
+
+    const start = Date.now()
+    await tool.call({ entity_id: 'shell_test', block: true, timeout_ms: 5_000 }, makeContext(() => false))
+    const elapsed = Date.now() - start
+
+    expect(elapsed).toBeGreaterThanOrEqual(4_500) // 等满 timeout
+    await fs.rm(dir, { recursive: true, force: true })
+  })
+
+  it('未接线(无探针)时行为与现状一致', { timeout: 15_000 }, async () => {
+    const dir = await fs.mkdtemp(join(tmpdir(), 'output-probe-'))
+    const logFile = join(dir, 'shell.log')
+    await fs.writeFile(logFile, '')
+
+    const tool = createOutputTool({
+      registry: shellRegistry(logFile),
+      cursorMap: new Map(),
+      taskId: 'w1',
+    })
+
+    const start = Date.now()
+    await tool.call({ entity_id: 'shell_test', block: true, timeout_ms: 3_000 }, {})
+    const elapsed = Date.now() - start
+
+    expect(elapsed).toBeGreaterThanOrEqual(2_500)
+    await fs.rm(dir, { recursive: true, force: true })
+  })
+
+  it('事故时序复现:日志先无输出,投递(探针翻转)后 Output 提前让位', async () => {
+    const dir = await fs.mkdtemp(join(tmpdir(), 'output-probe-'))
+    const logFile = join(dir, 'shell.log')
+    await fs.writeFile(logFile, '')
+
+    const tool = createOutputTool({
+      registry: shellRegistry(logFile),
+      cursorMap: new Map(),
+      taskId: 'w1',
+    })
+
+    // 模拟「投递在 block 等待中途到达」:fake 时间 300ms 后探针翻转(对应 sendInput → pending 非空)。
+    // 定时器必须在 useFakeTimers 之后注册才会进 fake 队列。
+    vi.useFakeTimers()
+    try {
+      let pending = false
+      setTimeout(() => { pending = true }, 300)
+      const call = tool.call({ entity_id: 'shell_test', block: true, timeout_ms: 60_000 }, makeContext(() => pending))
+      await vi.advanceTimersByTimeAsync(3_000) // 推进 fake 时间:300ms 翻转 + 2s poll 睡醒即见探针
+      const result = await call
+      expect(result.output).toContain('(no new output)') // 让位时日志仍无新内容
+    } finally {
+      vi.useRealTimers()
+    }
+    await fs.rm(dir, { recursive: true, force: true })
+  })
+})

--- a/crabot-agent/tests/workers/builtin-adapter.test.ts
+++ b/crabot-agent/tests/workers/builtin-adapter.test.ts
@@ -2228,8 +2228,8 @@ describe('BuiltinWorkerAdapter', () => {
           messageSnapshots.push({ ..._params, messages: [..._params.messages], tools: [..._params.tools] })
           const call = messageSnapshots.length
           return (async function* () {
-            if (call === 1) await toolGate
-            if (call === 2) await llmGate
+            if (call === 1) await toolGate.promise
+            if (call === 2) await llmGate.promise
             const r = call === 1
               ? { toolCalls: [{ name: 'probe_wait', id: 'call_1', input: {} }], stopReason: 'tool_use' as const }
               : { text: call === 2 ? '第一轮收尾' : '续 burst 完成', stopReason: 'end_turn' as const }
@@ -2290,6 +2290,53 @@ describe('BuiltinWorkerAdapter', () => {
     expect(typeof mainOptions?.hasPendingExternalInputs).toBe('function')
     expect(forkOptions2?.drainExternalInputs).toBeUndefined()
     expect(forkOptions2?.hasPendingExternalInputs).toBeUndefined()
+  })
+
+  it('注入消息遇 burst 内压缩:在压缩保留段进入后续上下文,不因压缩丢失', async () => {
+    const toolGate = deferred<void>()
+    const messageSnapshots: LLMStreamParams[] = []
+    const echoTurn = (id: string): TurnScript => ({
+      toolCalls: [{ name: 'echo', id, input: { s: id } }],
+      stopReason: 'tool_use',
+    })
+    const llm = makeCompactionAwareAdapter([
+      // 5 轮 echo 凑过 keepRecentMessages(6);gated 轮 usage 1900 > 阈值 1600,
+      // gated 轮挂起期间注入 → 下一轮开头 shouldCompact 命中,注入在保留段
+      echoTurn('e1'), echoTurn('e2'), echoTurn('e3'), echoTurn('e4'), echoTurn('e5'),
+      { toolCalls: [{ name: 'probe_wait', id: 'call_1', input: {} }], stopReason: 'tool_use', usage: { inputTokens: 1900, outputTokens: 50 } },
+      { text: '压缩后继续', stopReason: 'end_turn' },
+    ])
+    const baseStream = llm.stream as unknown as {
+      mock: { calls: Array<[{ messages: unknown[] }]> }
+    }
+    const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+    const s = spec({
+      adapter: llm as unknown as LLMAdapter,
+      contextWindowTokens: 2000,
+      tools: [ECHO_TOOL, gatedTool(toolGate.promise)],
+    })
+
+    const h = await adapter.spawn(s)
+    await waitState(adapter, h, 'running')
+    // 等 gated 轮的 LLM 调用开始(第 6 次非压缩调用)再投递,保证注入位于上下文尾部
+    await vi.waitFor(() => {
+      const turnCalls = baseStream.mock.calls.filter(([p]) => !isCompactionCall(p))
+      expect(turnCalls).toHaveLength(6)
+    })
+    await adapter.sendInput(h, '压缩前注入的指令')
+    toolGate.resolve()
+    await waitState(adapter, h, 'idle')
+
+    // 压缩真实发生;注入消息在保留段进入压缩后的上下文(下一轮 LLM 调用可见),
+    // 并随压缩后的序列落 session 树——不因压缩丢失
+    expect(llm.compactionCalls).toBeGreaterThanOrEqual(1)
+    const lastTurnMessages = (() => {
+      const turnCalls = baseStream.mock.calls.filter(([p]) => !isCompactionCall(p))
+      return JSON.stringify(turnCalls.at(-1)![0].messages)
+    })()
+    expect(lastTurnMessages).toContain('压缩前注入的指令')
+    const treeRaw = await fs.readFile(join(tmp, s.worker_id, 'session.jsonl'), 'utf-8')
+    expect(treeRaw).toContain('压缩前注入的指令')
   })
 
   it('appendManagerInput:turn 边界注入的输入经 traceHooks 落 message/user trace 事件', async () => {

--- a/crabot-agent/tests/workers/builtin-adapter.test.ts
+++ b/crabot-agent/tests/workers/builtin-adapter.test.ts
@@ -2339,6 +2339,55 @@ describe('BuiltinWorkerAdapter', () => {
     expect(treeRaw).toContain('压缩前注入的指令')
   })
 
+  it('系统通知不误标:同队列的 <bg-notification> 不加 [manager input] 前缀、不落 manager trace,manager 消息不受影响', async () => {
+    const toolGate = deferred<void>()
+    const managerInputs: string[] = []
+    const messageSnapshots: LLMStreamParams[] = []
+    const adapter = new BuiltinWorkerAdapter({
+      dataDir: tmp,
+      traceHooks: {
+        startIncarnationTrace: () => 'trace-1',
+        appendTurn: () => {},
+        appendManagerInput: (_traceId, text) => managerInputs.push(text),
+        finishIncarnationTrace: () => {},
+      },
+    })
+    const s = spec({
+      adapter: {
+        stream: vi.fn((_params: LLMStreamParams) => {
+          messageSnapshots.push({ ..._params, messages: [..._params.messages], tools: [..._params.tools] })
+          return (async function* () {
+            const r = messageSnapshots.length === 1
+              ? { toolCalls: [{ name: 'probe_wait', id: 'call_1', input: {} }], stopReason: 'tool_use' as const }
+              : { text: '看到', stopReason: 'end_turn' as const }
+            const content: unknown[] = []
+            if ('text' in r && r.text) content.push({ type: 'text', text: r.text })
+            for (const tc of r.toolCalls ?? []) content.push({ type: 'tool_use', id: tc.id, name: tc.name, input: tc.input })
+            yield* chunksFromContent(content, r.stopReason, { inputTokens: 10, outputTokens: 5 })
+          })()
+        }),
+        updateConfig: () => {},
+      } as unknown as LLMAdapter,
+      tools: [gatedTool(toolGate.promise)],
+    })
+
+    const h = await adapter.spawn(s)
+    await waitState(adapter, h, 'running')
+    // 复审识别的场景:running burst 中 bg shell 退出通知与 manager 投递先后进同一队列
+    await adapter.sendInput(h, '<bg-notification>\nshell_xxx 已退出，状态 completed\n</bg-notification>')
+    await adapter.sendInput(h, '真正的 manager 指令')
+    toolGate.resolve()
+    await waitState(adapter, h, 'idle')
+
+    const second = JSON.stringify(messageSnapshots[1]!.messages)
+    // 通知保持裸信封(无 manager 前缀),manager 消息带前缀——worker 可区分来源
+    expect(second).toContain('<bg-notification>\\nshell_xxx 已退出')
+    expect(second).not.toContain('[manager input]\\n<bg-notification>')
+    expect(second).toContain('[manager input]\\n真正的 manager 指令')
+    // trace 只落 manager 消息,不把系统通知误标为 manager 名义
+    expect(managerInputs).toEqual(['[manager input]\n真正的 manager 指令'])
+  })
+
   it('appendManagerInput:turn 边界注入的输入经 traceHooks 落 message/user trace 事件', async () => {
     const toolGate = deferred<void>()
     const managerInputs: string[] = []

--- a/crabot-agent/tests/workers/builtin-adapter.test.ts
+++ b/crabot-agent/tests/workers/builtin-adapter.test.ts
@@ -2094,6 +2094,243 @@ describe('BuiltinWorkerAdapter', () => {
     expect(meta.ended_reason).toBe('completed') // kill 没有覆盖掉原本的终态原因
   })
 
+  // --- turn 边界外部输入注入（spec 2026-08-29-worker-input-turn-boundary-delivery）---
+
+  /** 受 gate 控制的测试工具：call 挂起即把 burst 卡在「工具执行中」，便于在其间投递。 */
+  function gatedTool(gate: Promise<void>): ToolDefinition {
+    return defineTool({
+      name: 'probe_wait',
+      description: 'test gate tool',
+      inputSchema: { type: 'object', properties: {} },
+      isReadOnly: true,
+      call: async () => {
+        await gate
+        return { output: 'probe done', isError: false }
+      },
+    })
+  }
+
+  it('turn 边界注入:burst 工具执行期间投递的输入,在下一轮 LLM 调用前以 [manager input] user message 出现', async () => {
+    const toolGate = deferred<void>()
+    const messageSnapshots: LLMStreamParams[] = []
+    const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+    const s = spec({
+      adapter: {
+        stream: vi.fn((_params: LLMStreamParams) => {
+          messageSnapshots.push({ ..._params, messages: [..._params.messages], tools: [..._params.tools] })
+          return (async function* () {
+            const r = messageSnapshots.length === 1
+              ? { toolCalls: [{ name: 'probe_wait', id: 'call_1', input: {} }], stopReason: 'tool_use' as const }
+              : { text: '看到新指令了', stopReason: 'end_turn' as const }
+            const content: unknown[] = []
+            if ('text' in r && r.text) content.push({ type: 'text', text: r.text })
+            for (const tc of r.toolCalls ?? []) content.push({ type: 'tool_use', id: tc.id, name: tc.name, input: tc.input })
+            yield* chunksFromContent(content, r.stopReason, { inputTokens: 10, outputTokens: 5 })
+          })()
+        }),
+        updateConfig: () => {},
+      } as unknown as LLMAdapter,
+      tools: [gatedTool(toolGate.promise)],
+    })
+
+    const h = await adapter.spawn(s)
+    await waitState(adapter, h, 'running') // burst 已进入 probe_wait 的 gate
+    await adapter.sendInput(h, '中途指令')
+    toolGate.resolve()
+    await waitState(adapter, h, 'idle')
+
+    const second = messageSnapshots[1]
+    expect(second).toBeDefined()
+    const injected = second!.messages.filter(
+      (m) => m.role === 'user' && JSON.stringify(m).includes('[manager input]') && JSON.stringify(m).includes('中途指令'),
+    )
+    expect(injected).toHaveLength(1)
+  })
+
+  it('immediate 优先:turn 边界注入时 immediate_redirect 输入先于普通输入', async () => {
+    const toolGate = deferred<void>()
+    const messageSnapshots: LLMStreamParams[] = []
+    const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+    const s = spec({
+      adapter: {
+        stream: vi.fn((_params: LLMStreamParams) => {
+          messageSnapshots.push({ ..._params, messages: [..._params.messages], tools: [..._params.tools] })
+          return (async function* () {
+            const r = messageSnapshots.length === 1
+              ? { toolCalls: [{ name: 'probe_wait', id: 'call_1', input: {} }], stopReason: 'tool_use' as const }
+              : { text: '收到', stopReason: 'end_turn' as const }
+            const content: unknown[] = []
+            if ('text' in r && r.text) content.push({ type: 'text', text: r.text })
+            for (const tc of r.toolCalls ?? []) content.push({ type: 'tool_use', id: tc.id, name: tc.name, input: tc.input })
+            yield* chunksFromContent(content, r.stopReason, { inputTokens: 10, outputTokens: 5 })
+          })()
+        }),
+        updateConfig: () => {},
+      } as unknown as LLMAdapter,
+      tools: [gatedTool(toolGate.promise)],
+    })
+
+    const h = await adapter.spawn(s)
+    await waitState(adapter, h, 'running')
+    await adapter.sendInput(h, '普通排队输入')
+    await adapter.sendInput(h, '立即改向输入', { immediate_redirect: true })
+    toolGate.resolve()
+    await waitState(adapter, h, 'idle')
+
+    const second = JSON.stringify(messageSnapshots[1]!.messages)
+    expect(second).toContain('[manager input]')
+    expect(second.indexOf('立即改向输入')).toBeLessThan(second.indexOf('普通排队输入'))
+  })
+
+  it('幂等:turn 边界注入过的输入在 end_turn 收尾时不会被 drainQueuedInputs 重复注入', async () => {
+    const toolGate = deferred<void>()
+    const messageSnapshots: LLMStreamParams[] = []
+    const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+    const s = spec({
+      adapter: {
+        stream: vi.fn((_params: LLMStreamParams) => {
+          messageSnapshots.push({ ..._params, messages: [..._params.messages], tools: [..._params.tools] })
+          return (async function* () {
+            const r = messageSnapshots.length === 1
+              ? { toolCalls: [{ name: 'probe_wait', id: 'call_1', input: {} }], stopReason: 'tool_use' as const }
+              : { text: '完成', stopReason: 'end_turn' as const }
+            const content: unknown[] = []
+            if ('text' in r && r.text) content.push({ type: 'text', text: r.text })
+            for (const tc of r.toolCalls ?? []) content.push({ type: 'tool_use', id: tc.id, name: tc.name, input: tc.input })
+            yield* chunksFromContent(content, r.stopReason, { inputTokens: 10, outputTokens: 5 })
+          })()
+        }),
+        updateConfig: () => {},
+      } as unknown as LLMAdapter,
+      tools: [gatedTool(toolGate.promise)],
+    })
+
+    const h = await adapter.spawn(s)
+    await waitState(adapter, h, 'running')
+    await adapter.sendInput(h, '只注入一次的指令')
+    toolGate.resolve()
+    await waitState(adapter, h, 'idle')
+
+    const second = JSON.stringify(messageSnapshots[1]!.messages)
+    expect(second).toContain('只注入一次的指令')
+    // burst 到 end_turn 收尾为止,该输入在第二轮上下文中恰好出现一次(无收尾重复)
+    expect(second.split('只注入一次的指令')).toHaveLength(2) // 1 次出现 = 2 段
+  })
+
+  it('收尾兜底:turn 边界注入之后、收尾窗口内新到的输入仍走 drainQueuedInputs 续 burst', async () => {
+    const toolGate = deferred<void>()
+    const llmGate = deferred<void>()
+    const messageSnapshots: LLMStreamParams[] = []
+    const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+    const s = spec({
+      adapter: {
+        stream: vi.fn((_params: LLMStreamParams) => {
+          messageSnapshots.push({ ..._params, messages: [..._params.messages], tools: [..._params.tools] })
+          const call = messageSnapshots.length
+          return (async function* () {
+            if (call === 1) await toolGate
+            if (call === 2) await llmGate
+            const r = call === 1
+              ? { toolCalls: [{ name: 'probe_wait', id: 'call_1', input: {} }], stopReason: 'tool_use' as const }
+              : { text: call === 2 ? '第一轮收尾' : '续 burst 完成', stopReason: 'end_turn' as const }
+            const content: unknown[] = []
+            if ('text' in r && r.text) content.push({ type: 'text', text: r.text })
+            for (const tc of r.toolCalls ?? []) content.push({ type: 'tool_use', id: tc.id, name: tc.name, input: tc.input })
+            yield* chunksFromContent(content, r.stopReason, { inputTokens: 10, outputTokens: 5 })
+          })()
+        }),
+        updateConfig: () => {},
+      } as unknown as LLMAdapter,
+      tools: [gatedTool(toolGate.promise)],
+    })
+
+    const h = await adapter.spawn(s)
+    await waitState(adapter, h, 'running')
+    // ① 工具执行期间投递 → turn 边界注入
+    await adapter.sendInput(h, '边界注入')
+    toolGate.resolve()
+    // ② end_turn 前的 LLM 轮挂起期间投递 → end_turn 收尾窗口排队,走 drainQueuedInputs 续 burst
+    await vi.waitFor(async () => expect(messageSnapshots.length).toBe(2))
+    await adapter.sendInput(h, '收尾兜底')
+    llmGate.resolve()
+    await waitState(adapter, h, 'idle')
+
+    // 边界注入出现在第二轮(turn 边界),收尾兜底出现在第二轮且由收尾 drain 带入第三轮
+    expect(JSON.stringify(messageSnapshots[1]!.messages)).toContain('边界注入')
+    const third = messageSnapshots[2]
+    expect(third).toBeDefined()
+    expect(JSON.stringify(third!.messages)).toContain('收尾兜底')
+    expect(JSON.stringify(third!.messages)).toContain('边界注入') // 会话历史延续
+  })
+
+  it('fork 侧问不接输入源:主线 burst 的 engine options 带 drainExternalInputs,fork 的不带', async () => {
+    const runEngineSpy = vi.spyOn(engineModule, 'runEngine')
+    const gate = deferred<void>()
+    const adapter = new BuiltinWorkerAdapter({ dataDir: tmp })
+    const s = spec({
+      adapter: makeAdapterGatedFromSecondCall(gate.promise, [
+        { text: '首轮回复', stopReason: 'end_turn' },
+        { text: '侧问回复', stopReason: 'end_turn' },
+      ]),
+    })
+
+    const h = await adapter.spawn(s)
+    await waitState(adapter, h, 'idle')
+
+    const treeBeforeFork = await SessionTree.load(join(tmp, s.worker_id, 'session.jsonl'))
+    const prevRef: IncarnationRef = { worker_id: s.worker_id, seq: 1, session_ref: treeBeforeFork.latestTip()! }
+    const forkHandle = await adapter.fork(prevRef, '侧问问题', forkOptions())
+    gate.resolve()
+    await waitState(adapter, forkHandle, 'exited')
+
+    expect(runEngineSpy).toHaveBeenCalledTimes(2)
+    const mainOptions = runEngineSpy.mock.calls[0]?.[0].options
+    const forkOptions2 = runEngineSpy.mock.calls[1]?.[0].options
+    expect(typeof mainOptions?.drainExternalInputs).toBe('function')
+    expect(typeof mainOptions?.hasPendingExternalInputs).toBe('function')
+    expect(forkOptions2?.drainExternalInputs).toBeUndefined()
+    expect(forkOptions2?.hasPendingExternalInputs).toBeUndefined()
+  })
+
+  it('appendManagerInput:turn 边界注入的输入经 traceHooks 落 message/user trace 事件', async () => {
+    const toolGate = deferred<void>()
+    const managerInputs: string[] = []
+    const adapter = new BuiltinWorkerAdapter({
+      dataDir: tmp,
+      traceHooks: {
+        startIncarnationTrace: () => 'trace-1',
+        appendTurn: () => {},
+        appendManagerInput: (_traceId, text) => managerInputs.push(text),
+        finishIncarnationTrace: () => {},
+      },
+    })
+    const s = spec({
+      adapter: {
+        stream: vi.fn((_params: LLMStreamParams) => {
+          return (async function* () {
+            const r = managerInputs.length === 0
+              ? { toolCalls: [{ name: 'probe_wait', id: 'call_1', input: {} }], stopReason: 'tool_use' as const }
+              : { text: '看到', stopReason: 'end_turn' as const }
+            const content: unknown[] = []
+            if ('text' in r && r.text) content.push({ type: 'text', text: r.text })
+            for (const tc of r.toolCalls ?? []) content.push({ type: 'tool_use', id: tc.id, name: tc.name, input: tc.input })
+            yield* chunksFromContent(content, r.stopReason, { inputTokens: 10, outputTokens: 5 })
+          })()
+        }),
+        updateConfig: () => {},
+      } as unknown as LLMAdapter,
+      tools: [gatedTool(toolGate.promise)],
+    })
+
+    const h = await adapter.spawn(s)
+    await waitState(adapter, h, 'running')
+    await adapter.sendInput(h, '要进 trace 的输入')
+    toolGate.resolve()
+    await waitState(adapter, h, 'idle')
+
+    expect(managerInputs).toEqual(['[manager input]\n要进 trace 的输入'])
+  })
+
   // --- scanOrphans（崩溃恢复扫描）---
 
   describe('BuiltinWorkerAdapter.scanOrphans', () => {


### PR DESCRIPTION
## 背景

2026-08-29 事故：bot-2 会话「停止 B 组 runner」，manager 三次 `send_to_worker`（含两次 `immediate_redirect=true`）共 43 分钟未达——监控 worker 用 `Output(block=true)` 无限轮询，94 个 turn 连续 3.5 小时不 end_turn，而 builtin 投递消费点实际在 **burst 边界（end_turn）**，消息全部压队。

契约核查：用户确认**需求一直是 turn 边界**；协议 §5.5「burst 自然结束后」为措辞错误（协议 §4.3 / spec 2026-08-20 / manager prompt 三处均为 turn 边界语义，同 commit 7948a5b 内部即自相矛盾）。

## 改动（对应 spec 章节）

| 改动 | 位置 | spec 依据 |
|---|---|---|
| turn 边界注入点：`drainExternalInputs`（消费性）+ `hasPendingExternalInputs`（探针，经 `ToolCallContext` 透传） | `engine/query-loop.ts` `engine/types.ts` | §3.1 |
| Output(block=true) poll loop 感知探针提前返回（投递可见性 ≤2s） | `engine/tools/output-tool.ts` | §3.2 |
| adapter 接线：pendingInputs/pendingImmediateInputs → engine 注入（immediate 优先，`[manager input]` 标记）；收尾 `drainQueuedInputs` 保留兜底 | `workers/builtin/adapter.ts` | §3.1 §4 |
| trace 可见性：`traceHooks.appendManagerInput` → context_assembly+message_batch span（get_worker_activity 以 message/user 事件可见） | `unified-agent.ts` | §3.1 |
| 措辞对齐：send_to_worker 工具描述、worker prompt「连续 block 有上限」纪律 | `manager/tools/worker-tools.ts` `prompts/agent-sections.ts` | §6.4 §2 |

文档仓另行提交：协议 v3.6.15（§4.3/§5.5 措辞修正 + 版本记录）、spec 2026-08-20 同步。

## 新引入的失败路径及收口

1. `drainExternalInputs` 回调抛错 → engine 捕获记日志、当轮跳过、输入保留源队列重试，不崩 burst
2. `appendManagerInput` 为可选 → 未实现时跳过 trace 落盘，注入不受影响
3. 注入与 max_turns 收尾撞车 → 注入先于收尾判定进入 messages，随终态落盘
4. Output 提前返回 → 仅缩短等待，无新状态

## 测试

- 新增 10 条：builtin-adapter 6 条（turn 边界注入/immediate 优先/幂等/收尾兜底/fork 不接线/trace 可见性）+ output-tool 4 条（探针让位/等满超时/未接线一致/事故时序复现）
- 全量套件失败集合与基线 diff 为 flaky 随机分布（codex tmux、manager-integration 在基线上同样随机失败）；可疑用例已单跑复核通过

Spec: crabot-docs/superpowers/specs/2026-08-29-worker-input-turn-boundary-delivery-design.md（已 push docs main f1ebb7f）