### PR TITLE
feat(admin-chat): 删「思考中」占位气泡，新增已接收标记（UX 对齐 channel）

### DIFF
--- a/crabot-admin/src/chat-manager.test.ts
+++ b/crabot-admin/src/chat-manager.test.ts
@@ -196,7 +196,8 @@ describe('入站带附件消息（handleInboundMessage）', () => {
     expect(mgr.getMessages(10)).toHaveLength(1)
     // P6-A §11.4：失败不再立即 chat_error——dispatch loop 退避重试（上限后报错），
     // journal 保持 pending_dispatch；重启由 reconcileInboundDispatches 恢复。
-    expect(pushed.map((p) => p.type)).toEqual(['chat_status'])
+    // 2026-08-30：chat_status 占位推送退役（protocol-admin §3.20.2）——无推送。
+    expect(pushed).toEqual([])
     const journalPath = `${TEST_DATA_DIR}/chat-inbound-dispatch-journal/req-err.json`
     const journal = JSON.parse(await fs.readFile(journalPath, 'utf-8'))
     expect(journal.status).toBe('pending_dispatch')
@@ -596,5 +597,59 @@ describe('buildChatTaskSnapshot', () => {
     } as unknown as Task
     const snap = buildChatTaskSnapshot(task)
     expect(snap.step).toEqual({ index: 1, total: 2, description: '第二步' })
+  })
+})
+
+describe('ChatManager.chat_acknowledge（protocol-admin §3.20.2）', () => {
+  beforeEach(async () => {
+    await fs.rm(TEST_DATA_DIR, { recursive: true, force: true }).catch(() => {})
+    await fs.mkdir(TEST_DATA_DIR, { recursive: true })
+  })
+
+  afterEach(async () => {
+    await fs.rm(TEST_DATA_DIR, { recursive: true, force: true }).catch(() => {})
+  })
+
+  /** 落一条 user 消息并挂上可观察的 ws 客户端 */
+  async function makeManagerWithUserMessage(requestId: string): Promise<ChatManager> {
+    const mgr = await makeManager()
+    await mgr.handleInboundMessage({ request_id: requestId, text: '在吗', files: [] }, 'test-token')
+    const pushed: Array<Record<string, unknown>> = []
+    ;(mgr as unknown as { activeClient: unknown }).activeClient = {
+      readyState: 1, // WebSocket.OPEN
+      send: (data: string) => { pushed.push(JSON.parse(data)) },
+    }
+    ;(mgr as unknown as { testPushed?: Array<Record<string, unknown>> }).testPushed = pushed
+    return mgr
+  }
+
+  function pushedOf(mgr: ChatManager): Array<Record<string, unknown>> {
+    return (mgr as unknown as { testPushed?: Array<Record<string, unknown>> }).testPushed ?? []
+  }
+
+  it('打标：写 acknowledged_at、推 chat_message_acked、返回 1；重载后标记仍在（持久化）', async () => {
+    const mgr = await makeManagerWithUserMessage('req-ack-1')
+    expect(await mgr.acknowledgeRequests(['req-ack-1'])).toBe(1)
+
+    const user = mgr.getMessages(10).find((m) => m.role === 'user')
+    expect(user?.acknowledged_at).toBeTruthy()
+    expect(pushedOf(mgr).map((p) => p.type)).toEqual(['chat_message_acked'])
+    expect(pushedOf(mgr)[0].request_ids).toEqual(['req-ack-1'])
+
+    const mgr2 = await makeManager()
+    await mgr2.loadData()
+    expect(mgr2.getMessages(10).find((m) => m.role === 'user')?.acknowledged_at).toBeTruthy()
+  })
+
+  it('幂等：重复调用返回 0，不重复推送', async () => {
+    const mgr = await makeManagerWithUserMessage('req-ack-2')
+    expect(await mgr.acknowledgeRequests(['req-ack-2'])).toBe(1)
+    expect(await mgr.acknowledgeRequests(['req-ack-2'])).toBe(0)
+    expect(pushedOf(mgr)).toHaveLength(1)
+  })
+
+  it('未知 request_id 静默忽略，返回 0', async () => {
+    const mgr = await makeManager()
+    expect(await mgr.acknowledgeRequests(['nope'])).toBe(0)
   })
 })

--- a/crabot-admin/src/chat-manager.ts
+++ b/crabot-admin/src/chat-manager.ts
@@ -347,8 +347,9 @@ export class ChatManager {
         user_message_id: userMessage.message_id,
       })
 
-      this.pushToClient({ type: 'chat_status', request_id: params.request_id, status: 'processing' })
       // dispatch loop 后台跑；重启由 reconcileInboundDispatches 兜底。
