### PR TITLE
fix(manager): 人类消息 episode 运行中到达时 turn 边界注入,不再排队等 episode 跑完

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -18,16 +18,22 @@
   Output 探针提前返回，投递可见性从小时级降到 ≈2s）+ 协议 v3.6.15（docs `93975cf`）+
   spec 2026-08-20 同步。review 三轮：真实风险 2 项（测试 gate 失效、`[manager input]`
   前缀误标系统通知）已修。
-- PR #131（review 复审线程全部 resolve，待 approve）：manager 人类消息 episode 运行中
-  到达时先提交（commitHumanInputs 去重写 recent + 回调）再经 mailbox turn 边界注入；
-  attention flush 的结算委托给被注入 episode 的真实收尾（不再用注入分支占位值导致群聊
-  注意力错误 ×5 渐远）。review 首轮三条真实风险已修（未消费注入键在 recent 无=永久丢失；
-  假结算；档位沿用定性修正）。
-- **#131 follow-up 池（review 复审要求记录）**：
-  1. 群聊消息档位随消息——注入消息沿用 episode 起始 wake 发起人的 `principalPermissions`
-     （群聊 B 的指令以 A 的档位执行 worker）；spec 从未定义按发起人区分权限，属权限语义
-     设计项（方向：档位随消息 / 群聊回退排队），需单独立项。私聊同 session 唯一 friend
-     无影响。
+- PR #131（OPEN，等权限立项落地后合入）：manager 人类消息 episode 运行中到达时**同步**入
+  mailbox 走 turn 边界注入（check→push 零 await，与 routeWorkerEvent 同构原子）；store 提交
+  延后到 episode 收尾临界区统一落盘（mutex 内单写者，消除注入 RMW 与收尾 save 的 lost
+  update）；attention flush / 私聊 / Admin Chat 的结算与 fail-loud 全部委托被注入 episode
+  的真实收尾（占位 result 不参与判定）。五轮 review：真实风险累计 9 项已修（未消费注入
+  键在 recent 无=永久丢失；假结算 ×5 渐远；重复来源注入 LLM；RMW 并发；check-to-push
+  窗口；占位 result 打掉私聊/Admin Chat fail-loud；catch 分支丢注入；discard 打掉自唤醒；
+  currentEpisodeInjected 重复入账致 max_tokens 重试渲染两遍）。
+- **#131 待办与 follow-up 池**：
+  1. ~~群聊消息档位随消息~~ → **已定性更正并立项**：原条目「spec 从未定义按发起人区分
+     权限」不准确——§3.2.7 与 narrowWorkerPermissions（PR F/J）的既有实现就是按发言人
+     区分（reviewer 反驳成立）。用户拍板：**群聊权限群级统一、与发言人无关（含 master
+     在群里也按群档位），之前按发言人区分的 spec 视为设计错误**，单独立项推翻（spec
+     流程）；#131 在该立项落地前不合入，落地后注入与 primary wake 同档位，权限线程
+     前提消失。另：§4.1「首次 LLM/工具调用前原子写入」与收尾提交的字面冲突需协议补
+     注入场景例外（措辞随权限 spec 一并确认）。
   2. 注入路径未过 `assertWakeAdmission`——isClosing 关停期间消息被静默收下返回 completed，
      调用方拿不到 fail-loud 信号；已落盘不丢，后续统一收口。
   3. 结算钩子丢弃窗口——提前 return / `settleInjectedHooks` 之后到达的注入，其 hook 会在
@@ -36,10 +42,13 @@
      「更积极」而非「变哑」，可接受。
   4. 注入未被 drain 时的委托值失真——消息实际由自唤醒 episode 处理，却以被注入 episode
      的 repliedToHuman 结算；一次性误报非系统性偏置，可接受。
-  5. fail-loud 只闭合了「丢失」——注入消息随 episode 失败已补提交进 recent 不丢，但
-     调用方拿占位 completed 不触发兜底回复，消息等下一次真实唤醒才被处理；「失败即时
-     告知」留 follow-up（53905408 提交信息里「闭合 fail-loud 缺口」表述过头，以此为准）。
-  6. （#130 遗留）redirect 对 builtin 是否允许 interrupt/腰斩工具；v2 agent-handler 遗留
+  5. ~~fail-loud 只闭合了「丢失」~~ → **已修**（eef9f991）：onEpisodeSettled 透传
+     routeHumanMessages，私聊/Admin Chat 在真实收尾 failed/aborted 时补发 fail-loud
+     （Admin Chat 带 request_id 走 delivery CAS 结占位气泡）。
+  6. 成功收尾时未被消费的注入留 mailbox 交自唤醒（五审修法），其 reaction 回调随之丢失
+     （自唤醒无调用方回调）——与「写入即已接收」自洽（尚未写入本就不该打），窗口窄，
+     如实记录不立项。
+  7. （#130 遗留）redirect 对 builtin 是否允许 interrupt/腰斩工具；v2 agent-handler 遗留
      （humanQueue/ask_human）清理；Output 超时参数与连续 block 硬性封顶。
 
 ### 移除 macOS FDA 放开机制，受保护目录无条件排除：已合并（PR #129 → `3e268439`）

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5,6 +5,43 @@
 
 ## 当前状态
 
+### manager 人类消息 turn 间注入（含 builtin worker 输入 turn 边界投递）：PR #131（待合并）+ PR #130（已合并 `bad70ce4`）
+
+- 引线：2026-08-29 两起现网案例。① builtin 监控 worker 用 `Output(block=true)` 无限轮询
+  （94 turn 连续 3.5h 不 end_turn），manager 三次投递（含 immediate_redirect）压队 43 分钟
+  未达——投递消费点实际在 burst 边界（end_turn）；② 用户 19:35:50 发消息，manager 19:36:06
+  仍在问旧问题，19:36:47 才处理——`routeHumanWake` 直接 `runWake` 阻塞等前一 episode，
+  P7 cutover roadmap D 项「把人类消息接到 enqueueDuringEpisode」的接线在实现中遗漏。
+- 契约口径（用户拍板）：投递/注入消费点**一直是 turn 边界**；协议 §5.5「burst 自然结束后」
+  为 spec 措辞错误。两份契约文档随修复对齐。
+- PR #130（已合并）：builtin worker 输入 turn 边界注入（engine `drainExternalInputs` +
+  Output 探针提前返回，投递可见性从小时级降到 ≈2s）+ 协议 v3.6.15（docs `93975cf`）+
+  spec 2026-08-20 同步。review 三轮：真实风险 2 项（测试 gate 失效、`[manager input]`
+  前缀误标系统通知）已修。
+- PR #131（review 复审线程全部 resolve，待 approve）：manager 人类消息 episode 运行中
+  到达时先提交（commitHumanInputs 去重写 recent + 回调）再经 mailbox turn 边界注入；
+  attention flush 的结算委托给被注入 episode 的真实收尾（不再用注入分支占位值导致群聊
+  注意力错误 ×5 渐远）。review 首轮三条真实风险已修（未消费注入键在 recent 无=永久丢失；
+  假结算；档位沿用定性修正）。
+- **#131 follow-up 池（review 复审要求记录）**：
+  1. 群聊消息档位随消息——注入消息沿用 episode 起始 wake 发起人的 `principalPermissions`
+     （群聊 B 的指令以 A 的档位执行 worker）；spec 从未定义按发起人区分权限，属权限语义
+     设计项（方向：档位随消息 / 群聊回退排队），需单独立项。私聊同 session 唯一 friend
+     无影响。
+  2. 注入路径未过 `assertWakeAdmission`——isClosing 关停期间消息被静默收下返回 completed，
+     调用方拿不到 fail-loud 信号；已落盘不丢，后续统一收口。
+  3. 结算钩子丢弃窗口——提前 return / `settleInjectedHooks` 之后到达的注入，其 hook 会在
+     下个 episode 起始被清掉不触发 → 该批 flush 没人 reportResult。后果（review 追过
+     scheduler 实现）：仅 `lastActionTime` 不更新，下一条消息 enqueue 时立即 flush，是
+     「更积极」而非「变哑」，可接受。
+  4. 注入未被 drain 时的委托值失真——消息实际由自唤醒 episode 处理，却以被注入 episode
+     的 repliedToHuman 结算；一次性误报非系统性偏置，可接受。
+  5. fail-loud 只闭合了「丢失」——注入消息随 episode 失败已补提交进 recent 不丢，但
+     调用方拿占位 completed 不触发兜底回复，消息等下一次真实唤醒才被处理；「失败即时
+     告知」留 follow-up（53905408 提交信息里「闭合 fail-loud 缺口」表述过头，以此为准）。
+  6. （#130 遗留）redirect 对 builtin 是否允许 interrupt/腰斩工具；v2 agent-handler 遗留
+     （humanQueue/ask_human）清理；Output 超时参数与连续 block 硬性封顶。
+
 ### 移除 macOS FDA 放开机制，受保护目录无条件排除：已合并（PR #129 → `3e268439`）
 
 - 决策：FDA 放开机制要求「设 CRABOT_ENABLE_FDA → 系统设置授权 → 重启」，授权动作必须在

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -48,8 +48,11 @@
      仍能被 settleUnclaimedAdminChatWakes 结算）；b) 注入落在 runWake 计数 +1 与
      runEpisode 起始同步重置之间时，hook 与 pendingHumanCommit 记录一起被重置清掉——
      消息本身安全（已在 mailbox，作 carried envelope 走正常提交），仅 settle 与
-     reaction 回调不触发，窗口窄（恰好落在 mutex 获取那一跳）。后果（review 追过
-     scheduler 实现）：仅 `lastActionTime` 不更新，下一条消息 enqueue 时立即 flush，是
+     reaction 回调不触发，窗口窄（恰好落在 mutex 获取那一跳）；c) runEpisode 开头
+     「重复来源/空批空转」提前 return（committedHumanMessages===0 且 carriedTexts 空
+     且 eventText 空）同样不调 settleInjectedHooks 即返回，且前面隔着 ensureSession /
+     load / commitHumanInputs 三次真实 I/O await，窗口比 b 宽（七审补记，定性相同）。
+     后果（review 追过 scheduler 实现）：仅 `lastActionTime` 不更新，下一条消息 enqueue 时立即 flush，是
      「更积极」而非「变哑」，可接受。
   4. 注入未被 drain 时的委托值失真——消息实际由自唤醒 episode 处理，却以被注入 episode
      的 repliedToHuman 结算；一次性误报非系统性偏置，可接受。

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,6 +1,6 @@
 # Crabot 项目进度
 
-> 最后整理：2026-08-29
+> 最后整理：2026-08-30
 > 本文件只保留当前状态、明确 follow-up 和阶段性里程碑；详细实施流水、逐轮 review 与历史测试输出见 Git 历史。压缩前完整版本可用 `git show 49b9cb4:PROGRESS.md` 查看。
 
 ## 当前状态
@@ -18,14 +18,17 @@
   Output 探针提前返回，投递可见性从小时级降到 ≈2s）+ 协议 v3.6.15（docs `93975cf`）+
   spec 2026-08-20 同步。review 三轮：真实风险 2 项（测试 gate 失效、`[manager input]`
   前缀误标系统通知）已修。
-- PR #131（OPEN，等权限立项落地后合入）：manager 人类消息 episode 运行中到达时**同步**入
+- PR #131（OPEN，合并门禁：① 权限立项落地；② §4.1 注入例外措辞——六审固化为门禁，
+  两者均随权限 spec 一并待确认）：manager 人类消息 episode 运行中到达时**同步**入
   mailbox 走 turn 边界注入（check→push 零 await，与 routeWorkerEvent 同构原子）；store 提交
   延后到 episode 收尾临界区统一落盘（mutex 内单写者，消除注入 RMW 与收尾 save 的 lost
   update）；attention flush / 私聊 / Admin Chat 的结算与 fail-loud 全部委托被注入 episode
-  的真实收尾（占位 result 不参与判定）。五轮 review：真实风险累计 9 项已修（未消费注入
+  的真实收尾（占位 result 不参与判定）。六轮 review：真实风险累计 9 项已修（未消费注入
   键在 recent 无=永久丢失；假结算 ×5 渐远；重复来源注入 LLM；RMW 并发；check-to-push
   窗口；占位 result 打掉私聊/Admin Chat fail-loud；catch 分支丢注入；discard 打掉自唤醒；
-  currentEpisodeInjected 重复入账致 max_tokens 重试渲染两遍）。
+  currentEpisodeInjected 重复入账致 max_tokens 重试渲染两遍）。六审非阻塞观察已处置：
+  删 commitHumanInputs 的 injectedEnvelope 残留（无消费者）、两处注释纠偏、待办池补记
+  （见下 2/3）。
 - **#131 待办与 follow-up 池**：
   1. ~~群聊消息档位随消息~~ → **已定性更正并立项**：原条目「spec 从未定义按发起人区分
      权限」不准确——§3.2.7 与 narrowWorkerPermissions（PR F/J）的既有实现就是按发言人
@@ -35,9 +38,17 @@
      前提消失。另：§4.1「首次 LLM/工具调用前原子写入」与收尾提交的字面冲突需协议补
      注入场景例外（措辞随权限 spec 一并确认）。
   2. 注入路径未过 `assertWakeAdmission`——isClosing 关停期间消息被静默收下返回 completed，
-     调用方拿不到 fail-loud 信号；已落盘不丢，后续统一收口。
+     调用方拿不到 fail-loud 信号。~~已落盘不丢~~（六审指出该理由已过期：四审后注入改
+     为收尾才落盘）；实际收口路径：优雅停机走 abort → settleInjectedHooks(failed) →
+     settle 回调补 fail-loud，通路正常；硬杀才会丢（注入尚未落盘）。后续统一收口。
   3. 结算钩子丢弃窗口——提前 return / `settleInjectedHooks` 之后到达的注入，其 hook 会在
-     下个 episode 起始被清掉不触发 → 该批 flush 没人 reportResult。后果（review 追过
+     下个 episode 起始被清掉不触发 → 该批 flush 没人 reportResult。六审补记两个同定性
+     入口：a) 重复来源批次（newEntries.length===0）提前 return 时 settle hook **从未
+     注册**，该批 flush 永不 reportResult（Admin Chat 侧 claims 在 return 前已登记，
+     仍能被 settleUnclaimedAdminChatWakes 结算）；b) 注入落在 runWake 计数 +1 与
+     runEpisode 起始同步重置之间时，hook 与 pendingHumanCommit 记录一起被重置清掉——
+     消息本身安全（已在 mailbox，作 carried envelope 走正常提交），仅 settle 与
+     reaction 回调不触发，窗口窄（恰好落在 mutex 获取那一跳）。后果（review 追过
      scheduler 实现）：仅 `lastActionTime` 不更新，下一条消息 enqueue 时立即 flush，是
      「更积极」而非「变哑」，可接受。
   4. 注入未被 drain 时的委托值失真——消息实际由自唤醒 episode 处理，却以被注入 episode
@@ -52,7 +63,7 @@
      放弃分支里它自身抛错（store I/O 故障）时，catch 的二次调用看到空队列并报
      injectedHumansCommitted=true → 注入既未落盘也不重投。理论风险（收尾时 store 故障），
      后续统一收口。
-  7. （#130 遗留）redirect 对 builtin 是否允许 interrupt/腰斩工具；v2 agent-handler 遗留
+  8. （#130 遗留）redirect 对 builtin 是否允许 interrupt/腰斩工具；v2 agent-handler 遗留
      （humanQueue/ask_human）清理；Output 超时参数与连续 block 硬性封顶。
 
 ### 移除 macOS FDA 放开机制，受保护目录无条件排除：已合并（PR #129 → `3e268439`）

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -48,6 +48,10 @@
   6. 成功收尾时未被消费的注入留 mailbox 交自唤醒（五审修法），其 reaction 回调随之丢失
      （自唤醒无调用方回调）——与「写入即已接收」自洽（尚未写入本就不该打），窗口窄，
      如实记录不立项。
