### PR TITLE
fix(admin): 群聊权限群级统一——resolve_principal_permissions 忽略发言人（含 master）

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5,6 +5,26 @@
 
 ## 当前状态
 
+### 群聊权限群级统一（与发言人无关）：PR #133（待合并）
+
+- 决策（2026-08-30）：群聊有群聊的权限，与发言人无关（含 master 在群里也按群档位）；
+  推翻 protocol-admin §3.2.7 原按发言人解析的群聊语义。spec + 协议（admin 0.2.7 /
+  agent-v3 3.6.16 §4.1 注入例外）随 crabot-docs `ef6888ff` 落地。
+- 实现：admin `resolvePrincipalPermissions` 群聊路径提前返回（忽略 sender_friend_id、
+  只按 GroupSessionPermissionConfig/缺省 group_default 解析，模板缺失 → minimal）；
+  私聊不变；agent 侧无代码改动（唤醒边界照常调 RPC）。
+- 关联：落地后解除 PR #131 权限 review 线程前提（注入借 primary wake 档位提权），
+  #131 另一门禁（§4.1 协议例外）已随 docs 落地。
+- **follow-up（#133 review 记录，schedule 权限语义属 spec 非目标、另行立项）**：
+  `crabot-agent/src/manager/bootstrap.ts` `onScheduleWake` 用
+  `principals.get(key)?.principal.sessionType ?? 'private'` 猜会话类型——群聊会话在
+  agent 重启后、尚未被人类消息唤醒过的窗口内猜成 'private'，schedule 解析走私聊路径
+  （master creator 拿回 master_private、普通 creator 拿 friend∪session 并集，均 ≥ 群档位），
+  与群级统一不变量相悖。相对改动前无回归（旧代码群聊 master 本来也短路）；窗口窄
+  （需重启 + 该群无人类消息 + 恰有带 creator 的 schedule 触发）。修法方向：
+  TriggerScheduleParams.target_session 带 session_type（协议改动）或按 session_id
+  特征/配置反查，需 spec。
+
 ### 移除 macOS FDA 放开机制，受保护目录无条件排除：已合并（PR #129 → `3e268439`）
 
 - 决策：FDA 放开机制要求「设 CRABOT_ENABLE_FDA → 系统设置授权 → 重启」，授权动作必须在

