### PR TITLE
feat: manager 压缩 hardCap 按模型 context_window 推导

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -234,13 +234,13 @@
   天然有界），现网若观察到连续打回再收紧；③crashed 路径的 subagent 连带终止与通知抑制维持
   现状，是否改为留活自愈（subagent 完成通知经透明接续更快唤醒）待评估；④窄竞态：subagent 已
   完成、通知在途时 finish_task 放行，排队通知进 dead-letter（review 记录不改）。
-- **manager 压缩未接模型 context_window（2026-08-29 发现，既有缺口）**：worker 侧 compaction
-  阈值已按 `context_window × 0.8` 生效（未设置回退 200K）；manager 是自管压缩
-  （`disableCompaction: true` + `DEFAULT_MANAGER_COMPACTION_POLICY` 写死常量
-  foldTokenThreshold=20K / hardCapTokens=200K×0.8），且 bootstrap 构造 ManagerRegistry 从未传
-  `contextWindowTokens`——manager 压缩与模型窗口无关。fold 20K 是刻意保守策略可保留；
-  hardCapTokens 理论上应从 manager 实际模型（powerful 槽位）的窗口推导（128K 模型时 160K
-  hardCap 偏大，靠爆窗 force_hot 兜底）。改动属 manager 压缩行为语义变更，需单独 spec。
+- **manager 压缩 hardCap 接模型 context_window：已实现，待 PR review（PR #132）**。worker 侧
+  阈值本就按 `context_window × 0.8` 生效（未设置回退 200K）；manager 自管压缩此前是写死常量
+  （fold 20K / hardCap 160K）且 bootstrap 从未传 contextWindowTokens。现 `hardCapTokens` 从
+  manager 实际模型（powerful 槽位）窗口推导（floor(window×0.8)，未配置回退现状常量），
+  `foldTokenThreshold: 20K` 作为刻意保守策略保留不动；thunk 每 episode 解析（§11 热更语义）。
+  spec：crabot-docs `2026-08-29-manager-compaction-model-window-design.md`（`4eece36`）。
+  **需重建重启 agent 生效。**
 - **槽位思考强度 PR #127 review follow-up（2026-08-28）**：① anthropic 数字 budget 档位
   （`thinking:{type:'enabled',budget_tokens:N}`）会开启经典 extended thinking，但
   anthropic-adapter 流处理只消费 text/input_json delta，thinking block 与 signature 既不产出

