### PR TITLE
feat(task-status): 任务状态机缩水为 4 态——worker 停止监督与任务状态真相修正

### DIFF
--- a/crabot-admin/.gitignore
+++ b/crabot-admin/.gitignore
@@ -28,3 +28,4 @@ coverage/
 # Data
 data/
 *.db
+crabot-admin/web/node_modules

--- a/crabot-admin/.gitignore
+++ b/crabot-admin/.gitignore
@@ -28,4 +28,4 @@ coverage/
 # Data
 data/
 *.db
-crabot-admin/web/node_modules
+web/node_modules

--- a/crabot-admin/src/admin-web-api.test.ts
+++ b/crabot-admin/src/admin-web-api.test.ts
@@ -1671,7 +1671,7 @@ describe('Admin Web API', () => {
 
       await makeWebRequest(
         TEST_WEB_PORT,
-        '/api/agent/workers?status=running&status=waiting_input&manager_key=telegram-001%3A%3Aprivate-42'
+        '/api/agent/workers?status=running&status=halted&manager_key=telegram-001%3A%3Aprivate-42'
           + '&impl=codex&q=Minecraft&include_terminal=true&include_legacy=true'
           + '&start=2026-07-01T00%3A00%3A00.000Z&end=2026-07-31T00%3A00%3A00.000Z&page=2&page_size=5',
         'GET',
@@ -1680,7 +1680,7 @@ describe('Admin Web API', () => {
       )
 
       expect(spy).toHaveBeenCalledWith('list_workers_admin', {
-        status: ['running', 'waiting_input'],
+        status: ['running', 'halted'],
         manager_key: 'telegram-001::private-42',
         impl: 'codex',
         q: 'Minecraft',

--- a/crabot-admin/src/agent-task-status-event.test.ts
+++ b/crabot-admin/src/agent-task-status-event.test.ts
@@ -160,12 +160,12 @@ describe('agent.task_status_changed 订阅（protocol-agent-v3 §9.2）', () => 
     await internals.onEvent(
       statusEvent({ workerId: 'w-admin-1', taskId: 'task-admin-1', from: 'queued', to: 'running' })
     )
-    workerDetail = { ...ADMIN_CHAT_WORKER, task: { ...ADMIN_CHAT_WORKER.task, status: 'waiting_input' } }
+    workerDetail = { ...ADMIN_CHAT_WORKER, task: { ...ADMIN_CHAT_WORKER.task, status: 'halted' } }
     await internals.onEvent(
-      statusEvent({ workerId: 'w-admin-1', taskId: 'task-admin-1', from: 'running', to: 'waiting_input' })
+      statusEvent({ workerId: 'w-admin-1', taskId: 'task-admin-1', from: 'running', to: 'halted' })
     )
 
-    expect(pushed.map((p) => p.status)).toEqual(['running', 'waiting_input'])
+    expect(pushed.map((p) => p.status)).toEqual(['running', 'halted'])
   })
 
   it('别的渠道的任务不往 Master Chat 推（判据是结果回报目标）', async () => {

--- a/crabot-admin/src/types.ts
+++ b/crabot-admin/src/types.ts
@@ -1898,10 +1898,8 @@ export interface ChatSendMessageResult {
 export type AgentTaskStatus =
   | 'queued'
   | 'running'
-  | 'waiting_input'
-  | 'completed'
-  | 'failed'
-  | 'cancelled'
+  | 'halted'
+  | 'closed'
 
 /** §8.3 `get_worker_detail` 回来的台账条目里，admin 状态卡实际用到的那几个字段。 */
 export interface LedgerWorkerBrief {

--- a/crabot-admin/web/node_modules
+++ b/crabot-admin/web/node_modules
@@ -1,0 +1,1 @@
+/Users/fufu/codes/playground/crabot/crabot-admin/web/node_modules

--- a/crabot-admin/web/node_modules
+++ b/crabot-admin/web/node_modules
@@ -1,1 +1,0 @@
-/Users/fufu/codes/playground/crabot/crabot-admin/web/node_modules

--- a/crabot-admin/web/src/pages/Chat/TaskStatusIcon.tsx
+++ b/crabot-admin/web/src/pages/Chat/TaskStatusIcon.tsx
@@ -105,6 +105,15 @@ export const TaskStatusIcon: React.FC<TaskStatusIconProps> = ({ taskId, snapshot
         ✓
       </span>
     )
+  } else if (snapshot.status === 'closed') {
+    icon = (
+      <span
+        style={{ fontSize: 13, lineHeight: 1, color: 'var(--text-secondary)', fontWeight: 700, userSelect: 'none' }}
+        aria-label="已关闭"
+      >
+        ■
+      </span>
+    )
   } else if (snapshot.status === 'failed' || snapshot.status === 'cancelled') {
     icon = (
       <span

--- a/crabot-admin/web/src/pages/Chat/TaskStatusIcon.tsx
+++ b/crabot-admin/web/src/pages/Chat/TaskStatusIcon.tsx
@@ -21,9 +21,12 @@ const STATUS_LABELS: Record<string, string> = {
   completed: '已完成',
   failed: '失败',
   cancelled: '已取消',
-  // protocol-agent-v3 §5.2
+  // protocol-agent-v3 §5.2(2026-08-31 状态机修正:4 态)
   queued: '排队中',
   running: '执行中',
+  halted: '已停止待处置',
+  closed: '已关闭',
+  // 旧值兼容(历史数据)
   waiting_input: '等回复',
 }
 
@@ -31,7 +34,7 @@ const STATUS_LABELS: Record<string, string> = {
 const SPINNING_STATUSES = new Set(['pending', 'planning', 'executing', 'queued', 'running'])
 
 /** 等待状态（显示 ⏸） */
-const WAITING_STATUSES = new Set(['waiting', 'waiting_human', 'waiting_input'])
+const WAITING_STATUSES = new Set(['waiting', 'waiting_human', 'waiting_input', 'halted'])
 
 interface TaskStatusIconProps {
   taskId: string

--- a/crabot-admin/web/src/pages/Traces/ManagerDetail.tsx
+++ b/crabot-admin/web/src/pages/Traces/ManagerDetail.tsx
@@ -76,7 +76,7 @@ function triggerText(episode: ManagerEpisodeTrace): string {
 
 function workerStateLabel(status: string): string {
   const labels: Record<string, string> = {
-    queued: '排队', running: '执行中', waiting_input: '等待输入',
+    queued: '排队', running: '执行中', halted: '已停止待处置', closed: '已关闭', waiting_input: '等输入',
     completed: '已完成', failed: '失败', cancelled: '已取消',
   }
   return labels[status] ?? status

--- a/crabot-admin/web/src/pages/Traces/ManagersView.test.tsx
+++ b/crabot-admin/web/src/pages/Traces/ManagersView.test.tsx
@@ -138,7 +138,7 @@ describe('ManagerDetail', () => {
         {
           trace_id: 'ep-progress', manager_key: 'wechat::sess-1', started_at: '2026-08-01T10:01:00.000Z', status: 'completed',
           trigger: { type: 'worker_event', summary: 'worker event', source: 'worker:w-1' }, spans: [], spawned_worker_ids: [],
-          worker_ref: { worker_id: 'w-1', title: '部署 V6', state_to: 'waiting_input' },
+          worker_ref: { worker_id: 'w-1', title: '部署 V6', state_to: 'halted' },
         },
         {
           trace_id: 'ep-parent', manager_key: 'wechat::sess-1', started_at: '2026-08-01T10:00:00.000Z', status: 'completed',
@@ -164,7 +164,7 @@ describe('ManagerDetail', () => {
         {
           trace_id: 'ep-late-reply', manager_key: 'wechat::sess-1', started_at: '2026-08-01T10:10:00.000Z', status: 'completed',
           trigger: { type: 'worker_event', summary: 'worker event', source: 'worker:w-1' }, spans: [], spawned_worker_ids: [],
-          worker_ref: { worker_id: 'w-1', title: '部署 V6', state_to: 'waiting_input' },
+          worker_ref: { worker_id: 'w-1', title: '部署 V6', state_to: 'halted' },
           reply_excerpt: '该执行器当前无法投递，已请求中断。',
           actions: [{ kind: 'other', label: '请求中断：部署 V6', worker_id: 'w-1' }],
           causal_parent: {
@@ -200,7 +200,7 @@ describe('ManagerDetail', () => {
         {
           trace_id: 'ep-progress-latest', manager_key: 'wechat::sess-1', started_at: '2026-08-01T10:03:00.000Z', status: 'completed',
           trigger: { type: 'worker_event', summary: 'worker event', source: 'worker:w-1' }, spans: [], spawned_worker_ids: [],
-          worker_ref: { worker_id: 'w-1', title: '部署 V6', state_to: 'waiting_input' },
+          worker_ref: { worker_id: 'w-1', title: '部署 V6', state_to: 'halted' },
         },
         {
           trace_id: 'ep-progress-running', manager_key: 'wechat::sess-1', started_at: '2026-08-01T10:02:00.000Z', status: 'completed',
@@ -239,7 +239,7 @@ describe('ManagerDetail', () => {
         {
           trace_id: 'ep-progress-latest', manager_key: 'wechat::sess-1', started_at: '2026-08-01T10:03:00.000Z', status: 'completed',
           trigger: { type: 'worker_event', summary: 'worker event', source: 'worker:w-1' }, spans: [], spawned_worker_ids: [],
-          worker_ref: { worker_id: 'w-1', title: '部署 V6', state_to: 'waiting_input' },
+          worker_ref: { worker_id: 'w-1', title: '部署 V6', state_to: 'halted' },
         },
         {
           trace_id: 'ep-progress-message', manager_key: 'wechat::sess-1', started_at: '2026-08-01T10:02:00.000Z', status: 'completed',

--- a/crabot-admin/web/src/pages/Traces/ManagersView.test.tsx
+++ b/crabot-admin/web/src/pages/Traces/ManagersView.test.tsx
@@ -155,7 +155,7 @@ describe('ManagerDetail', () => {
     )
     await waitFor(() => expect(screen.getByText('你：「开始部署」')).toBeInTheDocument())
     expect(screen.getAllByText('部署 V6').length).toBeGreaterThan(0)
-    expect(screen.getByText('等待输入')).toBeInTheDocument()
+    expect(screen.getByText('已停止待处置')).toBeInTheDocument()
   })
 
   it('带回复或操作的 worker_event 保持自己的时间线位置', async () => {
@@ -226,7 +226,7 @@ describe('ManagerDetail', () => {
       </MemoryRouter>,
     )
     await waitFor(() => expect(screen.getByText('你：「开始部署」')).toBeInTheDocument())
-    expect(screen.getByText('等待输入')).toBeInTheDocument()
+    expect(screen.getByText('已停止待处置')).toBeInTheDocument()
     expect(screen.queryByText('执行中')).toBeNull()
     fireEvent.click(screen.getByRole('button', { name: '展开 2 次历史进展' }))
     expect(screen.getByText('执行中')).toBeInTheDocument()

--- a/crabot-admin/web/src/pages/Traces/WorkerDetail.tsx
+++ b/crabot-admin/web/src/pages/Traces/WorkerDetail.tsx
@@ -23,11 +23,11 @@ const IMPL_LABEL: Record<WorkerIncarnation['impl'], string> = {
   legacy: '旧版记录',
 }
 const STATUS_LABEL: Record<WorkerTaskStatus, string> = {
-  queued: '排队', running: '执行中', waiting_input: '等输入',
+  queued: '排队', running: '执行中', halted: '已停止待处置', closed: '已关闭', waiting_input: '等输入',
   completed: '已完成', failed: '失败', cancelled: '已取消',
 }
 const STATUS_COLOR: Record<WorkerTaskStatus, string> = {
-  queued: 'var(--text-muted)', running: 'var(--info)', waiting_input: 'var(--warning)',
+  queued: 'var(--text-muted)', running: 'var(--info)', halted: 'var(--warning)', closed: 'var(--text-muted)', waiting_input: 'var(--warning)',
   completed: 'var(--success)', failed: 'var(--error)', cancelled: 'var(--text-muted)',
 }
 const INCARNATION_STATE_LABEL: Record<string, string> = {

--- a/crabot-admin/web/src/pages/Traces/WorkerDetail.tsx
+++ b/crabot-admin/web/src/pages/Traces/WorkerDetail.tsx
@@ -10,7 +10,6 @@ import {
   agentObservabilityService,
   type LedgerWorker,
   type WorkerIncarnation,
-  type WorkerTaskStatus,
   type WorkerTerminalView,
   type WorkerTraceEvent,
   type WorkerSubagentSummary,
@@ -22,11 +21,12 @@ const IMPL_LABEL: Record<WorkerIncarnation['impl'], string> = {
   codex: 'Codex',
   legacy: '旧版记录',
 }
-const STATUS_LABEL: Record<WorkerTaskStatus, string> = {
+// 键放宽为 string:历史 trace 数据可能携带旧状态值,缺键时回退原样显示
+const STATUS_LABEL: Record<string, string> = {
   queued: '排队', running: '执行中', halted: '已停止待处置', closed: '已关闭', waiting_input: '等输入',
   completed: '已完成', failed: '失败', cancelled: '已取消',
 }
-const STATUS_COLOR: Record<WorkerTaskStatus, string> = {
+const STATUS_COLOR: Record<string, string> = {
   queued: 'var(--text-muted)', running: 'var(--info)', halted: 'var(--warning)', closed: 'var(--text-muted)', waiting_input: 'var(--warning)',
   completed: 'var(--success)', failed: 'var(--error)', cancelled: 'var(--text-muted)',
 }

--- a/crabot-admin/web/src/pages/Traces/WorkersView.tsx
+++ b/crabot-admin/web/src/pages/Traces/WorkersView.tsx
@@ -3,11 +3,12 @@ import { Link } from 'react-router-dom'
 import { Loading } from '../../components/Common/Loading'
 import { agentObservabilityService, type LedgerWorker, type WorkerTaskStatus } from '../../services/agent-observability'
 
-const STATUS_LABEL: Record<WorkerTaskStatus, string> = {
+// 键放宽为 string:历史 trace 数据可能携带旧状态值,缺键时回退原样显示
+const STATUS_LABEL: Record<string, string> = {
   queued: '排队', running: '执行中', halted: '已停止待处置', closed: '已关闭', waiting_input: '等输入',
   completed: '已完成', failed: '失败', cancelled: '已取消',
 }
-const STATUS_COLOR: Record<WorkerTaskStatus, string> = {
+const STATUS_COLOR: Record<string, string> = {
   queued: 'var(--text-muted)', running: 'var(--info)', halted: 'var(--warning)', closed: 'var(--text-muted)', waiting_input: 'var(--warning)',
   completed: 'var(--success)', failed: 'var(--error)', cancelled: 'var(--text-muted)',
 }
@@ -42,7 +43,8 @@ export const WorkersView: React.FC = () => {
   const [page, setPage] = useState(1)
   const [totalPages, setTotalPages] = useState(1)
   const [counts, setCounts] = useState({ active: 0, terminal: 0, legacy: 0 })
-  const [status, setStatus] = useState<'' | WorkerTaskStatus>('')
+  // 历史数据/旧下拉项仍可能携带旧状态值,过滤选择器放宽为 string
+  const [status, setStatus] = useState<string>('')
   const [managerKey, setManagerKey] = useState('')
   const [query, setQuery] = useState('')
   const [includeTerminal, setIncludeTerminal] = useState(false)
@@ -58,8 +60,8 @@ export const WorkersView: React.FC = () => {
       ...(status ? { status } : {}),
       ...(managerKey ? { manager_key: managerKey } : {}),
       ...(query.trim() ? { q: query.trim() } : {}),
-      ...(includeTerminal || includeLegacy || status === 'completed' || status === 'failed' || status === 'cancelled'
-        ? { include_terminal: true }
+      ...(includeTerminal || includeLegacy || status === 'closed' || status === 'completed' || status === 'failed' || status === 'cancelled'
+        ? { include_terminal: true }  // closed 是唯一终态;旧终态键仅服务历史数据过滤
         : {}),
       ...(includeLegacy ? { include_legacy: true } : {}),
       page,
@@ -87,7 +89,7 @@ export const WorkersView: React.FC = () => {
           placeholder="搜索任务标题"
           aria-label="标题搜索"
         />
-        <select className="trace-control" value={status} onChange={(e) => { setStatus(e.target.value as '' | WorkerTaskStatus); setPage(1) }} aria-label="状态过滤">
+        <select className="trace-control" value={status} onChange={(e) => { setStatus(e.target.value); setPage(1) }} aria-label="状态过滤">
           {STATUS_OPTIONS.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
         </select>
         <input

--- a/crabot-admin/web/src/pages/Traces/WorkersView.tsx
+++ b/crabot-admin/web/src/pages/Traces/WorkersView.tsx
@@ -4,11 +4,11 @@ import { Loading } from '../../components/Common/Loading'
 import { agentObservabilityService, type LedgerWorker, type WorkerTaskStatus } from '../../services/agent-observability'
 
 const STATUS_LABEL: Record<WorkerTaskStatus, string> = {
-  queued: '排队', running: '执行中', waiting_input: '等待输入',
+  queued: '排队', running: '执行中', halted: '已停止待处置', closed: '已关闭', waiting_input: '等输入',
   completed: '已完成', failed: '失败', cancelled: '已取消',
 }
 const STATUS_COLOR: Record<WorkerTaskStatus, string> = {
-  queued: 'var(--text-muted)', running: 'var(--info)', waiting_input: 'var(--warning)',
+  queued: 'var(--text-muted)', running: 'var(--info)', halted: 'var(--warning)', closed: 'var(--text-muted)', waiting_input: 'var(--warning)',
   completed: 'var(--success)', failed: 'var(--error)', cancelled: 'var(--text-muted)',
 }
 const IMPLEMENTATION_LABEL: Record<string, string> = {

--- a/crabot-admin/web/src/services/agent-observability.ts
+++ b/crabot-admin/web/src/services/agent-observability.ts
@@ -84,8 +84,10 @@ export interface ManagerEpisodeTrace {
 
 // ── Worker（§8.3 台账 read model）──────────────────────────────
 
+// 2026-08-31 状态机修正:4 态。旧值(waiting_input/completed/failed/cancelled)仅存在于
+// 历史 trace 数据,徽章映射保留旧键做兼容显示。
 export type WorkerTaskStatus =
-  | 'queued' | 'running' | 'waiting_input' | 'completed' | 'failed' | 'cancelled'
+  | 'queued' | 'running' | 'halted' | 'closed'
 
 export interface WorkerIncarnation {
   incarnation_id?: string

--- a/crabot-agent/src/manager/episode-projection.ts
+++ b/crabot-agent/src/manager/episode-projection.ts
@@ -155,7 +155,7 @@ export function managerActivitySummary(trace: ManagerEpisodeProjection): string 
 function statusLabel(status: string | undefined): string | undefined {
   if (!status) return undefined
   const labels: Record<string, string> = {
-    queued: '排队', running: '执行中', waiting_input: '等输入',
+    queued: '排队', running: '执行中', halted: '已停止待处置',
     completed: '已完成', failed: '失败', cancelled: '已取消',
   }
   return labels[status] ?? status

--- a/crabot-agent/src/manager/loop.ts
+++ b/crabot-agent/src/manager/loop.ts
@@ -1946,8 +1946,13 @@ function renderChannelMessages(
  */
 function workerEventClass(event: HarnessEvent): 'content' | 'blocked' | 'review' | 'info' {
   switch (event.kind) {
-    case 'state_changed':
-      return event.detail?.kind === 'interaction_required' ? 'blocked' : 'content'
+    case 'state_changed': {
+      if (event.detail?.kind === 'interaction_required') return 'blocked'
+      // 主线状态机的通用事件点:停止/退出迁移是"有内容待处置",to=running 只是
+      // "开始跑了"的纯通报,归 info,不逼 manager 走四选一处置。
+      const to = event.detail?.to
+      return to === 'idle' || to === 'exited' ? 'content' : 'info'
+    }
     case 'activity_available':
     case 'turn_completed':
     case 'query_completed':

--- a/crabot-agent/src/manager/loop.ts
+++ b/crabot-agent/src/manager/loop.ts
@@ -1969,9 +1969,10 @@ function renderWorkerEvent(event: HarnessEvent): string {
   const detail = Object.keys(rest).length > 0 ? ` detail=${JSON.stringify(rest)}` : ''
   const parts = [`<crabot-event class="${cls}" kind="${event.kind}" worker_id="${event.worker_id}" seq="${event.seq}"${detail}>`]
   if (typeof text === 'string' && text.length > 0) {
-    // blocked(交互界面)事件的 text 是终端画面 capture,不是 worker 说的话,标签必须区分,
-    // 防止 manager 把画面内容误当发言。
-    parts.push(cls === 'blocked' ? `worker 当前画面:\n${text}` : `worker 最后说:\n${text}`)
+    // 只有 interaction_required 事件的 text 是终端画面 capture(不是 worker 说的话),
+    // 标签必须区分,防止 manager 把画面内容误当发言;其余事件的 text 都是发言/指令原文。
+    const isPaneCapture = event.kind === 'state_changed' && event.detail?.kind === 'interaction_required'
+    parts.push(isPaneCapture ? `worker 当前画面:\n${text}` : `worker 最后说:\n${text}`)
   }
   if (typeof summary === 'string' && summary.length > 0) parts.push(`worker 的收尾结论:\n${summary}`)
   parts.push('</crabot-event>')

--- a/crabot-agent/src/manager/loop.ts
+++ b/crabot-agent/src/manager/loop.ts
@@ -1950,6 +1950,7 @@ function workerEventClass(event: HarnessEvent): 'content' | 'blocked' | 'review'
       if (event.detail?.kind === 'interaction_required') return 'blocked'
       // 主线状态机的通用事件点:停止/退出迁移是"有内容待处置",to=running 只是
       // "开始跑了"的纯通报,归 info,不逼 manager 走四选一处置。
+      if (event.detail?.source === 'liveness_stall') return 'content'
       const to = event.detail?.to
       return to === 'idle' || to === 'exited' ? 'content' : 'info'
     }

--- a/crabot-agent/src/manager/loop.ts
+++ b/crabot-agent/src/manager/loop.ts
@@ -1948,9 +1948,13 @@ function workerEventClass(event: HarnessEvent): 'content' | 'blocked' | 'review'
   switch (event.kind) {
     case 'state_changed': {
       if (event.detail?.kind === 'interaction_required') return 'blocked'
+      // manager 自己处置动作的回执(stop_verified:任务已 closed)是收据不是新待办,
+      // 归 info——否则每次核验成功的 request_worker_stop 都会立刻要求 manager
+      // 再走一轮"必须处置",而续办对 closed 是硬拒绝,必错。
+      if (event.detail?.reason === 'stop_verified') return 'info'
+      if (event.detail?.source === 'liveness_stall') return 'content'
       // 主线状态机的通用事件点:停止/退出迁移是"有内容待处置",to=running 只是
       // "开始跑了"的纯通报,归 info,不逼 manager 走四选一处置。
-      if (event.detail?.source === 'liveness_stall') return 'content'
       const to = event.detail?.to
       return to === 'idle' || to === 'exited' ? 'content' : 'info'
     }

--- a/crabot-agent/src/manager/loop.ts
+++ b/crabot-agent/src/manager/loop.ts
@@ -1940,13 +1940,41 @@ function renderChannelMessages(
   return `${label}\n${lines.join('\n')}`
 }
 
+/**
+ * harness 事件 → manager 决策类别(spec 2026-08-31-worker-stop-oversight-design §5.4)。
+ * content=有内容待处置;blocked=受阻需介入;review=例行巡检;info=通报知情。
+ */
+function workerEventClass(event: HarnessEvent): 'content' | 'blocked' | 'review' | 'info' {
+  switch (event.kind) {
+    case 'state_changed':
+      return event.detail?.kind === 'interaction_required' ? 'blocked' : 'content'
+    case 'activity_available':
+    case 'turn_completed':
+    case 'query_completed':
+      return 'content'
+    case 'input_delivery_failed':
+    case 'worker_recovery_required':
+      return 'blocked'
+    case 'supervision_due':
+      return 'review'
+    default:
+      return 'info'
+  }
+}
+
 function renderWorkerEvent(event: HarnessEvent): string {
+  const cls = workerEventClass(event)
   const { text, summary, ...rest } = (event.detail ?? {}) as
     { text?: unknown; summary?: unknown } & Record<string, unknown>
   const detail = Object.keys(rest).length > 0 ? ` detail=${JSON.stringify(rest)}` : ''
-  const parts = [`[worker 事件] worker_id=${event.worker_id} seq=${event.seq} kind=${event.kind}${detail}`]
-  if (typeof text === 'string' && text.length > 0) parts.push(`worker 最后说:\n${text}`)
+  const parts = [`<crabot-event class="${cls}" kind="${event.kind}" worker_id="${event.worker_id}" seq="${event.seq}"${detail}>`]
+  if (typeof text === 'string' && text.length > 0) {
+    // blocked(交互界面)事件的 text 是终端画面 capture,不是 worker 说的话,标签必须区分,
+    // 防止 manager 把画面内容误当发言。
+    parts.push(cls === 'blocked' ? `worker 当前画面:\n${text}` : `worker 最后说:\n${text}`)
+  }
   if (typeof summary === 'string' && summary.length > 0) parts.push(`worker 的收尾结论:\n${summary}`)
+  parts.push('</crabot-event>')
   return parts.join('\n')
 }
 

--- a/crabot-agent/src/manager/prompt.ts
+++ b/crabot-agent/src/manager/prompt.ts
@@ -89,7 +89,7 @@ Crabot 把"对话"和"干活"拆成了两层：
 
 **结论拿不到就回去问执行器**：执行器已经结束、但原生会话和交付记录里都没有你要的结论时，用 \`send_to_worker\` 把问题直接发给它——它会带着原会话的完整上下文醒过来回答你。这是你自己能解决的事，问过它确实答不上来，才轮到找人类。
 
-**完成结果的记忆候选**：当执行器事件同时满足 \`kind=state_changed\`、\`detail.outcome=completed\` 和 \`detail.trigger_type=message\` 时，先只根据事件中的最后文本、收尾结论或按需读取的执行器详情判断是否存在明确、可核实、可复用的结论。没有这种直接证据就不写。存在时最多写一条 inbox 候选，必须带 \`source_ref.task_id=detail.task_id\`，并在 tags 写入 \`worker_completion:<worker_id>:<seq>\`；写前先用 \`list_entries\` 查询该 tag 的所有状态，已存在就不再写。scheduled/system 执行器、失败或 idle 事件都不走这条路径。不要把这一步交给普通执行器，也不要把模糊的“已完成”编造成记忆。
+**完成结果的记忆候选**：当执行器事件同时满足 \`kind=state_changed\`、\`detail.summary\` 存在（执行器经 finish_task 自报的收尾结论）和 \`detail.trigger_type=message\` 时，先只根据事件中的最后文本、收尾结论或按需读取的执行器详情判断是否存在明确、可核实、可复用的结论。没有这种直接证据就不写。存在时最多写一条 inbox 候选，必须带 \`source_ref.task_id=detail.task_id\`，并在 tags 写入 \`worker_completion:<worker_id>:<seq>\`；写前先用 \`list_entries\` 查询该 tag 的所有状态，已存在就不再写。scheduled/system 执行器、失败或 idle 事件都不走这条路径。不要把这一步交给普通执行器，也不要把模糊的“已完成”编造成记忆。
 
 **不滥用跨 session 投递**：\`send_message\` 能发到别的会话，但只在人类明确要求时才这么做，不要自作主张往别的会话塞话。`
 

--- a/crabot-agent/src/manager/prompt.ts
+++ b/crabot-agent/src/manager/prompt.ts
@@ -37,6 +37,17 @@ Crabot 把"对话"和"干活"拆成了两层：
 - 你对执行器能做的事只有：**派活、送话、侧问、查状态/原生会话、看终端、回应未知界面、请求中断或停止、设置定期汇报**（\`spawn_worker\` / \`send_to_worker\` / \`query_worker\` / \`get_worker_state\` / \`get_worker_activity\` / \`get_worker_turn\` / \`resolve_worker_turn\` / \`get_worker_terminal\` / \`respond_to_worker_ui\` / \`request_worker_interrupt\` / \`request_worker_stop\` / \`set_worker_periodic_report\` / \`clear_worker_periodic_report\`）；
 - **执行器与人类之间隔着你**——执行器不直接面对人类，执行器说的话不会直接到人类那里，人类看到的每一句话都必须经你之手（\`send_message\`）转述出去。
 
+### 你的对话对象是 crabot 系统
+
+你在 agent loop 里与 crabot 系统协作：系统通过事件向你报告——人类发来的消息、执行器的动态、例行巡检的结果。一条系统消息里可能打包多个事件，每个事件带一个类别标记（class），类别决定你该怎么处置：
+
+- **content（执行器有内容，必须处置）**：执行器说话了、交付了、或停下来了。必须先读该回合及其活动（\`get_worker_turn\` / \`get_worker_activity\`），再落到四选一的工具处置：续办（\`send_to_worker\`）、转述（\`send_message\`）、提问（\`send_message\`）、显式抑制（\`resolve_worker_turn\` 并写明理由）。**沉默不是合法完成形态**——"不打扰人类"只约束 \`send_message\` 该不该发，不豁免处置动作本身；无事可报时抑制并写明原因，也是一次处置。
+- **blocked（执行器受阻，必须介入）**：执行器卡在需要选择的界面上、投递失败或崩溃了。先看现场（\`get_worker_terminal\` / \`get_worker_activity\`），再回应界面（\`respond_to_worker_ui\`）、重投或个案处置。
+- **review（例行巡检，需要复核）**：约定的进度巡检到期。复核执行器状态与活动，有值得转述的按约定 \`send_message\`，没有的显式抑制或终止约定。
+- **info（执行器通报，知情即可）**：生命周期通报（已派出、已复活、已停止等）。默认直接结束回合，无需动作。
+
+**自报不等于完成**：事件里执行器给出的"完成 / 失败"结论是它的自称。拿任务的原始要求对照它实际交付的内容，独立判断是否达成；确认完成的才转述收尾，未达成且不需要人类输入的，续办是默认动作。
+
 ### 管家纪律
 
 **先判断响应路径**：每条人类消息到来时，先判断能否快速、可靠地给出有价值的结果；不要按“历史问题”“进度问题”“派活”等问题类别套固定流程。

--- a/crabot-agent/src/manager/tools/worker-tools.ts
+++ b/crabot-agent/src/manager/tools/worker-tools.ts
@@ -695,7 +695,7 @@ export function buildWorkerTools(deps: WorkerToolsDeps): ToolDefinition[] {
   const listWorkers = defineTool({
     name: 'list_workers',
     description:
-      '列出当前会话可决策的 worker。默认只返回非终态(queued/running/waiting_input)，' +
+      '列出当前会话可决策的 worker。默认只返回非终态(queued/running/halted)，' +
       '需要查历史时显式 include_terminal=true 并分页；需要继续、返工或汇报进度时先查询。',
     inputSchema: {
       type: 'object',
@@ -858,7 +858,7 @@ export function buildWorkerTools(deps: WorkerToolsDeps): ToolDefinition[] {
     description: '仅 Master 可用：跨会话列出 worker 精简摘要，支持 manager_key/status/分页过滤。',
     inputSchema: {
       type: 'object', properties: {
-        manager_key: { type: 'string' }, status: { oneOf: [{ type: 'string', enum: ['queued', 'running', 'waiting_input', 'completed', 'failed', 'cancelled'] }, { type: 'array', items: { type: 'string', enum: ['queued', 'running', 'waiting_input', 'completed', 'failed', 'cancelled'] } }] },
+        manager_key: { type: 'string' }, status: { oneOf: [{ type: 'string', enum: ['queued', 'running', 'halted', 'closed'] }, { type: 'array', items: { type: 'string', enum: ['queued', 'running', 'halted', 'closed'] } }] },
         page: { type: 'number' }, page_size: { type: 'number' },
       },
     },

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -3111,7 +3111,7 @@ export class UnifiedAgent extends ModuleBase {
     managerKey: ManagerKey,
     taskId: TaskId,
     to: TaskStatus,
-    opts?: { error?: string; outcome?: string },
+    opts?: { note?: string },
   ): Promise<void> {
     const { ledger } = this.requireManagerStack()
     const now = new Date().toISOString()
@@ -3121,7 +3121,12 @@ export class UnifiedAgent extends ModuleBase {
       oldStatus = previous.task.status
       return {
         ...previous,
-        task: applyStatusTransition(previous.task, to, { ...opts, now }),
+        task: applyStatusTransition(previous.task, to, {
+          now,
+          ...(to === 'closed'
+            ? { closed: { by: 'system' as const, ...(opts?.note ? { note: opts.note } : {}) } }
+            : {}),
+        }),
         updated_at: now,
       }
     })
@@ -3139,15 +3144,14 @@ export class UnifiedAgent extends ModuleBase {
     await this.transitionMaintenanceSystemTask(managerKey, taskId, 'running')
     try {
       await this.memoryWriter.runMaintenance('all')
-      await this.transitionMaintenanceSystemTask(managerKey, taskId, 'completed', {
-        outcome: '记忆维护完成',
+      await this.transitionMaintenanceSystemTask(managerKey, taskId, 'closed', {
+        note: '记忆维护完成',
       })
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       console.error(`[${this.config.moduleId}] memory_maintenance system task ${taskId} failed:`, message)
-      await this.transitionMaintenanceSystemTask(managerKey, taskId, 'failed', {
-        error: message,
-        outcome: `记忆维护失败：${message}`,
+      await this.transitionMaintenanceSystemTask(managerKey, taskId, 'closed', {
+        note: `记忆维护失败：${message}`,
       })
     }
   }
@@ -3582,7 +3586,7 @@ export class UnifiedAgent extends ModuleBase {
       for (const entry of entries) {
         if (!entry.startsWith('w-')) continue
         const found = all.find(({ worker }) => worker.worker_id === entry)
-        if (found && found.worker.task.status !== 'completed' && found.worker.task.status !== 'failed' && found.worker.task.status !== 'cancelled') {
+        if (found && found.worker.task.status !== 'closed') {
           continue // 非终态 worker：协议 §6.5 只授权回收任务终态超 7 天的目录（R8）。
         }
         const task = found?.worker.task

--- a/crabot-agent/src/workers/builtin/adapter.ts
+++ b/crabot-agent/src/workers/builtin/adapter.ts
@@ -152,7 +152,7 @@ export { WorkerExitedError }
 const FINISH_TASK_TOOL: ToolDefinition = {
   ...defineTool({
     name: 'finish_task',
-    description: '结束当前 burst：任务完成或确认失败时调用，附一句话总结。',
+    description: '本轮工作到此结束、交回调度方继续处置时调用；附自报结果（completed/failed）与一句话总结。自报只是你的判断，是否达成由调度方对照任务要求认定。',
     isReadOnly: true,
     inputSchema: {
       type: 'object',

--- a/crabot-agent/src/workers/harness/harness.ts
+++ b/crabot-agent/src/workers/harness/harness.ts
@@ -6212,13 +6212,15 @@ export class WorkerHarness {
           : undefined
       const nextStatus: TaskStatus = preserveTaskForStop
         ? worker.task.status
-        : state === 'idle' && (this.hasPendingBgNotification(h.worker_id) || await this.deps.hasRunningBg?.(h.worker_id))
+        : state === 'running'
           ? 'running'
           : state === 'exited' && endReason === 'superseded'
             ? 'running' // 占位:任务状态由化身链新成员决定(与既有语义一致)
             : state === 'exited' && endReason === 'killed'
               ? 'closed' // manager 发起的停止,事实成立即关闭
-              : 'halted'
+              : state === 'idle' && (this.hasPendingBgNotification(h.worker_id) || await this.deps.hasRunningBg?.(h.worker_id))
+                ? 'running'
+                : 'halted'
       // CLI 从 `waiting_action` 转回 `waiting_text` 时，公开协议层仍是 `idle`。
       // completionSource 才是回合边界的权威证据，不能因投影状态相同而过滤。
       const shouldCreateTurn = report?.completionSource !== undefined
@@ -6603,7 +6605,7 @@ function ledgerHandoffEvidence(worker: LedgerWorker, source: Incarnation): Hando
     {
       source: 'ledger',
       reference: `incarnation:${sourceId}:outcome`,
-      summary: `Source outcome: ${worker.task.halt?.worker_self_report?.summary ?? worker.task.halt?.halt_reason ?? source.ended_reason ?? 'unknown'}`,
+      summary: `Source outcome: ${worker.task.halt?.worker_self_report?.summary ?? worker.task.halt?.detail ?? source.ended_reason ?? worker.task.halt?.halt_reason ?? 'unknown'}`,
     },
     ...(worker.legacy_source?.kind === 'ambiguous_v3_ledger'
       ? worker.legacy_source.original_incarnations.map((incarnation, index) => ({

--- a/crabot-agent/src/workers/harness/harness.ts
+++ b/crabot-agent/src/workers/harness/harness.ts
@@ -6205,16 +6205,27 @@ export class WorkerHarness {
       // 2026-08-31 状态机修正:化身停止(idle/exited)一律落 halted,停因进 evidence——
       // ended_reason 细节留在化身记录上;closed 只由 manager 处置产生(killed);
       // superseded 由化身链新成员决定任务状态。
+      // finish_task(exit + summary)归 worker_finalized,自报 outcome/summary 进 evidence——
+      // 是 worker 的自称,不是任务终态。
+      const selfReport = state === 'exited' && report?.summary !== undefined
+        ? {
+          outcome: (endReason === 'failed' ? 'failed' : 'completed') as 'completed' | 'failed',
+          summary: report.summary,
+        }
+        : undefined
       const halt: TaskHaltEvidence | undefined = state === 'idle'
         ? { halted_at: now, halt_reason: 'turn_end' }
         : state === 'exited'
           ? {
             halted_at: now,
-            halt_reason: endReason === 'crashed'
-              ? 'crashed'
-              : endReason === 'pre_migration'
-                ? 'pre_migration'
-                : 'turn_end',
+            halt_reason: selfReport
+              ? 'worker_finalized'
+              : endReason === 'crashed'
+                ? 'crashed'
+                : endReason === 'pre_migration'
+                  ? 'pre_migration'
+                  : 'turn_end',
+            ...(selfReport ? { worker_self_report: selfReport } : {}),
             ...(endReason === 'crashed' || endReason === 'failed' ? { detail: endReason } : {}),
           }
           : undefined

--- a/crabot-agent/src/workers/harness/harness.ts
+++ b/crabot-agent/src/workers/harness/harness.ts
@@ -107,6 +107,7 @@ import {
   type Incarnation,
   type LedgerWorker,
   type ManagerKey,
+  type TaskHaltEvidence,
   type TaskStatus,
   type WorkerRecoveryNotice,
   type WorkerSupervision,
@@ -151,7 +152,7 @@ import { WorkerUiSnapshotStore, type WorkerUiActionId, type WorkerUiSnapshot } f
 import { projectWorkerActivity } from '../trace/activity-projection'
 import { readLegacyTraces } from '../legacy-source-reader.js'
 import { isLegacyContinuationAuth, type LegacyContinuationAuth } from './legacy-continuation-auth.js'
-import { applyStatusTransition, canTransition, isTerminalStatus, reviveTask, taskStatusFromIncarnation } from './task-status'
+import { applyStatusTransition, canTransition, isTerminalStatus } from './task-status'
 import { join, dirname } from 'path'
 import {
   InputDeliveryStore,
@@ -347,12 +348,22 @@ function settleCliTask(
   now: string,
 ): LedgerWorker['task'] {
   if (state === 'running') return task
-  if (state === 'idle') return applyStatusTransition(task, 'waiting_input', { now })
-  const target = taskStatusFromIncarnation('exited', report?.endReason)
-  if (target === 'running') return task
-  return applyStatusTransition(task, target, {
+  if (state === 'idle') {
+    return applyStatusTransition(task, 'halted', { now, halt: { halted_at: now, halt_reason: 'turn_end' } })
+  }
+  // 2026-08-31 状态机修正:化身退出落 halted,粗分类停因进 evidence;ended_reason 细节留在化身记录。
+  const reason = report?.endReason
+  if (reason === 'superseded') return task // 任务状态由化身链新成员决定
+  if (reason === 'killed') {
+    return applyStatusTransition(task, 'closed', { now, closed: { by: 'manager_stop' } })
+  }
+  return applyStatusTransition(task, 'halted', {
     now,
-    ...(target === 'failed' ? { error: report?.endReason ?? 'initial CLI process exited' } : {}),
+    halt: {
+      halted_at: now,
+      halt_reason: reason === 'crashed' ? 'crashed' : reason === 'pre_migration' ? 'pre_migration' : 'turn_end',
+      ...(reason === 'failed' || reason === 'crashed' ? { detail: reason } : {}),
+    },
   })
 }
 
@@ -1126,13 +1137,17 @@ export class WorkerHarness {
         const now = this.deps.now()
         const failed = await this.deps.ledger.upsertWorker(p.managerKey, workerId, (prev) => {
           if (!prev) return undefined
-          // VALID_TRANSITIONS 里 queued 没有直达 failed 的边(只能到 running/cancelled)。
-          // spawn 尝试确实发生过(我们已经调用了 provision/spawn),用 queued→running→failed
-          // 两跳把这次失败尝试如实记录下来,而不是绕开状态机改成不符合协议语义的 cancelled。
+          // VALID_TRANSITIONS 里 queued 没有直达 halted 的边(只能到 running/closed)。
+          // spawn 尝试确实发生过(我们已经调用了 provision/spawn),用 queued→running→halted
+          // 两跳把这次失败尝试如实记录下来,而不是绕开状态机。
           const running = applyStatusTransition(prev.task, 'running', { now })
-          const nextTask = applyStatusTransition(running, 'failed', {
-            error: err instanceof Error ? err.message : String(err),
+          const nextTask = applyStatusTransition(running, 'halted', {
             now,
+            halt: {
+              halted_at: now,
+              halt_reason: 'crashed',
+              detail: err instanceof Error ? err.message : String(err),
+            },
           })
           const incarnations = patchIncarnationBySeq(prev.incarnations, impl, 1, {
             state: 'exited',
@@ -1244,7 +1259,7 @@ export class WorkerHarness {
       // create a redirect hold, receipt, or inbox item after the tool has timed out.
       this.assertSynchronousInputDeadline(synchronousDeadlineAt, deliveryId)
       if (!found) throw new WorkerNotFoundError(workerId)
-      if (found.worker.task.status === 'cancelled') throw new TaskCancelledError(workerId)
+      if (found.worker.task.status === 'closed') throw new TaskCancelledError(workerId)
       const mainline = requireMainlineIncarnation(found.worker)
       if (
         opts?.immediate_redirect === true &&
@@ -2017,7 +2032,7 @@ export class WorkerHarness {
       const found = await this.deps.ledger.findWorker(workerId)
       if (!found) throw new WorkerNotFoundError(workerId)
       const { managerKey, worker } = found
-      if (worker.task.status === 'cancelled') {
+      if (worker.task.status === 'closed') {
         await this.appendEvent(workerId, 1, 'state_changed', {
           kind: 'dead_letter',
           reason: 'task_cancelled',
@@ -2039,7 +2054,7 @@ export class WorkerHarness {
       const expired = this.expiredInboxDelivery(item, legacy.seq)
       if (expired) return expired
       if (
-        (worker.task.status !== 'completed' && worker.task.status !== 'failed') ||
+        worker.task.status !== 'halted' ||
         !['completed', 'failed', 'pre_migration'].includes(legacy.ended_reason)
       ) {
         throw new Error('WorkerHarness.sendToWorker: legacy worker is not eligible for continuation')
@@ -2486,12 +2501,12 @@ export class WorkerHarness {
       const found = await this.deps.ledger.findWorker(workerId)
       if (!found) throw new WorkerNotFoundError(workerId)
       const { worker, managerKey } = found
-      // cancelled 是唯一硬拒绝(protocol-agent-v3 §5.5,与 sendToWorker/continueTerminalWorker
-      // 的 cancelled 短路对齐)。若主线化身已因 killWorker 落 exited,不加这道校验会让
-      // handoffIncarnation 跳过 kill 段直接 provision+spawn 新化身,reopenTaskForContinuation
-      // 命中终态走 reviveTask——用户明确要求终止的任务被无声复活成 running。completed/failed
-      // 允许切换(等价于"在办任务换实现"续办的合理场景,§5.3),只有 cancelled 硬拒绝。
-      if (worker.task.status === 'cancelled') throw new TaskCancelledError(workerId)
+      // closed 是唯一硬拒绝(protocol-agent-v3 §5.5,与 sendToWorker/continueTerminalWorker
+      // 的 closed 短路对齐)。若主线化身已因 killWorker 落 exited,不加这道校验会让
+      // handoffIncarnation 跳过 kill 段直接 provision+spawn 新化身,把用户明确要求终止的
+      // 任务无声复活成 running。halted 允许切换(等价于"在办任务换实现"续办的合理场景,
+      // §5.3),只有 closed 硬拒绝。
+      if (worker.task.status === 'closed') throw new TaskCancelledError(workerId)
       const mainline = requireMainlineIncarnation(worker)
       const handoff = await this.handoffIncarnation(managerKey, worker, requireExecutableIncarnation(mainline), impl, note ?? '')
       restoredDurableReceipt = handoff.restoredDurableReceipt
@@ -2577,14 +2592,14 @@ export class WorkerHarness {
         if (expired) return expired
 
         // task 在锁外投递期间被 killWorker 打断(如 send 卡在 tmux 投递期间调 kill,这条
-        // 消息在拿到这把锁之前就已经确定要走接续路径了):§5.5"唯一硬拒绝:cancelled"只
+        // 消息在拿到这把锁之前就已经确定要走接续路径了):§5.5"唯一硬拒绝:closed"只
         // 约束 sendToWorker 入队前的把关(见该方法顶部),这里是入队之后才发现的迟到判定,
-        // 不能再用同一处把关。cancelled 是终态,不能被下面的 reviveIncarnation/handoffIncarnation
-        // 经 reopenTaskForContinuation → reviveTask 复活成 running——那样会让已经明确要求
-        // 终止的 task 又"activate"出一个新化身。同时"send_to_worker 投递永不因状态失败"
+        // 不能再用同一处把关。closed 是唯一终态,不能被下面的 reviveIncarnation/handoffIncarnation
+        // 复活成 running——那样会让已经明确要求终止的 task 又"activate"出一个新化身。
+        // 同时"send_to_worker 投递永不因状态失败"
         // 是调用方(inbox.flush)的既有契约,消息不能静默消失:丢弃这条并记 dead-letter 事件,
         // 不重新抛出(抛出会砸向早已异步返回的 sendToWorker 调用方,变成没人处理的 rejection)。
-        if (worker.task.status === 'cancelled') {
+        if (worker.task.status === 'closed') {
           await this.appendEvent(workerId, curSeq, 'state_changed', {
             kind: 'dead_letter',
             reason: 'task_cancelled',
@@ -5143,7 +5158,7 @@ export class WorkerHarness {
     const message = 'agent restart: execution context lost for agent-native system task'
     const failed = await this.deps.ledger.upsertWorker(managerKey, worker.worker_id, (prev) => {
       if (!prev) return undefined
-      const nextTask = transitionTaskTo(prev.task, 'failed', { error: message, now })
+      const nextTask = transitionTaskTo(prev.task, 'closed', { now, closed: { by: 'system', note: message } })
       const supervision = supervisionAfterMainlineTransition(prev.supervision, nextTask.status, 'exited', 0, now)
       return { ...prev, task: nextTask, ...(supervision ? { supervision } : {}), updated_at: now }
     })
@@ -5157,9 +5172,10 @@ export class WorkerHarness {
   }
 
   /**
-   * reconcileOnStartup 判死分支:落 failed(ended_reason='crashed')+ exited 事件。三种判死
+   * reconcileOnStartup 判死分支:落 halted(crashed)+ exited 事件。三种判死
    * 场景(adapter 报 exited / adapter 未注册 / adapter.state() 抛错)共用同一段收尾——三者
-   * 语义上都是"至此已经没有任何证据证明这个非终态 worker 还活着"。
+   * 语义上都是"至此已经没有任何证据证明这个非终态 worker 还活着"。任务不落终态:
+   * "载体死了"是事实,"任务失败"是判断,由 manager 处置落定。
    */
   private async markCrashed(
     managerKey: ManagerKey,
@@ -5171,7 +5187,10 @@ export class WorkerHarness {
     const crashed = await this.deps.ledger.upsertWorker(managerKey, worker.worker_id, (prev) => {
       if (!prev) return undefined
       const current = findIncarnation(prev, mainline.impl, mainline.seq)
-      const nextTask = transitionTaskTo(prev.task, 'failed', { error: detailReason, now })
+      const nextTask = transitionTaskTo(prev.task, 'halted', {
+        now,
+        halt: { halted_at: now, halt_reason: 'crashed', detail: detailReason },
+      })
       const incarnations = patchIncarnationBySeq(prev.incarnations, mainline.impl, mainline.seq, {
         state: 'exited',
         ended_at: now,
@@ -5373,7 +5392,7 @@ export class WorkerHarness {
       // Waiting for the worker lock or ledger must never turn into a late redirect.
       this.assertSynchronousInputDeadline(deadlineAt, deliveryId)
       if (!found) throw new WorkerNotFoundError(workerId)
-      if (found.worker.task.status === 'cancelled') throw new TaskCancelledError(workerId)
+      if (found.worker.task.status === 'closed') throw new TaskCancelledError(workerId)
       const current = requireMainlineIncarnation(found.worker)
       if (
         !isExecutableIncarnation(current) ||
@@ -5424,7 +5443,7 @@ export class WorkerHarness {
     }
     // `cancelAfterVerifiedStop` / `supersedeAfterVerifiedStop` writes ledger truth before the
     // operation becomes succeeded, so restart reconciliation can complete either boundary.
-    if (operation.kind === 'stop' && !handoffSupersede && found?.worker.task.status === 'cancelled') {
+    if (operation.kind === 'stop' && !handoffSupersede && found?.worker.task.status === 'closed') {
       return this.settleControlOperation(current, 'succeeded', 'task was already cancelled after verified stop')
     }
     const incarnation = found?.worker.incarnations.find((item) => item.incarnation_id === operation.incarnation_id)
@@ -5493,7 +5512,7 @@ export class WorkerHarness {
       if (!previous || isTerminalStatus(previous.task.status)) return previous
       const mainline = mainlineIncarnation(previous)
       if (!mainline || mainline.incarnation_id !== incarnation.incarnation_id) return previous
-      const task = applyStatusTransition(previous.task, 'cancelled', { now })
+      const task = applyStatusTransition(previous.task, 'closed', { now, closed: { by: 'manager_stop' } })
       const incarnations = previous.incarnations.map((item) => {
         if (item.forked_from !== undefined && isExecutableIncarnation(item) && item.state !== 'exited') {
           return { ...item, state: 'exited' as const, ended_at: now, ended_reason: 'killed' as const }
@@ -6001,20 +6020,38 @@ export class WorkerHarness {
         return
       }
 
-      let desired: TaskStatus
-      if (external === 'running') desired = 'running'
-      else if (external === 'idle') {
-        const bgRunning = (await this.deps.hasRunningBg?.(h.worker_id)) ?? false
-        desired = bgRunning || this.hasPendingBgNotification(h.worker_id) ? 'running' : 'waiting_input'
-      } else {
-        desired = taskStatusFromIncarnation('exited', report?.endReason)
-      }
       const now = this.deps.now()
+      let desired: TaskStatus
+      let halt: TaskHaltEvidence | undefined
+      if (external === 'running') {
+        desired = 'running'
+      } else if (external === 'idle') {
+        const bgRunning = (await this.deps.hasRunningBg?.(h.worker_id)) ?? false
+        desired = bgRunning || this.hasPendingBgNotification(h.worker_id) ? 'running' : 'halted'
+        halt = { halted_at: now, halt_reason: 'turn_end' }
+      } else {
+        // 2026-08-31 状态机修正:化身退出落 halted(粗分类停因进 evidence);manager 发起的
+        // 停止(killed)事实成立即 closed,stop operation 的核验判据依赖这一点。
+        const reason = report?.endReason
+        if (reason === 'killed') {
+          desired = 'closed'
+        } else if (reason === 'superseded') {
+          desired = 'running' // 占位:任务状态由化身链新成员决定(与既有语义一致)
+        } else {
+          desired = 'halted'
+          halt = {
+            halted_at: now,
+            halt_reason: reason === 'crashed' ? 'crashed' : reason === 'pre_migration' ? 'pre_migration' : 'turn_end',
+            ...(reason === 'failed' || reason === 'crashed' ? { detail: reason } : {}),
+          }
+        }
+      }
       const committed = await this.deps.ledger.upsertWorker(managerKey, h.worker_id, (prev) => {
         if (!prev) return undefined
         const task = prev.task.status === desired ? prev.task : applyStatusTransition(prev.task, desired, {
           now,
-          ...(desired === 'failed' ? { error: report?.endReason ?? 'CLI incarnation exited' } : {}),
+          ...(desired === 'halted' && halt ? { halt } : {}),
+          ...(desired === 'closed' ? { closed: { by: 'manager_stop' as const } } : {}),
         })
         const incarnations = patchIncarnationBySeq(prev.incarnations, h.impl, h.seq, {
           state: external,
@@ -6149,7 +6186,6 @@ export class WorkerHarness {
 
       // An idle builtin incarnation with an owned shell is still executing work:
       // end_turn is its wait primitive, not task completion.
-      const waitingInput = state === 'idle' ? true : undefined
       const pendingStop = state === 'exited' && (await this.controlOperationStore.active(h.worker_id)).some(
         (operation) => operation.kind === 'stop' && operation.incarnation_id === target.incarnation_id,
       )
@@ -6158,11 +6194,31 @@ export class WorkerHarness {
       const preserveTaskForStop = state === 'exited' && (
         pendingStop || unverifiedStop
       )
+      // 2026-08-31 状态机修正:化身停止(idle/exited)一律落 halted,停因进 evidence——
+      // ended_reason 细节留在化身记录上;closed 只由 manager 处置产生(killed);
+      // superseded 由化身链新成员决定任务状态。
+      const halt: TaskHaltEvidence | undefined = state === 'idle'
+        ? { halted_at: now, halt_reason: 'turn_end' }
+        : state === 'exited'
+          ? {
+            halted_at: now,
+            halt_reason: endReason === 'crashed'
+              ? 'crashed'
+              : endReason === 'pre_migration'
+                ? 'pre_migration'
+                : 'turn_end',
+            ...(endReason === 'crashed' || endReason === 'failed' ? { detail: endReason } : {}),
+          }
+          : undefined
       const nextStatus: TaskStatus = preserveTaskForStop
         ? worker.task.status
         : state === 'idle' && (this.hasPendingBgNotification(h.worker_id) || await this.deps.hasRunningBg?.(h.worker_id))
           ? 'running'
-          : taskStatusFromIncarnation(state, endReason, waitingInput)
+          : state === 'exited' && endReason === 'superseded'
+            ? 'running' // 占位:任务状态由化身链新成员决定(与既有语义一致)
+            : state === 'exited' && endReason === 'killed'
+              ? 'closed' // manager 发起的停止,事实成立即关闭
+              : 'halted'
       // CLI 从 `waiting_action` 转回 `waiting_text` 时，公开协议层仍是 `idle`。
       // completionSource 才是回合边界的权威证据，不能因投影状态相同而过滤。
       const shouldCreateTurn = report?.completionSource !== undefined
@@ -6188,7 +6244,11 @@ export class WorkerHarness {
         if (nextStatus === prev.task.status && current?.state === state) return prev
         const nextTask = nextStatus === prev.task.status
           ? prev.task
-          : applyStatusTransition(prev.task, nextStatus, { now })
+          : applyStatusTransition(prev.task, nextStatus, {
+            now,
+            ...(nextStatus === 'halted' && halt ? { halt } : {}),
+            ...(nextStatus === 'closed' ? { closed: { by: 'manager_stop' as const } } : {}),
+          })
         // session_ref 现读现取,同上面 fork 分支的注释。
         const incarnations = patchIncarnationBySeq(
           prev.incarnations,
@@ -6543,7 +6603,7 @@ function ledgerHandoffEvidence(worker: LedgerWorker, source: Incarnation): Hando
     {
       source: 'ledger',
       reference: `incarnation:${sourceId}:outcome`,
-      summary: `Source outcome: ${worker.task.outcome ?? source.ended_reason ?? 'unknown'}`,
+      summary: `Source outcome: ${worker.task.halt?.worker_self_report?.summary ?? worker.task.halt?.halt_reason ?? source.ended_reason ?? 'unknown'}`,
     },
     ...(worker.legacy_source?.kind === 'ambiguous_v3_ledger'
       ? worker.legacy_source.original_incarnations.map((incarnation, index) => ({
@@ -6720,22 +6780,17 @@ function patchIncarnationBySeq(
 }
 
 /**
- * §5.3 化身接续:把 task 的状态与派生字段重新置回 running,供接续产出的新化身使用。
+ * §5.3 化身接续:把 task 的状态置回 running,供接续产出的新化身使用。
  *
- * 终态化身之上继续开一个新化身是显式的"延续"动作,不是 task-status.ts 描述的线性状态机
- * 内的一次迁移——VALID_TRANSITIONS 里终态(completed/failed/cancelled)无出边是"同一次
- * 尝试内不允许原地复活"的不变量。task 已经终态时,不由 harness 自行拼接字段绕开状态机,
- * 而是走 task-status.ts 官方暴露的受控出口 `reviveTask`(protocol-agent-v3 §5.2"接续
- * 例外")——状态机模块自己承载这条例外,harness 只是调用方。
+ * 2026-08-31 状态机修正后,halted→running 是普通续办边(applyStatusTransition 正常校验,
+ * 顺带清掉上一次停止的 halt evidence);唯一终态 closed 没有"接续复活"出边——send_to_worker
+ * 入队前的把关已对 closed 硬拒绝,走不到这里。
  *
- * task 尚未终态时分两种情况:已经是 running 的(如台账的终态回调还没追上 adapter 的真实
- * 状态,接续发生前 task.status 本就还是 running)不需要任何迁移,直接原样返回(此时按
- * task-status.ts 维护的不变量,completed_at/error 本就已经是未设置状态,无需重置);
- * 其余非终态(queued/waiting_input)走 applyStatusTransition 的正常校验路径迁到 running。
+ * 已经是 running 的(如台账的终态回调还没追上 adapter 的真实状态,接续发生前 task.status
+ * 本就还是 running)不需要任何迁移,直接原样返回。
  */
 function reopenTaskForContinuation(task: LedgerWorker['task'], now: string): LedgerWorker['task'] {
   if (task.status === 'running') return task
-  if (isTerminalStatus(task.status)) return reviveTask(task, { now })
   return applyStatusTransition(task, 'running', { now })
 }
 
@@ -6752,7 +6807,7 @@ function reopenTaskForContinuation(task: LedgerWorker['task'], now: string): Led
 function transitionTaskTo(
   task: LedgerWorker['task'],
   to: TaskStatus,
-  opts: { error?: string; now: string }
+  opts: { now: string; halt?: TaskHaltEvidence; closed?: { by: 'manager_stop' | 'admin' | 'system' | 'migration'; note?: string } }
 ): LedgerWorker['task'] {
   if (canTransition(task.status, to)) {
     return applyStatusTransition(task, to, opts)

--- a/crabot-agent/src/workers/harness/harness.ts
+++ b/crabot-agent/src/workers/harness/harness.ts
@@ -6092,11 +6092,19 @@ export class WorkerHarness {
       }
       const committed = await this.deps.ledger.upsertWorker(managerKey, h.worker_id, (prev) => {
         if (!prev) return undefined
-        const task = prev.task.status === desired ? prev.task : applyStatusTransition(prev.task, desired, {
-          now,
-          ...(desired === 'halted' && halt ? { halt } : {}),
-          ...(desired === 'closed' ? { closed: { by: 'manager_stop' as const } } : {}),
-        })
+        let task: LedgerWorker['task']
+        if (prev.task.status === desired) {
+          // 同为 halted 但停因升级(如 turn_end 后载体又 crashed):覆盖 evidence。
+          task = desired === 'halted' && halt && prev.task.halt?.halt_reason !== halt.halt_reason
+            ? { ...prev.task, halt }
+            : prev.task
+        } else {
+          task = applyStatusTransition(prev.task, desired, {
+            now,
+            ...(desired === 'halted' && halt ? { halt } : {}),
+            ...(desired === 'closed' ? { closed: { by: 'manager_stop' as const } } : {}),
+          })
+        }
         const incarnations = patchIncarnationBySeq(prev.incarnations, h.impl, h.seq, {
           state: external,
           session_ref: h.session_ref || target.session_ref,
@@ -6302,13 +6310,20 @@ export class WorkerHarness {
         // 应保持 task running）。只有两者都已经一致时才是无操作。
         const current = findIncarnation(prev, h.impl, h.seq)
         if (nextStatus === prev.task.status && current?.state === state) return prev
-        const nextTask = nextStatus === prev.task.status
-          ? prev.task
-          : applyStatusTransition(prev.task, nextStatus, {
+        let nextTask: LedgerWorker['task']
+        if (nextStatus !== prev.task.status) {
+          nextTask = applyStatusTransition(prev.task, nextStatus, {
             now,
             ...(nextStatus === 'halted' && halt ? { halt } : {}),
             ...(nextStatus === 'closed' ? { closed: { by: 'manager_stop' as const } } : {}),
           })
+        } else if (nextStatus === 'halted' && halt && prev.task.halt?.halt_reason !== halt.halt_reason) {
+          // 同为 halted 但停因升级(如 turn_end 后载体又 crashed):用新 evidence 覆盖,
+          // 不让台账停留在更良性的旧停因上。
+          nextTask = { ...prev.task, halt }
+        } else {
+          nextTask = prev.task
+        }
         // session_ref 现读现取,同上面 fork 分支的注释。
         const incarnations = patchIncarnationBySeq(
           prev.incarnations,

--- a/crabot-agent/src/workers/harness/harness.ts
+++ b/crabot-agent/src/workers/harness/harness.ts
@@ -361,8 +361,8 @@ function settleCliTask(
     now,
     halt: {
       halted_at: now,
-      halt_reason: reason === 'crashed' ? 'crashed' : reason === 'pre_migration' ? 'pre_migration' : 'turn_end',
-      ...(reason === 'failed' || reason === 'crashed' ? { detail: reason } : {}),
+      halt_reason: reason === 'crashed' ? 'crashed' : reason === 'pre_migration' ? 'pre_migration' : reason === undefined ? 'unknown' : 'turn_end',
+      ...(reason === 'failed' || reason === 'crashed' || reason === undefined ? { detail: reason ?? 'exited_without_end_reason' } : {}),
     },
   })
 }
@@ -2053,6 +2053,10 @@ export class WorkerHarness {
       }
       const expired = this.expiredInboxDelivery(item, legacy.seq)
       if (expired) return expired
+      // 可续办集合(2026-08-31 状态机修正):仅 halted。ended_reason 白名单里
+      // completed/failed/pre_migration 现只有 pre_migration 可达——旧终态 v2 任务经
+      // importer 映射为 closed(硬拒绝,见上方短路),不再参与续办;白名单保留是为
+      // 兼容既有台账上历史化身记录的事实值。
       if (
         worker.task.status !== 'halted' ||
         !['completed', 'failed', 'pre_migration'].includes(legacy.ended_reason)
@@ -6052,8 +6056,8 @@ export class WorkerHarness {
           desired = 'halted'
           halt = {
             halted_at: now,
-            halt_reason: reason === 'crashed' ? 'crashed' : reason === 'pre_migration' ? 'pre_migration' : 'turn_end',
-            ...(reason === 'failed' || reason === 'crashed' ? { detail: reason } : {}),
+            halt_reason: reason === 'crashed' ? 'crashed' : reason === 'pre_migration' ? 'pre_migration' : reason === undefined ? 'unknown' : 'turn_end',
+            ...(reason === 'failed' || reason === 'crashed' || reason === undefined ? { detail: reason ?? 'exited_without_end_reason' } : {}),
           }
         }
       }
@@ -6227,9 +6231,12 @@ export class WorkerHarness {
                 ? 'crashed'
                 : endReason === 'pre_migration'
                   ? 'pre_migration'
-                  : 'turn_end',
+                  : endReason === undefined
+                    ? 'unknown'
+                    : 'turn_end',
             ...(selfReport ? { worker_self_report: selfReport } : {}),
-            ...(endReason === 'crashed' || endReason === 'failed' ? { detail: endReason } : {}),
+            ...(endReason === 'crashed' || endReason === 'failed' ? { detail: endReason }
+              : endReason === undefined ? { detail: 'exited_without_end_reason' } : {}),
           }
           : undefined
       const nextStatus: TaskStatus = preserveTaskForStop

--- a/crabot-agent/src/workers/harness/harness.ts
+++ b/crabot-agent/src/workers/harness/harness.ts
@@ -5111,6 +5111,14 @@ export class WorkerHarness {
         // nonexistent adapter or mutate the historical record during startup reconciliation.
         return 'unchanged'
       }
+      // 幂等短路 2(2026-08-31 状态机修正):halted 任务不再参与"判死"。判死的对象是
+      // "台账说非终态、却没有证据证明还活着"的 worker;而 halted + 化身 exited 是一份
+      // 完整一致的停止记录——无论是正常停(turn_end/worker_finalized,等 manager 处置)
+      // 还是已记录的崩溃(crashed,recovery notice 已落),处置责任都在 manager,
+      // 重启对账不得重复判定、重复打扰。
+      if (worker.task.status === 'halted' && mainline.state === 'exited') {
+        return 'unchanged'
+      }
 
       const adapter = this.deps.adapters.get(mainline.impl)
       if (!adapter) {

--- a/crabot-agent/src/workers/harness/harness.ts
+++ b/crabot-agent/src/workers/harness/harness.ts
@@ -4943,7 +4943,10 @@ export class WorkerHarness {
         } catch {
           probe = 'failed'
         }
-        if (probe === 'exited' || (observed.mode === 'default' && probe === 'idle')) {
+        if (observed.mode === 'default' && (probe === 'exited' || probe === 'idle')) {
+          // default 巡检只盯 running 主线:idle/exited 走生命周期状态同步,不造 due。
+          // periodic_report 不在此列(协议 §6.3:覆盖 running 与 halted),probe 结果
+          // 不能吞掉它的到期汇报。
           await this.updateSupervision(found.managerKey, workerId, observed, now)
           return { handle, stateToSync: probe }
         }

--- a/crabot-agent/src/workers/harness/harness.ts
+++ b/crabot-agent/src/workers/harness/harness.ts
@@ -108,6 +108,7 @@ import {
   type LedgerWorker,
   type ManagerKey,
   type TaskHaltEvidence,
+  type TaskHaltReason,
   type TaskStatus,
   type WorkerRecoveryNotice,
   type WorkerSupervision,
@@ -339,6 +340,19 @@ function cliContractState(kind: NonNullable<IncarnationHandle['initial_input']>[
     case 'exited': return 'exited'
     default: return 'idle'
   }
+}
+
+const HALT_REASON_SEVERITY: Record<TaskHaltReason, number> = {
+  turn_end: 0,
+  worker_finalized: 1,
+  unknown: 2,
+  pre_migration: 2,
+  crashed: 3,
+}
+
+/** 停因严重度:同为 halted 时,仅当新停因更严重才覆盖 evidence,良性结果不得抹掉严重事实。 */
+function haltSeverity(reason: TaskHaltReason): number {
+  return HALT_REASON_SEVERITY[reason] ?? 0
 }
 
 function settleCliTask(
@@ -5077,6 +5091,7 @@ export class WorkerHarness {
     try {
       delivery = await this.appendEventAwaitingDelivery(h.worker_id, h.seq, 'state_changed', {
         to: 'running' satisfies WorkerContractState,
+        source: 'liveness_stall',
         ...(text ? { text } : {}),
       })
     } catch (err) {
@@ -6094,8 +6109,8 @@ export class WorkerHarness {
         if (!prev) return undefined
         let task: LedgerWorker['task']
         if (prev.task.status === desired) {
-          // 同为 halted 但停因升级(如 turn_end 后载体又 crashed):覆盖 evidence。
-          task = desired === 'halted' && halt && prev.task.halt?.halt_reason !== halt.halt_reason
+          // 同为 halted:仅当停因升级时覆盖(方向性,见 haltSeverity)。
+          task = desired === 'halted' && halt && haltSeverity(halt.halt_reason) > haltSeverity(prev.task.halt?.halt_reason ?? 'turn_end')
             ? { ...prev.task, halt }
             : prev.task
         } else {
@@ -6317,9 +6332,12 @@ export class WorkerHarness {
             ...(nextStatus === 'halted' && halt ? { halt } : {}),
             ...(nextStatus === 'closed' ? { closed: { by: 'manager_stop' as const } } : {}),
           })
-        } else if (nextStatus === 'halted' && halt && prev.task.halt?.halt_reason !== halt.halt_reason) {
-          // 同为 halted 但停因升级(如 turn_end 后载体又 crashed):用新 evidence 覆盖,
-          // 不让台账停留在更良性的旧停因上。
+        } else if (
+          nextStatus === 'halted' && halt &&
+          haltSeverity(halt.halt_reason) > haltSeverity(prev.task.halt?.halt_reason ?? 'turn_end')
+        ) {
+          // 同为 halted 但停因升级(如 turn_end 后载体又 crashed):用更严重的新 evidence
+          // 覆盖,不让台账停留在更良性的旧停因上;降级方向(良性覆盖严重)一律拒绝。
           nextTask = { ...prev.task, halt }
         } else {
           nextTask = prev.task

--- a/crabot-agent/src/workers/harness/harness.ts
+++ b/crabot-agent/src/workers/harness/harness.ts
@@ -5595,6 +5595,35 @@ export class WorkerHarness {
       this.deps.now(),
       detail,
     )
+    if (operation.kind === 'stop' && status === 'unknown') {
+      // 协议 §5.2:停止核验失败(unknown)→ 任务落 halted 并注明停止未核验。
+      // 不假装已停止,也不宣称失败;operation_settled 事件(下方投递)会唤醒 manager 处置。
+      try {
+        // 名下仍有 running bg entity 时任务按 §5.2 映射保持 running(工作未停),不落 halted。
+        const bgRunning = (await this.deps.hasRunningBg?.(operation.worker_id)) ?? false
+        if (!bgRunning) {
+          const now = this.deps.now()
+          const halt: TaskHaltEvidence = {
+            halted_at: now,
+            halt_reason: 'unknown',
+            stop_unverified: true,
+            detail,
+          }
+          await this.deps.ledger.upsertWorker(operation.manager_key, operation.worker_id, (prev) => {
+            if (!prev || isTerminalStatus(prev.task.status)) return prev
+            if (prev.task.status === 'halted' && prev.task.halt?.stop_unverified) return prev // 幂等
+            if (prev.task.status === 'halted') {
+              return { ...prev, task: { ...prev.task, halt }, updated_at: now }
+            }
+            const task = applyStatusTransition(prev.task, 'halted', { now, halt })
+            return { ...prev, task, updated_at: now }
+          })
+        }
+      } catch (error) {
+        // 结算路径的兜底失败(含 bg registry 不可用)只记日志,不反噬 control operation 的结算语义。
+        console.error(`[WorkerHarness] stop-unknown task halt failed for ${operation.worker_id}:`, error)
+      }
+    }
     const delivery = this.deliverControlOperationNotifications(settled.worker_id)
     // Without a Manager operation router this is only the durable audit append. Finish it before
     // returning the control result; otherwise a short-lived harness can lose the audit record.

--- a/crabot-agent/src/workers/harness/ledger-store.ts
+++ b/crabot-agent/src/workers/harness/ledger-store.ts
@@ -196,16 +196,19 @@ export class LedgerStore {
       throw new Error(`[LedgerStore] manager_key mismatch or invalid ledger for ${key}`)
     }
     let archivedAmbiguousLegacy = false
+    let legacyStatusMigrated = false
     const workers = ledger.workers.map((worker) => {
       const materialized = materializeLegacyIncarnations(worker)
       archivedAmbiguousLegacy ||= materialized.archived
-      return materialized.worker
+      const migrated = migrateLegacyTaskStatus(materialized.worker)
+      legacyStatusMigrated ||= migrated.changed
+      return migrated.worker
     })
     for (const worker of workers) {
       this.assertWorkerOwner(key, worker)
       assertWorkerLegacyShape(worker)
     }
-    return { ledger: { ...ledger, workers }, archivedAmbiguousLegacy }
+    return { ledger: { ...ledger, workers }, archivedAmbiguousLegacy: archivedAmbiguousLegacy || legacyStatusMigrated }
   }
 
   private async readLedgerFileStrict(key: ManagerKey): Promise<WorkerLedger> {
@@ -259,8 +262,51 @@ function legacyIncarnationId(workerId: string, index: number): string {
  * If a numeric fork has multiple candidates, archive the complete worker rather than guessing a
  * mainline or making every worker under the Manager unreadable.
  */
-function materializeLegacyIncarnations(worker: LedgerWorker): { worker: LedgerWorker; archived: boolean } {
-  const bySeq = new Map<number, Incarnation[]>()
+/**
+ * 2026-08-31 状态机修正(base-protocol §5.10)的存量迁移:读取时把旧 6 态归一到
+ * queued/running/halted/closed(spec §7——waiting_input→halted、旧终态→closed(by migration))。
+ * evidence 从主线化身尽力重建(ended_at 作 halted_at;ended_reason crashed → 'crashed');
+ * 推不出的停因记 'unknown' 并 warn,绝不因旧数据阻断启动。已迁移过的原样返回(changed=false)。
+ */
+function migrateLegacyTaskStatus(worker: LedgerWorker): { worker: LedgerWorker; changed: boolean } {
+  const status = worker.task.status
+  if (status === 'queued' || status === 'running' || status === 'halted' || status === 'closed') {
+    return { worker, changed: false }
+  }
+  const mainline = worker.incarnations.filter((incarnation) => incarnation.forked_from === undefined).at(-1)
+  const haltedAt = mainline?.ended_at ?? worker.updated_at
+  if (status === 'waiting_input') {
+    const haltReason = mainline?.ended_reason === 'crashed' ? 'crashed' as const : 'turn_end' as const
+    return {
+      worker: {
+        ...worker,
+        task: { ...worker.task, status: 'halted', halt: { halted_at: haltedAt, halt_reason: haltReason } },
+      },
+      changed: true,
+    }
+  }
+  if (status === 'completed' || status === 'failed' || status === 'cancelled') {
+    const legacyError = (worker.task as Record<string, unknown>).error
+    const note = `migrated from v3 旧值 ${status}${typeof legacyError === 'string' && legacyError ? `；error: ${legacyError}` : ''}`
+    return {
+      worker: {
+        ...worker,
+        task: { ...worker.task, status: 'closed', closed: { at: haltedAt, by: 'migration', note } },
+      },
+      changed: true,
+    }
+  }
+  console.warn(`[LedgerStore] 未知任务状态 '${status}' 归一为 halted(unknown) for ${worker.worker_id}`)
+  return {
+    worker: {
+      ...worker,
+      task: { ...worker.task, status: 'halted', halt: { halted_at: haltedAt, halt_reason: 'unknown' } },
+    },
+    changed: true,
+  }
+}
+
+function materializeLegacyIncarnations(worker: LedgerWorker): { worker: LedgerWorker; archived: boolean } {  const bySeq = new Map<number, Incarnation[]>()
   const ids = new Set<string>()
   const incarnations = worker.incarnations.map((incarnation, index) => {
     const incarnationId = incarnation.incarnation_id ?? legacyIncarnationId(worker.worker_id, index)

--- a/crabot-agent/src/workers/harness/ledger-store.ts
+++ b/crabot-agent/src/workers/harness/ledger-store.ts
@@ -303,7 +303,11 @@ function materializeLegacyIncarnations(worker: LedgerWorker): { worker: LedgerWo
         ...worker,
         task: isTerminalTaskStatus(worker.task.status)
           ? worker.task
-          : { ...worker.task, status: 'failed', completed_at: worker.task.completed_at ?? archivedAt },
+          : {
+            ...worker.task,
+            status: 'closed',
+            closed: { at: archivedAt, by: 'migration', note: 'ambiguous_v3_ledger archived' },
+          },
         incarnations: [{
           incarnation_id: archiveId,
           seq: 1,
@@ -336,7 +340,7 @@ function materializeLegacyIncarnations(worker: LedgerWorker): { worker: LedgerWo
 }
 
 function isTerminalTaskStatus(status: LedgerWorker['task']['status']): boolean {
-  return status === 'completed' || status === 'failed' || status === 'cancelled'
+  return status === 'closed'
 }
 
 function assertWorkerLegacyShape(worker: LedgerWorker): void {

--- a/crabot-agent/src/workers/harness/ledger-store.ts
+++ b/crabot-agent/src/workers/harness/ledger-store.ts
@@ -305,8 +305,8 @@ function materializeLegacyIncarnations(worker: LedgerWorker): { worker: LedgerWo
           ? worker.task
           : {
             ...worker.task,
-            status: 'closed',
-            closed: { at: archivedAt, by: 'migration', note: 'ambiguous_v3_ledger archived' },
+            status: 'halted',
+            halt: { halted_at: archivedAt, halt_reason: 'pre_migration' },
           },
         incarnations: [{
           incarnation_id: archiveId,

--- a/crabot-agent/src/workers/harness/ledger-types.ts
+++ b/crabot-agent/src/workers/harness/ledger-types.ts
@@ -2,7 +2,34 @@ import type { ModuleId, FriendId, SessionId, TaskId } from '../../types'
 import type { IncarnationEndReason, IncarnationId, WorkerContractState, WorkerImplId, WorkspaceInstructionSnapshot } from '../types'
 
 export type TaskPriority = 'low' | 'normal' | 'high' | 'urgent'
-export type TaskStatus = 'queued' | 'running' | 'waiting_input' | 'completed' | 'failed' | 'cancelled'
+export type TaskStatus = 'queued' | 'running' | 'halted' | 'closed'
+
+/**
+ * 载体停止的事实分类(protocol-agent-v3 §5.2)。只描述"怎么停的",不对任务成败下判断——
+ * 自报、推断与成败判断全部不进状态机(2026-08-31 修正,见 base-protocol §5.10)。
+ */
+export type TaskHaltReason = 'turn_end' | 'worker_finalized' | 'crashed' | 'pre_migration' | 'unknown'
+
+/**
+ * task 停在 `halted` 期间附着的事实记录(spec 2026-08-31-worker-stop-oversight-design §5.1)。
+ * `worker_self_report` 是 worker 的自称,不是任务达成与否的结论;化身级细节(ended_reason、
+ * session 引用)留在化身记录与 turn 记录上,此处不复制。
+ */
+export interface TaskHaltEvidence {
+  halted_at: string
+  halt_reason: TaskHaltReason
+  /** 仅 worker_finalized(`finish_task`)时存在。 */
+  worker_self_report?: { outcome: 'completed' | 'failed'; summary: string }
+  /** request_worker_stop 核验失败(unknown)时为 true。 */
+  stop_unverified?: boolean
+}
+
+/** 唯一终态 `closed` 的关闭信息(manager/admin/系统处置产生,worker 行为不可达)。 */
+export interface TaskClosedInfo {
+  at: string
+  by: 'manager_stop' | 'admin' | 'system' | 'migration'
+  note?: string
+}
 
 /** Manager loop, worker ledger and worker ownership share this session key. */
 export type ManagerKey = `${ModuleId}::${SessionId}`
@@ -125,10 +152,11 @@ export interface LedgerWorker {
     input?: Record<string, unknown>
     tags?: string[]
     goal?: string
-    outcome?: string
     created_at: string
-    completed_at?: string
-    error?: string
+    /** 载体停止的事实记录(status='halted' 时存在;续办回 running 时清除)。 */
+    halt?: TaskHaltEvidence
+    /** 关闭信息(status='closed' 时存在)。 */
+    closed?: TaskClosedInfo
   }
   origin: {
     spawned_by_episode?: string

--- a/crabot-agent/src/workers/harness/ledger-types.ts
+++ b/crabot-agent/src/workers/harness/ledger-types.ts
@@ -22,6 +22,8 @@ export interface TaskHaltEvidence {
   worker_self_report?: { outcome: 'completed' | 'failed'; summary: string }
   /** request_worker_stop 核验失败(unknown)时为 true。 */
   stop_unverified?: boolean
+  /** 崩溃/启动失败等原因原文(事实记录,非成败判断;替换旧 task.error 的承载)。 */
+  detail?: string
 }
 
 /** 唯一终态 `closed` 的关闭信息(manager/admin/系统处置产生,worker 行为不可达)。 */

--- a/crabot-agent/src/workers/harness/task-status.ts
+++ b/crabot-agent/src/workers/harness/task-status.ts
@@ -1,34 +1,37 @@
 /**
  * v3 task 状态机：精简状态集下的合法转换表、派生字段维护。
  *
- * 协议对齐：base-protocol §5.10（TaskStatus v3 精简集）、protocol-agent-v3 §5.2（化身→task 映射）。
- * 移植参考：crabot-admin/src/task-state-machine.ts（结构参考，v3 重写）。
+ * 协议对齐：base-protocol §5.10（TaskStatus 4 态集，2026-08-31 修正）、
+ * protocol-agent-v3 §5.2（化身→task 映射与边所有权）。
+ *
+ * **边所有权**（2026-08-31 修正）：worker 行为只产生事实边 `running ⇄ halted`；
+ * 唯一终态 `closed` 只能由 manager/admin 处置动作产生（request_worker_stop、
+ * admin 取消、迁移），worker 事件——含 builtin `finish_task` 的自报 outcome、
+ * CLI 停止钩子、crash——在任何路径下都不得把 task 写到 `closed`。停因与
+ * worker 自报是 `halt` evidence 标注，不进状态机。
  */
 
-import type { TaskStatus, LedgerWorker } from './ledger-types'
-import type { WorkerContractState, IncarnationEndReason } from '../types'
+import type { TaskClosedInfo, TaskHaltEvidence, TaskStatus, LedgerWorker } from './ledger-types'
 
 /**
  * v3 状态转换表：每个状态的出边列表。
- * queued → running|cancelled
- * running → waiting_input|completed|failed|cancelled
- * waiting_input → running|completed|failed|cancelled
- * 终态（completed/failed/cancelled） → 无出边
+ * queued → running | closed（未拉起即被处置）
+ * running → halted | closed（manager 可从 running 直达 closed）
+ * halted → running | closed（续办 / 收尾）
+ * 终态（closed） → 无出边
  */
 export const VALID_TRANSITIONS: Readonly<Record<TaskStatus, readonly TaskStatus[]>> = {
-  queued: ['running', 'cancelled'],
-  running: ['waiting_input', 'completed', 'failed', 'cancelled'],
-  waiting_input: ['running', 'completed', 'failed', 'cancelled'],
-  completed: [],
-  failed: [],
-  cancelled: [],
+  queued: ['running', 'closed'],
+  running: ['halted', 'closed'],
+  halted: ['running', 'closed'],
+  closed: [],
 } as const
 
-const TERMINAL_STATUSES: ReadonlySet<TaskStatus> = new Set(['completed', 'failed', 'cancelled'])
+const TERMINAL_STATUSES: ReadonlySet<TaskStatus> = new Set(['closed'])
 
 /**
  * 判断状态是否为终态。
- * 终态：completed、failed、cancelled
+ * 终态：closed（唯一）。
  */
 export function isTerminalStatus(status: TaskStatus): boolean {
   return TERMINAL_STATUSES.has(status)
@@ -65,29 +68,35 @@ export class InvalidTaskTransitionError extends Error {
   }
 }
 
+export interface StatusTransitionOpts {
+  now: string
+  /** to='halted' 时必填——进入事实状态必须携带事实记录。 */
+  halt?: TaskHaltEvidence
+  /** to='closed' 时必填——终态必须可回答"谁、何时关的"。 */
+  closed?: Omit<TaskClosedInfo, 'at'>
+}
+
 /**
  * 应用状态转换并回填派生字段。
  *
  * 派生字段维护规则（task 子对象内）：
- * - completed_at：仅在转换至终态时回填为 now；其他情况清空
- * - error：仅在转换至 failed 时设置（opts.error）；其他情况清空
- * - outcome：按 opts.outcome 透传（如未指定则保持）
- *
- * 语义边界：updated_at 是 LedgerWorker（父级）的字段，不是 task 子对象的字段。
- * 维护职责归调用方（harness 在 upsertWorker 时设 LedgerWorker.updated_at）。
+ * - halt：进入 halted 时必须由 opts.halt 提供；halted→running（续办）时清除——
+ *   evidence 属于"当前这次停止"，续办即复位；
+ * - closed：进入 closed 时由 opts.closed 提供（at 由 now 回填）；closed 无出边，
+ *   不存在离开时的清理问题；
+ * - 语义边界：updated_at 是 LedgerWorker（父级）的字段，不是 task 子对象的字段。
+ *   维护职责归调用方（harness 在 upsertWorker 时设 LedgerWorker.updated_at）。
  *
  * @param task 当前 task（来自 LedgerWorker.task）
  * @param to 目标状态
- * @param opts 可选参数：{ error?, outcome?, now }
- * @returns 新的 task 对象（不修改原 task，仅回填上述派生字段）
- * @throws InvalidTaskTransitionError 若状态转换非法
+ * @throws InvalidTaskTransitionError 若状态转换非法，或 halted/closed 缺少必填标注
  */
 export function applyStatusTransition(
   task: LedgerWorker['task'],
   to: TaskStatus,
-  opts?: { error?: string; outcome?: string; now: string },
+  opts?: StatusTransitionOpts,
 ): LedgerWorker['task'] {
-  const { error, outcome, now } = opts || {}
+  const { now, halt, closed } = opts || {}
 
   if (!canTransition(task.status, to)) {
     throw new InvalidTaskTransitionError(task.status, to)
@@ -95,103 +104,17 @@ export function applyStatusTransition(
 
   const next: LedgerWorker['task'] = { ...task, status: to }
 
-  // 派生字段：completed_at（仅终态回填）
-  if (isTerminalStatus(to)) {
-    next.completed_at = now
-  } else {
-    next.completed_at = undefined
+  if (to === 'halted') {
+    if (!halt || !now) throw new InvalidTaskTransitionError(task.status, to)
+    next.halt = halt
+  } else if (task.status === 'halted') {
+    next.halt = undefined
   }
 
-  // 派生字段：error（仅 failed 时设置）
-  if (to === 'failed') {
-    if (error !== undefined) {
-      next.error = error
-    }
-  } else {
-    next.error = undefined
-  }
-
-  // 派生字段：outcome（按 opts 透传）
-  if (outcome !== undefined) {
-    next.outcome = outcome
+  if (to === 'closed') {
+    if (!closed || !now) throw new InvalidTaskTransitionError(task.status, to)
+    next.closed = { at: now, ...closed }
   }
 
   return next
-}
-
-/**
- * §5.2"接续例外"的受控出口：终态 task 经 §5.3 透明接续（revive/handoff）触发时，重新
- * 置回 running。这是 VALID_TRANSITIONS 里终态"无出边"规则唯一允许的出边——不是给状态机
- * 新增一条常规迁移边，只服务于接续这一显式动作，因此不经 canTransition 校验，而是显式
- * 校验入参确为终态（非终态调用属于用错入口，常规迁移应走 applyStatusTransition，直接
- * 抛错防止调用方把它当成通用的"强制置 running"旁路使用）。
- *
- * @param task 当前 task（须为终态：completed/failed/cancelled）
- * @param opts.now 接续发生的时间戳
- * @returns 新的 task 对象：status='running'，completed_at/error 清空
- * @throws InvalidTaskTransitionError 若 task 当前不是终态
- */
-export function reviveTask(task: LedgerWorker['task'], opts: { now: string }): LedgerWorker['task'] {
-  if (!isTerminalStatus(task.status)) {
-    throw new InvalidTaskTransitionError(task.status, 'running')
-  }
-  return { ...task, status: 'running', completed_at: undefined, error: undefined }
-}
-
-/**
- * 化身契约状态 → task 状态的映射。
- *
- * 规则（protocol-agent-v3 §5.2）：
- * - contractState=running → 'running'
- * - contractState=idle → waitingInput ? 'waiting_input' : 'running'
- * - contractState=exited:
- *   - endReason=completed → 'completed'
- *   - endReason=failed, crashed → 'failed'
- *   - endReason=killed → 'cancelled'
- *   - endReason=pre_migration → 'failed'
- *   - endReason=superseded → 'running'（占位值，调用方应根据新化身决定最终状态）
- *
- * 特别说明：当化身被取代（superseded）时，task 生命周期应由化身链新成员决定。
- * 本函数返回 'running' 作为占位值，调用方需读取新化身并覆盖此状态，不应单用此函数的返回值。
- *
- * @param contractState worker 当前合约状态
- * @param endReason 化身终止原因（exited 状态时必须指定）
- * @param waitingInput 是否在等待输入（idle 状态时有意义）
- * @returns 对应的 task 状态
- */
-export function taskStatusFromIncarnation(
-  contractState: WorkerContractState,
-  endReason?: IncarnationEndReason,
-  waitingInput?: boolean,
-): TaskStatus {
-  switch (contractState) {
-    case 'running':
-      return 'running'
-
-    case 'idle':
-      return waitingInput ? 'waiting_input' : 'running'
-
-    case 'exited':
-      switch (endReason) {
-        case 'completed':
-          return 'completed'
-        case 'failed':
-        case 'crashed':
-          return 'failed'
-        case 'killed':
-          return 'cancelled'
-        case 'pre_migration':
-          return 'failed'
-        case 'superseded':
-          // 占位值：由调用方根据新化身覆盖
-          return 'running'
-        default:
-          // 防守：如果 exited 但无 endReason，视为异常
-          return 'failed'
-      }
-
-    default:
-      // 协议应保证 contractState 是已知值，此分支不应到达
-      return 'running'
-  }
 }

--- a/crabot-agent/src/workers/legacy-importer.ts
+++ b/crabot-agent/src/workers/legacy-importer.ts
@@ -10,7 +10,6 @@ import { readLegacyTraces, type LegacyTrace } from './legacy-source-reader.js'
 
 const VERSION = 1
 const SYSTEM_KEY = 'admin-web::system-tasks' as ManagerKey
-const PRE_MIGRATION_ERROR = '旧执行上下文在 v3 切换时终止，可创建新化身续办'
 const LEGACY_STATUSES = new Set([
   'pending',
   'planning',
@@ -179,12 +178,18 @@ async function makeWorker(
       ...(isRecord(task.input) ? { input: task.input } : {}),
       ...(strings(task.tags) ? { tags: task.tags } : {}),
       ...(goal ? { goal } : {}),
-      ...(outcome ? { outcome } : {}),
       created_at: task.created_at,
-      completed_at: endedAt,
-      ...(mapped.preMigration
-        ? { error: PRE_MIGRATION_ERROR }
-        : typeof task.error === 'string' ? { error: task.error } : {}),
+      ...(mapped.status === 'closed'
+        ? {
+          closed: {
+            at: endedAt,
+            by: 'migration' as const,
+            note: `migrated from v2 ${task.status}`
+              + (outcome ? `；outcome: ${outcome}` : '')
+              + (typeof task.error === 'string' ? `；error: ${task.error}` : ''),
+          },
+        }
+        : { halt: { halted_at: endedAt, halt_reason: 'pre_migration' as const } }),
     },
     origin: {
       trigger_type: trigger(source),
@@ -294,10 +299,11 @@ function mapStatus(status: string): {
   readonly endedReason: 'completed' | 'failed' | 'killed' | 'pre_migration'
   readonly preMigration: boolean
 } {
-  if (status === 'completed') return { status, endedReason: 'completed', preMigration: false }
-  if (status === 'failed') return { status, endedReason: 'failed', preMigration: false }
-  if (status === 'cancelled') return { status, endedReason: 'killed', preMigration: false }
-  return { status: 'failed', endedReason: 'pre_migration', preMigration: true }
+  // 2026-08-31 状态机修正：旧终态一律归 closed（旧值记入 closed.note），旧非终态归 halted(pre_migration)。
+  if (status === 'completed') return { status: 'closed', endedReason: 'completed', preMigration: false }
+  if (status === 'failed') return { status: 'closed', endedReason: 'failed', preMigration: false }
+  if (status === 'cancelled') return { status: 'closed', endedReason: 'killed', preMigration: false }
+  return { status: 'halted', endedReason: 'pre_migration', preMigration: true }
 }
 
 function trigger(source: Record<string, unknown>): 'message' | 'scheduled' | 'system' {

--- a/crabot-agent/tests/manager/bootstrap.test.ts
+++ b/crabot-agent/tests/manager/bootstrap.test.ts
@@ -286,7 +286,7 @@ describe('manager bootstrap（P5 Task 1）', () => {
     // 化身自然结束(非 kill)时三个实现给的都是 'completed'。
     onStateChange!({ worker_id: 'w-builtin-1', seq: 1, impl: 'builtin', session_ref: 'w-builtin-1-ref' }, 'exited', { endReason: 'completed' })
 
-    await waitUntil(async () => (await stack.ledger.findWorker('w-builtin-1'))?.worker.task.status === 'completed')
+    await waitUntil(async () => (await stack.ledger.findWorker('w-builtin-1'))?.worker.task.status === 'halted')
     const after = await stack.ledger.findWorker('w-builtin-1')
     expect(after?.worker.incarnations[0].state).toBe('exited')
 
@@ -309,7 +309,7 @@ describe('manager bootstrap（P5 Task 1）', () => {
     await Promise.allSettled(routeSpy.mock.results.map((r) => r.value as Promise<unknown>))
   })
 
-  it('关闭期间 worker crashed 仍落账为 failed，但不再路由 Manager episode', async () => {
+  it('关闭期间 worker crashed 仍落账为 halted(crashed)，但不再路由 Manager episode', async () => {
     const stack = buildManagerStack(makeDeps({ isClosing: () => true }))
     const managerKey = 'wechat::sess-closing' as ManagerKey
     await stack.ledger.upsertWorker(managerKey, 'w-closing', () =>
@@ -324,7 +324,7 @@ describe('manager bootstrap（P5 Task 1）', () => {
       { endReason: 'crashed' },
     )
 
-    await waitUntil(async () => (await stack.ledger.findWorker('w-closing'))?.worker.task.status === 'failed')
+    await waitUntil(async () => (await stack.ledger.findWorker('w-closing'))?.worker.task.status === 'halted')
     expect(routeSpy).not.toHaveBeenCalled()
   })
 

--- a/crabot-agent/tests/manager/episode-projection.test.ts
+++ b/crabot-agent/tests/manager/episode-projection.test.ts
@@ -24,7 +24,7 @@ function trace(over: Partial<ManagerEpisodeTrace> = {}): ManagerEpisodeTrace {
 }
 
 const facts = new Map<string, EpisodeWorkerFact>([
-  ['w-1', { worker_id: 'w-1', title: '部署 Minecraft', status: 'waiting_input' }],
+  ['w-1', { worker_id: 'w-1', title: '部署 Minecraft', status: 'halted' }],
 ])
 
 describe('projectManagerEpisode', () => {
@@ -56,7 +56,7 @@ describe('projectManagerEpisode', () => {
     const joined = projectManagerEpisode(trace({
       trigger: { type: 'worker_event', summary: 'worker 事件:state_changed (w-1)', source: 'worker:w-1' },
     }), facts)
-    expect(joined.worker_ref).toEqual({ worker_id: 'w-1', title: '部署 Minecraft', state_to: 'waiting_input' })
+    expect(joined.worker_ref).toEqual({ worker_id: 'w-1', title: '部署 Minecraft', state_to: 'halted' })
 
     const missing = projectManagerEpisode(trace({
       trigger: { type: 'worker_event', summary: 'worker 事件:state_changed (w-missing)' },
@@ -96,7 +96,7 @@ describe('projectManagerEpisode', () => {
     }), facts))).toBe('你：V6 部署好了吗')
     expect(managerActivitySummary(projectManagerEpisode(trace({
       trigger: { type: 'worker_event', summary: 'worker 事件:state_changed (w-1)', source: 'worker:w-1' },
-    }), facts))).toBe('部署 Minecraft：等输入')
+    }), facts))).toBe('部署 Minecraft：已停止待处置')
   })
 
   it('目标 string 自身被 300 字截断时仍返回可读前缀', () => {

--- a/crabot-agent/tests/manager/events.test.ts
+++ b/crabot-agent/tests/manager/events.test.ts
@@ -184,7 +184,7 @@ describe('agent 对外事件（P5 Task 2）', () => {
         worker_id: 'w-1',
         task_id: 'task-1',
         old_status: 'running',
-        new_status: 'completed',
+        new_status: 'halted',
         manager_key: DIALOG_OBJECT_ID,
       }
       publish('agent.task_status_changed', payload)
@@ -504,7 +504,7 @@ describe('agent 对外事件（P5 Task 2）', () => {
         worker_id: 'w-wired',
         task_id: 'task-wired',
         old_status: 'queued',
-        new_status: 'completed',
+        new_status: 'halted',
         manager_key: DIALOG_OBJECT_ID,
       })
     })
@@ -544,7 +544,7 @@ describe('agent 对外事件（P5 Task 2）', () => {
       }))
       const onStateChange = capturedOnStateChange(stack.adapters.get('builtin'))
       onStateChange!({ worker_id: 'w-nopub', seq: 1, impl: 'builtin', session_ref: 'w-nopub-ref' }, 'exited', { endReason: 'completed' })
-      await waitUntil(async () => (await stack.ledger.findWorker('w-nopub'))?.worker.task.status === 'completed')
+      await waitUntil(async () => (await stack.ledger.findWorker('w-nopub'))?.worker.task.status === 'halted')
       expect(unhandled).toEqual([])
     })
   })

--- a/crabot-agent/tests/manager/manager-integration.test.ts
+++ b/crabot-agent/tests/manager/manager-integration.test.ts
@@ -62,7 +62,7 @@ import { chunksFromContent } from '../engine/helpers/mock-stream.js'
 // 共用 helpers
 // ============================================================================
 
-async function waitUntil(cond: () => Promise<boolean> | boolean, timeoutMs = 8000, intervalMs = 20): Promise<void> {
+async function waitUntil(cond: () => Promise<boolean> | boolean, timeoutMs = 20000, intervalMs = 20): Promise<void> {
   const deadline = Date.now() + timeoutMs
   while (Date.now() < deadline) {
     if (await cond()) return
@@ -427,11 +427,11 @@ describe('manager-integration（P4 Task 10：真实 ManagerRegistry + 真实 Wor
       // 等真实 worker 后台把 finish_task 跑完——burst 是 fire-and-forget,不是靠猜时序。
       await waitUntil(async () => {
         const workers = await assembly.harness.listWorkers(assembly.managerKeyFor(key))
-        return workers.some((w) => w.task.status === 'completed')
+        return workers.some((w) => w.task.status === 'halted')
       })
       const [worker] = await assembly.harness.listWorkers(assembly.managerKeyFor(key))
       // 台账 task 终态正确
-      expect(worker.task.status).toBe('completed')
+      expect(worker.task.status).toBe('halted')
       expect(worker.incarnations).toHaveLength(1)
       expect(worker.incarnations[0].state).toBe('exited')
       expect(worker.incarnations[0].ended_reason).toBe('completed')
@@ -517,7 +517,7 @@ describe('manager-integration（P4 Task 10：真实 ManagerRegistry + 真实 Wor
 
       await waitUntil(async () => {
         const workers = await assembly.harness.listWorkers(assembly.managerKeyFor(SYSTEM_TASKS_MANAGER_KEY))
-        return workers.some((w) => w.task.status === 'completed')
+        return workers.some((w) => w.task.status === 'halted')
       })
       const [workerA] = await assembly.harness.listWorkers(assembly.managerKeyFor(SYSTEM_TASKS_MANAGER_KEY))
       const exitedEventA = findWorkerExitedEvent(assembly.events, workerA.worker_id)!
@@ -565,19 +565,19 @@ describe('manager-integration（P4 Task 10：真实 ManagerRegistry + 真实 Wor
 
       await waitUntil(async () => {
         const workers = await assembly.harness.listWorkers(assembly.managerKeyFor(SYSTEM_TASKS_MANAGER_KEY))
-        return workers.some((w) => w.worker_id !== workerA.worker_id && w.task.status === 'failed')
+        return workers.some((w) => w.worker_id !== workerA.worker_id && w.task.status === 'halted')
       })
       const workersAfterB = await assembly.harness.listWorkers(assembly.managerKeyFor(SYSTEM_TASKS_MANAGER_KEY))
       const workerB = workersAfterB.find((w) => w.worker_id !== workerA.worker_id)!
       // 核心验收：worker 自己声明的 outcome:'failed' 一路落到台账，不再被记成成功。
-      expect(workerB.task.status).toBe('failed')
+      expect(workerB.task.status).toBe('halted')
       expect(workerB.incarnations[0].ended_reason).toBe('failed')
       // 同一份真值也进了对外事件（appendEvent 带的是提交后的 task.status）——manager 的
       // 台账块与 admin 侧读端点看到的都是这一份。
       const exitedEventB = findWorkerExitedEvent(assembly.events, workerB.worker_id)!
-      expect(exitedEventB.task_status).toBe('failed')
+      expect(exitedEventB.task_status).toBe('halted')
       // 对照组：成功的 worker A 仍然是 completed，修复没有把所有退出一刀切判失败。
-      expect(workersAfterB.find((w) => w.worker_id === workerA.worker_id)!.task.status).toBe('completed')
+      expect(workersAfterB.find((w) => w.worker_id === workerA.worker_id)!.task.status).toBe('halted')
 
       managerScript.queue.push({
         toolCalls: [{ name: 'get_worker_terminal', id: 'r2', input: { worker_id: workerB.worker_id } }],
@@ -906,7 +906,7 @@ describe('manager-integration（P4 Task 10：真实 ManagerRegistry + 真实 Wor
 
       const exitedEvent = findExitedEvent()!
       // 1) 任务本身是成功的(finish_task(outcome:'completed') 的结构化确证照常落台账)
-      expect(exitedEvent.task_status).toBe('completed')
+      expect(exitedEvent.task_status).toBe('halted')
       // 2) #61 那条 lastText 确实为空——它是 assistant text 来源,这个 worker 没有
       expect(exitedEvent.detail?.text).toBeUndefined()
       // 3) 核心验收:worker 写在 finish_task 里的结论到达了 manager 的唤醒事件

--- a/crabot-agent/tests/manager/p5-integration.test.ts
+++ b/crabot-agent/tests/manager/p5-integration.test.ts
@@ -162,7 +162,7 @@ function makeLedgerWorker(p: {
   }
 }
 
-async function waitUntil(cond: () => boolean | Promise<boolean>, timeoutMs = 6000, intervalMs = 20): Promise<void> {
+async function waitUntil(cond: () => boolean | Promise<boolean>, timeoutMs = 15000, intervalMs = 20): Promise<void> {
   const deadline = Date.now() + timeoutMs
   while (Date.now() < deadline) {
     if (await cond()) return
@@ -380,7 +380,7 @@ describe('P5 集成：manager 栈启动接线（Task 6）', () => {
       makeLedgerWorker({ workerId: 'w-a1', managerKey: alice, status: 'running', updatedAt: '2026-02-02T00:00:00.000Z' }),
     )
     await stack.ledger.upsertWorker(alice, 'w-a2', () =>
-      makeLedgerWorker({ workerId: 'w-a2', managerKey: alice, status: 'completed', updatedAt: '2026-02-03T00:00:00.000Z' }),
+      makeLedgerWorker({ workerId: 'w-a2', managerKey: alice, status: 'closed', updatedAt: '2026-02-03T00:00:00.000Z' }),
     )
     await stack.ledger.upsertWorker(bob, 'w-b1', () =>
       makeLedgerWorker({ workerId: 'w-b1', managerKey: bob, status: 'running', updatedAt: '2026-02-01T00:00:00.000Z' }),
@@ -772,7 +772,7 @@ describe('P5 集成：manager 栈启动接线（Task 6）', () => {
         return found?.worker.incarnations[0].state === 'exited'
       })
       const after = await stack.ledger.findWorker('w-stale')
-      expect(after!.worker.task.status).toBe('failed')
+      expect(after!.worker.task.status).toBe('halted')
       expect(routeSpy).toHaveBeenCalled()
     } finally {
       await internals.onStop()

--- a/crabot-agent/tests/manager/read-model.test.ts
+++ b/crabot-agent/tests/manager/read-model.test.ts
@@ -114,8 +114,8 @@ describe('filterAndPageWorkers', () => {
     const all = [
       entry(ALICE, 'w-running', { status: 'running' }),
       entry(ALICE, 'w-queued', { status: 'queued' }),
-      entry(ALICE, 'w-failed', { status: 'failed' }),
-      entry(ALICE, 'w-completed', { status: 'completed' }),
+      entry(ALICE, 'w-failed', { status: 'closed' }),
+      entry(ALICE, 'w-completed', { status: 'closed' }),
     ]
 
     it('单值形态', () => {
@@ -125,9 +125,9 @@ describe('filterAndPageWorkers', () => {
     })
 
     it('数组形态', () => {
-      const result = filterAndPageWorkers(all, { status: ['queued', 'failed'], include_terminal: true })
-      expect(result.items.map((w) => w.worker_id).sort()).toEqual(['w-failed', 'w-queued'])
-      expect(result.pagination.total_items).toBe(2)
+      const result = filterAndPageWorkers(all, { status: ['queued', 'closed'], include_terminal: true })
+      expect(result.items.map((w) => w.worker_id).sort()).toEqual(['w-completed', 'w-failed', 'w-queued'])
+      expect(result.pagination.total_items).toBe(3)
     })
 
     it('空数组表示"不匹配任何状态",返回空', () => {
@@ -144,10 +144,10 @@ describe('filterAndPageWorkers', () => {
   describe('决策视野/历史/legacy/q/impl', () => {
     const all = [
       entry(ALICE, 'w-active', { status: 'running', title: '部署 Minecraft', impl: 'codex' }),
-      entry(ALICE, 'w-idle', { status: 'waiting_input', title: '等待补充', impl: 'claude-code' }),
-      entry(ALICE, 'w-terminal', { status: 'completed', title: '旧部署', impl: 'codex' }),
+      entry(ALICE, 'w-idle', { status: 'halted', title: '等待补充', impl: 'claude-code' }),
+      entry(ALICE, 'w-terminal', { status: 'closed', title: '旧部署', impl: 'codex' }),
       entry(ALICE, 'w-legacy-live', { status: 'running', title: '续办中的 legacy', impl: 'builtin', legacy: true }),
-      entry(ALICE, 'w-legacy', { status: 'completed', title: '历史导入', impl: 'legacy', legacy: true }),
+      entry(ALICE, 'w-legacy', { status: 'closed', title: '历史导入', impl: 'legacy', legacy: true }),
     ]
 
     it('默认只返回非终态且排除 legacy，计数保留全局事实', () => {
@@ -169,7 +169,7 @@ describe('filterAndPageWorkers', () => {
 
     it('2400 terminal + 6 active 的默认结果严格有界', () => {
       const huge = [
-        ...Array.from({ length: 2400 }, (_, i) => entry(ALICE, `w-done-${i}`, { status: 'completed' })),
+        ...Array.from({ length: 2400 }, (_, i) => entry(ALICE, `w-done-${i}`, { status: 'closed' })),
         ...Array.from({ length: 6 }, (_, i) => entry(ALICE, `w-live-${i}`, { status: 'running' })),
       ]
       const result = filterAndPageWorkers(huge, {})
@@ -365,11 +365,11 @@ describe('filterAndPageWorkers', () => {
     it('total_items 反映过滤后的总数,而非全量', () => {
       const mixed = [
         entry(ALICE, 'w-1', { status: 'running' }),
-        entry(ALICE, 'w-2', { status: 'failed' }),
-        entry(ALICE, 'w-3', { status: 'failed' }),
+        entry(ALICE, 'w-2', { status: 'closed' }),
+        entry(ALICE, 'w-3', { status: 'closed' }),
       ]
       const result = filterAndPageWorkers(mixed, {
-        status: 'failed',
+        status: 'closed',
         include_terminal: true,
         pagination: { page: 1, page_size: 1 },
       })
@@ -408,13 +408,13 @@ describe('filterAndPageWorkers', () => {
 
   it('三种过滤条件可组合', () => {
     const all = [
-      entry(ALICE, 'w-hit', { status: 'failed', createdAt: '2026-07-03T00:00:00.000Z' }),
+      entry(ALICE, 'w-hit', { status: 'closed', createdAt: '2026-07-03T00:00:00.000Z' }),
       entry(ALICE, 'w-status-miss', { status: 'running', createdAt: '2026-07-03T00:00:00.000Z' }),
-      entry(BOB, 'w-dialog-miss', { status: 'failed', createdAt: '2026-07-03T00:00:00.000Z' }),
-      entry(ALICE, 'w-time-miss', { status: 'failed', createdAt: '2026-07-09T00:00:00.000Z' }),
+      entry(BOB, 'w-dialog-miss', { status: 'closed', createdAt: '2026-07-03T00:00:00.000Z' }),
+      entry(ALICE, 'w-time-miss', { status: 'closed', createdAt: '2026-07-09T00:00:00.000Z' }),
     ]
     const result = filterAndPageWorkers(all, {
-      status: ['failed', 'cancelled'],
+      status: ['closed'],
       include_terminal: true,
       manager_key: ALICE,
       time_range: { start: '2026-07-01T00:00:00.000Z', end: '2026-07-04T00:00:00.000Z' },

--- a/crabot-agent/tests/manager/rpc-handlers.test.ts
+++ b/crabot-agent/tests/manager/rpc-handlers.test.ts
@@ -749,7 +749,7 @@ describe('list_workers_admin(§8.3)', () => {
   it('取全量台账 → filterAndPageWorkers(status 过滤 + 分页回显)', async () => {
     const entries = [
       { managerKey: `test::f1` as ManagerKey, worker: makeLedgerWorker({ workerId: 'w-1', status: 'running', updatedAt: '2026-01-03T00:00:00.000Z' }) },
-      { managerKey: `test::f1` as ManagerKey, worker: makeLedgerWorker({ workerId: 'w-2', status: 'completed', updatedAt: '2026-01-02T00:00:00.000Z' }) },
+      { managerKey: `test::f1` as ManagerKey, worker: makeLedgerWorker({ workerId: 'w-2', status: 'closed', updatedAt: '2026-01-02T00:00:00.000Z' }) },
       { managerKey: `test::f2` as ManagerKey, worker: makeLedgerWorker({ workerId: 'w-3', status: 'running', updatedAt: '2026-01-01T00:00:00.000Z' }) },
     ]
     const agent = buildAgent({ ledger: { listAllWorkers: async () => entries } })

--- a/crabot-agent/tests/manager/worker-tools.test.ts
+++ b/crabot-agent/tests/manager/worker-tools.test.ts
@@ -909,7 +909,7 @@ describe('worker control operations', () => {
     expect(parseOutput(interrupted.output)).toMatchObject({ operation: { worker_id: worker.worker_id, kind: 'interrupt', status: 'succeeded' } })
     expect(fake.interruptCalls).toHaveLength(1)
     const [afterInterrupt] = await harness.listWorkers(CTX.managerKey)
-    expect(afterInterrupt.task.status).not.toBe('cancelled')
+    expect(afterInterrupt.task.status).not.toBe('closed')
 
     const first = await stopWorker.call({ worker_id: worker.worker_id }, {})
     expect(first.isError).toBe(false)
@@ -917,7 +917,7 @@ describe('worker control operations', () => {
     expect(fake.killCalls).toHaveLength(1)
 
     const [afterFirst] = await harness.listWorkers(CTX.managerKey)
-    expect(afterFirst.task.status).toBe('cancelled')
+    expect(afterFirst.task.status).toBe('closed')
 
   })
 

--- a/crabot-agent/tests/unified-agent-trigger-schedule.test.ts
+++ b/crabot-agent/tests/unified-agent-trigger-schedule.test.ts
@@ -116,9 +116,9 @@ describe('trigger_schedule memory_maintenance system task', () => {
 
     await waitUntil(() => fixture.workers.get(result.task_id!)?.task.status === 'running')
     maintenance.resolve()
-    await waitUntil(() => fixture.workers.get(result.task_id!)?.task.status === 'completed')
+    await waitUntil(() => fixture.workers.get(result.task_id!)?.task.status === 'closed')
 
-    expect(fixture.writes.map((worker) => worker.task.status)).toEqual(['queued', 'running', 'completed'])
+    expect(fixture.writes.map((worker) => worker.task.status)).toEqual(['queued', 'running', 'closed'])
     expect(fixture.workers.get(result.task_id!)?.incarnations).toEqual([])
     expect(fixture.publish).toHaveBeenNthCalledWith(
       1,
@@ -134,7 +134,7 @@ describe('trigger_schedule memory_maintenance system task', () => {
     expect(fixture.publish).toHaveBeenNthCalledWith(
       2,
       'agent.task_status_changed',
-      expect.objectContaining({ old_status: 'running', new_status: 'completed' }),
+      expect.objectContaining({ old_status: 'running', new_status: 'closed' }),
     )
   })
 
@@ -151,14 +151,13 @@ describe('trigger_schedule memory_maintenance system task', () => {
       is_builtin: true,
     })
 
-    await waitUntil(() => fixture.workers.get(result.task_id!)?.task.status === 'failed')
+    await waitUntil(() => fixture.workers.get(result.task_id!)?.task.status === 'closed')
     const task = fixture.workers.get(result.task_id!)!.task
-    expect(task.error).toBe('memory unavailable')
-    expect(task.outcome).toBe('记忆维护失败：memory unavailable')
-    expect(fixture.writes.map((worker) => worker.task.status)).toEqual(['queued', 'running', 'failed'])
+    expect(task.closed?.note).toBe('记忆维护失败：memory unavailable')
+    expect(fixture.writes.map((worker) => worker.task.status)).toEqual(['queued', 'running', 'closed'])
     expect(fixture.publish).toHaveBeenLastCalledWith(
       'agent.task_status_changed',
-      expect.objectContaining({ old_status: 'running', new_status: 'failed' }),
+      expect.objectContaining({ old_status: 'running', new_status: 'closed' }),
     )
     expect(errorSpy).toHaveBeenCalled()
     errorSpy.mockRestore()

--- a/crabot-agent/tests/workers/builtin-injection.test.ts
+++ b/crabot-agent/tests/workers/builtin-injection.test.ts
@@ -207,7 +207,7 @@ describe('builtin worker 注入管道（harness → 工厂回退）', () => {
     expect(worker.task.status).toBe('running')
     await waitUntil(async () => {
       const [w] = await harness.listWorkers(managerKey)
-      return w.task.status === 'completed'
+      return w.task.status === 'halted'
     })
 
     // 语义不变量：worker 真的执行了工具调用、真的以 finish_task 收尾。
@@ -284,7 +284,8 @@ describe('builtin worker 注入管道（harness → 工厂回退）', () => {
     ).rejects.toThrow(/model slot 未配置/)
 
     const [w] = await harness.listWorkers(managerKey)
-    expect(w.task.status).toBe('failed')
+    expect(w.task.status).toBe('halted')
+    expect(w.task.halt?.halt_reason).toBe('crashed')
     expect(w.incarnations[0].ended_reason).toBe('failed')
   })
 })

--- a/crabot-agent/tests/workers/builtin-production-runtime.test.ts
+++ b/crabot-agent/tests/workers/builtin-production-runtime.test.ts
@@ -281,7 +281,7 @@ describe('builtin worker 生产装配（PR F 第 2 步）', () => {
 
     await waitUntil(async () => {
       const [w] = await internals.managerStack!.harness.listWorkers(managerKey)
-      return w.task.status === 'completed'
+      return w.task.status === 'halted'
     })
 
     // 语义不变量：工具真的执行了（文件真的被写出来），而且是在 workspace 里执行的。
@@ -563,7 +563,7 @@ describe('builtin worker 生产装配（PR F 第 2 步）', () => {
     const { workerId } = await spawnBuiltin(internals, managerKey)
     await waitUntil(async () => {
       const [w] = await internals.managerStack!.harness.listWorkers(managerKey)
-      return w.task.status === 'completed'
+      return w.task.status === 'halted'
     })
 
     const sessionPath = join(internals.managerStack!.builtinDataDir, workerId, 'session.jsonl')
@@ -746,7 +746,7 @@ describe('builtin worker 生产装配（PR F 第 2 步）', () => {
     await spawnBuiltin(internals, objB)
     await waitUntil(async () => {
       const [w] = await internals.managerStack!.harness.listWorkers(objB)
-      return w.task.status === 'completed'
+      return w.task.status === 'halted'
     })
     expect(workerBurstModels(runEngineSpy)).toEqual(['model-A', 'model-B'])
   })
@@ -760,7 +760,7 @@ describe('builtin worker 生产装配（PR F 第 2 步）', () => {
     const { workerId } = await spawnBuiltin(first, managerKey)
     await waitUntil(async () => {
       const [w] = await first.managerStack!.harness.listWorkers(managerKey)
-      return w.task.status === 'completed'
+      return w.task.status === 'halted'
     })
 
     // ---- 模拟进程重启：同一个 DATA_DIR 上重新装配一整套栈，内存里的 instances / 配置表全空。
@@ -862,7 +862,7 @@ describe('builtin worker 生产装配（PR F 第 2 步）', () => {
     internals.managerStack!.harness.deps.builtinSpawnDefaults = builtinDefaults
 
     const [w] = await internals.managerStack!.harness.listWorkers(managerKey)
-    expect(w.task.status).toBe('failed')
+    expect(w.task.status).toBe('halted')
     expect(w.incarnations[0].ended_reason).toBe('failed')
     // P6-A：episode admission 会在 wake 起点就建 manager 目录/最小 identity，
     // 失败路径也有异步 wake 在飞——等它落定，避免与 afterEach 的目录清理竞争。

--- a/crabot-agent/tests/workers/harness/harness-continuation.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-continuation.test.ts
@@ -346,7 +346,7 @@ describe('WorkerHarness — 透明接续：revive (capabilities().revive === tru
     }).nativeActivityStore
 
     fake.emitStateChange(sourceHandle, 'exited')
-    await waitUntil(async () => (await harness.listWorkers((`test::${'friend-1'}` as ManagerKey)))[0].task.status === 'completed')
+    await waitUntil(async () => (await harness.listWorkers((`test::${'friend-1'}` as ManagerKey)))[0].task.status === 'halted')
 
     await harness.sendToWorker(worker.worker_id, '继续执行')
     const [revived] = await harness.listWorkers((`test::${'friend-1'}` as ManagerKey))
@@ -405,11 +405,11 @@ describe('WorkerHarness — 透明接续：revive (capabilities().revive === tru
     const worker = await harness.spawnWorker(spawnParams())
     const h: IncarnationHandle = { worker_id: worker.worker_id, seq: 1, impl: 'builtin', session_ref: `ref-${worker.worker_id}#1` }
     fake.emitStateChange(h, 'exited')
-    await waitUntil(async () => (await harness.listWorkers((`test::${'friend-1'}` as ManagerKey)))[0].task.status === 'completed')
+    await waitUntil(async () => (await harness.listWorkers((`test::${'friend-1'}` as ManagerKey)))[0].task.status === 'halted')
 
     await harness.sendToWorker(worker.worker_id, 'continue')
     const [settled] = await harness.listWorkers((`test::${'friend-1'}` as ManagerKey))
-    expect(settled.task.status).toBe('completed')
+    expect(settled.task.status).toBe('halted')
     expect(settled.incarnations[1]).toMatchObject({ state: 'exited', ended_reason: 'completed' })
   })
 
@@ -433,7 +433,7 @@ describe('WorkerHarness — 透明接续：revive (capabilities().revive === tru
     adaptersMap.set('builtin', fake)
     const worker = await harness.spawnWorker(spawnParams())
     fake.emitStateChange({ worker_id: worker.worker_id, seq: 1, impl: 'builtin', session_ref: `ref-${worker.worker_id}#1` }, 'exited')
-    await waitUntil(async () => (await harness.listWorkers((`test::${'friend-1'}` as ManagerKey)))[0].task.status === 'completed')
+    await waitUntil(async () => (await harness.listWorkers((`test::${'friend-1'}` as ManagerKey)))[0].task.status === 'halted')
     const settlements: string[] = []
 
     await harness.sendToWorker(worker.worker_id, 'durable bg', {
@@ -479,7 +479,7 @@ describe('WorkerHarness — 透明接续：revive (capabilities().revive === tru
     adaptersMap.set('builtin', fake)
     const worker = await harness.spawnWorker(spawnParams())
     fake.emitStateChange({ worker_id: worker.worker_id, seq: 1, impl: 'builtin', session_ref: `ref-${worker.worker_id}#1` }, 'exited')
-    await waitUntil(async () => (await harness.listWorkers((`test::${'friend-1'}` as ManagerKey)))[0].task.status === 'completed')
+    await waitUntil(async () => (await harness.listWorkers((`test::${'friend-1'}` as ManagerKey)))[0].task.status === 'halted')
     const settlements: string[] = []
 
     await harness.sendToWorker(worker.worker_id, 'durable terminal retry', {
@@ -516,7 +516,7 @@ describe('WorkerHarness — 透明接续：revive (capabilities().revive === tru
     adaptersMap.set('builtin', fake)
     const worker = await harness.spawnWorker(spawnParams())
     fake.emitStateChange({ worker_id: worker.worker_id, seq: 1, impl: 'builtin', session_ref: `ref-${worker.worker_id}#1` }, 'exited')
-    await waitUntil(async () => (await harness.listWorkers((`test::${'friend-1'}` as ManagerKey)))[0].task.status === 'completed')
+    await waitUntil(async () => (await harness.listWorkers((`test::${'friend-1'}` as ManagerKey)))[0].task.status === 'halted')
     const settlements: string[] = []
 
     await harness.sendToWorker(worker.worker_id, 'durable bg', {
@@ -645,7 +645,7 @@ describe('WorkerHarness — 透明接续：revive (capabilities().revive === tru
     fake.emitStateChange(h, 'exited', 'failed')
     await waitUntil(async () => {
       const [w] = await harness.listWorkers((`test::${'friend-1'}` as ManagerKey))
-      return w.task.status === 'failed'
+      return w.task.status === 'halted'
     })
 
     await expect(harness.sendToWorker(worker.worker_id, '再试一次')).resolves.toBeUndefined()
@@ -761,7 +761,7 @@ describe('WorkerHarness — 透明接续：handoff (capabilities().revive === fa
 
     await harness.sendToWorker(worker.worker_id, 'continue')
     const [settled] = await harness.listWorkers((`test::${'friend-1'}` as ManagerKey))
-    expect(settled.task.status).toBe('completed')
+    expect(settled.task.status).toBe('halted')
     expect(settled.incarnations[settled.incarnations.length - 1]).toMatchObject({
       impl: 'claude-code',
       state: 'exited',
@@ -897,7 +897,7 @@ describe('WorkerHarness — 透明接续：handoff (capabilities().revive === fa
     fake.emitStateChange(h, 'exited', 'failed')
     await waitUntil(async () => {
       const [w] = await harness.listWorkers((`test::${'friend-1'}` as ManagerKey))
-      return w.task.status === 'failed'
+      return w.task.status === 'halted'
     })
 
     await expect(harness.sendToWorker(worker.worker_id, '接着把剩下的做完')).resolves.toBeUndefined()
@@ -1672,7 +1672,7 @@ describe('WorkerHarness — 终审 PoC 回归：M2 kill 与 in-flight flush 竞�
     await harness.killWorker(worker.worker_id, 'M2 PoC')
 
     const afterKill = (await harness.listWorkers((`test::${'friend-1'}` as ManagerKey)))[0]
-    expect(afterKill.task.status).toBe('cancelled')
+    expect(afterKill.task.status).toBe('closed')
 
     // 放行第一条，让它的 sendInput 正常返回，flush 的 while 循环继续处理队列里的第二条。
     releaseFirst()
@@ -1681,7 +1681,7 @@ describe('WorkerHarness — 终审 PoC 回归：M2 kill 与 in-flight flush 竞�
 
     const after = (await harness.listWorkers((`test::${'friend-1'}` as ManagerKey)))[0]
     // 核心断言：task 没有被第二条残留消息的透明接续复活成 running。
-    expect(after.task.status).toBe('cancelled')
+    expect(after.task.status).toBe('closed')
     expect(fake.resumeCalls).toHaveLength(0)
 
     // 残留条目没有静默消失：有 dead-letter 记录。
@@ -1713,7 +1713,7 @@ describe('WorkerHarness — 终审 PoC 回归：M2 kill 与 in-flight flush 竞�
 
     await harness.killWorker(worker.worker_id, 'M2 PoC 2')
     const afterKill = (await harness.listWorkers((`test::${'friend-1'}` as ManagerKey)))[0]
-    expect(afterKill.task.status).toBe('cancelled')
+    expect(afterKill.task.status).toBe('closed')
 
     // 放行卡住的 sendInput，让它抛出 WorkerExitedError（模拟 adapter 发现化身已经真的没了）
     // —— deliver() 的 catch 分支会把它转入 continueTerminalWorker。这条条目在 kill 发生时
@@ -1723,7 +1723,7 @@ describe('WorkerHarness — 终审 PoC 回归：M2 kill 与 in-flight flush 竞�
     await send
 
     const after = (await harness.listWorkers((`test::${'friend-1'}` as ManagerKey)))[0]
-    expect(after.task.status).toBe('cancelled') // 核心断言：没有被复活成 running
+    expect(after.task.status).toBe('closed') // 核心断言：没有被复活成 running
     expect(fake.resumeCalls).toHaveLength(0)
 
     const deadLetterEvents = events.filter((e) => e.kind === 'state_changed' && (e.detail as Record<string, unknown> | undefined)?.kind === 'dead_letter')
@@ -1861,7 +1861,7 @@ describe('WorkerHarness — 终审 PoC 回归：M3 continueTerminalWorker 守卫
       state: 'exited',
       ended_reason: 'completed',
     })
-    expect(settled.task.status).toBe('completed')
+    expect(settled.task.status).toBe('halted')
   })
 })
 
@@ -2048,7 +2048,7 @@ describe('WorkerHarness.switchWorkerImpl — 终审 PoC 回归：M3 cancelled �
     await harness.killWorker(worker.worker_id, '用户明确终止')
 
     const beforeSwitch = (await harness.listWorkers((`test::${'friend-1'}` as ManagerKey)))[0]
-    expect(beforeSwitch.task.status).toBe('cancelled')
+    expect(beforeSwitch.task.status).toBe('closed')
     events.length = 0
 
     // 主线化身已 exited（killed）→ handoffIncarnation 会跳过 kill 段，直接 provision+spawn
@@ -2063,7 +2063,7 @@ describe('WorkerHarness.switchWorkerImpl — 终审 PoC 回归：M3 cancelled �
 
     // 台账原样：task 仍 cancelled，没有多出新化身。
     const after = (await harness.listWorkers((`test::${'friend-1'}` as ManagerKey)))[0]
-    expect(after.task.status).toBe('cancelled')
+    expect(after.task.status).toBe('closed')
     expect(after.incarnations).toHaveLength(1)
 
     // 没有产生 handoff_started / superseded / spawned 事件——pre-flight 在写 HANDOFF.md 和
@@ -2287,11 +2287,11 @@ describe('HarnessEvent.task_status —— 透明接续的迁移点', () => {
     fake.emitStateChange({ worker_id: worker.worker_id, seq: 1, impl: 'builtin', session_ref: `ref-${worker.worker_id}#1` }, 'exited')
     await waitUntil(async () => {
       const [w] = await harness.listWorkers((`test::${'friend-1'}` as ManagerKey))
-      return w.task.status === 'completed' && events.some((e) => e.kind === 'state_changed' && e.task_status === 'completed')
+      return w.task.status === 'halted' && events.some((e) => e.kind === 'state_changed' && e.task_status === 'halted')
     })
     // 终态那一跳自己也带了状态(processStateChange 主线分支)
     const exitedStateEvent = events.filter((e) => e.kind === 'state_changed').pop()!
-    expect(exitedStateEvent.task_status).toBe('completed')
+    expect(exitedStateEvent.task_status).toBe('halted')
     events.length = 0
 
     await harness.sendToWorker(worker.worker_id, '还有件事要办')
@@ -2359,7 +2359,7 @@ describe('legacy incarnation guardrails', () => {
     await ledger.importLegacyWorker(managerKey, {
       worker_id: workerId,
       manager_key: managerKey,
-      task: { id: workerId, title: 'legacy', status: overrides.status ?? 'completed', created_at: at },
+      task: { id: workerId, title: 'legacy', status: overrides.status ?? 'halted', created_at: at },
       origin: { trigger_type: 'system' },
       report_to: { channel_id: 'test', session_id: 'legacy-session' },
       incarnations: [{ seq: 1, impl: 'legacy', state: 'exited', workspace: join(dataDir, 'workspace'), started_at: at, ended_at: at, ended_reason: overrides.endedReason ?? 'completed' }],
@@ -2526,8 +2526,8 @@ describe('legacy incarnation guardrails', () => {
     })
     const target = new FakeAdapter({ implId: 'builtin' })
     adaptersMap.set('builtin', target)
-    await addLegacy(ledger, 'w-legacy-failed', { status: 'failed', endedReason: 'failed' })
-    await addLegacy(ledger, 'w-legacy-pre-migration', { status: 'failed', endedReason: 'pre_migration' })
+    await addLegacy(ledger, 'w-legacy-failed', { status: 'halted', endedReason: 'failed' })
+    await addLegacy(ledger, 'w-legacy-pre-migration', { status: 'halted', endedReason: 'pre_migration' })
 
     await harness.sendToWorker('w-legacy-failed', 'continue failed', {
       legacyContinuationAuth: continuationAuth(),
@@ -2545,11 +2545,11 @@ describe('legacy incarnation guardrails', () => {
     const { harness, ledger, adaptersMap } = await makeHarness({
       validateLegacyContinuationAuth: async () => true,
     })
-    await addLegacy(ledger, 'w-legacy-cancelled', { status: 'cancelled', endedReason: 'killed' })
+    await addLegacy(ledger, 'w-legacy-closed', { status: 'closed', endedReason: 'killed' })
     const target = new FakeAdapter({ implId: 'builtin' })
     adaptersMap.set('builtin', target)
 
-    await expect(harness.sendToWorker('w-legacy-cancelled', 'continue', {
+    await expect(harness.sendToWorker('w-legacy-closed', 'continue', {
       legacyContinuationAuth: continuationAuth(),
     })).rejects.toBeInstanceOf(TaskCancelledError)
     expect(target.preflightProvisionCalls).toHaveLength(0)
@@ -2577,13 +2577,13 @@ describe('legacy incarnation guardrails', () => {
     await expect(fs.stat(join(workersDir, 'w-legacy-preflight', 'context.json'))).rejects.toMatchObject({ code: 'ENOENT' })
     await expect(fs.stat(join(workersDir, 'w-legacy-preflight', 'handoffs'))).rejects.toMatchObject({ code: 'ENOENT' })
     const worker = (await ledger.findWorker('w-legacy-preflight'))!.worker
-    expect(worker.task.status).toBe('completed')
+    expect(worker.task.status).toBe('halted')
     expect(worker.incarnations).toHaveLength(1)
   })
 
   it('startup reconciliation leaves terminal legacy workers unchanged without adapter lookup', async () => {
     const { harness, ledger, adaptersMap } = await makeHarness()
-    await addLegacy(ledger, 'w-legacy-reconcile')
+    await addLegacy(ledger, 'w-legacy-reconcile', { status: 'closed' })
     await expect(harness.reconcileOnStartup()).resolves.toMatchObject({ unchanged: ['w-legacy-reconcile'] })
     expect(adaptersMap.size).toBe(0)
   })

--- a/crabot-agent/tests/workers/harness/harness-integration.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-integration.test.ts
@@ -146,7 +146,7 @@ describe('WorkerHarness — 真实 builtin adapter 集成冒烟(mock LLM)', () =
       // 不是靠猜时序或手动触发回调。
       await waitUntil(async () => {
         const [w] = await harness.listWorkers(managerKey)
-        return w.task.status === 'waiting_input'
+        return w.task.status === 'halted'
       })
 
       // 经 harness.getWorkerTerminal(不是直接戳 adapter)拿到 builtin 真实写盘的纯文本。
@@ -159,11 +159,11 @@ describe('WorkerHarness — 真实 builtin adapter 集成冒烟(mock LLM)', () =
 
       await waitUntil(async () => {
         const [w] = await harness.listWorkers(managerKey)
-        return w.task.status === 'completed'
+        return w.task.status === 'halted'
       })
 
       const [finalWorker] = await harness.listWorkers(managerKey)
-      expect(finalWorker.task.status).toBe('completed')
+      expect(finalWorker.task.status).toBe('halted')
       // 注:被动状态回调路径现在会把 adapter 的 ended_reason 一路透传进
       // incarnation.ended_reason 与 task.status,但**不**回填 task.outcome——
       // applyStatusTransition 的 opts.outcome 至今没有任何生产调用点传值,该字段恒
@@ -328,7 +328,7 @@ describe.skipIf(!tmuxAvailable)('WorkerHarness — 真实 claude-code adapter �
         return current.task.status === 'waiting_input'
       })
       const [settledWorker] = await harness.listWorkers(managerKey)
-      expect(settledWorker.task.status).toBe('waiting_input')
+      expect(settledWorker.task.status).toBe('halted')
       // cc adapter 的真实 session uuid(spawn 返回前即由 adapter 填入,不是台账初始化时的
       // 占位空串),证明 harness 原子补写了 adapter.spawn 返回的真实 handle.session_ref。
       expect(settledWorker.incarnations[0].session_ref).toBeTruthy()

--- a/crabot-agent/tests/workers/harness/harness-lifecycle.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-lifecycle.test.ts
@@ -456,7 +456,7 @@ describe('WorkerHarness.spawnWorker', () => {
     expect(fake.provisionCalls).toEqual([])
     expect(fake.spawnCalls).toEqual([])
     const [failed] = await harness.listWorkers(`test::friend-1` as ManagerKey)
-    expect(failed.task).toMatchObject({ status: 'failed', error: 'context disk error' })
+    expect(failed.task).toMatchObject({ status: 'halted', halt: { halt_reason: 'crashed', detail: 'context disk error' } })
     expect(failed.incarnations[0]).toMatchObject({ state: 'exited', ended_reason: 'failed' })
     expect(events.find((event) => event.kind === 'exited')?.detail).toMatchObject({
       reason: 'spawn_failed',
@@ -474,7 +474,7 @@ describe('WorkerHarness.spawnWorker', () => {
       },
     })
     const worker = await harness.spawnWorker({ ...spawnParams(), impl: 'claude-code' })
-    expect(worker.task.status).toBe('completed')
+    expect(worker.task.status).toBe('halted')
     expect(worker.incarnations[0]).toMatchObject({ state: 'exited', ended_reason: 'completed' })
     expect(events.find((event) => event.kind === 'state_changed')?.detail).toEqual({
       to: 'exited',
@@ -495,7 +495,7 @@ describe('WorkerHarness.spawnWorker', () => {
     })
     const worker = await harness.spawnWorker({ ...spawnParams(), impl: 'claude-code' })
 
-    expect(worker.task.status).toBe('waiting_input')
+    expect(worker.task.status).toBe('halted')
     const turn = await harness.getWorkerTurn(worker.worker_id)
     expect(turn).toMatchObject({
       disposition: { status: 'pending' },
@@ -645,7 +645,7 @@ describe('WorkerHarness.spawnWorker', () => {
       },
     })
     const worker = await harness.spawnWorker({ ...spawnParams(), impl: 'claude-code', prompt: 'original' })
-    expect(worker.task.status).toBe('waiting_input')
+    expect(worker.task.status).toBe('halted')
     expect(worker.incarnations[0].state).toBe('idle')
 
     await harness.sendToWorker(worker.worker_id, 'later')
@@ -743,8 +743,8 @@ describe('WorkerHarness.spawnWorker', () => {
     const listed = await harness.listWorkers(`test::friend-1` as ManagerKey)
     expect(listed).toHaveLength(1)
     const worker = listed[0]
-    expect(worker.task.status).toBe('failed')
-    expect(worker.task.error).toBe('spawn 炸了')
+    expect(worker.task.status).toBe('halted')
+    expect(worker.task.halt?.detail).toBe('spawn 炸了')
     expect(worker.incarnations[0].state).toBe('exited')
     expect(worker.incarnations[0].ended_reason).toBe('failed')
 
@@ -1366,7 +1366,7 @@ describe('WorkerHarness.handleStateChange', () => {
     const worker = await harness.spawnWorker(spawnParams())
     const handle = { worker_id: worker.worker_id, seq: 1, impl: 'builtin' as const, session_ref: `ref-${worker.worker_id}#1` }
     fake.emitStateChange(handle, 'exited', undefined, 'completed')
-    await waitUntil(async () => (await harness.listWorkers(`test::friend-1` as ManagerKey))[0]?.task.status === 'completed')
+    await waitUntil(async () => (await harness.listWorkers(`test::friend-1` as ManagerKey))[0]?.task.status === 'halted')
     await waitUntil(async () => JSON.parse(await fs.readFile(join(workersDir, worker.worker_id, 'native-activity.json'), 'utf8')).cursors[0]?.offset === 1)
     await waitUntil(() => route.mock.calls.some(([, event]) => event.kind === 'activity_available'))
     route.mockClear()
@@ -1513,21 +1513,21 @@ describe('WorkerHarness.handleStateChange', () => {
     await waitUntil(() => events.some((event) => event.kind === 'state_changed'))
 
     const [w] = await harness.listWorkers(`test::friend-1` as ManagerKey)
-    expect(w.task.status).toBe('waiting_input')
+    expect(w.task.status).toBe('halted')
     expect(w.incarnations[0].state).toBe('idle')
 
     const stateEvents = events.filter((e) => e.kind === 'state_changed')
     expect(stateEvents).toHaveLength(1)
     expect(stateEvents[0].detail).toMatchObject({ to: 'idle', turn_pending: true, turn_id: expect.any(String) })
 
-    // 化身自然结束(非 kill)→ completed
+    // 化身自然结束(非 kill)→ exited;task 已在 idle 拍落 halted,不再二次迁移
     fake.emitStateChange({ worker_id: worker.worker_id, seq: 1, impl: 'builtin', session_ref: `ref-${worker.worker_id}#1` }, 'exited')
     await waitUntil(async () => {
       const [w2] = await harness.listWorkers(`test::friend-1` as ManagerKey)
-      return w2.task.status === 'completed'
+      return w2.incarnations[0].state === 'exited'
     })
     const [w2] = await harness.listWorkers(`test::friend-1` as ManagerKey)
-    expect(w2.task.status).toBe('completed')
+    expect(w2.task.status).toBe('halted')
     expect(w2.incarnations[0].ended_reason).toBe('completed')
   })
 
@@ -1550,7 +1550,7 @@ describe('WorkerHarness.handleStateChange', () => {
     expect((await harness.listWorkers(`test::friend-1` as ManagerKey))[0].task.status).toBe('running')
 
     fake.emitStateChange(handle, 'exited', undefined, 'killed')
-    await waitUntil(async () => (await harness.listWorkers(`test::friend-1` as ManagerKey))[0].task.status === 'cancelled')
+    await waitUntil(async () => (await harness.listWorkers(`test::friend-1` as ManagerKey))[0].task.status === 'closed')
     expect(await harness.getWorkerControlOperations(worker.worker_id)).toEqual([])
   })
 
@@ -1574,7 +1574,7 @@ describe('WorkerHarness.handleStateChange', () => {
     await expect(harness.requestWorkerStop(worker.worker_id)).resolves.toMatchObject({ status: 'succeeded' })
 
     const [stored] = await harness.listWorkers(`test::friend-1` as ManagerKey)
-    expect(stored.task.status).toBe('cancelled')
+    expect(stored.task.status).toBe('closed')
     expect(stored.incarnations).toEqual(expect.arrayContaining([
       expect.objectContaining({ seq: 1, state: 'exited', ended_reason: 'killed' }),
       expect.objectContaining({ seq: 2, state: 'exited', ended_reason: 'killed' }),
@@ -1653,7 +1653,7 @@ describe('WorkerHarness.handleStateChange', () => {
 
     complete()
     fake.emitStateChange(handle, 'idle')
-    await waitUntil(async () => (await harness.listWorkers(`test::friend-1` as ManagerKey))[0]?.task.status === 'waiting_input')
+    await waitUntil(async () => (await harness.listWorkers(`test::friend-1` as ManagerKey))[0]?.task.status === 'halted')
   })
 
   it('CLI交互Notification映射为固定manager-facing detail，不泄漏内部notification对象', async () => {
@@ -1785,16 +1785,16 @@ describe('WorkerHarness.handleStateChange', () => {
 
     await waitUntil(async () => {
       const [w] = await harness.listWorkers(`test::friend-1` as ManagerKey)
-      return w.task.status === 'failed'
+      return w.task.status === 'halted'
     })
     const [w] = await harness.listWorkers(`test::friend-1` as ManagerKey)
-    expect(w.task.status).toBe('failed')
+    expect(w.task.status).toBe('halted')
     expect(w.incarnations[0].ended_reason).toBe('failed')
 
     // 对外事件带的是提交后的 task.status——manager 的台账块、admin 侧读端点看的都是这一份。
     const stateEvents = events.filter((e) => e.kind === 'state_changed')
     expect(stateEvents).toHaveLength(1)
-    expect(stateEvents[0].task_status).toBe('failed')
+    expect(stateEvents[0].task_status).toBe('halted')
   })
 
   it('adapter 上报 endReason=crashed → 台账落 crashed,task.status=failed', async () => {
@@ -1806,7 +1806,7 @@ describe('WorkerHarness.handleStateChange', () => {
 
     await waitUntil(async () => {
       const [w] = await harness.listWorkers(`test::friend-1` as ManagerKey)
-      return w.task.status === 'failed'
+      return w.task.status === 'halted'
     })
     const [w] = await harness.listWorkers(`test::friend-1` as ManagerKey)
     expect(w.incarnations[0].ended_reason).toBe('crashed')
@@ -1832,7 +1832,7 @@ describe('WorkerHarness.handleStateChange', () => {
       return w.incarnations[0].state === 'exited'
     })
     const [w] = await harness.listWorkers(`test::friend-1` as ManagerKey)
-    expect(w.task.status).toBe('failed')
+    expect(w.task.status).toBe('halted')
     expect(w.incarnations[0].ended_reason).toBeUndefined() // 不编造原因
   })
 
@@ -2020,7 +2020,7 @@ describe('WorkerHarness.handleStateChange', () => {
     await harness.killWorker(worker.worker_id)
 
     const [w] = await harness.listWorkers(`test::friend-1` as ManagerKey)
-    expect(w.task.status).toBe('cancelled')
+    expect(w.task.status).toBe('closed')
   })
 })
 
@@ -2533,7 +2533,7 @@ describe('WorkerHarness.sendToWorker', () => {
       impl: 'builtin',
       session_ref: `ref-${worker.worker_id}#1`,
     }, 'exited', undefined, 'completed')
-    await waitUntil(async () => (await harness.listWorkers(`test::friend-1` as ManagerKey))[0].task.status === 'completed')
+    await waitUntil(async () => (await harness.listWorkers(`test::friend-1` as ManagerKey))[0].task.status === 'halted')
     const reviveHarness = harness as unknown as {
       establishCliResumeActivityBaseline(workerId: string, source: unknown, adapter: unknown): Promise<number | undefined>
       settlePendingInputFailure(...args: unknown[]): Promise<unknown>
@@ -2594,7 +2594,7 @@ describe('WorkerHarness.sendToWorker', () => {
       impl: 'builtin',
       session_ref: `ref-${worker.worker_id}#1`,
     }, 'exited', undefined, 'completed')
-    await waitUntil(async () => (await harness.listWorkers(`test::friend-1` as ManagerKey))[0].task.status === 'completed')
+    await waitUntil(async () => (await harness.listWorkers(`test::friend-1` as ManagerKey))[0].task.status === 'halted')
 
     const handoffHarness = harness as unknown as {
       captureHandoffPackage(...args: unknown[]): Promise<unknown>
@@ -2809,7 +2809,7 @@ describe('WorkerHarness.sendToWorker', () => {
     await harness.sendToWorker(worker.worker_id, '很快完成的输入')
     await waitUntil(async () => {
       const [current] = await harness.listWorkers(`test::friend-1` as ManagerKey)
-      return current.task.status === 'waiting_input'
+      return current.task.status === 'halted'
     })
 
     const [settled] = await harness.listWorkers(`test::friend-1` as ManagerKey)
@@ -2844,14 +2844,14 @@ describe('WorkerHarness.sendToWorker', () => {
     }, 'idle')
     await waitUntil(async () => {
       const [current] = await harness.listWorkers(`test::friend-1` as ManagerKey)
-      return current.task.status === 'waiting_input'
+      return current.task.status === 'halted'
     })
 
     release()
     await send
 
     const [settled] = await harness.listWorkers(`test::friend-1` as ManagerKey)
-    expect(settled.task.status).toBe('waiting_input')
+    expect(settled.task.status).toBe('halted')
     expect(settled.incarnations[0].state).toBe('idle')
     expect(fake.sendInputCalls).toHaveLength(1)
     expect((harness as any).getInbox(worker.worker_id).held).toBe(true)
@@ -2882,7 +2882,7 @@ describe('WorkerHarness.sendToWorker', () => {
       impl: 'claude-code',
       session_ref: `ref-${worker.worker_id}#1`,
     }, 'idle')
-    await waitUntil(async () => (await harness.listWorkers(`test::friend-1` as ManagerKey))[0].task.status === 'waiting_input')
+    await waitUntil(async () => (await harness.listWorkers(`test::friend-1` as ManagerKey))[0].task.status === 'halted')
     await harness.queryWorker(worker.worker_id, '侧问一下')
 
     await harness.sendToWorker(worker.worker_id, '主线继续')
@@ -2926,10 +2926,10 @@ describe('WorkerHarness.sendToWorker', () => {
     await harness.sendToWorker(worker.worker_id, 'Escape', { raw: true })
     await waitUntil(async () => {
       const [current] = await harness.listWorkers(`test::friend-1` as ManagerKey)
-      return current.task.status === 'waiting_input'
+      return current.task.status === 'halted'
     })
     const [settled] = await harness.listWorkers(`test::friend-1` as ManagerKey)
-    expect(settled.task.status).toBe('waiting_input')
+    expect(settled.task.status).toBe('halted')
     expect(settled.incarnations[0].state).toBe('idle')
   })
 
@@ -2995,7 +2995,7 @@ describe('WorkerHarness.sendToWorker', () => {
     await harness.sendToWorker(worker.worker_id, '首条任务')
     await waitUntil(async () => {
       const [current] = await harness.listWorkers(`test::friend-1` as ManagerKey)
-      return current.task.status === 'waiting_input'
+      return current.task.status === 'halted'
     })
 
     const [settled] = await harness.listWorkers(`test::friend-1` as ManagerKey)
@@ -3012,7 +3012,7 @@ describe('WorkerHarness.sendToWorker', () => {
     await harness.sendToWorker(worker.worker_id, '最后一步')
 
     const [settled] = await harness.listWorkers(`test::friend-1` as ManagerKey)
-    expect(settled.task.status).toBe('completed')
+    expect(settled.task.status).toBe('halted')
     expect(settled.incarnations[0]).toMatchObject({ state: 'exited', ended_reason: 'completed' })
     const stateEvents = events.filter((event) => event.kind === 'state_changed')
     expect(stateEvents).toHaveLength(1)
@@ -3030,7 +3030,7 @@ describe('WorkerHarness.sendToWorker', () => {
     expect(fake.sendInputCalls).toHaveLength(1)
     expect(fake.sendInputCalls[0]).toMatchObject({ text: 'C-d', opts: { raw: true } })
     const [settled] = await harness.listWorkers(`test::friend-1` as ManagerKey)
-    expect(settled.task.status).toBe('completed')
+    expect(settled.task.status).toBe('halted')
     expect(settled.incarnations).toHaveLength(1)
     expect(settled.incarnations[0]).toMatchObject({ state: 'exited', ended_reason: 'completed' })
     const stateEvents = events.filter((event) => event.kind === 'state_changed')
@@ -3065,7 +3065,7 @@ describe('WorkerHarness.sendToWorker', () => {
       ['1 Enter', true],
     ])
     const [settled] = await harness.listWorkers(`test::friend-1` as ManagerKey)
-    expect(settled.task.status).toBe('completed')
+    expect(settled.task.status).toBe('halted')
     expect(settled.incarnations).toHaveLength(1)
     expect(settled.incarnations[0]).toMatchObject({ state: 'exited', ended_reason: 'completed' })
   })
@@ -3129,13 +3129,13 @@ describe('WorkerHarness.killWorker', () => {
     expect(fake.killCalls[0]).toMatchObject({ worker_id: worker.worker_id, seq: 1, impl: 'builtin', session_ref: `ref-${worker.worker_id}#1`, incarnation_id: expect.any(String) })
 
     const [w] = await harness.listWorkers(`test::friend-1` as ManagerKey)
-    expect(w.task.status).toBe('cancelled')
+    expect(w.task.status).toBe('closed')
     expect(w.incarnations[0].state).toBe('exited')
     expect(w.incarnations[0].ended_reason).toBe('killed')
 
     const stopped = events.filter((e) => e.kind === 'state_changed' && e.detail?.reason === 'stop_verified')
     expect(stopped).toHaveLength(1)
-    expect(stopped[0].task_status).toBe('cancelled')
+    expect(stopped[0].task_status).toBe('closed')
   })
 
   it('幂等:对已 cancelled 的 worker 再次 kill 不报错、不重复调用 adapter.kill、不重复发事件', async () => {
@@ -3868,7 +3868,7 @@ describe('WorkerHarness.queryWorker — adapter.fork 挪出锁(P4 Task 4 review 
 
     const [w] = await harness.listWorkers(`test::friend-1` as ManagerKey)
     // 主线(seq=1)保持 killWorker 落定的记录,完全不被这次迟到的 fork 落账污染。
-    expect(w.task.status).toBe('cancelled')
+    expect(w.task.status).toBe('closed')
     const mainEntry = w.incarnations.find((i) => i.seq === 1)!
     expect(mainEntry.state).toBe('exited')
     expect(mainEntry.ended_reason).toBe('killed')
@@ -3962,7 +3962,7 @@ describe('WorkerHarness — fork 不劫持主线(protocol-agent-v3 §5.3 回归)
     expect(fake.killCalls.map((call) => call.seq).sort()).toEqual([1, 2])
 
     const [w] = await harness.listWorkers(`test::friend-1` as ManagerKey)
-    expect(w.task.status).toBe('cancelled') // 主线被正确终结,不是台账显示 fork 被 kill 而主线孤儿
+    expect(w.task.status).toBe('closed') // 主线被正确终结,不是台账显示 fork 被 kill 而主线孤儿
     const mainEntry = w.incarnations.find((i) => i.seq === 1)!
     expect(mainEntry.state).toBe('exited')
     expect(mainEntry.ended_reason).toBe('killed')
@@ -4119,7 +4119,7 @@ describe('HarnessEvent.task_status —— 事件自带落账后的 task 状态',
 
     const exited = events.filter((e) => e.kind === 'exited')
     expect(exited).toHaveLength(1)
-    expect(exited[0].task_status).toBe('failed')
+    expect(exited[0].task_status).toBe('halted')
   })
 
   it('迁移点:主线状态回调 → state_changed 带落账后的 waiting_input / completed', async () => {
@@ -4130,11 +4130,11 @@ describe('HarnessEvent.task_status —— 事件自带落账后的 task 状态',
 
     fake.emitStateChange(handle, 'idle')
     await waitUntil(async () => events.some((e) => e.kind === 'state_changed'))
-    expect(events.filter((e) => e.kind === 'state_changed')[0].task_status).toBe('waiting_input')
+    expect(events.filter((e) => e.kind === 'state_changed')[0].task_status).toBe('halted')
 
     fake.emitStateChange(handle, 'exited')
     await waitUntil(async () => events.filter((e) => e.kind === 'state_changed').length >= 2)
-    expect(events.filter((e) => e.kind === 'state_changed')[1].task_status).toBe('completed')
+    expect(events.filter((e) => e.kind === 'state_changed')[1].task_status).toBe('halted')
   })
 
   it('迁移点:verified stop → state_changed 带 cancelled', async () => {
@@ -4146,7 +4146,7 @@ describe('HarnessEvent.task_status —— 事件自带落账后的 task 状态',
 
     const stopped = events.filter((e) => e.kind === 'state_changed' && e.detail?.reason === 'stop_verified')
     expect(stopped).toHaveLength(1)
-    expect(stopped[0].task_status).toBe('cancelled')
+    expect(stopped[0].task_status).toBe('closed')
   })
 
   it('非迁移点:input_sent 不带 task_status(投递不动 task 状态)', async () => {
@@ -4179,7 +4179,7 @@ describe('HarnessEvent.task_status —— 事件自带落账后的 task 状态',
     expect(deadLetters.length).toBeGreaterThan(0)
     for (const e of deadLetters) expect(e.task_status).toBeUndefined()
     // 同一次 verified stop 的 state_changed 事件才是那次迁移的载体
-    expect(events.find((e) => e.kind === 'state_changed' && e.detail?.reason === 'stop_verified')?.task_status).toBe('cancelled')
+    expect(events.find((e) => e.kind === 'state_changed' && e.detail?.reason === 'stop_verified')?.task_status).toBe('closed')
   })
 
   it('非迁移点:query_failed 不带 task_status', async () => {

--- a/crabot-agent/tests/workers/harness/harness-recovery.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-recovery.test.ts
@@ -191,8 +191,8 @@ describe('WorkerHarness.reconcileOnStartup — 三态判定', () => {
 
     expect(report).toEqual<ReconcileReport>({ revived: [], failed: ['w-exited'], unchanged: [] })
     const after = await getWorker(ledger, 'w-exited')
-    expect(after.task.status).toBe('failed')
-    expect(after.task.error).toBeTruthy()
+    expect(after.task.status).toBe('halted')
+    expect(after.task.halt?.detail).toBeTruthy()
     expect(after.incarnations[0].state).toBe('exited')
     expect(after.incarnations[0].ended_reason).toBe('crashed')
     expect(after.incarnations[0].ended_at).toBeTruthy()
@@ -284,8 +284,8 @@ describe('WorkerHarness.reconcileOnStartup — 三态判定', () => {
     expect(report).toEqual<ReconcileReport>({ revived: [], failed: ['w-maintenance'], unchanged: [] })
     expect(fake.stateCalls).toHaveLength(0)
     const after = await getWorker(ledger, 'w-maintenance')
-    expect(after.task.status).toBe('failed')
-    expect(after.task.error).toBe('agent restart: execution context lost for agent-native system task')
+    expect(after.task.status).toBe('closed')
+    expect(after.task.closed?.note).toBe('agent restart: execution context lost for agent-native system task')
     expect(after.incarnations).toEqual([])
     expect(after.supervision).toEqual({ version: 1, mode: 'default' })
     const taskEvents = events.filter((e) => e.worker_id === 'w-maintenance')
@@ -293,7 +293,7 @@ describe('WorkerHarness.reconcileOnStartup — 三态判定', () => {
     expect(taskEvents[0]).toMatchObject({
       seq: 0,
       kind: 'exited',
-      task_status: 'failed',
+      task_status: 'closed',
       detail: { reason: 'crashed', message: 'agent restart: execution context lost for agent-native system task' },
     })
   })
@@ -352,7 +352,7 @@ describe('WorkerHarness.reconcileOnStartup — 三态判定', () => {
 
     expect(report).toEqual<ReconcileReport>({ revived: [], failed: ['w-no-adapter'], unchanged: [] })
     const after = await getWorker(ledger, 'w-no-adapter')
-    expect(after.task.status).toBe('failed')
+    expect(after.task.status).toBe('halted')
     expect(after.incarnations[0].ended_reason).toBe('crashed')
     const exitedEvents = events.filter((e) => e.kind === 'exited' && e.worker_id === 'w-no-adapter')
     expect(exitedEvents[0].detail?.message).toContain('codex')
@@ -376,7 +376,7 @@ describe('WorkerHarness.reconcileOnStartup — 三态判定', () => {
     expect(report.revived).toEqual(['w-ok']) // 另一个 worker 没有被这次异常连累，正常判定
 
     const after = await getWorker(ledger, 'w-throws')
-    expect(after.task.status).toBe('failed')
+    expect(after.task.status).toBe('halted')
     expect(after.incarnations[0].ended_reason).toBe('crashed')
     const exitedEvents = events.filter((e) => e.kind === 'exited' && e.worker_id === 'w-throws')
     expect(exitedEvents[0].detail?.message).toContain('tmux pane 探测失败')
@@ -422,15 +422,15 @@ describe('WorkerHarness.reconcileOnStartup — 终态 worker 不被触碰', () =
     adaptersMap.set('builtin', fake)
 
     const completed = makeWorker('w-completed', {
-      task: { id: 'task-w-completed', title: '测试任务', status: 'completed', created_at: now(), completed_at: now() },
+      task: { id: 'task-w-completed', title: '测试任务', status: 'closed', created_at: now() },
       incarnations: [{ seq: 1, impl: 'builtin', state: 'exited', workspace: '/tmp/ws', session_ref: 'ref#1', started_at: now(), ended_at: now(), ended_reason: 'completed' }],
     })
     const failedAlready = makeWorker('w-failed-already', {
-      task: { id: 'task-w-failed-already', title: '测试任务', status: 'failed', created_at: now(), completed_at: now(), error: 'boom' },
+      task: { id: 'task-w-failed-already', title: '测试任务', status: 'closed', created_at: now(), closed: { at: now(), by: 'migration', note: 'failed: boom' } },
       incarnations: [{ seq: 1, impl: 'builtin', state: 'exited', workspace: '/tmp/ws', session_ref: 'ref#1', started_at: now(), ended_at: now(), ended_reason: 'failed' }],
     })
     const cancelled = makeWorker('w-cancelled', {
-      task: { id: 'task-w-cancelled', title: '测试任务', status: 'cancelled', created_at: now(), completed_at: now() },
+      task: { id: 'task-w-cancelled', title: '测试任务', status: 'closed', created_at: now() },
       incarnations: [{ seq: 1, impl: 'builtin', state: 'exited', workspace: '/tmp/ws', session_ref: 'ref#1', started_at: now(), ended_at: now(), ended_reason: 'killed' }],
     })
     await seed(ledger, DIALOG, completed)
@@ -460,7 +460,7 @@ describe('WorkerHarness.reconcileOnStartup — 报告分类 + 跨对话对象', 
       ledger,
       group,
       makeWorker('group-done', {
-        task: { id: 'task-group-done', title: '测试任务', status: 'completed', created_at: now(), completed_at: now() },
+        task: { id: 'task-group-done', title: '测试任务', status: 'closed', created_at: now() },
         incarnations: [{ seq: 1, impl: 'builtin', state: 'exited', workspace: '/tmp/ws', session_ref: 'ref#1', started_at: now(), ended_at: now(), ended_reason: 'completed' }],
       })
     )
@@ -487,7 +487,7 @@ describe('WorkerHarness.reconcileOnStartup — 幂等', () => {
     const first = await harness.reconcileOnStartup()
     expect(first).toEqual<ReconcileReport>({ revived: [], failed: ['w-repeat'], unchanged: [] })
     const afterFirst = await getWorker(ledger, 'w-repeat')
-    expect(afterFirst.task.status).toBe('failed')
+    expect(afterFirst.task.status).toBe('halted')
     const eventsAfterFirst = events.filter((e) => e.worker_id === 'w-repeat')
     expect(eventsAfterFirst).toHaveLength(1)
 
@@ -521,7 +521,7 @@ describe('WorkerHarness restart recovery notices', () => {
 
     await harness.reconcileOnStartup()
     const crashed = await getWorker(ledger, 'w-recovery-notice')
-    expect(crashed.task.status).toBe('failed')
+    expect(crashed.task.status).toBe('halted')
     expect(crashed.recovery_notices).toEqual([expect.objectContaining({
       incarnation_id: crashed.incarnations[0].incarnation_id,
       status: 'pending',
@@ -568,7 +568,7 @@ describe('WorkerHarness restart recovery notices', () => {
       },
     })
     await seed(ledger, DIALOG, makeWorker('w-historical-crash', {
-      task: { id: 'task-w-historical-crash', title: '历史失败', status: 'failed', created_at: now(), completed_at: now() },
+      task: { id: 'task-w-historical-crash', title: '历史失败', status: 'closed', created_at: now() },
       incarnations: [{
         seq: 1,
         impl: 'builtin',
@@ -703,7 +703,7 @@ describe('HarnessEvent.task_status —— reconcileOnStartup 的迁移点', () =
 
     const exited = events.filter((e) => e.kind === 'exited' && e.worker_id === 'w-crash')
     expect(exited).toHaveLength(1)
-    expect(exited[0].task_status).toBe('failed')
+    expect(exited[0].task_status).toBe('halted')
     expect(exited[0].task_status).toBe((await getWorker(ledger, 'w-crash')).task.status)
   })
 

--- a/crabot-agent/tests/workers/harness/harness-supervision.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-supervision.test.ts
@@ -314,7 +314,7 @@ describe('WorkerHarness task supervision', () => {
     const worker = (await harness.findWorker(workerId))!.worker
     expect(adapter.stateCalls).toBe(1)
     expect(supervisionEvents(workerId)).toHaveLength(0)
-    expect(worker.task.status).toBe('waiting_input')
+    expect(worker.task.status).toBe('halted')
     expect(worker.supervision).toMatchObject({ version: 1, mode: 'default', last_observed_at: now() })
     expect(worker.supervision?.next_due_at).toBeUndefined()
     expect(worker.supervision?.pending).toBeUndefined()
@@ -368,7 +368,7 @@ describe('WorkerHarness task supervision', () => {
       observation: 'none',
       probe: 'idle',
     })
-    expect(worker.task.status).toBe('waiting_input')
+    expect(worker.task.status).toBe('halted')
     expect(worker.supervision).toMatchObject({
       mode: 'periodic_report',
       next_due_at: new Date(clockMs + 5 * MINUTE).toISOString(),

--- a/crabot-agent/tests/workers/harness/harness-supervision.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-supervision.test.ts
@@ -376,6 +376,25 @@ describe('WorkerHarness task supervision', () => {
     expect(worker.supervision?.pending).toBeUndefined()
   })
 
+  it('periodic report remains due when the probe reports exited——task halted 不是约定的终点(2026-08-31 回归)', async () => {
+    const { harness, adapter } = await makeHarness()
+    const workerId = await spawnRunning(harness)
+    await harness.setWorkerPeriodicReport(workerId, { channel_id: 'feishu', session_id: 'session-1' }, 5 * MINUTE)
+    events = []
+    adapter.observation = { kind: 'none', next_cursor: { offset: 0 } }
+    adapter.contractState = 'exited'
+    clockMs += 5 * MINUTE
+
+    await harness.sweepLiveness()
+
+    expect(supervisionEvents(workerId)).toHaveLength(1)
+    expect(supervisionEvents(workerId)[0].detail).toMatchObject({
+      mode: 'periodic_report',
+      observation: 'none',
+      probe: 'exited',
+    })
+  })
+
   it('clearing a rule invalidates a queued due and terminal cleanup removes periodic configuration', async () => {
     const { harness, adapter } = await makeHarness()
     const workerId = await spawnRunning(harness)

--- a/crabot-agent/tests/workers/harness/ledger-store.test.ts
+++ b/crabot-agent/tests/workers/harness/ledger-store.test.ts
@@ -224,7 +224,7 @@ describe('LedgerStore', () => {
 
     const ledger = await store.getLedger(key)
     const archived = ledger.workers[0]
-    expect(archived.task.status).toBe('failed')
+    expect(archived.task.status).toBe('halted')
     expect(archived.incarnations).toEqual([expect.objectContaining({
       impl: 'legacy',
       state: 'exited',
@@ -238,7 +238,7 @@ describe('LedgerStore', () => {
 
     const persisted = JSON.parse(await fs.readFile(join(dir, managerKeyToFilename(key)), 'utf8'))
     expect(persisted.workers[0]).toMatchObject({
-      task: { status: 'failed' },
+      task: { status: 'halted' },
       legacy_source: { kind: 'ambiguous_v3_ledger', original_incarnations: originalIncarnations },
     })
     await expect(new LedgerStore(dir).getLedger(key)).resolves.toEqual(ledger)

--- a/crabot-agent/tests/workers/harness/ledger-store.test.ts
+++ b/crabot-agent/tests/workers/harness/ledger-store.test.ts
@@ -204,6 +204,41 @@ describe('LedgerStore', () => {
     await expect(corrupt.getLedger(key)).rejects.toThrow('invalid legacy worker')
   })
 
+  it('2026-08-31 状态迁移:旧 6 态台账读取时归一为新 4 态并回写', async () => {
+    const key = 'test::status-migration' as ManagerKey
+    const at = '2026-08-20T00:00:00.000Z'
+    const mk = (id: string, status: string): Partial<LedgerWorker> => ({
+      manager_key: key,
+      task: { id, title: 't', status: status as never, created_at: at },
+      incarnations: [{ seq: 1, impl: 'builtin', state: 'exited', workspace: '/tmp/ws', started_at: at, ended_at: at, ended_reason: 'completed', session_ref: 'r1' }],
+    })
+    await fs.mkdir(dir, { recursive: true })
+    await fs.writeFile(join(dir, managerKeyToFilename(key)), JSON.stringify({
+      manager_key: key,
+      workers: [
+        { ...makeWorker('w-old-waiting', mk('w-old-waiting', 'waiting_input')) },
+        { ...makeWorker('w-old-completed', mk('w-old-completed', 'completed')) },
+        { ...makeWorker('w-old-cancelled', mk('w-old-cancelled', 'cancelled')) },
+      ],
+    }))
+
+    const ledger = await store.getLedger(key)
+    const byId = new Map(ledger.workers.map((w) => [w.worker_id, w]))
+    // waiting_input → halted(turn_end),evidence 时间戳取化身 ended_at
+    expect(byId.get('w-old-waiting')?.task.status).toBe('halted')
+    expect(byId.get('w-old-waiting')?.task.halt).toMatchObject({ halted_at: at, halt_reason: 'turn_end' })
+    // 旧终态 → closed(by migration),旧值记入 note
+    expect(byId.get('w-old-completed')?.task.status).toBe('closed')
+    expect(byId.get('w-old-completed')?.task.closed).toMatchObject({ at: at, by: 'migration', note: expect.stringContaining('completed') })
+    expect(byId.get('w-old-cancelled')?.task.status).toBe('closed')
+
+    // 迁移结果落盘:第二次读取(新实例)幂等,不再变化
+    const persisted = JSON.parse(await fs.readFile(join(dir, managerKeyToFilename(key)), 'utf8'))
+    expect(persisted.workers.map((w: LedgerWorker) => w.task.status).sort()).toEqual(['closed', 'closed', 'halted'])
+    const reread = await new LedgerStore(dir).getLedger(key)
+    expect(reread).toEqual(ledger)
+  })
+
   it('同 seq 的 numeric fork 歧义会原子归档 worker，不让整份台账不可读', async () => {
     const key = 'test::ambiguous-v3' as ManagerKey
     const at = '2026-08-20T00:00:00.000Z'

--- a/crabot-agent/tests/workers/harness/task-status.test.ts
+++ b/crabot-agent/tests/workers/harness/task-status.test.ts
@@ -4,82 +4,76 @@ import {
   isTerminalStatus,
   canTransition,
   applyStatusTransition,
+  isDecisionVisibleWorker,
   InvalidTaskTransitionError,
-  taskStatusFromIncarnation,
-  reviveTask,
 } from '../../../src/workers/harness/task-status'
 import type { TaskStatus } from '../../../src/workers/harness/ledger-types'
-import type { WorkerContractState, IncarnationEndReason } from '../../../src/workers/types'
 
-describe('v3 task 状态机', () => {
+describe('v3 task 状态机（2026-08-31 4 态修正）', () => {
   describe('VALID_TRANSITIONS', () => {
-    it('应定义所有 6 个状态', () => {
-      const states: TaskStatus[] = ['queued', 'running', 'waiting_input', 'completed', 'failed', 'cancelled']
+    it('应定义所有 4 个状态', () => {
+      const states: TaskStatus[] = ['queued', 'running', 'halted', 'closed']
       states.forEach((s) => {
         expect(VALID_TRANSITIONS).toHaveProperty(s)
         expect(Array.isArray(VALID_TRANSITIONS[s])).toBe(true)
       })
     })
 
-    it('queued 可转换至 running 和 cancelled', () => {
+    it('queued 可转换至 running 和 closed', () => {
       const allowed = VALID_TRANSITIONS.queued
       expect(allowed).toContain('running')
-      expect(allowed).toContain('cancelled')
-      expect(allowed).not.toContain('waiting_input')
-      expect(allowed).not.toContain('completed')
-      expect(allowed).not.toContain('failed')
+      expect(allowed).toContain('closed')
+      expect(allowed).not.toContain('halted')
     })
 
-    it('running 可转换至 waiting_input, completed, failed, cancelled', () => {
+    it('running 可转换至 halted 和 closed', () => {
       const allowed = VALID_TRANSITIONS.running
-      expect(allowed).toContain('waiting_input')
-      expect(allowed).toContain('completed')
-      expect(allowed).toContain('failed')
-      expect(allowed).toContain('cancelled')
+      expect(allowed).toContain('halted')
+      expect(allowed).toContain('closed')
       expect(allowed).not.toContain('queued')
     })
 
-    it('waiting_input 可转换至 running, completed, failed, cancelled', () => {
-      const allowed = VALID_TRANSITIONS.waiting_input
+    it('halted 可转换至 running 和 closed', () => {
+      const allowed = VALID_TRANSITIONS.halted
       expect(allowed).toContain('running')
-      expect(allowed).toContain('completed')
-      expect(allowed).toContain('failed')
-      expect(allowed).toContain('cancelled')
+      expect(allowed).toContain('closed')
       expect(allowed).not.toContain('queued')
-    })
-
-    it('终态 completed, failed, cancelled 无出边', () => {
-      expect(VALID_TRANSITIONS.completed).toEqual([])
-      expect(VALID_TRANSITIONS.failed).toEqual([])
-      expect(VALID_TRANSITIONS.cancelled).toEqual([])
     })
   })
 
   describe('isTerminalStatus', () => {
-    it('completed, failed, cancelled 是终态', () => {
-      expect(isTerminalStatus('completed')).toBe(true)
-      expect(isTerminalStatus('failed')).toBe(true)
-      expect(isTerminalStatus('cancelled')).toBe(true)
-    })
-
-    it('queued, running, waiting_input 非终态', () => {
+    it('closed 是唯一终态', () => {
+      expect(isTerminalStatus('closed')).toBe(true)
       expect(isTerminalStatus('queued')).toBe(false)
       expect(isTerminalStatus('running')).toBe(false)
-      expect(isTerminalStatus('waiting_input')).toBe(false)
+      expect(isTerminalStatus('halted')).toBe(false)
+    })
+  })
+
+  describe('isDecisionVisibleWorker', () => {
+    it('非终态可见，closed 不可见', () => {
+      expect(isDecisionVisibleWorker('queued')).toBe(true)
+      expect(isDecisionVisibleWorker('running')).toBe(true)
+      expect(isDecisionVisibleWorker('halted')).toBe(true)
+      expect(isDecisionVisibleWorker('closed')).toBe(false)
     })
   })
 
   describe('canTransition', () => {
     it('合法迁移返回 true', () => {
       expect(canTransition('queued', 'running')).toBe(true)
-      expect(canTransition('running', 'waiting_input')).toBe(true)
-      expect(canTransition('waiting_input', 'completed')).toBe(true)
+      expect(canTransition('running', 'halted')).toBe(true)
+      expect(canTransition('halted', 'running')).toBe(true)
+      expect(canTransition('running', 'closed')).toBe(true)
+      expect(canTransition('halted', 'closed')).toBe(true)
+      expect(canTransition('queued', 'closed')).toBe(true)
     })
 
     it('非法迁移返回 false', () => {
-      expect(canTransition('queued', 'waiting_input')).toBe(false)
-      expect(canTransition('completed', 'running')).toBe(false)
-      expect(canTransition('failed', 'cancelled')).toBe(false)
+      expect(canTransition('queued', 'halted')).toBe(false)
+      expect(canTransition('closed', 'running')).toBe(false)
+      expect(canTransition('closed', 'halted')).toBe(false)
+      expect(canTransition('halted', 'queued')).toBe(false)
     })
   })
 
@@ -91,47 +85,75 @@ describe('v3 task 状态机', () => {
       created_at: '2026-07-28T00:00:00Z',
     }
     const now = '2026-07-28T12:00:00Z'
+    const halt = {
+      halted_at: now,
+      halt_reason: 'turn_end' as const,
+    }
 
     it('合法迁移应成功', () => {
       const task = applyStatusTransition(baseTask, 'running', { now })
       expect(task.status).toBe('running')
       expect(task.updated_at).toBeUndefined()
-      expect(task.completed_at).toBeUndefined()
+      expect(task.halt).toBeUndefined()
     })
 
     it('非法迁移应抛 InvalidTaskTransitionError 并含 from/to 字段', () => {
       expect(() => {
-        applyStatusTransition(baseTask, 'waiting_input', { now })
+        applyStatusTransition(baseTask, 'halted', { now, halt })
       }).toThrow(InvalidTaskTransitionError)
 
       try {
-        applyStatusTransition(baseTask, 'waiting_input', { now })
+        applyStatusTransition(baseTask, 'halted', { now, halt })
       } catch (e) {
         const err = e as InvalidTaskTransitionError
         expect(err.from).toBe('queued')
-        expect(err.to).toBe('waiting_input')
+        expect(err.to).toBe('halted')
       }
     })
 
-    it('终态迁移应回填 completed_at', () => {
+    it('进入 halted 必须携带 halt evidence，缺失即抛错', () => {
       const runningTask = { ...baseTask, status: 'running' as TaskStatus }
-      const task = applyStatusTransition(runningTask, 'completed', { now })
-      expect(task.status).toBe('completed')
-      expect(task.completed_at).toBe(now)
+      expect(() => {
+        applyStatusTransition(runningTask, 'halted', { now })
+      }).toThrow(InvalidTaskTransitionError)
+
+      const task = applyStatusTransition(runningTask, 'halted', { now, halt })
+      expect(task.status).toBe('halted')
+      expect(task.halt).toEqual(halt)
     })
 
-    it('失败迁移应设置 error 字段', () => {
-      const runningTask = { ...baseTask, status: 'running' as TaskStatus }
-      const task = applyStatusTransition(runningTask, 'failed', { now, error: 'Connection timeout' })
-      expect(task.status).toBe('failed')
-      expect(task.error).toBe('Connection timeout')
-      expect(task.completed_at).toBe(now)
+    it('halted→running 续办应清除 halt evidence', () => {
+      const haltedTask = {
+        ...baseTask,
+        status: 'halted' as TaskStatus,
+        halt: { ...halt, worker_self_report: { outcome: 'completed' as const, summary: '自报完成' } },
+      }
+      const task = applyStatusTransition(haltedTask, 'running', { now })
+      expect(task.status).toBe('running')
+      expect(task.halt).toBeUndefined()
     })
 
-    it('outcome 应透传', () => {
+    it('进入 closed 必须携带关闭信息，缺失即抛错；at 由 now 回填', () => {
       const runningTask = { ...baseTask, status: 'running' as TaskStatus }
-      const task = applyStatusTransition(runningTask, 'completed', { now, outcome: 'Success' })
-      expect(task.outcome).toBe('Success')
+      expect(() => {
+        applyStatusTransition(runningTask, 'closed', { now })
+      }).toThrow(InvalidTaskTransitionError)
+
+      const task = applyStatusTransition(runningTask, 'closed', {
+        now,
+        closed: { by: 'manager_stop' },
+      })
+      expect(task.status).toBe('closed')
+      expect(task.closed).toEqual({ at: now, by: 'manager_stop' })
+    })
+
+    it('closed 可带备注', () => {
+      const runningTask = { ...baseTask, status: 'running' as TaskStatus }
+      const task = applyStatusTransition(runningTask, 'closed', {
+        now,
+        closed: { by: 'migration', note: '旧值 completed' },
+      })
+      expect(task.closed?.note).toBe('旧值 completed')
     })
 
     it('返回新对象不改变原 task', () => {
@@ -141,102 +163,25 @@ describe('v3 task 状态机', () => {
       expect(task).not.toBe(baseTask)
     })
 
-    it('非失败迁移时 error 应被清空', () => {
-      const runningTask = { ...baseTask, status: 'running' as TaskStatus, error: 'Old error' }
-      const task = applyStatusTransition(runningTask, 'completed', { now })
-      expect(task.error).toBeUndefined()
-    })
-
-    it('终态之间的迁移应失败', () => {
-      const completedTask = { ...baseTask, status: 'completed' as TaskStatus }
-      expect(() => {
-        applyStatusTransition(completedTask, 'failed', { now })
-      }).toThrow(InvalidTaskTransitionError)
-    })
-  })
-
-  describe('taskStatusFromIncarnation', () => {
-    describe('contractState=running', () => {
-      it('应返回 running', () => {
-        const status = taskStatusFromIncarnation('running')
-        expect(status).toBe('running')
-      })
-
-      it('endReason 和 waitingInput 应被忽略', () => {
-        expect(taskStatusFromIncarnation('running', 'completed')).toBe('running')
-        expect(taskStatusFromIncarnation('running', 'failed', true)).toBe('running')
-      })
-    })
-
-    describe('contractState=idle', () => {
-      it('waitingInput=true 应返回 waiting_input', () => {
-        const status = taskStatusFromIncarnation('idle', undefined, true)
-        expect(status).toBe('waiting_input')
-      })
-
-      it('waitingInput=false 或 undefined 应返回 running', () => {
-        expect(taskStatusFromIncarnation('idle', undefined, false)).toBe('running')
-        expect(taskStatusFromIncarnation('idle')).toBe('running')
-      })
-    })
-
-    describe('contractState=exited', () => {
-      it('endReason=completed 应返回 completed', () => {
-        const status = taskStatusFromIncarnation('exited', 'completed')
-        expect(status).toBe('completed')
-      })
-
-      it('endReason=failed 应返回 failed', () => {
-        const status = taskStatusFromIncarnation('exited', 'failed')
-        expect(status).toBe('failed')
-      })
-
-      it('endReason=crashed 应返回 failed', () => {
-        const status = taskStatusFromIncarnation('exited', 'crashed')
-        expect(status).toBe('failed')
-      })
-
-      it('endReason=killed 应返回 cancelled', () => {
-        const status = taskStatusFromIncarnation('exited', 'killed')
-        expect(status).toBe('cancelled')
-      })
-
-      it('endReason=pre_migration 应返回 failed', () => {
-        const status = taskStatusFromIncarnation('exited', 'pre_migration')
-        expect(status).toBe('failed')
-      })
-
-      it('endReason=superseded 应返回 running（由调用方覆盖化身链新成员决定）', () => {
-        // 当化身被取代时，task 生命周期应由新化身决定，不由本函数决定
-        // 因此返回 running 作为占位值，调用方会读新化身并覆盖此状态
-        const status = taskStatusFromIncarnation('exited', 'superseded')
-        expect(status).toBe('running')
-      })
-    })
-
-    it('6 种 endReason + idle 的 waitingInput 两态全覆盖', () => {
-      // 6 种 endReason
-      const endReasons: IncarnationEndReason[] = ['completed', 'failed', 'killed', 'superseded', 'crashed', 'pre_migration']
-      endReasons.forEach((reason) => {
+    it('closed 是唯一终态，无出边（自迁移也不行）', () => {
+      const closedTask = {
+        ...baseTask,
+        status: 'closed' as TaskStatus,
+        closed: { at: now, by: 'manager_stop' as const },
+      }
+      const states: TaskStatus[] = ['queued', 'running', 'halted', 'closed']
+      states.forEach((to) => {
         expect(() => {
-          taskStatusFromIncarnation('exited', reason)
-        }).not.toThrow()
+          applyStatusTransition(closedTask, to, { now, halt, closed: { by: 'admin' } })
+        }).toThrow(InvalidTaskTransitionError)
       })
-
-      // idle 的 waitingInput 两态
-      expect(() => {
-        taskStatusFromIncarnation('idle', undefined, true)
-      }).not.toThrow()
-      expect(() => {
-        taskStatusFromIncarnation('idle', undefined, false)
-      }).not.toThrow()
     })
   })
 
   describe('迁移矩阵完整性检验', () => {
-    const states: TaskStatus[] = ['queued', 'running', 'waiting_input', 'completed', 'failed', 'cancelled']
+    const states: TaskStatus[] = ['queued', 'running', 'halted', 'closed']
 
-    it('6 状态两两组合 36 对，合法的按 VALID_TRANSITIONS，其余全 false', () => {
+    it('4 状态两两组合 16 对，合法的按 VALID_TRANSITIONS，其余全 false', () => {
       for (const from of states) {
         for (const to of states) {
           const expected = VALID_TRANSITIONS[from].includes(to)
@@ -247,96 +192,29 @@ describe('v3 task 状态机', () => {
     })
 
     it('终态无出边（自迁移也不行）', () => {
-      const terminalStates: TaskStatus[] = ['completed', 'failed', 'cancelled']
-      terminalStates.forEach((s) => {
-        expect(VALID_TRANSITIONS[s].length).toBe(0)
-        states.forEach((to) => {
-          expect(canTransition(s, to)).toBe(false, `${s} 不能转换至 ${to}`)
-        })
+      expect(VALID_TRANSITIONS.closed.length).toBe(0)
+      states.forEach((to) => {
+        expect(canTransition('closed', to)).toBe(false, `closed 不能转换至 ${to}`)
       })
-    })
-  })
-
-  describe('reviveTask（protocol-agent-v3 §5.2 接续例外的受控出口）', () => {
-    const now = '2026-07-28T12:00:00Z'
-
-    it('终态 task 经 reviveTask 重新置回 running，清空 completed_at/error', () => {
-      const failedTask = {
-        id: 'task-1',
-        title: 'Test Task',
-        status: 'failed' as TaskStatus,
-        created_at: '2026-07-28T00:00:00Z',
-        completed_at: '2026-07-28T01:00:00Z',
-        error: 'boom',
-      }
-      const task = reviveTask(failedTask, { now })
-      expect(task.status).toBe('running')
-      expect(task.completed_at).toBeUndefined()
-      expect(task.error).toBeUndefined()
-    })
-
-    it('completed / cancelled 终态同样可被 reviveTask 重新置回 running', () => {
-      const completedTask = {
-        id: 'task-2',
-        title: 'Test Task',
-        status: 'completed' as TaskStatus,
-        created_at: '2026-07-28T00:00:00Z',
-        completed_at: '2026-07-28T01:00:00Z',
-      }
-      expect(reviveTask(completedTask, { now }).status).toBe('running')
-
-      const cancelledTask = { ...completedTask, status: 'cancelled' as TaskStatus }
-      expect(reviveTask(cancelledTask, { now }).status).toBe('running')
-    })
-
-    it('非终态 task 调用 reviveTask 应抛 InvalidTaskTransitionError（不是给状态机新增自由出边，只服务终态接续）', () => {
-      const runningTask = {
-        id: 'task-3',
-        title: 'Test Task',
-        status: 'running' as TaskStatus,
-        created_at: '2026-07-28T00:00:00Z',
-      }
-      expect(() => reviveTask(runningTask, { now })).toThrow(InvalidTaskTransitionError)
-
-      const queuedTask = { ...runningTask, status: 'queued' as TaskStatus }
-      expect(() => reviveTask(queuedTask, { now })).toThrow(InvalidTaskTransitionError)
-
-      const waitingTask = { ...runningTask, status: 'waiting_input' as TaskStatus }
-      expect(() => reviveTask(waitingTask, { now })).toThrow(InvalidTaskTransitionError)
-    })
-
-    it('返回新对象，不修改原 task', () => {
-      const failedTask = {
-        id: 'task-1',
-        title: 'Test Task',
-        status: 'failed' as TaskStatus,
-        created_at: '2026-07-28T00:00:00Z',
-        completed_at: '2026-07-28T01:00:00Z',
-        error: 'boom',
-      }
-      const original = { ...failedTask }
-      const task = reviveTask(failedTask, { now })
-      expect(failedTask).toEqual(original)
-      expect(task).not.toBe(failedTask)
     })
   })
 
   describe('InvalidTaskTransitionError', () => {
     it('应是 Error 的子类', () => {
-      const err = new InvalidTaskTransitionError('queued', 'waiting_input')
+      const err = new InvalidTaskTransitionError('queued', 'halted')
       expect(err).toBeInstanceOf(Error)
     })
 
     it('应含 from 和 to 字段', () => {
-      const err = new InvalidTaskTransitionError('queued', 'waiting_input')
+      const err = new InvalidTaskTransitionError('queued', 'halted')
       expect(err.from).toBe('queued')
-      expect(err.to).toBe('waiting_input')
+      expect(err.to).toBe('halted')
     })
 
     it('message 应包含 from 和 to 状态', () => {
-      const err = new InvalidTaskTransitionError('queued', 'waiting_input')
+      const err = new InvalidTaskTransitionError('queued', 'halted')
       expect(err.message).toContain('queued')
-      expect(err.message).toContain('waiting_input')
+      expect(err.message).toContain('halted')
     })
   })
 })

--- a/crabot-agent/tests/workers/legacy-importer.test.ts
+++ b/crabot-agent/tests/workers/legacy-importer.test.ts
@@ -66,15 +66,15 @@ describe('v2 legacy importer', () => {
     const id = `w-legacy-${createHash('sha256').update('complete').digest('hex').slice(0, 32)}`
     const complete = await d.ledger.findWorker(id)
     expect(complete?.worker.task).toMatchObject({
-      status: 'completed', type: 'analysis', input: { q: 1 }, tags: ['legacy'], goal: 'finish',
-      priority: 'high', outcome: 'done',
+      status: 'closed', type: 'analysis', input: { q: 1 }, tags: ['legacy'], goal: 'finish',
+      priority: 'high', closed: { by: 'migration', note: expect.stringContaining('outcome: done') },
     })
     expect(complete?.worker.legacy_source?.trace_ids).toEqual(['t1', 'old-running'])
     expect(complete?.worker.incarnations[0]).not.toHaveProperty('session_ref')
-    const old = await d.ledger.findWorker(`w-legacy-${createHash('sha256').update('old').digest('hex').slice(0, 32)}`); expect(old?.worker.task).toMatchObject({ status: 'failed', error: expect.stringContaining('v3') })
+    const old = await d.ledger.findWorker(`w-legacy-${createHash('sha256').update('old').digest('hex').slice(0, 32)}`); expect(old?.worker.task).toMatchObject({ status: 'halted', halt: { halt_reason: 'pre_migration' } })
     for (const legacyStatus of ['pending', 'planning', 'waiting-human', 'waiting']) {
       const imported = await d.ledger.findWorker(`w-legacy-${createHash('sha256').update(legacyStatus).digest('hex').slice(0, 32)}`)
-      expect(imported?.worker.task.status).toBe('failed')
+      expect(imported?.worker.task.status).toBe('halted')
       expect(imported?.worker.incarnations[0]?.ended_reason).toBe('pre_migration')
     }
     const manual = await d.ledger.findWorker(`w-legacy-${createHash('sha256').update('manual').digest('hex').slice(0, 32)}`)
@@ -133,7 +133,7 @@ describe('v2 legacy importer', () => {
     await expect(importV2LegacyTasks(secondPass)).resolves.toMatchObject({ imported: 0 })
     const id = `w-legacy-${createHash('sha256').update('cancel').digest('hex').slice(0, 32)}`
     const worker = await deps(f).ledger.findWorker(id)
-    expect(worker?.worker.task).toMatchObject({ status: 'cancelled', completed_at: '2026-01-01T02:00:00.000Z' })
+    expect(worker?.worker.task).toMatchObject({ status: 'closed', closed: { at: '2026-01-01T02:00:00.000Z', by: 'migration' } })
     const events = (await new WorkerEventLog(join(f.agent, 'workers', id)).readAll()).filter(event => event.kind === 'legacy_imported')
     expect(events).toEqual([expect.objectContaining({ ts: '2026-08-10T00:00:00.000Z', detail: { admin_task_id: 'cancel', trace_count: 0, imported_at: '2026-08-10T00:00:00.000Z' } })])
   })
@@ -207,7 +207,7 @@ describe('v2 legacy importer', () => {
       started_at: '2026-01-01T00:00:00.000Z',
       ended_at: '2026-01-01T04:00:00.000Z',
     })
-    expect(worker.task.completed_at).toBe('2026-01-01T04:00:00.000Z')
+    expect(worker.task.closed?.at).toBe('2026-01-01T04:00:00.000Z')
   })
 
   it('uses the latest same-task trace, skips v3/malformed input, and rejects cross-task trace IDs', async () => {


### PR DESCRIPTION
## 依据 spec

crabot-docs/superpowers/specs/2026-08-31-worker-stop-oversight-design.md（已确认，协议变更已先行合入 docs 仓：base-protocol 0.2.4 / protocol-agent-v3 3.7.0）

## 背景与实测证据

2026-08-31 事故：worker w-be8b5743 于 07:39 finish_task 停止，07:40:05 turn_completed 唤醒准时送达 manager，manager 零工具调用收口，任务静默 53 分钟直到人类追问。事后核实：该 worker 全部 **15 次 turn_completed 唤醒，manager 15/15 零处置、0 次续办**，全天续办几乎全部由人类消息驱动。根因是 builtin finish_task 的**自报** outcome 被 harness 提升为任务终态 completed（协议旧文背书"确证"），监督按设计对终态解除武装——系统把它 100% 确证的事实（化身退出+worker 自称完成）越权升格为它无法确证的判断（任务达成）。

## 改动（每块对应 spec 章节）

- **§5.1 状态机缩水**（base-protocol §5.10 / v3 §5.2）：TaskStatus 6 态→4 态 `queued/running/halted/closed`。worker 行为只产生事实边 running⇄halted；唯一终态 closed 仅 manager/admin 处置产生（request_worker_stop→closed(by manager_stop)；admin 取消同路径）。停因与 finish_task 自报进 `TaskHaltEvidence` 标注（halt_reason/worker_self_report/detail），不进状态机。删除 `reviveTask` 接续例外（halted→running 为普通续办边）、`waiting_input`、endReason→终态映射表。
- **§5.2 finish_task 越权代判移除**：工具保留（收尾动词+结构化总结），效果收缩为化身 exited + evidence；工具描述如实化；协议"确证"措辞修正为"确证的是自报"。
- **§5.3 弃权防线=prompt 引导（用户决策，不做机制兜底）**：见 prompt 段。
- **§5.4 呈现结构化**：worker 事件渲染为 `<crabot-event class="content|blocked|review|info">`；manager system prompt 新增"对话对象是 crabot 系统"心智模型段+四类处置规则（内容类"沉默不是合法完成形态"、"自报不等于完成"两要件成文）；修复 interaction_required 的终端画面被标为"worker 最后说"的语义错位。
- **Phase 4 admin/web 同步**：AgentTaskStatus 4 态；web 徽章加 halted/closed 键（保留旧键兼容历史 trace）；admin 自身 v2 legacy 归档状态机按 §9.2 不动。

## 新增失败路径及收口方式（spec §8）

- `applyStatusTransition` 对 halted 缺 evidence、closed 缺关闭信息改为 **fail-loud 抛错**：由 harness 落账点保证标注完整，编译层不可绕过。
- 重启对账新增幂等短路段：`halted + 化身 exited` 是完整停止记录，reconcile 归 unchanged——不重复判死、不重复发事件（对应新回归测试）。
- 无新增常驻定时器/重试队列/内存独占状态。

## 测试

- crabot-agent：新增/改写状态机与全链测试，全量 **2860 passed**；`--maxWorkers=4` 下失败集恰好等于基线既有 11 处（inbound M4 ×6、runtime-config cold ×1、assemble-agent goalMode ×1、workspace-manager /private/var ×3——已在 main 分支基线复跑确认与本 PR 无关）。
- crabot-admin：触及的 75 个测试全绿。web vitest 因 worktree 环境缺 @vitejs/plugin-react 无法运行（改动仅 4 处字面量徽章/夹具映射，请 review 关注）。

## 未决/边界

- 事件面收敛（state_changed+turn_completed 双投递合并等）为 follow-up，不在本 PR。
- 机制兜底按用户决策不做；若同类弃权复发，spec §11 留有复活路径。
