### PR TITLE
feat(agent): LLM 429 分类重试 + 重试层扁平化 + 重试期间配置热切换

### DIFF
--- a/crabot-agent/src/agent/agent-handler.ts
+++ b/crabot-agent/src/agent/agent-handler.ts
@@ -464,6 +464,12 @@ export interface AgentHandlerOptions {
   imageCapability?: { available: boolean; reason?: string }
   /** UnifiedAgent 共享的 Worker background entity registry。 */
   bgRegistry?: BgEntityRegistry
+  /**
+   * 运行时配置已原子替换后的通知源（spec 2026-08-30-llm-retry-config-hotreload）：
+   * worker loop 用它构造 configChangedSignal，LLM 重试 sleep 期间配置落地时提前唤醒，
+   * onConfigChanged 现解析 this.sdkEnv 换新 adapter/model 重试。未注入时无此能力。
+   */
+  runtimeConfigAppliedSource?: (listener: () => void) => () => void
 }
 
 export interface ExecuteTriggerMessageParams {
@@ -600,6 +606,8 @@ export class AgentHandler {
   private readonly workerShellExitSettlementTimers = new Map<string, NodeJS.Timeout>()
   /** Interval handle for periodic 24h GC of dead entities */
   private gcIntervalHandle?: NodeJS.Timeout
+  /** 运行时配置原子替换通知源（见 AgentHandlerOptions.runtimeConfigAppliedSource）。 */
+  private readonly runtimeConfigAppliedSource?: (listener: () => void) => () => void
 
   constructor(
     sdkEnv: SdkEnvConfig,
@@ -613,6 +621,7 @@ export class AgentHandler {
     )
     this.sdkEnv = sdkEnv
     this.mcpConfigFactory = options?.mcpConfigFactory
+    this.runtimeConfigAppliedSource = options?.runtimeConfigAppliedSource
     this.deps = options?.deps
     this.systemPrompt = config.systemPrompt
     this.builtinToolConfig = options?.builtinToolConfig
@@ -1336,6 +1345,9 @@ export class AgentHandler {
     // ProgressDigest 与 Worker loop 同生命周期；静默 / text_forward 模式保持 undefined。
     let digest: ProgressDigest | undefined
     let loopSpanId: string | undefined
+    // 运行时配置替换通知的退订句柄（spec 2026-08-30-llm-retry-config-hotreload）：
+    // 在 runEngine 前订阅，outer finally 确定性退订——任何退出路径都不泄漏监听器。
+    let offRuntimeConfigApplied: () => void = () => undefined
 
     try {
       // Skill 工具直接读 admin 传来的 skill_dir 绝对路径；agent 不再复制 SKILL.md 到 instance 目录。
@@ -1824,6 +1836,12 @@ export class AgentHandler {
       // 80% 窗口时自动 compaction 兜底。真正死循环可通过用户 supplement（dispatcher 注入）或 abort 中断。
       let compactionSpanId: string | undefined = undefined
       let compactionStartedAtMs: number | undefined = undefined
+      // LLM 重试期间配置热切换（spec 2026-08-30-llm-retry-config-hotreload）：
+      // adapter 本身仍是 loop 级快照；只有重试 sleep 阶段会被配置落地唤醒，
+      // onConfigChanged 现解析 this.sdkEnv 换新 adapter/model 继续本 attempt 的后续重试。
+      const configChanged = new AbortController()
+      offRuntimeConfigApplied = this.runtimeConfigAppliedSource?.(() => configChanged.abort())
+        ?? (() => undefined)
       const engineResult = await runEngine({
         prompt: taskMessage,
         adapter,
@@ -1837,6 +1855,11 @@ export class AgentHandler {
           ...(this.sdkEnv.thinking !== undefined ? { thinking: this.sdkEnv.thinking } : {}),
           maxTurns: 2000,
           supportsVision: this.sdkEnv.supportsVision,
+          configChangedSignal: configChanged.signal,
+          onConfigChanged: async () => ({
+            adapter: adapterFromSdkEnv(this.sdkEnv),
+            model: this.sdkEnv.modelId,
+          }),
           permissionConfig: initialPermissionConfig,
           timezone: this.getTimezone(),
           abortSignal: taskState.abortController.signal as AbortSignal,
@@ -2141,6 +2164,7 @@ export class AgentHandler {
       }
 
     } finally {
+      offRuntimeConfigApplied()
       digest?.dispose()
       if (!opts?.skipCleanup) {
         this.humanQueues.get(task.task_id)?.clearBarrier()

--- a/crabot-agent/src/agent/agent-handler.ts
+++ b/crabot-agent/src/agent/agent-handler.ts
@@ -1864,6 +1864,10 @@ export class AgentHandler {
           onConfigChanged: async () => ({
             adapter: adapterFromSdkEnv(this.sdkEnv),
             model: this.sdkEnv.modelId,
+            // maxTokens/thinking 是 per-model 字段，随 model 一并替换（显式 undefined =
+            // 新模型无该配置，从请求中移除），否则旧模型参数发给新模型可能 400。
+            maxTokens: this.sdkEnv.maxTokens,
+            thinking: this.sdkEnv.thinking,
           }),
           permissionConfig: initialPermissionConfig,
           timezone: this.getTimezone(),

--- a/crabot-agent/src/agent/agent-handler.ts
+++ b/crabot-agent/src/agent/agent-handler.ts
@@ -465,11 +465,13 @@ export interface AgentHandlerOptions {
   /** UnifiedAgent 共享的 Worker background entity registry。 */
   bgRegistry?: BgEntityRegistry
   /**
-   * 运行时配置已原子替换后的通知源（spec 2026-08-30-llm-retry-config-hotreload）：
-   * worker loop 用它构造 configChangedSignal，LLM 重试 sleep 期间配置落地时提前唤醒，
+   * 运行时配置已原子替换后的通知源与代数 getter（spec 2026-08-30-llm-retry-config-hotreload）：
+   * worker loop 用通知源构造 configChangedSignal（sleep 期间边沿唤醒），用代数 getter
+   * 作为 configGeneration 探针（消费 sleep 窗口之外落地的变更）；两者触发时
    * onConfigChanged 现解析 this.sdkEnv 换新 adapter/model 重试。未注入时无此能力。
    */
   runtimeConfigAppliedSource?: (listener: () => void) => () => void
+  runtimeConfigAppliedGeneration?: () => number
 }
 
 export interface ExecuteTriggerMessageParams {
@@ -606,8 +608,9 @@ export class AgentHandler {
   private readonly workerShellExitSettlementTimers = new Map<string, NodeJS.Timeout>()
   /** Interval handle for periodic 24h GC of dead entities */
   private gcIntervalHandle?: NodeJS.Timeout
-  /** 运行时配置原子替换通知源（见 AgentHandlerOptions.runtimeConfigAppliedSource）。 */
+  /** 运行时配置原子替换通知源与代数 getter（见 AgentHandlerOptions 同名字段）。 */
   private readonly runtimeConfigAppliedSource?: (listener: () => void) => () => void
+  private readonly runtimeConfigAppliedGeneration?: () => number
 
   constructor(
     sdkEnv: SdkEnvConfig,
@@ -622,6 +625,7 @@ export class AgentHandler {
     this.sdkEnv = sdkEnv
     this.mcpConfigFactory = options?.mcpConfigFactory
     this.runtimeConfigAppliedSource = options?.runtimeConfigAppliedSource
+    this.runtimeConfigAppliedGeneration = options?.runtimeConfigAppliedGeneration
     this.deps = options?.deps
     this.systemPrompt = config.systemPrompt
     this.builtinToolConfig = options?.builtinToolConfig
@@ -1856,6 +1860,7 @@ export class AgentHandler {
           maxTurns: 2000,
           supportsVision: this.sdkEnv.supportsVision,
           configChangedSignal: configChanged.signal,
+          configGeneration: this.runtimeConfigAppliedGeneration,
           onConfigChanged: async () => ({
             adapter: adapterFromSdkEnv(this.sdkEnv),
             model: this.sdkEnv.modelId,

--- a/crabot-agent/src/engine/anthropic-adapter.ts
+++ b/crabot-agent/src/engine/anthropic-adapter.ts
@@ -13,7 +13,8 @@ import type {
 } from '@anthropic-ai/sdk/resources/messages'
 import { proxyManager } from 'crabot-shared'
 import type { LLMAdapter, LLMAdapterConfig, LLMStreamParams, LLMThinkingConfig } from './llm-adapter-types.js'
-import { streamWithTimeoutAndRetry } from './stream-timeout.js'
+import { withStreamTimeout } from './stream-timeout.js'
+import { HttpResponseError, parseRetryAfterMs } from './retry-utils.js'
 import { isToolResultMessage, mergeConsecutiveUserMessages, capToolResultForLLM } from './llm-adapter-types.js'
 import type {
   EngineMessage,
@@ -265,10 +266,29 @@ export class AnthropicAdapter implements LLMAdapter {
   }
 
   async *stream(params: LLMStreamParams): AsyncGenerator<StreamChunk> {
-    yield* streamWithTimeoutAndRetry('anthropic-adapter', (p) => this.streamOnce(p), params)
+    // 只加 TTFB/空闲超时；重试统一由 callNonStreaming 单层处理（含配置热切换唤醒）。
+    yield* withStreamTimeout((signal) => this.streamOnce({ ...params, signal }), params.signal)
   }
 
   private async *streamOnce(params: LLMStreamParams): AsyncGenerator<StreamChunk> {
+    try {
+      yield* this.streamOnceUnsafe(params)
+    } catch (err) {
+      // Anthropic SDK 把 429 以 SDK error 抛出，retry-utils 无法直接读取 Retry-After 与 body code。
+      // 仅对 429 包装成 HttpResponseError，让 429 分类策略生效。
+      const status = (err as Error & { status?: number }).status
+      if (status === 429) {
+        const headers = (err as Error & { headers?: Record<string, string> }).headers
+        const retryAfter = parseRetryAfterMs(headers?.['retry-after'])
+        const body = (err as Error & { error?: unknown }).error
+        const bodyText = typeof body === 'string' ? body : JSON.stringify(body ?? { message: (err as Error).message })
+        throw new HttpResponseError(429, bodyText, 'anthropic-adapter', retryAfter)
+      }
+      throw err
+    }
+  }
+
+  private async *streamOnceUnsafe(params: LLMStreamParams): AsyncGenerator<StreamChunk> {
     const tools = params.tools.map(AnthropicAdapter.toAnthropicTool)
     // A fork intentionally exposes no callable tools. Anthropic still rejects a
     // request containing historical tool blocks unless the wire request defines

--- a/crabot-agent/src/engine/anthropic-adapter.ts
+++ b/crabot-agent/src/engine/anthropic-adapter.ts
@@ -235,7 +235,7 @@ export class AnthropicAdapter implements LLMAdapter {
       baseURL: config.endpoint,
       apiKey: config.apikey,
       httpAgent: proxyManager.getHttpsAgent(),
-      // Retries are handled by streamWithRetry() at the adapter layer.
+      // Retries are handled by callNonStreaming()（唯一缓冲整流重试层）。
       maxRetries: 0,
     })
   }

--- a/crabot-agent/src/engine/llm-adapter-types.ts
+++ b/crabot-agent/src/engine/llm-adapter-types.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_MAX_RETRIES,
   DEFAULT_RETRY_DELAY_MS,
   OVERLOADED_WITHOUT_RETRY_AFTER_MAX_RETRIES,
+  RETRY_AFTER_MAX_MS,
   computeRetryDelayMs,
   getRetryAfterMs,
   interruptibleSleep,
@@ -79,10 +80,18 @@ export interface LLMStreamParams {
   readonly thinking?: LLMThinkingConfig
   readonly signal?: AbortSignal
   /**
-   * 配置变更信号。重试 sleep 期间若该信号触发，会提前唤醒并调用 onConfigChanged，
-   * 让下一次 attempt 有机会使用新的 adapter/model。
+   * 配置变更信号（边沿事件）。仅在重试 sleep **期间**触发时提前唤醒并调用
+   * onConfigChanged；入口时已 aborted 不触发任何回调（一次性信号的历史 abort
+   * 不是变更事件，否则会永久归零后续退避）。
    */
   readonly configChangedSignal?: AbortSignal
+  /**
+   * 当前已应用的配置代数 getter（与 configChangedSignal 同源，均来自运行时配置
+   * 原子替换通知）。callNonStreaming 自己记账「上次消费到的代数」：本次 attempt
+   * 失败时代数已前进 → 立即换新配置重试（跳过本次 sleep）；代数未变 → 正常退避。
+   * 这样 sleep 窗口之外的变更也不会丢，且退避只被跳过一次。
+   */
+  readonly configGeneration?: () => number
   /**
    * 配置变更后的刷新回调。返回新的 adapter/model，callNonStreaming 会在下一次 attempt 使用它们。
    */
@@ -136,11 +145,15 @@ async function withStreamConsumptionRetry(
   const startedAt = Date.now()
 
   // 重试期间配置可能热更新：currentAdapter / currentModel 允许被 onConfigChanged 替换。
+  // configGeneration 自己记账：代数已前进 → 立即换配置并跳过本次 sleep（只跳一次）；
+  // 代数未变 → 正常退避。configChangedSignal 只负责「sleep 期间」的边沿唤醒。
   let currentAdapter = adapter
   let currentModel = params.model
   let generic429Count = 0
+  let appliedGeneration = params.configGeneration?.()
 
   const applyConfigChange = async (): Promise<void> => {
+    appliedGeneration = params.configGeneration?.()
     const update = await params.onConfigChanged?.()
     if (update?.adapter) currentAdapter = update.adapter
     if (update?.model !== undefined) currentModel = update.model
@@ -182,6 +195,12 @@ async function withStreamConsumptionRetry(
     } catch (err) {
       if (params.signal?.aborted) throw err
       if (!isRetryableError(err)) throw err
+      // Retry-After 超上限：provider 要求等的时间比总预算还长，不再等待，按重试耗尽失败
+      // （错误上带尝试次数/总耗时，可诊断）。
+      const retryAfterMs = getRetryAfterMs(err)
+      if (retryAfterMs !== undefined && retryAfterMs > RETRY_AFTER_MAX_MS) {
+        throw enrichGiveUp(err, attempt + 1, Date.now() - startedAt)
+      }
       // 无 Retry-After 的通用 429 单独限制次数，避免额度耗尽类伪装成通用 429 时无限拖。
       if (isOverloadedWithoutRetryAfter(err)) {
         generic429Count++
@@ -192,7 +211,7 @@ async function withStreamConsumptionRetry(
       // 放弃可重试错误时把"尝试次数/总耗时"写进错误，让失败 trace 可诊断
       // （否则 outcome 只剩一句裸 "fetch failed"，看不出是重试耗尽还是首次即挂）
       if (attempt >= maxRetries) throw enrichGiveUp(err, attempt + 1, Date.now() - startedAt)
-      const actualDelay = computeRetryDelayMs(attempt, delayMs, true, getRetryAfterMs(err))
+      const actualDelay = computeRetryDelayMs(attempt, delayMs, true, retryAfterMs)
       console.error(
         `[callNonStreaming] stream attempt ${attempt + 1}/${maxRetries + 1} failed, retrying in ${actualDelay}ms (backoff):`,
         err,
@@ -206,11 +225,16 @@ async function withStreamConsumptionRetry(
           source: 'stream',
         })
       } catch { /* observability callback must not break retry */ }
-      await interruptibleSleep(actualDelay, {
-        abortSignal: params.signal,
-        configChangedSignal: params.configChangedSignal,
-        onConfigChanged: applyConfigChange,
-      })
+      if (params.configGeneration && params.configGeneration() !== appliedGeneration) {
+        // 配置在本次 attempt 期间/之间已落地：立即换新配置重试，跳过本次 sleep。
+        await applyConfigChange()
+      } else {
+        await interruptibleSleep(actualDelay, {
+          abortSignal: params.signal,
+          configChangedSignal: params.configChangedSignal,
+          onConfigChanged: applyConfigChange,
+        })
+      }
       // 下一轮 loop 会用全新 processor + 重新 call adapter.stream()，
       // 服务端生成新 response（partial 浪费，但 task 能完成）
     }

--- a/crabot-agent/src/engine/llm-adapter-types.ts
+++ b/crabot-agent/src/engine/llm-adapter-types.ts
@@ -6,9 +6,12 @@ import { StreamProcessor } from './stream-processor.js'
 import {
   DEFAULT_MAX_RETRIES,
   DEFAULT_RETRY_DELAY_MS,
+  OVERLOADED_WITHOUT_RETRY_AFTER_MAX_RETRIES,
   computeRetryDelayMs,
+  getRetryAfterMs,
+  interruptibleSleep,
+  isOverloadedWithoutRetryAfter,
   isRetryableError,
-  sleep,
 } from './retry-utils.js'
 import { capWithMarker } from './byte-cap.js'
 import type {
@@ -28,19 +31,7 @@ export interface LLMRetryEvent {
   readonly maxAttempts: number  // 总配额
   readonly delayMs: number      // 即将 sleep 多久后 retry
   readonly error: Error         // 触发本次 retry 的错
-  readonly source: 'pre-stream' | 'mid-stream'  // 哪一层 retry
-}
-
-/**
- * 把 LLMStreamParams.onRetry 包装成 retry-utils 的 onRetry 签名（差别只是补一个 source 字段）。
- * 三个 adapter（anthropic/openai/openai-responses）的 stream / complete 方法共用此 helper。
- */
-export function wrapOnRetry(
-  cb: ((e: LLMRetryEvent) => void) | undefined,
-  source: LLMRetryEvent['source'],
-): ((e: { attempt: number; maxAttempts: number; delayMs: number; error: Error }) => void) | undefined {
-  if (!cb) return undefined
-  return (e) => cb({ ...e, source })
+  readonly source: 'stream'     // 重试统一在 callNonStreaming 层处理
 }
 
 /** 槽位思考强度（base-protocol §5.14 thinking_level/thinking_custom 的运行时形态）。 */
@@ -87,6 +78,15 @@ export interface LLMStreamParams {
   /** 思考强度；undefined = 跟随模型默认（请求中不出现任何思考参数） */
   readonly thinking?: LLMThinkingConfig
   readonly signal?: AbortSignal
+  /**
+   * 配置变更信号。重试 sleep 期间若该信号触发，会提前唤醒并调用 onConfigChanged，
+   * 让下一次 attempt 有机会使用新的 adapter/model。
+   */
+  readonly configChangedSignal?: AbortSignal
+  /**
+   * 配置变更后的刷新回调。返回新的 adapter/model，callNonStreaming 会在下一次 attempt 使用它们。
+   */
+  readonly onConfigChanged?: () => Promise<{ adapter?: LLMAdapter; model?: string } | void>
   /** 可观测性回调：retry 发生时触发；用于 worker → admin web 实时显示"LLM 正在重试" */
   readonly onRetry?: (event: LLMRetryEvent) => void
 }
@@ -135,13 +135,24 @@ async function withStreamConsumptionRetry(
   const delayMs = DEFAULT_RETRY_DELAY_MS
   const startedAt = Date.now()
 
+  // 重试期间配置可能热更新：currentAdapter / currentModel 允许被 onConfigChanged 替换。
+  let currentAdapter = adapter
+  let currentModel = params.model
+  let generic429Count = 0
+
+  const applyConfigChange = async (): Promise<void> => {
+    const update = await params.onConfigChanged?.()
+    if (update?.adapter) currentAdapter = update.adapter
+    if (update?.model !== undefined) currentModel = update.model
+  }
+
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     const attemptStart = Date.now()
     let firstChunkMs: number | undefined
     let chunkCount = 0
     try {
       const processor = new StreamProcessor()
-      for await (const chunk of adapter.stream(params)) {
+      for await (const chunk of currentAdapter.stream({ ...params, model: currentModel })) {
         if (params.signal?.aborted) {
           throw new DOMException('Aborted', 'AbortError')
         }
@@ -171,10 +182,17 @@ async function withStreamConsumptionRetry(
     } catch (err) {
       if (params.signal?.aborted) throw err
       if (!isRetryableError(err)) throw err
+      // 无 Retry-After 的通用 429 单独限制次数，避免额度耗尽类伪装成通用 429 时无限拖。
+      if (isOverloadedWithoutRetryAfter(err)) {
+        generic429Count++
+        if (generic429Count > OVERLOADED_WITHOUT_RETRY_AFTER_MAX_RETRIES) {
+          throw enrichGiveUp(err, attempt + 1, Date.now() - startedAt)
+        }
+      }
       // 放弃可重试错误时把"尝试次数/总耗时"写进错误，让失败 trace 可诊断
       // （否则 outcome 只剩一句裸 "fetch failed"，看不出是重试耗尽还是首次即挂）
       if (attempt >= maxRetries) throw enrichGiveUp(err, attempt + 1, Date.now() - startedAt)
-      const actualDelay = computeRetryDelayMs(attempt, delayMs, true)
+      const actualDelay = computeRetryDelayMs(attempt, delayMs, true, getRetryAfterMs(err))
       console.error(
         `[callNonStreaming] stream attempt ${attempt + 1}/${maxRetries + 1} failed, retrying in ${actualDelay}ms (backoff):`,
         err,
@@ -185,10 +203,14 @@ async function withStreamConsumptionRetry(
           maxAttempts: maxRetries + 1,
           delayMs: actualDelay,
           error: err instanceof Error ? err : new Error(String(err)),
-          source: 'mid-stream',
+          source: 'stream',
         })
       } catch { /* observability callback must not break retry */ }
-      await sleep(actualDelay, params.signal)
+      await interruptibleSleep(actualDelay, {
+        abortSignal: params.signal,
+        configChangedSignal: params.configChangedSignal,
+        onConfigChanged: applyConfigChange,
+      })
       // 下一轮 loop 会用全新 processor + 重新 call adapter.stream()，
       // 服务端生成新 response（partial 浪费，但 task 能完成）
     }

--- a/crabot-agent/src/engine/llm-adapter-types.ts
+++ b/crabot-agent/src/engine/llm-adapter-types.ts
@@ -93,11 +93,24 @@ export interface LLMStreamParams {
    */
   readonly configGeneration?: () => number
   /**
-   * 配置变更后的刷新回调。返回新的 adapter/model，callNonStreaming 会在下一次 attempt 使用它们。
+   * 配置变更后的刷新回调。返回新配置的 adapter 与 per-attempt 请求参数
+   * （model/maxTokens/thinking 是 per-model 字段，换 provider 后必须一并替换——
+   * 只换 adapter/model 会把旧模型的 max_tokens/thinking 发给新模型，可能触发
+   * 400 invalid_request_error 这类不可重试失败，protocol-agent-v3 §11 3.6.17）。
+   * 字段缺省 = 维持原值；显式 undefined = 从请求中移除该参数。
+   * callNonStreaming 会在下一次 attempt 使用它们。
    */
-  readonly onConfigChanged?: () => Promise<{ adapter?: LLMAdapter; model?: string } | void>
+  readonly onConfigChanged?: () => Promise<LLMConfigSwap | void>
   /** 可观测性回调：retry 发生时触发；用于 worker → admin web 实时显示"LLM 正在重试" */
   readonly onRetry?: (event: LLMRetryEvent) => void
+}
+
+/** onConfigChanged 的返回形态（review 2nd：随 model 一并替换 per-model 请求参数）。 */
+export interface LLMConfigSwap {
+  readonly adapter?: LLMAdapter
+  readonly model?: string
+  readonly maxTokens?: number
+  readonly thinking?: LLMThinkingConfig
 }
 
 export interface LLMAdapter {
@@ -144,19 +157,37 @@ async function withStreamConsumptionRetry(
   const delayMs = DEFAULT_RETRY_DELAY_MS
   const startedAt = Date.now()
 
-  // 重试期间配置可能热更新：currentAdapter / currentModel 允许被 onConfigChanged 替换。
+  // 重试期间配置可能热更新：adapter 与 per-attempt 请求参数（model/maxTokens/thinking）
+  // 允许被 onConfigChanged 替换——后三者是 per-model 字段，只换 adapter/model 会把旧
+  // 模型的参数发给新模型（可能 400 invalid_request_error，不可重试）。
   // configGeneration 自己记账：代数已前进 → 立即换配置并跳过本次 sleep（只跳一次）；
   // 代数未变 → 正常退避。configChangedSignal 只负责「sleep 期间」的边沿唤醒。
   let currentAdapter = adapter
-  let currentModel = params.model
+  let currentRequestParams: { model: string; maxTokens?: number; thinking?: LLMThinkingConfig } = {
+    model: params.model,
+    ...(params.maxTokens !== undefined ? { maxTokens: params.maxTokens } : {}),
+    ...(params.thinking !== undefined ? { thinking: params.thinking } : {}),
+  }
   let generic429Count = 0
   let appliedGeneration = params.configGeneration?.()
 
   const applyConfigChange = async (): Promise<void> => {
     appliedGeneration = params.configGeneration?.()
     const update = await params.onConfigChanged?.()
-    if (update?.adapter) currentAdapter = update.adapter
-    if (update?.model !== undefined) currentModel = update.model
+    if (!update) return
+    if (update.adapter) currentAdapter = update.adapter
+    const next = { ...currentRequestParams } as { model: string; maxTokens?: number; thinking?: LLMThinkingConfig }
+    if (update.model !== undefined) next.model = update.model
+    // 显式 undefined = 新模型无该配置，从请求中移除；字段缺省 = 维持原值。
+    if ('maxTokens' in update) {
+      if (update.maxTokens === undefined) delete next.maxTokens
+      else next.maxTokens = update.maxTokens
+    }
+    if ('thinking' in update) {
+      if (update.thinking === undefined) delete next.thinking
+      else next.thinking = update.thinking
+    }
+    currentRequestParams = next
   }
 
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
@@ -165,7 +196,8 @@ async function withStreamConsumptionRetry(
     let chunkCount = 0
     try {
       const processor = new StreamProcessor()
-      for await (const chunk of currentAdapter.stream({ ...params, model: currentModel })) {
+      const { model: _pModel, maxTokens: _pMaxTokens, thinking: _pThinking, ...baseParams } = params
+      for await (const chunk of currentAdapter.stream({ ...baseParams, ...currentRequestParams } as LLMStreamParams)) {
         if (params.signal?.aborted) {
           throw new DOMException('Aborted', 'AbortError')
         }

--- a/crabot-agent/src/engine/llm-adapter-types.ts
+++ b/crabot-agent/src/engine/llm-adapter-types.ts
@@ -170,9 +170,15 @@ async function withStreamConsumptionRetry(
   }
   let generic429Count = 0
   let appliedGeneration = params.configGeneration?.()
+  // 每次消费配置变更授予 1 次额外 attempt 预算（封顶 maxRetries）——变更本身不挤占
+  // 旧 provider 已消耗的配额（协议 3.6.17「不消耗 attempt 配额」），且配置抖动下
+  // 总尝试仍有界（≤ 2×(maxRetries+1)）。新 provider 的 429 计数独立起算。
+  let configSwitchBudget = 0
 
   const applyConfigChange = async (): Promise<void> => {
     appliedGeneration = params.configGeneration?.()
+    configSwitchBudget = Math.min(configSwitchBudget + 1, maxRetries)
+    generic429Count = 0
     const update = await params.onConfigChanged?.()
     if (!update) return
     if (update.adapter) currentAdapter = update.adapter
@@ -190,7 +196,8 @@ async function withStreamConsumptionRetry(
     currentRequestParams = next
   }
 
-  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+  let lastError: unknown
+  for (let attempt = 0; attempt <= maxRetries + configSwitchBudget; attempt++) {
     const attemptStart = Date.now()
     let firstChunkMs: number | undefined
     let chunkCount = 0
@@ -225,8 +232,17 @@ async function withStreamConsumptionRetry(
         },
       }
     } catch (err) {
+      lastError = err
       if (params.signal?.aborted) throw err
       if (!isRetryableError(err)) throw err
+      // 配置变更消费必须先于所有放弃判定（review 3rd）：变更落在最后一次失败上时，
+      // 新 provider 也要拿到尝试机会——旧 provider 的 Retry-After 结论 / 退避结论 /
+      // attempt 配额都不应结束本次调用。
+      if (params.configGeneration && params.configGeneration() !== appliedGeneration) {
+        // 立即换新配置重试：跳过本次 sleep（旧 provider 的等待指示不适用于新 provider）
+        await applyConfigChange()
+        continue
+      }
       // Retry-After 超上限：provider 要求等的时间比总预算还长，不再等待，按重试耗尽失败
       // （错误上带尝试次数/总耗时，可诊断）。
       const retryAfterMs = getRetryAfterMs(err)
@@ -241,37 +257,36 @@ async function withStreamConsumptionRetry(
         }
       }
       // 放弃可重试错误时把"尝试次数/总耗时"写进错误，让失败 trace 可诊断
-      // （否则 outcome 只剩一句裸 "fetch failed"，看不出是重试耗尽还是首次即挂）
-      if (attempt >= maxRetries) throw enrichGiveUp(err, attempt + 1, Date.now() - startedAt)
+      // （否则 outcome 只剩一句裸 "fetch failed"，看不出是重试耗尽还是首次即挂）。
+      // 配额 = maxRetries + 每次配置变更授予的额外预算（applyConfigChange 内累计）。
+      if (attempt >= maxRetries + configSwitchBudget) {
+        throw enrichGiveUp(err, attempt + 1, Date.now() - startedAt)
+      }
       const actualDelay = computeRetryDelayMs(attempt, delayMs, true, retryAfterMs)
       console.error(
-        `[callNonStreaming] stream attempt ${attempt + 1}/${maxRetries + 1} failed, retrying in ${actualDelay}ms (backoff):`,
+        `[callNonStreaming] stream attempt ${attempt + 1}/${maxRetries + configSwitchBudget + 1} failed, retrying in ${actualDelay}ms (backoff):`,
         err,
       )
       try {
         params.onRetry?.({
           attempt: attempt + 1,
-          maxAttempts: maxRetries + 1,
+          maxAttempts: maxRetries + configSwitchBudget + 1,
           delayMs: actualDelay,
           error: err instanceof Error ? err : new Error(String(err)),
           source: 'stream',
         })
       } catch { /* observability callback must not break retry */ }
-      if (params.configGeneration && params.configGeneration() !== appliedGeneration) {
-        // 配置在本次 attempt 期间/之间已落地：立即换新配置重试，跳过本次 sleep。
-        await applyConfigChange()
-      } else {
-        await interruptibleSleep(actualDelay, {
-          abortSignal: params.signal,
-          configChangedSignal: params.configChangedSignal,
-          onConfigChanged: applyConfigChange,
-        })
-      }
+      await interruptibleSleep(actualDelay, {
+        abortSignal: params.signal,
+        configChangedSignal: params.configChangedSignal,
+        onConfigChanged: applyConfigChange,
+      })
       // 下一轮 loop 会用全新 processor + 重新 call adapter.stream()，
       // 服务端生成新 response（partial 浪费，但 task 能完成）
     }
   }
-  throw new Error('callNonStreaming: retry loop exited unexpectedly')
+  // 循环条件耗尽（含 configSwitchBudget 路径）也要给出可诊断的放弃错误
+  throw enrichGiveUp(lastError ?? new Error('callNonStreaming: no attempt recorded'), maxRetries + configSwitchBudget + 1, Date.now() - startedAt)
 }
 
 /** 放弃重试时给错误补上"尝试次数/总耗时"上下文，原错误挂在 cause 上。 */

--- a/crabot-agent/src/engine/openai-adapter.ts
+++ b/crabot-agent/src/engine/openai-adapter.ts
@@ -5,8 +5,8 @@
 import type { LLMAdapter, LLMAdapterConfig, LLMStreamParams } from './llm-adapter-types.js'
 import { isToolResultMessage, extractText, buildImageUrl, readSSELines, mergeConsecutiveUserMessages, capToolResultForLLM, thinkingEffortValue } from './llm-adapter-types.js'
 import type { EngineMessage, ToolDefinition, StreamChunk, ContentBlock, LLMTokenUsage } from './types.js'
-import { HttpResponseError, StreamProtocolError } from './retry-utils.js'
-import { streamWithTimeoutAndRetry } from './stream-timeout.js'
+import { HttpResponseError, StreamProtocolError, parseRetryAfterMs } from './retry-utils.js'
+import { withStreamTimeout } from './stream-timeout.js'
 
 // --- OpenAI Message Types ---
 
@@ -164,7 +164,8 @@ export class OpenAIAdapter implements LLMAdapter {
   }
 
   async *stream(params: LLMStreamParams): AsyncGenerator<StreamChunk> {
-    yield* streamWithTimeoutAndRetry('openai-adapter', (p) => this.streamOnce(p), params)
+    // 只加 TTFB/空闲超时；重试统一由 callNonStreaming 单层处理（含配置热切换唤醒）。
+    yield* withStreamTimeout((signal) => this.streamOnce({ ...params, signal }), params.signal)
   }
 
   private async *streamOnce(params: LLMStreamParams): AsyncGenerator<StreamChunk> {
@@ -200,7 +201,8 @@ export class OpenAIAdapter implements LLMAdapter {
 
     if (!response.ok) {
       const errorText = await response.text()
-      throw new HttpResponseError(response.status, errorText, 'openai-adapter')
+      const retryAfter = parseRetryAfterMs(response.headers.get('retry-after'))
+      throw new HttpResponseError(response.status, errorText, 'openai-adapter', retryAfter)
     }
 
     if (!response.body) {

--- a/crabot-agent/src/engine/openai-responses-adapter.ts
+++ b/crabot-agent/src/engine/openai-responses-adapter.ts
@@ -7,8 +7,8 @@
 import type { LLMAdapter, LLMAdapterConfig, LLMStreamParams } from './llm-adapter-types.js'
 import { isToolResultMessage, extractText, buildImageUrl, readSSEEvents, capToolResultForLLM, thinkingEffortValue } from './llm-adapter-types.js'
 import type { EngineMessage, ToolDefinition, StreamChunk, ContentBlock, LLMTokenUsage } from './types.js'
-import { HttpResponseError, StreamProtocolError } from './retry-utils.js'
-import { streamWithTimeoutAndRetry } from './stream-timeout.js'
+import { HttpResponseError, StreamProtocolError, parseRetryAfterMs } from './retry-utils.js'
+import { withStreamTimeout } from './stream-timeout.js'
 
 // --- Responses API Message Normalization ---
 
@@ -149,7 +149,8 @@ export class OpenAIResponsesAdapter implements LLMAdapter {
   }
 
   async *stream(params: LLMStreamParams): AsyncGenerator<StreamChunk> {
-    yield* streamWithTimeoutAndRetry('openai-responses-adapter', (p) => this.streamOnce(p), params)
+    // 只加 TTFB/空闲超时；重试统一由 callNonStreaming 单层处理（含配置热切换唤醒）。
+    yield* withStreamTimeout((signal) => this.streamOnce({ ...params, signal }), params.signal)
   }
 
   private async *streamOnce(params: LLMStreamParams): AsyncGenerator<StreamChunk> {
@@ -205,7 +206,8 @@ export class OpenAIResponsesAdapter implements LLMAdapter {
 
     if (!response.ok) {
       const errorText = await response.text()
-      throw new HttpResponseError(response.status, errorText, 'openai-responses-adapter')
+      const retryAfter = parseRetryAfterMs(response.headers.get('retry-after'))
+      throw new HttpResponseError(response.status, errorText, 'openai-responses-adapter', retryAfter)
     }
 
     if (!response.body) {

--- a/crabot-agent/src/engine/query-loop.ts
+++ b/crabot-agent/src/engine/query-loop.ts
@@ -179,6 +179,8 @@ export async function runEngine(params: RunEngineParams): Promise<EngineResult> 
         maxTokens: options.maxTokens,
         thinking: options.thinking,
         signal: abortSignal,
+        configChangedSignal: options.configChangedSignal,
+        onConfigChanged: options.onConfigChanged,
         onRetry: (event) => {
           if (options.onLiveProgress) {
             options.onLiveProgress({

--- a/crabot-agent/src/engine/query-loop.ts
+++ b/crabot-agent/src/engine/query-loop.ts
@@ -180,6 +180,7 @@ export async function runEngine(params: RunEngineParams): Promise<EngineResult> 
         thinking: options.thinking,
         signal: abortSignal,
         configChangedSignal: options.configChangedSignal,
+        configGeneration: options.configGeneration,
         onConfigChanged: options.onConfigChanged,
         onRetry: (event) => {
           if (options.onLiveProgress) {

--- a/crabot-agent/src/engine/retry-utils.ts
+++ b/crabot-agent/src/engine/retry-utils.ts
@@ -140,6 +140,7 @@ export function isRetryableStatus(status: number): boolean {
 export function parseRetryAfterMs(value: string | null | undefined): number | undefined {
   if (!value) return undefined
   const trimmed = value.trim()
+  if (!trimmed) return undefined
   const seconds = Number(trimmed)
   if (Number.isFinite(seconds) && Number.isInteger(seconds) && seconds >= 0) {
     return seconds * 1000

--- a/crabot-agent/src/engine/retry-utils.ts
+++ b/crabot-agent/src/engine/retry-utils.ts
@@ -2,7 +2,7 @@ export const DEFAULT_MAX_RETRIES = 5
 export const DEFAULT_RETRY_DELAY_MS = 1_000
 export const BACKOFF_MAX_DELAY_MS = 8_000
 
-/** Retry-After 延迟上限：超过此值不再等待，直接失败。 */
+/** Retry-After 延迟上限：上游要求等待超过此值时不再等待，按重试耗尽失败处理。 */
 export const RETRY_AFTER_MAX_MS = 60_000
 
 /** 无 Retry-After 的通用 429 最多重试次数。 */
@@ -198,7 +198,8 @@ export function isOverloadedError(err: unknown): boolean {
 
 /**
  * 计算单次重试前的等待时间。
- *   - retryAfterMs 有值：优先使用，上限 RETRY_AFTER_MAX_MS。
+ *   - retryAfterMs 有值：优先使用；本函数只做防御性 clamp 到 RETRY_AFTER_MAX_MS，
+ *     「超过上限按失败处理」的判定的职责在调用方（withStreamConsumptionRetry）。
  *   - useBackoff=false：固定 baseDelayMs。
  *   - useBackoff=true：base * 2^attempt（cap 在 BACKOFF_MAX_DELAY_MS）。
  *
@@ -294,17 +295,19 @@ export interface InterruptibleSleepOptions {
 
 /**
  * 可被用户取消或配置变更打断的 sleep。
- * - abortSignal 触发 → 抛 AbortError（用户主动取消）。
- * - configChangedSignal 触发 → 调用 onConfigChanged 并正常 resolve，让外层继续下一次 attempt。
+ * - abortSignal 触发 → 抛 AbortError（用户主动取消）。入口已 aborted 同样立即抛。
+ * - configChangedSignal 在**本次 sleep 期间**触发 → 调用 onConfigChanged 并正常
+ *   resolve，让外层继续下一次 attempt。
+ *
+ * 注意：configChangedSignal 是一次性 AbortSignal（AbortController 不可 reset），因此
+ * 它只表达「sleep 期间发生了变更」这一**边沿事件**；入口时已 aborted 不触发任何回调、
+ * 照常睡满——「sleep 窗口之外发生的变更」由调用方经 configGeneration 探针消费（见
+ * withStreamConsumptionRetry），否则一次变更后本次 run 内所有后续退避都会被永久归零。
  */
 export async function interruptibleSleep(ms: number, options: InterruptibleSleepOptions = {}): Promise<void> {
   const { abortSignal, configChangedSignal, onConfigChanged } = options
   if (abortSignal?.aborted) {
     throw new DOMException('Aborted', 'AbortError')
-  }
-  if (configChangedSignal?.aborted) {
-    await onConfigChanged?.()
-    return
   }
   return new Promise<void>((resolve, reject) => {
     const timer = setTimeout(() => {

--- a/crabot-agent/src/engine/retry-utils.ts
+++ b/crabot-agent/src/engine/retry-utils.ts
@@ -1,6 +1,12 @@
-export const DEFAULT_MAX_RETRIES = 10
+export const DEFAULT_MAX_RETRIES = 5
 export const DEFAULT_RETRY_DELAY_MS = 1_000
 export const BACKOFF_MAX_DELAY_MS = 8_000
+
+/** Retry-After 延迟上限：超过此值不再等待，直接失败。 */
+export const RETRY_AFTER_MAX_MS = 60_000
+
+/** 无 Retry-After 的通用 429 最多重试次数。 */
+export const OVERLOADED_WITHOUT_RETRY_AFTER_MAX_RETRIES = 3
 
 const RETRYABLE_CODES = new Set([
   // POSIX
@@ -27,7 +33,7 @@ const OVERLOADED_BODY_CODES = new Set([
 // 错误（过载 / 路由抖动 / token 过期）伪装成 400，按状态码白名单一刀切会错杀整轮请求。
 const NON_RETRYABLE_HTTP_STATUS = new Set([401, 403, 404, 405, 422])
 
-// body code 黑名单：上游把"客户端永久错误"塞进 HTTP 400 body 的特殊 code。
+// body code 黑名单：上游把"客户端永久错误"塞进 HTTP 400/429 body 的特殊 code。
 // 这类错误重试也不会成功（同输入再发还是被拦），必须在状态码默认重试之前先短路。
 const NON_RETRYABLE_BODY_CODES = new Set([
   'content_filter',           // 内容审查命中（OpenAI）
@@ -37,6 +43,12 @@ const NON_RETRYABLE_BODY_CODES = new Set([
   'invalid_request_error',    // 通用请求错（OpenAI 风格）
   'invalid_api_key',
   'invalid_authentication',
+  // 额度 / 计费类：再发多少次都没用，必须 fail-fast 让用户换 provider
+  'insufficient_quota',
+  'quota_exceeded',
+  'balance_exhausted',
+  'credit_exhausted',
+  'billing_not_active',
 ])
 
 export class HttpResponseError extends Error {
@@ -46,6 +58,8 @@ export class HttpResponseError extends Error {
     public readonly status: number,
     public readonly body: string,
     label: string,
+    /** 上游 Retry-After 头解析后的毫秒数（如有）。 */
+    public readonly retryAfterMs?: number,
   ) {
     super(`${label} HTTP ${status}: ${body.slice(0, 300)}`)
     this.name = 'HttpResponseError'
@@ -118,10 +132,54 @@ export function isRetryableStatus(status: number): boolean {
 }
 
 /**
+ * 解析 Retry-After 头值为毫秒数。
+ *   - 纯秒数（如 "5"）→ 直接 ×1000。
+ *   - HTTP-date（如 "Wed, 21 Oct 2026 07:28:00 GMT"）→ 与当前时间差。
+ *   - 无法解析 → undefined。
+ */
+export function parseRetryAfterMs(value: string | null | undefined): number | undefined {
+  if (!value) return undefined
+  const trimmed = value.trim()
+  const seconds = Number(trimmed)
+  if (Number.isFinite(seconds) && Number.isInteger(seconds) && seconds >= 0) {
+    return seconds * 1000
+  }
+  const date = Date.parse(trimmed)
+  if (Number.isFinite(date)) {
+    return Math.max(0, date - Date.now())
+  }
+  return undefined
+}
+
+/** 从已知错误形态中提取 Retry-After 毫秒数。 */
+export function getRetryAfterMs(err: unknown): number | undefined {
+  if (err instanceof HttpResponseError) return err.retryAfterMs
+  const headers = (err as Error & { headers?: Record<string, string | string[]> }).headers
+  if (headers) {
+    const value = headers['retry-after'] ?? headers['Retry-After']
+    return parseRetryAfterMs(Array.isArray(value) ? value[0] : value)
+  }
+  return undefined
+}
+
+/** 判断是否为「无 Retry-After 的通用 429」，需要单独限制重试次数。 */
+export function isOverloadedWithoutRetryAfter(err: unknown): boolean {
+  if (err instanceof HttpResponseError) {
+    return err.status === 429 && err.retryAfterMs === undefined
+  }
+  const status = (err as Error & { status?: unknown }).status
+  if (status !== 429) return false
+  return getRetryAfterMs(err) === undefined
+}
+
+/**
  * 是否属于过载/限流类错误，需要走指数退避。包含：
  *   - HTTP 429（标准限流）
  *   - HttpResponseError body code 命中 OVERLOADED_BODY_CODES（如 server_is_overloaded 走 HTTP 400）
  *   - SDK error 自带 status === 429
+ *
+ * 注意：本函数只做「分类」，不做「是否还应继续重试」的判断。
+ * 无 Retry-After 的通用 429 另有次数上限（见 withStreamConsumptionRetry）。
  */
 export function isOverloadedError(err: unknown): boolean {
   if (!(err instanceof Error)) return false
@@ -140,12 +198,16 @@ export function isOverloadedError(err: unknown): boolean {
 
 /**
  * 计算单次重试前的等待时间。
- *   - useBackoff=false：固定 baseDelayMs
- *   - useBackoff=true：base * 2^attempt（cap 在 BACKOFF_MAX_DELAY_MS）
+ *   - retryAfterMs 有值：优先使用，上限 RETRY_AFTER_MAX_MS。
+ *   - useBackoff=false：固定 baseDelayMs。
+ *   - useBackoff=true：base * 2^attempt（cap 在 BACKOFF_MAX_DELAY_MS）。
  *
  * attempt 为 0-indexed —— 第一次失败时 attempt=0，对应 base * 1。
  */
-export function computeRetryDelayMs(attempt: number, baseDelayMs: number, useBackoff: boolean): number {
+export function computeRetryDelayMs(attempt: number, baseDelayMs: number, useBackoff: boolean, retryAfterMs?: number): number {
+  if (retryAfterMs !== undefined) {
+    return Math.min(Math.max(retryAfterMs, 0), RETRY_AFTER_MAX_MS)
+  }
   if (!useBackoff) return baseDelayMs
   return Math.min(baseDelayMs * Math.pow(2, attempt), BACKOFF_MAX_DELAY_MS)
 }
@@ -218,6 +280,59 @@ export interface RetryOptions {
    * 主要用途是 worker → admin web 显示"LLM 正在重试中"。
    */
   readonly onRetry?: (event: { attempt: number; maxAttempts: number; delayMs: number; error: Error }) => void
+  /** 配置变更信号；触发时重试 sleep 会提前结束并由 onConfigChanged 刷新配置。 */
+  readonly configChangedSignal?: AbortSignal
+  /** 配置变更信号触发后调用；调用方应在此刷新 adapter/model 等运行时配置。 */
+  readonly onConfigChanged?: () => Promise<void>
+}
+
+export interface InterruptibleSleepOptions {
+  readonly abortSignal?: AbortSignal
+  readonly configChangedSignal?: AbortSignal
+  readonly onConfigChanged?: () => Promise<void>
+}
+
+/**
+ * 可被用户取消或配置变更打断的 sleep。
+ * - abortSignal 触发 → 抛 AbortError（用户主动取消）。
+ * - configChangedSignal 触发 → 调用 onConfigChanged 并正常 resolve，让外层继续下一次 attempt。
+ */
+export async function interruptibleSleep(ms: number, options: InterruptibleSleepOptions = {}): Promise<void> {
+  const { abortSignal, configChangedSignal, onConfigChanged } = options
+  if (abortSignal?.aborted) {
+    throw new DOMException('Aborted', 'AbortError')
+  }
+  if (configChangedSignal?.aborted) {
+    await onConfigChanged?.()
+    return
+  }
+  return new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      cleanup()
+      resolve()
+    }, ms)
+    const cleanup = (): void => {
+      clearTimeout(timer)
+      abortSignal?.removeEventListener('abort', onAbort)
+      configChangedSignal?.removeEventListener('abort', onConfigChangedAbort)
+    }
+    const onAbort = (): void => {
+      cleanup()
+      reject(new DOMException('Aborted', 'AbortError'))
+    }
+    const onConfigChangedAbort = async (): Promise<void> => {
+      cleanup()
+      try {
+        await onConfigChanged?.()
+      } catch (err) {
+        reject(err)
+        return
+      }
+      resolve()
+    }
+    abortSignal?.addEventListener('abort', onAbort, { once: true })
+    configChangedSignal?.addEventListener('abort', onConfigChangedAbort, { once: true })
+  })
 }
 
 export interface StreamRetryOptions<T = unknown> extends RetryOptions {
@@ -253,7 +368,7 @@ export async function withRetry<T>(
       if (abortSignal?.aborted) throw err
       if (!isRetryableError(err)) throw err
       if (attempt >= maxRetries) throw err
-      const actualDelay = computeRetryDelayMs(attempt, delayMs, true)
+      const actualDelay = computeRetryDelayMs(attempt, delayMs, true, getRetryAfterMs(err))
       console.error(
         `[${label}] attempt ${attempt + 1} failed, retrying in ${actualDelay}ms (backoff):`,
         err,
@@ -266,7 +381,11 @@ export async function withRetry<T>(
           error: err instanceof Error ? err : new Error(String(err)),
         })
       } catch { /* observability callback must not break retry */ }
-      await sleep(actualDelay, abortSignal)
+      await interruptibleSleep(actualDelay, {
+        abortSignal,
+        configChangedSignal: options.configChangedSignal,
+        onConfigChanged: options.onConfigChanged,
+      })
     }
   }
 }
@@ -303,7 +422,7 @@ export async function* streamWithRetry<T>(
       if (abortSignal?.aborted) throw err
       if (!isRetryableError(err)) throw err
       if (attempt >= maxRetries) throw err
-      const actualDelay = computeRetryDelayMs(attempt, delayMs, true)
+      const actualDelay = computeRetryDelayMs(attempt, delayMs, true, getRetryAfterMs(err))
       console.error(
         `[${label}] attempt ${attempt + 1} failed, retrying in ${actualDelay}ms (backoff):`,
         err,
@@ -316,7 +435,11 @@ export async function* streamWithRetry<T>(
           error: err instanceof Error ? err : new Error(String(err)),
         })
       } catch { /* observability callback must not break retry */ }
-      await sleep(actualDelay, abortSignal)
+      await interruptibleSleep(actualDelay, {
+        abortSignal,
+        configChangedSignal: options.configChangedSignal,
+        onConfigChanged: options.onConfigChanged,
+      })
     }
   }
 }

--- a/crabot-agent/src/engine/stream-processor.ts
+++ b/crabot-agent/src/engine/stream-processor.ts
@@ -3,7 +3,8 @@ import type { StreamChunk, ToolUseBlock, RawReasoningBlock, LLMTokenUsage } from
 
 /**
  * 判断 chunk 是否对消费者可见。message_start 仅携带 messageId，
- * `StreamProcessor.process` 对其 noop —— 仅在它后面断流时允许 streamWithRetry 重试。
+ * `StreamProcessor.process` 对其 noop —— 仅它属于「重试可安全丢弃」的元事件
+ * （重试层为 callNonStreaming 的缓冲整流；streamWithRetry 供非 adapter 场景复用）。
  * 此谓词与 process() 中 noop 分支的判定保持单点同步。
  */
 export function isMaterialChunk(chunk: StreamChunk): boolean {

--- a/crabot-agent/src/engine/stream-timeout.ts
+++ b/crabot-agent/src/engine/stream-timeout.ts
@@ -10,9 +10,7 @@
  * 取消（userSignal）严格区分——后者原样抛出 AbortError，不可重试。
  */
 
-import { StreamTimeoutError, streamWithRetry } from './retry-utils.js'
-import { isMaterialChunk } from './stream-processor.js'
-import { wrapOnRetry, type LLMStreamParams } from './llm-adapter-types.js'
+import { StreamTimeoutError } from './retry-utils.js'
 import type { StreamChunk } from './types.js'
 
 // 默认值偏保守，容得下慢 prefill 的大上下文请求；可用环境变量覆盖。
@@ -86,28 +84,4 @@ export async function* withStreamTimeout<T>(
     if (timer) clearTimeout(timer)
     if (userSignal && onUserAbort) userSignal.removeEventListener('abort', onUserAbort)
   }
-}
-
-/**
- * adapter.stream() 的统一封装：内层 = streamOnce + TTFB/空闲超时，外层 = pre-material 重试
- * （streamWithRetry，超时抛 StreamTimeoutError 被判定可重试 → 换新连接重发）。
- *
- * 三个 adapter 共用此封装，避免新 adapter 漏接超时或重试中的一半。
- * 超时的 abort 必须经 withStreamTimeout 注入的 signal 才能传到底层 fetch，所以封装在
- * 这一层（而非 adapter.stream() 外面）。
- */
-export async function* streamWithTimeoutAndRetry(
-  label: string,
-  streamOnce: (params: LLMStreamParams) => AsyncGenerator<StreamChunk>,
-  params: LLMStreamParams,
-): AsyncGenerator<StreamChunk> {
-  yield* streamWithRetry(
-    label,
-    () => withStreamTimeout((signal) => streamOnce({ ...params, signal }), params.signal),
-    {
-      abortSignal: params.signal,
-      isMaterial: isMaterialChunk,
-      onRetry: wrapOnRetry(params.onRetry, 'pre-stream'),
-    },
-  )
 }

--- a/crabot-agent/src/engine/types.ts
+++ b/crabot-agent/src/engine/types.ts
@@ -353,12 +353,14 @@ export interface EngineOptions {
   /**
    * LLM 重试期间配置热切换（spec 2026-08-30-llm-retry-config-hotreload）。
    *
-   * configChangedSignal 在「运行时配置 revision 已前进」时 abort；callNonStreaming 的
-   * 重试 sleep 被它提前唤醒后调用 onConfigChanged，用返回的新 adapter/model 继续
-   * 下一次 attempt（attempt 配额不因此消耗）。仅在重试 sleep 阶段生效：已经开始向
-   * 下游交付 chunk 的调用不中断。不传时行为与现状一致（重试始终用调用时的 adapter）。
+   * configChangedSignal 是「sleep 期间发生配置变更」的边沿唤醒；configGeneration 是
+   * 当前已应用配置代数的探针（callNonStreaming 记账消费，代数前进时立即换新配置并
+   * 跳过一次退避）。唤醒/换代后由 onConfigChanged 返回的新 adapter/model 继续
+   * 下一次 attempt（attempt 配额不因此消耗）。仅覆盖重试等待阶段：已经开始向下游
+   * 交付 chunk 的调用不中断。不传时行为与现状一致（重试始终用调用时的 adapter）。
    */
   readonly configChangedSignal?: AbortSignal
+  readonly configGeneration?: () => number
   readonly onConfigChanged?: () => Promise<{ adapter?: LLMAdapter; model?: string } | void>
   /** 已组装本轮 messages、即将调用 Provider 前的内部准入观察点。 */
   readonly onBeforeLlmCall?: () => void | Promise<void>

--- a/crabot-agent/src/engine/types.ts
+++ b/crabot-agent/src/engine/types.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'crypto'
-import type { LLMThinkingConfig } from './llm-adapter-types.js'
+import type { LLMAdapter, LLMThinkingConfig } from './llm-adapter-types.js'
 
 // --- Content Blocks ---
 
@@ -269,12 +269,12 @@ export type LiveProgressEvent =
       }>
     }
   | {
-      /** LLM 调用 mid-stream / pre-stream / complete 路径 retry 触发；用于 admin web 显示"正在重试"状态 */
+      /** LLM 调用重试触发；用于 admin web 显示"正在重试"状态 */
       readonly type: 'llm_retry'
       readonly turn: number          // 当前正在尝试的 turn 编号
       readonly attempt: number       // 第几次失败 (1-indexed)
       readonly maxAttempts: number   // 总配额
-      readonly source: 'pre-stream' | 'mid-stream'
+      readonly source: 'stream'
       readonly error: string         // 触发 retry 的 error message（截断 200）
     }
 
@@ -350,6 +350,16 @@ export interface EngineOptions {
    * 写入的数组本身是 ReadonlyArray —— 外部只读，不应原地修改。
    */
   readonly messagesRef?: EngineMessagesRef
+  /**
+   * LLM 重试期间配置热切换（spec 2026-08-30-llm-retry-config-hotreload）。
+   *
+   * configChangedSignal 在「运行时配置 revision 已前进」时 abort；callNonStreaming 的
+   * 重试 sleep 被它提前唤醒后调用 onConfigChanged，用返回的新 adapter/model 继续
+   * 下一次 attempt（attempt 配额不因此消耗）。仅在重试 sleep 阶段生效：已经开始向
+   * 下游交付 chunk 的调用不中断。不传时行为与现状一致（重试始终用调用时的 adapter）。
+   */
+  readonly configChangedSignal?: AbortSignal
+  readonly onConfigChanged?: () => Promise<{ adapter?: LLMAdapter; model?: string } | void>
   /** 已组装本轮 messages、即将调用 Provider 前的内部准入观察点。 */
   readonly onBeforeLlmCall?: () => void | Promise<void>
   /**

--- a/crabot-agent/src/engine/types.ts
+++ b/crabot-agent/src/engine/types.ts
@@ -361,7 +361,7 @@ export interface EngineOptions {
    */
   readonly configChangedSignal?: AbortSignal
   readonly configGeneration?: () => number
-  readonly onConfigChanged?: () => Promise<{ adapter?: LLMAdapter; model?: string } | void>
+  readonly onConfigChanged?: () => Promise<import('./llm-adapter-types.js').LLMConfigSwap | void>
   /** 已组装本轮 messages、即将调用 Provider 前的内部准入观察点。 */
   readonly onBeforeLlmCall?: () => void | Promise<void>
   /**

--- a/crabot-agent/src/manager/bootstrap.ts
+++ b/crabot-agent/src/manager/bootstrap.ts
@@ -137,10 +137,13 @@ export interface BootstrapDeps {
   /**
    * 运行时配置**已原子替换**后的通知源(spec 2026-08-30-llm-retry-config-hotreload):
    * 订阅者拿它 abort 自己的 configChangedSignal,让 LLM 重试 sleep 提前唤醒并用
-   * `managerAdapter()/managerModel()` 现解析的新配置重试。必须是 apply 完成后才触发
+   * `managerAdapter()/managerModel()` 现解析的新配置重试。必须在 apply 完成后触发
    * ——在 acceptRevision 时就触发会抢在 agentConfig 替换之前,重试拿到的还是旧配置。
    */
   readonly onRuntimeConfigApplied?: (listener: () => void) => () => void
+  /** 已应用配置代数 getter(每次原子替换 +1,与 onRuntimeConfigApplied 同点递增);
+   *  callNonStreaming 记账消费,用于消费「sleep 窗口之外落地的变更」。 */
+  readonly runtimeConfigAppliedGeneration?: () => number
   /** manager 的槽位思考强度(随 powerful slot),thunk 以支持热更;返回 undefined = 跟随默认 */
   readonly managerThinking?: () => import('../engine/llm-adapter-types.js').LLMThinkingConfig | undefined
   /** manager 模型的上下文窗口(随 powerful slot),thunk 以支持热更;返回 undefined = engine 默认 200K */
@@ -516,6 +519,7 @@ export function buildManagerStack(deps: BootstrapDeps): ManagerStack {
     adapter: deps.managerAdapter,
     model: deps.managerModel,
     onRuntimeConfigApplied: deps.onRuntimeConfigApplied,
+    runtimeConfigAppliedGeneration: deps.runtimeConfigAppliedGeneration,
     thinking: deps.managerThinking,
     contextWindowTokens: deps.managerContextWindowTokens,
     now: () => new Date(deps.now()),

--- a/crabot-agent/src/manager/bootstrap.ts
+++ b/crabot-agent/src/manager/bootstrap.ts
@@ -134,6 +134,13 @@ export interface BootstrapDeps {
   /** manager 的 LLM 来源(2026-08 收敛后即 powerful slot),thunk 以支持热更 */
   readonly managerAdapter: () => LLMAdapter
   readonly managerModel: () => string
+  /**
+   * 运行时配置**已原子替换**后的通知源(spec 2026-08-30-llm-retry-config-hotreload):
+   * 订阅者拿它 abort 自己的 configChangedSignal,让 LLM 重试 sleep 提前唤醒并用
+   * `managerAdapter()/managerModel()` 现解析的新配置重试。必须是 apply 完成后才触发
+   * ——在 acceptRevision 时就触发会抢在 agentConfig 替换之前,重试拿到的还是旧配置。
+   */
+  readonly onRuntimeConfigApplied?: (listener: () => void) => () => void
   /** manager 的槽位思考强度(随 powerful slot),thunk 以支持热更;返回 undefined = 跟随默认 */
   readonly managerThinking?: () => import('../engine/llm-adapter-types.js').LLMThinkingConfig | undefined
   /** manager 模型的上下文窗口(随 powerful slot),thunk 以支持热更;返回 undefined = engine 默认 200K */
@@ -508,6 +515,7 @@ export function buildManagerStack(deps: BootstrapDeps): ManagerStack {
     ledger,
     adapter: deps.managerAdapter,
     model: deps.managerModel,
+    onRuntimeConfigApplied: deps.onRuntimeConfigApplied,
     thinking: deps.managerThinking,
     contextWindowTokens: deps.managerContextWindowTokens,
     now: () => new Date(deps.now()),

--- a/crabot-agent/src/manager/loop.ts
+++ b/crabot-agent/src/manager/loop.ts
@@ -209,11 +209,13 @@ export interface ManagerLoopDeps {
   readonly adapter: () => LLMAdapter
   readonly model: () => string
   /**
-   * 运行时配置已原子替换后的通知源(spec 2026-08-30-llm-retry-config-hotreload):
-   * runAttempt 用它构造 configChangedSignal——LLM 重试 sleep 期间配置落地时提前唤醒,
-   * onConfigChanged 现解析 adapter/model 后下一次 attempt 换新配置重试。
+   * 运行时配置已原子替换后的通知源与代数 getter(spec 2026-08-30-llm-retry-config-hotreload):
+   * runAttempt 用前者构造 configChangedSignal——LLM 重试 sleep 期间配置落地时提前唤醒,
+   * onConfigChanged 现解析 adapter/model 后下一次 attempt 换新配置重试;后者作为
+   * configGeneration 探针传给 engine,消费「sleep 窗口之外落地的变更」。
    */
   readonly onRuntimeConfigApplied?: (listener: () => void) => () => void
+  readonly runtimeConfigAppliedGeneration?: () => number
   readonly maxTurns?: number
   /** manager 模型的上下文窗口(thunk,episode 内与 adapter/model 同点解析);undefined = engine 默认 200K */
   readonly contextWindowTokens?: () => number | undefined
@@ -1237,9 +1239,11 @@ export class ManagerLoop {
       onTurn: (event) => this.recordTurnSpans(episodeId, event),
       // LLM 重试期间配置热切换（spec 2026-08-30-llm-retry-config-hotreload）：
       // onRuntimeConfigApplied 在 agentConfig 原子替换完成后触发 → abort signal →
-      // callNonStreaming 的重试 sleep 提前结束，onConfigChanged 现解析 powerful slot
-      // 后下一次 attempt 换新 adapter/model。仅覆盖重试阶段，episode 快照语义不变。
+      // callNonStreaming 的重试 sleep 提前结束；configGeneration 探针由 engine 记账，
+      // 消费 sleep 窗口之外落地的变更。onConfigChanged 现解析 powerful slot 后下一
+      // 次 attempt 换新 adapter/model。仅覆盖重试阶段，episode 快照语义不变。
       configChangedSignal: configChanged.signal,
+      configGeneration: this.deps.runtimeConfigAppliedGeneration,
       onConfigChanged: async () => ({
         adapter: this.deps.adapter(),
         model: this.deps.model(),

--- a/crabot-agent/src/manager/loop.ts
+++ b/crabot-agent/src/manager/loop.ts
@@ -1247,6 +1247,8 @@ export class ManagerLoop {
       onConfigChanged: async () => ({
         adapter: this.deps.adapter(),
         model: this.deps.model(),
+        // thinking 是 per-model 字段，随 model 一并替换；manager 不发 max_tokens。
+        ...(this.deps.thinking ? { thinking: this.deps.thinking() } : {}),
       }),
     }
 

--- a/crabot-agent/src/manager/loop.ts
+++ b/crabot-agent/src/manager/loop.ts
@@ -208,6 +208,12 @@ export interface ManagerLoopDeps {
    */
   readonly adapter: () => LLMAdapter
   readonly model: () => string
+  /**
+   * 运行时配置已原子替换后的通知源(spec 2026-08-30-llm-retry-config-hotreload):
+   * runAttempt 用它构造 configChangedSignal——LLM 重试 sleep 期间配置落地时提前唤醒,
+   * onConfigChanged 现解析 adapter/model 后下一次 attempt 换新配置重试。
+   */
+  readonly onRuntimeConfigApplied?: (listener: () => void) => () => void
   readonly maxTurns?: number
   /** manager 模型的上下文窗口(thunk,episode 内与 adapter/model 同点解析);undefined = engine 默认 200K */
   readonly contextWindowTokens?: () => number | undefined
@@ -1181,6 +1187,12 @@ export class ManagerLoop {
     }
     const tools = (): ReadonlyArray<ToolDefinition> => this.deps.toolFace(effectiveWake)
 
+    // LLM 重试期间配置热切换的订阅（spec 2026-08-30-llm-retry-config-hotreload）：
+    // 只覆盖本 attempt 的 runEngine 生命周期，结束时确定性退订，不泄漏监听器。
+    const configChanged = new AbortController()
+    const offRuntimeConfigApplied = this.deps.onRuntimeConfigApplied?.(() => configChanged.abort())
+      ?? (() => undefined)
+
     const options: EngineOptions = {
       systemPrompt,
       tools,
@@ -1223,16 +1235,28 @@ export class ManagerLoop {
       // P6-A §6.4：onTurn 是事后观察钩子，用它生成 llm_call/tool_call span；
       // 不复制执行语义、不新增第二个 query loop。
       onTurn: (event) => this.recordTurnSpans(episodeId, event),
+      // LLM 重试期间配置热切换（spec 2026-08-30-llm-retry-config-hotreload）：
+      // onRuntimeConfigApplied 在 agentConfig 原子替换完成后触发 → abort signal →
+      // callNonStreaming 的重试 sleep 提前结束，onConfigChanged 现解析 powerful slot
+      // 后下一次 attempt 换新 adapter/model。仅覆盖重试阶段，episode 快照语义不变。
+      configChangedSignal: configChanged.signal,
+      onConfigChanged: async () => ({
+        adapter: this.deps.adapter(),
+        model: this.deps.model(),
+      }),
     }
 
-    const result = await runEngine({
-      prompt: '', // 被忽略:initialMessages 非空时 runEngine 不使用 prompt(见 query-loop.ts)
-      adapter,
-      options,
-      initialMessages,
-    })
-
-    return { result, hasSummaryMarker, initialMessageCount: initialMessages.length }
+    try {
+      const result = await runEngine({
+        prompt: '', // 被忽略:initialMessages 非空时 runEngine 不使用 prompt(见 query-loop.ts)
+        adapter,
+        options,
+        initialMessages,
+      })
+      return { result, hasSummaryMarker, initialMessageCount: initialMessages.length }
+    } finally {
+      offRuntimeConfigApplied()
+    }
   }
 
 }

--- a/crabot-agent/src/manager/registry.ts
+++ b/crabot-agent/src/manager/registry.ts
@@ -91,6 +91,8 @@ export interface ManagerRegistryDeps {
    */
   readonly adapter: () => LLMAdapter
   readonly model: () => string
+  /** 运行时配置已原子替换后的通知源(spec 2026-08-30-llm-retry-config-hotreload);原样下传 ManagerLoopDeps。 */
+  readonly onRuntimeConfigApplied?: (listener: () => void) => () => void
   readonly maxTurns?: number
   /** manager 模型的上下文窗口(随 powerful slot,thunk 支持 hot-reload);undefined = engine 默认 200K */
   readonly contextWindowTokens?: () => number | undefined
@@ -227,6 +229,7 @@ export class ManagerRegistry {
       estimateTokens: this.deps.estimateTokens,
       adapter: this.deps.adapter,
       model: this.deps.model,
+      onRuntimeConfigApplied: this.deps.onRuntimeConfigApplied,
       maxTurns: this.deps.maxTurns,
       contextWindowTokens: this.deps.contextWindowTokens,
       // thunk 原样下传：thinking 的解析在 episode 内与 adapter/model 同点发生（同样的

--- a/crabot-agent/src/manager/registry.ts
+++ b/crabot-agent/src/manager/registry.ts
@@ -91,8 +91,9 @@ export interface ManagerRegistryDeps {
    */
   readonly adapter: () => LLMAdapter
   readonly model: () => string
-  /** 运行时配置已原子替换后的通知源(spec 2026-08-30-llm-retry-config-hotreload);原样下传 ManagerLoopDeps。 */
+  /** 运行时配置已原子替换后的通知源与代数 getter(spec 2026-08-30-llm-retry-config-hotreload);原样下传 ManagerLoopDeps。 */
   readonly onRuntimeConfigApplied?: (listener: () => void) => () => void
+  readonly runtimeConfigAppliedGeneration?: () => number
   readonly maxTurns?: number
   /** manager 模型的上下文窗口(随 powerful slot,thunk 支持 hot-reload);undefined = engine 默认 200K */
   readonly contextWindowTokens?: () => number | undefined
@@ -230,6 +231,7 @@ export class ManagerRegistry {
       adapter: this.deps.adapter,
       model: this.deps.model,
       onRuntimeConfigApplied: this.deps.onRuntimeConfigApplied,
+      runtimeConfigAppliedGeneration: this.deps.runtimeConfigAppliedGeneration,
       maxTurns: this.deps.maxTurns,
       contextWindowTokens: this.deps.contextWindowTokens,
       // thunk 原样下传：thinking 的解析在 episode 内与 adapter/model 同点发生（同样的

--- a/crabot-agent/src/types.ts
+++ b/crabot-agent/src/types.ts
@@ -453,7 +453,7 @@ export interface LiveTaskSnapshot {
   readonly llm_retry?: {
     readonly attempt: number
     readonly max_attempts: number
-    readonly source: 'pre-stream' | 'mid-stream'
+    readonly source: 'stream'
     readonly last_error: string
     readonly since: number  // ms timestamp
   }

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -543,6 +543,8 @@ export class UnifiedAgent extends ModuleBase {
   /** A failed pull destructively detached runtime resources; recovery must rebuild them
    *  even when the revision does not advance. */
   private configResourcesDetached = false
+  /** 运行时配置原子替换后的通知监听器（spec 2026-08-30-llm-retry-config-hotreload）。 */
+  private runtimeConfigAppliedListeners = new Set<() => void>()
 
   // 端口缓存
   private adminPort?: number
@@ -913,6 +915,8 @@ export class UnifiedAgent extends ModuleBase {
         return thinkingParam(conn.thinking_level, conn.thinking_custom)
       },
       managerContextWindowTokens: () => resolveManagerModelConfig(this.agentConfig?.model_config).context_window,
+      // LLM 重试期间配置热切换的通知源（spec 2026-08-30-llm-retry-config-hotreload）
+      onRuntimeConfigApplied: (listener) => this.addRuntimeConfigAppliedListener(listener),
       // crab-messaging：与 `createMcpConfigs` 同款依赖，但不传 `getTaskContext`——manager 不是
       // task，且 tool-face 已把 `send_message` 的 intent 去掉，ask_human 路径对 manager 不存在。
       messagingDeps: {
@@ -1374,6 +1378,8 @@ export class UnifiedAgent extends ModuleBase {
       ...(this.agentConfig?.tmp_page_base_url ? { tmpPageBaseUrl: this.agentConfig.tmp_page_base_url } : {}),
     }, {
       mcpConfigFactory: createMcpConfigs,
+      // LLM 重试期间配置热切换的通知源（spec 2026-08-30-llm-retry-config-hotreload）
+      runtimeConfigAppliedSource: (listener) => this.addRuntimeConfigAppliedListener(listener),
       deps: {
         rpcClient: this.rpcClient,
         moduleId: this.config.moduleId,
@@ -1539,6 +1545,18 @@ export class UnifiedAgent extends ModuleBase {
       this.runRuntimeConfigPull()
     }, 50)
     this.configPullTimer.unref?.()
+  }
+
+  /** 订阅「运行时配置已原子替换」通知；返回退订函数。listener 抛错不影响通知循环。 */
+  private addRuntimeConfigAppliedListener(listener: () => void): () => void {
+    this.runtimeConfigAppliedListeners.add(listener)
+    return () => { this.runtimeConfigAppliedListeners.delete(listener) }
+  }
+
+  private notifyRuntimeConfigApplied(): void {
+    for (const listener of this.runtimeConfigAppliedListeners) {
+      try { listener() } catch { /* listener must not break config apply path */ }
+    }
   }
 
   /** Single-flight wrapper around pullRuntimeConfig with dirty-coalesce and backoff retry. */
@@ -1723,6 +1741,9 @@ export class UnifiedAgent extends ModuleBase {
     this.digestSdkEnv = nextDigestSdk
     this.imageConnInfo = nextImageConn
     this.imageCapability = nextImageCapability
+    // live 字段已原子替换（spec 2026-08-30-llm-retry-config-hotreload）：通知正在
+    // LLM 重试 sleep 中的 manager/worker episode——它们据此提前唤醒并现解析新配置重试。
+    this.notifyRuntimeConfigApplied()
 
     // worker implementation desired config 在 agentConfig 等 live 字段就位后、任何分支
     // return 前应用（R3：early-return 分支曾让这里在热路径上永远走不到）。registry 失败

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -545,6 +545,12 @@ export class UnifiedAgent extends ModuleBase {
   private configResourcesDetached = false
   /** 运行时配置原子替换后的通知监听器（spec 2026-08-30-llm-retry-config-hotreload）。 */
   private runtimeConfigAppliedListeners = new Set<() => void>()
+  /**
+   * 已应用配置代数：每次原子替换 +1。LLM 重试路径用它区分「sleep 期间的边沿唤醒」与
+   * 「sleep 窗口之外落地的变更」——后者由 callNonStreaming 记账消费，避免一次性
+   * AbortSignal 把后续退避永久归零。
+   */
+  private runtimeConfigAppliedGeneration = 0
 
   // 端口缓存
   private adminPort?: number
@@ -915,8 +921,9 @@ export class UnifiedAgent extends ModuleBase {
         return thinkingParam(conn.thinking_level, conn.thinking_custom)
       },
       managerContextWindowTokens: () => resolveManagerModelConfig(this.agentConfig?.model_config).context_window,
-      // LLM 重试期间配置热切换的通知源（spec 2026-08-30-llm-retry-config-hotreload）
+      // LLM 重试期间配置热切换的通知源与代数探针（spec 2026-08-30-llm-retry-config-hotreload）
       onRuntimeConfigApplied: (listener) => this.addRuntimeConfigAppliedListener(listener),
+      runtimeConfigAppliedGeneration: () => this.getRuntimeConfigAppliedGeneration(),
       // crab-messaging：与 `createMcpConfigs` 同款依赖，但不传 `getTaskContext`——manager 不是
       // task，且 tool-face 已把 `send_message` 的 intent 去掉，ask_human 路径对 manager 不存在。
       messagingDeps: {
@@ -1378,8 +1385,9 @@ export class UnifiedAgent extends ModuleBase {
       ...(this.agentConfig?.tmp_page_base_url ? { tmpPageBaseUrl: this.agentConfig.tmp_page_base_url } : {}),
     }, {
       mcpConfigFactory: createMcpConfigs,
-      // LLM 重试期间配置热切换的通知源（spec 2026-08-30-llm-retry-config-hotreload）
+      // LLM 重试期间配置热切换的通知源与代数探针（spec 2026-08-30-llm-retry-config-hotreload）
       runtimeConfigAppliedSource: (listener) => this.addRuntimeConfigAppliedListener(listener),
+      runtimeConfigAppliedGeneration: () => this.getRuntimeConfigAppliedGeneration(),
       deps: {
         rpcClient: this.rpcClient,
         moduleId: this.config.moduleId,
@@ -1553,7 +1561,12 @@ export class UnifiedAgent extends ModuleBase {
     return () => { this.runtimeConfigAppliedListeners.delete(listener) }
   }
 
+  private getRuntimeConfigAppliedGeneration(): number {
+    return this.runtimeConfigAppliedGeneration
+  }
+
   private notifyRuntimeConfigApplied(): void {
+    this.runtimeConfigAppliedGeneration += 1
     for (const listener of this.runtimeConfigAppliedListeners) {
       try { listener() } catch { /* listener must not break config apply path */ }
     }
@@ -1741,9 +1754,6 @@ export class UnifiedAgent extends ModuleBase {
     this.digestSdkEnv = nextDigestSdk
     this.imageConnInfo = nextImageConn
     this.imageCapability = nextImageCapability
-    // live 字段已原子替换（spec 2026-08-30-llm-retry-config-hotreload）：通知正在
-    // LLM 重试 sleep 中的 manager/worker episode——它们据此提前唤醒并现解析新配置重试。
-    this.notifyRuntimeConfigApplied()
 
     // worker implementation desired config 在 agentConfig 等 live 字段就位后、任何分支
     // return 前应用（R3：early-return 分支曾让这里在热路径上永远走不到）。registry 失败
@@ -1767,6 +1777,10 @@ export class UnifiedAgent extends ModuleBase {
       if (candidate.tmp_page_base_url !== undefined) this.agentHandler.updateTmpPageBaseUrl(candidate.tmp_page_base_url)
       this.agentHandler.updateImageConfig(nextImageConn, nextImageCapability)
       this.scheduledTaskRunner.setWorkerHandler(this.agentHandler)
+      // 配置落地通知必须在 handler 的 sdkEnv 同步完成之后（review 风险 1）：worker 的
+      // onConfigChanged 在 abort() 的同步栈里就读 this.sdkEnv 建新 adapter——通知早于
+      // updateSdkEnv 会让重试换上的仍是旧 provider。
+      this.notifyRuntimeConfigApplied()
       return
     }
 
@@ -1776,6 +1790,8 @@ export class UnifiedAgent extends ModuleBase {
       this.scheduledTaskRunner.setWorkerHandler(coldHandler)
       this.contextAssembler.setLiveSnapshotProvider((taskId) => this.agentHandler?.getLiveSnapshot(taskId))
     }
+    // 冷启动路径同点通知：live 字段 + handler 均已就位。
+    this.notifyRuntimeConfigApplied()
 
   }
 

--- a/crabot-agent/tests/engine/call-non-streaming.test.ts
+++ b/crabot-agent/tests/engine/call-non-streaming.test.ts
@@ -325,20 +325,27 @@ describe('callNonStreaming', () => {
       const configChanged = new AbortController()
       let attempt = 0
       const modelsSeen: string[] = []
+      // adapterA 只会失败；成功路径必须真的经过被换上的 adapterB，
+      // 断言「adapter 被替换」而不只是 model 透传。
       const adapterA: LLMAdapter = {
         async *stream(params: LLMStreamParams): AsyncGenerator<StreamChunk> {
           attempt++
           modelsSeen.push(params.model)
           yield { type: 'message_start', messageId: 'msg' }
-          if (attempt === 1) {
-            throw new HttpResponseError(429, 'rate limited', 'test', 60_000)
-          }
+          throw new HttpResponseError(429, 'rate limited', 'test', 60_000)
+        },
+        updateConfig() {},
+      }
+      const adapterB: LLMAdapter = {
+        async *stream(params: LLMStreamParams): AsyncGenerator<StreamChunk> {
+          attempt++
+          modelsSeen.push(params.model)
+          yield { type: 'message_start', messageId: 'msg' }
           yield { type: 'text_delta', text: 'from-' + params.model }
           yield { type: 'message_end', stopReason: 'end_turn' }
         },
         updateConfig() {},
       }
-      const adapterB: LLMAdapter = adapterA
 
       const resultPromise = callNonStreaming(adapterA, {
         ...defaultParams,
@@ -355,6 +362,92 @@ describe('callNonStreaming', () => {
       expect(attempt).toBe(2)
       expect(modelsSeen).toEqual(['old-model', 'new-model'])
       expect(result.content).toEqual([{ type: 'text', text: 'from-new-model' }])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('consumes a generation change that landed outside the sleep window, then resumes normal backoff (stale-signal regression)', async () => {
+    vi.useFakeTimers()
+    try {
+      // 场景（review 风险 2）：configChangedSignal 在上一轮已被 abort（一次性信号），
+      // 且变更代数在 attempt 之间前进。要求：①立即换新配置且跳过一次 sleep；
+      // ②之后的退避恢复正常——Retry-After 指定的等待不被归零。
+      const configChanged = new AbortController()
+      let generation = 1
+      let attempt = 0
+      const modelsSeen: string[] = []
+      const adapterA: LLMAdapter = {
+        async *stream(params: LLMStreamParams): AsyncGenerator<StreamChunk> {
+          attempt++
+          modelsSeen.push(params.model)
+          yield { type: 'message_start', messageId: 'msg' }
+          throw new HttpResponseError(429, 'rate limited', 'test', 5_000)
+        },
+        updateConfig() {},
+      }
+      const adapterB: LLMAdapter = {
+        async *stream(params: LLMStreamParams): AsyncGenerator<StreamChunk> {
+          attempt++
+          modelsSeen.push(params.model)
+          yield { type: 'message_start', messageId: 'msg' }
+          if (attempt === 2) {
+            // 换到新 provider 后仍被限流（无 Retry-After → 通用 429 路径，1s 退避）
+            throw new HttpResponseError(429, 'slow down', 'test')
+          }
+          yield { type: 'text_delta', text: 'from-' + params.model }
+          yield { type: 'message_end', stopReason: 'end_turn' }
+        },
+        updateConfig() {},
+      }
+
+      const resultPromise = callNonStreaming(adapterA, {
+        ...defaultParams,
+        model: 'old-model',
+        // 模拟同一次 run 中更早的变更已把信号耗掉
+        configChangedSignal: configChanged.signal,
+        configGeneration: () => generation,
+        onConfigChanged: async () => ({ adapter: adapterB, model: 'new-model' }),
+      })
+
+      // attempt 1（adapterA）失败：generation 已前进 → 不 sleep，立即换 adapterB
+      generation = 2
+      await vi.advanceTimersByTimeAsync(0)
+      expect(attempt).toBe(2)
+      expect(modelsSeen).toEqual(['old-model', 'new-model'])
+
+      // attempt 2（adapterB）失败（通用 429，attempt index 1 → 2s 退避）：信号已 aborted、
+      // generation 未变，退避必须照常等待——2s 内不得发起第三次 attempt
+      await vi.advanceTimersByTimeAsync(1_999)
+      expect(attempt).toBe(2)
+      await vi.advanceTimersByTimeAsync(1)
+      const result = await resultPromise
+
+      expect(attempt).toBe(3)
+      expect(modelsSeen).toEqual(['old-model', 'new-model', 'new-model'])
+      expect(result.content).toEqual([{ type: 'text', text: 'from-new-model' }])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('gives up immediately when Retry-After exceeds RETRY_AFTER_MAX_MS', async () => {
+    vi.useFakeTimers()
+    try {
+      let attempt = 0
+      const adapter: LLMAdapter = {
+        async *stream(): AsyncGenerator<StreamChunk> {
+          attempt++
+          yield { type: 'message_start', messageId: 'msg' }
+          throw new HttpResponseError(429, 'come back in an hour', 'test', 3_600_000)
+        },
+        updateConfig() {},
+      }
+
+      const expectation = expect(callNonStreaming(adapter, defaultParams)).rejects.toThrow(/次尝试/)
+      // 不推进任何时间：不得发起第二次 attempt
+      await expectation
+      expect(attempt).toBe(1)
     } finally {
       vi.useRealTimers()
     }

--- a/crabot-agent/tests/engine/call-non-streaming.test.ts
+++ b/crabot-agent/tests/engine/call-non-streaming.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { callNonStreaming, type LLMAdapter, type LLMStreamParams } from '../../src/engine/llm-adapter'
+import { HttpResponseError, OVERLOADED_WITHOUT_RETRY_AFTER_MAX_RETRIES } from '../../src/engine/retry-utils'
 import type { StreamChunk } from '../../src/engine/types'
 
 function makeMockAdapter(chunks: StreamChunk[]): LLMAdapter {
@@ -180,7 +181,8 @@ describe('callNonStreaming', () => {
 
     expect(retries).toHaveLength(1)
     expect(retries[0].attempt).toBe(1)
-    expect(retries[0].source).toBe('mid-stream')
+    // 重试层扁平化后 source 统一为 'stream'（由 callNonStreaming 单层处理）
+    expect(retries[0].source).toBe('stream')
     expect(retries[0].error).toBe('socket dropped')
   }, 30_000)
 
@@ -215,6 +217,144 @@ describe('callNonStreaming', () => {
       expect(attempt).toBe(2)
       expect(result.content).toEqual([{ type: 'text', text: 'partial recovered' }])
       expect(result.diagnostics?.retries).toBe(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('caps total attempts at DEFAULT_MAX_RETRIES + 1 (single retry layer)', async () => {
+    vi.useFakeTimers()
+    try {
+      let attempt = 0
+      const adapter: LLMAdapter = {
+        async *stream(): AsyncGenerator<StreamChunk> {
+          attempt++
+          yield { type: 'message_start', messageId: 'msg' }
+          const e = new Error('socket dropped') as Error & { code?: string }
+          e.code = 'ETIMEDOUT'
+          throw e
+        },
+        updateConfig() {},
+      }
+
+      // 退避 1+2+4+8+8 = 23s 后耗尽 DEFAULT_MAX_RETRIES
+      const expectation = expect(callNonStreaming(adapter, defaultParams)).rejects.toThrow(/次尝试/)
+      await vi.advanceTimersByTimeAsync(24_000)
+      await expectation
+      expect(attempt).toBe(6)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('fails fast on quota-class 429 without any retry', async () => {
+    let attempt = 0
+    const adapter: LLMAdapter = {
+      async *stream(): AsyncGenerator<StreamChunk> {
+        attempt++
+        yield { type: 'message_start', messageId: 'msg' }
+        throw new HttpResponseError(429, JSON.stringify({ error: { code: 'insufficient_quota' } }), 'test')
+      },
+      updateConfig() {},
+    }
+
+    await expect(callNonStreaming(adapter, defaultParams)).rejects.toThrow(/insufficient_quota/)
+    expect(attempt).toBe(1)
+  })
+
+  it('limits generic 429 (no Retry-After) to 3 retries before giving up', async () => {
+    vi.useFakeTimers()
+    try {
+      let attempt = 0
+      const adapter: LLMAdapter = {
+        async *stream(): AsyncGenerator<StreamChunk> {
+          attempt++
+          yield { type: 'message_start', messageId: 'msg' }
+          throw new HttpResponseError(429, 'Too Many Requests', 'test')
+        },
+        updateConfig() {},
+      }
+
+      const expectation = expect(callNonStreaming(adapter, defaultParams)).rejects.toThrow(/次尝试/)
+      await vi.advanceTimersByTimeAsync(10_000)
+      await expectation
+      expect(attempt).toBe(OVERLOADED_WITHOUT_RETRY_AFTER_MAX_RETRIES + 1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('honors Retry-After delay on 429 retries', async () => {
+    vi.useFakeTimers()
+    try {
+      let attempt = 0
+      const delays: number[] = []
+      const adapter: LLMAdapter = {
+        async *stream(): AsyncGenerator<StreamChunk> {
+          attempt++
+          yield { type: 'message_start', messageId: 'msg' }
+          if (attempt === 1) {
+            throw new HttpResponseError(429, 'rate limited', 'test', 7_000)
+          }
+          yield { type: 'text_delta', text: 'ok' }
+          yield { type: 'message_end', stopReason: 'end_turn' }
+        },
+        updateConfig() {},
+      }
+
+      const resultPromise = callNonStreaming(adapter, {
+        ...defaultParams,
+        onRetry: (e) => delays.push(e.delayMs),
+      })
+      // Retry-After=7000ms：7s 内不应发起第二次 attempt
+      await vi.advanceTimersByTimeAsync(6_999)
+      expect(attempt).toBe(1)
+      await vi.advanceTimersByTimeAsync(1)
+      const result = await resultPromise
+      expect(attempt).toBe(2)
+      expect(delays).toEqual([7_000])
+      expect(result.content).toEqual([{ type: 'text', text: 'ok' }])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('wakes retry sleep early on config change and switches adapter/model for the next attempt', async () => {
+    vi.useFakeTimers()
+    try {
+      const configChanged = new AbortController()
+      let attempt = 0
+      const modelsSeen: string[] = []
+      const adapterA: LLMAdapter = {
+        async *stream(params: LLMStreamParams): AsyncGenerator<StreamChunk> {
+          attempt++
+          modelsSeen.push(params.model)
+          yield { type: 'message_start', messageId: 'msg' }
+          if (attempt === 1) {
+            throw new HttpResponseError(429, 'rate limited', 'test', 60_000)
+          }
+          yield { type: 'text_delta', text: 'from-' + params.model }
+          yield { type: 'message_end', stopReason: 'end_turn' }
+        },
+        updateConfig() {},
+      }
+      const adapterB: LLMAdapter = adapterA
+
+      const resultPromise = callNonStreaming(adapterA, {
+        ...defaultParams,
+        model: 'old-model',
+        configChangedSignal: configChanged.signal,
+        onConfigChanged: async () => ({ adapter: adapterB, model: 'new-model' }),
+      })
+
+      // 第一次 attempt 失败后进入 60s Retry-After sleep；1s 时配置落地 → 提前唤醒
+      await vi.advanceTimersByTimeAsync(1_000)
+      configChanged.abort()
+      const result = await resultPromise
+
+      expect(attempt).toBe(2)
+      expect(modelsSeen).toEqual(['old-model', 'new-model'])
+      expect(result.content).toEqual([{ type: 'text', text: 'from-new-model' }])
     } finally {
       vi.useRealTimers()
     }

--- a/crabot-agent/tests/engine/call-non-streaming.test.ts
+++ b/crabot-agent/tests/engine/call-non-streaming.test.ts
@@ -458,4 +458,92 @@ describe('callNonStreaming', () => {
       vi.useRealTimers()
     }
   })
+
+  it('still switches to the new provider when the change lands on the final failed attempt (review 3rd regression)', async () => {
+    vi.useFakeTimers()
+    try {
+      // 场景：旧 provider 连续失败到第 6 次（配额耗尽边缘），配置变更恰好落在
+      // 最后一次失败上 → 必须换新 provider 再试一次，而不是直接放弃。
+      const configChanged = new AbortController()
+      let generation = 1
+      let attempt = 0
+      const adapterA: LLMAdapter = {
+        async *stream(params: LLMStreamParams): AsyncGenerator<StreamChunk> {
+          attempt++
+          yield { type: 'message_start', messageId: 'msg' }
+          // 网络类错误（非 429）才不会被通用 429 的 3 次上限提前掐断，
+          // 能活到 maxRetries 耗尽边界——本用例测的正是这个边界上的变更消费
+          const e = new Error('dead provider A') as Error & { code?: string }
+          e.code = 'ETIMEDOUT'
+          throw e
+        },
+        updateConfig() {},
+      }
+      const adapterB: LLMAdapter = {
+        async *stream(params: LLMStreamParams): AsyncGenerator<StreamChunk> {
+          attempt++
+          yield { type: 'message_start', messageId: 'msg' }
+          yield { type: 'text_delta', text: 'saved-by-' + params.model }
+          yield { type: 'message_end', stopReason: 'end_turn' }
+        },
+        updateConfig() {},
+      }
+
+      const resultPromise = callNonStreaming(adapterA, {
+        ...defaultParams,
+        model: 'old-model',
+        configChangedSignal: configChanged.signal,
+        configGeneration: () => generation,
+        onConfigChanged: async () => ({ adapter: adapterB, model: 'new-model' }),
+      })
+
+      // 退避 1+2+4+8+8 = 23s：变更落在第 6 次失败（idx5，原配额的最后一次）上
+      await vi.advanceTimersByTimeAsync(22_000)
+      expect(attempt).toBe(5)
+      generation = 2
+      await vi.advanceTimersByTimeAsync(1_000)
+      const result = await resultPromise
+
+      // 变更被消费 → 授予 1 次额外预算 → 第 7 次调用（新 provider）成功
+      expect(attempt).toBe(7)
+      expect(result.content).toEqual([{ type: 'text', text: 'saved-by-new-model' }])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('grants one extra attempt per config change, bounded at maxRetries', async () => {
+    vi.useFakeTimers()
+    try {
+      // 配置连续抖动：每次消费 +1 额外预算但封顶 maxRetries(5)，
+      // 总尝试 ≤ maxRetries + budget + 1 = 11（有界，不死循环）。
+      let generation = 1
+      let attempt = 0
+      const adapter: LLMAdapter = {
+        async *stream(): AsyncGenerator<StreamChunk> {
+          attempt++
+          yield { type: 'message_start', messageId: 'msg' }
+          throw new HttpResponseError(429, 'always failing', 'test')
+        },
+        updateConfig() {},
+      }
+
+      const expectation = expect(callNonStreaming(adapter, {
+        ...defaultParams,
+        configGeneration: () => generation,
+        onConfigChanged: async () => { generation += 1 },
+      })).rejects.toThrow(/次尝试/)
+
+      // 每次退避间隙都推进 generation（模拟抖动），推进足够多的假时间让全部 attempt 跑完
+      const churn = setInterval(() => { generation += 1 }, 500)
+      await vi.advanceTimersByTimeAsync(120_000)
+      clearInterval(churn)
+      await expectation
+
+      expect(attempt).toBeLessThanOrEqual(11)
+      expect(attempt).toBeGreaterThanOrEqual(7)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 })

--- a/crabot-agent/tests/engine/call-non-streaming.test.ts
+++ b/crabot-agent/tests/engine/call-non-streaming.test.ts
@@ -390,6 +390,10 @@ describe('callNonStreaming', () => {
         async *stream(params: LLMStreamParams): AsyncGenerator<StreamChunk> {
           attempt++
           modelsSeen.push(params.model)
+          // per-model 参数必须随切换一并替换：旧模型显式带 max_tokens=8192，
+          // 新模型无该配置 → 请求中不得出现 max_tokens
+          expect(params.maxTokens).toBeUndefined()
+          expect(params.thinking).toBeUndefined()
           yield { type: 'message_start', messageId: 'msg' }
           if (attempt === 2) {
             // 换到新 provider 后仍被限流（无 Retry-After → 通用 429 路径，1s 退避）
@@ -404,10 +408,12 @@ describe('callNonStreaming', () => {
       const resultPromise = callNonStreaming(adapterA, {
         ...defaultParams,
         model: 'old-model',
+        maxTokens: 8192,
+        thinking: { level: 'high' },
         // 模拟同一次 run 中更早的变更已把信号耗掉
         configChangedSignal: configChanged.signal,
         configGeneration: () => generation,
-        onConfigChanged: async () => ({ adapter: adapterB, model: 'new-model' }),
+        onConfigChanged: async () => ({ adapter: adapterB, model: 'new-model', maxTokens: undefined, thinking: undefined }),
       })
 
       // attempt 1（adapterA）失败：generation 已前进 → 不 sleep，立即换 adapterB

--- a/crabot-agent/tests/engine/retry-utils.test.ts
+++ b/crabot-agent/tests/engine/retry-utils.test.ts
@@ -2,9 +2,12 @@ import { describe, it, expect } from 'vitest'
 import {
   BACKOFF_MAX_DELAY_MS,
   HttpResponseError,
+  RETRY_AFTER_MAX_MS,
   computeRetryDelayMs,
   isOverloadedError,
+  isOverloadedWithoutRetryAfter,
   isRetryableError,
+  parseRetryAfterMs,
   streamWithRetry,
   withRetry,
 } from '../../src/engine/retry-utils'
@@ -211,10 +214,40 @@ describe('streamWithRetry', () => {
     expect(err.bodyCode).toBe('server_is_overloaded')
   })
 
-  it('treats HTTP 429 as retryable + backoff regardless of body', async () => {
+  it('treats HTTP 429 without Retry-After as retryable but limited to 3 attempts in callNonStreaming', async () => {
     const err = new HttpResponseError(429, 'Too Many Requests', 'test')
     expect(isRetryableError(err)).toBe(true)
     expect(isOverloadedError(err)).toBe(true)
+    expect(isOverloadedWithoutRetryAfter(err)).toBe(true)
+  })
+
+  it('treats HTTP 429 with Retry-After as retryable and preserves retryAfterMs', async () => {
+    const err = new HttpResponseError(429, 'Too Many Requests', 'test', 5_000)
+    expect(isRetryableError(err)).toBe(true)
+    expect(isOverloadedWithoutRetryAfter(err)).toBe(false)
+    expect(err.retryAfterMs).toBe(5_000)
+  })
+
+  it('treats quota/billing body codes as non-retryable even on HTTP 429', async () => {
+    for (const code of ['insufficient_quota', 'quota_exceeded', 'balance_exhausted', 'credit_exhausted', 'billing_not_active']) {
+      const err = new HttpResponseError(429, JSON.stringify({ code }), 'test')
+      expect(isRetryableError(err)).toBe(false)
+    }
+  })
+
+  it('parseRetryAfterMs: parses seconds and HTTP-date', () => {
+    expect(parseRetryAfterMs('5')).toBe(5_000)
+    expect(parseRetryAfterMs('120')).toBe(120_000)
+    expect(parseRetryAfterMs('0')).toBe(0)
+    expect(parseRetryAfterMs('not-a-number')).toBeUndefined()
+    const future = new Date(Date.now() + 7_000).toUTCString()
+    expect(parseRetryAfterMs(future)).toBeGreaterThanOrEqual(6_000)
+    expect(parseRetryAfterMs(future)).toBeLessThanOrEqual(8_000)
+  })
+
+  it('computeRetryDelayMs: uses Retry-When present and caps it', () => {
+    expect(computeRetryDelayMs(0, 1_000, true, 5_000)).toBe(5_000)
+    expect(computeRetryDelayMs(0, 1_000, true, 120_000)).toBe(RETRY_AFTER_MAX_MS)
   })
 
   it('computeRetryDelayMs: fixed delay when useBackoff=false', () => {


### PR DESCRIPTION
## 背景

事故（2026-08-29）：z-ai/glm-5.3-flash 返回额度类 429 后，adapter 层 `streamWithRetry`（10 次）× `callNonStreaming` 层（10 次）嵌套双重重试 ≈121 次尝试、13+ 分钟 sleep；期间 Admin 已切换默认模型，但 episode 级 adapter 快照 + 重试循环锁死旧配置，agent 始终打旧 provider 直至耗尽。

spec：`crabot-docs/superpowers/specs/2026-08-30-llm-retry-config-hotreload-design.md`（已与用户确认方向：额度类 429 不重试；重试期间配置变更应换新配置重试）。

## 改动

### 1. 429 分类（spec §5.1）
- 额度/计费类 body code（`insufficient_quota` / `quota_exceeded` / `balance_exhausted` / `credit_exhausted` / `billing_not_active`）→ `NON_RETRYABLE_BODY_CODES`，一次都不重试。
- 带 `Retry-After` 的 429：按 header 延迟重试（秒数或 HTTP-date），上限 `RETRY_AFTER_MAX_MS=60s`；openai/responses adapter 读响应头，anthropic adapter 捕获 SDK 429 包装为 `HttpResponseError`（读 `err.headers`）。
- 无 `Retry-After` 的通用 429：最多 3 次短退避（`OVERLOADED_WITHOUT_RETRY_AFTER_MAX_RETRIES=3`）。

### 2. 重试层扁平化（spec §5.2）
- adapter `stream()` 只保留 `withStreamTimeout`（TTFB/空闲超时），删除 `streamWithTimeoutAndRetry` 封装；重试唯一发生在 `withStreamConsumptionRetry`。
- 单条 LLM 调用最大尝试 = `DEFAULT_MAX_RETRIES`(10→**5**)+1 = **6**（原 121）。

### 3. 重试期间配置热切换（spec §5.3）
- `LLMStreamParams`/`EngineOptions` 新增 `configChangedSignal` + `onConfigChanged`；`interruptibleSleep` 在 sleep 期间被信号唤醒 → 调用回调换新 adapter/model 继续下一 attempt（**不消耗 attempt 配额**；已开始交付 chunk 的调用不中断）。
- 触发时机：`applyRuntimeConfigCandidate` **原子替换 live 字段之后** `notifyRuntimeConfigApplied()`（在 `ConfigLoader.acceptRevision` 时触发会抢在 `agentConfig` 替换前，重试仍拿旧配置——故不采用）。
- 注入路径：`BootstrapDeps`/`ManagerRegistryDeps.onRuntimeConfigApplied`（manager `runAttempt` try/finally 订阅退订）；`AgentHandlerOptions.runtimeConfigAppliedSource`（worker loop outer finally 退订）。
- 语义边界：episode/loop 级快照默认语义不变（协议 §11 热更表），本例外仅覆盖同一次 LLM 调用的重试等待阶段。

### 4. 附带收敛
- `LLMRetryEvent.source` 收敛为 `'stream'`；移除随之失去调用方的 `wrapOnRetry`、`ConfigLoader.onRevisionAccepted`（首版设计，被 emitter 方案取代）。

## spec 偏离（需 review 关注）

**§5.4 Admin invalidation 兜底：不改代码。** 复核 `drainOutbox` + 启动序列后确认：gate 关闭窗口（启动 seeding / cutover）静默跳过是既有设计——该窗口 web server 未启动、无运行中 Agent 消费者（authenticated 启动 pull / 激活后 `drainPendingInvalidation()` 兜底）；正常服务期 gate 恒为 true，publish 失败已有 outbox 保留 + `scheduleConfigDrainRetry` 退避。spec 描述的"运行期事件被静默丢弃"不可达；改为 throw 会破坏"启动 seeding 不被网络发布阻塞"的既有设计。spec 文本将同步修订。

## 新引入的失败路径与收口

| 路径 | 收口 |
|---|---|
| `onConfigChanged` 回调抛错 | reject 终止该次调用走既有失败路径；回调为纯内存解析（manager=`deps.adapter()`，worker=`adapterFromSdkEnv(this.sdkEnv)`），无 IO |
| 配置抖动反复唤醒 | 不消耗 attempt 配额，但总量受 `maxRetries` + generic-429 上限约束，不会无限循环 |
| 监听器泄漏 | manager per-attempt try/finally；worker outer finally；退订句柄均确定性执行 |
| 未注入 signal（测试/降级） | 行为与现状逐字相同 |

## 验证

- `tsc --noEmit` 干净。
- engine 628/628 全绿；新增 10 例：429 额度类 fail-fast、Retry-After 解析/延迟/cap、通用 429 上限、单层重试总数、配置唤醒换 adapter/model。
- 全量 15 失败与 HEAD 基线（throwaway worktree 对照）逐一一致，均为存量环境/flaky（`/private/var` symlink、prompt fixture、capability fixture、负载 flaky），无新增失败。