+      // 「已接收」反馈由 Agent commit 后经 chat_acknowledge 打标（protocol-admin §3.20.2），
+      // 入站不再推 chat_status 占位状态。
       void this.runInboundDispatch(journal).catch((error) => {
         console.error(`[ChatManager] inbound dispatch loop failed for ${params.request_id}:`,
           error instanceof Error ? error.message : String(error))
@@ -524,7 +525,6 @@ export class ChatManager {
         fingerprint,
         user_message_id: userMessage.message_id,
       })
-      this.pushToClient({ type: 'chat_status', request_id: params.request_id, status: 'processing' })
       void this.runInboundDispatch(journal).catch((error) => {
         console.error(`[ChatManager] inbound dispatch loop failed for ${params.request_id}:`,
           error instanceof Error ? error.message : String(error))
@@ -550,6 +550,27 @@ export class ChatManager {
     expected: { manager_key: 'admin-web::admin-chat'; request_id: string; payload_sha256: string }
   }): Promise<{ consumed: true; expires_at: string }> {
     return this.assertions.consume(params.assertion, params.expected)
+  }
+
+  /**
+   * chat_acknowledge（protocol-admin §3.20.2）：为入站 request IDs 打「已接收」标记。
+   * 幂等（已打标跳过），未知 request_id 静默忽略；标记随聊天记录持久化，并推一条
+   * `chat_message_acked` 给 ws 客户端（前端据此渲染标记，刷新经聊天历史恢复显示）。
+   */
+  async acknowledgeRequests(requestIds: string[]): Promise<number> {
+    const acknowledgedAt = new Date().toISOString()
+    const marked: string[] = []
+    for (const requestId of requestIds) {
+      const userMessageId = this.requestIndex.get(requestId)?.user_message_id
+      const message = userMessageId ? this.messages.get(userMessageId) : undefined
+      if (!message || message.role !== 'user' || message.acknowledged_at) continue
+      message.acknowledged_at = acknowledgedAt
+      marked.push(requestId)
+    }
+    if (marked.length === 0) return 0
+    await this.saveData()
+    this.pushToClient({ type: 'chat_message_acked', request_ids: marked })
+    return marked.length
   }
 
   private pushToClient(message: ChatServerMessage): void {

--- a/crabot-admin/src/index.ts
+++ b/crabot-admin/src/index.ts
@@ -141,6 +141,7 @@ import {
   type GetChatHistoryResult,
   type UpsertPendingMessageParams,
   type UpsertPendingMessageResult,
+  type ChatAcknowledgeParams,
   type ChatSendMessageParams,
   type ChatSendMessageResult,
   type ChatTaskSnapshot,
@@ -801,6 +802,8 @@ export class AdminModule extends ModuleBase {
     this.registerMethod('get_chat_history', this.handleGetChatHistory.bind(this))
     // admin-web 伪 channel：worker send_message 出站收口（spec 2026-06-10-master-chat-redesign §4）
     this.registerMethod('send_message', this.handleChatSendMessage.bind(this))
+    // chat_acknowledge（protocol-admin §3.20.2）：Agent 人类输入 commit 后打「已接收」标记
+    this.registerMethod('chat_acknowledge', this.handleChatAcknowledge.bind(this))
 
     // TaskGoal 管理（spec: 2026-05-23-goal-mode-design.md §3）
     this.registerMethod('set_task_goal', this.handleSetTaskGoal.bind(this))
@@ -9367,6 +9370,13 @@ export class AdminModule extends ModuleBase {
       throw new Error('Chat manager not initialized')
     }
     return this.chatManager.handleSendMessage(params)
+  }
+
+  private async handleChatAcknowledge(params: ChatAcknowledgeParams): Promise<{ acknowledged: number }> {
+    if (!this.chatManager) {
+      throw new Error('Chat manager not initialized')
+    }
+    return { acknowledged: await this.chatManager.acknowledgeRequests(params.request_ids) }
   }
 
   /** admin-web 来源的非终态任务快照（进行中任务条数据源） */

--- a/crabot-admin/src/types.ts
+++ b/crabot-admin/src/types.ts
@@ -1856,6 +1856,8 @@ export interface ChatMessage {
   /** P6-A §11：本条 assistant 消息的 delivery 事务 ID。 */
   delivery_id?: string
   task_id?: TaskId
+  /** 人类输入已被 Agent 写入 Manager 会话历史的时间（chat_acknowledge 落盘，ISO 8601）；未打标省略。 */
+  acknowledged_at?: string
   timestamp: string
 }
 
@@ -1875,6 +1877,12 @@ export interface ChatSendMessageParams {
   delivery_id?: string
   /** P6-A §11.6：本 delivery 结算的入站 request IDs；空/缺席 = proactive 追加。 */
   request_ids?: string[]
+}
+
+/** chat_acknowledge RPC（protocol-admin §3.20.2）入参：Agent 在人类输入 commit 后打「已接收」标记。 */
+export interface ChatAcknowledgeParams {
+  /** 本次 commit 结算的入站请求集合（与 ChatMessage.request_ids 同源）。 */
+  request_ids: string[]
 }
 
 /** send_message RPC 返回 */
@@ -1914,10 +1922,14 @@ export interface ChatTaskSnapshot {
 
 /** 服务端发送的聊天消息 */
 export interface ChatServerMessage {
-  type: 'chat_reply' | 'chat_status' | 'chat_error' | 'chat_push' | 'chat_task_update' | 'chat_message_tagged' | 'chat_message_deleted'
+  type: 'chat_reply' | 'chat_error' | 'chat_push' | 'chat_task_update' | 'chat_message_tagged' | 'chat_message_deleted' | 'chat_message_acked'
+  /** 单 ID 兼容；新写可为一个 request_ids 成员。 */
   request_id?: string
+  /** 同一 assistant response 显式结算的请求集合；chat_message_acked 携带已接收标记的请求集合；主动 push 省略。 */
+  request_ids?: string[]
   content?: string
-  status?: 'processing' | 'completed' | 'failed'
+  /** 仅 chat_reply 携带（历史兼容）；processing 占位语义随 chat_status 退役（2026-08-30）。 */
+  status?: 'completed' | 'failed'
   /**
    * chat_reply 携带任务关联时填写；chat_message_tagged 必填。
    * 对应 protocol-admin §3.20 ChatServerMessage.task_id 字段。

--- a/crabot-admin/tests/chat-integration.test.ts
+++ b/crabot-admin/tests/chat-integration.test.ts
@@ -104,35 +104,41 @@ describe('Admin Master Chat 集成测试', () => {
     })
   })
 
-  it('应该能够发送消息并接收 processing 状态', async () => {
-    return new Promise<void>((resolve, reject) => {
+  it('应该能够发送消息并写入聊天记录（chat_status processing 占位推送已退役，以落库为准）', async () => {
+    const requestId = 'test-' + Date.now()
+    await new Promise<void>((resolve, reject) => {
       const ws = new WebSocket(`ws://localhost:${webPort}/ws/chat?token=${jwtToken}`)
 
       ws.on('open', () => {
-        const testMessage = {
+        ws.send(JSON.stringify({
           type: 'chat_message',
-          request_id: 'test-' + Date.now(),
+          request_id: requestId,
           content: '测试消息',
-        }
-
-        ws.send(JSON.stringify(testMessage))
-      })
-
-      ws.on('message', (data) => {
-        const message = JSON.parse(data.toString())
-
-        if (message.type === 'chat_status' && message.status === 'processing') {
-          ws.close()
-          resolve()
-        }
+        }))
+        resolve()
       })
 
       ws.on('error', (error) => {
         reject(error)
       })
 
-      setTimeout(() => reject(new Error('未收到响应')), 5000)
+      setTimeout(() => reject(new Error('发送超时')), 5000)
     })
+
+    // 轮询等待受理落库
+    const deadline = Date.now() + 5000
+    while (Date.now() < deadline) {
+      const response = await fetch(`http://localhost:${webPort}/api/chat/messages?limit=10`, {
+        headers: {
+          'Authorization': `Bearer ${jwtToken}`,
+        },
+      })
+      expect(response.status).toBe(200)
+      const data = await response.json() as { messages: Array<{ request_id?: string }> }
+      if (data.messages.some((m) => m.request_id === requestId)) return
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    }
+    throw new Error('消息未写入聊天记录')
   })
 
   it('应该能够通过 REST API 查询聊天记录', async () => {

--- a/crabot-admin/tests/chat-integration.test.ts
+++ b/crabot-admin/tests/chat-integration.test.ts
@@ -115,6 +115,7 @@ describe('Admin Master Chat 集成测试', () => {
           request_id: requestId,
           content: '测试消息',
         }))
+        ws.close()
         resolve()
       })
 

--- a/crabot-admin/web/src/pages/Chat/ChatMessageItem.tsx
+++ b/crabot-admin/web/src/pages/Chat/ChatMessageItem.tsx
@@ -18,7 +18,7 @@ import type { ChatMessage, ChatTaskSnapshot } from '../../types/chat'
 
 /** 消息状态（从 index.tsx 迁入，UI 层扩展字段） */
 export interface MessageState extends ChatMessage {
-  status?: 'sending' | 'sent' | 'processing' | 'completed' | 'failed'
+  status?: 'sending' | 'sent' | 'completed' | 'failed'
   reply_type?: 'direct_reply' | 'task_created' | 'task_completed' | 'task_failed'
   error?: string
 }
@@ -39,7 +39,6 @@ interface ChatMessageItemProps {
 export const ChatMessageItem = React.memo(function ChatMessageItem({ message, onContextMenu, taskSnapshot, highlighted }: ChatMessageItemProps) {
   const navigate = useNavigate()
   const isUser = message.role === 'user'
-  const isProcessing = message.status === 'processing'
 
   // task_created 消息（含历史存量）渲染为居中单行系统提示样式，不挂右键引用、不挂任务图标
   if (message.task_id && message.content.text?.startsWith('已创建任务')) {
@@ -118,88 +117,88 @@ export const ChatMessageItem = React.memo(function ChatMessageItem({ message, on
           border: isUser ? 'none' : '1px solid var(--border)',
         }}
       >
-        {isProcessing ? (
-          <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-            <div className="spinner" style={{ width: '16px', height: '16px', borderWidth: '2px' }} />
-            <span style={{ color: 'var(--text-secondary)' }}>思考中...</span>
-          </div>
-        ) : (
-          <>
-            {getReplyTypeHint()}
-            <div
-              className="markdown-content"
-              style={{
-                wordBreak: 'break-word',
-                lineHeight: '1.6',
+        {getReplyTypeHint()}
+        <div
+          className="markdown-content"
+          style={{
+            wordBreak: 'break-word',
+            lineHeight: '1.6',
+          }}
+        >
+          {isUser ? (
+            // user 消息：前导 "> " 行（与 composeWithQuote 格式对应）渲染为引用块
+            (() => {
+              const lines = (message.content.text ?? '').split('\n')
+              let quoteEnd = 0
+              while (quoteEnd < lines.length && lines[quoteEnd].startsWith('> ')) quoteEnd++
+              // 引用块后紧跟的空行也跳过（composeWithQuote 会在引用块后加一行）
+              if (quoteEnd > 0 && quoteEnd < lines.length && lines[quoteEnd] === '') quoteEnd++
+              const quoteBlock = quoteEnd > 0
+                ? lines.slice(0, quoteEnd).join('\n').replace(/^> /gm, '').trimEnd()
+                : null
+              const bodyText = lines.slice(quoteEnd).join('\n')
+              return (
+                <>
+                  {quoteBlock && (
+                    <div
+                      style={{
+                        borderLeft: '3px solid rgba(255,255,255,0.5)',
+                        paddingLeft: '0.6rem',
+                        marginBottom: '0.4rem',
+                        fontSize: '0.82rem',
+                        color: 'rgba(255,255,255,0.75)',
+                        whiteSpace: 'pre-wrap',
+                      }}
+                    >
+                      {quoteBlock}
+                    </div>
+                  )}
+                  <div style={{ whiteSpace: 'pre-wrap' }}>{bodyText}</div>
+                </>
+              )
+            })()
+          ) : (
+            <ReactMarkdown
+              remarkPlugins={[remarkGfm]}
+              components={{
+                // worker 在正文 markdown 嵌 store 图时统一补 token
+                img: ({ src, alt }) => (
+                  <img
+                    src={typeof src === 'string' ? chatService.mediaSrc(src) : undefined}
+                    alt={alt ?? ''}
+                    style={{ maxWidth: '100%', borderRadius: '8px' }}
+                  />
+                ),
+                // 链接（含临时页面 URL）在新标签打开，不顶掉当前 Admin 页面
+                a: ({ href, children }) => (
+                  <a href={href} target="_blank" rel="noopener noreferrer">
+                    {children}
+                  </a>
+                ),
               }}
             >
-              {isUser ? (
-                // user 消息：前导 "> " 行（与 composeWithQuote 格式对应）渲染为引用块
-                (() => {
-                  const lines = (message.content.text ?? '').split('\n')
-                  let quoteEnd = 0
-                  while (quoteEnd < lines.length && lines[quoteEnd].startsWith('> ')) quoteEnd++
-                  // 引用块后紧跟的空行也跳过（composeWithQuote 会在引用块后加一行）
-                  if (quoteEnd > 0 && quoteEnd < lines.length && lines[quoteEnd] === '') quoteEnd++
-                  const quoteBlock = quoteEnd > 0
-                    ? lines.slice(0, quoteEnd).join('\n').replace(/^> /gm, '').trimEnd()
-                    : null
-                  const bodyText = lines.slice(quoteEnd).join('\n')
-                  return (
-                    <>
-                      {quoteBlock && (
-                        <div
-                          style={{
-                            borderLeft: '3px solid rgba(255,255,255,0.5)',
-                            paddingLeft: '0.6rem',
-                            marginBottom: '0.4rem',
-                            fontSize: '0.82rem',
-                            color: 'rgba(255,255,255,0.75)',
-                            whiteSpace: 'pre-wrap',
-                          }}
-                        >
-                          {quoteBlock}
-                        </div>
-                      )}
-                      <div style={{ whiteSpace: 'pre-wrap' }}>{bodyText}</div>
-                    </>
-                  )
-                })()
-              ) : (
-                <ReactMarkdown
-                  remarkPlugins={[remarkGfm]}
-                  components={{
-                    // worker 在正文 markdown 嵌 store 图时统一补 token
-                    img: ({ src, alt }) => (
-                      <img
-                        src={typeof src === 'string' ? chatService.mediaSrc(src) : undefined}
-                        alt={alt ?? ''}
-                        style={{ maxWidth: '100%', borderRadius: '8px' }}
-                      />
-                    ),
-                    // 链接（含临时页面 URL）在新标签打开，不顶掉当前 Admin 页面
-                    a: ({ href, children }) => (
-                      <a href={href} target="_blank" rel="noopener noreferrer">
-                        {children}
-                      </a>
-                    ),
-                  }}
-                >
-                  {message.content.text ?? ''}
-                </ReactMarkdown>
-              )}
-            </div>
-            {message.content.media && message.content.media.length > 0 && (
-              <MessageMedia media={message.content.media} />
-            )}
-            {message.error && (
-              <div style={{ marginTop: '0.5rem', fontSize: '0.85rem', color: 'var(--error)' }}>
-                {message.error}
-              </div>
-            )}
-          </>
+              {message.content.text ?? ''}
+            </ReactMarkdown>
+          )}
+        </div>
+        {message.content.media && message.content.media.length > 0 && (
+          <MessageMedia media={message.content.media} />
+        )}
+        {message.error && (
+          <div style={{ marginTop: '0.5rem', fontSize: '0.85rem', color: 'var(--error)' }}>
+            {message.error}
+          </div>
         )}
       </div>
+      {/* 「已接收」标记（user 消息；agent commit 后经 chat_acknowledge 打标，对齐 channel acknowledged reaction） */}
+      {isUser && message.acknowledged_at && (
+        <span
+          title={`已接收 ${new Date(message.acknowledged_at).toLocaleString()}`}
+          style={{ fontSize: '0.78rem', color: 'var(--text-secondary)', flexShrink: 0 }}
+        >
+          ✓
+        </span>
+      )}
       {/* assistant 消息：任务图标在气泡右侧（后渲染图标） */}
       {message.task_id && !isUser && (
         <TaskStatusIcon taskId={message.task_id} snapshot={taskSnapshot} />

--- a/crabot-admin/web/src/pages/Chat/index.test.tsx
+++ b/crabot-admin/web/src/pages/Chat/index.test.tsx
@@ -16,6 +16,7 @@ const sendMessage = vi.fn()
 const getTaskSnapshot = vi.fn()
 const toastMocks = vi.hoisted(() => ({ success: vi.fn(), error: vi.fn(), info: vi.fn() }))
 let messageHandler: ((m: ChatServerMessage) => void) | null = null
+let statusHandler: ((s: 'connected') => void) | null = null
 
 vi.mock('../../components/Layout/MainLayout', () => ({
   MainLayout: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
@@ -29,7 +30,10 @@ vi.mock('../../services/chat', () => ({
   chatService: {
     get status() { return 'connected' },
     connect: vi.fn(),
-    onStatusChange: () => () => {},
+    onStatusChange: (handler: (s: 'connected') => void) => {
+      statusHandler = handler
+      return () => { statusHandler = null }
+    },
     onMessage: (handler: (m: ChatServerMessage) => void) => {
       messageHandler = handler
       return () => { messageHandler = null }
@@ -93,6 +97,7 @@ describe('Master Chat 无占位追加流与已接收标记', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     messageHandler = null
+    statusHandler = null
     loadHistory.mockResolvedValue([])
     getTaskSnapshot.mockResolvedValue(null)
   })
@@ -158,5 +163,31 @@ describe('Master Chat 无占位追加流与已接收标记', () => {
     await push({ type: 'chat_message_acked', request_ids: ['req-other'] })
 
     expect(screen.queryByTitle(/已接收/)).not.toBeInTheDocument()
+  })
+
+  it('重连后补齐断连期间的服务端消息：回复追加、✓ 标记经 acknowledged_at 恢复', async () => {
+    await renderAndSend('req-8')
+    // 断连期间服务端落库（loadHistory 倒序：最新在前）
+    loadHistory.mockResolvedValue([
+      { message_id: 'srv_reply', role: 'assistant', content: { type: 'text', text: '断连前的回复' }, request_id: 'req-8', timestamp: new Date().toISOString() },
+      { message_id: 'srv_user', role: 'user', content: { type: 'text', text: '帮我看下这个' }, request_id: 'req-8', acknowledged_at: new Date().toISOString(), timestamp: new Date().toISOString() },
+    ])
+    await act(async () => { statusHandler!('connected') })
+
+    expect(screen.getByText('断连前的回复')).toBeInTheDocument()
+    expect(screen.getByTitle(/已接收/)).toBeInTheDocument()
+    // 本地乐观 user 消息被落库版本取代（同 request_id），不重复显示
+    expect(screen.getAllByText('帮我看下这个')).toHaveLength(1)
+  })
+
+  it('重连补齐幂等：重复合并已知的消息不重复追加', async () => {
+    await renderAndSend('req-9')
+    loadHistory.mockResolvedValue([
+      { message_id: 'srv_reply9', role: 'assistant', content: { type: 'text', text: '只此一条' }, request_id: 'req-9', timestamp: new Date().toISOString() },
+    ])
+    await act(async () => { statusHandler!('connected') })
+    await act(async () => { statusHandler!('connected') })
+
+    expect(screen.getAllByText('只此一条')).toHaveLength(1)
   })
 })

--- a/crabot-admin/web/src/pages/Chat/index.test.tsx
+++ b/crabot-admin/web/src/pages/Chat/index.test.tsx
@@ -170,7 +170,7 @@ describe('Master Chat 无占位追加流与已接收标记', () => {
     // 断连期间服务端落库（loadHistory 倒序：最新在前）
     loadHistory.mockResolvedValue([
       { message_id: 'srv_reply', role: 'assistant', content: { type: 'text', text: '断连前的回复' }, request_id: 'req-8', timestamp: new Date().toISOString() },
-      { message_id: 'srv_user', role: 'user', content: { type: 'text', text: '帮我看下这个' }, request_id: 'req-8', acknowledged_at: new Date().toISOString(), timestamp: new Date().toISOString() },
+      { message_id: 'srv_user', role: 'user', content: { type: 'text', text: '帮我看下这个' }, request_id: 'req-8', acknowledged_at: new Date().toISOString(), timestamp: new Date(Date.now() - 1000).toISOString() },
     ])
     await act(async () => { statusHandler!('connected') })
 
@@ -189,5 +189,25 @@ describe('Master Chat 无占位追加流与已接收标记', () => {
     await act(async () => { statusHandler!('connected') })
 
     expect(screen.getAllByText('只此一条')).toHaveLength(1)
+  })
+
+  it('回复先到、重连补 user 消息：按时间戳归位，提问不沉到回复后面', async () => {
+    await renderAndSend('req-10')
+    // 回复经 chat_push 先到（服务端 UUID 进入已知集合）
+    await push(assistantPush('回复先到了', 'req-10'))
+    // 重连拉历史：回复已 known 被去重跳过，只剩 user 消息进 fresh——
+    // 若 concat 队尾，提问会渲染到回复后面（review 指出的必现顺序错乱）
+    loadHistory.mockResolvedValue([
+      { message_id: 'srv_回复先到了', role: 'assistant', content: { type: 'text', text: '回复先到了' }, request_id: 'req-10', timestamp: new Date().toISOString() },
+      { message_id: 'srv_user', role: 'user', content: { type: 'text', text: '帮我看下这个' }, request_id: 'req-10', acknowledged_at: new Date().toISOString(), timestamp: new Date(Date.now() - 1000).toISOString() },
+    ])
+    await act(async () => { statusHandler!('connected') })
+
+    expect(screen.getAllByText('帮我看下这个')).toHaveLength(1)
+    expect(screen.getAllByText('回复先到了')).toHaveLength(1)
+    // user 消息必须出现在回复之前（DOM 顺序）
+    const user = screen.getByText('帮我看下这个')
+    const reply = screen.getByText('回复先到了')
+    expect(user.compareDocumentPosition(reply) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
   })
 })

--- a/crabot-admin/web/src/pages/Chat/index.test.tsx
+++ b/crabot-admin/web/src/pages/Chat/index.test.tsx
@@ -1,9 +1,8 @@
 /**
- * Master Chat 「处理中」占位气泡的收口路径。
+ * Master Chat 无占位气泡的追加流 + 「已接收」标记（protocol-admin §3.20.2）。
  *
- * cutover 后 manager 正常回复走 send_message → chat_push（完整 ChatMessage，含 media），
- * 前端必须按 request_id 把占位原地替换掉，否则每条回复后都会留一个永远转圈的气泡。
- * 失败兜底（chat_reply）/ chat_error 两条老路径必须照旧。
+ * 占位退役后：发送只本地追加用户消息；回复（chat_push / chat_reply 历史兼容）一律作为
+ * 独立消息追加；chat_error 走 toast 提示；chat_message_acked 在用户消息上渲染 ✓ 标记。
  */
 import React from 'react'
 import { MemoryRouter } from 'react-router-dom'
@@ -15,6 +14,7 @@ import type { ChatMessage, ChatServerMessage } from '../../types/chat'
 const loadHistory = vi.fn()
 const sendMessage = vi.fn()
 const getTaskSnapshot = vi.fn()
+const toastMocks = vi.hoisted(() => ({ success: vi.fn(), error: vi.fn(), info: vi.fn() }))
 let messageHandler: ((m: ChatServerMessage) => void) | null = null
 
 vi.mock('../../components/Layout/MainLayout', () => ({
@@ -22,7 +22,7 @@ vi.mock('../../components/Layout/MainLayout', () => ({
 }))
 
 vi.mock('../../contexts/ToastContext', () => ({
-  useToast: () => ({ success: vi.fn(), error: vi.fn(), info: vi.fn() }),
+  useToast: () => toastMocks,
 }))
 
 vi.mock('../../services/chat', () => ({
@@ -54,7 +54,7 @@ beforeAll(() => {
   Element.prototype.scrollIntoView = vi.fn()
 })
 
-/** 渲染并发出一条消息，返回它的 request_id（占位气泡此时已生出） */
+/** 渲染并发送一条消息，返回它的 request_id */
 async function renderAndSend(requestId: string): Promise<void> {
   sendMessage.mockReturnValue(requestId)
   render(
@@ -69,8 +69,6 @@ async function renderAndSend(requestId: string): Promise<void> {
   await act(async () => {
     fireEvent.click(screen.getByText('发送'))
   })
-  // 占位气泡在位
-  expect(screen.getByText('思考中...')).toBeInTheDocument()
 }
 
 /** 把一条服务端推送喂给组件已注册的 handler */
@@ -91,7 +89,7 @@ function assistantPush(text: string, requestId?: string): ChatServerMessage {
   return { type: 'chat_push', message }
 }
 
-describe('Master Chat 占位气泡收口', () => {
+describe('Master Chat 无占位追加流与已接收标记', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     messageHandler = null
@@ -99,71 +97,66 @@ describe('Master Chat 占位气泡收口', () => {
     getTaskSnapshot.mockResolvedValue(null)
   })
 
-  it('正常回复：chat_push 按 request_id 原地替换占位，不残留转圈', async () => {
+  it('发送后只显示用户消息，无「思考中」占位', async () => {
     await renderAndSend('req-1')
-    await push(assistantPush('看完了，结论是这样', 'req-1'))
 
+    expect(screen.getByText('帮我看下这个')).toBeInTheDocument()
     expect(screen.queryByText('思考中...')).not.toBeInTheDocument()
+  })
+
+  it('chat_push 回复直接追加为独立消息', async () => {
+    await renderAndSend('req-2')
+    await push(assistantPush('看完了，结论是这样', 'req-2'))
+
+    expect(screen.getByText('帮我看下这个')).toBeInTheDocument()
     expect(screen.getByText('看完了，结论是这样')).toBeInTheDocument()
   })
 
-  it('manager 主动推送（无 request_id）：纯追加，不吃掉在途占位', async () => {
-    await renderAndSend('req-2')
-    await push(assistantPush('顺嘴提醒你一句'))
-
-    // 占位照旧转圈（那条请求还没被回答），主动推送作为新气泡追加
-    expect(screen.getByText('思考中...')).toBeInTheDocument()
-    expect(screen.getByText('顺嘴提醒你一句')).toBeInTheDocument()
-  })
-
-  it('request_id 对不上的 chat_push：纯追加，不误伤别人的占位', async () => {
+  it('一轮多条回复：全部追加，互不覆盖', async () => {
     await renderAndSend('req-3')
-    await push(assistantPush('这是另一轮的回复', 'req-other'))
+    await push(assistantPush('收到，我去办', 'req-3'))
+    await push(assistantPush('办好了，结果如下'))
 
-    expect(screen.getByText('思考中...')).toBeInTheDocument()
-    expect(screen.getByText('这是另一轮的回复')).toBeInTheDocument()
-  })
-
-  it('一轮多条回复：第一条替换占位，后续追加（admin 侧认领即消费，后续不带 request_id）', async () => {
-    await renderAndSend('req-4')
-    await push(assistantPush('收到，我去办', 'req-4'))
-    await push(assistantPush('办好了，结果如下', undefined))
-
-    expect(screen.queryByText('思考中...')).not.toBeInTheDocument()
     expect(screen.getByText('收到，我去办')).toBeInTheDocument()
     expect(screen.getByText('办好了，结果如下')).toBeInTheDocument()
   })
 
-  it('占位已被 chat_push 收口后，同 request_id 再来一条 chat_push：追加而不是覆盖', async () => {
-    await renderAndSend('req-5')
-    await push(assistantPush('第一条', 'req-5'))
-    await push(assistantPush('第二条', 'req-5'))
-
-    expect(screen.queryByText('思考中...')).not.toBeInTheDocument()
-    expect(screen.getByText('第一条')).toBeInTheDocument()
-    expect(screen.getByText('第二条')).toBeInTheDocument()
-  })
-
-  it('失败兜底（chat_reply）路径不受影响：仍按 request_id 收口占位', async () => {
-    await renderAndSend('req-6')
+  it('chat_reply（历史兼容路径）同样追加为独立消息', async () => {
+    await renderAndSend('req-4')
     await push({
       type: 'chat_reply',
-      request_id: 'req-6',
+      request_id: 'req-4',
       content: '我这条消息没处理完，暂时回不了你。',
       reply_type: 'direct_reply',
       status: 'completed',
     })
 
-    expect(screen.queryByText('思考中...')).not.toBeInTheDocument()
     expect(screen.getByText('我这条消息没处理完，暂时回不了你。')).toBeInTheDocument()
   })
 
-  it('chat_error 路径不受影响：占位转 failed 并显示错误', async () => {
-    await renderAndSend('req-7')
-    await push({ type: 'chat_error', request_id: 'req-7', error: '系统暂时不可用，请稍后重试' })
+  it('chat_error 以 toast 提示，不改写消息流', async () => {
+    await renderAndSend('req-5')
+    await push({ type: 'chat_error', request_id: 'req-5', error: '系统暂时不可用，请稍后重试' })
 
-    expect(screen.queryByText('思考中...')).not.toBeInTheDocument()
-    // chat_error 把同 request_id 的 user / assistant 两条都标 failed，错误文案出现不止一处
-    expect(screen.getAllByText(/系统暂时不可用，请稍后重试/).length).toBeGreaterThan(0)
+    expect(toastMocks.error).toHaveBeenCalledWith('系统暂时不可用，请稍后重试')
+    expect(screen.getByText('帮我看下这个')).toBeInTheDocument()
+  })
+
+  it('chat_message_acked 后用户消息出现已接收标记；发送后先无标记', async () => {
+    await renderAndSend('req-6')
+
+    // 未打标：无 ✓ 标记
+    expect(screen.queryByTitle(/已接收/)).not.toBeInTheDocument()
+
+    await push({ type: 'chat_message_acked', request_ids: ['req-6'] })
+
+    expect(screen.getByTitle(/已接收/)).toBeInTheDocument()
+  })
+
+  it('chat_message_acked 对不上的 request_id：不误标别人的消息', async () => {
+    await renderAndSend('req-7')
+    await push({ type: 'chat_message_acked', request_ids: ['req-other'] })
+
+    expect(screen.queryByTitle(/已接收/)).not.toBeInTheDocument()
   })
 })

--- a/crabot-admin/web/src/pages/Chat/index.tsx
+++ b/crabot-admin/web/src/pages/Chat/index.tsx
@@ -127,67 +127,12 @@ export const Chat: React.FC = () => {
 
     const unsubStatus = chatService.onStatusChange((status) => {
       setConnectionStatus(status)
-      if (status === 'connected') {
-        // 检查并更新 processing 状态的消息
-        chatService.loadHistory(PAGE_SIZE).then((history) => {
-          if (history.length === 0) return
-          const historyMap = new Map(history.map((m) => [m.message_id, m]))
-          setMessages((prev) => {
-            const hasStuck = prev.some((m) => m.status === 'processing')
-            if (!hasStuck) return prev
-            return prev.map((m) => {
-              if (m.status !== 'processing') return m
-              const found = historyMap.get(m.message_id)
-              if (found) return { ...found, status: 'completed' as const }
-              // 通过 request_id 匹配（占位消息的 message_id 是临时生成的）
-              const byReqId = history.find((h) => h.request_id === m.request_id && h.role === 'assistant')
-              if (byReqId) return { ...byReqId, status: 'completed' as const }
-              return m
-            })
-          })
-        }).catch(() => {/* ignore */})
-      }
     })
     const unsubMessage = chatService.onMessage(handleServerMessage)
-
-    // 轮询修复：每 8 秒检查是否有 processing 超过 15 秒的消息
-    // 用于修复 WS 连通但 chat_reply 事件丢失的情况
-    const stuckMessageTimes = new Map<string, number>()
-    const pollInterval = setInterval(() => {
-      setMessages((prev) => {
-        const now = Date.now()
-        const hasStuck = prev.some((m) => {
-          if (m.status !== 'processing') return false
-          const firstSeen = stuckMessageTimes.get(m.message_id)
-          if (!firstSeen) {
-            stuckMessageTimes.set(m.message_id, now)
-            return false
-          }
-          return now - firstSeen > 15000
-        })
-        if (!hasStuck) return prev
-        // 有卡住的消息，从 API 加载最近消息，精确更新 processing 的
-        chatService.loadHistory(PAGE_SIZE).then((history) => {
-          if (history.length === 0) return
-          setMessages((current) => {
-            const stillStuck = current.some((m) => m.status === 'processing')
-            if (!stillStuck) return current
-            return current.map((m) => {
-              if (m.status !== 'processing') return m
-              const byReqId = history.find((h) => h.request_id === m.request_id && h.role === 'assistant')
-              if (byReqId) return { ...byReqId, status: 'completed' as const }
-              return m
-            })
-          })
-        }).catch(() => {/* ignore */})
-        return prev
-      })
-    }, 8000)
 
     return () => {
       unsubStatus()
       unsubMessage()
-      clearInterval(pollInterval)
     }
   }, [])
 
@@ -357,15 +302,7 @@ export const Chat: React.FC = () => {
           timestamp: new Date().toISOString(),
           status: 'completed',
         }
-        // 占位仍在 processing → 原地转为系统提示；否则（已被 direct_reply 填充）追加新消息
-        const idx = prev.findIndex(
-          (m) => m.request_id === message.request_id && m.role === 'assistant' && m.status === 'processing'
-        )
-        if (idx >= 0) {
-          const updated = [...prev]
-          updated[idx] = { ...cardMsg, message_id: prev[idx].message_id }
-          return updated
-        }
+        // 直接追加为独立消息（占位气泡已退役，无原地转换对象）
         return [...prev, cardMsg]
       })
       // task_created：本地 upsert 初始快照 + tag 同 request_id 的 user 消息
@@ -436,46 +373,25 @@ export const Chat: React.FC = () => {
           )
         )
       }
-    } else if (message.type === 'chat_status') {
-      // 只更新 assistant 占位消息的状态为 processing
+    } else if (message.type === 'chat_error') {
+      // 占位气泡退役后无原地收口对象：错误以普通系统提示呈现（toast）。
+      // 失败说明（fail-loud）另经 chat_push 作为独立消息到达，与此不重复。
+      toast.error(message.error || '消息处理失败')
+    } else if (message.type === 'chat_push') {
+      // manager 经 send_message 伪 channel 回流的新消息（完整 ChatMessage，含 media）：
+      // 直接追加为独立消息（占位气泡已退役，无原地结算对象，UX 对齐 channel）。
+      setMessages((prev) => [...prev, { ...message.message, status: 'completed' as const }])
+    } else if (message.type === 'chat_message_acked') {
+      // 「已接收」标记（protocol-admin §3.20.2）：agent 在人类输入 commit 后经
+      // chat_acknowledge 打标并推送。本地时间即可（刷新后经聊天历史读到持久化值）。
       setMessages((prev) =>
         prev.map((m) =>
-          m.request_id === message.request_id && m.role === 'assistant'
-            ? { ...m, status: 'processing' as const }
+          m.role === 'user' && !m.acknowledged_at && m.request_id !== undefined
+            && message.request_ids.includes(m.request_id)
+            ? { ...m, acknowledged_at: new Date().toISOString() }
             : m
         )
       )
-    } else if (message.type === 'chat_error') {
-      if (message.request_id) {
-        setMessages((prev) =>
-          prev.map((m) =>
-            m.request_id === message.request_id
-              ? { ...m, status: 'failed' as const, error: message.error }
-              : m
-          )
-        )
-      }
-    } else if (message.type === 'chat_push') {
-      // manager 经 send_message 伪 channel 回流的新消息（完整 ChatMessage，含 media）。
-      // admin 落库时会把当时 in-flight 的 request_id 盖上（chat-manager.storeAssistantMessage），
-      // 命中同 request_id 的 processing 占位就原地替换——正常回复的转圈气泡靠这一步收口。
-      // 没有 request_id（manager 主动推送）或占位已被别的路径收口过 → 维持原来的追加行为。
-      const incoming = message.message
-      setMessages((prev) => {
-        const next: MessageState = { ...incoming, status: 'completed' as const }
-        // P6-A §11：delivery 携带 request_ids（一条回复可原子结算多条占位）；
-        // request_id（单数）只读历史兼容。
-        const claimIds = incoming.request_ids ?? (incoming.request_id ? [incoming.request_id] : [])
-        if (claimIds.length === 0) return [...prev, next]
-        const isPendingFor = (m: MessageState) =>
-          m.role === 'assistant' && m.status === 'processing' && m.request_id !== undefined && claimIds.includes(m.request_id)
-        const idx = prev.findIndex(isPendingFor)
-        if (idx < 0) return [...prev, next]
-        const updated = [...prev]
-        updated[idx] = next
-        // 同 delivery 结算的其余占位一并收口（它们的正式内容就是这条回复）。
-        return updated.filter((m, i) => i === idx || !isPendingFor(m))
-      })
     } else if (message.type === 'chat_task_update') {
       // 任务状态/计划变更：upsert 进 taskStatuses（终态也保留供图标显示 ✓/✗）
       upsertTaskStatus(message.task)
@@ -584,29 +500,22 @@ export const Chat: React.FC = () => {
         // 清空动作放在发送成功之后：失败时保留 input/attachments/quote 让用户直接重试
         const files = attachments
         const composed = composeWithQuote(content)
-        const { message, request_id } = await chatService.sendMessageWithAttachments(composed, files)
+        const { message } = await chatService.sendMessageWithAttachments(composed, files)
         setAttachments([])
         setInput('')
         setQuote(null)
         releasePreviewUrls(files)
+        // 只追加用户消息；回复由 chat_push 作为独立消息到达（占位气泡已退役）。
         setMessages((prev) => [
           ...prev,
           { ...message, status: 'sent' as const },
-          {
-            message_id: `msg_${Date.now()}_assistant`,
-            role: 'assistant' as const,
-            content: { type: 'text' as const, text: '' },
-            request_id,
-            timestamp: new Date().toISOString(),
-            status: 'processing' as const,
-          },
         ])
       } else {
         // 既有 WS 纯文本路径（入口已保证 content 非空）
         const composed = composeWithQuote(content)
         const request_id = chatService.sendMessage(composed)
 
-        // 添加用户消息（内容含引用块前缀）
+        // 添加用户消息（内容含引用块前缀）；回复由 chat_push 作为独立消息到达
         const userMessage: MessageState = {
           message_id: `msg_${Date.now()}`,
           role: 'user',
@@ -616,17 +525,7 @@ export const Chat: React.FC = () => {
           status: 'sent',
         }
 
-        // 添加占位的 assistant 消息
-        const assistantPlaceholder: MessageState = {
-          message_id: `msg_${Date.now()}_assistant`,
-          role: 'assistant',
-          content: { type: 'text', text: '' },
-          request_id,
-          timestamp: new Date().toISOString(),
-          status: 'processing',
-        }
-
-        setMessages((prev) => [...prev, userMessage, assistantPlaceholder])
+        setMessages((prev) => [...prev, userMessage])
         setInput('')
         setQuote(null)
       }

--- a/crabot-admin/web/src/pages/Chat/index.tsx
+++ b/crabot-admin/web/src/pages/Chat/index.tsx
@@ -127,6 +127,26 @@ export const Chat: React.FC = () => {
 
     const unsubStatus = chatService.onStatusChange((status) => {
       setConnectionStatus(status)
+      if (status === 'connected') {
+        // 重连补齐：pushToClient 断连即丢，断连期间的回复与 ✓ 标记经重拉历史找回。
+        // 服务端消息为权威：按 message_id 去重合并；被落库版本取代的本地乐观 user
+        // 消息（msg_ 前缀临时 id，同 request_id）丢弃，未落库的乐观消息原样保留。
+        chatService.loadHistory(PAGE_SIZE).then((history) => {
+          if (history.length === 0) return
+          setMessages((prev) => {
+            const known = new Set(prev.map((m) => m.message_id))
+            const fresh = [...history].reverse().filter((m) => !known.has(m.message_id))
+            if (fresh.length === 0) return prev
+            const settled = new Set(
+              fresh.map((m) => m.request_id).filter((id): id is string => id !== undefined)
+            )
+            const kept = prev.filter(
+              (m) => !(m.message_id.startsWith('msg_') && m.request_id !== undefined && settled.has(m.request_id))
+            )
+            return [...kept, ...fresh.map((m) => ({ ...m, status: 'completed' as const }))]
+          })
+        }).catch(() => {/* ignore */})
+      }
     })
     const unsubMessage = chatService.onMessage(handleServerMessage)
 

--- a/crabot-admin/web/src/pages/Chat/index.tsx
+++ b/crabot-admin/web/src/pages/Chat/index.tsx
@@ -143,7 +143,11 @@ export const Chat: React.FC = () => {
             const kept = prev.filter(
               (m) => !(m.message_id.startsWith('msg_') && m.request_id !== undefined && settled.has(m.request_id))
             )
-            return [...kept, ...fresh.map((m) => ({ ...m, status: 'completed' as const }))]
+            // fresh 里可能混有本会话早先已收到回复的 user 消息（WS 文本路径前端不知道
+            // 服务端 UUID，只能等重连补齐）——不能一律 concat 到队尾，按时间戳归位。
+            const merged = [...kept, ...fresh.map((m) => ({ ...m, status: 'completed' as const }))]
+            merged.sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime())
+            return merged
           })
         }).catch(() => {/* ignore */})
       }

--- a/crabot-admin/web/src/types/chat.ts
+++ b/crabot-admin/web/src/types/chat.ts
@@ -30,6 +30,8 @@ export interface ChatMessage {
   /** P6-A §11：本条 assistant 消息的 delivery 事务 ID。 */
   delivery_id?: string
   task_id?: string
+  /** 人类输入已被 Agent 写入 Manager 会话历史的时间（chat_acknowledge 落盘，ISO 8601）；未打标省略。 */
+  acknowledged_at?: string
   timestamp: string
 }
 
@@ -50,12 +52,12 @@ export type ChatServerMessage =
       reply_type: 'direct_reply' | 'task_created' | 'task_completed' | 'task_failed'
       status: 'completed' | 'failed'
     }
-  | { type: 'chat_status'; request_id: string; status: 'processing' }
   | { type: 'chat_error'; request_id?: string; error: string }
   | { type: 'chat_push'; message: ChatMessage }
   | { type: 'chat_task_update'; task: ChatTaskSnapshot }
   | { type: 'chat_message_tagged'; message_id: string; task_id: string }
   | { type: 'chat_message_deleted'; message_id: string }
+  | { type: 'chat_message_acked'; request_ids: string[] }
 
 /** 任务状态快照（chat_task_update / GET /api/chat/tasks/:id） */
 export interface ChatTaskSnapshot {

--- a/crabot-agent/src/manager/loop.ts
+++ b/crabot-agent/src/manager/loop.ts
@@ -373,7 +373,7 @@ export class ManagerLoop {
 
   /**
    * prepare 失败（staging/落盘抛错）时归还 claim：这些 ID 没有任何 delivery record，
-   * 不归还会让 manager 的重发拿到空 claim、回复退化成 proactive、占位气泡永久转圈。
+   * 不归还会让 manager 的重发拿到空 claim、回复退化成 proactive、人类消息得不到回复。
    */
   unclaimAdminChatRequestIds(ids: ReadonlyArray<string>): void {
     for (const id of ids) {

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -1952,6 +1952,27 @@ export class UnifiedAgent extends ModuleBase {
   }
 
   /**
+   * Master Chat 的「已接收」标记（protocol-admin §3.20.2）：admin-web 没有 channel 侧
+   * platform message 可打 reaction，改用 admin 的 `chat_acknowledge` RPC 达成同一语义
+   * （人类输入已被 manager 消费）。admin 侧幂等，未知 request_id 静默忽略。
+   */
+  private async ackAdminChatHumanInput(requestId: string): Promise<void> {
+    try {
+      await this.rpcClient.call(
+        await this.getAdminPort(),
+        'chat_acknowledge',
+        { request_ids: [requestId] },
+        this.config.moduleId,
+      )
+    } catch (err) {
+      console.warn(
+        `[${this.config.moduleId}] chat_acknowledge failed (ignored):`,
+        err instanceof Error ? err.message : String(err),
+      )
+    }
+  }
+
+  /**
    * fail-loud 兜底：manager episode 没能把话说出来时，**不经 manager、不经 LLM**
    * 直接告诉人类一声。
    *
@@ -2453,7 +2474,8 @@ export class UnifiedAgent extends ModuleBase {
    *
    * 「三不」不变：不进 SessionLane（admin REST 前端 fetch 等响应才发下一条，天然单线）、
    * 不进注意力调度（master 直连每条都要处理）、不打 `add_reaction`（admin-web 没有
-   * channel 侧 platform message 可回应）。
+   * channel 侧 platform message 可回应——「已接收」标记改走 admin `chat_acknowledge`，
+   * 见 routeHumanMessages 的 commit 回调）。
    */
   private async processAdminChatMessage(
     message: ChannelMessage,
@@ -2486,6 +2508,10 @@ export class UnifiedAgent extends ModuleBase {
         [message],
         MASTER_FRIEND,
         { admin_chat_request_ids: [callbackInfo.request_id] },
+        // 「已接收」标记（protocol-agent-v3 §4.1 / protocol-admin §3.20.2）：人类输入
+        // commit 进 manager 会话后 best-effort 通知 admin，web 在对应用户消息上渲染标记，
+        // 与 channel 的 acknowledged reaction 同语义同时机。失败只落日志，不影响回复链路。
+        () => this.ackAdminChatHumanInput(callbackInfo.request_id),
       )
     } catch (err) {
       // F2：episode 中途抛错。

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -2520,7 +2520,7 @@ export class UnifiedAgent extends ModuleBase {
         err instanceof Error ? err.message : String(err),
       )
       // 送不出去（冷却命中 / chat_callback 也失败）就把异常原样抛回 admin —— 那边的
-      // `dispatchToAgent` catch 会推 `chat_error`，占位气泡照样收口，且不会往消息库里
+      // `dispatchToAgent` catch 会推 `chat_error`（前端 toast 提示），且不会往消息库里
       // 再落一条重复的兜底文案。冷却在这里保住的正是"不重复落库"这一层。
       if (!(await this.sendFailLoudReply('admin-web', sessionId, { kind: 'threw', error: err }, callbackInfo.request_id))) {
         throw err

--- a/crabot-agent/tests/inbound/process-admin-chat-message.test.ts
+++ b/crabot-agent/tests/inbound/process-admin-chat-message.test.ts
@@ -460,6 +460,38 @@ describe('processAdminChatMessage —— admin chat 入站（cutover 后下游�
   })
 
   // ==========================================================================
+  // 已接收标记（chat_acknowledge，protocol-admin §3.20.2）
+  // ==========================================================================
+
+  describe('已接收标记（chat_acknowledge）', () => {
+    it('人类输入 commit 后调用 chat_acknowledge，路由到 admin 模块并携带 request_id', async () => {
+      boot({ turns: [[reply()]] })
+      await runAdminChat(amsg({ id: 'a-ack-1' }), 'req-ack-1')
+      // commit 回调是 fire-and-forget：跑完一轮 episode 后补几个宏任务让它落地
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      const ack = rpcCalls.find((c) => c.method === 'chat_acknowledge')
+      expect(ack).toBeDefined()
+      expect(ack!.port).toBe(ADMIN_PORT)
+      expect(ack!.params).toEqual({ request_ids: ['req-ack-1'] })
+    })
+
+    it('chat_acknowledge 失败只落日志：回复链路不受影响（best-effort）', async () => {
+      boot({ turns: [[reply('这就去办')]] })
+      const inner = internals.rpcClient.call
+      internals.rpcClient.call = async (port, method, params, from) => {
+        if (method === 'chat_acknowledge') throw new Error('admin down')
+        return inner(port, method, params, from)
+      }
+
+      const result = await runAdminChat(amsg({ id: 'a-ack-2' }), 'req-ack-2')
+
+      expect(result).toEqual({ decision_types: ['direct_reply'] })
+      expect(rpcCalls.find((c) => c.method === 'send_message')).toBeDefined()
+    })
+  })
+
+  // ==========================================================================
   // master 身份与记忆档位
   // ==========================================================================
 


### PR DESCRIPTION
## 需求出处

用户拍板（2026-08-30）：**直接删除 admin-web 上的「思考中」占位气泡；admin chat 增加类似 feishu 的 reaction 机制，人类消息被消费时做一个标记显示，把 UX 和 feishu channel 对齐。**

- Spec：`crabot-docs/superpowers/specs/2026-08-30-admin-chat-ack-reaction-design.md`（已确认）
- 协议：protocol-admin **0.2.8**（§3.20.2 `chat_acknowledge`、`chat_message_acked` 事件、`ChatMessage.acknowledged_at`、`chat_status processing` 退役）；protocol-agent-v3 **3.6.18**（§4.1 admin-web 已接收标记与 Channel reaction 同语义同时机）

## 背景与动机

现网占位机制在失败路径留有永久转圈面（PR #131 九审实证：episode 失败 + fail-loud 5 分钟冷却命中时占位无任何收口路径，挂到 agent 重启）。本设计从根上移除占位物本身——回复是独立消息、失败 = fail-loud 失败说明或沉默（与 channel 完全一致），#131 九审唯一阻塞线程的前提随之消失。

## 改动（逐块对应）

| 侧 | 改动 |
|---|---|
| agent | `processAdminChatMessage` 给 `routeHumanMessages` 接上 `onHumanInputCommitted` commit 回调 → best-effort 调 admin `chat_acknowledge`（catch+warn，不重试、不阻塞；protocol-agent-v3 §4.1） |
| admin | 新增 `chat_acknowledge` RPC：按 request_id 找 user ChatMessage → 写 `acknowledged_at`（持久化）→ 推 `chat_message_acked` → 返回实际标记数；幂等、未知 request_id 静默忽略。两处 `chat_status processing` 推送退役，`ChatServerMessage` 与协议 0.2.8 同步 |
| web | 删两处占位插入、8 秒轮询修卡死、`chat_status` handler、delivery/chat_reply/task_created 原地收口（一律独立追加）；`chat_error` 改 toast；新增 `chat_message_acked` → user 消息 ✓「已接收」标记（刷新经聊天历史恢复） |

## 新引入失败路径及收口

- `chat_acknowledge` RPC 失败：仅 `console.warn`——标记是 UX 增强，**不构成提交的一部分**（协议明文）；admin 侧幂等使重复触发无害
- web 兜底 = 无标记，与 channel「无 reaction」一致；回复到达不受任何影响
- 占位退役后不存在任何可永久挂死的中间态

## 时机语义（与 channel 对齐）

- 直接路径：commit 在首次 LLM 调用前 → 标记亚秒级出现
- 注入路径（#131）：commit 在宿主 episode 收尾临界区 → 标记此时出现；失败重投留 mailbox 的消息由后续 episode 提交时不带调用方回调，不打标（无标记兜底，与 channel「无 reaction」一致——首轮 review #3 描述纠偏）

## 验证

- admin `chat-manager` 36/36（+3 ack 用例：打标+持久化+推送 / 幂等 / 未知 id 静默忽略）
- admin `chat-integration` 6/6（原「收到 processing 状态」用例随占位退役改为以落库为准）
- web Chat 7/7（重写：无占位追加流、ack 标记出现/不误标）
- agent 新增 2 用例（commit 触发 ack 带 request_id、ack 失败不阻塞回复）+ manager loop/registry 92/92
- agent/admin/web `tsc` 干净；web `vite build` 通过
- 全量失败集合均为既有基线（M4 tmp-page ×6、超时 flaky、v1-cleanup 预存），与本次改动文件无交集，单跑复验通过

## 关联

- 落地后 PR #131 九审唯一阻塞线程（占位气泡挂死）前提消失，settle 回调补 fail-loud 保留，#131 随后复核合入
- 需重建重启 admin + agent 生效