+  7. commitPendingHumanInputs 在首个 await 前清空 pendingHumanCommit（六审非阻塞观察）：
+     放弃分支里它自身抛错（store I/O 故障）时，catch 的二次调用看到空队列并报
+     injectedHumansCommitted=true → 注入既未落盘也不重投。理论风险（收尾时 store 故障），
+     后续统一收口。
   7. （#130 遗留）redirect 对 builtin 是否允许 interrupt/腰斩工具；v2 agent-handler 遗留
      （humanQueue/ask_human）清理；Output 超时参数与连续 block 硬性封顶。
 

--- a/crabot-agent/src/manager/loop.ts
+++ b/crabot-agent/src/manager/loop.ts
@@ -482,8 +482,15 @@ export class ManagerLoop {
     // 协议 §4.1「重复来源不得新增历史、LLM episode 或 reaction」:整批都已提交过
     // (messageCount=0,at-least-once 重放/渠道重发撞上在跑 episode)→ 不注入,与
     // runEpisode 的空转守卫同语义;部分重叠 → 只注入新消息的投影,已提交的那部分
-    // 不再进 LLM 输入。
-    if (committed.messageCount === 0) return
+    // 不再进 LLM 输入。重复消息携带的 admin chat request ids 仍要登记进 claims——
+    // 当前 episode 收尾的 settleUnclaimedAdminChatWakes 会结掉它,与 idle 空转守卫
+    // 的结算行为对称(否则 journal 条目 pending、每次启动被 no-op 重放)。
+    if (committed.messageCount === 0) {
+      for (const id of envelope.correlation?.admin_chat_request_ids ?? []) {
+        if (!this.adminChatClaims.has(id)) this.adminChatClaims.set(id, 'unclaimed')
+      }
+      return
+    }
     this.enqueueDuringEpisode(committed.injectedEnvelope ?? envelope, { humanWakePreCommitted: true })
     // 结算委托:调用方关心的「这批消息最终有没有被回复」由被注入 episode 的收尾
     // 真实 result 回答(同 episode 收尾 detectRepliedToHuman),不由注入调用编造。
@@ -948,7 +955,8 @@ export class ManagerLoop {
     readonly messageCount: number
     readonly lastCurrentWakeCommittedMessageId?: string
     /** 只含新提交消息的投影 envelope(按 platform_message_id 去重后);messageCount=0 时为 undefined。
-     *  注入路径用它喂 LLM——已提交过的旧消息不得再进 LLM 输入(协议 §4.1)。 */
+     *  注入路径用它喂 LLM——已提交过的旧消息不得再进 LLM 输入(协议 §4.1)。
+     *  仅对**单 envelope** 调用有意义(envelopes 多于一个时本字段只含第一份投影)。 */
     readonly injectedEnvelope?: TimedWakeEnvelope
   }> {
     const committedIds = new Set(state.committedHumanMessageIds ?? [])

--- a/crabot-agent/src/manager/loop.ts
+++ b/crabot-agent/src/manager/loop.ts
@@ -425,10 +425,15 @@ export class ManagerLoop {
   }
 
   /** episode 进行中到达的新事件:渲染成文本推进内部邮箱,由 engine 的 humanMessageQueue
-   *  在 turn 间隙注入;episode 不在跑时同样入队,行为见 `mailbox` 字段注释。 */
-  enqueueDuringEpisode(envelope: TimedWakeEnvelope): void {
+   *  在 turn 间隙注入;episode 不在跑时同样入队,行为见 `mailbox` 字段注释。
+   *
+   *  人类消息默认拒绝:必须先经 commitHumanInputs 写入会话历史(协议 §4.1「人类入站
+   *  提交」)才可注入,否则 failed/aborted 后会把 LLM 已见过的输入当新 wake 重放。
+   *  唯一合法入口是 `enqueueHumanWakeDuringActiveEpisode`(先提交、再带
+   *  `humanWakePreCommitted` 放行)。 */
+  enqueueDuringEpisode(envelope: TimedWakeEnvelope, opts?: { humanWakePreCommitted?: boolean }): void {
     assertTimedWakeEnvelope(envelope)
-    if (isHumanWake(envelope.wake)) {
+    if (isHumanWake(envelope.wake) && !opts?.humanWakePreCommitted) {
       throw new Error('human messages must be committed through wakeUp, not queued during an episode')
     }
     this.mailbox.push(envelope)
@@ -436,6 +441,37 @@ export class ManagerLoop {
     for (const id of envelope.correlation?.admin_chat_request_ids ?? []) {
       if (!this.adminChatClaims.has(id)) this.adminChatClaims.set(id, 'unclaimed')
     }
+  }
+
+  /**
+   * episode 运行中到达的人类消息(P7 cutover 遗留接线,2026-08-29 补):先提交——经
+   * commitHumanInputs 按 platform_message_id 去重写入 state.recent(store),满足协议
+   * §4.1「首次 LLM/工具调用前原子写入」;再入 mailbox 走 turn 边界注入,当前 episode
+   * 的下一轮 LLM 即可见,不再等本 episode 跑完(与 builtin worker 输入注入同语义,
+   * 参照 PR #130)。
+   *
+   * 时序窗口与收口(如实记录):
+   * - 提交的 store.save 与当前 episode 收尾的 save 均基于各自快照,毫秒级并发窗口内
+   *   存在覆盖;若注入未被消费,mailbox 残留由 hasPendingMailbox 自唤醒(#54)取出并
+   *   经 commitHumanInputs 去重重新提交——消息不丢,仅延迟到下一 episode。
+   * - 本 episode failed/aborted:收尾失败分支对已注入(被 drainPending 消费)的人类
+   *   envelope 先补提交进 state.recent,再走既有 settle 重投(去重键使其跳过),下一
+   *   episode 经 tailMessages(state.recent) 重新看到,不丢不重。
+   */
+  async enqueueHumanWakeDuringActiveEpisode(
+    envelope: TimedWakeEnvelope,
+    onHumanInputCommitted?: (lastCommittedMessageId: string) => Promise<void>,
+  ): Promise<void> {
+    await this.deps.store.ensureSession(this.deps.key)
+    const committed = await this.commitHumanInputs(
+      await this.deps.store.load(this.deps.key),
+      [envelope],
+      envelope,
+    )
+    if (committed.lastCurrentWakeCommittedMessageId) {
+      this.notifyHumanInputCommitted(onHumanInputCommitted, committed.lastCurrentWakeCommittedMessageId)
+    }
+    this.enqueueDuringEpisode(envelope, { humanWakePreCommitted: true })
   }
 
   /**
@@ -772,7 +808,21 @@ export class ManagerLoop {
     if (consumedEvents) {
       const priorRecent = state.recent
       const newRecent = attempt.result.finalMessages.slice(attempt.hasSummaryMarker ? 1 : 0)
-      state = { ...state, recent: newRecent, lastActiveAt: this.deps.now().toISOString() }
+      // mid-episode 注入的人类 envelope 其去重键在 enqueueHumanWakeDuringActiveEpisode
+      // 提交时已写入 store;收尾 save 基于本 episode 的旧快照,必须把键合并进来,否则
+      // 会覆盖掉已提交键——channel 重发同 platform_message_id 时会重复提交。
+      const injectedHumanMessageIds = (this.currentEpisodeInjected ?? [])
+        .filter((item) => isHumanWake(item.wake))
+        .flatMap((item) => item.wake.messages.map((m) => m.platform_message_id))
+      const committedIds = injectedHumanMessageIds.length > 0
+        ? Array.from(new Set([...(state.committedHumanMessageIds ?? []), ...injectedHumanMessageIds]))
+        : state.committedHumanMessageIds
+      state = {
+        ...state,
+        recent: newRecent,
+        lastActiveAt: this.deps.now().toISOString(),
+        ...(committedIds !== undefined ? { committedHumanMessageIds: committedIds } : {}),
+      }
       await this.deps.store.save(state)
       const localSupervisionSummary = defaultSupervisionHistorySummary({
         envelope,
@@ -808,6 +858,14 @@ export class ManagerLoop {
       // 清空 mailbox 里可能残留的"尚未被消费"那一段(它是 currentEpisodeInjected 的后缀,
       // 不清空会和下面的整体重投重复),再按到达顺序整体重投,保证至少一次投递、不丢失、不重复。
       const injectedEnvelopes = this.currentEpisodeInjected ?? []
+      // 被 turn 边界注入消费过的人类 envelope:LLM 已见过,失败后必须提交进 recent
+      // (下一 episode 的 tailMessages 重新看到),而不是当作未消费重投——否则既不在
+      // recent(失败路径不做 recent 替换)又被重投去重跳过,消息直接丢失。
+      const injectedHumanEnvelopes = injectedEnvelopes.filter((item) => isHumanWake(item.wake))
+      if (injectedHumanEnvelopes.length > 0) {
+        const committedInjection = await this.commitHumanInputs(state, injectedHumanEnvelopes, undefined)
+        if (committedInjection.messageCount > 0) state = committedInjection.state
+      }
       await this.settleFailedEpisodeEnvelopes(carriedEnvelopes, envelope, injectedEnvelopes, true)
     }
 

--- a/crabot-agent/src/manager/loop.ts
+++ b/crabot-agent/src/manager/loop.ts
@@ -273,6 +273,12 @@ export class ManagerLoop {
    */
   private currentEpisodeInjected: TimedWakeEnvelope[] | null = null
   /**
+   * 注入方委托的结算钩子(PR #131 review):mid-episode 注入的人类消息(如群聊
+   * attention flush)其调用方关心的处理结果由被注入 episode 的真实收尾回答——
+   * episode 收尾时以真实 result 逐个调用并清空。runEpisode 进入时重置。
+   */
+  private currentEpisodeSettleHooks: Array<(result: EpisodeResult) => void> = []
+  /**
    * P5 Task 4 additive:本 episode 的 primary 唤醒事件,供非 daily reflection 的
    * `deps.toolFace(wakeEvent)` 按"这次是被什么唤醒的"装配工具面。与 `currentEpisodeInjected`
    * 同一套生命周期纪律(runEpisode 进入时置、finally 清),因此天然是**每 episode 精确**的
@@ -450,17 +456,19 @@ export class ManagerLoop {
    * 的下一轮 LLM 即可见,不再等本 episode 跑完(与 builtin worker 输入注入同语义,
    * 参照 PR #130)。
    *
-   * 时序窗口与收口(如实记录):
-   * - 提交的 store.save 与当前 episode 收尾的 save 均基于各自快照,毫秒级并发窗口内
-   *   存在覆盖;若注入未被消费,mailbox 残留由 hasPendingMailbox 自唤醒(#54)取出并
-   *   经 commitHumanInputs 去重重新提交——消息不丢,仅延迟到下一 episode。
-   * - 本 episode failed/aborted:收尾失败分支对已注入(被 drainPending 消费)的人类
-   *   envelope 先补提交进 state.recent,再走既有 settle 重投(去重键使其跳过),下一
-   *   episode 经 tailMessages(state.recent) 重新看到,不丢不重。
+   * 时序窗口与收口(如实记录,PR #131 review 修正):
+   * - 注入被 engine drain 消费(进了 finalMessages):成功收尾的 recent 替换天然含它,
+   *   收尾键合并只纳入这类「已消费」envelope;failed/aborted 收尾由失败分支补提交进
+   *   state.recent——两条路都保证消息进历史、去重键成立。
+   * - 注入未被消费(落在最后一次 drainPending 之后):envelope 残留 mailbox。收尾
+   *   save 基于旧快照会抹掉 enqueue 时写入的 recent 追加,**此时绝不能记去重键**
+   *   (键在而 recent 无 = 自唤醒重提交被去重跳过 = 永久丢失);键不记,残留 envelope
+   *   由 hasPendingMailbox 自唤醒(#54)取出按正常路径提交,消息不丢。
    */
   async enqueueHumanWakeDuringActiveEpisode(
     envelope: TimedWakeEnvelope,
     onHumanInputCommitted?: (lastCommittedMessageId: string) => Promise<void>,
+    onEpisodeSettled?: (result: EpisodeResult) => void,
   ): Promise<void> {
     await this.deps.store.ensureSession(this.deps.key)
     const committed = await this.commitHumanInputs(
@@ -471,6 +479,9 @@ export class ManagerLoop {
     if (committed.lastCurrentWakeCommittedMessageId) {
       this.notifyHumanInputCommitted(onHumanInputCommitted, committed.lastCurrentWakeCommittedMessageId)
     }
+    // 结算委托:调用方关心的「这批消息最终有没有被回复」由被注入 episode 的收尾
+    // 真实 result 回答(同 episode 收尾 detectRepliedToHuman),不由注入调用编造。
+    if (onEpisodeSettled) this.currentEpisodeSettleHooks.push(onEpisodeSettled)
     this.enqueueDuringEpisode(envelope, { humanWakePreCommitted: true })
   }
 
@@ -480,6 +491,20 @@ export class ManagerLoop {
    */
   private renderEnvelope(envelope: TimedWakeEnvelope): string {
     return renderTimedWakeEnvelope(envelope)
+  }
+
+  /** 注入结算钩子的统一出口(PR #131):正常收口 / 失败收口 / throw 三条路径都以各自
+   *  的真实 result 调用注册方(见 enqueueHumanWakeDuringActiveEpisode),调用后清空。 */
+  private settleInjectedHooks(result: EpisodeResult): void {
+    const hooks = this.currentEpisodeSettleHooks
+    this.currentEpisodeSettleHooks = []
+    for (const hook of hooks) {
+      try {
+        hook(result)
+      } catch (error) {
+        console.warn('[ManagerLoop] episode settle hook failed (ignored):', error instanceof Error ? error.message : String(error))
+      }
+    }
   }
 
   /** `event === undefined` ⇒ 自唤醒(见 `drainMailbox`):只处理 mailbox 残留,不渲染唤醒事件。 */
@@ -506,6 +531,7 @@ export class ManagerLoop {
       }
     }
     this.currentEpisodeInjected = []
+    this.currentEpisodeSettleHooks = []
     this.currentWakeEvent = envelope ?? null
     this.currentEpisodeEnvelopes = episodeEnvelopes
     this.needsSpawnRecheck = false
@@ -600,6 +626,7 @@ export class ManagerLoop {
       // 否则 wake 永不 settled，每次 Agent 重启都重放历史消息。已 claim 的由 delivery
       // confirm 结算；失败（consumedEvents=false）的整批重投不结算。
       if (result.consumedEvents) await this.settleUnclaimedAdminChatWakes()
+      this.settleInjectedHooks(result)
       return result
     } catch (err) {
       // admission 与直接 throw 都在这里收口。人类提交一旦完成，仅重投非人类事件；否则保留
@@ -623,6 +650,14 @@ export class ManagerLoop {
       this.mailbox.clearContextAdmissions()
       this.admittedActivityReceipts.clear()
       this.rejectedActivityReceipts.clear()
+      this.settleInjectedHooks({
+        episodeId,
+        outcome: 'failed',
+        turns: 0,
+        consumedEvents: false,
+        repliedToHuman: false,
+        successfulSendMessageTargets: [],
+      })
       throw err
     } finally {
       this.currentEpisodeInjected = null
@@ -808,14 +843,31 @@ export class ManagerLoop {
     if (consumedEvents) {
       const priorRecent = state.recent
       const newRecent = attempt.result.finalMessages.slice(attempt.hasSummaryMarker ? 1 : 0)
-      // mid-episode 注入的人类 envelope 其去重键在 enqueueHumanWakeDuringActiveEpisode
-      // 提交时已写入 store;收尾 save 基于本 episode 的旧快照,必须把键合并进来,否则
-      // 会覆盖掉已提交键——channel 重发同 platform_message_id 时会重复提交。
-      const injectedHumanMessageIds = (this.currentEpisodeInjected ?? [])
-        .filter((item) => isHumanWake(item.wake))
-        .flatMap((item) => item.wake.messages.map((m) => m.platform_message_id))
-      const committedIds = injectedHumanMessageIds.length > 0
-        ? Array.from(new Set([...(state.committedHumanMessageIds ?? []), ...injectedHumanMessageIds]))
+      // mid-episode 注入的人类 envelope 去重键的收口(PR #131 review 真实风险 1):
+      // - **被 engine drain 消费过的**(渲染文本出现在 finalMessages——渲染是 envelope
+      //   的纯函数,见 renderEnvelope):消息已随 recent 替换进入历史,键必须合并保留,
+      //   否则收尾 save 抹掉 enqueue 提交写入的键,channel 重发同 platform_message_id
+      //   会重复提交。
+      // - **未被消费的**(落在最后一次 drainPending 之后):收尾 save 会抹掉 enqueue 时
+      //   写入的 recent 追加——此时键也必须一并抹掉。键在而 recent 无 = 自唤醒重提交
+      //   被去重跳过 = 消息永久丢失。键不记,残留 envelope 由 hasPendingMailbox 自唤醒
+      //   (#54)按正常路径提交,消息不丢。
+      const finalTexts = new Set(
+        attempt.result.finalMessages.map((m) => ('content' in m && typeof m.content === 'string' ? m.content : '')),
+      )
+      // 消费判定:注入渲染文本(envelope 的纯函数)出现在 finalMessages 中 = 已被 drain。
+      const consumedHumanIds = (this.currentEpisodeInjected ?? [])
+        .filter((item) => {
+          if (!isHumanWake(item.wake)) return false
+          const rendered = this.renderEnvelope(item)
+          return finalTexts.has(rendered)
+        })
+        .flatMap((item) => {
+          if (!isHumanWake(item.wake)) return []
+          return item.wake.messages.map((m) => m.platform_message_id)
+        })
+      const committedIds = consumedHumanIds.length > 0
+        ? Array.from(new Set([...(state.committedHumanMessageIds ?? []), ...consumedHumanIds]))
         : state.committedHumanMessageIds
       state = {
         ...state,

--- a/crabot-agent/src/manager/loop.ts
+++ b/crabot-agent/src/manager/loop.ts
@@ -948,14 +948,9 @@ export class ManagerLoop {
     readonly humanMessages: ReadonlyArray<EngineMessage>
     readonly messageCount: number
     readonly lastCurrentWakeCommittedMessageId?: string
-    /** 只含新提交消息的投影 envelope(按 platform_message_id 去重后);messageCount=0 时为 undefined。
-     *  注入路径用它喂 LLM——已提交过的旧消息不得再进 LLM 输入(协议 §4.1)。
-     *  仅对**单 envelope** 调用有意义(envelopes 多于一个时本字段只含第一份投影)。 */
-    readonly injectedEnvelope?: TimedWakeEnvelope
   }> {
     const committedIds = new Set(state.committedHumanMessageIds ?? [])
     const committedMessages: EngineMessage[] = []
-    const injectedEnvelopes: TimedWakeEnvelope[] = []
     let lastCurrentWakeCommittedMessageId: string | undefined
 
     for (const envelope of envelopes) {
@@ -967,7 +962,6 @@ export class ManagerLoop {
 
       for (const { message } of newEntries) committedIds.add(message.platform_message_id)
       committedMessages.push(createUserMessage(this.renderEnvelope(projectHumanEnvelope(envelope, newEntries))))
-      injectedEnvelopes.push(projectHumanEnvelope(envelope, newEntries))
       if (envelope === currentEnvelope) {
         lastCurrentWakeCommittedMessageId = newEntries[newEntries.length - 1].message.platform_message_id
       }
@@ -988,7 +982,6 @@ export class ManagerLoop {
       humanMessages: committedMessages,
       messageCount: committedMessages.length,
       lastCurrentWakeCommittedMessageId,
-      injectedEnvelope: injectedEnvelopes[0],
     }
   }
 

--- a/crabot-agent/src/manager/loop.ts
+++ b/crabot-agent/src/manager/loop.ts
@@ -279,6 +279,21 @@ export class ManagerLoop {
    */
   private currentEpisodeSettleHooks: Array<(result: EpisodeResult) => void> = []
   /**
+   * 待提交的注入人类消息(PR #131 四审):注入路径不做 store RMW(与在跑 episode 的
+   * 收尾 save 并发会互相覆盖),只登记到这里;episode 收尾临界区(mutex 内)统一
+   * commitHumanInputs 落盘。runEpisode 进入时清空。
+   */
+  private pendingHumanCommit: Array<{
+    envelope: TimedWakeEnvelope
+    onHumanInputCommitted?: (lastCommittedMessageId: string) => Promise<void>
+  }> = []
+  /**
+   * 本 episode 已提交人类消息 id 的内存镜像(runEpisode 开头 commit 后置位):注入
+   * 投影的同步判定依据。与 store 的偏差方向安全——镜像缺失的 id 在收尾提交时仍被
+   * store 层去重兜底。
+   */
+  private knownCommittedHumanIds: Set<string> = new Set()
+  /**
    * P5 Task 4 additive:本 episode 的 primary 唤醒事件,供非 daily reflection 的
    * `deps.toolFace(wakeEvent)` 按"这次是被什么唤醒的"装配工具面。与 `currentEpisodeInjected`
    * 同一套生命周期纪律(runEpisode 进入时置、finally 清),因此天然是**每 episode 精确**的
@@ -465,33 +480,41 @@ export class ManagerLoop {
    *   (键在而 recent 无 = 自唤醒重提交被去重跳过 = 永久丢失);键不记,残留 envelope
    *   由 hasPendingMailbox 自唤醒(#54)取出按正常路径提交,消息不丢。
    */
-  async enqueueHumanWakeDuringActiveEpisode(
+  /**
+   * episode 运行中到达的人类消息(P7 cutover 遗留接线,2026-08-29 补):**同步**入
+   * mailbox 走 turn 边界注入(check 与 push 之间无 await,与 routeWorkerEvent 同构
+   * 原子);store 提交延后到本 episode 收尾临界区(mutex 内,见 commitPendingHumanInputs)
+   * ——绝不在 mutex 外对 session state 做第二个 RMW(PR #131 四审真实风险:与收尾
+   * save 并发互相覆盖)。
+   *
+   * - 投影按 knownCommittedHumanIds 内存镜像同步计算:整批已提交(重放/渠道重发)→
+   *   只登记 admin chat claims 后返回,不进 LLM(协议 §4.1 重复来源守卫,与 idle
+   *   空转守卫同语义);部分重叠 → 只注入新消息投影。
+   * - 崩溃窗口如实说明:提交延后意味着「注入后、收尾前」进程崩溃时该消息丢失——
+   *   与修复前消息在 lane 内存队列等 mutex 的崩溃窗口同级,不劣于现状。
+   */
+  enqueueHumanWakeDuringActiveEpisode(
     envelope: TimedWakeEnvelope,
     onHumanInputCommitted?: (lastCommittedMessageId: string) => Promise<void>,
     onEpisodeSettled?: (result: EpisodeResult) => void,
-  ): Promise<void> {
-    await this.deps.store.ensureSession(this.deps.key)
-    const committed = await this.commitHumanInputs(
-      await this.deps.store.load(this.deps.key),
-      [envelope],
-      envelope,
-    )
-    if (committed.lastCurrentWakeCommittedMessageId) {
-      this.notifyHumanInputCommitted(onHumanInputCommitted, committed.lastCurrentWakeCommittedMessageId)
+  ): void {
+    assertTimedWakeEnvelope(envelope)
+    const newEntries = isHumanWake(envelope.wake)
+      ? envelope.wake.messages
+          .map((message, index) => ({ message, index }))
+          .filter(({ message }) => !this.knownCommittedHumanIds.has(message.platform_message_id))
+      : []
+    for (const id of envelope.correlation?.admin_chat_request_ids ?? []) {
+      if (!this.adminChatClaims.has(id)) this.adminChatClaims.set(id, 'unclaimed')
     }
-    // 协议 §4.1「重复来源不得新增历史、LLM episode 或 reaction」:整批都已提交过
-    // (messageCount=0,at-least-once 重放/渠道重发撞上在跑 episode)→ 不注入,与
-    // runEpisode 的空转守卫同语义;部分重叠 → 只注入新消息的投影,已提交的那部分
-    // 不再进 LLM 输入。重复消息携带的 admin chat request ids 仍要登记进 claims——
-    // 当前 episode 收尾的 settleUnclaimedAdminChatWakes 会结掉它,与 idle 空转守卫
-    // 的结算行为对称(否则 journal 条目 pending、每次启动被 no-op 重放)。
-    if (committed.messageCount === 0) {
-      for (const id of envelope.correlation?.admin_chat_request_ids ?? []) {
-        if (!this.adminChatClaims.has(id)) this.adminChatClaims.set(id, 'unclaimed')
-      }
-      return
-    }
-    this.enqueueDuringEpisode(committed.injectedEnvelope ?? envelope, { humanWakePreCommitted: true })
+    if (newEntries.length === 0) return
+    for (const { message } of newEntries) this.knownCommittedHumanIds.add(message.platform_message_id)
+    const projected = isHumanWake(envelope.wake)
+      ? projectHumanEnvelope(envelope, newEntries)
+      : envelope
+    this.pendingHumanCommit.push({ envelope: projected, onHumanInputCommitted })
+    this.currentEpisodeInjected?.push(projected)
+    this.enqueueDuringEpisode(projected, { humanWakePreCommitted: true })
     // 结算委托:调用方关心的「这批消息最终有没有被回复」由被注入 episode 的收尾
     // 真实 result 回答(同 episode 收尾 detectRepliedToHuman),不由注入调用编造。
     if (onEpisodeSettled) this.currentEpisodeSettleHooks.push(onEpisodeSettled)
@@ -544,6 +567,8 @@ export class ManagerLoop {
     }
     this.currentEpisodeInjected = []
     this.currentEpisodeSettleHooks = []
+    this.pendingHumanCommit = []
+    this.knownCommittedHumanIds = new Set()
     this.currentWakeEvent = envelope ?? null
     this.currentEpisodeEnvelopes = episodeEnvelopes
     this.needsSpawnRecheck = false
@@ -575,6 +600,8 @@ export class ManagerLoop {
       state = committed.state
       committedHumanMessages = committed.messageCount
       humanInputsCommitted = true
+      // 已提交人类消息 id 的内存镜像:mid-episode 注入的投影判定用它(同步、无 store I/O)
+      this.knownCommittedHumanIds = new Set(state.committedHumanMessageIds ?? [])
       if (committed.lastCurrentWakeCommittedMessageId) {
         this.notifyHumanInputCommitted(onHumanInputCommitted, committed.lastCurrentWakeCommittedMessageId)
       }
@@ -855,38 +882,7 @@ export class ManagerLoop {
     if (consumedEvents) {
       const priorRecent = state.recent
       const newRecent = attempt.result.finalMessages.slice(attempt.hasSummaryMarker ? 1 : 0)
-      // mid-episode 注入的人类 envelope 去重键的收口(PR #131 review 真实风险 1):
-      // - **被 engine drain 消费过的**(渲染文本出现在 finalMessages——渲染是 envelope
-      //   的纯函数,见 renderEnvelope):消息已随 recent 替换进入历史,键必须合并保留,
-      //   否则收尾 save 抹掉 enqueue 提交写入的键,channel 重发同 platform_message_id
-      //   会重复提交。
-      // - **未被消费的**(落在最后一次 drainPending 之后):收尾 save 会抹掉 enqueue 时
-      //   写入的 recent 追加——此时键也必须一并抹掉。键在而 recent 无 = 自唤醒重提交
-      //   被去重跳过 = 消息永久丢失。键不记,残留 envelope 由 hasPendingMailbox 自唤醒
-      //   (#54)按正常路径提交,消息不丢。
-      const finalTexts = new Set(
-        attempt.result.finalMessages.map((m) => ('content' in m && typeof m.content === 'string' ? m.content : '')),
-      )
-      // 消费判定:注入渲染文本(envelope 的纯函数)出现在 finalMessages 中 = 已被 drain。
-      const consumedHumanIds = (this.currentEpisodeInjected ?? [])
-        .filter((item) => {
-          if (!isHumanWake(item.wake)) return false
-          const rendered = this.renderEnvelope(item)
-          return finalTexts.has(rendered)
-        })
-        .flatMap((item) => {
-          if (!isHumanWake(item.wake)) return []
-          return item.wake.messages.map((m) => m.platform_message_id)
-        })
-      const committedIds = consumedHumanIds.length > 0
-        ? Array.from(new Set([...(state.committedHumanMessageIds ?? []), ...consumedHumanIds]))
-        : state.committedHumanMessageIds
-      state = {
-        ...state,
-        recent: newRecent,
-        lastActiveAt: this.deps.now().toISOString(),
-        ...(committedIds !== undefined ? { committedHumanMessageIds: committedIds } : {}),
-      }
+      state = { ...state, recent: newRecent, lastActiveAt: this.deps.now().toISOString() }
       await this.deps.store.save(state)
       const localSupervisionSummary = defaultSupervisionHistorySummary({
         envelope,
@@ -907,6 +903,9 @@ export class ManagerLoop {
         }
         await this.deps.store.save(state)
       }
+      // 注入人类消息的收尾提交(PR #131 四审):必须在 recent 替换与 supervision save
+      // 之后——load 拿到的是最新 state,未被 drain 消费的追加不会被后续 save 覆盖。
+      await this.commitPendingHumanInputs(true)
     } else {
       // 放弃 episode:已落盘的折叠不回滚(见文件头)——若本次途中发生过 force_hot 折叠
       // (上面 max_tokens 兜底重试路径),carriedTexts/eventText 有可能已经作为
@@ -921,15 +920,10 @@ export class ManagerLoop {
       // currentEpisodeInjected 都完整记录了原始文本,是唯一权威来源;先 drainPending()
       // 清空 mailbox 里可能残留的"尚未被消费"那一段(它是 currentEpisodeInjected 的后缀,
       // 不清空会和下面的整体重投重复),再按到达顺序整体重投,保证至少一次投递、不丢失、不重复。
+      // 注入的人类消息由 commitPendingHumanInputs 先落 recent(它们随失败一起丢了
+      // finalMessages 副本,必须以 recent 形式保留),之后 settle 重投按去重键跳过。
       const injectedEnvelopes = this.currentEpisodeInjected ?? []
-      // 被 turn 边界注入消费过的人类 envelope:LLM 已见过,失败后必须提交进 recent
-      // (下一 episode 的 tailMessages 重新看到),而不是当作未消费重投——否则既不在
-      // recent(失败路径不做 recent 替换)又被重投去重跳过,消息直接丢失。
-      const injectedHumanEnvelopes = injectedEnvelopes.filter((item) => isHumanWake(item.wake))
-      if (injectedHumanEnvelopes.length > 0) {
-        const committedInjection = await this.commitHumanInputs(state, injectedHumanEnvelopes, undefined)
-        if (committedInjection.messageCount > 0) state = committedInjection.state
-      }
+      await this.commitPendingHumanInputs(false)
       await this.settleFailedEpisodeEnvelopes(carriedEnvelopes, envelope, injectedEnvelopes, true)
     }
 
@@ -1010,6 +1004,54 @@ export class ManagerLoop {
     } catch (err) {
       console.warn('[ManagerLoop] human input committed callback failed (ignored):', err instanceof Error ? err.message : String(err))
     }
+  }
+
+  /**
+   * 注入人类消息的收尾提交(PR #131 四审重构):mid-episode 注入路径不做 store RMW
+   * (与在跑 episode 的收尾 save 并发会互相覆盖——review 真实风险),消息登记在
+   * pendingHumanCommit,由本方法在 episode 收尾临界区(loop mutex 内)统一落盘。
+   *
+   * @param recentReplaced 本 episode 是否以 finalMessages 替换过 recent(成功收尾)。
+   *   按它分派每条注入消息:
+   *   - 已被 engine drain 消费(不在 mailbox.pending)且 recentReplaced:文本已随
+   *     替换进入历史 → 只补记去重键,不重复追加;
+   *   - 其余情况(未被消费;或失败收尾 recent 未替换、finalMessages 已丢弃):先从
+   *     mailbox 移除,再正常提交(recent 追加文本+去重键)。
+   * 回调(onHumanInputCommitted)在提交落定后触发。调用方必须在 loop mutex 内。
+   */
+  private async commitPendingHumanInputs(recentReplaced: boolean): Promise<void> {
+    if (this.pendingHumanCommit.length === 0) return
+    const pending = this.pendingHumanCommit
+    this.pendingHumanCommit = []
+    let state = await this.deps.store.load(this.deps.key)
+    let dirty = false
+    for (const rec of pending) {
+      const lastMessageId = isHumanWake(rec.envelope.wake)
+        ? rec.envelope.wake.messages.at(-1)?.platform_message_id
+        : undefined
+      if (recentReplaced && !this.mailbox.isPending(rec.envelope)) {
+        // 已被 drain 消费且 recent 已替换:文本已进历史,只补去重键
+        const ids = isHumanWake(rec.envelope.wake)
+          ? rec.envelope.wake.messages.map((m) => m.platform_message_id)
+          : []
+        const merged = new Set([...(state.committedHumanMessageIds ?? []), ...ids])
+        state = { ...state, committedHumanMessageIds: Array.from(merged) }
+        dirty = dirty || ids.length > 0
+      } else {
+        // 未被消费(残留 mailbox,先移除避免与 carry 重投重复)或失败收尾(finalMessages
+        // 已随失败丢弃,必须以 recent 形式保留):正常提交追加。
+        this.mailbox.discard(rec.envelope)
+        const committed = await this.commitHumanInputs(state, [rec.envelope], rec.envelope)
+        if (committed.messageCount > 0) {
+          state = committed.state
+          dirty = true
+        }
+      }
+      if (lastMessageId) {
+        this.notifyHumanInputCommitted(rec.onHumanInputCommitted, lastMessageId)
+      }
+    }
+    if (dirty) await this.deps.store.save(state)
   }
 
   private requeueUncommittedEnvelopes(
@@ -1504,6 +1546,17 @@ class TimedWakeMailbox implements HumanMessageQueueLike {
     const drained = this.pending
     this.pending = []
     return drained
+  }
+
+  /** 该 envelope 是否仍在等待注入(引用比较)。收尾提交用它区分「已被 drain 消费/未消费」。 */
+  isPending(envelope: TimedWakeEnvelope): boolean {
+    return this.pending.includes(envelope)
+  }
+
+  /** 按引用移除一个尚未注入的 envelope(收尾提交改为直接落 recent 时使用)。 */
+  discard(envelope: TimedWakeEnvelope): void {
+    const index = this.pending.indexOf(envelope)
+    if (index >= 0) this.pending.splice(index, 1)
   }
 
   takePendingActivityEnvelopes(): TimedWakeEnvelope[] {

--- a/crabot-agent/src/manager/loop.ts
+++ b/crabot-agent/src/manager/loop.ts
@@ -465,22 +465,6 @@ export class ManagerLoop {
   }
 
   /**
-   * episode 运行中到达的人类消息(P7 cutover 遗留接线,2026-08-29 补):先提交——经
-   * commitHumanInputs 按 platform_message_id 去重写入 state.recent(store),满足协议
-   * §4.1「首次 LLM/工具调用前原子写入」;再入 mailbox 走 turn 边界注入,当前 episode
-   * 的下一轮 LLM 即可见,不再等本 episode 跑完(与 builtin worker 输入注入同语义,
-   * 参照 PR #130)。
-   *
-   * 时序窗口与收口(如实记录,PR #131 review 修正):
-   * - 注入被 engine drain 消费(进了 finalMessages):成功收尾的 recent 替换天然含它,
-   *   收尾键合并只纳入这类「已消费」envelope;failed/aborted 收尾由失败分支补提交进
-   *   state.recent——两条路都保证消息进历史、去重键成立。
-   * - 注入未被消费(落在最后一次 drainPending 之后):envelope 残留 mailbox。收尾
-   *   save 基于旧快照会抹掉 enqueue 时写入的 recent 追加,**此时绝不能记去重键**
-   *   (键在而 recent 无 = 自唤醒重提交被去重跳过 = 永久丢失);键不记,残留 envelope
-   *   由 hasPendingMailbox 自唤醒(#54)取出按正常路径提交,消息不丢。
-   */
-  /**
    * episode 运行中到达的人类消息(P7 cutover 遗留接线,2026-08-29 补):**同步**入
    * mailbox 走 turn 边界注入(check 与 push 之间无 await,与 routeWorkerEvent 同构
    * 原子);store 提交延后到本 episode 收尾临界区(mutex 内,见 commitPendingHumanInputs)
@@ -513,7 +497,8 @@ export class ManagerLoop {
       ? projectHumanEnvelope(envelope, newEntries)
       : envelope
     this.pendingHumanCommit.push({ envelope: projected, onHumanInputCommitted })
-    this.currentEpisodeInjected?.push(projected)
+    // currentEpisodeInjected 由 enqueueDuringEpisode 内部统一入账,此处不重复 push
+    // (五审:重复 push 会让 max_tokens 兜底重试把同一消息渲染两遍)。
     this.enqueueDuringEpisode(projected, { humanWakePreCommitted: true })
     // 结算委托:调用方关心的「这批消息最终有没有被回复」由被注入 episode 的收尾
     // 真实 result 回答(同 episode 收尾 detectRepliedToHuman),不由注入调用编造。
@@ -677,11 +662,26 @@ export class ManagerLoop {
         })
       }
       const injectedEnvelopes = this.currentEpisodeInjected ?? []
+      // 注入的人类消息先补提交(PR #131 五审真实风险:catch 分支原来没有这一步,
+      // pendingHumanCommit 里的注入既不在 store、又被 settleFailedEpisodeEnvelopes
+      // drain+按主 wake 提交状态跳过重投 → 永久丢失)。与放弃分支同语义:throw 已
+      // 丢弃 finalMessages 副本,必须以 recent 形式保留。提交失败(往往就是 store
+      // 故障与本 err 同源)只记日志、不掩盖原 err;injectedHumansCommitted=false 时
+      // settleFailedEpisodeEnvelopes 把注入人类 wake requeue 回 mailbox,自唤醒按
+      // 正常路径重新提交,消息仍不丢。
+      let injectedHumansCommitted = false
+      try {
+        await this.commitPendingHumanInputs(false)
+        injectedHumansCommitted = true
+      } catch (commitErr) {
+        console.error('[ManagerLoop] episode throw 后注入人类消息补提交失败:', commitErr)
+      }
       await this.settleFailedEpisodeEnvelopes(
         carriedEnvelopes,
         envelope,
         injectedEnvelopes,
         humanInputsCommitted,
+        injectedHumansCommitted,
       )
       this.currentEpisodeInjected = null
       this.currentWakeEvent = null
@@ -1015,8 +1015,15 @@ export class ManagerLoop {
    *   按它分派每条注入消息:
    *   - 已被 engine drain 消费(不在 mailbox.pending)且 recentReplaced:文本已随
    *     替换进入历史 → 只补记去重键,不重复追加;
-   *   - 其余情况(未被消费;或失败收尾 recent 未替换、finalMessages 已丢弃):先从
-   *     mailbox 移除,再正常提交(recent 追加文本+去重键)。
+   *   - 未被消费且 recentReplaced(成功收尾):**不提交、不 discard、不记键、不回调**,
+   *     envelope 原样留在 mailbox——收尾后 hasPendingMailbox 触发自唤醒(#54),下个
+   *     episode 按正常路径提交+投喂,消息立即被处理(PR #131 五审:提交了就没有
+   *     任何 episode 去回答它,「先提交再留邮箱」则自唤醒被去重键打成空转);代价是
+   *     该消息的 reaction 回调挂起到自唤醒提交时——自唤醒无调用方回调,reaction
+   *     实际丢失,与「写入即已接收」自洽(尚未写入,本就不该打);
+   *   - recentReplaced=false(failed/aborted/throw,finalMessages 已丢弃):先从
+   *     mailbox 移除,再正常提交(recent 追加文本+去重键)——消息必须以 recent
+   *     形式保留,fail-loud 由 settle 回调补发。
    * 回调(onHumanInputCommitted)在提交落定后触发。调用方必须在 loop mutex 内。
    */
   private async commitPendingHumanInputs(recentReplaced: boolean): Promise<void> {
@@ -1026,10 +1033,11 @@ export class ManagerLoop {
     let state = await this.deps.store.load(this.deps.key)
     let dirty = false
     for (const rec of pending) {
+      if (recentReplaced && this.mailbox.isPending(rec.envelope)) continue // 留 mailbox 交自唤醒
       const lastMessageId = isHumanWake(rec.envelope.wake)
         ? rec.envelope.wake.messages.at(-1)?.platform_message_id
         : undefined
-      if (recentReplaced && !this.mailbox.isPending(rec.envelope)) {
+      if (recentReplaced) {
         // 已被 drain 消费且 recent 已替换:文本已进历史,只补去重键
         const ids = isHumanWake(rec.envelope.wake)
           ? rec.envelope.wake.messages.map((m) => m.platform_message_id)
@@ -1038,8 +1046,8 @@ export class ManagerLoop {
         state = { ...state, committedHumanMessageIds: Array.from(merged) }
         dirty = dirty || ids.length > 0
       } else {
-        // 未被消费(残留 mailbox,先移除避免与 carry 重投重复)或失败收尾(finalMessages
-        // 已随失败丢弃,必须以 recent 形式保留):正常提交追加。
+        // 失败收尾(finalMessages 已随失败丢弃,必须以 recent 形式保留;残留 mailbox
+        // 的先移除,避免与 settleFailedEpisodeEnvelopes 的 carry 重投重复):正常提交追加。
         this.mailbox.discard(rec.envelope)
         const committed = await this.commitHumanInputs(state, [rec.envelope], rec.envelope)
         if (committed.messageCount > 0) {
@@ -1070,6 +1078,10 @@ export class ManagerLoop {
     envelope: TimedWakeEnvelope | undefined,
     injectedEnvelopes: ReadonlyArray<TimedWakeEnvelope>,
     humanInputsCommitted: boolean,
+    // 注入的人类 wake 是否已提交(五审):与主 wake 的 humanInputsCommitted 解耦——
+    // catch 分支先跑 commitPendingHumanInputs,注入已提交时此处必须为 true(跳过重投),
+    // 而主 wake 自身的提交状态不变。缺省跟随 humanInputsCommitted(B 分支调用现状)。
+    injectedHumansCommitted: boolean = humanInputsCommitted,
   ): Promise<void> {
     this.mailbox.drainEnvelopes()
     this.mailbox.clearContextAdmissions()
@@ -1080,7 +1092,7 @@ export class ManagerLoop {
     ])
     this.requeueUncommittedEnvelopes(carriedEnvelopes, humanInputsCommitted)
     if (envelope) this.requeueUncommittedEnvelopes([envelope], humanInputsCommitted)
-    this.requeueUncommittedEnvelopes(injectedEnvelopes, humanInputsCommitted)
+    this.requeueUncommittedEnvelopes(injectedEnvelopes, injectedHumansCommitted)
   }
 
   private admitActivityEnvelopes(envelopes: ReadonlyArray<TimedWakeEnvelope>): void {

--- a/crabot-agent/src/manager/loop.ts
+++ b/crabot-agent/src/manager/loop.ts
@@ -857,6 +857,14 @@ export class ManagerLoop {
         ...attempt.result.finalMessages,
         createUserMessage(POST_SEND_ACTION_RECHECK_PROMPT),
       ]
+      // 复核 continuation 期间 engine 可能在 turn 间隙 drain 掉注入(含人类消息)。其
+      // finalMessages 只在下方接管(attempt = continuation)时保留;失败分支丢弃它们——
+      // 被 drain 的注入人类消息若不还原,收尾会按「已被消费」只补去重键,渠道重投被键
+      // 挡掉、mailbox 又空(不触发自唤醒)→ 键在文本无 = 静默永久丢失(十审真实风险)。
+      // 捕获期间被 drain 的 envelope,失败时把人类消息还原回 mailbox,走收尾既有的
+      // 「留 mailbox 交自唤醒」分支(键未记、文本未提交,下个 episode 正常提交+投喂);
+      // 非人类事件维持既有行为(其丢失不违反本 PR 的「人类消息不丢」承诺)。
+      this.mailbox.startDrainCapture()
       const continuation = await this.runAttempt(
         episodeId,
         state,
@@ -873,10 +881,15 @@ export class ManagerLoop {
           ...successfulSendMessageTargetsOf(continuation.result.finalMessages.slice(continuation.initialMessageCount)),
         ]
         attempt = continuation
+        // 文本已随接管保留在 finalMessages,丢弃捕获记录即可。
+        this.mailbox.takeDrainedForReplay()
       } else {
         // The recheck is advisory. Its own failure must not replay an already
         // consumable episode.
         this.recordPostSendDecision('recheck_failed_open')
+        for (const drained of this.mailbox.takeDrainedForReplay()) {
+          if (isHumanWake(drained.wake)) this.mailbox.push(drained)
+        }
       }
     }
 
@@ -1578,6 +1591,8 @@ function successfulSendMessageTargetsOf(
 class TimedWakeMailbox implements HumanMessageQueueLike {
   private pending: TimedWakeEnvelope[] = []
   private contextAdmissionEnvelopes: TimedWakeEnvelope[] = []
+  /** 非 null 时记录此后 drainPending() 拿走的 envelope(复核 continuation 失败还原用,见 runEpisodeBody)。 */
+  private drainCapture: TimedWakeEnvelope[] | null = null
   private barrierResolve: (() => void) | null = null
   private barrierTimer: ReturnType<typeof setTimeout> | null = null
 
@@ -1595,6 +1610,18 @@ class TimedWakeMailbox implements HumanMessageQueueLike {
   /** 该 envelope 是否仍在等待注入(引用比较)。收尾提交用它区分「已被 drain 消费/未消费」。 */
   isPending(envelope: TimedWakeEnvelope): boolean {
     return this.pending.includes(envelope)
+  }
+
+  /** 开始记录此后 drainPending() 拿走的 envelope;与 takeDrainedForReplay 成对使用。 */
+  startDrainCapture(): void {
+    this.drainCapture = []
+  }
+
+  /** 结束记录并返回期间被 drain 的 envelope(按原顺序);未开启时返回空。 */
+  takeDrainedForReplay(): TimedWakeEnvelope[] {
+    const captured = this.drainCapture ?? []
+    this.drainCapture = null
+    return captured
   }
 
   /** 按引用移除一个尚未注入的 envelope(收尾提交改为直接落 recent 时使用)。 */
@@ -1617,6 +1644,7 @@ class TimedWakeMailbox implements HumanMessageQueueLike {
   drainPending(): string[] {
     const drained = this.drainEnvelopes()
     this.contextAdmissionEnvelopes.push(...drained)
+    this.drainCapture?.push(...drained)
     return drained.map(renderTimedWakeEnvelope)
   }
 

--- a/crabot-agent/src/manager/loop.ts
+++ b/crabot-agent/src/manager/loop.ts
@@ -479,10 +479,15 @@ export class ManagerLoop {
     if (committed.lastCurrentWakeCommittedMessageId) {
       this.notifyHumanInputCommitted(onHumanInputCommitted, committed.lastCurrentWakeCommittedMessageId)
     }
+    // 协议 §4.1「重复来源不得新增历史、LLM episode 或 reaction」:整批都已提交过
+    // (messageCount=0,at-least-once 重放/渠道重发撞上在跑 episode)→ 不注入,与
+    // runEpisode 的空转守卫同语义;部分重叠 → 只注入新消息的投影,已提交的那部分
+    // 不再进 LLM 输入。
+    if (committed.messageCount === 0) return
+    this.enqueueDuringEpisode(committed.injectedEnvelope ?? envelope, { humanWakePreCommitted: true })
     // 结算委托:调用方关心的「这批消息最终有没有被回复」由被注入 episode 的收尾
     // 真实 result 回答(同 episode 收尾 detectRepliedToHuman),不由注入调用编造。
     if (onEpisodeSettled) this.currentEpisodeSettleHooks.push(onEpisodeSettled)
-    this.enqueueDuringEpisode(envelope, { humanWakePreCommitted: true })
   }
 
   /**
@@ -942,9 +947,13 @@ export class ManagerLoop {
     readonly humanMessages: ReadonlyArray<EngineMessage>
     readonly messageCount: number
     readonly lastCurrentWakeCommittedMessageId?: string
+    /** 只含新提交消息的投影 envelope(按 platform_message_id 去重后);messageCount=0 时为 undefined。
+     *  注入路径用它喂 LLM——已提交过的旧消息不得再进 LLM 输入(协议 §4.1)。 */
+    readonly injectedEnvelope?: TimedWakeEnvelope
   }> {
     const committedIds = new Set(state.committedHumanMessageIds ?? [])
     const committedMessages: EngineMessage[] = []
+    const injectedEnvelopes: TimedWakeEnvelope[] = []
     let lastCurrentWakeCommittedMessageId: string | undefined
 
     for (const envelope of envelopes) {
@@ -956,6 +965,7 @@ export class ManagerLoop {
 
       for (const { message } of newEntries) committedIds.add(message.platform_message_id)
       committedMessages.push(createUserMessage(this.renderEnvelope(projectHumanEnvelope(envelope, newEntries))))
+      injectedEnvelopes.push(projectHumanEnvelope(envelope, newEntries))
       if (envelope === currentEnvelope) {
         lastCurrentWakeCommittedMessageId = newEntries[newEntries.length - 1].message.platform_message_id
       }
@@ -971,7 +981,13 @@ export class ManagerLoop {
       committedHumanMessageIds: Array.from(committedIds),
     }
     await this.deps.store.save(next)
-    return { state: next, humanMessages: committedMessages, messageCount: committedMessages.length, lastCurrentWakeCommittedMessageId }
+    return {
+      state: next,
+      humanMessages: committedMessages,
+      messageCount: committedMessages.length,
+      lastCurrentWakeCommittedMessageId,
+      injectedEnvelope: injectedEnvelopes[0],
+    }
   }
 
   private notifyHumanInputCommitted(

--- a/crabot-agent/src/manager/registry.ts
+++ b/crabot-agent/src/manager/registry.ts
@@ -353,6 +353,23 @@ export class ManagerRegistry {
       kind === 'human_messages'
         ? { kind: 'human_messages', messages, ...withFriend, ...withPerms }
         : { kind: 'attention_flush', messages, ...withFriend, ...withPerms }
+    // P7 cutover 遗留接线补齐(2026-08-29):episode 运行中到达的人类消息进入当前
+    // episode mailbox,turn 边界注入当前 episode 的下一轮 LLM——不再阻塞在 wakeUp 的
+    // mutex 上等本 episode 跑完。先提交(写历史+去重+回调)再注入,语义与 builtin
+    // worker 输入注入一致(参照 PR #130)。协议 §4.1「episode 进行中到达的事件直接
+    // 进入当前 Manager mailbox」同样涵盖人类消息。
+    const loop = this.getOrCreate(key)
+    if (this.isEpisodeActive(key)) {
+      await loop.enqueueHumanWakeDuringActiveEpisode({ ...envelope, wake: event }, onHumanInputCommitted)
+      return {
+        episodeId: '',
+        outcome: 'completed',
+        turns: 0,
+        consumedEvents: true,
+        repliedToHuman: false,
+        successfulSendMessageTargets: [],
+      }
+    }
     return this.runWake(key, { ...envelope, wake: event }, 0, onHumanInputCommitted)
   }
 

--- a/crabot-agent/src/manager/registry.ts
+++ b/crabot-agent/src/manager/registry.ts
@@ -286,9 +286,12 @@ export class ManagerRegistry {
     correlation?: import('./loop.js').ManagerWakeCorrelation,
     /** 人类输入已持久化进对应 Manager 会话后的非关键通知。 */
     onHumanInputCommitted?: (lastCommittedMessageId: string) => Promise<void>,
+    /** 消息被注入在跑 episode 时(PR #131),处理结果的结算委托给该 episode 的真实
+     * 收尾 result——调用方以此补跑 fail-loud,不用注入分支立即返回的占位值。 */
+    onEpisodeSettled?: (result: EpisodeResult) => void,
   ): Promise<EpisodeResult> {
     const capture = this.captureIngress()
-    return this.routeHumanWake(capture, 'human_messages', channelId, sessionId, messages, friend, correlation, onHumanInputCommitted)
+    return this.routeHumanWake(capture, 'human_messages', channelId, sessionId, messages, friend, correlation, onHumanInputCommitted, onEpisodeSettled)
   }
 
   /**

--- a/crabot-agent/src/manager/registry.ts
+++ b/crabot-agent/src/manager/registry.ts
@@ -310,9 +310,12 @@ export class ManagerRegistry {
     friend?: Friend,
     /** 人类输入已持久化进对应 Manager 会话后的非关键通知。 */
     onHumanInputCommitted?: (lastCommittedMessageId: string) => Promise<void>,
+    /** flush 消息被注入在跑 episode 时(PR #131),处理结果的结算委托给该 episode 的
+     * 真实收尾 result——调用方以此 reportResult,不用注入分支立即返回的占位值。 */
+    onEpisodeSettled?: (result: EpisodeResult) => void,
   ): Promise<EpisodeResult> {
     const capture = this.captureIngress()
-    return this.routeHumanWake(capture, 'attention_flush', channelId, sessionId, messages, friend, undefined, onHumanInputCommitted)
+    return this.routeHumanWake(capture, 'attention_flush', channelId, sessionId, messages, friend, undefined, onHumanInputCommitted, onEpisodeSettled)
   }
 
   /** 两个人类消息入口的公共路径:解析发起人身份(唤醒边界的唯一一次异步)→ 按 kind 造事件唤醒。 */
@@ -325,6 +328,7 @@ export class ManagerRegistry {
     friend?: Friend,
     correlation?: import('./loop.js').ManagerWakeCorrelation,
     onHumanInputCommitted?: (lastCommittedMessageId: string) => Promise<void>,
+    onEpisodeSettled?: (result: EpisodeResult) => void,
   ): Promise<EpisodeResult> {
     const key = `${channelId}::${sessionId}` as ManagerKey
     // 私/群不新增数据来源:它就在消息自己的 session 上。空批(理论上不该发生)按私聊算,
@@ -360,7 +364,7 @@ export class ManagerRegistry {
     // 进入当前 Manager mailbox」同样涵盖人类消息。
     const loop = this.getOrCreate(key)
     if (this.isEpisodeActive(key)) {
-      await loop.enqueueHumanWakeDuringActiveEpisode({ ...envelope, wake: event }, onHumanInputCommitted)
+      await loop.enqueueHumanWakeDuringActiveEpisode({ ...envelope, wake: event }, onHumanInputCommitted, onEpisodeSettled)
       return {
         episodeId: '',
         outcome: 'completed',
@@ -706,7 +710,8 @@ export class ManagerRegistry {
   /**
    * episode 收口后的 mailbox 兜底(P7 阻塞项 #5):engine 在 end_turn 收口前做最后一次
    * `drainPending`,落在那之后的 `enqueueDuringEpisode` 内容没有任何消费者在等,不自唤醒
-   * 就会一直停滞在内存 mailbox 里。人类输入由 `wakeUp()` 串行提交，不走这条内存补充路径；
+   * 就会一直停滞在内存 mailbox 里。人类输入由 `wakeUp()` 串行提交或经
+   * `enqueueHumanWakeDuringActiveEpisode` 提交后注入(PR #131);
    * 这里在 episode 刚收口、引用计数刚归零的同步窗口里补一次自唤醒。
    *
    * 四道门,缺一不可:

--- a/crabot-agent/src/manager/registry.ts
+++ b/crabot-agent/src/manager/registry.ts
@@ -364,7 +364,9 @@ export class ManagerRegistry {
     // 进入当前 Manager mailbox」同样涵盖人类消息。
     const loop = this.getOrCreate(key)
     if (this.isEpisodeActive(key)) {
-      await loop.enqueueHumanWakeDuringActiveEpisode({ ...envelope, wake: event }, onHumanInputCommitted, onEpisodeSettled)
+      // 同步入队(check 与 push 之间无 await,与 routeWorkerEvent 同构原子):
+      // 提交延后到当前 episode 收尾临界区,由 settle hook 拿真实处理结果。
+      loop.enqueueHumanWakeDuringActiveEpisode({ ...envelope, wake: event }, onHumanInputCommitted, onEpisodeSettled)
       return {
         episodeId: '',
         outcome: 'completed',

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -1810,6 +1810,8 @@ export class UnifiedAgent extends ModuleBase {
     const session = messages[0].session
 
     let result
+    // 消息被注入在跑 episode 时(PR #131):占位 result 的 outcome 恒为 completed,
+    // fail-loud 委托给被注入 episode 的真实收尾——失败在这里补发兜底回复。
     try {
       result = await this.requireManagerStack().registry.routeHumanMessages(
         session.channel_id,
@@ -1822,6 +1824,17 @@ export class UnifiedAgent extends ModuleBase {
           session.session_id,
           lastCommittedMessageId,
         ),
+        (settled) => {
+          if (settled.outcome === 'failed' || settled.outcome === 'aborted') {
+            console.error(
+              `[${this.config.moduleId}] processDirectBatch injected episode outcome=${settled.outcome}`,
+            )
+            void this.sendFailLoudReply(session.channel_id, session.session_id, {
+              kind: 'outcome',
+              outcome: settled.outcome,
+            }).catch((err) => console.error(`[${this.config.moduleId}] processDirectBatch settle fail-loud failed:`, err))
+          }
+        },
       )
     } catch (err) {
       console.error(
@@ -1831,6 +1844,9 @@ export class UnifiedAgent extends ModuleBase {
       await this.sendFailLoudReply(session.channel_id, session.session_id, { kind: 'threw', error: err })
       return
     }
+
+    // 注入占位:真实收尾前 outcome/repliedToHuman 都是编造的,不做任何判定与计数。
+    if (result.episodeId === '') return
 
     if (result.outcome === 'failed' || result.outcome === 'aborted') {
       console.error(
@@ -2496,6 +2512,19 @@ export class UnifiedAgent extends ModuleBase {
         [message],
         MASTER_FRIEND,
         { admin_chat_request_ids: [callbackInfo.request_id] },
+        undefined,
+        // 注入在跑 episode 时(PR #131):占位 result 恒 completed,F1 判不到真实失败——
+        // 若被注入 episode 最终 failed/aborted,在此补发 fail-loud 收掉占位气泡(否则
+        // consumedEvents=false 不走 settleUnclaimedAdminChatWakes,气泡转到 agent 重启)。
+        (settled) => {
+          if (settled.outcome === 'failed' || settled.outcome === 'aborted') {
+            console.error(
+              `[${this.config.moduleId}] processAdminChatMessage injected episode outcome=${settled.outcome}`,
+            )
+            void this.sendFailLoudReply('admin-web', sessionId, { kind: 'outcome', outcome: settled.outcome }, callbackInfo.request_id)
+              .catch((err) => console.error(`[${this.config.moduleId}] processAdminChatMessage settle fail-loud failed:`, err))
+          }
+        },
       )
     } catch (err) {
       // F2：episode 中途抛错。
@@ -2511,6 +2540,11 @@ export class UnifiedAgent extends ModuleBase {
       }
       return { decision_types: [] }
     }
+
+    // 注入占位:真实收尾前 outcome/repliedToHuman 都是编造的——F1 与沉默计数都
+    // 等 settle 回调(失败已在上面补发 fail-loud);RPC 先按"暂无直接回复"返回,
+    // 真实回复由后续 delivery 结算占位气泡。
+    if (result.episodeId === '') return { decision_types: [] }
 
     if (result.outcome === 'failed' || result.outcome === 'aborted') {
       // F1：`ManagerLoop` 记下 failed/aborted 后**正常 resolve**，不抛。只写 try/catch 抓不住。

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -1875,6 +1875,10 @@ export class UnifiedAgent extends ModuleBase {
     const session = messages[0].session
 
     let repliedToHuman = false
+    // flush 消息被注入在跑 episode 时(PR #131):结算委托给该 episode 的真实收尾
+    // (episodeId==='' 的占位 result 不带真实 repliedToHuman),不能再用它 reportResult——
+    // 否则「实际回复了」会被记成沉默,群聊注意力错误 ×5 渐远。
+    let settleDelegated = false
     try {
       const result = await this.requireManagerStack().registry.routeAttentionFlush(
         session.channel_id,
@@ -1886,8 +1890,13 @@ export class UnifiedAgent extends ModuleBase {
           sessionId,
           lastCommittedMessageId,
         ),
+        (settled) => {
+          settleDelegated = true
+          this.attentionScheduler.reportResult(sessionId, settled.repliedToHuman)
+        },
       )
       repliedToHuman = result.repliedToHuman
+      settleDelegated = result.episodeId === ''
       if (result.outcome === 'failed' || result.outcome === 'aborted') {
         console.error(
           `[${this.config.moduleId}] processGroupLaneBatch manager episode outcome=${result.outcome}`,
@@ -1907,7 +1916,10 @@ export class UnifiedAgent extends ModuleBase {
 
     // 兜底回复不是 manager 在说话：退避档位仍按"这一轮没出声"上报，
     // 否则故障期间群聊巡检间隔会被冻结在当前值。
-    this.attentionScheduler.reportResult(sessionId, repliedToHuman)
+    // 注入委托场景(settleDelegated)已由被注入 episode 收尾以真实结果结算,此处跳过。
+    if (!settleDelegated) {
+      this.attentionScheduler.reportResult(sessionId, repliedToHuman)
+    }
   }
 
   /**

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -1797,7 +1797,8 @@ export class UnifiedAgent extends ModuleBase {
    * （私聊一般同一人；个别 friend 切换的边缘情况按最新一条处理）。
    *
    * **必须 await manager episode**：lane 的串行语义靠它，兜底回复（fail-loud）也要靠它
-   * 拿到 outcome。改成 fire-and-forget 会让两者同时失效。
+   * 拿到 outcome。改成 fire-and-forget 会让两者同时失效。（例外：mid-episode 注入分支
+   * 返回占位 result 即走，顺序改由 mailbox 与宿主 episode 收尾保证，见 episodeId === '' 判定。）
    *
    * Spec: crabot-docs/superpowers/plans/2026-08-01-mw-p7-j-cutover.md §一
    */
@@ -2553,9 +2554,9 @@ export class UnifiedAgent extends ModuleBase {
       return { decision_types: [] }
     }
 
-    // 注入占位:真实收尾前 outcome/repliedToHuman 都是编造的——F1 与沉默计数都
-    // 等 settle 回调(失败已在上面补发 fail-loud);RPC 先按"暂无直接回复"返回,
-    // 真实回复由后续 delivery 结算占位气泡。
+    // 注入占位:真实收尾前 outcome/repliedToHuman 都是编造的——失败由 settle 回调补发
+    // fail-loud(见上面回调);noteEpisodeSilence 在注入场景不触发(私聊同,仅影响排障
+    // 日志)。RPC 先按"暂无直接回复"返回,真实回复由后续 delivery 结算占位气泡。
     if (result.episodeId === '') return { decision_types: [] }
 
     if (result.outcome === 'failed' || result.outcome === 'aborted') {

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -1909,6 +1909,18 @@ export class UnifiedAgent extends ModuleBase {
         (settled) => {
           settleDelegated = true
           this.attentionScheduler.reportResult(sessionId, settled.repliedToHuman)
+          // 注入场景占位 result 的 outcome 恒为 completed(六审):被注入 episode 真实
+          // 收尾 failed/aborted 时在此补发兜底回复,与 processDirectBatch 对称;
+          // 多条注入同 episode 失败的刷屏由 sendFailLoudReply 的按 key 冷却收口。
+          if (settled.outcome === 'failed' || settled.outcome === 'aborted') {
+            console.error(
+              `[${this.config.moduleId}] processGroupLaneBatch injected episode outcome=${settled.outcome}`,
+            )
+            void this.sendFailLoudReply(session.channel_id, sessionId, {
+              kind: 'outcome',
+              outcome: settled.outcome,
+            }).catch((err) => console.error(`[${this.config.moduleId}] processGroupLaneBatch settle fail-loud failed:`, err))
+          }
         },
       )
       repliedToHuman = result.repliedToHuman

--- a/crabot-agent/tests/inbound/process-group-lane-batch.test.ts
+++ b/crabot-agent/tests/inbound/process-group-lane-batch.test.ts
@@ -680,6 +680,35 @@ describe('processGroupLaneBatch —— 群聊 lane handler（cutover 后下游�
     })
 
     /**
+     * 注入占位(六审):flush 撞上在跑 episode 时占位 result 恒 completed,F1 判不到
+     * 真实失败;被注入 episode 收尾 failed/aborted 时由 settle 回调补发兜底回复,
+     * 与私聊 processDirectBatch 对称。占位自身不得触发 fail-loud。
+     */
+    it('注入占位不触发 fail-loud,真实收尾 failed 经 settle 回调补发', async () => {
+      boot({ attentionMinMs: 1000 })
+      internals.managerStack.registry.routeAttentionFlush = async (
+        _ch: string, _sid: string, _msgs: unknown, _friend: unknown, _onCommitted: unknown,
+        onSettled?: (result: { episodeId: string; outcome: string; turns: number; consumedEvents: boolean; repliedToHuman: boolean }) => void,
+      ) => {
+        queueMicrotask(() => onSettled?.({
+          episodeId: 'ep-real', outcome: 'failed', turns: 3, consumedEvents: true, repliedToHuman: false,
+        }))
+        return { episodeId: '', outcome: 'completed', turns: 0, consumedEvents: true, repliedToHuman: false }
+      }
+
+      await deliverMention(gmsg({ id: 'g-1', mention: true }))
+      // settle 回调是 fire-and-forget,等一拍让它落地
+      await new Promise((r) => setTimeout(r, 20))
+
+      const sent = failLoudSent()
+      expect(sent).toHaveLength(1)
+      expect(sent[0].port).toBe(WECHAT_PORT)
+      expect((sent[0].params.content as { text: string }).text).toContain('管理员')
+      // 退避按 settle 回调的真实 repliedToHuman=false 上报(且只上一次,占位不重复报)
+      expect(internals.attentionScheduler.getCurrentIntervalMs(GROUP_SESSION)).toBe(5000)
+    })
+
+    /**
      * 兜底回复不是 manager 在说话：退避档位仍按"这一轮没出声"上报。
      * 按"出声"算 = 故障期间群聊巡检间隔被冻结在最短值，反而更吵。
      */

--- a/crabot-agent/tests/manager/loop.test.ts
+++ b/crabot-agent/tests/manager/loop.test.ts
@@ -670,6 +670,126 @@ describe('ManagerLoop', () => {
     expect(turn1Messages).not.toContain('sched-1')
   })
 
+  it('episode 运行中到达的人类消息:先提交(store recent+去重键+回调)再注入,当前 episode 下一轮可见', async () => {
+    const { adapter, queue, calls } = makeAdapter()
+    queue.push({ toolCalls: [{ name: 'noop_tool', id: 'call_1', input: {} }], stopReason: 'tool_use' })
+    queue.push({ text: '已处理完毕', stopReason: 'end_turn' })
+
+    let loop!: ManagerLoop
+    const committedIds: string[] = []
+    const deps = baseDeps({
+      store,
+      adapter,
+      toolFace: () => [
+        {
+          name: 'noop_tool',
+          description: 'noop',
+          inputSchema: { type: 'object', properties: {} },
+          isReadOnly: false,
+          call: async () => {
+            // 模拟 episode 运行中人类消息到达(P7 cutover 遗留接线):提交+注入一步完成
+            await loop.enqueueHumanWakeDuringActiveEpisode(
+              timed({ kind: 'human_messages', messages: [makeChannelMessage('中途新指令')] }),
+              async (id) => { committedIds.push(id) },
+            )
+            return { output: 'ok', isError: false }
+          },
+        },
+      ],
+    })
+    loop = new ManagerLoop(deps)
+
+    const result = await loop.wakeUp(timed({ kind: 'human_messages', messages: [makeChannelMessage('开始任务')] }))
+    expect(result.outcome).toBe('completed')
+
+    // 注入可见:turn2 含人类新消息,turn1 不含(turn 间隙注入,不是 initialMessages)
+    const nonFoldCalls = calls.filter((c) => !c.systemPrompt.includes(FOLD_SYSTEM_PROMPT_MARKER))
+    expect(JSON.stringify(nonFoldCalls[1].messages)).toContain('中途新指令')
+    expect(JSON.stringify(nonFoldCalls[0].messages)).not.toContain('中途新指令')
+
+    // 提交落盘:store recent 含消息、去重键记录、commit 回调触发
+    const state = await store.load(KEY)
+    expect(JSON.stringify(state.recent)).toContain('中途新指令')
+    expect(state.committedHumanMessageIds?.length).toBe(2) // 主 wake + mid-episode 注入
+    expect(committedIds).toHaveLength(1)
+  })
+
+  it('episode 失败:被注入消费的人类消息补提交进 recent,下次唤醒经 tailMessages 重新可见且不重复', async () => {
+    const { adapter, queue } = makeAdapter()
+    queue.push({ toolCalls: [{ name: 'noop_tool', id: 'call_1', input: {} }], stopReason: 'tool_use' })
+
+    let loop!: ManagerLoop
+    let nonFoldCallCount = 0
+    let turn2Messages: EngineMessage[] | undefined
+    const throwOnTurn2: LLMAdapter = {
+      async *stream(params) {
+        if (params.systemPrompt.includes(FOLD_SYSTEM_PROMPT_MARKER)) {
+          yield* adapter.stream(params)
+          return
+        }
+        nonFoldCallCount++
+        if (nonFoldCallCount === 2) {
+          turn2Messages = [...params.messages]
+          throw new Error('boom: simulated failure after human injection drain')
+        }
+        yield* adapter.stream(params)
+      },
+      updateConfig: () => {},
+    }
+
+    const deps = baseDeps({
+      store,
+      adapter: throwOnTurn2,
+      toolFace: () => [
+        {
+          name: 'noop_tool',
+          description: 'noop',
+          inputSchema: { type: 'object', properties: {} },
+          isReadOnly: false,
+          call: async () => {
+            await loop.enqueueHumanWakeDuringActiveEpisode(
+              timed({ kind: 'human_messages', messages: [makeChannelMessage('失败前的人类指令')] }),
+            )
+            return { output: 'ok', isError: false }
+          },
+        },
+      ],
+    })
+    loop = new ManagerLoop(deps)
+
+    const first = await loop.wakeUp(timed({ kind: 'human_messages', messages: [makeChannelMessage('开始任务')] }))
+    expect(first.outcome).toBe('failed')
+
+    // 证明确实被注入消费过:turn2 的请求里能看到人类指令
+    expect(turn2Messages).toBeDefined()
+    expect(JSON.stringify(turn2Messages)).toContain('失败前的人类指令')
+
+    // 失败收尾把已消费的人类消息补提交进 recent——下一 episode 经 tailMessages 重新看到
+    const stateAfterFailure = await store.load(KEY)
+    expect(JSON.stringify(stateAfterFailure.recent)).toContain('失败前的人类指令')
+
+    // 下次唤醒:recent 已含该指令(不重复渲染),新输入正常处理
+    queue.push({ text: '正常处理', stopReason: 'end_turn' })
+    const second = await loop.wakeUp(timed({ kind: 'human_messages', messages: [makeChannelMessage('新的话')] }))
+    expect(second.outcome).toBe('completed')
+
+    const finalState = await store.load(KEY)
+    const serialized = JSON.stringify(finalState.recent)
+    expect(serialized).toContain('失败前的人类指令')
+    expect(serialized).toContain('新的话')
+    // 失败 episode 的重投不产生重复:该指令只出现一次
+    expect(serialized.split('失败前的人类指令')).toHaveLength(2)
+  })
+
+  it('未提交的人类消息仍被 enqueueDuringEpisode 拒绝(提交前置守卫保留)', async () => {
+    const { adapter } = makeAdapter()
+    const deps = baseDeps({ store, adapter })
+    const loop = new ManagerLoop(deps)
+
+    expect(() => loop.enqueueDuringEpisode(timed({ kind: 'human_messages', messages: [makeChannelMessage('x')] })))
+      .toThrow('human messages must be committed through wakeUp')
+  })
+
   it('activity 仅入 mailbox 时保持 pending，进入下一次 LLM 输入前才确认', async () => {
     const { adapter, queue, calls } = makeAdapter()
     queue.push({ toolCalls: [{ name: 'inject_activity', id: 'call-activity', input: {} }], stopReason: 'tool_use' })

--- a/crabot-agent/tests/manager/loop.test.ts
+++ b/crabot-agent/tests/manager/loop.test.ts
@@ -790,6 +790,84 @@ describe('ManagerLoop', () => {
       .toThrow('human messages must be committed through wakeUp')
   })
 
+  it('重复来源(整批已提交)注入在跑 episode 时不进 LLM(协议 §4.1 重复来源守卫)', async () => {
+    const { adapter, queue, calls } = makeAdapter()
+    queue.push({ toolCalls: [{ name: 'noop_tool', id: 'call_1', input: {} }], stopReason: 'tool_use' })
+    queue.push({ text: '已回复', stopReason: 'end_turn' })
+
+    let loop!: ManagerLoop
+    const deps = baseDeps({
+      store,
+      adapter,
+      toolFace: () => [
+        {
+          name: 'noop_tool',
+          description: 'noop',
+          inputSchema: { type: 'object', properties: {} },
+          isReadOnly: false,
+          call: async () => {
+            // 第一次:新消息,正常注入;第二次:同一 platform_message_id 重放(at-least-once),必须被挡
+            const env = timed({ kind: 'human_messages', messages: [makeChannelMessage('重放攻击消息')] })
+            await loop.enqueueHumanWakeDuringActiveEpisode(env)
+            await loop.enqueueHumanWakeDuringActiveEpisode(env)
+            return { output: 'ok', isError: false }
+          },
+        },
+      ],
+    })
+    loop = new ManagerLoop(deps)
+
+    const result = await loop.wakeUp(timed({ kind: 'human_messages', messages: [makeChannelMessage('开始任务')] }))
+    expect(result.outcome).toBe('completed')
+
+    // 消息只被注入一次:最终上下文中恰好出现一次(messages 快照跨轮累积,看最后一轮)
+    const nonFoldCalls = calls.filter((c) => !c.systemPrompt.includes(FOLD_SYSTEM_PROMPT_MARKER))
+    const lastMessages = JSON.stringify(nonFoldCalls.at(-1)!.messages)
+    expect(lastMessages.split('重放攻击消息')).toHaveLength(2) // 1 次出现
+    // 去重键只记一条
+    const state = await store.load(KEY)
+    expect((state.committedHumanMessageIds ?? []).length).toBe(2) // 主 wake + 注入一次
+  })
+
+  it('部分重叠批次:已提交的旧消息不进 LLM,只注入新消息投影', async () => {
+    const { adapter, queue, calls } = makeAdapter()
+    queue.push({ toolCalls: [{ name: 'noop_tool', id: 'call_1', input: {} }], stopReason: 'tool_use' })
+    queue.push({ text: '已回复', stopReason: 'end_turn' })
+
+    const oldMsg = makeChannelMessage('已经答复过的旧消息')
+    let loop!: ManagerLoop
+    const deps = baseDeps({
+      store,
+      adapter,
+      toolFace: () => [
+        {
+          name: 'noop_tool',
+          description: 'noop',
+          inputSchema: { type: 'object', properties: {} },
+          isReadOnly: false,
+          call: async () => {
+            // 第一批:旧消息单独到达并提交
+            await loop.enqueueHumanWakeDuringActiveEpisode(timed({ kind: 'human_messages', messages: [oldMsg] }))
+            // 第二批:同一旧消息 + 一条新消息(渠道合并重发场景)
+            await loop.enqueueHumanWakeDuringActiveEpisode(
+              timed({ kind: 'human_messages', messages: [oldMsg, makeChannelMessage('全新的消息')] }),
+            )
+            return { output: 'ok', isError: false }
+          },
+        },
+      ],
+    })
+    loop = new ManagerLoop(deps)
+
+    await loop.wakeUp(timed({ kind: 'human_messages', messages: [makeChannelMessage('开始任务')] }))
+
+    // 旧消息只出现一次(第一次注入),第二次注入只带新消息投影——看最终上下文
+    const nonFoldCalls = calls.filter((c) => !c.systemPrompt.includes(FOLD_SYSTEM_PROMPT_MARKER))
+    const lastMessages = JSON.stringify(nonFoldCalls.at(-1)!.messages)
+    expect(lastMessages.split('已经答复过的旧消息')).toHaveLength(2) // 1 次出现
+    expect(lastMessages.split('全新的消息')).toHaveLength(2) // 1 次出现
+  })
+
   it('注入委托的结算钩子在 episode 收尾以真实 result 触发(群聊注意力结算用)', async () => {
     const { adapter, queue, calls } = makeAdapter()
     queue.push({ toolCalls: [{ name: 'noop_tool', id: 'call_1', input: {} }], stopReason: 'tool_use' })

--- a/crabot-agent/tests/manager/loop.test.ts
+++ b/crabot-agent/tests/manager/loop.test.ts
@@ -790,6 +790,102 @@ describe('ManagerLoop', () => {
       .toThrow('human messages must be committed through wakeUp')
   })
 
+  it('注入委托的结算钩子在 episode 收尾以真实 result 触发(群聊注意力结算用)', async () => {
+    const { adapter, queue, calls } = makeAdapter()
+    queue.push({ toolCalls: [{ name: 'noop_tool', id: 'call_1', input: {} }], stopReason: 'tool_use' })
+    queue.push({ text: '已回复群消息', stopReason: 'end_turn' })
+
+    let loop!: ManagerLoop
+    const settlements: Array<{ outcome: string; repliedToHuman: boolean }> = []
+    const deps = baseDeps({
+      store,
+      adapter,
+      toolFace: () => [
+        {
+          name: 'noop_tool',
+          description: 'noop',
+          inputSchema: { type: 'object', properties: {} },
+          isReadOnly: false,
+          call: async () => {
+            await loop.enqueueHumanWakeDuringActiveEpisode(
+              timed({ kind: 'human_messages', messages: [makeChannelMessage('群里的后续消息')] }),
+              undefined,
+              (result) => settlements.push({ outcome: result.outcome, repliedToHuman: result.repliedToHuman }),
+            )
+            return { output: 'ok', isError: false }
+          },
+        },
+      ],
+    })
+    loop = new ManagerLoop(deps)
+
+    const result = await loop.wakeUp(timed({ kind: 'human_messages', messages: [makeChannelMessage('开始任务')] }))
+    expect(result.outcome).toBe('completed')
+
+    // 结算钩子以被注入 episode 的真实收尾触发一次(不是注入瞬间的编造值):
+    // 本回合以 end_turn 文本收尾(未调 send_message)→ repliedToHuman 如实为 false
+    expect(settlements).toHaveLength(1)
+    expect(settlements[0]).toEqual({ outcome: 'completed', repliedToHuman: false })
+  })
+
+  it('注入未被消费(最后一轮 drain 之后)时不记去重键,自唤醒/下次唤醒按正常路径提交,消息不丢', async () => {
+    const { adapter, queue, calls } = makeAdapter()
+    // maxTurns=2:turn1 工具(注入未发生) → turn2 工具(此处注入,但其后 hasRemainingTurn=false 不 drain)
+    // → 轮次耗尽 max_turns 收尾(consumedEvents=true)
+    queue.push({ toolCalls: [{ name: 'noop_tool', id: 'call_1', input: {} }], stopReason: 'tool_use' })
+    queue.push({ toolCalls: [{ name: 'inject_tool', id: 'call_2', input: {} }], stopReason: 'tool_use' })
+
+    let loop!: ManagerLoop
+    const deps = baseDeps({
+      store,
+      adapter,
+      maxTurns: 2,
+      toolFace: () => [
+        {
+          name: 'noop_tool',
+          description: 'noop',
+          inputSchema: { type: 'object', properties: {} },
+          isReadOnly: false,
+          call: async () => ({ output: 'ok', isError: false }),
+        },
+        {
+          name: 'inject_tool',
+          description: 'inject',
+          inputSchema: { type: 'object', properties: {} },
+          isReadOnly: false,
+          call: async () => {
+            // 最后一轮的工具执行后 engine 不再 drain——注入滞留 mailbox
+            await loop.enqueueHumanWakeDuringActiveEpisode(
+              timed({ kind: 'human_messages', messages: [makeChannelMessage('滞留指令')] }),
+            )
+            return { output: 'ok', isError: false }
+          },
+        },
+      ],
+    })
+    loop = new ManagerLoop(deps)
+
+    const first = await loop.wakeUp(timed({ kind: 'human_messages', messages: [makeChannelMessage('开始任务')] }))
+    expect(first.outcome).toBe('max_turns') // 轮次耗尽,按已消费收口(consumedEvents=true)
+
+    // 风险 1 回归:未消费 → recent 不含注入文本、去重键不记(键在而 recent 无 = 永久丢失)
+    const stateAfter = await store.load(KEY)
+    expect(JSON.stringify(stateAfter.recent)).not.toContain('滞留指令')
+    expect(stateAfter.committedHumanMessageIds ?? []).toHaveLength(1) // 仅主 wake
+    expect(loop.hasPendingMailbox).toBe(true)
+
+    // 下次唤醒:mailbox 残留经 carry 正常提交,LLM 看到滞留指令
+    queue.push({ text: '补看滞留消息', stopReason: 'end_turn' })
+    const second = await loop.wakeUp(timed({ kind: 'human_messages', messages: [makeChannelMessage('新的话')] }))
+    expect(second.outcome).toBe('completed')
+
+    const secondCall = calls[calls.length - 1]
+    expect(JSON.stringify(secondCall.messages)).toContain('滞留指令')
+    const finalState = await store.load(KEY)
+    expect(JSON.stringify(finalState.recent)).toContain('滞留指令')
+    expect(finalState.committedHumanMessageIds?.length).toBe(3) // 主 wake + 滞留 + 新的话
+  })
+
   it('activity 仅入 mailbox 时保持 pending，进入下一次 LLM 输入前才确认', async () => {
     const { adapter, queue, calls } = makeAdapter()
     queue.push({ toolCalls: [{ name: 'inject_activity', id: 'call-activity', input: {} }], stopReason: 'tool_use' })

--- a/crabot-agent/tests/manager/loop.test.ts
+++ b/crabot-agent/tests/manager/loop.test.ts
@@ -588,6 +588,77 @@ describe('ManagerLoop', () => {
     expect(serialized).toContain('新的话') // 第二次唤醒的新事件
   })
 
+  it('runEpisodeBody 直接 throw 时,mid-episode 注入的人类消息由 catch 分支补提交进 recent,不丢不重复', async () => {
+    const { adapter, queue } = makeAdapter()
+    // 同上一用例的 throw 路径(force-hot 折叠抛错),但 mid-episode 注入的是**人类消息**——
+    // 五审真实风险:catch 分支原来没有 commitPendingHumanInputs,注入消息不在 store、
+    // mailbox 被 drain、requeue 又按主 wake(人类,已提交)跳过 → 永久丢失。
+    queue.push({ toolCalls: [{ name: 'noop_tool', id: 'call_1', input: {} }], stopReason: 'tool_use' })
+    queue.push({ stopReason: 'max_tokens' })
+
+    let loop!: ManagerLoop
+    const throwOnFold: LLMAdapter = {
+      async *stream(params) {
+        if (params.systemPrompt.includes(FOLD_SYSTEM_PROMPT_MARKER)) {
+          throw new Error('boom: fold llm exhausted retries')
+        }
+        yield* adapter.stream(params)
+      },
+      updateConfig: () => {},
+    }
+
+    const policy: CompactionPolicy = { keepRecent: 2, cacheTtlMs: 1000, foldTokenThreshold: 1_000_000, hardCapTokens: 1_000_000 }
+    const deps = baseDeps({
+      store,
+      adapter: throwOnFold,
+      policy,
+      toolFace: () => [
+        {
+          name: 'noop_tool',
+          description: 'noop',
+          inputSchema: { type: 'object', properties: {} },
+          isReadOnly: false,
+          call: async () => {
+            await loop.enqueueHumanWakeDuringActiveEpisode(
+              timed({ kind: 'human_messages', messages: [makeChannelMessage('抛错前注入的指令')] }),
+            )
+            return { output: 'ok', isError: false }
+          },
+        },
+      ],
+    })
+    loop = new ManagerLoop(deps)
+
+    const seedMessages: EngineMessage[] = [
+      createUserMessage('旧消息1'),
+      createUserMessage('旧消息2'),
+      createUserMessage('旧消息3'),
+    ]
+    await store.save({ key: KEY, recent: seedMessages, foldedCount: 0 })
+
+    await expect(
+      loop.wakeUp(timed({ kind: 'human_messages', messages: [makeChannelMessage('触发超限并在折叠时抛错')] }))
+    ).rejects.toThrow('boom: fold llm exhausted retries')
+
+    // catch 分支补提交:注入消息落 recent + 去重键(键与文本同进),mailbox 无残留
+    const stateAfterThrow = await store.load(KEY)
+    expect(JSON.stringify(stateAfterThrow.recent)).toContain('抛错前注入的指令')
+    expect(stateAfterThrow.committedHumanMessageIds ?? []).toHaveLength(2) // 主 wake + 注入
+    expect(loop.hasPendingMailbox).toBe(false)
+
+    // 下次唤醒:注入消息经 tailMessages 可见,commitHumanInputs 按键去重不重复追加
+    queue.push({ text: '正常处理', stopReason: 'end_turn' })
+    const second = await loop.wakeUp(timed({ kind: 'human_messages', messages: [makeChannelMessage('新的话')] }))
+    expect(second.outcome).toBe('completed')
+
+    const finalState = await store.load(KEY)
+    const serialized = JSON.stringify(finalState.recent)
+    expect(serialized).toContain('抛错前注入的指令')
+    expect(serialized).toContain('新的话')
+    // 「抛错前注入的指令」全历史只出现一次(tailMessages 引用同一份 recent,不重复追加)
+    expect(serialized.split('抛错前注入的指令')).toHaveLength(2)
+  })
+
   it('episode 成功:mid-episode 注入的内容已被消费进历史,下次唤醒不会重复投递', async () => {
     const { adapter, queue, calls } = makeAdapter()
     // turn1:调用工具(工具执行期间注入一条新事件,强制进入第二轮);turn2:正常结束
@@ -906,7 +977,7 @@ describe('ManagerLoop', () => {
     expect(settlements[0]).toEqual({ outcome: 'completed', repliedToHuman: false })
   })
 
-  it('注入未被消费(最后一轮 drain 之后)时收尾统一提交进 recent,下次唤醒经 tailMessages 重新可见', async () => {
+  it('注入未被消费(最后一轮 drain 之后)时不提交不 discard,留 mailbox 由自唤醒按正常路径提交+投喂', async () => {
     const { adapter, queue, calls } = makeAdapter()
     // maxTurns=2:turn1 工具(注入未发生) → turn2 工具(此处注入,但其后 hasRemainingTurn=false 不 drain)
     // → 轮次耗尽 max_turns 收尾(consumedEvents=true)
@@ -946,20 +1017,21 @@ describe('ManagerLoop', () => {
     const first = await loop.wakeUp(timed({ kind: 'human_messages', messages: [makeChannelMessage('开始任务')] }))
     expect(first.outcome).toBe('max_turns') // 轮次耗尽,按已消费收口(consumedEvents=true)
 
-    // 风险 1 回归(四审重构语义):未被消费的注入在收尾临界区统一提交——recent 含
-    // 消息、去重键同步落盘(键在 recent 也在),mailbox 已 discard 无残留
+    // 五审语义:未被消费的注入在成功收尾**不提交、不 discard、不记键**,envelope 留在
+    // mailbox——hasPendingMailbox 触发自唤醒,由下个 episode 按正常路径提交+投喂(提交
+    // 了就没有 episode 回答它;先提交再留邮箱则自唤醒被去重键打成空转)
     const stateAfter = await store.load(KEY)
-    expect(JSON.stringify(stateAfter.recent)).toContain('滞留指令')
-    expect(stateAfter.committedHumanMessageIds ?? []).toHaveLength(2) // 主 wake + 滞留
-    expect(loop.hasPendingMailbox).toBe(false)
+    expect(JSON.stringify(stateAfter.recent)).not.toContain('滞留指令')
+    expect(stateAfter.committedHumanMessageIds ?? []).toHaveLength(1) // 仅主 wake
+    expect(loop.hasPendingMailbox).toBe(true)
 
-    // 下次唤醒:tailMessages(state.recent) 含滞留指令,LLM 重新看到,不重复
+    // 自唤醒/下次唤醒:mailbox 残留经 carry 正常提交(键未记,不被去重跳过),LLM 看到
     queue.push({ text: '补看滞留消息', stopReason: 'end_turn' })
     const second = await loop.wakeUp(timed({ kind: 'human_messages', messages: [makeChannelMessage('新的话')] }))
     expect(second.outcome).toBe('completed')
 
     const secondCall = calls[calls.length - 1]
-    expect(secondCall.messages.filter((m) => JSON.stringify(m).includes('滞留指令'))).toHaveLength(1)
+    expect(JSON.stringify(secondCall.messages)).toContain('滞留指令')
     const finalState = await store.load(KEY)
     const finalText = JSON.stringify(finalState.recent)
     expect(finalText).toContain('滞留指令')

--- a/crabot-agent/tests/manager/loop.test.ts
+++ b/crabot-agent/tests/manager/loop.test.ts
@@ -1761,6 +1761,97 @@ describe('ManagerLoop', () => {
       expect(JSON.stringify(calls[2].messages).match(/已经确认入站的人类输入/g)).toHaveLength(1)
     })
 
+    it('复核 continuation（max_turns 外层）失败时，期间被 drain 的注入人类消息还原回 mailbox 不丢失', async () => {
+      // 十审真实风险：外层复核 continuation 的 finalMessages 仅在接管时保留，失败分支
+      // 丢弃——期间被 engine drain 掉的注入人类消息文本随之丢失。若收尾只按「已被消费」
+      // 补去重键，渠道重投被键挡掉、mailbox 又空（不触发自唤醒）→ 键在文本无=静默永久丢失。
+      const { states, traceWriter } = traceRecorder()
+      let streamCount = 0
+      let loop!: ManagerLoop
+      const injectedMsgs: ChannelMessage[] = [
+        { ...makeChannelMessage('首次注入的指令'), platform_message_id: 'pm-injected-first' },
+        { ...makeChannelMessage('复核期间注入的指令'), platform_message_id: 'pm-injected-recheck' },
+      ]
+      const adapter: LLMAdapter = {
+        async *stream() {
+          streamCount++
+          if (streamCount === 1) {
+            // 第一次尝试 turn1：send（记复核标记）+ noop（tool 内注入）
+            yield* chunksFromContent([
+              { type: 'tool_use', id: 'send-1', name: 'send_message', input: { post_send_action: 'spawn_worker' } },
+              { type: 'tool_use', id: 'noop-1', name: 'noop_tool', input: {} },
+            ], 'tool_use')
+            return
+          }
+          if (streamCount === 2) {
+            // 第一次尝试 turn2：继续 tool_use，让第一次尝试以 max_turns 收口（走外层复核）
+            yield* chunksFromContent([
+              { type: 'tool_use', id: 'noop-2', name: 'noop_tool', input: {} },
+            ], 'tool_use')
+            return
+          }
+          if (streamCount === 3) {
+            // 复核 continuation turn1：noop tool 内注入——该注入在其 turn2 前被 drain 吃掉
+            yield* chunksFromContent([
+              { type: 'tool_use', id: 'noop-3', name: 'noop_tool', input: {} },
+            ], 'tool_use')
+            return
+          }
+          // 复核 continuation turn2：drain 已吃掉注入，此后 continuation 失败——
+          // 其 finalMessages（含注入文本）被丢弃
+          throw new Error('recheck provider unavailable')
+        },
+        updateConfig: () => {},
+      }
+      loop = new ManagerLoop(baseDeps({
+        store,
+        adapter,
+        maxTurns: 2,
+        traceWriter,
+        toolFace: () => [
+          defineTool({
+            name: 'send_message', description: 'deliver', inputSchema: { type: 'object', properties: {} },
+            call: async () => {
+              loop.recordPostSendAction()
+              return { output: 'sent' }
+            },
+          }),
+          defineTool({
+            name: 'noop_tool', description: 'noop', inputSchema: { type: 'object', properties: {} },
+            call: async () => {
+              const message = injectedMsgs.shift()
+              if (message) {
+                await loop.enqueueHumanWakeDuringActiveEpisode(
+                  timed({ kind: 'human_messages', messages: [message] }),
+                )
+              }
+              return { output: 'ok', isError: false }
+            },
+          }),
+        ],
+      }))
+
+      const failed = await loop.wakeUp(timed({
+        kind: 'human_messages',
+        messages: [makeChannelMessage('原始请求')],
+      }))
+
+      expect(failed.outcome).toBe('max_turns')
+      expect(failed.consumedEvents).toBe(true)
+      expect(states).toEqual(['marked', 'recheck_injected', 'recheck_failed_open', 'unresolved_accepted'])
+      // 修复判据：注入消息未被消费——还原回 mailbox 触发自唤醒，store 无键无文本（同进同出）
+      expect(loop.hasPendingMailbox).toBe(true)
+      const state = await store.load(KEY)
+      expect(JSON.stringify(state.recent)).not.toContain('复核期间注入的指令')
+      expect(state.committedHumanMessageIds ?? []).not.toContain('pm-injected-recheck')
+
+      // 自唤醒补跑：注入消息正常提交+投喂
+      await loop.drainMailbox()
+      const after = await store.load(KEY)
+      expect(JSON.stringify(after.recent)).toContain('复核期间注入的指令')
+      expect(JSON.stringify(after.recent)).toContain('原始请求')
+    })
+
     it('失败 episode 不保留标记：记录 unresolved_failed，重试时不再注入复核', async () => {
       const calls: LLMStreamParams[] = []
       let streamCount = 0

--- a/crabot-agent/tests/manager/loop.test.ts
+++ b/crabot-agent/tests/manager/loop.test.ts
@@ -906,7 +906,7 @@ describe('ManagerLoop', () => {
     expect(settlements[0]).toEqual({ outcome: 'completed', repliedToHuman: false })
   })
 
-  it('注入未被消费(最后一轮 drain 之后)时不记去重键,自唤醒/下次唤醒按正常路径提交,消息不丢', async () => {
+  it('注入未被消费(最后一轮 drain 之后)时收尾统一提交进 recent,下次唤醒经 tailMessages 重新可见', async () => {
     const { adapter, queue, calls } = makeAdapter()
     // maxTurns=2:turn1 工具(注入未发生) → turn2 工具(此处注入,但其后 hasRemainingTurn=false 不 drain)
     // → 轮次耗尽 max_turns 收尾(consumedEvents=true)
@@ -946,21 +946,24 @@ describe('ManagerLoop', () => {
     const first = await loop.wakeUp(timed({ kind: 'human_messages', messages: [makeChannelMessage('开始任务')] }))
     expect(first.outcome).toBe('max_turns') // 轮次耗尽,按已消费收口(consumedEvents=true)
 
-    // 风险 1 回归:未消费 → recent 不含注入文本、去重键不记(键在而 recent 无 = 永久丢失)
+    // 风险 1 回归(四审重构语义):未被消费的注入在收尾临界区统一提交——recent 含
+    // 消息、去重键同步落盘(键在 recent 也在),mailbox 已 discard 无残留
     const stateAfter = await store.load(KEY)
-    expect(JSON.stringify(stateAfter.recent)).not.toContain('滞留指令')
-    expect(stateAfter.committedHumanMessageIds ?? []).toHaveLength(1) // 仅主 wake
-    expect(loop.hasPendingMailbox).toBe(true)
+    expect(JSON.stringify(stateAfter.recent)).toContain('滞留指令')
+    expect(stateAfter.committedHumanMessageIds ?? []).toHaveLength(2) // 主 wake + 滞留
+    expect(loop.hasPendingMailbox).toBe(false)
 
-    // 下次唤醒:mailbox 残留经 carry 正常提交,LLM 看到滞留指令
+    // 下次唤醒:tailMessages(state.recent) 含滞留指令,LLM 重新看到,不重复
     queue.push({ text: '补看滞留消息', stopReason: 'end_turn' })
     const second = await loop.wakeUp(timed({ kind: 'human_messages', messages: [makeChannelMessage('新的话')] }))
     expect(second.outcome).toBe('completed')
 
     const secondCall = calls[calls.length - 1]
-    expect(JSON.stringify(secondCall.messages)).toContain('滞留指令')
+    expect(secondCall.messages.filter((m) => JSON.stringify(m).includes('滞留指令'))).toHaveLength(1)
     const finalState = await store.load(KEY)
-    expect(JSON.stringify(finalState.recent)).toContain('滞留指令')
+    const finalText = JSON.stringify(finalState.recent)
+    expect(finalText).toContain('滞留指令')
+    expect(finalText).toContain('新的话')
     expect(finalState.committedHumanMessageIds?.length).toBe(3) // 主 wake + 滞留 + 新的话
   })
 

--- a/crabot-agent/tests/manager/registry.test.ts
+++ b/crabot-agent/tests/manager/registry.test.ts
@@ -15,6 +15,7 @@ import {
   shouldWakeOnHarnessEvent,
 } from '../../src/manager/inbound-adapters.js'
 import { ManagerSessionStore } from '../../src/manager/session-store.js'
+import type { EpisodeResult } from '../../src/manager/loop.js'
 import type { CompactionPolicy } from '../../src/manager/compaction.js'
 import type { ManagerKey } from '../../src/manager/types.js'
 import type { ChannelMessage, Friend } from '../../src/types.js'
@@ -930,6 +931,56 @@ describe('ManagerRegistry', () => {
     expect(JSON.stringify(calls[0].messages)).toContain('received_at=\\"2026-08-10T10:00:00+08:00\\"')
     expect(JSON.stringify(calls[1].messages)).toContain('received_at=\\"2026-08-10T10:00:30+08:00\\"')
     expect(JSON.stringify(calls[1].messages)).toContain('second')
+  })
+
+  it('routeHumanMessages 注入在跑 episode 时 onEpisodeSettled 以真实收尾 result 触发(含失败),占位 result 不带真实值', async () => {
+    const firstTurnEntered = deferred()
+    const releaseFirstTurn = deferred()
+    let turn = 0
+    const adapter: LLMAdapter = {
+      async *stream(params) {
+        if (isAssistantTextEndTurnReminder(params)) {
+          yield* chunksFromContent([], 'end_turn', { inputTokens: 10, outputTokens: 5 })
+          return
+        }
+        turn++
+        if (turn === 1) {
+          firstTurnEntered.resolve()
+          await releaseFirstTurn.promise
+          yield* chunksFromContent([{ type: 'text', text: 'ok' }], 'end_turn', { inputTokens: 10, outputTokens: 5 })
+          return
+        }
+        throw new Error('llm down')
+      },
+      updateConfig: () => {},
+    }
+    const registry = new ManagerRegistry(baseRegistryDeps({ adapter }))
+
+    const first = registry.routeHumanMessages('wechat', 'settle-key', [makeChannelMessage('first')])
+    await firstTurnEntered.promise
+
+    const settlements: EpisodeResult[] = []
+    const second = await registry.routeHumanMessages(
+      'wechat',
+      'settle-key',
+      [makeChannelMessage('second')],
+      undefined,
+      undefined,
+      undefined,
+      (settled) => { settlements.push(settled) },
+    )
+    // 占位:outcome 是编造的 completed,不带真实 episodeId
+    expect(second).toMatchObject({ outcome: 'completed', episodeId: '' })
+    expect(settlements).toHaveLength(0)
+
+    releaseFirstTurn.resolve()
+    const firstResult = await first
+    // turn2 抛错 → episode failed;注入消息的 settle 回调以真实 result 触发,
+    // 调用方(processDirectBatch/processAdminChatMessage)据此补发 fail-loud
+    expect(firstResult.outcome).toBe('failed')
+    expect(settlements).toHaveLength(1)
+    expect(settlements[0].outcome).toBe('failed')
+    expect(settlements[0].episodeId).not.toBe('')
   })
 
   // --- evictIdle ---

--- a/crabot-agent/tests/manager/registry.test.ts
+++ b/crabot-agent/tests/manager/registry.test.ts
@@ -888,7 +888,7 @@ describe('ManagerRegistry', () => {
     expect(scheduleMessages).not.toContain('occurred_at=')
   })
 
-  it('同一 ManagerKey 并发排队的后到事件保留各自入口时间', async () => {
+  it('同一 ManagerKey episode 运行中到达的后到人类消息注入当前 episode,并保留各自入口时间', async () => {
     const calls: LLMStreamParams[] = []
     const firstTurnEntered = deferred()
     const releaseFirstTurn = deferred()
@@ -919,13 +919,17 @@ describe('ManagerRegistry', () => {
     const first = registry.routeHumanMessages('wechat', 'same-key', [makeChannelMessage('first')])
     await firstTurnEntered.promise
     nowMs = Date.parse('2026-08-10T02:00:30.000Z')
-    const second = registry.routeHumanMessages('wechat', 'same-key', [makeChannelMessage('second')])
+    // episode 在跑:后到消息注入当前 episode(turn 间隙),不再排队等独立 episode
+    const second = await registry.routeHumanMessages('wechat', 'same-key', [makeChannelMessage('second')])
+    expect(second).toMatchObject({ outcome: 'completed', episodeId: '' })
     nowMs = Date.parse('2026-08-10T02:05:00.000Z')
     releaseFirstTurn.resolve()
-    await Promise.all([first, second])
+    await first
 
+    // turn1 只见 first;turn2(注入后)见 second,且后到消息的入口时间原样保留
     expect(JSON.stringify(calls[0].messages)).toContain('received_at=\\"2026-08-10T10:00:00+08:00\\"')
-    expect(JSON.stringify(calls[2].messages)).toContain('received_at=\\"2026-08-10T10:00:30+08:00\\"')
+    expect(JSON.stringify(calls[1].messages)).toContain('received_at=\\"2026-08-10T10:00:30+08:00\\"')
+    expect(JSON.stringify(calls[1].messages)).toContain('second')
   })
 
   // --- evictIdle ---
@@ -1017,10 +1021,13 @@ describe('ManagerRegistry', () => {
     const loopBefore = registry.getOrCreate(key)
 
     // 同 key 连续发起两次唤醒、不等第一次完成——B 在 ManagerLoop 内部 mutex 上排队等 A。
-    // routeHumanMessages 内部在第一个 await 之前就已经同步完成 activeEpisodes 计数 +1，
+    // routeHumanMessages 在 episode 运行中已改为 mailbox 注入并立即返回(不再排队),
+    // 因此这里用 routeSchedule 触发两个真正排队的在途 episode,保留对 activeEpisodes
+    // 引用计数的保护意图。
+    // runWake 内部在第一个 await 之前就已经同步完成 activeEpisodes 计数 +1，
     // 因此这里不需要额外同步手段就能保证两次唤醒都已经"在途"。
-    const pA = registry.routeHumanMessages('wechat', 'sess-concurrent', [makeChannelMessage('A')])
-    const pB = registry.routeHumanMessages('wechat', 'sess-concurrent', [makeChannelMessage('B')])
+    const pA = registry.routeSchedule({ scheduleId: 'concurrent-a', title: 'A', description: 'A', targetSession: { channel_id: 'wechat', session_id: 'sess-concurrent' } })
+    const pB = registry.routeSchedule({ scheduleId: 'concurrent-b', title: 'B', description: 'B', targetSession: { channel_id: 'wechat', session_id: 'sess-concurrent' } })
 
     const resultA = await pA // A 的 episode 已经 resolve：引用计数应从 2 降到 1，而不是被误删到 0
     expect(resultA.outcome).toBe('completed')


### PR DESCRIPTION
## 背景

用户报告:19:35:50 发出指令,manager 19:36:06 的回复仍在问同一件事(「要我现在派另一个 worker 吗」),19:36:47 才处理——等了 57 秒。

**定性:实现 bug(实现与 roadmap 计划偏差),非新设计。** P7 cutover roadmap D 项明文「cutover 会把人类消息接到那个入口(enqueueDuringEpisode)」,#54 先修了丢失窗口,但接线本身遗漏:`routeHumanWake` 直接 `runWake`,人类消息在 wakeUp 的 mutex 上阻塞等前一 episode 跑完。用户确认预期一直是 turn 间注入(与 builtin worker 同语义,参照 PR #130)。plan 文档已补记(docs 79ca33e)。

## 修复(补齐计划中的接线;四审重构后为当前口径)

| 改动 | 说明 |
|---|---|
| `registry.routeHumanWake` 分支 | episode active 时 `enqueueHumanWakeDuringActiveEpisode`——**同步** check→push 零 await 入 mailbox + 登记 `pendingHumanCommit` + 注册 settle hook,立即返回占位 result(`episodeId:''`);idle 时原路径不变;`attention_flush` 走同一公共路径自动覆盖群聊 |
| 同步原子性 | `isEpisodeActive` 判定与入 mailbox 之间无 await,与 routeWorkerEvent 同构,消灭「落进无消费者 mailbox」窗口 |
| 提交延后到收尾临界区 | 注入路径**不做** store RMW(与在跑 episode 的收尾 save 并发写同一份 session state 会互相覆盖);消息登记在 `pendingHumanCommit`,由 `commitPendingHumanInputs` 在 episode 收尾临界区(loop mutex 内单写者)统一落盘 |
| 收尾三分派 | 已消费+成功收尾:只补去重键(文本随 finalMessages 进 recent);未消费+成功:**不提交不 discard 不记键**,envelope 留 mailbox 交 `hasPendingMailbox` 自唤醒,下一 episode 正常提交投喂;失败/throw:discard 后正常提交(recent 追加+去重键),`injectedHumansCommitted` 与主 wake 提交状态解耦 |
| 结算与 fail-loud 委托 | 占位 result 不参与判定;私聊/群聊/Admin Chat 的 `reportResult` 与 fail-loud 全部由 `onEpisodeSettled` 回调在**真实收尾** failed/aborted 时补发(Admin Chat 带 request_id 走 delivery CAS 结占位气泡;刷屏由 `sendFailLoudReply` 按 key 冷却收口) |
| 重复来源守卫 | 整批已提交(`newEntries.length===0`)时提前 return 不注入——「重复来源不得新增 LLM 调用」在注入路径同样成立 |

## 新引入的失败路径及收口

1. **注入后、收尾落盘前进程崩溃**:消息不在历史中,渠道 at-least-once 重投会按新消息重新处理——包括崩溃前已触发的副作用(已发出的回复、已 spawn 的 worker)可能重复。窗口与改动前「消息在 lane 内存队列等 episode 结束时崩溃」同量级,是 turn 间注入语义的固有权衡(要在收尾前注入就不可能在 store 临界区完成整页 RMW 落盘而不引入 lost update)。协议 §4.1 例外措辞待人类拍板(见合并门禁 2)
2. **catch 分支**:`commitPendingHumanInputs(false)` 补提交(自身抛错仅 console.error,不掩护主错误),`settleFailedEpisodeEnvelopes` 按 `injectedHumansCommitted` 决定是否重投,不重复
3. **settle hook 丢弃的三个窄窗口**(提前 return / runWake 计数与 runEpisode 重置间隙 / 空转 return):消息本身安全(留 mailbox 走自唤醒正常提交),仅 `reportResult` 与 reaction 回调不触发;对 attention 调度的实际后果是「更积极」而非「变哑」。已记 PROGRESS 待办池

## 合并门禁(当前阻塞项,均为人类决策)

1. **权限线程**:群聊权限群级统一立项(spec: crabot-docs `superpowers/specs/2026-08-30-group-uniform-permissions-design.md`,待确认)落地前本 PR 不合入;私聊同构前提是否纳入该立项亦待拍板
2. **协议线程**:protocol-agent-v3 §4.1 补 mid-episode 注入例外措辞(草案在同一 spec 内,含去重键同进同出 + 崩溃窗口显式口径),先改协议文档再合入

## 测试

- loop.test:注入主路径(下一轮可见+收尾落盘+去重键)/失败补提交不丢不重/守卫保留/未消费留 mailbox 自唤醒/runEpisodeBody 直接 throw 时 catch 分支补提交
- registry.test:注入在跑 episode 时 onEpisodeSettled 以真实收尾 result 触发(含失败),占位 result 不带真实值
- process-group-lane-batch.test:注入占位不触发 fail-loud,真实收尾 failed 经 settle 回调补发(reportResult 恰好一次)
- manager 全量通过;全量套件失败集合与基线 diff 零新增(失败均为既有 flaky/环境问题)