--- a/crabot-agent/src/manager/bootstrap.ts
+++ b/crabot-agent/src/manager/bootstrap.ts
@@ -136,6 +136,8 @@ export interface BootstrapDeps {
   readonly managerModel: () => string
   /** manager 的槽位思考强度(随 powerful slot),thunk 以支持热更;返回 undefined = 跟随默认 */
   readonly managerThinking?: () => import('../engine/llm-adapter-types.js').LLMThinkingConfig | undefined
+  /** manager 模型的上下文窗口(随 powerful slot),thunk 以支持热更;返回 undefined = engine 默认 200K */
+  readonly managerContextWindowTokens?: () => number | undefined
   readonly messagingDeps: CrabMessagingDeps
   /**
    * crab-memory server **工厂**(P7 J:原本是一个建好的 `McpServer` 定值)。
@@ -507,6 +509,7 @@ export function buildManagerStack(deps: BootstrapDeps): ManagerStack {
     adapter: deps.managerAdapter,
     model: deps.managerModel,
     thinking: deps.managerThinking,
+    contextWindowTokens: deps.managerContextWindowTokens,
     now: () => new Date(deps.now()),
     isClosing: deps.isClosing,
     timezone: deps.timezone,

--- a/crabot-agent/src/manager/compaction.ts
+++ b/crabot-agent/src/manager/compaction.ts
@@ -15,6 +15,7 @@
 
 import { callNonStreaming, createUserMessage } from '../engine/index.js'
 import type { EngineMessage, LLMAdapter } from '../engine/index.js'
+import { DEFAULT_COMPACT_THRESHOLD } from '../engine/context-manager.js'
 import type { ManagerSessionState } from './types.js'
 
 export interface CompactionPolicy {
@@ -40,6 +41,20 @@ export type CompactionDecision =
       readonly foldMessages: ReadonlyArray<EngineMessage>
       readonly keep: ReadonlyArray<EngineMessage>
     }
+
+/**
+ * 按模型上下文窗口推导生效策略（2026-08-29 spec，PR 后续）：hardCap = floor(window × 0.8)，
+ * 与 worker 侧 compaction 阈值同源同比例。window 未配置（模型没填 context_window）时原样
+ * 返回 policy——即回退 engine 既有默认 200K 对应的常量 hardCap。
+ * foldTokenThreshold / keepRecent / cacheTtlMs 是刻意保守的轻量策略，不随窗口变。
+ */
+export function managerPolicyForWindow(
+  policy: CompactionPolicy,
+  contextWindowTokens: number | undefined,
+): CompactionPolicy {
+  if (contextWindowTokens === undefined) return policy
+  return { ...policy, hardCapTokens: Math.floor(contextWindowTokens * DEFAULT_COMPACT_THRESHOLD) }
+}
 
 /**
  * 纯决策函数:无 IO、无 LLM 调用、不读系统时钟——nowMs 与 estimateTokens 均由调用方

--- a/crabot-agent/src/manager/loop.ts
+++ b/crabot-agent/src/manager/loop.ts
@@ -48,7 +48,7 @@ import type { HumanMessageQueueLike } from '../engine/types.js'
 import { AsyncMutex } from '../workers/async-mutex'
 import { formatChannelMessageLine } from '../prompt-manager.js'
 import { resolveSenderIdentity } from '../utils/sender-identity.js'
-import { decideCompaction, foldIntoSummary, type CompactionPolicy, type CompactionDecision } from './compaction.js'
+import { decideCompaction, foldIntoSummary, managerPolicyForWindow, type CompactionPolicy, type CompactionDecision } from './compaction.js'
 import { assembleManagerSystemPrompt } from './prompt.js'
 import { summarizeSpanInput, summarizeSpanOutput } from './span-summary.js'
 import type { ManagerSessionStore } from './session-store.js'
@@ -209,7 +209,8 @@ export interface ManagerLoopDeps {
   readonly adapter: () => LLMAdapter
   readonly model: () => string
   readonly maxTurns?: number
-  readonly contextWindowTokens?: number
+  /** manager 模型的上下文窗口(thunk,episode 内与 adapter/model 同点解析);undefined = engine 默认 200K */
+  readonly contextWindowTokens?: () => number | undefined
   /** manager 的槽位思考强度(thunk,episode 内与 adapter/model 同点解析);undefined = 跟随默认 */
   readonly thinking?: () => import('../engine/llm-adapter-types.js').LLMThinkingConfig | undefined
   /**
@@ -618,6 +619,10 @@ export class ManagerLoop {
     const adapter = this.deps.adapter()
     const model = this.deps.model()
     const thinking = this.deps.thinking?.()
+    // 上下文窗口与折叠策略同点快照（§11 热更语义：下一 episode 生效）：
+    // hardCap 按模型窗口推导（spec 2026-08-29），fold/keepRecent/cacheTtl 保持原策略。
+    const contextWindowTokens = this.deps.contextWindowTokens?.()
+    const policy = managerPolicyForWindow(this.deps.policy, contextWindowTokens)
 
     let state = initialState
     let historyState = withoutProtectedTail(state, committedHumanMessages.length)
@@ -626,7 +631,7 @@ export class ManagerLoop {
     const wakeDecision = decideCompaction({
       state: historyState,
       nowMs,
-      policy: this.deps.policy,
+      policy,
       estimateTokens: this.deps.estimateTokens,
     })
     if (wakeDecision.kind !== 'none') {
@@ -649,6 +654,7 @@ export class ManagerLoop {
 
     let attempt = await this.runAttempt(episodeId, state, tailMessages, adapter, model, {
       thinking,
+      contextWindowTokens,
       contextEnvelopes: currentInputEnvelopes,
     })
     let totalTurnsUsed = attempt.result.totalTurns
@@ -673,7 +679,7 @@ export class ManagerLoop {
     if (isContextOverflow(attempt.result)) {
       // Only pre-existing history may be folded. The current initial wake, carried
       // envelopes and mid-episode supplements are a protected tail (§14.4).
-      const forceDecision = forceHotFold(historyState, this.deps.policy, this.deps.estimateTokens, nowMs)
+      const forceDecision = forceHotFold(historyState, policy, this.deps.estimateTokens, nowMs)
       if (forceDecision.kind !== 'none') {
         usedForceHotRetry = true
         state = await this.applyFoldWithSpan(
@@ -698,6 +704,7 @@ export class ManagerLoop {
         ]
         const retryAttempt = await this.runAttempt(episodeId, state, retryTailMessages, adapter, model, {
           thinking,
+          contextWindowTokens,
           contextEnvelopes: [...retryCurrentEnvelopes, ...retryInjectedEnvelopes],
         })
         totalTurnsUsed += retryAttempt.result.totalTurns
@@ -738,7 +745,7 @@ export class ManagerLoop {
         [],
         adapter,
         model,
-        { thinking, initialMessages: continuationInitial },
+        { thinking, contextWindowTokens, initialMessages: continuationInitial },
       )
       totalTurnsUsed += continuation.result.totalTurns
       if (continuation.result.outcome === 'completed' || continuation.result.outcome === 'max_turns') {
@@ -1143,6 +1150,8 @@ export class ManagerLoop {
       readonly contextEnvelopes?: ReadonlyArray<TimedWakeEnvelope>
       /** 本 episode 的槽位思考强度快照（与 adapter/model 同点解析，episode 内固定） */
       readonly thinking?: import('../engine/llm-adapter-types.js').LLMThinkingConfig
+      /** 本 episode 的模型上下文窗口快照（同上） */
+      readonly contextWindowTokens?: number
     },
   ): Promise<{ readonly result: EngineResult; readonly hasSummaryMarker: boolean; readonly initialMessageCount: number }> {
     this.attemptCounter += 1
@@ -1177,7 +1186,7 @@ export class ManagerLoop {
       tools,
       model,
       maxTurns: this.deps.maxTurns,
-      contextWindowTokens: this.deps.contextWindowTokens,
+      ...(overrides?.contextWindowTokens !== undefined ? { contextWindowTokens: overrides.contextWindowTokens } : {}),
       ...(overrides?.thinking !== undefined ? { thinking: overrides.thinking } : {}),
       disableCompaction: true,
       humanMessageQueue: this.mailbox,

--- a/crabot-agent/src/manager/registry.ts
+++ b/crabot-agent/src/manager/registry.ts
@@ -92,7 +92,8 @@ export interface ManagerRegistryDeps {
   readonly adapter: () => LLMAdapter
   readonly model: () => string
   readonly maxTurns?: number
-  readonly contextWindowTokens?: number
+  /** manager 模型的上下文窗口(随 powerful slot,thunk 支持 hot-reload);undefined = engine 默认 200K */
+  readonly contextWindowTokens?: () => number | undefined
   /** manager 的槽位思考强度(随 powerful slot,thunk 支持 hot-reload);undefined = 跟随默认 */
   readonly thinking?: () => import('../engine/llm-adapter-types.js').LLMThinkingConfig | undefined
   readonly now: () => Date

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -912,6 +912,7 @@ export class UnifiedAgent extends ModuleBase {
         const conn = resolveManagerModelConfig(this.agentConfig?.model_config)
         return thinkingParam(conn.thinking_level, conn.thinking_custom)
       },
+      managerContextWindowTokens: () => resolveManagerModelConfig(this.agentConfig?.model_config).context_window,
       // crab-messaging：与 `createMcpConfigs` 同款依赖，但不传 `getTaskContext`——manager 不是
       // task，且 tool-face 已把 `send_message` 的 intent 去掉，ask_human 路径对 manager 不存在。
       messagingDeps: {

--- a/crabot-agent/tests/manager/compaction.test.ts
+++ b/crabot-agent/tests/manager/compaction.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import {
   decideCompaction,
   foldIntoSummary,
+  managerPolicyForWindow,
   type CompactionPolicy,
 } from '../../src/manager/compaction'
 import type { ManagerSessionState, ManagerKey } from '../../src/manager/types'
@@ -269,5 +270,39 @@ describe('foldIntoSummary', () => {
     expect(result).toBe('首次摘要')
     const sentText = JSON.stringify(captured.params?.messages)
     expect(sentText).toContain('第一批历史')
+  })
+})
+
+// --- managerPolicyForWindow（2026-08-29 spec：hardCap 按模型窗口推导，fold 等保持） ---
+
+describe('managerPolicyForWindow', () => {
+  it('window 有值 → hardCap = floor(window × 0.8)，其余字段保持原策略', () => {
+    const out = managerPolicyForWindow(POLICY, 128_000)
+    expect(out.hardCapTokens).toBe(102_400)
+    expect(out.foldTokenThreshold).toBe(POLICY.foldTokenThreshold)
+    expect(out.keepRecent).toBe(POLICY.keepRecent)
+    expect(out.cacheTtlMs).toBe(POLICY.cacheTtlMs)
+    expect(managerPolicyForWindow(POLICY, 1_000_000).hardCapTokens).toBe(800_000)
+  })
+
+  it('window 未配置 → 原样返回 policy（回退现状常量 hardCap）', () => {
+    expect(managerPolicyForWindow(POLICY, undefined)).toBe(POLICY)
+  })
+
+  it('decideCompaction 全链路：force_hot 判定用的是推导后的 hardCap', () => {
+    const history = makeHistory(12) // 12*50 = 600 token
+    const nowMs = 10_000
+    const hotState = baseState({ recent: history, lastActiveAt: new Date(nowMs - 500).toISOString() })
+    const estimate = (msgs: ReadonlyArray<EngineMessage>) => msgs.length * 50
+
+    // window=700 → hardCap=560 < 600 → force_hot（原 policy 500 也触发，这里验证的是推导值生效）
+    expect(decideCompaction({
+      state: hotState, nowMs, policy: managerPolicyForWindow(POLICY, 700), estimateTokens: estimate,
+    })).toMatchObject({ kind: 'force_hot' })
+
+    // window=800 → hardCap=640 ≥ 600 → none（原 policy 500 会触发；证明推导后的 hardCap 取代了常量）
+    expect(decideCompaction({
+      state: hotState, nowMs, policy: managerPolicyForWindow(POLICY, 800), estimateTokens: estimate,
+    })).toEqual({ kind: 'none' })
   })
 })


### PR DESCRIPTION
## 概要

实现 [spec：manager 压缩 hardCap 接模型 context_window](https://github.com/smilefufu/crabot-docs/blob/main/superpowers/specs/2026-08-29-manager-compaction-model-window-design.md)（crabot-docs `4eece36`，设计方向已由用户在对话中确认）。协议无涉及（§4.2 为"建议实现"，压缩常量是内部实现细节）。

## 背景

PR #127 后 worker 侧 compaction 阈值已按 `context_window × 0.8` 生效；manager 是自管压缩（`disableCompaction: true`），策略是写死常量（fold 20K / hardCap 160K = 默认窗口×0.8），与模型窗口脱节：128K 模型 hardCap 偏大（爆窗才兜底）、1M 模型偏保守。

## 改动（单 commit，6 文件）

- `managerPolicyForWindow(policy, window?)`：hardCap = floor(window × 0.8)；window 缺省原样返回（回退现状常量）
- 透传链：`BootstrapDeps.managerContextWindowTokens`（unified-agent 从 `resolveManagerModelConfig().context_window` 取）→ registry deps（`number` → thunk，无存量调用方）→ loop deps → `runEpisodeBody` 与 adapter/model 同点解析（§11 热更快照语义）
- `decideCompaction` 与 `forceHotFold` 两个消费点都用推导后 policy；EngineOptions.contextWindowTokens 经 runAttempt overrides 下传

## 明确不动

- `foldTokenThreshold: 20K` / `keepRecent` / `cacheTtlMs`：刻意的轻量策略，不随窗口放大
- engine（query-loop / context-manager）零改动；CLI worker 不涉及

## 失败路径声明

无新增失败路径：window 缺失时行为与现状逐字节一致（回退常量）；manager 缺 powerful 的报错时机不变（episode 内解析，不在唤醒路径）。

## 验证

- 新增 `managerPolicyForWindow` 3 例（128K→102400 / 1M→800000 / undefined 原样）+ decideCompaction 全链路阈值切换验证
- manager 系 23 文件 **393 例全绿**；agent 全量失败均为既有基线/负载 flaky（worker-mcp-capability、bg-shell、manager/events 等单跑复验通过）
- tsc 通过

**需重建重启 agent 生效。**