### PR TITLE
feat(event-surface): 事件面收敛——两档分层、停止单回执、崩溃单醒、回合单通知

### DIFF
--- a/crabot-agent/src/manager/bootstrap.ts
+++ b/crabot-agent/src/manager/bootstrap.ts
@@ -454,6 +454,9 @@ export function buildManagerStack(deps: BootstrapDeps): ManagerStack {
       )
     },
     onOperationNotification: (managerKey, event, activityReceipt) => {
+      // 对外事件与 onEvent 通道同理:operation_settled 自带落账后 task_status 后,
+      // 停止/核验的 closed·halted 推送只经这条通道到达(唤醒面的对应事件已降审计)。
+      publishTaskStatusChanged?.(event)
       if (!registry) return { consumed: false }
       return registry.routeOperationNotification(managerKey, event, activityReceipt).catch((err) => {
         console.error(

--- a/crabot-agent/src/manager/inbound-adapters.ts
+++ b/crabot-agent/src/manager/inbound-adapters.ts
@@ -38,12 +38,11 @@ export function attentionFlushToWakeEvent(msgs: ReadonlyArray<ChannelMessage>): 
   return { kind: 'attention_flush', messages: msgs }
 }
 
-/** manager 不需要为之醒来的 harness 事件 kind:manager 自己发起 send_to_worker 时已经在同一次
- *  工具调用里同步拿到了投递结果(engine tool_result),不需要再靠事件唤醒一次去获知"已发送"
- *  这件事本身。其余 kind(spawned/input_held/state_changed/exited/killed/superseded/
- *  handoff_started/resumed/query_failed)都代表 worker 生命周期或侧问的进展/终局,manager
- *  需要据此决定要不要转述给人类或采取下一步动作,一律唤醒。`legacy_imported` 只是一条
- *  cutover 历史记录，只落盘，不能批量唤醒 Manager。 */
+/** 审计档事件（protocol-agent-v3 §4.1 两档分层）：只落 events.jsonl，永不唤醒 manager。
+ *  `input_sent`——manager 自己发起 send_to_worker 时已经在同一次工具调用里同步拿到了投递结果，
+ *  不需要再靠事件唤醒一次去获知"已发送"这件事本身；`legacy_imported` 只是 cutover 历史记录。
+ *  其余 kind 都是唤醒档：worker 生命周期/交互/巡检/侧问的进展或终局，manager 需要据此决定
+ *  要不要转述给人类或采取下一步动作。 */
 const NO_WAKE_KINDS: ReadonlySet<HarnessEventKind> = new Set(['input_sent', 'legacy_imported'])
 
 /** harness 事件是否值得唤醒 manager(过滤规则见 `NO_WAKE_KINDS` 注释)。 */

--- a/crabot-agent/src/manager/loop.ts
+++ b/crabot-agent/src/manager/loop.ts
@@ -1948,10 +1948,6 @@ function renderChannelMessages(
 function workerEventClass(event: HarnessEvent): 'content' | 'blocked' | 'review' | 'info' {
   switch (event.kind) {
     case 'state_changed': {
-      // manager 自己处置动作的回执(stop_verified:任务已 closed)是收据不是新待办,
-      // 归 info——否则每次核验成功的 request_worker_stop 都会立刻要求 manager
-      // 再走一轮"必须处置",而续办对 closed 是硬拒绝,必错。
-      if (event.detail?.reason === 'stop_verified') return 'info'
       // 主线状态机的通用事件点:停止/退出迁移是"有内容待处置",to=running 只是
       // "开始跑了"的纯通报,归 info,不逼 manager 走四选一处置。
       const to = event.detail?.to

--- a/crabot-agent/src/manager/loop.ts
+++ b/crabot-agent/src/manager/loop.ts
@@ -1948,17 +1948,18 @@ function renderChannelMessages(
 function workerEventClass(event: HarnessEvent): 'content' | 'blocked' | 'review' | 'info' {
   switch (event.kind) {
     case 'state_changed': {
-      if (event.detail?.kind === 'interaction_required') return 'blocked'
       // manager 自己处置动作的回执(stop_verified:任务已 closed)是收据不是新待办,
       // 归 info——否则每次核验成功的 request_worker_stop 都会立刻要求 manager
       // 再走一轮"必须处置",而续办对 closed 是硬拒绝,必错。
       if (event.detail?.reason === 'stop_verified') return 'info'
-      if (event.detail?.source === 'liveness_stall') return 'content'
       // 主线状态机的通用事件点:停止/退出迁移是"有内容待处置",to=running 只是
       // "开始跑了"的纯通报,归 info,不逼 manager 走四选一处置。
       const to = event.detail?.to
       return to === 'idle' || to === 'exited' ? 'content' : 'info'
     }
+    case 'interaction_required':
+      return 'blocked'
+    case 'liveness_stall':
     case 'activity_available':
     case 'turn_completed':
     case 'query_completed':
@@ -1982,7 +1983,7 @@ function renderWorkerEvent(event: HarnessEvent): string {
   if (typeof text === 'string' && text.length > 0) {
     // 只有 interaction_required 事件的 text 是终端画面 capture(不是 worker 说的话),
     // 标签必须区分,防止 manager 把画面内容误当发言;其余事件的 text 都是发言/指令原文。
-    const isPaneCapture = event.kind === 'state_changed' && event.detail?.kind === 'interaction_required'
+    const isPaneCapture = event.kind === 'interaction_required'
     parts.push(isPaneCapture ? `worker 当前画面:\n${text}` : `worker 最后说:\n${text}`)
   }
   if (typeof summary === 'string' && summary.length > 0) parts.push(`worker 的收尾结论:\n${summary}`)

--- a/crabot-agent/src/manager/prompt.ts
+++ b/crabot-agent/src/manager/prompt.ts
@@ -91,7 +91,7 @@ Crabot 为了能够在把事儿办好的基础上给人类一个更好的使用�
 
 **结论拿不到就回去问执行器**：执行器已经结束、但原生会话和交付记录里都没有你要的结论时，用 \`send_to_worker\` 把问题直接发给它——它会带着原会话的完整上下文醒过来回答你。这是你自己能解决的事，问过它确实答不上来，才轮到找人类。
 
-**完成结果的记忆候选**：当执行器事件同时满足 \`kind=state_changed\`、\`detail.summary\` 存在（执行器经 finish_task 自报的收尾结论）和 \`detail.trigger_type=message\` 时，先只根据事件中的最后文本、收尾结论或按需读取的执行器详情判断是否存在明确、可核实、可复用的结论。没有这种直接证据就不写。存在时最多写一条 inbox 候选，必须带 \`source_ref.task_id=detail.task_id\`，并在 tags 写入 \`worker_completion:<worker_id>:<seq>\`；写前先用 \`list_entries\` 查询该 tag 的所有状态，已存在就不再写。scheduled/system 执行器、失败或 idle 事件都不走这条路径。不要把这一步交给普通执行器，也不要把模糊的“已完成”编造成记忆。
+**完成结果的记忆候选**：当执行器事件同时满足 \`kind=turn_completed\`、\`detail.summary\` 存在（执行器经 finish_task 自报的收尾结论）和 \`detail.trigger_type=message\` 时，先只根据事件中的最后文本、收尾结论或按需读取的执行器详情判断是否存在明确、可核实、可复用的结论。没有这种直接证据就不写。存在时最多写一条 inbox 候选，必须带 \`source_ref.task_id=detail.task_id\`，并在 tags 写入 \`worker_completion:<worker_id>:<seq>\`；写前先用 \`list_entries\` 查询该 tag 的所有状态，已存在就不再写。scheduled/system 执行器、失败或 idle 事件都不走这条路径。不要把这一步交给普通执行器，也不要把模糊的“已完成”编造成记忆。
 
 **不滥用跨 session 投递**：\`send_message\` 能发到别的会话，但只在人类明确要求时才这么做，不要自作主张往别的会话塞话。`
 

--- a/crabot-agent/src/manager/registry.ts
+++ b/crabot-agent/src/manager/registry.ts
@@ -470,14 +470,18 @@ export class ManagerRegistry {
       }
       return { consumed: false, registered: true }
     }
-    const capture = this.captureIngress()
-    const envelope = this.makeEnvelope(capture, { kind: 'worker_event', event }, event.ts)
-    const loop = this.getOrCreate(key)
-    if (this.isEpisodeActive(key)) {
+    // 与 onEvent 通道同一份 detail 形态：trigger_type / task_id / outcome 由
+    // prepareWorkerEventRoute 现读台账注入（manager 的 prompt 判据如「完成结果的记忆候选」
+    // 依赖它们）——durable 通道不能因为是通知就少了这层丰富化。路由目标以台账
+    // manager_key 为准（与 routeWorkerEvent 一致）；台账查不到时退回入参 key——它是
+    // harness 持久化通知时记下的快照，比系统线程更贴近原投递意图。
+    const { key: routedKey, envelope } = await this.prepareWorkerEventRoute(event, key)
+    const loop = this.getOrCreate(routedKey)
+    if (this.isEpisodeActive(routedKey)) {
       loop.enqueueDuringEpisode(envelope)
       return { consumed: true }
     }
-    const result = await this.runWake(key, envelope)
+    const result = await this.runWake(routedKey, envelope)
     return { consumed: result.consumedEvents === true }
   }
 
@@ -598,7 +602,7 @@ export class ManagerRegistry {
     return { now, timezone, received_at: formatOffsetIso(now, timezone) }
   }
 
-  private async prepareWorkerEventRoute(event: HarnessEvent): Promise<{
+  private async prepareWorkerEventRoute(event: HarnessEvent, fallbackKey?: ManagerKey): Promise<{
     key: ManagerKey
     envelope: TimedWakeEnvelope
   }> {
@@ -616,7 +620,7 @@ export class ManagerRegistry {
         }
       : event
     return {
-      key: found?.worker.manager_key ?? SYSTEM_TASKS_MANAGER_KEY,
+      key: found?.worker.manager_key ?? fallbackKey ?? SYSTEM_TASKS_MANAGER_KEY,
       envelope: this.makeEnvelope(
         capture,
         { kind: 'worker_event', event: eventWithOrigin },

--- a/crabot-agent/src/workers/harness/harness.ts
+++ b/crabot-agent/src/workers/harness/harness.ts
@@ -2053,7 +2053,7 @@ export class WorkerHarness {
       if (!found) throw new WorkerNotFoundError(workerId)
       const { managerKey, worker } = found
       if (worker.task.status === 'closed') {
-        await this.appendEvent(workerId, 1, 'state_changed', {
+        await this.appendAuditEvent(workerId, 1, 'state_changed', {
           kind: 'dead_letter',
           reason: 'task_cancelled',
           text_len: item.text.length,
@@ -2090,7 +2090,7 @@ export class WorkerHarness {
         !this.deps.validateLegacyContinuationAuth ||
         !await this.deps.validateLegacyContinuationAuth(auth)
       ) {
-        await this.appendEvent(workerId, legacy.seq, 'state_changed', {
+        await this.appendAuditEvent(workerId, legacy.seq, 'state_changed', {
           kind: 'dead_letter',
           reason: 'legacy_continuation_authorization_invalid',
           text_len: item.text.length,
@@ -2626,7 +2626,7 @@ export class WorkerHarness {
         // 是调用方(inbox.flush)的既有契约,消息不能静默消失:丢弃这条并记 dead-letter 事件,
         // 不重新抛出(抛出会砸向早已异步返回的 sendToWorker 调用方,变成没人处理的 rejection)。
         if (worker.task.status === 'closed') {
-          await this.appendEvent(workerId, curSeq, 'state_changed', {
+          await this.appendAuditEvent(workerId, curSeq, 'state_changed', {
             kind: 'dead_letter',
             reason: 'task_cancelled',
             text_len: text.length,
@@ -5564,9 +5564,11 @@ export class WorkerHarness {
       const supervision = supervisionAfterMainlineTransition(previous.supervision, task.status, 'exited', incarnation.seq, now)
       return { ...previous, task, incarnations, ...(supervision ? { supervision } : {}), updated_at: now }
     })
-    await this.appendEvent(worker.worker_id, incarnation.seq, 'state_changed', { to: 'exited', reason: 'stop_verified' }, cancelled?.task.status)
+    // 停止核验事实与收件箱清空只落审计：一次停止对 manager 的唯一唤醒由 operation_settled
+    // 承载（携带落账后 task_status，见 deliverControlOperationNotifications）。
+    await this.appendAuditEvent(worker.worker_id, incarnation.seq, 'state_changed', { to: 'exited', reason: 'stop_verified' }, cancelled?.task.status)
     for (const item of this.getInbox(worker.worker_id).drain()) {
-      await this.appendEvent(worker.worker_id, incarnation.seq, 'state_changed', {
+      await this.appendAuditEvent(worker.worker_id, incarnation.seq, 'state_changed', {
         kind: 'dead_letter',
         reason: 'task_cancelled',
         text_len: item.text.length,
@@ -5668,13 +5670,31 @@ export class WorkerHarness {
     await mutex.run(async () => {
       for (const notification of await this.controlOperationStore.pendingNotifications(workerId)) {
         const { operation } = notification
-        const event = this.buildEvent(workerId, operation.seq, 'operation_settled', {
-          operation_id: operation.operation_id,
-          incarnation_id: operation.incarnation_id,
-          kind: operation.kind,
-          status: operation.status,
-          detail: operation.detail ?? '',
-        })
+        // operation_settled 是一次停止对 manager 的唯一唤醒（协议 §5.5.4）：必须携带落账后
+        // task_status——succeeded 的 closed、unknown 的 halted（含 stop_unverified 现网缺口）
+        // 都由这一条送达，不再另有 state_changed(stop_verified)/死信唤醒。事件首次落盘即
+        // 固化该值；重投读回首次落盘的那一条（task 可能已再迁移，现读台账会造出错误事实）。
+        let event: HarnessEvent
+        if (notification.event_written) {
+          event = (await this.getEventLog(workerId).readAll())
+            .filter((entry) => entry.kind === 'operation_settled' && entry.detail?.operation_id === operation.operation_id)
+            .pop()
+            ?? this.buildEvent(workerId, operation.seq, 'operation_settled', {
+              operation_id: operation.operation_id,
+              incarnation_id: operation.incarnation_id,
+              kind: operation.kind,
+              status: operation.status,
+              detail: operation.detail ?? '',
+            })
+        } else {
+          event = this.buildEvent(workerId, operation.seq, 'operation_settled', {
+            operation_id: operation.operation_id,
+            incarnation_id: operation.incarnation_id,
+            kind: operation.kind,
+            status: operation.status,
+            detail: operation.detail ?? '',
+          }, (await this.deps.ledger.findWorker(workerId))?.worker.task.status)
+        }
         try {
           if (!notification.event_written) {
             await this.getEventLog(workerId).append(event)
@@ -6399,10 +6419,11 @@ export class WorkerHarness {
         ...uiSnapshotDetail(uiSnapshot),
         ...(turn ? { turn_id: turn.turn_id, turn_pending: true } : {}),
       }
-      if (endReason === 'superseded') {
-        // handoff 进度节点（源化身退出）：只落审计——任务状态保持 running 占位，
-        // 对 manager 的唤醒由新化身就位的 lifecycle_changed 承载（一次 handoff 一次唤醒）。
-        await this.appendAuditEvent(h.worker_id, h.seq, cliReportEventKind(report), mainlineEventDetail)
+      if (endReason === 'superseded' || endReason === 'killed') {
+        // handoff 进度节点（源化身退出）/ 我方 stop 的化身退出：只落审计——前者的唤醒由
+        // 新化身就位的 lifecycle_changed 承载；后者由 operation_settled 承载（一次停止
+        // 一张回执）。审计事件仍自带落账后 task_status，供 trace/排查还原状态迁移。
+        await this.appendAuditEvent(h.worker_id, h.seq, cliReportEventKind(report), mainlineEventDetail, committed?.task.status)
       } else {
         await this.appendEvent(
           h.worker_id,
@@ -6559,9 +6580,10 @@ export class WorkerHarness {
     seq: number,
     kind: HarnessEventKind,
     detail?: Record<string, unknown>,
+    taskStatus?: TaskStatus
   ): Promise<void> {
     try {
-      await this.getEventLog(workerId).append(this.buildEvent(workerId, seq, kind, detail))
+      await this.getEventLog(workerId).append(this.buildEvent(workerId, seq, kind, detail, taskStatus))
     } catch (error) {
       console.error(
         `[WorkerHarness] failed to append operation audit event ` +

--- a/crabot-agent/src/workers/harness/harness.ts
+++ b/crabot-agent/src/workers/harness/harness.ts
@@ -4635,15 +4635,25 @@ export class WorkerHarness {
         const found = await this.deps.ledger.findWorker(workerId)
         const notice = found?.worker.recovery_notices?.find((item) => item.notice_id === noticeId)
         if (!found || !notice || notice.status !== 'pending' || !recoveryNoticeDue(notice, this.deps.now())) return undefined
+        // 投递前校验（协议 §5.5.3）：只有 task 仍为 crash 停摆才值得唤醒。Manager 的处置
+        // 动作（续办回 running / 交接 / 停止落 closed）本身即视为已消费——直接标 consumed，
+        // 不拿过期事实新开 episode。
+        const task = found.worker.task
+        if (task.status !== 'halted' || task.halt?.halt_reason !== 'crashed') {
+          await this.markRecoveryNoticeConsumed(found.managerKey, workerId, noticeId)
+          return undefined
+        }
         const incarnation = found.worker.incarnations.find((item) => item.incarnation_id === notice.incarnation_id)
         if (!incarnation || !isExecutableIncarnation(incarnation)) return undefined
         return {
           managerKey: found.managerKey,
+          // 携带投递时落账后的 task_status：这条通知是一次崩溃对 manager 的唯一唤醒，
+          // 唤醒面的 state_changed(crashed)/exited 已降审计，halted 只能由它送达。
           event: this.buildEvent(workerId, incarnation.seq, 'worker_recovery_required', {
             notice_id: notice.notice_id,
             incarnation_id: notice.incarnation_id,
             text: '[crabot] worker 的执行载体在重启后确认已中断。请先读取 worker 状态和必要的原生会话活动，再决定继续、交接、汇报或停止。',
-          }),
+          }, task.status),
         }
       })
       if (!prepared) return
@@ -4656,9 +4666,16 @@ export class WorkerHarness {
         console.error(`[WorkerHarness] recovery notice delivery failed for ${workerId}/${noticeId}:`, error)
       }
 
+      if (consumed) {
+        await this.withLock(workerId, async () => {
+          // A route that overlapped shutdown has no durable consumption confirmation. Keep the
+          // notice untouched so the next process can route it again after its gate opens.
+          if (this.recoveryNoticeDeliveryStopped || this.deps.isClosing?.()) return
+          await this.markRecoveryNoticeConsumed(prepared.managerKey, workerId, noticeId)
+        })
+        return
+      }
       await this.withLock(workerId, async () => {
-        // A route that overlapped shutdown has no durable consumption confirmation. Keep the
-        // notice untouched so the next process can route it again after its gate opens.
         if (this.recoveryNoticeDeliveryStopped || this.deps.isClosing?.()) return
         const now = this.deps.now()
         await this.deps.ledger.upsertWorker(prepared.managerKey, workerId, (prev) => {
@@ -4668,16 +4685,29 @@ export class WorkerHarness {
           const current = index < 0 ? undefined : notices[index]
           if (!current || current.status !== 'pending') return prev
           const next = [...notices]
-          next[index] = consumed
-            ? { ...current, status: 'consumed', consumed_at: now, retry_after_at: undefined }
-            : {
-                ...current,
-                attempts: current.attempts + 1,
-                retry_after_at: plusMs(now, recoveryNoticeRetryDelayMs(current.attempts + 1)),
-              }
+          next[index] = {
+            ...current,
+            attempts: current.attempts + 1,
+            retry_after_at: plusMs(now, recoveryNoticeRetryDelayMs(current.attempts + 1)),
+          }
           return { ...prev, recovery_notices: next, updated_at: now }
         })
       })
+    })
+  }
+
+  /** 把 pending 恢复通知标为已消费（manager 处置过 / episode 确认消费两种入口共用）。 */
+  private async markRecoveryNoticeConsumed(managerKey: ManagerKey, workerId: string, noticeId: string): Promise<void> {
+    const now = this.deps.now()
+    await this.deps.ledger.upsertWorker(managerKey, workerId, (prev) => {
+      if (!prev) return undefined
+      const notices = prev.recovery_notices ?? []
+      const index = notices.findIndex((item) => item.notice_id === noticeId)
+      const current = index < 0 ? undefined : notices[index]
+      if (!current || current.status !== 'pending') return prev
+      const next = [...notices]
+      next[index] = { ...current, status: 'consumed', consumed_at: now, retry_after_at: undefined }
+      return { ...prev, recovery_notices: next, updated_at: now }
     })
   }
 
@@ -5212,10 +5242,13 @@ export class WorkerHarness {
   }
 
   /**
-   * reconcileOnStartup 判死分支:落 halted(crashed)+ exited 事件。三种判死
+   * reconcileOnStartup 判死分支:落 halted(crashed)+ exited 审计事件。三种判死
    * 场景(adapter 报 exited / adapter 未注册 / adapter.state() 抛错)共用同一段收尾——三者
    * 语义上都是"至此已经没有任何证据证明这个非终态 worker 还活着"。任务不落终态:
    * "载体死了"是事实,"任务失败"是判断,由 manager 处置落定。
+   *
+   * 事件只落审计:判死同时落 recovery notice,对 manager 的唯一唤醒由 durable 的
+   * worker_recovery_required 承载(一次崩溃只醒一次,协议 §5.5.3)。
    */
   private async markCrashed(
     managerKey: ManagerKey,
@@ -5255,7 +5288,7 @@ export class WorkerHarness {
         updated_at: now,
       }
     })
-    await this.appendEvent(
+    await this.appendAuditEvent(
       worker.worker_id,
       mainline.seq,
       'exited',
@@ -6419,10 +6452,14 @@ export class WorkerHarness {
         ...uiSnapshotDetail(uiSnapshot),
         ...(turn ? { turn_id: turn.turn_id, turn_pending: true } : {}),
       }
-      if (endReason === 'superseded' || endReason === 'killed') {
-        // handoff 进度节点（源化身退出）/ 我方 stop 的化身退出：只落审计——前者的唤醒由
-        // 新化身就位的 lifecycle_changed 承载；后者由 operation_settled 承载（一次停止
-        // 一张回执）。审计事件仍自带落账后 task_status，供 trace/排查还原状态迁移。
+      if (endReason === 'superseded' || endReason === 'killed' || (endReason === 'crashed' && !preserveTaskForStop)) {
+        // 只落审计的三类退出（一次物理事实 = manager 只醒一次）：
+        // - superseded：handoff 进度节点，唤醒由新化身就位的 lifecycle_changed 承载；
+        // - killed：我方 stop，唤醒由 operation_settled 承载（一次停止一张回执）；
+        // - crashed（非停止核验途中）：唤醒由 durable 的 worker_recovery_required 承载
+        //   （一次崩溃只醒一次，协议 §5.5.3）。停止核验途中崩溃（preserveTaskForStop）
+        //   不建恢复通知，state_changed 保留唤醒作为唯一事实通道。
+        // 审计事件仍自带落账后 task_status，供 trace/排查还原状态迁移。
         await this.appendAuditEvent(h.worker_id, h.seq, cliReportEventKind(report), mainlineEventDetail, committed?.task.status)
       } else {
         await this.appendEvent(

--- a/crabot-agent/src/workers/harness/harness.ts
+++ b/crabot-agent/src/workers/harness/harness.ts
@@ -5297,13 +5297,16 @@ export class WorkerHarness {
   }
 
   /**
-   * reconcileOnStartup 判死分支:落 halted(crashed)+ exited 审计事件。三种判死
+   * reconcileOnStartup 判死分支:落 halted(crashed)+ exited 事件。三种判死
    * 场景(adapter 报 exited / adapter 未注册 / adapter.state() 抛错)共用同一段收尾——三者
    * 语义上都是"至此已经没有任何证据证明这个非终态 worker 还活着"。任务不落终态:
    * "载体死了"是事实,"任务失败"是判断,由 manager 处置落定。
    *
-   * 事件只落审计:判死同时落 recovery notice,对 manager 的唯一唤醒由 durable 的
-   * worker_recovery_required 承载(一次崩溃只醒一次,协议 §5.5.3)。
+   * 事件降审计的前提是真的落了 recovery notice（对 manager 的唯一唤醒由 durable 的
+   * worker_recovery_required 承载,一次崩溃只醒一次,协议 §5.5.3）。notice 创建有条件
+   * （mainline 尚未 exited 等）——停止残局（化身已 exited、task 非终态:handoff 第 2 步后
+   * 重启 / stop unknown 有 bg 的 op settle 后重启）不建 notice,此时必须保留唤醒档,否则
+   * 这次崩溃零唤醒零推送、任务永久静默（PR #137 review）。
    */
   private async markCrashed(
     managerKey: ManagerKey,
@@ -5312,6 +5315,7 @@ export class WorkerHarness {
     detailReason: string
   ): Promise<void> {
     const now = this.deps.now()
+    let recoveryCreated = false
     const crashed = await this.deps.ledger.upsertWorker(managerKey, worker.worker_id, (prev) => {
       if (!prev) return undefined
       const current = findIncarnation(prev, mainline.impl, mainline.seq)
@@ -5334,6 +5338,7 @@ export class WorkerHarness {
       const recovery = current?.forked_from === undefined && current?.state !== 'exited' && current?.incarnation_id
         ? appendRecoveryNotice(prev.recovery_notices, current.incarnation_id, now)
         : undefined
+      recoveryCreated = recovery?.created === true
       return {
         ...prev,
         task: nextTask,
@@ -5343,13 +5348,24 @@ export class WorkerHarness {
         updated_at: now,
       }
     })
-    await this.appendAuditEvent(
-      worker.worker_id,
-      mainline.seq,
-      'exited',
-      { reason: 'crashed', message: detailReason },
-      crashed?.task.status
-    )
+    if (recoveryCreated) {
+      await this.appendAuditEvent(
+        worker.worker_id,
+        mainline.seq,
+        'exited',
+        { reason: 'crashed', message: detailReason },
+        crashed?.task.status
+      )
+    } else {
+      // 无 recovery notice 兜底（停止残局/同化身重复判死）——保留唤醒档,宁可多醒一次。
+      await this.appendEvent(
+        worker.worker_id,
+        mainline.seq,
+        'exited',
+        { reason: 'crashed', message: detailReason },
+        crashed?.task.status
+      )
+    }
   }
 
   /**

--- a/crabot-agent/src/workers/harness/harness.ts
+++ b/crabot-agent/src/workers/harness/harness.ts
@@ -414,6 +414,42 @@ function cliReportEventKind(report: StateChangeReport | undefined): 'interaction
   return report?.notification ? 'interaction_required' : 'state_changed'
 }
 
+/**
+ * 完成回合边界的唤醒材料（协议 §6.3）：迁入 enriched turn_completed 的化身落点与正文，
+ * 以及事件级的落账后 task 状态。
+ */
+interface TurnBoundaryWake {
+  readonly to: WorkerContractState
+  readonly text?: string
+  readonly summary?: string
+  readonly taskStatus?: TaskStatus
+}
+
+/**
+ * createPendingTurn 的结果：`notificationPersisted=false` 时调用方必须回退补发一条
+ * fire-and-forget state_changed 保在线送达（回合通知没能持久化，durable 唤醒不存在）。
+ */
+interface TurnBoundaryOutcome {
+  readonly turn: WorkerTurn
+  readonly notificationPersisted: boolean
+}
+
+/** 首轮输入即完成一个回合时的唤醒材料（与主线 turn 边界同一份 truncate 口径）。 */
+function initialTurnWake(
+  state: WorkerContractState,
+  report: StateChangeReport | undefined,
+  taskStatus: TaskStatus | undefined,
+): TurnBoundaryWake {
+  const text = truncateWakeText(report?.lastText, WAKE_TEXT_MAX_CHARS, '', 'head')
+  const summary = truncateWakeText(report?.summary, WAKE_SUMMARY_MAX_CHARS, '', 'head')
+  return {
+    to: state,
+    ...(text ? { text } : {}),
+    ...(summary ? { summary } : {}),
+    ...(taskStatus ? { taskStatus } : {}),
+  }
+}
+
 function uiSnapshotDetail(snapshot: WorkerUiSnapshot | undefined): Record<string, unknown> {
   if (!snapshot) return {}
   return {
@@ -1234,12 +1270,16 @@ export class WorkerHarness {
 
       await this.appendEvent(workerId, 1, 'lifecycle_changed', { change: 'spawned', impl }, spawned?.task.status)
       const uiSnapshot = await this.prepareUiSnapshot(spawnedHandle, p.managerKey, initialInput?.report, now)
-      const turn = await this.createInitialInputTurn(p.managerKey, spawnedHandle, initialInput, now)
-      if (initialInput && (initialInput.disposition !== 'accepted' || initialState !== 'running')) {
+      const turnOutcome = await this.createInitialInputTurn(p.managerKey, spawnedHandle, initialInput, now,
+        initialTurnWake(initialState, initialInput?.report, spawned?.task.status))
+      // 首轮完成回合边界的唤醒已由 enriched turn_completed 承载（协议 §6.3）；
+      // 仅当无 turn（首投未干净接受/交互通知）或回合通知持久化失败时才补发 state_changed。
+      if (initialInput && (initialInput.disposition !== 'accepted' || initialState !== 'running')
+        && !turnOutcome?.notificationPersisted) {
         await this.appendEvent(workerId, 1, cliReportEventKind(initialInput.report), {
           ...cliReportDetail(initialState, initialInput.report),
           ...uiSnapshotDetail(uiSnapshot),
-          ...(turn ? { turn_id: turn.turn_id, turn_pending: true } : {}),
+          ...(turnOutcome ? { turn_id: turnOutcome.turn.turn_id, turn_pending: true } : {}),
         }, spawned?.task.status)
       }
       return spawned as LedgerWorker
@@ -2361,8 +2401,10 @@ export class WorkerHarness {
         updated?.task.status,
       )
       const uiSnapshot = await this.prepareUiSnapshot(handle, managerKey, initialInput?.report, now)
-      const turn = await this.createInitialInputTurn(managerKey, handle, initialInput, now)
-      if (initialInput && (initialInput.disposition !== 'accepted' || initialState !== 'running')) {
+      const turnOutcome = await this.createInitialInputTurn(managerKey, handle, initialInput, now,
+        initialTurnWake(initialState, initialInput?.report, updated?.task.status))
+      if (initialInput && (initialInput.disposition !== 'accepted' || initialState !== 'running')
+        && !turnOutcome?.notificationPersisted) {
         await this.appendEvent(
           worker.worker_id,
           handle.seq,
@@ -2370,7 +2412,7 @@ export class WorkerHarness {
           {
             ...cliReportDetail(initialState, initialInput.report),
             ...uiSnapshotDetail(uiSnapshot),
-            ...(turn ? { turn_id: turn.turn_id, turn_pending: true } : {}),
+            ...(turnOutcome ? { turn_id: turnOutcome.turn.turn_id, turn_pending: true } : {}),
           },
           updated?.task.status,
         )
@@ -2966,12 +3008,14 @@ export class WorkerHarness {
     const replayedConsumed = inbox.requeueConsumed()
     await this.appendEvent(worker.worker_id, newHandle.seq, 'lifecycle_changed', { change: 'resumed', from_seq: mainline.seq }, revived?.task.status)
     const uiSnapshot = await this.prepareUiSnapshot(newHandle, managerKey, initialInput?.report, now)
-    const turn = await this.createInitialInputTurn(managerKey, newHandle, initialInput, now)
-    if (initialInput && (initialInput.disposition !== 'accepted' || initialState !== 'running')) {
+    const turnOutcome = await this.createInitialInputTurn(managerKey, newHandle, initialInput, now,
+      initialTurnWake(initialState, initialInput?.report, revived?.task.status))
+    if (initialInput && (initialInput.disposition !== 'accepted' || initialState !== 'running')
+      && !turnOutcome?.notificationPersisted) {
       await this.appendEvent(worker.worker_id, newHandle.seq, cliReportEventKind(initialInput.report), {
         ...cliReportDetail(initialState, initialInput.report),
         ...uiSnapshotDetail(uiSnapshot),
-        ...(turn ? { turn_id: turn.turn_id, turn_pending: true } : {}),
+        ...(turnOutcome ? { turn_id: turnOutcome.turn.turn_id, turn_pending: true } : {}),
       }, revived?.task.status)
     }
     return continuationDelivery(initialInput, initialState, newHandle, replayedConsumed)
@@ -3334,12 +3378,14 @@ export class WorkerHarness {
       handedOff?.task.status
     )
     const uiSnapshot = await this.prepareUiSnapshot(newHandle, managerKey, initialInput?.report, now)
-    const turn = await this.createInitialInputTurn(managerKey, newHandle, initialInput, now)
-    if (initialInput && (initialInput.disposition !== 'accepted' || initialState !== 'running')) {
+    const turnOutcome = await this.createInitialInputTurn(managerKey, newHandle, initialInput, now,
+      initialTurnWake(initialState, initialInput?.report, handedOff?.task.status))
+    if (initialInput && (initialInput.disposition !== 'accepted' || initialState !== 'running')
+      && !turnOutcome?.notificationPersisted) {
       await this.appendEvent(worker.worker_id, newHandle.seq, cliReportEventKind(initialInput.report), {
         ...cliReportDetail(initialState, initialInput.report),
         ...uiSnapshotDetail(uiSnapshot),
-        ...(turn ? { turn_id: turn.turn_id, turn_pending: true } : {}),
+        ...(turnOutcome ? { turn_id: turnOutcome.turn.turn_id, turn_pending: true } : {}),
       }, handedOff?.task.status)
     }
     return {
@@ -3649,7 +3695,8 @@ export class WorkerHarness {
     handle: IncarnationHandle,
     report: StateChangeReport | undefined,
     completedAt: string,
-  ): Promise<WorkerTurn | undefined> {
+    wake?: TurnBoundaryWake,
+  ): Promise<TurnBoundaryOutcome | undefined> {
     if (!handle.incarnation_id || !report?.completionSource) return undefined
     const prior = await this.turnStore.latestForIncarnation(handle.worker_id, handle.incarnation_id)
     let activityFrom = prior?.activity_through ?? '0'
@@ -3682,16 +3729,17 @@ export class WorkerHarness {
       completion_source: report.completionSource,
     })
     try {
-      await this.persistTurnNotification(turn)
+      await this.persistTurnNotification(turn, wake)
       void this.deliverNativeActivityNotifications(turn.worker_id).catch((error) => {
         console.error(`[WorkerHarness] native activity notification delivery failed for ${turn.worker_id}:`, error)
       })
+      return { turn, notificationPersisted: true }
     } catch (error) {
-      // processStateChange emits a durable state_changed event carrying turn_id below. Keep that
-      // path live even when the supplementary turn_completed notification cannot be recorded.
+      // 回合通知持久化失败时，调用方回退补发一条 fire-and-forget state_changed 保在线送达
+      // （协议 §6.3）——所以这里必须把"没存上"如实交回去，不能吞成"发了 turn_completed"。
       console.error(`[WorkerHarness] failed to persist completed-turn notification ${turn.turn_id}:`, error)
+      return { turn, notificationPersisted: false }
     }
-    return turn
   }
 
   /** Claude/Codex resume 复用同一原生 session 文件，offset 不会随化身重置。 */
@@ -3757,7 +3805,8 @@ export class WorkerHarness {
     handle: IncarnationHandle,
     initialInput: InitialInputResult | undefined,
     completedAt: string,
-  ): Promise<WorkerTurn | undefined> {
+    wake?: TurnBoundaryWake,
+  ): Promise<TurnBoundaryOutcome | undefined> {
     if (!initialInput?.report?.completionSource) return undefined
     try {
       await this.collectNativeActivityLocked(handle, managerKey)
@@ -3765,7 +3814,7 @@ export class WorkerHarness {
       // The adapter's completion result is authoritative. Activity collection is supplementary.
       console.error(`[WorkerHarness] native activity collection failed at initial turn boundary for ${handle.worker_id}#${handle.seq}:`, error)
     }
-    return this.createPendingTurn(managerKey, handle, initialInput.report, completedAt)
+    return this.createPendingTurn(managerKey, handle, initialInput.report, completedAt, wake)
   }
 
   private async collectNativeActivity(h: IncarnationHandle, baselineUnobserved = false): Promise<void> {
@@ -3883,7 +3932,10 @@ export class WorkerHarness {
     })
   }
 
-  private async persistTurnNotification(turn: WorkerTurn): Promise<void> {
+  private async persistTurnNotification(turn: WorkerTurn, wake?: TurnBoundaryWake): Promise<void> {
+    // turn_completed 是完成回合边界对 Manager 的唯一唤醒（协议 §6.3）：detail 合并承载
+    // 化身落点 to、worker 最后发言 text、收尾结论 summary，事件级携带落账后 task_status；
+    // 同拍不再另发 state_changed 唤醒。
     const event = this.buildEvent(turn.worker_id, turn.seq, 'turn_completed', {
       turn_id: turn.turn_id,
       incarnation_id: turn.incarnation_id,
@@ -3891,7 +3943,10 @@ export class WorkerHarness {
       activity_through: turn.activity_through,
       completion_source: turn.completion_source,
       turn_pending: true,
-    })
+      ...(wake ? { to: wake.to } : {}),
+      ...(wake?.text ? { text: wake.text } : {}),
+      ...(wake?.summary ? { summary: wake.summary } : {}),
+    }, wake?.taskStatus)
     await this.nativeActivityStore.record({
       worker_id: turn.worker_id,
       manager_key: turn.manager_key,
@@ -6437,13 +6492,19 @@ export class WorkerHarness {
         }
       })
       settledCurrentExit = state === 'exited' && committed !== undefined
-      const turn = shouldCreateTurn && committed
+      const turnOutcome = shouldCreateTurn && committed
         ? await this.createPendingTurn(managerKey, {
             ...h,
             ...(target.incarnation_id ? { incarnation_id: target.incarnation_id } : {}),
             session_ref: h.session_ref || target.session_ref,
-          }, report, now)
+          }, report, now, {
+            to: state,
+            ...(wakeText ? { text: wakeText } : {}),
+            ...(wakeSummary ? { summary: wakeSummary } : {}),
+            taskStatus: committed.task.status,
+          })
         : undefined
+      const turn = turnOutcome?.turn
       // 主线分支是 task 状态机的主要推进点——事件必须自带落账后的状态,否则订阅方现读台账
       // 时若已经有下一次落账(如 §5.3 透明接续把终态拉回 running),这次迁移(含 completed
       // 这类终态)会被整条吞掉。见 worker-events.ts `HarnessEvent.task_status`。
@@ -6461,7 +6522,12 @@ export class WorkerHarness {
         //   不建恢复通知，state_changed 保留唤醒作为唯一事实通道。
         // 审计事件仍自带落账后 task_status，供 trace/排查还原状态迁移。
         await this.appendAuditEvent(h.worker_id, h.seq, cliReportEventKind(report), mainlineEventDetail, committed?.task.status)
+      } else if (turnOutcome?.notificationPersisted) {
+        // enriched turn_completed 是本拍完成回合边界对 manager 的唯一唤醒（协议 §6.3，
+        // durable 通道），同拍不再另发 state_changed。持久化失败时走下方回退。
       } else {
+        // 无 turn（普通状态跳动/交互通知）或回合通知持久化失败：fire-and-forget
+        // state_changed/interaction_required 保在线送达。
         await this.appendEvent(
           h.worker_id,
           h.seq,

--- a/crabot-agent/src/workers/harness/harness.ts
+++ b/crabot-agent/src/workers/harness/harness.ts
@@ -389,9 +389,10 @@ function cliReportDetail(state: WorkerContractState, report: StateChangeReport |
     return { to: state, kind: 'initial_input_settled' }
   }
   if (report?.notification) {
+    // interaction_required 已提升为独立事件 kind（protocol §6.3 CliInteractionRequiredDetail），
+    // detail 不再带 kind 字段；事件 kind 由调用方按 report.notification 选择。
     return {
       to: state,
-      kind: 'interaction_required',
       wait_mode: 'action',
       wait_reason: report.waitReason ?? 'interaction_required',
       notification_type: report.notification.type,
@@ -406,6 +407,11 @@ function cliReportDetail(state: WorkerContractState, report: StateChangeReport |
     ...(state === 'idle' ? { wait_mode: 'action' } : {}),
     ...(report?.waitReason ? { wait_reason: report.waitReason } : {}),
   }
+}
+
+/** 交互通知（notification）提升为独立 kind，其余 report 形态仍走 state_changed。 */
+function cliReportEventKind(report: StateChangeReport | undefined): 'interaction_required' | 'state_changed' {
+  return report?.notification ? 'interaction_required' : 'state_changed'
 }
 
 function uiSnapshotDetail(snapshot: WorkerUiSnapshot | undefined): Record<string, unknown> {
@@ -1226,11 +1232,11 @@ export class WorkerHarness {
         inbox.hold('input_pending')
       }
 
-      await this.appendEvent(workerId, 1, 'spawned', { impl }, spawned?.task.status)
+      await this.appendEvent(workerId, 1, 'lifecycle_changed', { change: 'spawned', impl }, spawned?.task.status)
       const uiSnapshot = await this.prepareUiSnapshot(spawnedHandle, p.managerKey, initialInput?.report, now)
       const turn = await this.createInitialInputTurn(p.managerKey, spawnedHandle, initialInput, now)
       if (initialInput && (initialInput.disposition !== 'accepted' || initialState !== 'running')) {
-        await this.appendEvent(workerId, 1, 'state_changed', {
+        await this.appendEvent(workerId, 1, cliReportEventKind(initialInput.report), {
           ...cliReportDetail(initialState, initialInput.report),
           ...uiSnapshotDetail(uiSnapshot),
           ...(turn ? { turn_id: turn.turn_id, turn_pending: true } : {}),
@@ -2243,7 +2249,9 @@ export class WorkerHarness {
         discardPreparedLegacyContinuation()
         return expiredAfterContextWrite
       }
-      await this.appendEvent(worker.worker_id, legacy.seq, 'handoff_started', {
+      // handoff 进度节点：只落审计。完成点（新化身就位的 lifecycle_changed）才唤醒 manager。
+      await this.appendAuditEvent(worker.worker_id, legacy.seq, 'lifecycle_changed', {
+        change: 'handoff_started',
         target_impl: targetImpl,
         legacy: true,
         handoff_id: handoff.package_id,
@@ -2348,8 +2356,8 @@ export class WorkerHarness {
       await this.appendEvent(
         worker.worker_id,
         handle.seq,
-        'spawned',
-        { impl: targetImpl, from_seq: legacy.seq, legacy: true },
+        'lifecycle_changed',
+        { change: 'spawned', impl: targetImpl, from_seq: legacy.seq, legacy: true },
         updated?.task.status,
       )
       const uiSnapshot = await this.prepareUiSnapshot(handle, managerKey, initialInput?.report, now)
@@ -2358,7 +2366,7 @@ export class WorkerHarness {
         await this.appendEvent(
           worker.worker_id,
           handle.seq,
-          'state_changed',
+          cliReportEventKind(initialInput.report),
           {
             ...cliReportDetail(initialState, initialInput.report),
             ...uiSnapshotDetail(uiSnapshot),
@@ -2956,11 +2964,11 @@ export class WorkerHarness {
     const inbox = this.getInbox(worker.worker_id)
     inbox.release()
     const replayedConsumed = inbox.requeueConsumed()
-    await this.appendEvent(worker.worker_id, newHandle.seq, 'resumed', { from_seq: mainline.seq }, revived?.task.status)
+    await this.appendEvent(worker.worker_id, newHandle.seq, 'lifecycle_changed', { change: 'resumed', from_seq: mainline.seq }, revived?.task.status)
     const uiSnapshot = await this.prepareUiSnapshot(newHandle, managerKey, initialInput?.report, now)
     const turn = await this.createInitialInputTurn(managerKey, newHandle, initialInput, now)
     if (initialInput && (initialInput.disposition !== 'accepted' || initialState !== 'running')) {
-      await this.appendEvent(worker.worker_id, newHandle.seq, 'state_changed', {
+      await this.appendEvent(worker.worker_id, newHandle.seq, cliReportEventKind(initialInput.report), {
         ...cliReportDetail(initialState, initialInput.report),
         ...uiSnapshotDetail(uiSnapshot),
         ...(turn ? { turn_id: turn.turn_id, turn_pending: true } : {}),
@@ -3157,7 +3165,9 @@ export class WorkerHarness {
         if (admission) void admission.dispose().catch(() => {})
         return { restoredDurableReceipt: false, delivery: expiredBeforeHandoffEvent }
       }
-      await this.appendEvent(worker.worker_id, source.seq, 'handoff_started', {
+      // handoff 进度节点：只落审计。完成点（新化身就位的 lifecycle_changed）才唤醒 manager。
+      await this.appendAuditEvent(worker.worker_id, source.seq, 'lifecycle_changed', {
+        change: 'handoff_started',
         target_impl: targetImpl,
         handoff_id: handoff.package_id,
       })
@@ -3313,19 +3323,20 @@ export class WorkerHarness {
     }
     const replayedConsumed = inbox.requeueConsumed()
     const restoredDurableReceipt = replayedConsumed > 0
-    // 与 reviveIncarnation 收尾时发 'resumed' 事件对称——交接产出的新化身同样是一次"开工",
-    // 缺了这个事件会让事件流看不到 handoff 之后新主线是何时、以何种 impl 建起来的。
+    // 与 reviveIncarnation 收尾时发 lifecycle_changed(resumed) 事件对称——交接产出的新化身同样是
+    // 一次"开工",缺了这个事件会让事件流看不到 handoff 之后新主线是何时、以何种 impl 建起来的。
+    // 这是 handoff 全流程对 manager 的唯一唤醒（进度节点只落审计）。
     await this.appendEvent(
       worker.worker_id,
       newHandle.seq,
-      'spawned',
-      { impl: targetImpl, from_seq: source.seq, handoff_id: handoff.package_id },
+      'lifecycle_changed',
+      { change: 'spawned', impl: targetImpl, from_seq: source.seq, handoff_id: handoff.package_id },
       handedOff?.task.status
     )
     const uiSnapshot = await this.prepareUiSnapshot(newHandle, managerKey, initialInput?.report, now)
     const turn = await this.createInitialInputTurn(managerKey, newHandle, initialInput, now)
     if (initialInput && (initialInput.disposition !== 'accepted' || initialState !== 'running')) {
-      await this.appendEvent(worker.worker_id, newHandle.seq, 'state_changed', {
+      await this.appendEvent(worker.worker_id, newHandle.seq, cliReportEventKind(initialInput.report), {
         ...cliReportDetail(initialState, initialInput.report),
         ...uiSnapshotDetail(uiSnapshot),
         ...(turn ? { turn_id: turn.turn_id, turn_pending: true } : {}),
@@ -5061,7 +5072,7 @@ export class WorkerHarness {
   }
 
   /**
-   * 上报一次停摆,走 `state_changed` + `detail.text` 这条既有的唤醒形状,并按投递结局更新
+   * 上报一次停摆,走独立的 `liveness_stall` kind + `detail.text` 这条唤醒形状,并按投递结局更新
    * 已报标记(含退避)。
    *
    * **首报带停摆事实、重试不重复**(`attempts`):Harness 不主动读取终端；Manager 若需要
@@ -5089,9 +5100,8 @@ export class WorkerHarness {
     }
     let delivery: HarnessEventDelivery | undefined
     try {
-      delivery = await this.appendEventAwaitingDelivery(h.worker_id, h.seq, 'state_changed', {
+      delivery = await this.appendEventAwaitingDelivery(h.worker_id, h.seq, 'liveness_stall', {
         to: 'running' satisfies WorkerContractState,
-        source: 'liveness_stall',
         ...(text ? { text } : {}),
       })
     } catch (err) {
@@ -5590,11 +5600,12 @@ export class WorkerHarness {
       })
       return { ...previous, incarnations, updated_at: now }
     })
-    await this.appendEvent(
+    // handoff 进度节点：只落审计。完成点（新化身就位的 lifecycle_changed）才唤醒 manager。
+    await this.appendAuditEvent(
       worker.worker_id,
       incarnation.seq,
-      'superseded',
-      { reason: 'handoff_stop_verified' },
+      'lifecycle_changed',
+      { change: 'superseded', reason: 'handoff_stop_verified' },
     )
   }
 
@@ -6139,7 +6150,7 @@ export class WorkerHarness {
       this.fireIncarnationTerminal(h)
     }
     if (report) {
-      await this.appendEvent(h.worker_id, h.seq, 'state_changed', cliReportDetail(external, report), committedStatus)
+      await this.appendEvent(h.worker_id, h.seq, cliReportEventKind(report), cliReportDetail(external, report), committedStatus)
     } else if (external !== 'running') {
       await this.appendEvent(h.worker_id, h.seq, 'state_changed', { to: external }, committedStatus)
     }
@@ -6383,17 +6394,24 @@ export class WorkerHarness {
       // 主线分支是 task 状态机的主要推进点——事件必须自带落账后的状态,否则订阅方现读台账
       // 时若已经有下一次落账(如 §5.3 透明接续把终态拉回 running),这次迁移(含 completed
       // 这类终态)会被整条吞掉。见 worker-events.ts `HarnessEvent.task_status`。
-      await this.appendEvent(
-        h.worker_id,
-        h.seq,
-        'state_changed',
-          {
-            ...(report?.notification ? cliReportDetail(state, report) : { to: state, ...wakeDetail }),
-            ...uiSnapshotDetail(uiSnapshot),
-            ...(turn ? { turn_id: turn.turn_id, turn_pending: true } : {}),
-        },
-        committed?.task.status
-      )
+      const mainlineEventDetail = {
+        ...(report?.notification ? cliReportDetail(state, report) : { to: state, ...wakeDetail }),
+        ...uiSnapshotDetail(uiSnapshot),
+        ...(turn ? { turn_id: turn.turn_id, turn_pending: true } : {}),
+      }
+      if (endReason === 'superseded') {
+        // handoff 进度节点（源化身退出）：只落审计——任务状态保持 running 占位，
+        // 对 manager 的唤醒由新化身就位的 lifecycle_changed 承载（一次 handoff 一次唤醒）。
+        await this.appendAuditEvent(h.worker_id, h.seq, cliReportEventKind(report), mainlineEventDetail)
+      } else {
+        await this.appendEvent(
+          h.worker_id,
+          h.seq,
+          cliReportEventKind(report),
+          mainlineEventDetail,
+          committed?.task.status
+        )
+      }
     })
     await this.deliverNativeActivityNotifications(h.worker_id)
     if (recoveryNoticeCreated) {
@@ -6488,11 +6506,11 @@ export class WorkerHarness {
    * `HarnessEvent.task_status` 的字段注释(为什么必须由事件自带,以及缺席时的语义)。
    *
    * 本文件里带这个参数的调用点(8 处,均为 task 级迁移):spawnWorker 的失败/成功收尾、
-   * reviveIncarnation 的 `resumed`、handoffIncarnation 第 4 步的 `spawned`、markCrashed 的
-   * `exited`、realignAliveIncarnation 的 `state_changed`、killWorker 的 `killed`、
-   * processStateChange 主线分支的 `state_changed`。其余调用点(化身级事件:input_sent /
-   * fork 分支 state_changed / query_failed / dead-letter / superseded / handoff_started …)
-   * 都不动 task.status,一律不传。
+   * reviveIncarnation 的 lifecycle_changed(resumed)、handoffIncarnation 第 4 步的
+   * lifecycle_changed(spawned)、markCrashed 的 `exited`、realignAliveIncarnation 的
+   * `state_changed`、kill 核验后化身退出的 `state_changed`、processStateChange 主线分支的
+   * `state_changed`。其余调用点(化身级事件:input_sent / fork 分支 state_changed /
+   * query_failed / dead-letter / handoff 进度节点 …)都不动 task.status,一律不传。
    *
    * upsert 的 mutator 返回 undefined(worker 已不在台账)时 `committed` 是 undefined,这里
    * 原样落成"不带该字段",订阅方退回现读台账兜底,不构造假状态。

--- a/crabot-agent/src/workers/harness/worker-events.ts
+++ b/crabot-agent/src/workers/harness/worker-events.ts
@@ -20,7 +20,6 @@ export type HarnessEventKind =
   | 'turn_completed'
   | 'operation_settled'
   | 'input_sent'
-  | 'input_held'
   | 'state_changed'
   | 'exited'
   | 'killed'

--- a/crabot-agent/src/workers/harness/worker-events.ts
+++ b/crabot-agent/src/workers/harness/worker-events.ts
@@ -15,17 +15,22 @@ import { AsyncMutex } from '../async-mutex'
 import type { TaskStatus } from './ledger-types'
 
 export type HarnessEventKind =
-  | 'spawned'
+  /**
+   * 化身链变更（protocol-agent-v3 §4.1）：`detail.change` 区分 `spawned`（含 handoff 完成
+   * 新化身就位）/ `resumed` / `handoff_started` / `superseded`。spawn/resume/handoff 完成点
+   * 唤醒 manager；handoff 进度节点（started/superseded/源退出）只落审计。
+   */
+  | 'lifecycle_changed'
   | 'activity_available'
   | 'turn_completed'
   | 'operation_settled'
   | 'input_sent'
   | 'state_changed'
   | 'exited'
-  | 'killed'
-  | 'superseded'
-  | 'handoff_started'
-  | 'resumed'
+  /** 交互需介入（旧 `state_changed` 的 `detail.kind='interaction_required'` 子形态提升）。 */
+  | 'interaction_required'
+  /** 活性巡检发现疑似停摆（旧 `state_changed` 的 `detail.source='liveness_stall'` 子形态提升）。 */
+  | 'liveness_stall'
   | 'input_delivery_failed'
   /**
    * query 建立或执行失败的持久审计事件。建立失败同时在原工具调用返回结构化错误；执行失败

--- a/crabot-agent/src/workers/trace/composite-reader.ts
+++ b/crabot-agent/src/workers/trace/composite-reader.ts
@@ -87,9 +87,16 @@ function normalizeHarnessEvent(
 /** lifecycle 行的 summary 带上关键 detail——裸事件名（如 state_changed 无目标态）是噪音。 */
 function harnessSummary(event: HarnessEvent): string {
   const detail = (event.detail ?? {}) as Record<string, unknown>
-  switch (event.kind) {
+  // 按 string 匹配：2026-09-01 事件面收敛前的历史 events.jsonl 里还有 spawned/superseded 等
+  // 已退役 kind（见下方 legacy case），类型枚举只覆盖新 kind。
+  switch (event.kind as string) {
     case 'state_changed':
       return detail.to ? `state_changed → ${String(detail.to)}` : 'state_changed'
+    case 'lifecycle_changed': {
+      const change = typeof detail.change === 'string' ? detail.change : 'lifecycle_changed'
+      return detail.impl ? `${change} (${String(detail.impl)})` : change
+    }
+    // 服务 2026-09-01 事件面收敛前的历史 events.jsonl（旧 kind 读路径兼容）。
     case 'spawned':
       return detail.impl ? `spawned (${String(detail.impl)})` : 'spawned'
     case 'input_sent':

--- a/crabot-agent/tests/manager/events.test.ts
+++ b/crabot-agent/tests/manager/events.test.ts
@@ -261,7 +261,7 @@ describe('agent 对外事件（P5 Task 2）', () => {
       const { ledger } = makeLedgerStub([{ status: 'running' }], { taskId: 'task-42' })
       const bridge = makeTaskStatusEventBridge({ ledger, publish })
 
-      bridge(harnessEvent({ kind: 'spawned', worker_id: 'w-42' }))
+      bridge(harnessEvent({ kind: 'lifecycle_changed', worker_id: 'w-42' }))
       await flush()
 
       expect(publish).toHaveBeenCalledTimes(1)
@@ -290,7 +290,7 @@ describe('agent 对外事件（P5 Task 2）', () => {
       const bridge = makeTaskStatusEventBridge({ ledger, publish })
 
       // 第一条把 task 从初始 queued 带到 running（这是真实迁移，应发）
-      bridge(harnessEvent({ kind: 'spawned' }))
+      bridge(harnessEvent({ kind: 'lifecycle_changed' }))
       await flush()
       expect(publish).toHaveBeenCalledTimes(1)
 
@@ -336,7 +336,7 @@ describe('agent 对外事件（P5 Task 2）', () => {
       ])
       const bridge = makeTaskStatusEventBridge({ ledger, publish })
 
-      bridge(harnessEvent({ kind: 'spawned' }))
+      bridge(harnessEvent({ kind: 'lifecycle_changed' }))
       bridge(harnessEvent({ kind: 'exited' }))
       await flush(20)
 
@@ -363,7 +363,7 @@ describe('agent 对外事件（P5 Task 2）', () => {
       const bridge = makeTaskStatusEventBridge({ ledger, publish })
 
       // ① spawn：台账落 running，事件带 running
-      bridge(harnessEvent({ kind: 'spawned', worker_id: 'w-swallow', task_status: 'running' }))
+      bridge(harnessEvent({ kind: 'lifecycle_changed', worker_id: 'w-swallow', task_status: 'running' }))
       await flush()
 
       // ② 化身自然结束：台账落 completed、harness 发 exited……
@@ -376,7 +376,7 @@ describe('agent 对外事件（P5 Task 2）', () => {
       await flush()
 
       // ③ 接续产出新化身
-      bridge(harnessEvent({ kind: 'resumed', worker_id: 'w-swallow', task_status: 'running' }))
+      bridge(harnessEvent({ kind: 'lifecycle_changed', worker_id: 'w-swallow', task_status: 'running' }))
       await flush()
 
       expect(publish.mock.calls.map(([, p]) => [p.old_status, p.new_status])).toEqual([
@@ -394,7 +394,7 @@ describe('agent 对外事件（P5 Task 2）', () => {
       const { ledger } = makeLedgerStub([{ status: 'running' }])
       const bridge = makeTaskStatusEventBridge({ ledger, publish })
 
-      bridge(harnessEvent({ kind: 'killed', worker_id: 'w-evt', task_status: 'cancelled' }))
+      bridge(harnessEvent({ kind: 'state_changed', worker_id: 'w-evt', task_status: 'cancelled' }))
       await flush()
 
       expect(publish.mock.calls.map(([, p]) => [p.old_status, p.new_status])).toEqual([['queued', 'cancelled']])

--- a/crabot-agent/tests/manager/fail-loud-worker-event.test.ts
+++ b/crabot-agent/tests/manager/fail-loud-worker-event.test.ts
@@ -283,7 +283,7 @@ describe('worker 事件路径的 fail-loud（bootstrap.onEvent → reportEpisode
 
     const wakeTexts = async (): Promise<string[]> =>
       (await stack.harness.readWorkerEvents(workerId))
-        .filter((e) => e.kind === 'state_changed' && typeof e.detail?.text === 'string')
+        .filter((e) => e.kind === 'liveness_stall' && typeof e.detail?.text === 'string')
         .map((e) => e.detail!.text as string)
 
     await stack.harness.sweepLiveness()

--- a/crabot-agent/tests/manager/manager-integration.test.ts
+++ b/crabot-agent/tests/manager/manager-integration.test.ts
@@ -429,6 +429,8 @@ describe('manager-integration（P4 Task 10：真实 ManagerRegistry + 真实 Wor
       expect(assembly.toolCallLog.some((c) => c.name === 'spawn_worker')).toBe(true)
 
       // 等真实 worker 后台把 finish_task 跑完——burst 是 fire-and-forget,不是靠猜时序。
+      // 回合边界事件走 durable 通道（persist + 异步投递），比台账 halted 晚一跳，
+      // 直接等事件本身出现（场景五同款模式）。
       await waitUntil(async () => {
         const workers = await assembly.harness.listWorkers(assembly.managerKeyFor(key))
         return workers.some((w) => w.task.status === 'halted')
@@ -440,6 +442,7 @@ describe('manager-integration（P4 Task 10：真实 ManagerRegistry + 真实 Wor
       expect(worker.incarnations[0].state).toBe('exited')
       expect(worker.incarnations[0].ended_reason).toBe('completed')
 
+      await waitUntil(() => findWorkerExitedEvent(assembly.events, worker.worker_id) !== undefined)
       const exitedEvent = findWorkerExitedEvent(assembly.events, worker.worker_id)
       expect(exitedEvent).toBeDefined()
 
@@ -524,6 +527,8 @@ describe('manager-integration（P4 Task 10：真实 ManagerRegistry + 真实 Wor
         return workers.some((w) => w.task.status === 'halted')
       })
       const [workerA] = await assembly.harness.listWorkers(assembly.managerKeyFor(SYSTEM_TASKS_MANAGER_KEY))
+      // durable 通道事件比台账 halted 晚一跳，等事件本身出现（同场景一）
+      await waitUntil(() => findWorkerExitedEvent(assembly.events, workerA.worker_id) !== undefined)
       const exitedEventA = findWorkerExitedEvent(assembly.events, workerA.worker_id)!
 
       managerScript.queue.push({
@@ -578,6 +583,7 @@ describe('manager-integration（P4 Task 10：真实 ManagerRegistry + 真实 Wor
       expect(workerB.incarnations[0].ended_reason).toBe('failed')
       // 同一份真值也进了对外事件（appendEvent 带的是提交后的 task.status）——manager 的
       // 台账块与 admin 侧读端点看到的都是这一份。
+      await waitUntil(() => findWorkerExitedEvent(assembly.events, workerB.worker_id) !== undefined)
       const exitedEventB = findWorkerExitedEvent(assembly.events, workerB.worker_id)!
       expect(exitedEventB.task_status).toBe('halted')
       // 对照组：成功的 worker A 仍然是 completed，修复没有把所有退出一刀切判失败。

--- a/crabot-agent/tests/manager/manager-integration.test.ts
+++ b/crabot-agent/tests/manager/manager-integration.test.ts
@@ -164,15 +164,16 @@ function channelSessionFromKey(key: ManagerKey): { channel_id: string; session_i
 }
 
 /**
- * worker 自然跑到终态(finish_task/burst 正常收尾)时,harness.processStateChange 落的事件
- * kind 恒为 'state_changed'、`detail.to==='exited'`——`'exited'` 这个 HarnessEventKind 只在
- * spawn 失败 / reconcileOnStartup 判崩 / fork 化身完成三条路径使用(读 harness.ts 的
- * `appendEvent(..., 'exited', ...)` 调用点确认,不是猜测),不对应本文件场景一/二里
- * worker 主线正常 finish_task 收尾这条路径。取最后一条匹配的事件(理论上只有一条:该 worker
- * 单轮 burst 内直接从 running 转 exited,不经过 idle 中间态)。
+ * worker 自然跑到终态(finish_task/burst 正常收尾)时,唤醒事件是 enriched turn_completed
+ * (协议 §6.3:完成回合边界对 manager 的唯一唤醒,durable 通道投递)——同拍不再另发
+ * state_changed。`'exited'` 这个 HarnessEventKind 只在 spawn 失败 / reconcileOnStartup
+ * 判崩 / fork 化身完成三条路径使用(读 harness.ts 的 `appendEvent(..., 'exited', ...)`
+ * 调用点确认,不是猜测),不对应本文件场景一/二里 worker 主线正常 finish_task 收尾这条
+ * 路径。取最后一条匹配的事件(理论上只有一条:该 worker 单轮 burst 内直接从 running 转
+ * exited,不经过 idle 中间态)。
  */
 function findWorkerExitedEvent(events: readonly HarnessEvent[], workerId: string): HarnessEvent | undefined {
-  return [...events].reverse().find((e) => e.worker_id === workerId && e.kind === 'state_changed' && e.detail?.to === 'exited')
+  return [...events].reverse().find((e) => e.worker_id === workerId && e.kind === 'turn_completed')
 }
 
 // ============================================================================
@@ -275,6 +276,9 @@ async function setupAssembly(opts: AssemblyOptions): Promise<Assembly> {
     workersDir,
     now: harnessNow,
     onEvent: (e) => events.push(e),
+    // durable 通知通道(turn_completed / operation_settled 等):收进同一个 events 数组供断言,
+    // 回执 undefined(无人消费)——通知保持 pending,事件在投递前已落 events.jsonl。
+    onOperationNotification: async (_managerKey, e) => { events.push(e); return undefined },
     builtinSpawnDefaults: () => {
       const cfg = builtinConfigQueue.shift()
       if (!cfg) throw new Error('测试装配缺口:没有为下一次 builtin spawn 预置 builtinConfigQueue 条目')
@@ -763,12 +767,12 @@ describe('manager-integration（P4 Task 10：真实 ManagerRegistry + 真实 Wor
       expect(episode1.outcome).toBe('completed')
 
       const [worker] = await assembly.harness.listWorkers(assembly.managerKeyFor(key))
-      // 等**事件**本身出现，不是等台账转 idle——processStateChange 先 upsert 台账、再 appendEvent，
-      // 盯台账会在这两步之间抢跑（实测在全量并发下偶发）。
+      // 等**事件**本身出现，不是等台账转 idle——回合边界的唤醒是 durable 通道的
+      // turn_completed（persist + 异步投递），盯台账会在事件到达前抢跑。
       const findIdleEvent = () =>
         [...assembly.events]
           .reverse()
-          .find((e) => e.worker_id === worker.worker_id && e.kind === 'state_changed' && e.detail?.to === 'idle')
+          .find((e) => e.worker_id === worker.worker_id && e.kind === 'turn_completed' && e.detail?.to === 'idle')
       await waitUntil(() => findIdleEvent() !== undefined)
 
       // 1) harness 事件本身带上了正文（不是只有一个 {to:'idle'}）

--- a/crabot-agent/tests/manager/p5-integration.test.ts
+++ b/crabot-agent/tests/manager/p5-integration.test.ts
@@ -751,9 +751,12 @@ describe('P5 集成：manager 栈启动接线（Task 6）', () => {
   it('启动时异步跑一次启动对账（register 之后发起）：台账里残留的 running 化身被对账掉，且不阻塞启动', async () => {
     boot()
     const stack = internals.managerStack!
-    // 对账把化身判死会落 `exited` 事件，onEvent 的另一条支路会去唤醒监护 manager（要跑 LLM）。
-    // 那条路由本身由 bootstrap.test.ts 覆盖，这里挡掉，免得用例结束后还留着一个在重试的 LLM 请求。
-    const routeSpy = vi.spyOn(stack.registry, 'routeWorkerEvent').mockResolvedValue(undefined)
+    // 对账判死的唤醒已改由 durable 恢复通知承载（worker_recovery_required →
+    // routeOperationNotification；markCrashed 的 exited 降审计，不再走 routeWorkerEvent）。
+    // 两条路由都要跑 LLM episode，这里挡掉，免得用例结束后还留着在重试的 LLM 请求。
+    vi.spyOn(stack.registry, 'routeWorkerEvent').mockResolvedValue(undefined)
+    const routeOpSpy = vi.spyOn(stack.registry, 'routeOperationNotification')
+      .mockResolvedValue({ consumed: true })
     // 对账判死同样会发 §9.2 事件（下一条用例专门验它）；这里挡住投递，免得没有 MM 的测试环境
     // 刷一屏 ECONNREFUSED——注意 publisher 本身把失败吃掉了，不挡也不会让用例失败。
     vi.spyOn(internals.rpcClient, 'publishEvent').mockResolvedValue(1)
@@ -773,7 +776,8 @@ describe('P5 集成：manager 栈启动接线（Task 6）', () => {
       })
       const after = await stack.ledger.findWorker('w-stale')
       expect(after!.worker.task.status).toBe('halted')
-      expect(routeSpy).toHaveBeenCalled()
+      // 判死 → 恢复通知 durable 投递 → 唤醒监护 manager
+      await waitUntil(async () => routeOpSpy.mock.calls.length > 0)
     } finally {
       await internals.onStop()
     }

--- a/crabot-agent/tests/manager/registry.test.ts
+++ b/crabot-agent/tests/manager/registry.test.ts
@@ -1455,7 +1455,6 @@ describe('inbound-adapters', () => {
 
     const otherKinds: HarnessEventKind[] = [
       'spawned',
-      'input_held',
       'state_changed',
       'exited',
       'killed',

--- a/crabot-agent/tests/manager/registry.test.ts
+++ b/crabot-agent/tests/manager/registry.test.ts
@@ -606,6 +606,34 @@ describe('ManagerRegistry', () => {
     }
   })
 
+  it('routeOperationNotification: turn_completed 等非 activity 通知同样注入 task_id / trigger_type(detail 形态与通道无关)', async () => {
+    const { adapter, queue, calls } = makeAdapter()
+    queue.push({ text: '记录回合完成', stopReason: 'end_turn' })
+    const owningKey = 'wechat::op-memory-owner' as ManagerKey
+    const baseWorker = makeLedgerWorker('w-op-memory', owningKey)
+    const worker = { ...baseWorker, task: { ...baseWorker.task, id: 'task-op-memory' } }
+    const registry = new ManagerRegistry(baseRegistryDeps({
+      adapter,
+      ledger: fakeLedger({ 'w-op-memory': worker }),
+    }))
+
+    await registry.routeOperationNotification(owningKey, {
+      ts: '2026-01-01T00:00:00.000Z',
+      kind: 'turn_completed',
+      worker_id: 'w-op-memory',
+      seq: 3,
+      task_status: 'halted',
+      detail: { turn_id: 'turn-1', turn_pending: true, summary: '明确结论' },
+    })
+
+    const rendered = calls[0].messages.map((message) =>
+      typeof message.content === 'string' ? message.content : JSON.stringify(message.content),
+    ).join('\n')
+    expect(rendered).toContain('"trigger_type":"message"')
+    expect(rendered).toContain('"task_id":"task-op-memory"')
+    expect(rendered).toContain('"outcome":"halted"')
+  })
+
   it('operation notification 在 owning Manager 正执行时进入当前 mailbox，下一轮 LLM 批量读取', async () => {
     const calls: LLMStreamParams[] = []
     const entered = deferred()

--- a/crabot-agent/tests/manager/registry.test.ts
+++ b/crabot-agent/tests/manager/registry.test.ts
@@ -1454,13 +1454,11 @@ describe('inbound-adapters', () => {
     expect(shouldWakeOnHarnessEvent({ ...base, kind: 'legacy_imported' })).toBe(false)
 
     const otherKinds: HarnessEventKind[] = [
-      'spawned',
+      'lifecycle_changed',
       'state_changed',
       'exited',
-      'killed',
-      'superseded',
-      'handoff_started',
-      'resumed',
+      'interaction_required',
+      'liveness_stall',
       'query_failed',
     ]
     for (const kind of otherKinds) {

--- a/crabot-agent/tests/workers/harness/harness-continuation.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-continuation.test.ts
@@ -1656,7 +1656,7 @@ describe('WorkerHarness — 终审 PoC 回归：M1 主线守卫按 (impl,seq) �
 
 describe('WorkerHarness — 终审 PoC 回归：M2 kill 与 in-flight flush 竞态', () => {
   it('send 卡在投递期间 kill：残留队列条目被 drain 并记 dead-letter，task 保持 cancelled，不触发 resume 复活', async () => {
-    const { harness, adaptersMap } = await makeHarness()
+    const { harness, adaptersMap, workersDir } = await makeHarness()
     let releaseFirst!: () => void
     const firstGate = new Promise<void>((resolve) => {
       releaseFirst = resolve
@@ -1699,13 +1699,14 @@ describe('WorkerHarness — 终审 PoC 回归：M2 kill 与 in-flight flush 竞�
     expect(after.task.status).toBe('closed')
     expect(fake.resumeCalls).toHaveLength(0)
 
-    // 残留条目没有静默消失：有 dead-letter 记录。
-    const deadLetterEvents = events.filter((e) => e.kind === 'state_changed' && (e.detail as Record<string, unknown> | undefined)?.kind === 'dead_letter')
+    // 残留条目没有静默消失：有 dead-letter 记录（死信已降审计，读 events.jsonl 而非唤醒面）。
+    const auditM2a = await readAuditLog(workersDir, after.worker_id)
+    const deadLetterEvents = auditM2a.filter((e) => e.kind === 'state_changed' && (e.detail as Record<string, unknown> | undefined)?.kind === 'dead_letter')
     expect(deadLetterEvents.length).toBeGreaterThan(0)
   })
 
   it('send 卡住期间被 kill，之后 adapter.sendInput 才抛 WorkerExitedError 走透明接续：in-flight 条目不经过 drain，cancelled task 仍不被 continueTerminalWorker 复活', async () => {
-    const { harness, adaptersMap } = await makeHarness()
+    const { harness, adaptersMap, workersDir } = await makeHarness()
     let releaseGate!: (err: Error) => void
     const gate = new Promise<void>((_resolve, reject) => {
       releaseGate = (err) => reject(err)
@@ -1741,7 +1742,9 @@ describe('WorkerHarness — 终审 PoC 回归：M2 kill 与 in-flight flush 竞�
     expect(after.task.status).toBe('closed') // 核心断言：没有被复活成 running
     expect(fake.resumeCalls).toHaveLength(0)
 
-    const deadLetterEvents = events.filter((e) => e.kind === 'state_changed' && (e.detail as Record<string, unknown> | undefined)?.kind === 'dead_letter')
+    // 死信已降审计：读 events.jsonl 而非唤醒面
+    const auditM2b = await readAuditLog(workersDir, after.worker_id)
+    const deadLetterEvents = auditM2b.filter((e) => e.kind === 'state_changed' && (e.detail as Record<string, unknown> | undefined)?.kind === 'dead_letter')
     expect(deadLetterEvents.length).toBeGreaterThan(0)
   })
 })
@@ -1882,7 +1885,7 @@ describe('WorkerHarness — 终审 PoC 回归：M3 continueTerminalWorker 守卫
 
 describe('WorkerHarness — 二轮 review PoC 回归：continueTerminalWorker 补送分支的终态竞态收口（锁内可重入求值）', () => {
   it('deliver 卡在旧主线投递期间发生跨实现切换，且新主线在本调用拿锁前也已自然终态（台账已落 exited）：不误对已终态化身调 sendInput，径直转接续，调用方无感', async () => {
-    const { harness, adaptersMap } = await makeHarness()
+    const { harness, adaptersMap, workersDir } = await makeHarness()
     let releaseGate!: (err: Error) => void
     const gate = new Promise<void>((_resolve, reject) => {
       releaseGate = (err) => reject(err)
@@ -1968,15 +1971,16 @@ describe('WorkerHarness — 二轮 review PoC 回归：continueTerminalWorker �
     expect(finalMainline.impl).toBe('codex')
     expect(finalMainline.state).toBe('running')
 
-    // 消息没有滞留：没有产生 dead-letter。
-    const deadLetterEvents = events.filter(
+    // 消息没有滞留：没有产生 dead-letter（死信已降审计，读 events.jsonl 而非唤醒面）。
+    const auditM3a = await readAuditLog(workersDir, worker.worker_id)
+    const deadLetterEvents = auditM3a.filter(
       (e) => e.kind === 'state_changed' && (e.detail as Record<string, unknown> | undefined)?.kind === 'dead_letter'
     )
     expect(deadLetterEvents).toHaveLength(0)
   })
 
   it('新主线仍存活（台账未落终态）但 adapter.sendInput 权威地抛 WorkerExitedError：同样转入接续，不砸向调用方', async () => {
-    const { harness, adaptersMap } = await makeHarness()
+    const { harness, adaptersMap, workersDir } = await makeHarness()
     let releaseGate!: (err: Error) => void
     const gate = new Promise<void>((_resolve, reject) => {
       releaseGate = (err) => reject(err)
@@ -2044,7 +2048,9 @@ describe('WorkerHarness — 二轮 review PoC 回归：continueTerminalWorker �
     expect(finalMainline.impl).toBe('codex')
     expect(finalMainline.state).toBe('running')
 
-    const deadLetterEvents = events.filter(
+    // 死信已降审计：读 events.jsonl 而非唤醒面
+    const auditM3b = await readAuditLog(workersDir, worker.worker_id)
+    const deadLetterEvents = auditM3b.filter(
       (e) => e.kind === 'state_changed' && (e.detail as Record<string, unknown> | undefined)?.kind === 'dead_letter'
     )
     expect(deadLetterEvents).toHaveLength(0)
@@ -2393,13 +2399,14 @@ describe('legacy incarnation guardrails', () => {
 
   it('sendToWorker dead-letters a legacy item without auth before adapter lookup', async () => {
     const settled: string[] = []
-    const { harness, ledger, adaptersMap } = await makeHarness()
+    const { harness, ledger, adaptersMap, workersDir } = await makeHarness()
     await addLegacy(ledger, 'w-legacy-send')
     await expect(harness.sendToWorker('w-legacy-send', 'continue', {
       onSettled: (result) => { settled.push(result) },
     })).resolves.toBeUndefined()
     expect(settled).toEqual(['dead_letter'])
-    expect(events).toContainEqual(expect.objectContaining({
+    // 死信已降审计：读 events.jsonl 而非唤醒面
+    expect(await readAuditLog(workersDir, 'w-legacy-send')).toContainEqual(expect.objectContaining({
       kind: 'state_changed',
       detail: expect.objectContaining({ reason: 'legacy_continuation_authorization_invalid' }),
     }))

--- a/crabot-agent/tests/workers/harness/harness-continuation.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-continuation.test.ts
@@ -14,6 +14,7 @@ import { LedgerStore, managerKeyToFilename } from '../../../src/workers/harness/
 import { WorkspaceManager } from '../../../src/workers/harness/workspace-manager'
 import type { LedgerWorker, ManagerKey } from '../../../src/workers/harness/ledger-types'
 import type { HarnessEvent } from '../../../src/workers/harness/worker-events'
+import { WorkerEventLog } from '../../../src/workers/harness/worker-events'
 import { CliInputStallError, WorkerExitedError } from '../../../src/workers/errors'
 import { BuiltinWorkerAdapter } from '../../../src/workers/builtin/adapter'
 import type { BuiltinRuntimeContext } from '../../../src/workers/builtin/runtime'
@@ -274,6 +275,14 @@ async function readHandoffPackage(workersDir: string, workerId: string, prompt: 
   return JSON.parse(await fs.readFile(join(workersDir, workerId, 'handoffs', `${handoffId}.json`), 'utf8')) as Record<string, unknown>
 }
 
+/** lifecycle_changed 事件的 detail.change 取值（事件面收敛后 handoff 进度节点只落审计日志）。 */
+const changeOf = (e: HarnessEvent): string | undefined => (e.detail as { change?: string } | undefined)?.change
+
+/** 读 worker 的 events.jsonl 审计日志（handoff 进度节点等审计事件不走 onEvent 唤醒面）。 */
+async function readAuditLog(workersDir: string, workerId: string): Promise<HarnessEvent[]> {
+  return new WorkerEventLog(join(workersDir, workerId)).readAll()
+}
+
 describe('WorkerHarness — 透明接续：revive (capabilities().revive === true)', () => {
   it('台账主线化身已 exited → adapter.resume 被调用（prevRef 用主线化身的 handle）→ 新化身入主线链 → sendToWorker 无感返回 → 事件 resumed', async () => {
     const { harness, adaptersMap } = await makeHarness()
@@ -308,8 +317,9 @@ describe('WorkerHarness — 透明接续：revive (capabilities().revive === tru
     expect(w.incarnations[1].impl).toBe('builtin')
     expect(w.task.status).toBe('running') // 终态化身之上接续，task 重新回到 running
 
-    const resumedEvents = events.filter((e) => e.kind === 'resumed')
+    const resumedEvents = events.filter((e) => e.kind === 'lifecycle_changed')
     expect(resumedEvents).toHaveLength(1)
+    expect(resumedEvents[0].detail).toMatchObject({ change: 'resumed' })
     expect(resumedEvents[0].seq).toBe(w.incarnations[1].seq)
   })
 
@@ -547,8 +557,9 @@ describe('WorkerHarness — 透明接续：revive (capabilities().revive === tru
 
     expect(fake.sendInputCalls).toHaveLength(1) // 确实尝试过一次正常投递，才捕获到 WorkerExitedError
     expect(fake.resumeCalls).toHaveLength(1)
-    const resumedEvents = events.filter((e) => e.kind === 'resumed')
+    const resumedEvents = events.filter((e) => e.kind === 'lifecycle_changed')
     expect(resumedEvents).toHaveLength(1)
+    expect(resumedEvents[0].detail).toMatchObject({ change: 'resumed' })
   })
 
   it('adapter.sendInput 抛 WorkerExitedError 时台账主线化身仍是 running（迟到状态回调没追上）→ revive 前先把旧化身回填终态，不再永久卡在 running（评审 PoC 实证的修复）', async () => {
@@ -726,10 +737,13 @@ describe('WorkerHarness — 透明接续：handoff (capabilities().revive === fa
     expect(newEntry.state).toBe('running')
     expect(w.task.status).toBe('running')
 
-    const handoffEvents = events.filter((e) => e.kind === 'handoff_started')
+    // handoff 进度节点（handoff_started / superseded）已降为审计事件：不出现在唤醒面，
+    // 只落 events.jsonl。
+    const audit = await readAuditLog(workersDir, worker.worker_id)
+    const handoffEvents = audit.filter((e) => e.kind === 'lifecycle_changed' && changeOf(e) === 'handoff_started')
     expect(handoffEvents).toHaveLength(1)
     expect(handoffEvents[0].seq).toBe(1)
-    const supersededEvents = events.filter((e) => e.kind === 'superseded')
+    const supersededEvents = audit.filter((e) => e.kind === 'lifecycle_changed' && changeOf(e) === 'superseded')
     expect(supersededEvents).toHaveLength(1)
   })
 
@@ -1007,13 +1021,13 @@ describe('WorkerHarness.handoffIncarnation — fixed capability snapshot', () =>
     const [current] = await harness.listWorkers((`test::${'friend-1'}` as ManagerKey))
     expect(current.incarnations).toHaveLength(1)
     expect(current.incarnations[0].state).toBe('running')
-    expect(events.filter((event) => event.kind === 'handoff_started' || event.kind === 'superseded')).toEqual([])
+    expect(events.filter((event) => event.kind === 'lifecycle_changed')).toEqual([])
   })
 })
 
 describe('WorkerHarness.switchWorkerImpl — 跨实现切换', () => {
   it('走同一条 handoff 路径，目标 adapter 由参数指定，源化身仍存活时先 kill 再标 superseded', async () => {
-    const { harness, adaptersMap } = await makeHarness()
+    const { harness, adaptersMap, workersDir } = await makeHarness()
     const source = new FakeAdapter({ implId: 'claude-code', caps: { revive: true }, onStateChange: harness.handleStateChange, outputChunk: '侧问一半的输出' })
     const target = new FakeAdapter({ implId: 'codex', caps: { revive: true }, onStateChange: harness.handleStateChange })
     adaptersMap.set('claude-code', source)
@@ -1040,8 +1054,10 @@ describe('WorkerHarness.switchWorkerImpl — 跨实现切换', () => {
     expect(newEntry.impl).toBe('codex')
     expect(newEntry.forked_from).toBeUndefined()
 
-    expect(events.filter((e) => e.kind === 'handoff_started')).toHaveLength(1)
-    expect(events.filter((e) => e.kind === 'superseded')).toHaveLength(1)
+    // handoff 进度节点（handoff_started / superseded）已降为审计事件，只落 events.jsonl。
+    const auditSwitch = await readAuditLog(workersDir, worker.worker_id)
+    expect(auditSwitch.filter((e) => e.kind === 'lifecycle_changed' && changeOf(e) === 'handoff_started')).toHaveLength(1)
+    expect(auditSwitch.filter((e) => e.kind === 'lifecycle_changed' && changeOf(e) === 'superseded')).toHaveLength(1)
   })
 
   it('replays and settles a consumed durable receipt on the target incarnation', async () => {
@@ -1224,8 +1240,7 @@ describe('WorkerHarness.handoffIncarnation — handoff 目标是 builtin 时的 
 
     await expect(fs.readFile(join(workspaceRoot, 'HANDOFF.md'), 'utf-8')).rejects.toThrow() // 文件未被创建
 
-    expect(events.filter((e) => e.kind === 'handoff_started')).toHaveLength(0)
-    expect(events.filter((e) => e.kind === 'superseded')).toHaveLength(0)
+    expect(events.filter((e) => e.kind === 'lifecycle_changed')).toHaveLength(0)
   })
 
   it('目标是 builtin 且配置了 HarnessDeps.builtinSpawnDefaults → handoff 正常完成，新化身 spawn 时带上了注入的 builtin 配置', async () => {
@@ -1617,8 +1632,8 @@ describe('WorkerHarness — 终审 PoC 回归：M1 主线守卫按 (impl,seq) �
     expect(newMainline.seq).toBe(1)
     expect(afterHandoff.task.status).toBe('running')
 
-    // 顺带修复：handoff 产出的新化身也发了 spawned 事件（与 revive 路径的 resumed 对称）。
-    expect(events.filter((e) => e.kind === 'spawned')).toHaveLength(1)
+    // 顺带修复：handoff 产出的新化身也发了 lifecycle_changed(spawned) 事件（与 revive 路径的 resumed 对称）。
+    expect(events.filter((e) => e.kind === 'lifecycle_changed' && changeOf(e) === 'spawned')).toHaveLength(1)
 
     // 旧 adapter（claude-code）的迟到 exited 回调打到 handoff 之前的 handle 上，seq 与新
     // 主线 codex#1 相同——只比 seq 不比 impl 的守卫会把它误判成"当前主线化身的回调"。
@@ -2066,10 +2081,9 @@ describe('WorkerHarness.switchWorkerImpl — 终审 PoC 回归：M3 cancelled �
     expect(after.task.status).toBe('closed')
     expect(after.incarnations).toHaveLength(1)
 
-    // 没有产生 handoff_started / superseded / spawned 事件——pre-flight 在写 HANDOFF.md 和
-    // kill 旧化身之前就已经拒绝。
-    expect(events.filter((e) => e.kind === 'handoff_started')).toHaveLength(0)
-    expect(events.filter((e) => e.kind === 'spawned')).toHaveLength(0)
+    // 没有产生 handoff 相关事件——pre-flight 在写 HANDOFF.md 和 kill 旧化身之前就已经拒绝
+    //（进度节点为审计事件，完成点为唤醒事件，两者都不该出现）。
+    expect(events.filter((e) => e.kind === 'lifecycle_changed')).toHaveLength(0)
   })
 })
 
@@ -2154,10 +2168,8 @@ describe('WorkerHarness — 三轮 review PoC 回归：handoff 目标是该 work
     // The rejected preflight does not create a second package.
     expect(await fs.readdir(handoffDir)).toEqual(handoffBefore)
 
-    // 没有产生新的 handoff_started / superseded 事件——pre-flight 在构造 package 和 kill
-    // 源化身之前就已经拒绝。
-    expect(events.filter((e) => e.kind === 'handoff_started')).toHaveLength(0)
-    expect(events.filter((e) => e.kind === 'superseded')).toHaveLength(0)
+    // 没有产生新的 handoff 事件——pre-flight 在构造 package 和 kill 源化身之前就已经拒绝。
+    expect(events.filter((e) => e.kind === 'lifecycle_changed')).toHaveLength(0)
   })
 
   it('switchWorkerImpl 切到当前正在用的同一个 impl（未曾切换过）→ 同样被 ImplAlreadyUsedError 拒绝，源化身原样存活', async () => {
@@ -2188,11 +2200,11 @@ describe('WorkerHarness — 三轮 review PoC 回归：handoff 目标是该 work
     expect(after.incarnations[0].ended_reason).toBeUndefined()
 
     await expect(fs.readFile(join(workspaceRoot, 'HANDOFF.md'), 'utf-8')).rejects.toThrow() // 文件未被创建
-    expect(events.filter((e) => e.kind === 'handoff_started')).toHaveLength(0)
+    expect(events.filter((e) => e.kind === 'lifecycle_changed')).toHaveLength(0)
   })
 
   it('sendToWorker 触发的自动 handoff（revive:false）在"原 impl 已用过"时改选一个未用过的 impl 并成功', async () => {
-    const { harness, adaptersMap } = await makeHarness()
+    const { harness, adaptersMap, workersDir } = await makeHarness()
     const spawnedOnce = new Set<string>()
     // mainline 用的实现（revive:false，触发自动 handoff）——它本身就是"已用过"的那个 impl，
     // handoffIncarnation 若沿用它会必然撞上 spawn 守卫。
@@ -2229,7 +2241,8 @@ describe('WorkerHarness — 三轮 review PoC 回归：handoff 目标是该 work
     expect(newEntry.impl).toBe('builtin')
     expect(newEntry.state).toBe('running')
     expect(w.task.status).toBe('running')
-    expect(events.filter((e) => e.kind === 'handoff_started')).toHaveLength(1)
+    const auditAuto = await readAuditLog(workersDir, worker.worker_id)
+    expect(auditAuto.filter((e) => e.kind === 'lifecycle_changed' && changeOf(e) === 'handoff_started')).toHaveLength(1)
   })
 
   it('sendToWorker 触发的自动 handoff（revive:false）在所有已注册 impl 都用过时 → 抛 ImplAlreadyUsedError，不动源化身', async () => {
@@ -2266,7 +2279,7 @@ describe('WorkerHarness — 三轮 review PoC 回归：handoff 目标是该 work
     expect(after.incarnations[0].ended_reason).toBeUndefined()
 
     await expect(fs.readFile(join(workspaceRoot, 'HANDOFF.md'), 'utf-8')).rejects.toThrow() // 文件未被创建
-    expect(events.filter((e) => e.kind === 'handoff_started')).toHaveLength(0)
+    expect(events.filter((e) => e.kind === 'lifecycle_changed')).toHaveLength(0)
   })
 })
 
@@ -2275,7 +2288,8 @@ describe('WorkerHarness — 三轮 review PoC 回归：handoff 目标是该 work
  * (reviveIncarnation 的 `resumed`、handoffIncarnation 第 4 步的 `spawned`)。这两处是把
  * **终态 task 拉回 running** 的唯一合法出边(§5.2 接续例外),也正是评审 PoC 里让"读晚一步"
  * 吞掉终态 `completed` 的那次落账;事件自带状态之后,终态与这次复活各发各的,不再互相覆盖。
- * 同一条路径上的纯记录事件(handoff_started / superseded)不动 task.status,一律不带。
+ * 同一条路径上的纯记录节点(handoff_started / superseded,已折入 lifecycle_changed 且只落审计)不动
+ * task.status,一律不带。
  */
 describe('HarnessEvent.task_status —— 透明接续的迁移点', () => {
   it('revive:终态化身之上接续 → resumed 带 running(与台账落账值一致)', async () => {
@@ -2296,7 +2310,7 @@ describe('HarnessEvent.task_status —— 透明接续的迁移点', () => {
 
     await harness.sendToWorker(worker.worker_id, '还有件事要办')
 
-    const resumed = events.filter((e) => e.kind === 'resumed')
+    const resumed = events.filter((e) => e.kind === 'lifecycle_changed' && changeOf(e) === 'resumed')
     expect(resumed).toHaveLength(1)
     expect(resumed[0].task_status).toBe('running')
     const [w] = await harness.listWorkers((`test::${'friend-1'}` as ManagerKey))
@@ -2304,7 +2318,7 @@ describe('HarnessEvent.task_status —— 透明接续的迁移点', () => {
   })
 
   it('handoff:交接产出新化身 → spawned 带 running;handoff_started / superseded 不带', async () => {
-    const { harness, adaptersMap } = await makeHarness()
+    const { harness, adaptersMap, workersDir } = await makeHarness()
     const fake = new FakeAdapter({
       caps: { revive: false },
       onStateChange: harness.handleStateChange,
@@ -2320,12 +2334,14 @@ describe('HarnessEvent.task_status —— 透明接续的迁移点', () => {
 
     await harness.sendToWorker(worker.worker_id, '接着把剩下的做完')
 
-    const spawned = events.filter((e) => e.kind === 'spawned')
+    const spawned = events.filter((e) => e.kind === 'lifecycle_changed' && changeOf(e) === 'spawned')
     expect(spawned).toHaveLength(1)
     expect(spawned[0].task_status).toBe('running')
 
-    expect(events.filter((e) => e.kind === 'handoff_started')[0].task_status).toBeUndefined()
-    expect(events.filter((e) => e.kind === 'superseded')[0].task_status).toBeUndefined()
+    // handoff_started / superseded 已降审计：读 events.jsonl 而非唤醒面
+    const audit = await readAuditLog(workersDir, worker.worker_id)
+    expect(audit.filter((e) => e.kind === 'lifecycle_changed' && changeOf(e) === 'handoff_started')[0].task_status).toBeUndefined()
+    expect(audit.filter((e) => e.kind === 'lifecycle_changed' && changeOf(e) === 'superseded')[0].task_status).toBeUndefined()
   })
 })
 
@@ -2445,7 +2461,8 @@ describe('legacy incarnation guardrails', () => {
     expect(JSON.stringify(handoff)).toContain('old-task')
     expect(JSON.stringify(handoff)).not.toContain('resume_checkpoint')
     await expect(fs.stat(join(dataDir, 'workspace', 'HANDOFF.md'))).rejects.toMatchObject({ code: 'ENOENT' })
-    expect(events.some((event) => event.kind === 'handoff_started')).toBe(true)
+    const auditLegacy = await readAuditLog(workersDir, 'w-legacy-success')
+    expect(auditLegacy.some((event) => event.kind === 'lifecycle_changed' && changeOf(event) === 'handoff_started')).toBe(true)
   })
 
   it('歧义 v3 历史先归档，再只用归档台账和持久 activity 生成 handoff', async () => {

--- a/crabot-agent/tests/workers/harness/harness-continuation.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-continuation.test.ts
@@ -225,6 +225,8 @@ async function makeHarness(
     workersDir,
     now,
     onEvent: (e) => events.push(e),
+    // 无回调时 durable 通知不投递、turn_completed 不落 events.jsonl（见 harness-lifecycle 同款注释）
+    onOperationNotification: async () => undefined,
     mintActivityCursor: async ({ offset }) => `opaque-activity-${['start', 'one', 'two', 'three'][offset] ?? 'later'}`,
     // 本文件里 FakeAdapter 缺省 implId 就是 'builtin'（多数测试拿它当泛化的"随便一个实现"
     // 桩用，不关心真实 LLM 注入）；handoffIncarnation 的 pre-flight（裁决 B 修复）对目标
@@ -1433,11 +1435,12 @@ describe('BuiltinWorkerAdapter → WorkerHarness — session_ref 时效性修复
     const [afterSecondBurst] = await harness.listWorkers((`test::${'friend-1'}` as ManagerKey))
     expect(afterSecondBurst.incarnations[0].session_ref).not.toBe(afterFirstBurstRef)
     expect(afterSecondBurst.incarnations[0].session_ref).not.toBe(spawnTimeSessionRef)
-    await waitUntil(async () => events.filter((event) =>
-      event.worker_id === worker.worker_id &&
-      event.kind === 'state_changed' &&
-      event.detail?.to === 'idle',
-    ).length === 2)
+    // 两轮 idle 拍各落一条 enriched turn_completed（回合边界唯一唤醒，durable 通道，
+    // 写 events.jsonl，不经 onEvent 的 events 数组）。
+    await waitUntil(async () =>
+      (await harness.readWorkerEvents(worker.worker_id)).filter((event) =>
+        event.kind === 'turn_completed' && event.detail?.to === 'idle',
+      ).length >= 2)
     await builtinAdapter.dispose()
   })
 })

--- a/crabot-agent/tests/workers/harness/harness-integration.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-integration.test.ts
@@ -173,7 +173,8 @@ describe('WorkerHarness — 真实 builtin adapter 集成冒烟(mock LLM)', () =
       expect(finalWorker.incarnations[0].state).toBe('exited')
       expect(finalWorker.incarnations[0].ended_reason).toBe('completed')
 
-      expect(events.filter((e) => e.kind === 'spawned')).toHaveLength(1)
+      expect(events.filter((e) => e.kind === 'lifecycle_changed'
+        && (e.detail as { change?: string } | undefined)?.change === 'spawned')).toHaveLength(1)
       expect(events.filter((e) => e.kind === 'input_sent')).toHaveLength(1)
       // 至少两次真实状态回调(idle 一次、exited 一次)经 handleStateChange 落盘并外发。
       expect(events.filter((e) => e.kind === 'state_changed').length).toBeGreaterThanOrEqual(2)
@@ -367,9 +368,11 @@ describe.skipIf(!tmuxAvailable)('WorkerHarness — 真实 claude-code adapter �
       expect(finalWorker.incarnations[0].state).toBe('exited')
       expect(finalWorker.incarnations[0].ended_reason).toBe('killed')
 
-      expect(events.filter((e) => e.kind === 'spawned')).toHaveLength(1)
+      expect(events.filter((e) => e.kind === 'lifecycle_changed'
+        && (e.detail as { change?: string } | undefined)?.change === 'spawned')).toHaveLength(1)
       expect(events.filter((e) => e.kind === 'input_sent')).toHaveLength(1)
-      expect(events.filter((e) => e.kind === 'killed')).toHaveLength(1)
+      // 停止操作结算回执(killed kind 已随事件面收敛删除,停止事实由 operation_settled 承载)
+      expect(events.filter((e) => e.kind === 'operation_settled')).toHaveLength(1)
     },
     20000,
   )

--- a/crabot-agent/tests/workers/harness/harness-integration.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-integration.test.ts
@@ -113,6 +113,8 @@ describe('WorkerHarness — 真实 builtin adapter 集成冒烟(mock LLM)', () =
         workersDir,
         now,
         onEvent: (e) => events.push(e),
+        // 无回调时 durable 通知不投递、turn_completed 不落 events.jsonl（见 harness-lifecycle 同款注释）
+        onOperationNotification: async () => undefined,
       }
       const harness = new WorkerHarness(deps)
       // onStateChange 接线契约(harness.ts 文件头):harness 先构造好、把 handleStateChange
@@ -176,8 +178,10 @@ describe('WorkerHarness — 真实 builtin adapter 集成冒烟(mock LLM)', () =
       expect(events.filter((e) => e.kind === 'lifecycle_changed'
         && (e.detail as { change?: string } | undefined)?.change === 'spawned')).toHaveLength(1)
       expect(events.filter((e) => e.kind === 'input_sent')).toHaveLength(1)
-      // 至少两次真实状态回调(idle 一次、exited 一次)经 handleStateChange 落盘并外发。
-      expect(events.filter((e) => e.kind === 'state_changed').length).toBeGreaterThanOrEqual(2)
+      // 至少两次真实状态回调(idle 一次、exited 一次)经 handleStateChange 落盘——回合边界
+      // 的唯一唤醒是 enriched turn_completed(durable 通道,写 events.jsonl,不经 onEvent)。
+      await waitUntil(async () =>
+        (await harness.readWorkerEvents(worker.worker_id)).filter((e) => e.kind === 'turn_completed').length >= 2)
 
       // reconcileOnStartup 幂等:worker 已是终态,巡检不该把它错误判成 revived/failed,
       // 也不该再调用 adapter.state()(harness.ts reconcileOnStartup 的设计:已终态 worker

--- a/crabot-agent/tests/workers/harness/harness-lifecycle.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-lifecycle.test.ts
@@ -339,8 +339,9 @@ describe('WorkerHarness.spawnWorker', () => {
     expect(fake.spawnCalls).toHaveLength(1)
     expect(fake.spawnCalls[0].worker_id).toBe(worker.worker_id)
 
-    const spawnedEvents = events.filter((e) => e.kind === 'spawned')
+    const spawnedEvents = events.filter((e) => e.kind === 'lifecycle_changed')
     expect(spawnedEvents).toHaveLength(1)
+    expect(spawnedEvents[0].detail).toMatchObject({ change: 'spawned' })
     expect(spawnedEvents[0].worker_id).toBe(worker.worker_id)
     expect(spawnedEvents[0].seq).toBe(1)
 
@@ -529,11 +530,10 @@ describe('WorkerHarness.spawnWorker', () => {
       },
     })
     const worker = await harness.spawnWorker({ ...spawnParams(), impl: 'claude-code' })
-    const detail = events.find((event) => event.worker_id === worker.worker_id && event.kind === 'state_changed')?.detail
+    const detail = events.find((event) => event.worker_id === worker.worker_id && event.kind === 'interaction_required')?.detail
     const snapshotId = detail?.snapshot_id
 
     expect(detail).toMatchObject({
-      kind: 'interaction_required',
       snapshot_id: expect.any(String),
       snapshot_expires_at: expect.any(String),
       actions: UI_ACTIONS,
@@ -574,7 +574,7 @@ describe('WorkerHarness.spawnWorker', () => {
       },
     })
     const worker = await harness.spawnWorker({ ...spawnParams(), impl: 'claude-code' })
-    const detail = events.find((event) => event.worker_id === worker.worker_id && event.kind === 'state_changed')?.detail
+    const detail = events.find((event) => event.worker_id === worker.worker_id && event.kind === 'interaction_required')?.detail
 
     nowValue += 11 * 60_000
     await expect(harness.respondToWorkerUi(worker.worker_id, detail?.snapshot_id as string, 'confirm')).rejects.toThrow(
@@ -600,7 +600,7 @@ describe('WorkerHarness.spawnWorker', () => {
     })
     const worker = await harness.spawnWorker({ ...spawnParams(), impl: 'claude-code' })
     const incarnation = worker.incarnations[0]
-    const firstSnapshotId = events.find((event) => event.worker_id === worker.worker_id && event.kind === 'state_changed')
+    const firstSnapshotId = events.find((event) => event.worker_id === worker.worker_id && event.kind === 'interaction_required')
       ?.detail?.snapshot_id as string
     const handle: IncarnationHandle = {
       worker_id: worker.worker_id,
@@ -1673,12 +1673,11 @@ describe('WorkerHarness.handleStateChange', () => {
       ui: { fingerprint: 'question:yes-no', actions: UI_ACTIONS },
       notification: { type: 'permission_prompt', message: 'Choose', title: 'Question' },
     })
-    await waitUntil(() => events.some((event) => event.kind === 'state_changed'))
+    await waitUntil(() => events.some((event) => event.kind === 'interaction_required'))
 
-    const detail = events.find((event) => event.kind === 'state_changed')?.detail
+    const detail = events.find((event) => event.kind === 'interaction_required')?.detail
     expect(detail).toMatchObject({
       to: 'idle',
-      kind: 'interaction_required',
       wait_mode: 'action',
       wait_reason: 'interaction_required',
       notification_type: 'permission_prompt',
@@ -1706,10 +1705,9 @@ describe('WorkerHarness.handleStateChange', () => {
       ui: { fingerprint: 'claude_exit_plan:1-2', actions: UI_ACTIONS },
       notification: { type: 'automatic_interaction_failed' },
     })
-    await waitUntil(() => events.some((event) => event.kind === 'state_changed'))
+    await waitUntil(() => events.some((event) => event.kind === 'interaction_required'))
 
-    expect(events.find((event) => event.kind === 'state_changed')?.detail).toMatchObject({
-      kind: 'interaction_required',
+    expect(events.find((event) => event.kind === 'interaction_required')?.detail).toMatchObject({
       notification_type: 'automatic_interaction_failed',
       text: 'Exit plan mode?',
       snapshot_id: expect.any(String),
@@ -1742,7 +1740,7 @@ describe('WorkerHarness.handleStateChange', () => {
       waitReason: 'interaction_required',
       notification: { type: 'permission_prompt', message: '请选择' },
     })
-    await waitUntil(() => events.some((event) => event.worker_id === notificationWorker.worker_id && event.kind === 'state_changed'))
+    await waitUntil(() => events.some((event) => event.worker_id === notificationWorker.worker_id && event.kind === 'interaction_required'))
     expect(await harness.getWorkerTurn(notificationWorker.worker_id)).toBeUndefined()
   })
 
@@ -1755,7 +1753,7 @@ describe('WorkerHarness.handleStateChange', () => {
       waitReason: 'interaction_required',
       notification: { type: 'permission_prompt', message: '请选择' },
     })
-    await waitUntil(() => events.some((event) => event.worker_id === worker.worker_id && event.kind === 'state_changed'))
+    await waitUntil(() => events.some((event) => event.worker_id === worker.worker_id && event.kind === 'interaction_required'))
     expect(await harness.getWorkerTurn(worker.worker_id)).toBeUndefined()
 
     fake.emitStateChange(handle, 'idle', '交互完成后的本轮结果')
@@ -2640,7 +2638,8 @@ describe('WorkerHarness.sendToWorker', () => {
       for (let step = 0; step < 5; step++) await Promise.resolve()
 
       expect((await harness.readWorkerEvents(worker.worker_id))
-        .filter((event) => event.kind === 'handoff_started')).toEqual([])
+        .filter((event) => event.kind === 'lifecycle_changed'
+          && (event.detail as { change?: string } | undefined)?.change === 'handoff_started')).toEqual([])
       expect(target.spawnCalls).toEqual([])
     } finally {
       releaseCapture.resolve()
@@ -3147,7 +3146,7 @@ describe('WorkerHarness.killWorker', () => {
 
     await expect(harness.killWorker(worker.worker_id)).resolves.toBeUndefined()
     expect(fake.killCalls).toHaveLength(1) // 未被再次调用
-    expect(events.filter((e) => e.kind === 'killed')).toHaveLength(0)
+    expect(events).toHaveLength(0) // 不再发任何事件(killed kind 已随事件面收敛删除)
   })
 
   it('不存在的 worker_id → WorkerNotFoundError', async () => {
@@ -4107,8 +4106,9 @@ describe('HarnessEvent.task_status —— 事件自带落账后的 task 状态',
     const { harness } = await makeHarness()
     const worker = await harness.spawnWorker(spawnParams())
 
-    const spawned = events.filter((e) => e.kind === 'spawned')
+    const spawned = events.filter((e) => e.kind === 'lifecycle_changed')
     expect(spawned).toHaveLength(1)
+    expect(spawned[0].detail).toMatchObject({ change: 'spawned' })
     expect(spawned[0].task_status).toBe('running')
     expect(spawned[0].task_status).toBe(worker.task.status)
   })

--- a/crabot-agent/tests/workers/harness/harness-lifecycle.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-lifecycle.test.ts
@@ -1600,6 +1600,28 @@ describe('WorkerHarness.handleStateChange', () => {
     expect((await harness.listWorkers(`test::friend-1` as ManagerKey))[0].task.status).toBe('running')
   })
 
+  it('stop 核验 unknown 且无 bg → task 落 halted(stop_unverified)，operation_settled 携带 halted(现网缺口修复)', async () => {
+    const opEvents: HarnessEvent[] = []
+    const { harness, fake } = await makeHarness({}, {
+      hasRunningBg: async () => false,
+      onOperationNotification: async (_managerKey, e) => { opEvents.push(e); return { consumed: true } },
+    })
+    const worker = await harness.spawnWorker(spawnParams())
+    // 核验阶段 adapter.state 不可用 → 结算 unknown
+    vi.spyOn(fake, 'state').mockRejectedValue(new Error('tmux session gone'))
+
+    await expect(harness.requestWorkerStop(worker.worker_id)).resolves.toMatchObject({ status: 'unknown' })
+
+    const [stored] = await harness.listWorkers(`test::friend-1` as ManagerKey)
+    expect(stored.task.status).toBe('halted')
+    expect(stored.task.halt?.stop_unverified).toBe(true)
+    // 修复前：这次 halted 迁移没有任何事件携带，Admin 收不到推送；现在由唯一回执承载。
+    await waitUntil(() => opEvents.some((e) => e.kind === 'operation_settled'))
+    const settled = opEvents.find((e) => e.kind === 'operation_settled')!
+    expect(settled.detail?.status).toBe('unknown')
+    expect(settled.task_status).toBe('halted')
+  })
+
   it('同步 stop 退出在核验 unknown 后仍保留 task 状态，重启对账也不改写成 cancelled 或 failed', async () => {
     const { harness, fake } = await makeHarness({}, { hasRunningBg: async () => true })
     const worker = await harness.spawnWorker(spawnParams())
@@ -3118,7 +3140,10 @@ describe('WorkerHarness.sendToWorker', () => {
 
 describe('WorkerHarness.killWorker', () => {
   it('adapter.kill 被调用,台账落 cancelled,化身 exited(killed),事件外发', async () => {
-    const { harness, fake } = await makeHarness()
+    const opEvents: HarnessEvent[] = []
+    const { harness, fake } = await makeHarness({}, {
+      onOperationNotification: async (_managerKey, e) => { opEvents.push(e); return { consumed: true } },
+    })
     const worker = await harness.spawnWorker(spawnParams())
     events.length = 0
 
@@ -3132,9 +3157,17 @@ describe('WorkerHarness.killWorker', () => {
     expect(w.incarnations[0].state).toBe('exited')
     expect(w.incarnations[0].ended_reason).toBe('killed')
 
-    const stopped = events.filter((e) => e.kind === 'state_changed' && e.detail?.reason === 'stop_verified')
-    expect(stopped).toHaveLength(1)
-    expect(stopped[0].task_status).toBe('closed')
+    // 一次停止一张回执：operation_settled 是对 manager 的唯一唤醒，自带落账后 closed。
+    // （operation 通知是异步投递，等它到达）
+    await waitUntil(() => opEvents.filter((e) => e.kind === 'operation_settled').length === 1)
+    const settled = opEvents.filter((e) => e.kind === 'operation_settled')
+    expect(settled[0].task_status).toBe('closed')
+    // stop_verified 已降审计：不进唤醒面，events.jsonl 里仍可查（同样带 closed）。
+    expect(events.filter((e) => e.detail?.reason === 'stop_verified')).toHaveLength(0)
+    const auditStopped = (await harness.readWorkerEvents(worker.worker_id))
+      .filter((e) => e.kind === 'state_changed' && e.detail?.reason === 'stop_verified')
+    expect(auditStopped).toHaveLength(1)
+    expect(auditStopped[0].task_status).toBe('closed')
   })
 
   it('幂等:对已 cancelled 的 worker 再次 kill 不报错、不重复调用 adapter.kill、不重复发事件', async () => {
@@ -4137,16 +4170,19 @@ describe('HarnessEvent.task_status —— 事件自带落账后的 task 状态',
     expect(events.filter((e) => e.kind === 'state_changed')[1].task_status).toBe('halted')
   })
 
-  it('迁移点:verified stop → state_changed 带 cancelled', async () => {
-    const { harness } = await makeHarness()
+  it('迁移点:verified stop → operation_settled 带 closed(stop_verified 已降审计)', async () => {
+    const opEvents: HarnessEvent[] = []
+    const { harness } = await makeHarness({}, {
+      onOperationNotification: async (_managerKey, e) => { opEvents.push(e); return { consumed: true } },
+    })
     const worker = await harness.spawnWorker(spawnParams())
     events.length = 0
 
     await harness.killWorker(worker.worker_id, '用户要求终止')
 
-    const stopped = events.filter((e) => e.kind === 'state_changed' && e.detail?.reason === 'stop_verified')
-    expect(stopped).toHaveLength(1)
-    expect(stopped[0].task_status).toBe('closed')
+    await waitUntil(() => opEvents.filter((e) => e.kind === 'operation_settled').length === 1)
+    const settled = opEvents.filter((e) => e.kind === 'operation_settled')
+    expect(settled[0].task_status).toBe('closed')
   })
 
   it('非迁移点:input_sent 不带 task_status(投递不动 task 状态)', async () => {
@@ -4161,10 +4197,13 @@ describe('HarnessEvent.task_status —— 事件自带落账后的 task 状态',
     expect(inputSent[0].task_status).toBeUndefined()
   })
 
-  it('非迁移点:stop 后 drain 出的 dead_letter 不带 task_status(迁移由 stop_verified 事件承载)', async () => {
+  it('非迁移点:stop 后 drain 出的 dead_letter 不带 task_status(迁移由 operation_settled 承载)', async () => {
+    const opEvents: HarnessEvent[] = []
     const { harness } = await makeHarness({
       // 让第一条卡在投递里,第二条就会留在队列上等 killWorker 去 drain
       sendInputBehavior: () => new Promise((resolve) => setTimeout(resolve, 30)),
+    }, {
+      onOperationNotification: async (_managerKey, e) => { opEvents.push(e); return { consumed: true } },
     })
     const worker = await harness.spawnWorker(spawnParams())
     events.length = 0
@@ -4175,11 +4214,14 @@ describe('HarnessEvent.task_status —— 事件自带落账后的 task 状态',
     await inFlight.catch(() => undefined)
     await queued
 
-    const deadLetters = events.filter((e) => e.kind === 'state_changed' && e.detail?.kind === 'dead_letter')
+    // 死信已降审计：读 events.jsonl 而非唤醒面
+    const deadLetters = (await harness.readWorkerEvents(worker.worker_id))
+      .filter((e) => e.kind === 'state_changed' && e.detail?.kind === 'dead_letter')
     expect(deadLetters.length).toBeGreaterThan(0)
     for (const e of deadLetters) expect(e.task_status).toBeUndefined()
-    // 同一次 verified stop 的 state_changed 事件才是那次迁移的载体
-    expect(events.find((e) => e.kind === 'state_changed' && e.detail?.reason === 'stop_verified')?.task_status).toBe('closed')
+    // 同一次 verified stop 的迁移载体是 operation_settled（唯一唤醒，自带 closed）
+    await waitUntil(() => opEvents.some((e) => e.kind === 'operation_settled'))
+    expect(opEvents.find((e) => e.kind === 'operation_settled')?.task_status).toBe('closed')
   })
 
   it('非迁移点:query_failed 不带 task_status', async () => {

--- a/crabot-agent/tests/workers/harness/harness-lifecycle.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-lifecycle.test.ts
@@ -1949,6 +1949,38 @@ describe('WorkerHarness.handleStateChange', () => {
     })
   })
 
+  it('回合通知持久化失败 → 回退补发 fire-and-forget state_changed 保在线送达(协议 §6.3)', async () => {
+    const { harness } = await makeHarness()
+    const worker = await harness.spawnWorker(spawnParams())
+    events.length = 0
+
+    const h = { worker_id: worker.worker_id, seq: 1, impl: 'builtin' as const, session_ref: `ref-${worker.worker_id}#1` }
+    // 下一次 persist 落盘失败：durable 唤醒不存在,必须回退补发 fire-and-forget
+    // state_changed（PR #137 review #7：这条新引入的失败路径要有定向用例钉住）。
+    const recordSpy = vi.spyOn(NativeActivityStore.prototype, 'record').mockRejectedValueOnce(new Error('disk full'))
+    try {
+      harness.handleStateChange(h, 'idle', {
+        completionSource: 'builtin_end_turn',
+        lastText: '收尾正文',
+      })
+
+      await waitUntil(() => events.some((e) => e.kind === 'state_changed'))
+      const fallback = events.filter((e) => e.kind === 'state_changed')
+      expect(fallback).toHaveLength(1)
+      expect(fallback[0].detail).toMatchObject({
+        to: 'idle',
+        text: '收尾正文',
+        turn_id: expect.any(String),
+        turn_pending: true,
+      })
+      expect(fallback[0].task_status).toBe('halted')
+      // durable 通道侧：通知没落盘,events.jsonl 里不应有 turn_completed
+      expect((await harness.readWorkerEvents(worker.worker_id)).some((e) => e.kind === 'turn_completed')).toBe(false)
+    } finally {
+      recordSpy.mockRestore()
+    }
+  })
+
   it('CLI 终端画面不随状态事件自动转发，manager 需要时再显式读取', async () => {
     const { harness } = await makeHarness()
     const worker = await harness.spawnWorker(spawnParams())

--- a/crabot-agent/tests/workers/harness/harness-lifecycle.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-lifecycle.test.ts
@@ -244,6 +244,18 @@ let dataDir: string
 let nowValue: number
 const events: HarnessEvent[] = []
 
+/**
+ * turn 边界事件（turn_completed）走 durable 通知通道：写入 events.jsonl 发生在
+ * deliverNativeActivityNotifications 的异步投递里（且需要 onOperationNotification 回调
+ * 存在才走投递），onEvent 收集的 events 数组看不到它。
+ * 这里等待并读回 jsonl（事件面收敛后，完成回合边界对 manager 的唯一唤醒就是它）。
+ */
+async function readTurnCompleted(harness: WorkerHarness, workerId: string): Promise<HarnessEvent[]> {
+  await waitUntil(async () =>
+    (await harness.readWorkerEvents(workerId)).some((e) => e.kind === 'turn_completed'))
+  return (await harness.readWorkerEvents(workerId)).filter((e) => e.kind === 'turn_completed')
+}
+
 function now(): string {
   nowValue += 1000
   return new Date(nowValue).toISOString()
@@ -288,6 +300,10 @@ async function makeHarness(
     workersDir,
     now,
     onEvent: (e) => events.push(e),
+    // durable 通知通道默认给个"无人消费"的回执——没有回调时 deliver*Notifications 根本
+    // 不走投递，turn_completed / operation_settled 也就不会落 events.jsonl；返回 undefined
+    // 保持通知 pending（与 queryWorker deadline 巡检等用例的语义一致）。
+    onOperationNotification: async () => undefined,
     mintActivityCursor: async ({ offset }) => `opaque-activity-${['start', 'one', 'two', 'three'][offset] ?? 'later'}`,
     ...depsOverrides,
   }
@@ -507,12 +523,16 @@ describe('WorkerHarness.spawnWorker', () => {
     await expect(harness.getWorkerTurnActivities(turn)).resolves.toEqual({
       events: [expect.objectContaining({ role: 'assistant', summary: '首轮已经完成', source_offset: 0 })],
     })
-    expect(events.find((event) => event.kind === 'state_changed')?.detail).toMatchObject({
+    // 首轮完成回合边界的唯一唤醒是 enriched turn_completed（initial_input_settled 的
+    // state_changed 不再另发；落账后状态事件级携带）
+    const turnEvents = await readTurnCompleted(harness, worker.worker_id)
+    expect(turnEvents[0]?.detail).toMatchObject({
       to: 'idle',
-      kind: 'initial_input_settled',
       turn_id: expect.any(String),
       turn_pending: true,
     })
+    expect(turnEvents[0]?.task_status).toBe('halted')
+    expect(events.filter((e) => e.kind === 'state_changed')).toHaveLength(0)
   })
 
   it('CLI首投遇到未知界面时创建短期快照，只允许 Manager 应答一次', async () => {
@@ -1500,25 +1520,24 @@ describe('WorkerHarness.handleStateChange', () => {
     )
   })
 
-  it('状态回调驱动台账 task.status 与化身 state,并经 onEvent 外发', async () => {
+  it('状态回调驱动台账 task.status 与化身 state,turn 边界经 turn_completed 单醒外发', async () => {
     const { harness, fake } = await makeHarness()
     const worker = await harness.spawnWorker(spawnParams())
     events.length = 0
 
     fake.emitStateChange({ worker_id: worker.worker_id, seq: 1, impl: 'builtin', session_ref: `ref-${worker.worker_id}#1` }, 'idle')
 
-    // handleStateChange 签名对齐 adapter 的同步回调(h, state) => void,内部是 fire-and-forget
-    // 的异步台账更新——用轮询等待收敛(与 tests/workers/contract-suite.ts 的 waitForState
-    // 同一套路,不是"睡一下猜时序",是"有界轮询直到可观察结果达到预期,超时即失败")。
-    await waitUntil(() => events.some((event) => event.kind === 'state_changed'))
+    // 完成回合边界的唯一唤醒是 enriched turn_completed（durable 通道，落 events.jsonl）
+    const stateEvents = await readTurnCompleted(harness, worker.worker_id)
 
     const [w] = await harness.listWorkers(`test::friend-1` as ManagerKey)
     expect(w.task.status).toBe('halted')
     expect(w.incarnations[0].state).toBe('idle')
 
-    const stateEvents = events.filter((e) => e.kind === 'state_changed')
     expect(stateEvents).toHaveLength(1)
     expect(stateEvents[0].detail).toMatchObject({ to: 'idle', turn_pending: true, turn_id: expect.any(String) })
+    // 单醒：同拍不再另发 state_changed 唤醒
+    expect(events.filter((e) => e.kind === 'state_changed')).toHaveLength(0)
 
     // 化身自然结束(非 kill)→ exited;task 已在 idle 拍落 halted,不再二次迁移
     fake.emitStateChange({ worker_id: worker.worker_id, seq: 1, impl: 'builtin', session_ref: `ref-${worker.worker_id}#1` }, 'exited')
@@ -1780,13 +1799,9 @@ describe('WorkerHarness.handleStateChange', () => {
 
     fake.emitStateChange(handle, 'idle', '交互完成后的本轮结果')
     await waitUntil(async () => (await harness.getWorkerTurn(worker.worker_id))?.completion_source === 'claude_stop')
-    await waitUntil(() => events.some((event) =>
-      event.worker_id === worker.worker_id &&
-      event.kind === 'state_changed' &&
-      typeof event.detail?.turn_id === 'string',
-    ))
+    const turns = await readTurnCompleted(harness, worker.worker_id)
 
-    const detail = events.filter((event) => event.worker_id === worker.worker_id && event.kind === 'state_changed').at(-1)?.detail
+    const detail = turns.at(-1)?.detail
     expect(detail).toMatchObject({ to: 'idle', turn_id: expect.any(String), turn_pending: true })
   })
 
@@ -1881,8 +1896,7 @@ describe('WorkerHarness.handleStateChange', () => {
     const h = { worker_id: worker.worker_id, seq: 1, impl: 'builtin' as const, session_ref: `ref-${worker.worker_id}#1` }
     fake.emitStateChange(h, 'idle', '  调研完成,结论是 X 方案可行。  ')
 
-    await waitUntil(() => events.some((e) => e.kind === 'state_changed'))
-    const [ev] = events.filter((e) => e.kind === 'state_changed')
+    const [ev] = await readTurnCompleted(harness, worker.worker_id)
     expect(ev.detail).toMatchObject({
       to: 'idle',
       text: '调研完成,结论是 X 方案可行。',
@@ -1900,8 +1914,7 @@ describe('WorkerHarness.handleStateChange', () => {
     const h = { worker_id: worker.worker_id, seq: 1, impl: 'builtin' as const, session_ref: `ref-${worker.worker_id}#1` }
     fake.emitStateChange(h, 'idle', long)
 
-    await waitUntil(() => events.some((e) => e.kind === 'state_changed'))
-    const [ev] = events.filter((e) => e.kind === 'state_changed')
+    const [ev] = await readTurnCompleted(harness, worker.worker_id)
     const text = (ev.detail as { text: string }).text
     // 保留头部 2000 字符；完整文本可由结构化活动流提供，不伪造终端历史入口。
     expect(text.startsWith('啊'.repeat(2000))).toBe(true)
@@ -1926,8 +1939,7 @@ describe('WorkerHarness.handleStateChange', () => {
       summary: '  盘点完成:三处配置漂移已修正,另有一处需人工确认。  ',
     })
 
-    await waitUntil(() => events.some((e) => e.kind === 'state_changed'))
-    const [ev] = events.filter((e) => e.kind === 'state_changed')
+    const [ev] = await readTurnCompleted(harness, worker.worker_id)
     expect(ev.detail).toMatchObject({
       to: 'exited',
       text: '已经全部跑完了。',
@@ -2015,10 +2027,11 @@ describe('WorkerHarness.handleStateChange', () => {
 
     const h = { worker_id: worker.worker_id, seq: 1, impl: 'builtin' as const, session_ref: `ref-${worker.worker_id}#1` }
     fake.emitStateChange(h, 'idle')
-    await waitUntil(() => events.some((e) => e.kind === 'state_changed'))
-    expect(events.filter((e) => e.kind === 'state_changed')[0].detail).toMatchObject({ to: 'idle', turn_pending: true })
+    const idleTurns = await readTurnCompleted(harness, worker.worker_id)
+    expect(idleTurns[0].detail).toMatchObject({ to: 'idle', turn_pending: true })
 
-    // 纯空白同样折成"没有正文",不塞空字段。
+    // 纯空白同样折成"没有正文",不塞空字段。（running 拍无 completionSource，仍走
+    // fire-and-forget state_changed）
     events.length = 0
     fake.emitStateChange(h, 'running', '   \n  ')
     await waitUntil(() => events.some((e) => e.kind === 'state_changed'))
@@ -4157,19 +4170,21 @@ describe('HarnessEvent.task_status —— 事件自带落账后的 task 状态',
     expect(exited[0].task_status).toBe('halted')
   })
 
-  it('迁移点:主线状态回调 → state_changed 带落账后的 waiting_input / completed', async () => {
+  it('迁移点:主线状态回调 → turn_completed 带落账后的 task 状态(turn 边界唯一唤醒)', async () => {
     const { harness, fake } = await makeHarness()
     const worker = await harness.spawnWorker(spawnParams())
     const handle = { worker_id: worker.worker_id, seq: 1, impl: 'builtin' as WorkerImplId, session_ref: `ref-${worker.worker_id}#1` }
     events.length = 0
 
     fake.emitStateChange(handle, 'idle')
-    await waitUntil(async () => events.some((e) => e.kind === 'state_changed'))
-    expect(events.filter((e) => e.kind === 'state_changed')[0].task_status).toBe('halted')
+    const idleTurns = await readTurnCompleted(harness, worker.worker_id)
+    expect(idleTurns[0].task_status).toBe('halted')
 
     fake.emitStateChange(handle, 'exited')
-    await waitUntil(async () => events.filter((e) => e.kind === 'state_changed').length >= 2)
-    expect(events.filter((e) => e.kind === 'state_changed')[1].task_status).toBe('halted')
+    await waitUntil(async () =>
+      (await harness.readWorkerEvents(worker.worker_id)).filter((e) => e.kind === 'turn_completed').length >= 2)
+    const allTurns = (await harness.readWorkerEvents(worker.worker_id)).filter((e) => e.kind === 'turn_completed')
+    expect(allTurns[1].task_status).toBe('halted')
   })
 
   it('迁移点:verified stop → operation_settled 带 closed(stop_verified 已降审计)', async () => {

--- a/crabot-agent/tests/workers/harness/harness-lifecycle.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-lifecycle.test.ts
@@ -1980,8 +1980,10 @@ describe('WorkerHarness.handleStateChange', () => {
     const h = { worker_id: worker.worker_id, seq: 1, impl: 'builtin' as const, session_ref: `ref-${worker.worker_id}#1` }
     harness.handleStateChange(h, 'exited', { endReason: 'crashed' })
 
-    await waitUntil(() => events.some((e) => e.kind === 'state_changed'))
-    const [ev] = events.filter((e) => e.kind === 'state_changed')
+    // crashed 退出已降审计（唤醒由 worker_recovery_required 承载）：读 events.jsonl 验证
+    // detail 形状——审计与唤醒共用同一个 detail 构造函数。
+    await waitUntil(async () => (await harness.readWorkerEvents(worker.worker_id)).some((e) => e.kind === 'state_changed'))
+    const [ev] = (await harness.readWorkerEvents(worker.worker_id)).filter((e) => e.kind === 'state_changed')
     expect(ev.detail).toMatchObject({ to: 'exited' })
   })
 

--- a/crabot-agent/tests/workers/harness/harness-liveness.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-liveness.test.ts
@@ -146,10 +146,10 @@ function spawnParams(overrides: Partial<SpawnWorkerParams> = {}): SpawnWorkerPar
   }
 }
 
-/** 巡检发出的唤醒事件:state_changed + detail.text(#70 同款形状,零新 kind、零新状态)。 */
+/** 巡检发出的唤醒事件:liveness_stall 独立 kind(事件面收敛后,不再借用 state_changed)。 */
 function wakeEvents(workerId: string): HarnessEvent[] {
   return events.filter(
-    (e) => e.worker_id === workerId && e.kind === 'state_changed' && typeof e.detail?.text === 'string',
+    (e) => e.worker_id === workerId && e.kind === 'liveness_stall',
   )
 }
 
@@ -197,8 +197,8 @@ describe.each<WorkerImplId>(['claude-code', 'codex'])('WorkerHarness.sweepLivene
     expect(text).toContain('读取状态和原生会话活动')
     expect(text).not.toContain('⏺ 正在读取文件…')
     expect(adapter.readTerminalCalls).toHaveLength(0)
-    // 零新事件 kind、零新状态
-    expect(woke[0].kind).toBe('state_changed')
+    // 独立 kind、零新状态
+    expect(woke[0].kind).toBe('liveness_stall')
   })
 
   it('② lastActivityAt 持续前进(真实任务进展)→ 零事件', async () => {

--- a/crabot-agent/tests/workers/harness/harness-recovery.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-recovery.test.ts
@@ -203,6 +203,39 @@ describe('WorkerHarness.reconcileOnStartup — 三态判定', () => {
     expect(exitedEvents[0].detail?.reason).toBe('crashed')
   })
 
+  it('停止残局(mainline 已 exited(superseded)、task 仍 running)判死 → 无 notice 可建,exited 保留唤醒档', async () => {
+    const { harness, ledger, adaptersMap } = await makeHarness()
+    const fake = new FakeAdapter('builtin')
+    adaptersMap.set('builtin', fake)
+    // handoff 第 2 步已把源化身落盘 exited(superseded)、task 仍 running，第 3 步 spawn 目标
+    // 期间进程重启留下的台账形态（PR #137 review 指出的零唤醒缝隙：notice 创建以
+    // "化身尚未 exited" 为条件，此形态建不出 notice，判死事件必须保留唤醒档）。
+    const worker = makeWorker('w-handoff-remnant', {
+      task: { id: 'task-w-handoff-remnant', title: '测试任务', status: 'running', created_at: now() },
+      incarnations: [{
+        incarnation_id: 'incarnation-handoff-remnant',
+        seq: 1, impl: 'builtin', state: 'exited', ended_reason: 'superseded',
+        workspace: '/tmp/ws', session_ref: 'ref-w-handoff-remnant#1', started_at: now(),
+      }],
+    })
+    await seed(ledger, DIALOG, worker)
+    fake.setState({ worker_id: 'w-handoff-remnant', seq: 1 }, 'exited')
+
+    const report = await harness.reconcileOnStartup()
+
+    expect(report.failed).toEqual(['w-handoff-remnant'])
+    const after = await getWorker(ledger, 'w-handoff-remnant')
+    expect(after.task.status).toBe('halted')
+    expect(after.task.halt?.halt_reason).toBe('crashed')
+    // 化身已是 exited → 建不出 recovery notice……
+    expect(after.recovery_notices ?? []).toHaveLength(0)
+    // ……因此判死事件必须保留唤醒档（经 onEvent 到达 manager + §9.2 推送），不能只是审计
+    const exitedWakes = events.filter((e) => e.worker_id === 'w-handoff-remnant' && e.kind === 'exited')
+    expect(exitedWakes).toHaveLength(1)
+    expect(exitedWakes[0].detail?.reason).toBe('crashed')
+    expect(exitedWakes[0].task_status).toBe('halted')
+  })
+
   it('adapter 报 running 且与台账一致 → 台账保持不动、不发事件，归 revived', async () => {
     const { harness, ledger, adaptersMap } = await makeHarness()
     const fake = new FakeAdapter('builtin')

--- a/crabot-agent/tests/workers/harness/harness-recovery.test.ts
+++ b/crabot-agent/tests/workers/harness/harness-recovery.test.ts
@@ -197,7 +197,8 @@ describe('WorkerHarness.reconcileOnStartup — 三态判定', () => {
     expect(after.incarnations[0].ended_reason).toBe('crashed')
     expect(after.incarnations[0].ended_at).toBeTruthy()
 
-    const exitedEvents = events.filter((e) => e.kind === 'exited' && e.worker_id === 'w-exited')
+    // 判死事件已降审计（唤醒由 worker_recovery_required 承载）：读 events.jsonl 而非唤醒面
+    const exitedEvents = (await harness.readWorkerEvents('w-exited')).filter((e) => e.kind === 'exited')
     expect(exitedEvents).toHaveLength(1)
     expect(exitedEvents[0].detail?.reason).toBe('crashed')
   })
@@ -354,7 +355,7 @@ describe('WorkerHarness.reconcileOnStartup — 三态判定', () => {
     const after = await getWorker(ledger, 'w-no-adapter')
     expect(after.task.status).toBe('halted')
     expect(after.incarnations[0].ended_reason).toBe('crashed')
-    const exitedEvents = events.filter((e) => e.kind === 'exited' && e.worker_id === 'w-no-adapter')
+    const exitedEvents = (await harness.readWorkerEvents('w-no-adapter')).filter((e) => e.kind === 'exited')
     expect(exitedEvents[0].detail?.message).toContain('codex')
     expect(builtinFake.stateCalls).toHaveLength(0) // 不存在的 impl，不该错调到别的 adapter 上
   })
@@ -378,7 +379,7 @@ describe('WorkerHarness.reconcileOnStartup — 三态判定', () => {
     const after = await getWorker(ledger, 'w-throws')
     expect(after.task.status).toBe('halted')
     expect(after.incarnations[0].ended_reason).toBe('crashed')
-    const exitedEvents = events.filter((e) => e.kind === 'exited' && e.worker_id === 'w-throws')
+    const exitedEvents = (await harness.readWorkerEvents('w-throws')).filter((e) => e.kind === 'exited')
     expect(exitedEvents[0].detail?.message).toContain('tmux pane 探测失败')
   })
 })
@@ -488,7 +489,8 @@ describe('WorkerHarness.reconcileOnStartup — 幂等', () => {
     expect(first).toEqual<ReconcileReport>({ revived: [], failed: ['w-repeat'], unchanged: [] })
     const afterFirst = await getWorker(ledger, 'w-repeat')
     expect(afterFirst.task.status).toBe('halted')
-    const eventsAfterFirst = events.filter((e) => e.worker_id === 'w-repeat')
+    // 判死事件已降审计：读 events.jsonl 而非唤醒面
+    const eventsAfterFirst = (await harness.readWorkerEvents('w-repeat')).filter((e) => e.kind === 'exited')
     expect(eventsAfterFirst).toHaveLength(1)
 
     const second = await harness.reconcileOnStartup()
@@ -496,7 +498,7 @@ describe('WorkerHarness.reconcileOnStartup — 幂等', () => {
     // adapter.state() 完全不会再被这个已终态 worker 调用第二次。
     expect(fake.stateCalls.filter((h) => h.worker_id === 'w-repeat')).toHaveLength(1)
     // 没有产生第二条事件。
-    expect(events.filter((e) => e.worker_id === 'w-repeat')).toHaveLength(1)
+    expect((await harness.readWorkerEvents('w-repeat')).filter((e) => e.kind === 'exited')).toHaveLength(1)
     const afterSecond = await getWorker(ledger, 'w-repeat')
     expect(afterSecond).toEqual(afterFirst) // 台账没有被第二次改写
   })
@@ -537,6 +539,8 @@ describe('WorkerHarness restart recovery notices', () => {
       expect(delivered[index]).toMatchObject({
         kind: 'worker_recovery_required',
         worker_id: 'w-recovery-notice',
+        // 一次崩溃对 manager 的唯一唤醒：必须携带落账后 task_status（唤醒面 exited 已降审计）
+        task_status: 'halted',
         detail: expect.objectContaining({ notice_id: crashed.recovery_notices?.[0].notice_id }),
       })
       const pending = (await getWorker(ledger, 'w-recovery-notice')).recovery_notices?.[0]
@@ -554,6 +558,35 @@ describe('WorkerHarness restart recovery notices', () => {
     await harness.reconcileRecoveryNoticesOnStartup()
     expect(delivered).toHaveLength(6)
     expect((await getWorker(ledger, 'w-recovery-notice')).recovery_notices?.[0]).toMatchObject({
+      status: 'consumed',
+      consumed_at: expect.any(String),
+    })
+  })
+
+  it('投递前校验：notice 到期时 task 已被 manager 处置(非 crash 停摆) → 直接标 consumed，不拿过期事实唤醒', async () => {
+    const delivered: HarnessEvent[] = []
+    const { harness, ledger, adaptersMap } = await makeHarness({
+      onOperationNotification: async (_managerKey, event) => {
+        delivered.push(event)
+        return { consumed: true }
+      },
+    })
+    const fake = new FakeAdapter('builtin')
+    adaptersMap.set('builtin', fake)
+    await seed(ledger, DIALOG, makeWorker('w-stale-notice'))
+    fake.setState({ worker_id: 'w-stale-notice', seq: 1 }, 'exited')
+    await harness.reconcileOnStartup()
+    expect((await getWorker(ledger, 'w-stale-notice')).recovery_notices).toHaveLength(1)
+
+    // manager 在通知投递前已经处置：停止落定 closed（续办回 running 同理不再 crash 停摆）
+    await harness.killWorker('w-stale-notice')
+    expect((await getWorker(ledger, 'w-stale-notice')).task.status).toBe('closed')
+
+    await harness.reconcileRecoveryNoticesOnStartup()
+
+    // 不投递过期事实；notice 被处置动作本身视为已消费
+    expect(delivered.filter((e) => e.kind === 'worker_recovery_required')).toEqual([])
+    expect((await getWorker(ledger, 'w-stale-notice')).recovery_notices?.[0]).toMatchObject({
       status: 'consumed',
       consumed_at: expect.any(String),
     })
@@ -687,12 +720,14 @@ describe('WorkerHarness restart recovery notices', () => {
 })
 
 /**
- * P5 修复:`HarnessEvent.task_status` —— 对账路径上的两个 task 级迁移点
+ * `HarnessEvent.task_status` —— 对账路径上的两个 task 级迁移点
  * (markCrashed 的 `exited`、realignAliveIncarnation 的 `state_changed`)必须自带落账后的
- * 状态,订阅方不再现读台账。分类总表见 harness.ts `appendEvent` 注释。
+ * 状态。markCrashed 已降审计（唤醒由 worker_recovery_required 承载），这里读 events.jsonl
+ * 验证审计事件仍自带状态；realignAliveIncarnation 仍在唤醒面。分类总表见 harness.ts
+ * `appendEvent` 注释。
  */
 describe('HarnessEvent.task_status —— reconcileOnStartup 的迁移点', () => {
-  it('判死(markCrashed)的 exited 事件带 failed', async () => {
+  it('判死(markCrashed)的 exited 审计事件带 halted', async () => {
     const { harness, ledger, adaptersMap } = await makeHarness()
     const fake = new FakeAdapter('builtin')
     adaptersMap.set('builtin', fake)
@@ -701,7 +736,7 @@ describe('HarnessEvent.task_status —— reconcileOnStartup 的迁移点', () =
 
     await harness.reconcileOnStartup()
 
-    const exited = events.filter((e) => e.kind === 'exited' && e.worker_id === 'w-crash')
+    const exited = (await harness.readWorkerEvents('w-crash')).filter((e) => e.kind === 'exited')
     expect(exited).toHaveLength(1)
     expect(exited[0].task_status).toBe('halted')
     expect(exited[0].task_status).toBe((await getWorker(ledger, 'w-crash')).task.status)

--- a/crabot-agent/tests/workers/harness/worker-events.test.ts
+++ b/crabot-agent/tests/workers/harness/worker-events.test.ts
@@ -20,12 +20,12 @@ describe('WorkerEventLog', () => {
 
   it('append 后 readAll 能原样往返读回', async () => {
     const log = new WorkerEventLog(workerDir)
-    await log.append({ kind: 'spawned', worker_id: 'w-1', seq: 0, ts: '2026-01-01T00:00:00Z' })
+    await log.append({ kind: 'lifecycle_changed', worker_id: 'w-1', seq: 0, ts: '2026-01-01T00:00:00Z' })
     await log.append({ kind: 'state_changed', worker_id: 'w-1', seq: 0, detail: { from: 'idle', to: 'running' } })
 
     const events: HarnessEvent[] = await log.readAll()
     expect(events).toHaveLength(2)
-    expect(events[0]).toEqual({ kind: 'spawned', worker_id: 'w-1', seq: 0, ts: '2026-01-01T00:00:00Z' })
+    expect(events[0]).toEqual({ kind: 'lifecycle_changed', worker_id: 'w-1', seq: 0, ts: '2026-01-01T00:00:00Z' })
     expect(events[1].kind).toBe('state_changed')
     expect(events[1].detail).toEqual({ from: 'idle', to: 'running' })
     expect(typeof events[1].ts).toBe('string')
@@ -47,7 +47,7 @@ describe('WorkerEventLog', () => {
   it('目录不存在时 append 自动创建', async () => {
     const nested = join(dir, 'a', 'b', 'worker-x')
     const log = new WorkerEventLog(nested)
-    await log.append({ kind: 'spawned', worker_id: 'w-x', seq: 0 })
+    await log.append({ kind: 'lifecycle_changed', worker_id: 'w-x', seq: 0 })
 
     const stat = await fs.stat(join(nested, 'events.jsonl'))
     expect(stat.isFile()).toBe(true)


### PR DESCRIPTION
## 事件面收敛（PR #136 follow-up）

spec：`crabot-docs/superpowers/specs/2026-09-01-event-surface-convergence-design.md`（已确认）
协议：`protocol-agent-v3.md`（P1 已随协议仓同步更新）

**核心原则**：kind 粒度 = manager 处置规则粒度；一次物理事实 = manager 只醒一次。

### 五阶段（本 PR 按 commit 分阶段）

| commit | 阶段 | 内容 |
|---|---|---|
| bbd19005 | P1 | 事件两档分层成文（协议仓先行）；删除无发射点的 `input_held` 死代码 |
| 43bcf892 | P2 | 事件名拆合：`lifecycle_changed` 合并（detail.change=spawned/resumed/handoff_started/superseded）；`interaction_required` / `liveness_stall` 独立成 kind |
| 2984ea24 | P3 | 停止单回执：`operation_settled` 携带结算结果 + 落账后 task_status（首次落盘固化，重投从 jsonl 读回同一条）；stop_verified/死信/killed-exit 降审计；附带修复现网缺口「stop 核验 unknown 且无 bg → task 落 halted(stop_unverified)」 |
| 6d7ff07a | P4 | 崩溃单醒：`worker_recovery_required` 携带 task_status + **投递前校验**（task 非 halted+crashed → 标 consumed 不唤醒）；markCrashed 的 exited 与 crashed 主线 state_changed 降审计；preserveTaskForStop 例外保留唤醒 |
| 4e8d1cde | P5 | **回合单通知合并（核心）**：enriched `turn_completed`（detail 迁入 to/text/summary + 事件级 task_status）是完成回合边界的唯一唤醒，同拍不再发 state_changed；persist 失败回退补发 state_changed。`routeOperationNotification` 非 activity 通知补齐 origin 注入（trigger_type/task_id/outcome，与 onEvent 通道同形态）；prompt 记忆候选判据迁到 turn_completed |

### 新引入的失败路径与收口

- 回合通知持久化失败 → 如实返回 `notificationPersisted=false`，调用方回退补发 fire-and-forget state_changed（在线送达，无 durable 重投——与 P5 前语义相同）
- operation_settled 重投 → 从 events.jsonl 按 operation_id 读回首次落盘那条，task_status 不丢
- worker_recovery_required 投递时 task 已被处置 → 标 consumed 不拿过期事实唤醒
- routeOperationNotification 台账查不到 worker → 退回 harness 通知快照 key（不落系统线程）

### 验证

- `npx tsc --noEmit` 绿
- 定向：`tests/workers/harness/` + `tests/manager/` 全绿（805 + 429）
- 全量 2983 中 19 失败均已归因：14 个为基线既有（已在 P4 commit 上对照核实：workspace-manager×3、inbound×6、runtime-config-invalidation×2、assemble-agent×1、builtin-production-runtime×2），5 个为并发抖动（单跑全绿）

### 明确排除 / follow-up

- `activity_available` 分支（带 receipt）的 origin 注入未动——P5 之前即走该通道的既有行为，不在本 spec 范围
- admin-web 事件枚举徽章映射已在 #136 后删除，本 PR 不涉及前端

@claude 请 review。