--- a/crabot-admin/src/admin-web-api.test.ts
+++ b/crabot-admin/src/admin-web-api.test.ts
@@ -1372,7 +1372,7 @@ describe('Admin Web API', () => {
   })
 
   describe('resolve_principal_permissions REST', () => {
-    it('master friend → 全 write 短路', async () => {
+    it('master friend → 全 write 短路（私聊；群聊已群级统一、不短路）', async () => {
       const token = await loginAndGetToken()
       const friendId = 'master-resolve-test'
       admin['friends'].set(friendId, {
@@ -1388,7 +1388,7 @@ describe('Admin Web API', () => {
         TEST_WEB_PORT,
         `/api/permissions/resolve-principal`,
         'POST',
-        { sender_friend_id: friendId, session_id: 'any-session', session_type: 'group' },
+        { sender_friend_id: friendId, session_id: 'any-session', session_type: 'private' },
         token,
       )
       expect(response.statusCode).toBe(200)
@@ -1418,7 +1418,7 @@ describe('Admin Web API', () => {
       expect(response.body.sources.session_template_id).toBe('group_scheduler')
     })
 
-    it('friend(standard) ∪ session(group_scheduler) → 并集中 schedule=write', async () => {
+    it('（私聊）friend(standard) ∪ session(group_scheduler) → 并集中 schedule=write', async () => {
       const token = await loginAndGetToken()
       const friendId = 'normal-union-test'
       const sessionId = 'union-session-test'
@@ -1440,7 +1440,7 @@ describe('Admin Web API', () => {
         TEST_WEB_PORT,
         `/api/permissions/resolve-principal`,
         'POST',
-        { sender_friend_id: friendId, session_id: sessionId, session_type: 'group' },
+        { sender_friend_id: friendId, session_id: sessionId, session_type: 'private' },
         token,
       )
       expect(response.statusCode).toBe(200)

--- a/crabot-admin/src/index.ts
+++ b/crabot-admin/src/index.ts
@@ -9112,14 +9112,14 @@ export class AdminModule extends ModuleBase {
   }
 
   /**
-   * 解析"消息发起人"的 effective permissions（friend ∪ session 并集）
+   * 解析"消息发起人"的 effective permissions
    *
-   * 设计意图：让 hook 层用统一一份 ResolvedPermissions 判断 cli_access / tool_access，
-   * 不再在 agent 侧分私聊/群聊两条解析路径。
+   * 设计意图：让 hook 层用统一一份 ResolvedPermissions 判断 cli_access / tool_access。
    *
-   * 语义：
-   * - master friend 短路：直接返回 master_private 模板的解析结果
-   * - 非 master：friend ResolvedPermissions ∪ session ResolvedPermissions
+   * 语义（protocol-admin §3.2.7，2026-08-30 群聊权限群级统一）：
+   * - 群聊：与发言人无关——只按 GroupSessionPermissionConfig（缺省 group_default）解析
+   * - 私聊 master friend 短路：直接返回 master_private 模板的解析结果
+   * - 私聊非 master：friend ResolvedPermissions ∪ session ResolvedPermissions
    * - 都缺：fallback 到 minimal 模板
    */
   private async resolvePrincipalPermissions(

--- a/crabot-admin/src/index.ts
+++ b/crabot-admin/src/index.ts
@@ -9127,7 +9127,27 @@ export class AdminModule extends ModuleBase {
   ): Promise<ResolvePrincipalPermissionsResult> {
     const sources: ResolvePrincipalPermissionsResult['sources'] = {}
 
-    // 1. friend 侧
+    // 群聊：群级统一，与发言人无关（2026-08-30 决策，protocol-admin §3.2.7 语义 1）——
+    // 忽略 sender_friend_id，不做 friend 侧解析、不做 master 短路，只按该群的
+    // GroupSessionPermissionConfig（缺省 group_default 基底）解析。模板缺失 → minimal 兜底。
+    if (params.session_type === 'group') {
+      const sessionConfig = this.sessionConfigs.get(params.session_id) ?? null
+      const sessionTemplateId = sessionConfig?.template_id ?? 'group_default'
+      try {
+        return {
+          resolved: this.permissionTemplateManager.resolvePermissions(sessionTemplateId, sessionConfig),
+          sources: { session_template_id: sessionTemplateId },
+        }
+      } catch (err) {
+        console.warn(`[Admin] resolvePrincipalPermissions: session template '${sessionTemplateId}' missing for session ${params.session_id}:`, err)
+        return {
+          resolved: this.permissionTemplateManager.resolvePermissions('minimal', null),
+          sources: { fallback: 'minimal' },
+        }
+      }
+    }
+
+    // 1. friend 侧（私聊）
     let friendResolved: ResolvedPermissions | null = null
     if (params.sender_friend_id) {
       // 'master' 是 admin chat 的合成身份（chat-manager 固定 friend_id='master'，
@@ -9155,15 +9175,11 @@ export class AdminModule extends ModuleBase {
       }
     }
 
-    // 2. session 侧
-    // 群聊：始终以 group_default 作为基底（叠 sessionConfig 字段覆盖），
-    //   非 friend 发言人也按群聊默认权限处理 —— 这是合并 resolveGroupPermissions 时
-    //   语义遗失的回填（commit c609772 引入的 regression）。
-    // 私聊：仅当 sessionConfig 显式 template_id 时才解析；陌生人走 minimal 兜底。
+    // 2. session 侧（私聊：仅当 sessionConfig 显式 template_id 时才解析；陌生人走 minimal 兜底。
+    // 群聊已在上方群级统一路径提前返回，不会走到这里）
     let sessionResolved: ResolvedPermissions | null = null
     const sessionConfig = this.sessionConfigs.get(params.session_id) ?? null
-    const sessionTemplateId = sessionConfig?.template_id
-      ?? (params.session_type === 'group' ? 'group_default' : null)
+    const sessionTemplateId = sessionConfig?.template_id ?? null
     if (sessionTemplateId) {
       try {
         sessionResolved = this.permissionTemplateManager.resolvePermissions(
@@ -9176,7 +9192,7 @@ export class AdminModule extends ModuleBase {
       }
     }
 
-    // 3. 都没有 → minimal 兜底（仅私聊路径会到这里；群聊已被 group_default 兜住）
+    // 3. 都没有 → minimal 兜底（私聊路径）
     if (!friendResolved && !sessionResolved) {
       sources.fallback = 'minimal'
       return {

--- a/crabot-admin/tests/group-uniform-permissions.test.ts
+++ b/crabot-admin/tests/group-uniform-permissions.test.ts
@@ -1,0 +1,119 @@
+/**
+ * resolve_principal_permissions 群聊路径群级统一（与发言人无关）
+ *
+ * 背景：2026-08-30 决策推翻 §3.2.7 按发言人解析的群聊语义——群聊有群聊的权限，
+ * master 在群里也按群档位（spec: crabot-docs/superpowers/specs/2026-08-30-group-uniform-permissions-design.md）。
+ * 修复前群内 master 发言人短路拿 master_private 全量档位、普通成员取 friend∪session 并集，
+ * 群内不同成员持有不同档位；该差异是 PR #131 注入路径提权问题（已单独立项消除）的前提。
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import fs from 'node:fs/promises'
+import AdminModule from '../src/index.js'
+
+const TEST_PROTOCOL_PORT = 19841
+const TEST_WEB_PORT = 13041
+const TEST_DATA_DIR = './test-data/admin-group-uniform-perm-test'
+
+describe('resolvePrincipalPermissions: 群聊群级统一', () => {
+  let admin: AdminModule
+
+  beforeAll(async () => {
+    await fs.rm(TEST_DATA_DIR, { recursive: true, force: true }).catch(() => {})
+    admin = new AdminModule(
+      {
+        moduleId: 'admin-group-uniform-perm-test',
+        moduleType: 'admin',
+        version: '0.1.0',
+        protocolVersion: '0.1.0',
+        port: TEST_PROTOCOL_PORT,
+        subscriptions: [],
+      },
+      {
+        web_port: TEST_WEB_PORT,
+        data_dir: TEST_DATA_DIR,
+        password_env: 'TEST_ADMIN_PASSWORD_GROUPPERM',
+        jwt_secret_env: 'TEST_JWT_SECRET_GROUPPERM',
+        token_ttl: 3600,
+      }
+    )
+    process.env.TEST_ADMIN_PASSWORD_GROUPPERM = 'test_password_123'
+    process.env.TEST_JWT_SECRET_GROUPPERM = 'test_jwt_secret_at_least_32_chars'
+    await admin.start()
+  })
+
+  afterAll(async () => {
+    await admin.stop()
+    await fs.rm(TEST_DATA_DIR, { recursive: true, force: true }).catch(() => {})
+  })
+
+  it('群聊 + master sender 不短路：按 group_default 解析，sources 无 friend 侧；同一 sender 私聊仍短路（对照）', async () => {
+    const group = await (admin as any).resolvePrincipalPermissions({
+      sender_friend_id: 'master',
+      session_id: 'group-a',
+      session_type: 'group',
+    })
+    expect(group.sources.friend_template_id).toBeUndefined()
+    expect(group.sources.session_template_id).toBe('group_default')
+    expect(group.sources.fallback).toBeUndefined()
+
+    const priv = await (admin as any).resolvePrincipalPermissions({
+      sender_friend_id: 'master',
+      session_id: 'admin-chat',
+      session_type: 'private',
+    })
+    expect(priv.sources.friend_template_id).toBe('master_private')
+  })
+
+  it('同一群内 master / 陌生 id / 不带 sender → 解析结果恒等（sender 被完全忽略）', async () => {
+    const asMaster = await (admin as any).resolvePrincipalPermissions({
+      sender_friend_id: 'master',
+      session_id: 'group-a',
+      session_type: 'group',
+    })
+    const asStranger = await (admin as any).resolvePrincipalPermissions({
+      sender_friend_id: 'no-such-friend',
+      session_id: 'group-a',
+      session_type: 'group',
+    })
+    const asAnonymous = await (admin as any).resolvePrincipalPermissions({
+      session_id: 'group-a',
+      session_type: 'group',
+    })
+    expect(asMaster.resolved).toEqual(asStranger.resolved)
+    expect(asMaster.resolved).toEqual(asAnonymous.resolved)
+    expect(asMaster.sources).toEqual(asStranger.sources)
+    expect(asMaster.sources).toEqual(asAnonymous.sources)
+  })
+
+  it('群聊自定义 template_id：按 session 配置解析（不再并上 friend 侧）', async () => {
+    ;(admin as any).sessionConfigs.set('group-custom', {
+      template_id: 'standard',
+      updated_at: '2026-08-30T00:00:00.000Z',
+    })
+    const result = await (admin as any).resolvePrincipalPermissions({
+      sender_friend_id: 'master',
+      session_id: 'group-custom',
+      session_type: 'group',
+    })
+    expect(result.sources.session_template_id).toBe('standard')
+    expect(result.resolved).toEqual(
+      (admin as any).permissionTemplateManager.resolvePermissions('standard', null)
+    )
+  })
+
+  it('群模板缺失 → minimal 兜底（沿用降级链路）', async () => {
+    ;(admin as any).sessionConfigs.set('group-broken', {
+      template_id: 'no-such-template',
+      updated_at: '2026-08-30T00:00:00.000Z',
+    })
+    const result = await (admin as any).resolvePrincipalPermissions({
+      sender_friend_id: 'master',
+      session_id: 'group-broken',
+      session_type: 'group',
+    })
+    expect(result.sources.fallback).toBe('minimal')
+    expect(result.resolved).toEqual(
+      (admin as any).permissionTemplateManager.resolvePermissions('minimal', null)
+    )
+  })
+})

--- a/crabot-agent/src/manager/bootstrap.ts
+++ b/crabot-agent/src/manager/bootstrap.ts
@@ -529,7 +529,10 @@ export function buildManagerStack(deps: BootstrapDeps): ManagerStack {
     //   `narrowWorkerPermissions(base, null)` 原样返回它,与 admin 侧"空 creator → master_private"
     //   的既有规则同解。
     // - 有 creator → 按该 friend 解析。`sessionType` 取该会话上一次解析出来的私/群(未知按
-    //   'private'):这一项只影响 admin 侧要不要并上 group_default,猜错只会更严,不会更宽。
+    //   'private'):这一项只影响 admin 侧解析路径。2026-08-30 群聊权限群级统一(PR #133)后,
+    //   群聊会话猜成 'private' 是**更宽**而非更严(master creator 拿回 master_private、普通
+    //   creator 拿 friend∪session 并集,均 ≥ 群档位)——agent 重启后该群尚未被人类消息唤醒过
+    //   的窗口内可达;已记 PROGRESS follow-up(schedule 权限语义属 spec 非目标,另行立项)。
     onScheduleWake: async ({ key, creatorFriendId, isBuiltin }) => {
       if (isBuiltin || !creatorFriendId) return null
       const { sessionId } = splitManagerKey(key)

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -2082,13 +2082,14 @@ export class UnifiedAgent extends ModuleBase {
   }
 
   /**
-   * 调 admin RPC 解析"消息发起人"effective permissions（friend ∪ session 并集）。
+   * 调 admin RPC 解析"消息发起人"effective permissions。
    *
    * 取代旧的 resolveSessionPermissions / resolveGroupPermissions 双路径：
    * - master 短路、minimal 兜底、friend explicit-config 优先于 template 等语义
    *   全部由 admin 侧 `resolve_principal_permissions` 统一实现
-   * - 私聊：senderFriend = 私聊对端 friend
-   * - 群聊：senderFriend = 该批次最后一条消息的 friend（即真实发言者，享其个人 friend 模板）
+   * - 私聊：senderFriend = 私聊对端 friend，按 friend ∪ session 并集解析
+   * - 群聊：senderFriend = 该批次最后一条消息的 friend（仅作身份标识；2026-08-30
+   *   群聊权限群级统一后 admin 侧忽略 sender_friend_id，档位只按群配置解析）
    *
    * @param senderFriendId 发起人 friend id（陌生人/无 friend_id 时传 undefined）。收 id 而不是
    *                       Friend 对象：admin 那侧本来就只用 `sender_friend_id`，而 scheduled


### PR DESCRIPTION
## 背景

2026-08-30 决策（spec 已确认：`crabot-docs/superpowers/specs/2026-08-30-group-uniform-permissions-design.md`，随 docs 仓 `ef6888ff` 落地）：**群聊有群聊的权限，与发言人无关**——推翻 protocol-admin §3.2.7 原按发言人解析的群聊语义（master 短路 / friend∪session 并集 / minimal 兜底），此前该设计让群内不同成员持有不同档位，也是 PR #131 注入路径提权 review 线程的前提。

协议已先行修订（同 commit ef6888ff）：protocol-admin §3.2.7 语义 1（群级统一）+ 0.2.7 版本条目；protocol-agent-v3 §4.1 注入例外 + 3.6.16 版本条目。

## 改动

| 位置 | 内容 |
|---|---|
| `resolvePrincipalPermissions` 群聊路径 | 提前返回：忽略 `sender_friend_id`，不做 friend 侧解析、不做 master 短路，只按 GroupSessionPermissionConfig（缺省 `group_default` 基底）解析；模板缺失 → minimal 兜底（既有降级链路）。`sources.friend_template_id` 群聊恒缺省 |
| 私聊路径 | 不变（master 短路 / friend∪session 并集 / minimal 兜底）；session 侧的 group_default 三元分支随提前返回成为死路，一并清理 |

关键语义不变量：群聊权限档位 = f(channel_id, session_id) 纯函数，与发言人、唤醒 kind、注入与否无关；master 在群里不享有超出群档位的权限，完整权限仅在私聊 / Admin Chat 生效。

## 明确排除（spec 非目标）

schedule 任务权限语义（§4.4 按 creator 解析）；worker 权限快照机制（存量快照按落盘值复用，不重解析）；`narrowWorkerPermissions` 交集规则；friends/friend-permission-configs 数据与私聊消费路径；Admin Web 前端。

Agent 侧无代码改动：`ManagerPrincipalStore.resolve` / `routeHumanWake` 唤醒边界解析照常调 RPC，群聊返回档位天然与发言人无关；v2 supplement 热刷新原样调用即自然得到群档位（sender 被忽略，无需特判）；`applyGroupScopeFallback` 不变。

## 新引入的失败路径及收口

无。群模板缺失走既有 minimal 兜底；解析失败不抛出、不阻塞消息链路（fail-soft 与改动前一致）。

## 测试

- 新增 `crabot-admin/tests/group-uniform-permissions.test.ts` 4 用例：① master 群聊不短路 + 同 sender 私聊仍短路（对照）；② 同群内 master / 陌生 id / 不带 sender 解析恒等（sender 被完全忽略）；③ 自定义 template_id 按 session 配置解析、不再并 friend 侧；④ 群模板缺失 → minimal 兜底
- 私聊回归：`chat-master-permission.test.ts` 3 用例全过
- `tsc` 构建通过

## 合入后

解除 PR #131 权限 review 线程的前提（群内注入借 primary wake 档位提权——统一后同群任何 wake 解析恒等，注入与 primary wake 无权限差异）。#131 的另一门禁（§4.1 协议例外）已随本 PR 前置的 docs 修订落地。