### PR TITLE
fix(agent): 用来源登记解析 Session 归属

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,9 +1,18 @@
 # Crabot 项目进度
 
-> 最后整理：2026-09-04
+> 最后整理：2026-09-05
 > 本文件只保留当前状态、明确 follow-up 和阶段性里程碑；详细实施流水、逐轮 review 与历史测试输出见 Git 历史。压缩前完整版本可用 `git show 49b9cb4:PROGRESS.md` 查看。
 
 ## 当前状态
+
+### send_message 缺 channel_id 的确定性修复改为来源登记：实现与验证完成，待 PR review
+
+- 已将发送时的 Channel 枚举与逐实例 `get_session` 探测替换为当前 Manager 的运行时多值索引：
+  成功的结构化 messaging 结果登记 `session_id → Set<channel_id>`，缺参发送只做本地查询；
+  唯一命中或当前 Manager Channel 可消歧时补全，其余继续原样透传。
+- 索引不持久化、不跨 Manager 共享，也不作为权限或当前可路由性的事实源；Loop 回收或 Agent
+  重启后自然清空。raw MCP 仍要求显式 `channel_id`，内部观察元数据不进入工具结果。
+- 正式协议 crab-messaging v0.3.7 与修订 Spec 已先行发布（crabot-docs `b725b1c`）。
 
 ### Agent Engine 自适应增量上下文压缩：实现与验证完成，待 PR #139 review
 

--- a/crabot-agent/src/manager/bootstrap.ts
+++ b/crabot-agent/src/manager/bootstrap.ts
@@ -618,8 +618,11 @@ export function buildManagerStack(deps: BootstrapDeps): ManagerStack {
           triggerType: scheduleIdentity ? 'scheduled' : isSystemThread ? 'system' : 'message',
         }),
         messagingDeps: deps.messagingDeps,
-        // send_message 省略 channel_id 时使用的 manager 归属目标（spec 2026-09-03-tool-input-repair）
+        // send_message 省略 channel_id 时使用的 manager 归属目标与结构化 Session 观察索引
+        // （spec 2026-09-03-tool-input-repair）。两条桥都在工具调用时动态读取当前 Loop。
         managerTarget: channelSessionFromManagerKey(key),
+        sessionChannelsFor: traceHooks?.sessionChannelsFor,
+        onObservedSessionTargets: traceHooks?.onObservedSessionTargets,
         onPostSendAction: traceHooks?.onPostSendAction,
         // 记忆档位按**这个会话最近一次解析出来的发起人身份**现建。这里刻意不用
         // `humanPrincipal`:worker 事件唤醒的 episode 里没人说话,但该会话的记忆可见范围

--- a/crabot-agent/src/manager/loop.ts
+++ b/crabot-agent/src/manager/loop.ts
@@ -72,6 +72,7 @@ import type { ManagerSessionState, ManagerKey } from './types.js'
 import type { WorkerHarness } from '../workers/harness/harness'
 import type { ActivityContextAdmissionReceipt, HarnessEvent } from '../workers/harness/worker-events'
 import type { ChannelMessage, Friend, ResolvedPermissions } from '../types'
+import type { SessionTarget } from '../mcp/crab-messaging.js'
 
 const ASSISTANT_TEXT_END_TURN_REMINDER = '[系统提醒] 你刚才直接输出了一段文字、没有调用 send_message，然后结束了回复。\n'
   + '请注意：直接输出的文字只留在系统内部，人类看不到；只有 send_message 发送的内容才能送达人类。\n'
@@ -359,6 +360,8 @@ export class ManagerLoop {
   /** Delivery/continuation evidence belongs to one Manager episode and is never inferred from history. */
   private readonly successfulSendMessageTargetsInCurrentEpisode = new Set<string>()
   private readonly continuedWorkersInCurrentEpisode = new Set<string>()
+  /** 当前 Manager 从成功的结构化 messaging 结果观察到的多值 Session 归属；随 Loop 回收。 */
+  private readonly sessionChannels = new Map<string, Set<string>>()
 
   /** 当前 episode 的 trace id（仅 episode 进行中）；registry 桥/worker-tools 读取用。 */
   get currentEpisodeTraceId(): string | undefined {
@@ -372,6 +375,27 @@ export class ManagerLoop {
   recordSuccessfulSendMessage(target: { channel_id: string; session_id: string }): void {
     if (this.currentTraceId !== undefined) {
       this.successfulSendMessageTargetsInCurrentEpisode.add(`${target.channel_id}\u0000${target.session_id}`)
+    }
+  }
+
+  sessionChannelsFor(sessionId: string): ReadonlySet<string> | undefined {
+    return this.sessionChannels.get(sessionId)
+  }
+
+  recordObservedSessionTargets(targets: ReadonlyArray<SessionTarget>): void {
+    for (const target of targets) {
+      if (
+        typeof target.channel_id !== 'string'
+        || target.channel_id.length === 0
+        || typeof target.session_id !== 'string'
+        || target.session_id.length === 0
+      ) continue
+      let channels = this.sessionChannels.get(target.session_id)
+      if (!channels) {
+        channels = new Set()
+        this.sessionChannels.set(target.session_id, channels)
+      }
+      channels.add(target.channel_id)
     }
   }
 

--- a/crabot-agent/src/manager/registry.ts
+++ b/crabot-agent/src/manager/registry.ts
@@ -41,6 +41,7 @@ import type {
   HarnessEventDelivery,
 } from '../workers/harness/worker-events'
 import type { ChannelMessage, Friend, ResolvedPermissions } from '../types'
+import type { SessionTarget } from '../mcp/crab-messaging.js'
 import type { HumanPrincipal } from './principal.js'
 import { resolveTimezone } from '../utils/time.js'
 
@@ -177,6 +178,8 @@ export interface ManagerRegistryDeps {
       onPostSendAction: () => void
       hasSuccessfulSendMessageTo: (target: { channel_id: string; session_id: string }) => boolean
       onSuccessfulSendMessage: (target: { channel_id: string; session_id: string }) => void
+      sessionChannelsFor: (sessionId: string) => ReadonlySet<string> | undefined
+      onObservedSessionTargets: (targets: ReadonlyArray<SessionTarget>) => void
       hasContinuedWorker: (workerId: string) => boolean
       onWorkerContinuation: (workerId: string) => void
     },
@@ -257,6 +260,8 @@ export class ManagerRegistry {
             onPostSendAction: () => this.loops.get(key)?.recordPostSendAction(),
             hasSuccessfulSendMessageTo: (target) => this.loops.get(key)?.hasSuccessfulSendMessageTo(target) ?? false,
             onSuccessfulSendMessage: (target) => this.loops.get(key)?.recordSuccessfulSendMessage(target),
+            sessionChannelsFor: (sessionId) => this.loops.get(key)?.sessionChannelsFor(sessionId),
+            onObservedSessionTargets: (targets) => this.loops.get(key)?.recordObservedSessionTargets(targets),
             hasContinuedWorker: (workerId) => this.loops.get(key)?.hasContinuedWorker(workerId) ?? false,
             onWorkerContinuation: (workerId) => this.loops.get(key)?.recordWorkerContinuation(workerId),
           },

--- a/crabot-agent/src/manager/tools/tool-face.ts
+++ b/crabot-agent/src/manager/tools/tool-face.ts
@@ -22,7 +22,13 @@ import type { McpServer } from '../../mcp/mcp-helpers.js'
 import { mcpServerToToolDefinitions } from '../../agent/mcp-tool-bridge.js'
 import { CRAB_MEMORY_MANAGER_TOOL_NAMES } from '../../mcp/crab-memory.js'
 import { buildMessagingTools, createSendMessageChannelRepair } from '../../mcp/crab-messaging.js'
-import type { CrabMessagingDeps, MessagingTool, MessagingToolSet } from '../../mcp/crab-messaging.js'
+import type {
+  CrabMessagingDeps,
+  MessagingTool,
+  MessagingToolSet,
+  SessionChannelLookup,
+  SessionTarget,
+} from '../../mcp/crab-messaging.js'
 import { buildWorkerTools } from './worker-tools.js'
 import type { WorkerHarness } from '../../workers/harness/harness'
 import { buildCrabotInfoTools } from './crabot-info.js'
@@ -41,10 +47,11 @@ export interface ToolFaceDeps {
   /** 复用现有类型 —— crab-messaging 的依赖注入接口。 */
   readonly messagingDeps: CrabMessagingDeps
   /** 本 manager 的归属目标（来自 managerKey `channel::session`）。用于确定性补全 send_message.channel_id。 */
-  readonly managerTarget?: {
-    readonly channel_id: string
-    readonly session_id: string
-  }
+  readonly managerTarget?: SessionTarget
+  /** 当前 Manager 已从可信结构化结果观察到的 Session 归属。 */
+  readonly sessionChannelsFor?: SessionChannelLookup
+  /** 将成功 messaging 调用产生的可信结构化 Session 归属登记到当前 Manager。 */
+  readonly onObservedSessionTargets?: (targets: ReadonlyArray<SessionTarget>) => void
   /** crab-memory，现有 createCrabMemoryServer 产物。 */
   readonly memoryServer: McpServer
   readonly callAdmin: <P, R>(m: string, p: P) => Promise<R>
@@ -172,6 +179,18 @@ const HUMAN_DELIVERY_TOOL_NAMES = new Set([
   'send_master_private',
 ])
 
+const MANAGER_SEND_MESSAGE_CHANNEL_SCHEMA = z.string().optional().describe(
+  'Channel 模块实例 ID；可省略，省略时系统按当前 Manager 已登记的结构化 Session 归属补全（多渠道命中时仅取当前 Manager 归属渠道）',
+)
+
+const POST_SEND_ACTION_SCHEMA = z.enum(['none', 'spawn_worker']).describe(
+  '本条消息发出后是否预计新建 Worker；仅供系统在本轮结束时做一次内部复核，不会自动派发或重复发送消息',
+)
+
+const DAILY_REFLECTION_SUMMARY_SCHEMA = z.object({
+  content: z.string().describe('给人类看的自然语言摘要'),
+})
+
 function messagingToolToDefinition(tool: MessagingTool, deps: ToolFaceDeps): ToolDefinition {
   const isSendMessage = tool.name === 'send_message'
   const isHumanDelivery = HUMAN_DELIVERY_TOOL_NAMES.has(tool.name)
@@ -181,13 +200,11 @@ function messagingToolToDefinition(tool: MessagingTool, deps: ToolFaceDeps): Too
         ...Object.fromEntries(
           Object.entries(tool.schema).filter(([key]) => key !== 'intent' && key !== 'channel_id'),
         ),
-        channel_id: z.string().optional().describe(
-          'Channel 模块实例 ID；可省略，省略时系统按 session_id 反查归属渠道（多渠道命中时取当前 manager 归属渠道）',
-        ),
+        channel_id: MANAGER_SEND_MESSAGE_CHANNEL_SCHEMA,
       }
     : tool.schema
   const shape = isHumanDelivery
-    ? { ...baseShape, post_send_action: z.enum(['none', 'spawn_worker']).describe('本条消息发出后是否预计新建 Worker；仅供系统在本轮结束时做一次内部复核，不会自动派发或重复发送消息') }
+    ? { ...baseShape, post_send_action: POST_SEND_ACTION_SCHEMA }
     : baseShape
 
   let inputSchema: Record<string, unknown> = { type: 'object', properties: {} }
@@ -205,8 +222,8 @@ function messagingToolToDefinition(tool: MessagingTool, deps: ToolFaceDeps): Too
     ...(isSendMessage
       ? {
           // 确定性参数修复（spec 2026-09-03-tool-input-repair）：channel_id 省略时按
-          // session_id 反查归属渠道。修复失败/不适用由规则内部原样透传，无任何额外输出。
-          repairInput: createSendMessageChannelRepair(deps.messagingDeps, deps.managerTarget),
+          // 当前 Manager 已登记的 Session 归属补全。未知/歧义时原样透传，无额外输出。
+          repairInput: createSendMessageChannelRepair(deps.sessionChannelsFor, deps.managerTarget),
         }
       : {}),
     call: async (input): Promise<ToolCallResult> => {
@@ -217,6 +234,13 @@ function messagingToolToDefinition(tool: MessagingTool, deps: ToolFaceDeps): Too
       const args = Object.fromEntries(Object.entries(input).filter(([key]) => key !== 'intent' && key !== 'post_send_action'))
       try {
         const result = await tool.handler(args)
+        if (result.observedSessionTargets?.length) {
+          try {
+            deps.onObservedSessionTargets?.(result.observedSessionTargets)
+          } catch {
+            // 派生观察登记失败不得改变原工具结果。
+          }
+        }
         if (!result.isError && postSendAction === 'spawn_worker') deps.onPostSendAction?.('spawn_worker')
         const text = result.content.map((block) => block.text).join('\n')
         if (isSendMessage && !result.isError) {
@@ -251,9 +275,7 @@ function buildDailyReflectionMessagingFace(deps: ToolFaceDeps): ToolDefinition[]
   return [defineTool({
     name: 'send_daily_reflection_summary',
     description: '将每日反思的必要摘要发送到 Admin Web 系统任务线程。仅接收人类可读文本，投递目标固定且不可修改。',
-    inputSchema: z.toJSONSchema(z.object({
-      content: z.string().describe('给人类看的自然语言摘要'),
-    })) as Record<string, unknown>,
+    inputSchema: z.toJSONSchema(DAILY_REFLECTION_SUMMARY_SCHEMA) as Record<string, unknown>,
     isReadOnly: false,
     call: async (input): Promise<ToolCallResult> => {
       try {
@@ -261,6 +283,13 @@ function buildDailyReflectionMessagingFace(deps: ToolFaceDeps): ToolDefinition[]
           ...DAILY_REFLECTION_SUMMARY_TARGET,
           content: input.content as string,
         })
+        if (result.observedSessionTargets?.length) {
+          try {
+            deps.onObservedSessionTargets?.(result.observedSessionTargets)
+          } catch {
+            // 派生观察登记失败不得改变原工具结果。
+          }
+        }
         return {
           output: result.content.map((block) => block.text).join('\n'),
           isError: !!result.isError,

--- a/crabot-agent/src/mcp/crab-messaging.ts
+++ b/crabot-agent/src/mcp/crab-messaging.ts
@@ -10,7 +10,7 @@
 import { resolvePath } from '../engine/tools/utils.js'
 import { createMcpServer, type McpServer } from './mcp-helpers.js'
 import { z } from 'zod/v4'
-import { RpcCallError, SYSTEM_CHANNEL_ID, SYSTEM_SESSION_ID, type RpcClient } from 'crabot-shared'
+import { SYSTEM_CHANNEL_ID, SYSTEM_SESSION_ID, type RpcClient } from 'crabot-shared'
 import type { Friend, MessageContent } from '../types.js'
 import { annotatePagination } from './pagination-annotator.js'
 import { translateChannelError } from './error-translator.js'
@@ -169,23 +169,70 @@ const ASK_HUMAN_BARRIER_TIMEOUT_MS = 24 * 60 * 60 * 1000 + 15 * 60 * 1000
 // 工具类型定义
 // ============================================================================
 
+export interface SessionTarget {
+  readonly channel_id: string
+  readonly session_id: string
+}
+
+export interface MessagingToolResult {
+  content: Array<{ type: 'text'; text: string }>
+  isError?: boolean
+  /** Manager 内部消费的可信结构化观察；不得暴露到 MCP/LLM 输出。 */
+  observedSessionTargets?: ReadonlyArray<SessionTarget>
+}
+
 export interface MessagingTool {
   name: string
   description: string
   schema: Record<string, z.ZodTypeAny>
-  handler: (args: Record<string, unknown>) => Promise<{
-    content: Array<{ type: 'text'; text: string }>
-    isError?: boolean
-  }>
+  handler: (args: Record<string, unknown>) => Promise<MessagingToolResult>
 }
 
 // ============================================================================
 // 内部 helper
 // ============================================================================
 
-function wrapText(payload: unknown, opts?: { isError?: boolean }) {
+function wrapText(payload: unknown, opts?: { isError?: boolean }): MessagingToolResult {
   const base = { content: [{ type: 'text' as const, text: JSON.stringify(payload) }] }
   return opts?.isError ? { ...base, isError: true } : base
+}
+
+function withObservedSessionTargets(
+  result: MessagingToolResult,
+  targets: ReadonlyArray<SessionTarget>,
+): MessagingToolResult {
+  const valid = targets.filter(
+    (target) =>
+      typeof target.channel_id === 'string'
+      && target.channel_id.length > 0
+      && typeof target.session_id === 'string'
+      && target.session_id.length > 0,
+  )
+  return valid.length > 0
+    ? { ...result, observedSessionTargets: valid }
+    : result
+}
+
+function sessionTarget(channelId: string, sessionId: string): SessionTarget {
+  return { channel_id: channelId, session_id: sessionId }
+}
+
+function sessionTargetsFromItems(items: unknown): SessionTarget[] {
+  if (!Array.isArray(items)) return []
+  const targets: SessionTarget[] = []
+  for (const item of items) {
+    if (!item || typeof item !== 'object') continue
+    const { id, channel_id } = item as { id?: unknown; channel_id?: unknown }
+    if (
+      typeof id === 'string'
+      && id.length > 0
+      && typeof channel_id === 'string'
+      && channel_id.length > 0
+    ) {
+      targets.push(sessionTarget(channel_id, id))
+    }
+  }
+  return targets
 }
 
 /**
@@ -420,16 +467,19 @@ const FETCH_MEDIA_SCHEMA = {
 // send_message 参数修复规则（spec 2026-09-03-tool-input-repair）
 // ================================================================
 
+export type SessionChannelLookup = (
+  sessionId: string,
+) => ReadonlySet<string> | undefined
+
 /**
- * `send_message` 省略 `channel_id` 时按 `session_id` 反查归属渠道的确定性修复规则。
+ * `send_message` 省略 `channel_id` 时按当前 Manager 已登记的 Session 归属确定性补全。
  *
- * 仅当 `channel_id` 缺失且 `session_id` 为非空字符串时介入。目标恰好命中一个渠道时补全；
- * 多渠道命中时仅在当前 manager 归属渠道也命中时选择该渠道。任一列表、端口解析或探测步骤
- * 无法给出确定结果时原样透传，由工具自身处理。本规则不生成错误，也不改写工具返回内容。
+ * 只查本地索引，不枚举 Channel、探测 Session 或在 miss 时回退扫描。无确定结果或索引读取
+ * 失败时原样透传，由工具自身处理；本规则不生成错误，也不改写工具返回内容。
  */
 export function createSendMessageChannelRepair(
-  deps: Pick<CrabMessagingDeps, 'rpcClient' | 'moduleId' | 'getAdminPort' | 'resolveChannelPort'>,
-  managerTarget?: { readonly channel_id: string; readonly session_id: string },
+  lookupSessionChannels: SessionChannelLookup | undefined,
+  managerTarget?: SessionTarget,
 ): (input: Record<string, unknown>) => Promise<Record<string, unknown>> {
   return async (input) => {
     if (input.channel_id !== undefined) return input
@@ -441,70 +491,22 @@ export function createSendMessageChannelRepair(
     }
 
     try {
-      const adminPort = await deps.getAdminPort()
-      const ids: string[] = []
-      const pageSize = 50
-      let page = 1
-      let totalPages: number
-
-      do {
-        const result = await deps.rpcClient.call<
-          { page: number; page_size: number },
-          {
-            items: Array<{ id: string }>
-            pagination: {
-              page: number
-              page_size: number
-              total_items: number
-              total_pages: number
-            }
-          }
-        >(adminPort, 'list_channel_instances', { page, page_size: pageSize }, deps.moduleId)
-        if (
-          !result
-          || !Array.isArray(result.items)
-          || !result.items.every((item) => item && typeof item.id === 'string')
-          || !result.pagination
-          || !Number.isInteger(result.pagination.total_pages)
-          || result.pagination.total_pages < 0
-          || result.pagination.page !== page
-        ) {
-          return input
-        }
-        ids.push(...result.items.map((item) => item.id))
-        totalPages = result.pagination.total_pages
-        page += 1
-      } while (page <= totalPages)
-
-      const hits: string[] = []
-      for (const channelId of ids) {
-        const port = await deps.resolveChannelPort(channelId)
-        if (!port) return input
-        try {
-          const result = await deps.rpcClient.call<
-            { session_id: string },
-            { session: { id: string } }
-          >(port, 'get_session', { session_id: sessionId }, deps.moduleId)
-          if (!result?.session || typeof result.session.id !== 'string') return input
-          hits.push(channelId)
-        } catch (error) {
-          if (error instanceof RpcCallError && error.code === 'NOT_FOUND') continue
-          return input
-        }
+      const channels = lookupSessionChannels?.(sessionId)
+      if (!channels || channels.size === 0) return input
+      if (channels.size === 1) {
+        const channelId = channels.values().next().value
+        return channelId === undefined
+          ? input
+          : { ...input, channel_id: channelId }
       }
-
-      if (hits.length === 1) return { ...input, channel_id: hits[0] }
-      if (
-        hits.length > 1
-        && managerTarget !== undefined
-        && hits.includes(managerTarget.channel_id)
-      ) {
+      if (managerTarget && channels.has(managerTarget.channel_id)) {
         return { ...input, channel_id: managerTarget.channel_id }
       }
-      return input
     } catch {
-      return input
+      // 派生索引不可用不应改变原工具的输入/错误语义。
     }
+
+    return input
   }
 }
 
@@ -722,7 +724,10 @@ export function buildMessagingTools(
             { type: args.type as string | undefined, pagination: { page, page_size } },
             moduleId,
           )
-          return wrapText(annotatePagination(result, { requestedPage: page, requestedPageSize: page_size, userSpecifiedPageSize }))
+          return withObservedSessionTargets(
+            wrapText(annotatePagination(result, { requestedPage: page, requestedPageSize: page_size, userSpecifiedPageSize })),
+            sessionTargetsFromItems(result.items),
+          )
         } catch (err) {
           return wrapText(translateChannelError(err))
         }
@@ -771,7 +776,10 @@ export function buildMessagingTools(
             { session_id, pagination: { page, page_size } },
             moduleId,
           )
-          return wrapText(annotatePagination(result, { requestedPage: page, requestedPageSize: page_size, userSpecifiedPageSize }))
+          return withObservedSessionTargets(
+            wrapText(annotatePagination(result, { requestedPage: page, requestedPageSize: page_size, userSpecifiedPageSize })),
+            [sessionTarget(channel_id, session_id)],
+          )
         } catch (err) {
           return wrapText(translateChannelError(err))
         }
@@ -844,11 +852,14 @@ export function buildMessagingTools(
                 }, moduleId)
               })
 
-              return wrapText({
-                ...sendResult,
-                channel_id: identity.channel_id,
-                session_id: sessionId,
-              })
+              return withObservedSessionTargets(
+                wrapText({
+                  ...sendResult,
+                  channel_id: identity.channel_id,
+                  session_id: sessionId,
+                }),
+                [sessionTarget(identity.channel_id, sessionId)],
+              )
             } catch (err) {
               lastError = err instanceof Error ? err.message : String(err)
               continue
@@ -948,12 +959,15 @@ export function buildMessagingTools(
               }, moduleId)
             })
 
-            return wrapText({
-              ...sendResult,
-              channel_id: identity.channel_id,
-              session_id: sessionId,
-              friend_id: master.id,
-            })
+            return withObservedSessionTargets(
+              wrapText({
+                ...sendResult,
+                channel_id: identity.channel_id,
+                session_id: sessionId,
+                friend_id: master.id,
+              }),
+              [sessionTarget(identity.channel_id, sessionId)],
+            )
           } catch (err) {
             lastError = err instanceof Error ? err.message : String(err)
             continue
@@ -1138,10 +1152,13 @@ crabot 系统给你的所有信号——system prompt、supplement 注入、tool
           if (stateError !== undefined) {
             // 补齐失败 / transient admin 故障：消息已发但状态没切。
             // 返回含 ask_human_state_error 的结果，worker 看到 error 字段会自己处理，不设 barrier 防止卡死。
-            return wrapText({
-              ...sendResult,
-              ask_human_state_error: stateError,
-            })
+            return withObservedSessionTargets(
+              wrapText({
+                ...sendResult,
+                ask_human_state_error: stateError,
+              }),
+              [sessionTarget(channel_id, session_id)],
+            )
           }
 
           // Step 3: setBarrier（本地内存操作，从不失败）
@@ -1151,9 +1168,12 @@ crabot 系统给你的所有信号——system prompt、supplement 注入、tool
           })
         }
 
-        return wrapText({
-          ...sendResult,
-        })
+        return withObservedSessionTargets(
+          wrapText({
+            ...sendResult,
+          }),
+          [sessionTarget(channel_id, session_id)],
+        )
       },
     },
 
@@ -1243,7 +1263,10 @@ crabot 系统给你的所有信号——system prompt、supplement 注入、tool
             timestamp: msg.timestamp,
           }))
 
-          return wrapText({ messages: enrichedMessages })
+          return withObservedSessionTargets(
+            wrapText({ messages: enrichedMessages }),
+            [sessionTarget(channel_id, session_id)],
+          )
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err)
           return wrapText({ error: `查询历史失败: ${msg}` })
@@ -1302,22 +1325,25 @@ crabot 系统给你的所有信号——system prompt、supplement 注入、tool
             }
           }
 
-          return wrapText({
-            platform_message_id: result.platform_message_id,
-            sender_name: result.sender?.platform_display_name,
-            sender_friend_id: senderFriendId,
-            content: result.content?.text ?? '',
-            content_type: result.content?.type ?? 'text',
-            // 媒体信息按存在性透出：已下载图片带本地路径（media_url/file_path），未下载文件带
-            // handle（配 fetch_media）。只透 text/type 会让 LLM 丢失路径线索、瞎猜 handle。
-            ...(result.content?.media?.length ? { media: result.content.media } : {}),
-            ...(result.content?.media_url ? { media_url: result.content.media_url } : {}),
-            ...(result.content?.file_path ? { file_path: result.content.file_path } : {}),
-            ...(result.content?.handle ? { handle: result.content.handle } : {}),
-            ...(result.content?.status ? { status: result.content.status } : {}),
-            timestamp: result.platform_timestamp,
-            quote_message_id: result.features?.quote_message_id,
-          })
+          return withObservedSessionTargets(
+            wrapText({
+              platform_message_id: result.platform_message_id,
+              sender_name: result.sender?.platform_display_name,
+              sender_friend_id: senderFriendId,
+              content: result.content?.text ?? '',
+              content_type: result.content?.type ?? 'text',
+              // 媒体信息按存在性透出：已下载图片带本地路径（media_url/file_path），未下载文件带
+              // handle（配 fetch_media）。只透 text/type 会让 LLM 丢失路径线索、瞎猜 handle。
+              ...(result.content?.media?.length ? { media: result.content.media } : {}),
+              ...(result.content?.media_url ? { media_url: result.content.media_url } : {}),
+              ...(result.content?.file_path ? { file_path: result.content.file_path } : {}),
+              ...(result.content?.handle ? { handle: result.content.handle } : {}),
+              ...(result.content?.status ? { status: result.content.status } : {}),
+              timestamp: result.platform_timestamp,
+              quote_message_id: result.features?.quote_message_id,
+            }),
+            [sessionTarget(channel_id, session_id)],
+          )
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err)
           return wrapText({ error: `查询消息失败: ${msg}` })
@@ -1461,7 +1487,16 @@ export function createCrabMessagingServer(
 
   const tools = buildWorkerMessagingTools(deps, sandboxPathMappingsRef)
   for (const t of tools) {
-    server.registerTool(t.name, { description: t.description, inputSchema: t.schema }, t.handler as never)
+    server.registerTool(
+      t.name,
+      { description: t.description, inputSchema: t.schema },
+      (async (args: Record<string, unknown>) => {
+        const result = await t.handler(args)
+        return result.isError
+          ? { content: result.content, isError: true }
+          : { content: result.content }
+      }) as never,
+    )
   }
 
   return server

--- a/crabot-agent/tests/agent/crab-messaging-list.test.ts
+++ b/crabot-agent/tests/agent/crab-messaging-list.test.ts
@@ -112,15 +112,48 @@ describe('crab-messaging list_contacts 工具', () => {
 })
 
 describe('crab-messaging list_sessions 工具', () => {
-  it('返回也带分页元信息', async () => {
+  it('返回分页元信息，并用 canonical Session.id + channel_id 暴露结构化归属观察', async () => {
     const deps = makeDeps()
     deps.rpcClient.call = vi.fn().mockResolvedValue({
-      items: [{ session_id: 's1', type: 'group', title: 'X', participant_count: 5 }],
+      items: [
+        { id: 's1', channel_id: 'wechat-x', type: 'group', title: 'X', participant_count: 5 },
+        { id: '', channel_id: 'wechat-x', type: 'group', title: 'malformed' },
+        { session_id: 'legacy-only', channel_id: 'wechat-x', type: 'private' },
+      ],
       pagination: { page: 1, page_size: 20, total_items: 80, total_pages: 4 },
     })
     const tools = buildWorkerMessagingTools(deps as never)
     const out = await findTool(tools, 'list_sessions').handler({ channel_id: 'wechat-x' })
     const parsed = parseToolResult(out)
     expect(parsed.pagination).toMatchObject({ has_more: true, next_page: 2 })
+    expect(out.observedSessionTargets).toEqual([
+      { channel_id: 'wechat-x', session_id: 's1' },
+    ])
+    expect(parsed).not.toHaveProperty('observedSessionTargets')
+  })
+})
+
+describe('crab-messaging list_group_members 工具', () => {
+  it('底层查询成功后暴露完整目标归属，失败时不把调用参数登记为观察', async () => {
+    const deps = makeDeps()
+    deps.rpcClient.call = vi.fn()
+      .mockResolvedValueOnce({
+        items: [],
+        pagination: { page: 1, page_size: 50, total_items: 0, total_pages: 0 },
+        member_count: 0,
+        members_complete: true,
+      })
+      .mockRejectedValueOnce(new Error('channel unavailable'))
+    const tool = findTool(buildWorkerMessagingTools(deps as never), 'list_group_members')
+
+    const success = await tool.handler({ channel_id: 'wechat-x', session_id: 'group-1' })
+    expect(success.observedSessionTargets).toEqual([
+      { channel_id: 'wechat-x', session_id: 'group-1' },
+    ])
+    expect(parseToolResult(success)).not.toHaveProperty('observedSessionTargets')
+
+    const failure = await tool.handler({ channel_id: 'wechat-x', session_id: 'untrusted' })
+    expect(failure.observedSessionTargets).toBeUndefined()
+    expect(parseToolResult(failure)).toHaveProperty('error')
   })
 })

--- a/crabot-agent/tests/manager/bootstrap.test.ts
+++ b/crabot-agent/tests/manager/bootstrap.test.ts
@@ -27,7 +27,6 @@ import type { LLMAdapter, LLMStreamParams } from '../../src/engine/index.js'
 import type { ChannelMessage, ResolvedPermissions } from '../../src/types.js'
 import { CLI_DOMAINS } from '../../src/types.js'
 import { createCrabMemoryServer } from '../../src/mcp/crab-memory.js'
-import { RpcCallError } from 'crabot-shared'
 import { chunksFromContent } from '../engine/helpers/mock-stream.js'
 
 // ============================================================================
@@ -403,29 +402,45 @@ describe('manager bootstrap（P5 Task 1）', () => {
     expect(rpcCall.mock.calls.map((call) => call[1])).toEqual(['send_message'])
   })
 
-  it('跨会话 repair 仍按 Channel NOT_FOUND 扫描，而非误用当前 Manager session', async () => {
+  it('跨 episode 先从 list_sessions 登记来源，后续 send_message 只查当前 Loop 本地索引', async () => {
     const rpcCall = vi.fn(async (port: number, method: string) => {
-      if (method === 'list_channel_instances') {
+      if (method === 'get_sessions') {
+        expect(port).toBe(19010)
         return {
-          items: [{ id: 'wechat' }, { id: 'telegram' }],
-          pagination: { page: 1, page_size: 50, total_items: 2, total_pages: 1 },
+          items: [{ id: 'other-session', channel_id: 'telegram', type: 'private' }],
+          pagination: { page: 1, page_size: 20, total_items: 1, total_pages: 1 },
         }
       }
-      if (method === 'get_session') {
-        if (port === 19010) return { session: { id: 'other-session' } }
-        throw new RpcCallError('NOT_FOUND', 'Session not found')
+      if (method === 'send_message') {
+        expect(port).toBe(19010)
+        return { platform_message_id: 'pm-other', sent_at: '2026-09-05T00:00:00.000Z' }
       }
-      throw new Error(`unexpected ${method}`)
+      throw new Error(`不应扫描或探测 ${method}`)
     })
-    let checked = false
+    let episode = 0
     const stack = buildManagerStack(makeDeps({
       managerAdapter: () => ({
         async *stream(params: LLMStreamParams) {
-          if (!checked) {
-            checked = true
+          episode += 1
+          if (episode === 1) {
+            const list = params.tools.find((tool) => tool.name === 'list_sessions')!
+            const result = await list.call({ channel_id: 'telegram' }, {} as never)
+            expect(result.isError).toBe(false)
+          } else if (episode === 2) {
             const send = params.tools.find((tool) => tool.name === 'send_message')!
-            await expect(send.repairInput!({ session_id: 'other-session', content: 'x' }))
-              .resolves.toEqual({ channel_id: 'telegram', session_id: 'other-session', content: 'x' })
+            const repaired = await send.repairInput!({
+              session_id: 'other-session',
+              content: 'x',
+              post_send_action: 'none',
+            })
+            expect(repaired).toEqual({
+              channel_id: 'telegram',
+              session_id: 'other-session',
+              content: 'x',
+              post_send_action: 'none',
+            })
+            const result = await send.call(repaired, {} as never)
+            expect(result.isError).toBe(false)
           }
           yield* chunksFromContent([], 'end_turn', { inputTokens: 10, outputTokens: 5 })
         },
@@ -434,12 +449,60 @@ describe('manager bootstrap（P5 Task 1）', () => {
       messagingDeps: {
         ...makeMessagingDeps(),
         rpcClient: { call: rpcCall } as never,
-        resolveChannelPort: async (channelId: string) => channelId === 'wechat' ? 19009 : 19010,
+        resolveChannelPort: async (channelId: string) => channelId === 'telegram' ? 19010 : 19009,
       },
     }))
 
-    await stack.registry.routeHumanMessages('wechat', 'sess-boot', [makeChannelMessage('查另一个会话')])
-    expect(checked).toBe(true)
+    await stack.registry.routeHumanMessages('wechat', 'sess-boot', [makeChannelMessage('先列出会话')])
+    await stack.registry.routeHumanMessages('wechat', 'sess-boot', [makeChannelMessage('再发送')])
+
+    expect(episode).toBe(2)
+    expect(rpcCall.mock.calls.map((call) => call[1])).toEqual(['get_sessions', 'send_message'])
+  })
+
+  it('Session 归属索引按 Manager 隔离，不从其他 Manager 的观察补全', async () => {
+    const rpcCall = vi.fn(async (port: number, method: string) => {
+      if (method === 'get_sessions') {
+        expect(port).toBe(19010)
+        return {
+          items: [{ id: 'shared-session', channel_id: 'telegram', type: 'private' }],
+          pagination: { page: 1, page_size: 20, total_items: 1, total_pages: 1 },
+        }
+      }
+      throw new Error(`unexpected ${method}`)
+    })
+    const seenKeys = new Set<string>()
+    const stack = buildManagerStack(makeDeps({
+      managerAdapter: () => ({
+        async *stream(params: LLMStreamParams) {
+          const wake = params.messages.at(-1)?.content
+          const key = typeof wake === 'string' && wake.includes('登记') ? 'source' : 'other'
+          if (!seenKeys.has(key)) {
+            seenKeys.add(key)
+            if (key === 'source') {
+              const list = params.tools.find((tool) => tool.name === 'list_sessions')!
+              await list.call({ channel_id: 'telegram' }, {} as never)
+            } else {
+              const send = params.tools.find((tool) => tool.name === 'send_message')!
+              const input = { session_id: 'shared-session', content: 'x' }
+              await expect(send.repairInput!(input)).resolves.toBe(input)
+            }
+          }
+          yield* chunksFromContent([], 'end_turn', { inputTokens: 10, outputTokens: 5 })
+        },
+        updateConfig: () => {},
+      }),
+      messagingDeps: {
+        ...makeMessagingDeps(),
+        rpcClient: { call: rpcCall } as never,
+        resolveChannelPort: async (channelId: string) => channelId === 'telegram' ? 19010 : 19009,
+      },
+    }))
+
+    await stack.registry.routeHumanMessages('wechat', 'sess-source', [makeChannelMessage('登记目标会话')])
+    await stack.registry.routeHumanMessages('wechat', 'sess-other', [makeChannelMessage('尝试使用目标')])
+
+    expect(rpcCall.mock.calls.map((call) => call[1])).toEqual(['get_sessions'])
   })
 
   // --- ④ 空台账对账 ---

--- a/crabot-agent/tests/manager/loop.test.ts
+++ b/crabot-agent/tests/manager/loop.test.ts
@@ -188,6 +188,25 @@ describe('ManagerLoop', () => {
     await fs.rm(dataDir, { recursive: true, force: true })
   })
 
+  it('结构化 Session 归属在同一 Loop 内多值保留且重复登记幂等，新 Loop 从空索引开始', () => {
+    const { adapter } = makeAdapter()
+    const loop = new ManagerLoop(baseDeps({ store, adapter }))
+
+    loop.recordObservedSessionTargets([
+      { channel_id: 'ch-a', session_id: 'shared' },
+      { channel_id: 'ch-a', session_id: 'shared' },
+      { channel_id: 'ch-b', session_id: 'shared' },
+      { channel_id: '', session_id: 'ignored' },
+      { channel_id: 'ignored', session_id: '' },
+    ])
+
+    expect(loop.sessionChannelsFor('shared')).toEqual(new Set(['ch-a', 'ch-b']))
+    expect(loop.sessionChannelsFor('ignored')).toBeUndefined()
+
+    const freshLoop = new ManagerLoop(baseDeps({ store, adapter }))
+    expect(freshLoop.sessionChannelsFor('shared')).toBeUndefined()
+  })
+
   it('拒绝绕过 registry 直接提交裸 WakeEvent', async () => {
     const { adapter } = makeAdapter()
     const loop = new ManagerLoop(baseDeps({ store, adapter }))

--- a/crabot-agent/tests/manager/registry.test.ts
+++ b/crabot-agent/tests/manager/registry.test.ts
@@ -1059,6 +1059,10 @@ describe('ManagerRegistry', () => {
 
     await registry.routeHumanMessages('wechat', 'sess-evict', [makeChannelMessage('你好')])
     const loopBefore = registry.getOrCreate(key)
+    loopBefore.recordObservedSessionTargets([
+      { channel_id: 'telegram', session_id: 'observed-before-eviction' },
+    ])
+    expect(loopBefore.sessionChannelsFor('observed-before-eviction')).toEqual(new Set(['telegram']))
 
     nowMs += 10 * 60 * 1000 // 10 分钟后
     const evicted = registry.evictIdle(5 * 60 * 1000, nowMs) // 5 分钟阈值
@@ -1068,8 +1072,10 @@ describe('ManagerRegistry', () => {
     const result = await registry.routeHumanMessages('wechat', 'sess-evict', [makeChannelMessage('还在吗')])
     expect(result.outcome).toBe('completed')
 
-    // 回收后再次唤醒重建了新的 ManagerLoop 实例
-    expect(registry.getOrCreate(key)).not.toBe(loopBefore)
+    // 回收后再次唤醒重建了新的 ManagerLoop 实例，运行时归属索引不持久化。
+    const loopAfter = registry.getOrCreate(key)
+    expect(loopAfter).not.toBe(loopBefore)
+    expect(loopAfter.sessionChannelsFor('observed-before-eviction')).toBeUndefined()
 
     // 但盘上历史连续，两次唤醒的内容都还在
     const state = await store.load(key)

--- a/crabot-agent/tests/manager/tool-face.test.ts
+++ b/crabot-agent/tests/manager/tool-face.test.ts
@@ -11,7 +11,6 @@
  * - 可见性门与运行时门同源：可见的 send_private_message 真调一次不被 requireDeclaredShortcut 拦
  */
 import { describe, it, expect, vi } from 'vitest'
-import { RpcCallError } from 'crabot-shared'
 import { executeToolBatches } from '../../src/engine/tool-orchestration'
 import { buildManagerToolFace, assertClosedToolFace, type ToolFaceDeps } from '../../src/manager/tools/tool-face'
 import { CRAB_MEMORY_MANAGER_TOOL_NAMES, createCrabMemoryServer } from '../../src/mcp/crab-memory'
@@ -149,14 +148,16 @@ describe('buildManagerToolFace', () => {
     expect(systemNames).toEqual([...normalNames, 'send_master_private'].sort())
   })
 
-  it('builtin daily reflection 只暴露固定 Admin Web 摘要动作', async () => {
+  it('builtin daily reflection 只暴露固定 Admin Web 摘要动作，并登记成功投递的固定目标', async () => {
     const call = vi.fn(async () => ({
       platform_message_id: 'pm-daily',
       sent_at: '2026-08-21T02:00:00.000Z',
     }))
+    const onObservedSessionTargets = vi.fn()
     const tools = buildManagerToolFace(makeDeps({
       isSystemThread: true,
       isBuiltinDailyReflection: true,
+      onObservedSessionTargets,
       messagingDeps: makeMessagingDeps({
         rpcClient: { call } as never,
         resolveChannelPort: async (channelId: string) => channelId === 'admin-web' ? 19001 : 19009,
@@ -187,6 +188,35 @@ describe('buildManagerToolFace', () => {
       },
       'manager-test',
     )
+    expect(onObservedSessionTargets).toHaveBeenCalledWith([
+      { channel_id: 'admin-web', session_id: 'system-tasks' },
+    ])
+    expect(result.output).not.toContain('observedSessionTargets')
+  })
+
+  it('builtin daily reflection 的观察回调失败不改变原工具结果', async () => {
+    const call = vi.fn(async () => ({
+      platform_message_id: 'pm-daily',
+      sent_at: '2026-08-21T02:00:00.000Z',
+    }))
+    const onObservedSessionTargets = vi.fn(() => { throw new Error('index unavailable') })
+    const summary = buildManagerToolFace(makeDeps({
+      isSystemThread: true,
+      isBuiltinDailyReflection: true,
+      onObservedSessionTargets,
+      messagingDeps: makeMessagingDeps({ rpcClient: { call } as never }),
+    })).find((tool) => tool.name === 'send_daily_reflection_summary')!
+
+    const result = await summary.call({ content: '今日无重大变化。' }, {} as never)
+
+    expect(result).toEqual({
+      output: JSON.stringify({
+        platform_message_id: 'pm-daily',
+        sent_at: '2026-08-21T02:00:00.000Z',
+      }),
+      isError: false,
+    })
+    expect(onObservedSessionTargets).toHaveBeenCalledOnce()
   })
 
   it('存在飞书 channel 实例时：两类 manager 都多出 §2.10 只读三件套，都不含 feishu_write', () => {
@@ -308,7 +338,7 @@ describe('buildManagerToolFace', () => {
     expect(onSuccessfulSendMessage).not.toHaveBeenCalled()
   })
 
-  it('普通 manager 真调一次 send_private_message：不被 requireDeclaredShortcut 拦，RPC 真的打出去', async () => {
+  it('普通 manager 真调一次 send_private_message：不被 requireDeclaredShortcut 拦，RPC 真的打出去并登记真实目标', async () => {
     const call = vi.fn(async (_port: number, method: string) => {
       switch (method) {
         case 'get_friend':
@@ -321,8 +351,10 @@ describe('buildManagerToolFace', () => {
           throw new Error(`未预期的 RPC: ${method}`)
       }
     })
+    const onObservedSessionTargets = vi.fn()
     const tools = buildManagerToolFace(makeDeps({
       isSystemThread: false,
+      onObservedSessionTargets,
       messagingDeps: makeMessagingDeps({ rpcClient: { call } as never }),
     }))
     const sendPrivate = tools.find((t) => t.name === 'send_private_message')!
@@ -334,6 +366,9 @@ describe('buildManagerToolFace', () => {
     expect(result.isError).toBe(false)
     expect(result.output).not.toContain('SCHEDULED_ONLY_TOOL')
     expect(JSON.parse(result.output)).toMatchObject({ channel_id: 'ch-1', session_id: 'sess-9', platform_message_id: 'pm-1' })
+    expect(onObservedSessionTargets).toHaveBeenCalledWith([
+      { channel_id: 'ch-1', session_id: 'sess-9' },
+    ])
     expect(call.mock.calls.map((c) => c[1])).toEqual(['get_friend', 'find_or_create_private_session', 'send_message'])
   })
 
@@ -386,62 +421,30 @@ describe('buildManagerToolFace', () => {
   })
 
   describe('send_message 参数修复（spec 2026-09-03-tool-input-repair）', () => {
-    // 渠道 ch-2 上存在 session 'sess-9'；其余渠道没有。portOf 约定与实现探测顺序无关。
-    function makeRoutingMessagingDeps(): ToolFaceDeps['messagingDeps'] {
-      const channels: Record<string, string[]> = { 'ch-1': [], 'ch-2': ['sess-9'] }
-      const ids = Object.keys(channels)
-      const portOf = new Map(ids.map((id, i) => [id, 20_000 + i]))
-      return {
-        rpcClient: {
-          call: async <P, R>(_port: number, method: string, params: P): Promise<R> => {
-            if (method === 'list_channel_instances') {
-              return {
-                items: ids.map((id) => ({ id })),
-                pagination: {
-                  page: 1,
-                  page_size: 50,
-                  total_items: ids.length,
-                  total_pages: 1,
-                },
-              } as R
-            }
-            if (method === 'get_session') {
-              const session = (params as { session_id: string }).session_id
-              const channelId = ids.find((id) => portOf.get(id) === _port)
-              if (channelId && channels[channelId].includes(session)) {
-                return { session: { id: session } } as R
-              }
-              throw new RpcCallError('NOT_FOUND', 'Session not found')
-            }
-            throw new Error(`unexpected method: ${method}`)
-          },
-        } as never,
-        moduleId: 'manager-test',
-        getAdminPort: async () => 19001,
-        resolveChannelPort: async (channelId: string) => portOf.get(channelId) ?? 0,
-      }
-    }
-
-    it('send_message 携带 repairInput，省略 channel_id 时按 session 反查补全', async () => {
+    it('send_message 携带 repairInput，省略 channel_id 时只查当前 Manager 已登记归属', async () => {
+      const lookup = vi.fn((sessionId: string) =>
+        sessionId === 'sess-9' ? new Set(['ch-2']) : undefined
+      )
       const tools = buildManagerToolFace(makeDeps({
         managerTarget: { channel_id: 'ch-1', session_id: 'sess-1' },
-        messagingDeps: makeRoutingMessagingDeps(),
+        sessionChannelsFor: lookup,
       }))
       const send = tools.find((t) => t.name === 'send_message')
       expect(send?.repairInput).toBeTypeOf('function')
       const repaired = await send!.repairInput!({ session_id: 'sess-9', content: 'x' })
       expect(repaired).toEqual({ channel_id: 'ch-2', session_id: 'sess-9', content: 'x' })
+      expect(lookup).toHaveBeenCalledOnce()
+      expect(lookup).toHaveBeenCalledWith('sess-9')
     })
 
-    it('零命中时透传；repairInput 只挂在 send_message 上', async () => {
+    it('零命中时原对象透传；repairInput 只挂在 send_message 上', async () => {
       const tools = buildManagerToolFace(makeDeps({
         managerTarget: { channel_id: 'ch-1', session_id: 'sess-1' },
-        messagingDeps: makeRoutingMessagingDeps(),
+        sessionChannelsFor: () => undefined,
       }))
       const send = tools.find((t) => t.name === 'send_message')!
       const input = { session_id: 'no-such', content: 'x' }
-      expect(await send.repairInput!(input)).toEqual(input)
-      // 其余工具（含其他投递工具）不带修复规则
+      expect(await send.repairInput!(input)).toBe(input)
       for (const tool of tools) {
         if (tool.name !== 'send_message') expect(tool.repairInput, tool.name).toBeUndefined()
       }
@@ -461,30 +464,23 @@ describe('buildManagerToolFace', () => {
       expect(raw.repairInput).toBeUndefined()
     })
 
-    it('engine 真实调用链使用 repaired target，且原工具返回内容不被改写', async () => {
+    it('engine 真实调用链使用 repaired target，不扫描 Channel，也不改写原工具返回', async () => {
       const call = vi.fn(async (_port: number, method: string) => {
-        if (method === 'list_channel_instances') {
-          return {
-            items: [{ id: 'ch-1' }, { id: 'ch-2' }],
-            pagination: { page: 1, page_size: 50, total_items: 2, total_pages: 1 },
-          }
-        }
-        if (method === 'get_session') {
-          if (_port === 19002) return { session: { id: 'sess-9' } }
-          throw new RpcCallError('NOT_FOUND', 'Session not found')
-        }
         if (method === 'send_message') {
-          return { platform_message_id: 'pm-1', sent_at: '2026-09-04T00:00:00.000Z' }
+          return { platform_message_id: 'pm-1', sent_at: '2026-09-05T00:00:00.000Z' }
         }
         throw new Error(`未预期的 RPC: ${method}`)
       })
       const onSuccessfulSendMessage = vi.fn()
+      const onObservedSessionTargets = vi.fn()
       const tools = buildManagerToolFace(makeDeps({
         managerTarget: { channel_id: 'ch-1', session_id: 'sess-1' },
+        sessionChannelsFor: () => new Set(['ch-2']),
         onSuccessfulSendMessage,
+        onObservedSessionTargets,
         messagingDeps: makeMessagingDeps({
           rpcClient: { call } as never,
-          resolveChannelPort: async (channelId) => channelId === 'ch-1' ? 19001 : 19002,
+          resolveChannelPort: async (channelId) => channelId === 'ch-2' ? 19002 : 0,
         }),
       }))
 
@@ -498,15 +494,71 @@ describe('buildManagerToolFace', () => {
       )
 
       expect(result.is_error).toBe(false)
-      expect(result.content).toContain('pm-1')
-      expect(result.content).not.toContain('repaired')
+      expect(JSON.parse(result.content.slice(result.content.indexOf('\n') + 1))).toEqual({
+        platform_message_id: 'pm-1',
+        sent_at: '2026-09-05T00:00:00.000Z',
+      })
+      expect(result.content).not.toContain('observedSessionTargets')
+      expect(call.mock.calls.map((entry) => entry[1])).toEqual(['send_message'])
       expect(call).toHaveBeenCalledWith(
         19002,
         'send_message',
         expect.objectContaining({ session_id: 'sess-9' }),
         'manager-test',
       )
+      expect(onObservedSessionTargets).toHaveBeenCalledWith([
+        { channel_id: 'ch-2', session_id: 'sess-9' },
+      ])
       expect(onSuccessfulSendMessage).toHaveBeenCalledWith({ channel_id: 'ch-2', session_id: 'sess-9' })
+    })
+
+    it('只消费成功 handler 提供的结构化观察，observer 抛错不改变工具结果', async () => {
+      const onObservedSessionTargets = vi.fn(() => { throw new Error('index unavailable') })
+      const call = vi.fn(async (_port: number, method: string) => {
+        if (method === 'get_sessions') {
+          return {
+            items: [{ id: 'sess-9', channel_id: 'ch-2', type: 'private' }],
+            pagination: { page: 1, page_size: 20, total_items: 1, total_pages: 1 },
+          }
+        }
+        throw new Error(`未预期的 RPC: ${method}`)
+      })
+      const tools = buildManagerToolFace(makeDeps({
+        onObservedSessionTargets,
+        messagingDeps: makeMessagingDeps({ rpcClient: { call } as never }),
+      }))
+      const listSessions = tools.find((tool) => tool.name === 'list_sessions')!
+
+      const result = await listSessions.call({ channel_id: 'ch-2' }, {} as never)
+
+      expect(result.isError).toBe(false)
+      expect(JSON.parse(result.output)).toMatchObject({
+        items: [{ id: 'sess-9', channel_id: 'ch-2' }],
+      })
+      expect(result.output).not.toContain('observedSessionTargets')
+      expect(onObservedSessionTargets).toHaveBeenCalledWith([
+        { channel_id: 'ch-2', session_id: 'sess-9' },
+      ])
+    })
+
+    it('失败的目标操作不登记模型提供的 pair', async () => {
+      const onObservedSessionTargets = vi.fn()
+      const tools = buildManagerToolFace(makeDeps({
+        onObservedSessionTargets,
+        messagingDeps: makeMessagingDeps({
+          rpcClient: { call: vi.fn(async () => { throw new Error('channel down') }) } as never,
+        }),
+      }))
+
+      const result = await tools.find((tool) => tool.name === 'get_message')!.call({
+        channel_id: 'ch-2',
+        session_id: 'sess-untrusted',
+        platform_message_id: 'pm-1',
+      }, {} as never)
+
+      expect(result.isError).toBe(false)
+      expect(JSON.parse(result.output)).toMatchObject({ error: expect.stringContaining('channel down') })
+      expect(onObservedSessionTargets).not.toHaveBeenCalled()
     })
   })
 })

--- a/crabot-agent/tests/mcp/crab-messaging-ask-human.test.ts
+++ b/crabot-agent/tests/mcp/crab-messaging-ask-human.test.ts
@@ -269,6 +269,11 @@ describe('send_message intent=ask_human', () => {
     const parsed = JSON.parse(text)
     expect(parsed.ask_human_state_error).toBeDefined()
     expect(parsed.ask_human_state_error).toContain('update_task_status')
+    // 消息已经成功发出，即使后续状态切换失败，目标仍是可信观察。
+    expect(result.observedSessionTargets).toEqual([
+      { channel_id: 'telegram-001', session_id: 's1' },
+    ])
+    expect(parsed).not.toHaveProperty('observedSessionTargets')
   })
 
   it('persistent state machine reject（ADMIN_INVALID_STATUS_TRANSITION）时先补齐状态机再 setBarrier', async () => {

--- a/crabot-agent/tests/mcp/crab-messaging-get-message-media.test.ts
+++ b/crabot-agent/tests/mcp/crab-messaging-get-message-media.test.ts
@@ -60,6 +60,10 @@ describe('get_message 媒体字段透出', () => {
     ])
     expect(result.media_url).toBe('/data/media/om_img-1.jpg')
     expect(result.status).toBe('ready')
+    expect(out.observedSessionTargets).toEqual([
+      { channel_id: 'feishu-1', session_id: 's1' },
+    ])
+    expect(result).not.toHaveProperty('observedSessionTargets')
   })
 
   it('not_fetched 文件消息 → 透出 handle 供 fetch_media 使用', async () => {

--- a/crabot-agent/tests/mcp/crab-messaging-send-master-private.test.ts
+++ b/crabot-agent/tests/mcp/crab-messaging-send-master-private.test.ts
@@ -220,6 +220,10 @@ describe('send_master_private', () => {
       session_id: 'sess-abc',
       friend_id: 'master-friend',
     })
+    expect(result.observedSessionTargets).toEqual([
+      { channel_id: 'feishu-001', session_id: 'sess-abc' },
+    ])
+    expect(payload).not.toHaveProperty('observedSessionTargets')
 
     // 用第一个 channel 的端口发送
     const sendCall = calls.find(c => c.method === 'send_message')

--- a/crabot-agent/tests/mcp/crab-messaging-session-observation.test.ts
+++ b/crabot-agent/tests/mcp/crab-messaging-session-observation.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
+import {
+  buildWorkerMessagingTools,
+  createCrabMessagingServer,
+} from '../../src/mcp/crab-messaging.js'
+
+function findTool(tools: ReturnType<typeof buildWorkerMessagingTools>, name: string) {
+  const tool = tools.find((candidate) => candidate.name === name)
+  if (!tool) throw new Error(`tool ${name} not found`)
+  return tool
+}
+
+function makeDeps(call: ReturnType<typeof vi.fn>) {
+  return {
+    rpcClient: { call } as never,
+    moduleId: 'agent-test',
+    getAdminPort: async () => 19001,
+    resolveChannelPort: async () => 19009,
+    getTaskContext: () => null,
+  }
+}
+
+const cleanup: Array<() => Promise<void>> = []
+
+afterEach(async () => {
+  await Promise.allSettled(cleanup.splice(0).map((close) => close()))
+})
+
+describe('crab-messaging Session 归属观察', () => {
+  it('get_history 仅在目标查询整体成功后暴露结构化观察', async () => {
+    const successCall = vi.fn(async (_port: number, method: string) => {
+      if (method === 'get_history') return { items: [] }
+      throw new Error(`unexpected RPC: ${method}`)
+    })
+    const successTool = findTool(buildWorkerMessagingTools(makeDeps(successCall)), 'get_history')
+
+    const success = await successTool.handler({ channel_id: 'ch-1', session_id: 'sess-1' })
+
+    expect(success.observedSessionTargets).toEqual([
+      { channel_id: 'ch-1', session_id: 'sess-1' },
+    ])
+    expect(JSON.parse(success.content[0].text)).not.toHaveProperty('observedSessionTargets')
+
+    const failureTool = findTool(buildWorkerMessagingTools(makeDeps(
+      vi.fn(async () => { throw new Error('channel down') }),
+    )), 'get_history')
+    const failure = await failureTool.handler({ channel_id: 'ch-1', session_id: 'untrusted' })
+
+    expect(failure.observedSessionTargets).toBeUndefined()
+    expect(JSON.parse(failure.content[0].text)).toHaveProperty('error')
+  })
+
+  it('raw MCP 响应剥离 Manager 内部的 observedSessionTargets 元数据', async () => {
+    const call = vi.fn(async (_port: number, method: string) => {
+      if (method === 'get_sessions') {
+        return {
+          items: [{ id: 'sess-1', channel_id: 'ch-1', type: 'private' }],
+          pagination: { page: 1, page_size: 20, total_items: 1, total_pages: 1 },
+        }
+      }
+      throw new Error(`unexpected RPC: ${method}`)
+    })
+    const server = createCrabMessagingServer(makeDeps(call))
+    const client = new Client(
+      { name: 'crab-messaging-observation-test', version: '1.0.0' },
+      { capabilities: {} },
+    )
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+    cleanup.push(async () => { await client.close() })
+    cleanup.push(async () => { await server.close() })
+    await server.connect(serverTransport)
+    await client.connect(clientTransport)
+
+    const result = await client.callTool({
+      name: 'list_sessions',
+      arguments: { channel_id: 'ch-1' },
+    })
+
+    expect(result).not.toHaveProperty('observedSessionTargets')
+    const text = result.content.find((block) => block.type === 'text')
+    if (!text || text.type !== 'text') throw new Error('list_sessions returned no text result')
+    expect(JSON.parse(text.text)).not.toHaveProperty('observedSessionTargets')
+  })
+})

--- a/crabot-agent/tests/mcp/crab-messaging-system-session.test.ts
+++ b/crabot-agent/tests/mcp/crab-messaging-system-session.test.ts
@@ -81,13 +81,17 @@ describe('send_message rejects SYSTEM_SESSION sentinel', () => {
     })
 
     const sendTool = findTool(tools, 'send_message')
-    await sendTool.handler({
+    const result = await sendTool.handler({
       channel_id: 'wechat-real',
       session_id: 'sess-real',
       content: 'real send',
     })
 
     expect(callMock).toHaveBeenCalled()
+    expect(result.observedSessionTargets).toEqual([
+      { channel_id: 'wechat-real', session_id: 'sess-real' },
+    ])
+    expect(JSON.parse(result.content[0].text)).not.toHaveProperty('observedSessionTargets')
   })
 
   it('marks a channel delivery failure as a tool error', async () => {
@@ -112,6 +116,7 @@ describe('send_message rejects SYSTEM_SESSION sentinel', () => {
     })
 
     expect(result.isError).toBe(true)
+    expect(result.observedSessionTargets).toBeUndefined()
     expect(JSON.parse(result.content[0].text)).toMatchObject({ error: '发送失败: channel offline' })
   })
 })

--- a/crabot-agent/tests/mcp/send-message-channel-repair.test.ts
+++ b/crabot-agent/tests/mcp/send-message-channel-repair.test.ts
@@ -1,227 +1,124 @@
 /**
  * send_message 省略 channel_id 的确定性参数修复规则单测
  * （spec 2026-09-03-tool-input-repair）。
- *
- * 覆盖：
- * - 唯一命中 → 补全 channel_id，其余入参原样保留
- * - 多命中且 manager 归属渠道在列 → 取归属渠道
- * - 多命中但归属渠道不在列（归属渠道不可用/不存在）→ 不猜，透传
- * - 零命中 / 双参全缺 / channel_id 已提供 / session_id 非字符串 → 透传
- * - 修复路径自身失败（admin 列表 RPC 抛错）→ 透传
- * - 零介入：channel_id 已提供时不发生任何 RPC
  */
-import { describe, it, expect } from 'vitest'
-import { RpcCallError } from 'crabot-shared'
+import { describe, expect, it, vi } from 'vitest'
 import { createSendMessageChannelRepair } from '../../src/mcp/crab-messaging'
 
-interface RepairOptions {
-  channels: Record<string, string[]>
-  pageSize?: number
-  deadPorts?: string[]
-  unavailablePorts?: string[]
-  brokenSessions?: Record<string, string>
-  breakList?: boolean
-  malformedList?: boolean
-  malformedSessions?: string[]
-}
-
-function makeDeps(opts: RepairOptions) {
-  const calls: Array<{ method: string; params: unknown }> = []
-  const ids = Object.keys(opts.channels)
-  const portOf = new Map(ids.map((id, i) => [id, 10_000 + i]))
-  const pageSize = opts.pageSize ?? 50
-  const deps = {
-    moduleId: 'test-agent',
-    getAdminPort: async () => 1,
-    resolveChannelPort: async (channelId: string) => {
-      if (opts.deadPorts?.includes(channelId)) throw new Error('channel down')
-      if (opts.unavailablePorts?.includes(channelId)) return 0
-      return portOf.get(channelId) ?? 0
-    },
-    rpcClient: {
-      call: async <P, R>(_port: number, method: string, params: P, _source?: string): Promise<R> => {
-        calls.push({ method, params })
-        if (opts.breakList && method === 'list_channel_instances') throw new Error('admin unreachable')
-        if (method === 'list_channel_instances') {
-          if (opts.malformedList) return { nope: true } as R
-          const { page = 1, page_size = pageSize } = params as { page?: number; page_size?: number }
-          const start = (page - 1) * page_size
-          return {
-            items: ids.slice(start, start + page_size).map((id) => ({ id })),
-            pagination: {
-              page,
-              page_size,
-              total_items: ids.length,
-              total_pages: Math.max(1, Math.ceil(ids.length / page_size)),
-            },
-          } as R
-        }
-        if (method === 'get_session') {
-          const session = (params as { session_id: string }).session_id
-          const channelId = ids.find((id) => portOf.get(id) === _port)
-          if (!channelId) throw new Error('unknown channel port')
-          if (opts.brokenSessions?.[channelId]) {
-            throw new RpcCallError(opts.brokenSessions[channelId], 'session probe failed')
-          }
-          if (opts.malformedSessions?.includes(channelId)) return { nope: true } as R
-          if (opts.channels[channelId]?.includes(session)) {
-            return { session: { id: session } } as R
-          }
-          throw new RpcCallError('NOT_FOUND', 'Session not found')
-        }
-        throw new Error(`unexpected method: ${method}`)
-      },
-    },
-  }
-  return { deps, calls }
-}
-
 describe('createSendMessageChannelRepair', () => {
-  it('唯一命中 → 补全 channel_id 且保留其余入参', async () => {
-    const { deps } = makeDeps({ channels: { bot: ['s1'], other: ['s2'] } })
-    const repair = createSendMessageChannelRepair(deps, { channel_id: 'bot', session_id: 'home-session' })
-    const input = { session_id: 's1', content: 'hi', post_send_action: 'none' }
-    expect(await repair(input)).toEqual({ channel_id: 'bot', session_id: 's1', content: 'hi', post_send_action: 'none' })
-    // 入参对象本身不被改写
-    expect(input).not.toHaveProperty('channel_id')
-  })
-
-  it('多命中且归属渠道在列 → 取归属渠道', async () => {
-    const { deps } = makeDeps({ channels: { bot: ['s1'], tg: ['s1'] } })
-    const repair = createSendMessageChannelRepair(deps, { channel_id: 'bot', session_id: 'home-session' })
-    expect(await repair({ session_id: 's1', content: 'x' })).toEqual({ channel_id: 'bot', session_id: 's1', content: 'x' })
-  })
-
-  it('多命中但归属渠道不在列 → 透传', async () => {
-    const { deps } = makeDeps({ channels: { a: ['s1'], b: ['s1'] } })
-    const repair = createSendMessageChannelRepair(deps, { channel_id: 'bot', session_id: 'home-session' })
-    expect(await repair({ session_id: 's1', content: 'x' })).toEqual({ session_id: 's1', content: 'x' })
-  })
-
-  it('零命中 → 透传', async () => {
-    const { deps } = makeDeps({ channels: { bot: ['s2'] } })
-    const repair = createSendMessageChannelRepair(deps, { channel_id: 'bot', session_id: 'home-session' })
-    expect(await repair({ session_id: 's9', content: 'x' })).toEqual({ session_id: 's9', content: 'x' })
-  })
-
-  it('channel_id 已提供 → 透传且不发生任何 RPC（零介入）', async () => {
-    const { deps, calls } = makeDeps({ channels: { bot: ['s1'] } })
-    const repair = createSendMessageChannelRepair(deps, { channel_id: 'bot', session_id: 'home-session' })
-    const input = { channel_id: 'bot', session_id: 's1', content: 'x' }
-    expect(await repair(input)).toBe(input)
-    expect(calls).toHaveLength(0)
-  })
-
-  it('双参全缺 / session_id 非字符串 → 透传且不发生任何 RPC', async () => {
-    const { deps, calls } = makeDeps({ channels: { bot: ['s1'] } })
-    const repair = createSendMessageChannelRepair(deps, { channel_id: 'bot', session_id: 'home-session' })
-    expect(await repair({ content: 'x' })).toEqual({ content: 'x' })
-    expect(await repair({ session_id: 123, content: 'x' })).toEqual({ session_id: 123, content: 'x' })
-    expect(calls).toHaveLength(0)
-  })
-
-  it('admin 列表 RPC 失败 → 透传', async () => {
-    const { deps } = makeDeps({ channels: { bot: ['s1'] }, breakList: true })
-    const repair = createSendMessageChannelRepair(deps, { channel_id: 'bot', session_id: 'home-session' })
-    expect(await repair({ session_id: 's1', content: 'x' })).toEqual({ session_id: 's1', content: 'x' })
-  })
-
-  it.each([
-    ['resolveChannelPort 抛错', { deadPorts: ['bot'] }],
-    ['resolveChannelPort 返回不可用端口', { unavailablePorts: ['bot'] }],
-    ['get_session 返回非 NOT_FOUND 错误', { brokenSessions: { bot: 'INTERNAL_ERROR' } }],
-  ])('%s 时规则失败并原样透传，不用剩余局部结果猜目标', async (_label, failure) => {
-    const { deps } = makeDeps({
-      channels: { bot: ['s1'], tg: ['s1'] },
-      ...failure,
+  it('唯一已登记归属 → 补全 channel_id 且不原地修改输入', async () => {
+    const lookup = vi.fn(() => new Set(['bot']))
+    const repair = createSendMessageChannelRepair(lookup, {
+      channel_id: 'home',
+      session_id: 'home-session',
     })
-    const repair = createSendMessageChannelRepair(deps, { channel_id: 'bot', session_id: 'home-session' })
-    const input = { session_id: 's1', content: 'x' }
-    expect(await repair(input)).toBe(input)
+    const input = { session_id: 's1', content: 'hi', post_send_action: 'none' }
+
+    expect(await repair(input)).toEqual({
+      channel_id: 'bot',
+      session_id: 's1',
+      content: 'hi',
+      post_send_action: 'none',
+    })
+    expect(input).not.toHaveProperty('channel_id')
+    expect(lookup).toHaveBeenCalledOnce()
+    expect(lookup).toHaveBeenCalledWith('s1')
   })
 
-  it('只有明确 NOT_FOUND 才继续扫描，普通 Error 视为规则失败', async () => {
-    const { deps } = makeDeps({ channels: { bot: [], tg: ['s1'] } })
-    const call = deps.rpcClient.call
-    deps.rpcClient.call = (async <P, R>(port: number, method: string, params: P, source?: string): Promise<R> => {
-      if (method === 'get_session' && port === 10_000) throw new Error('Session not found')
-      return call(port, method, params, source)
-    }) as typeof deps.rpcClient.call
-    const repair = createSendMessageChannelRepair(deps, { channel_id: 'bot', session_id: 'home-session' })
-    const input = { session_id: 's1', content: 'x' }
-    expect(await repair(input)).toBe(input)
-  })
+  it('多归属且当前 Manager Channel 在集合中 → 取当前 Channel', async () => {
+    const repair = createSendMessageChannelRepair(
+      () => new Set(['bot', 'telegram']),
+      { channel_id: 'bot', session_id: 'home-session' },
+    )
 
-  it('当前 manager 自己的 session 直接补归属 channel，Admin Web 也不探测 RPC', async () => {
-    const { deps, calls } = makeDeps({ channels: {} })
-    const repair = createSendMessageChannelRepair(deps, { channel_id: 'admin-web', session_id: 'admin-chat' })
-    const input = { session_id: 'admin-chat', content: 'x' }
-    expect(await repair(input)).toEqual({ channel_id: 'admin-web', session_id: 'admin-chat', content: 'x' })
-    expect(calls).toHaveLength(0)
-  })
-
-  it('遍历所有分页并使用平铺 page/page_size 参数', async () => {
-    const channels = Object.fromEntries(Array.from({ length: 51 }, (_, index) => [
-      `ch-${index + 1}`,
-      index === 50 ? ['target'] : [],
-    ]))
-    const { deps, calls } = makeDeps({ channels })
-    const repair = createSendMessageChannelRepair(deps)
-    expect(await repair({ session_id: 'target', content: 'x' })).toEqual({
-      channel_id: 'ch-51',
-      session_id: 'target',
+    expect(await repair({ session_id: 's1', content: 'x' })).toEqual({
+      channel_id: 'bot',
+      session_id: 's1',
       content: 'x',
     })
-    expect(calls.filter((call) => call.method === 'list_channel_instances').map((call) => call.params)).toEqual([
-      { page: 1, page_size: 50 },
-      { page: 2, page_size: 50 },
-    ])
   })
 
-  it('跨页多命中时不误判为唯一命中', async () => {
-    const channels = Object.fromEntries(Array.from({ length: 51 }, (_, index) => [
-      `ch-${index + 1}`,
-      index === 0 || index === 50 ? ['target'] : [],
-    ]))
-    const { deps } = makeDeps({ channels })
-    const repair = createSendMessageChannelRepair(deps)
-    const input = { session_id: 'target', content: 'x' }
-    expect(await repair(input)).toBe(input)
-  })
-
-  it('未注册的归属 channel 不被盲目探测或用于多命中决策', async () => {
-    const { deps, calls } = makeDeps({ channels: { a: ['s1'], b: ['s1'] } })
-    const repair = createSendMessageChannelRepair(deps, { channel_id: 'bot', session_id: 'home-session' })
+  it('多归属但当前 Manager Channel 不在集合中 → 原样透传', async () => {
+    const repair = createSendMessageChannelRepair(
+      () => new Set(['a', 'b']),
+      { channel_id: 'bot', session_id: 'home-session' },
+    )
     const input = { session_id: 's1', content: 'x' }
+
     expect(await repair(input)).toBe(input)
-    expect(calls.filter((call) => call.method === 'get_session')).toHaveLength(2)
+  })
+
+  it('无已登记归属 → 原样透传', async () => {
+    const repair = createSendMessageChannelRepair(() => undefined, {
+      channel_id: 'bot',
+      session_id: 'home-session',
+    })
+    const input = { session_id: 's9', content: 'x' }
+
+    expect(await repair(input)).toBe(input)
+  })
+
+  it('当前 Manager 自身 Session 直接补全，包括 admin-web，且不查索引', async () => {
+    const lookup = vi.fn(() => new Set(['wrong']))
+    const repair = createSendMessageChannelRepair(lookup, {
+      channel_id: 'admin-web',
+      session_id: 'admin-chat',
+    })
+
+    expect(await repair({ session_id: 'admin-chat', content: 'x' })).toEqual({
+      channel_id: 'admin-web',
+      session_id: 'admin-chat',
+      content: 'x',
+    })
+    expect(lookup).not.toHaveBeenCalled()
+  })
+
+  it('索引读取抛错 → 原样透传', async () => {
+    const repair = createSendMessageChannelRepair(() => {
+      throw new Error('index unavailable')
+    })
+    const input = { session_id: 's1', content: 'x' }
+
+    expect(await repair(input)).toBe(input)
+  })
+
+  it('显式 channel_id 时零介入', async () => {
+    const lookup = vi.fn(() => new Set(['other']))
+    const repair = createSendMessageChannelRepair(lookup, {
+      channel_id: 'bot',
+      session_id: 'home-session',
+    })
+    const input = { channel_id: 'bot', session_id: 's1', content: 'x' }
+
+    expect(await repair(input)).toBe(input)
+    expect(lookup).not.toHaveBeenCalled()
   })
 
   it.each([
-    ['列表响应格式错误', { malformedList: true }],
-    ['session 响应格式错误', { malformedSessions: ['bot'] }],
-  ])('%s 时规则失败并原样透传', async (_label, failure) => {
-    const { deps } = makeDeps({ channels: { bot: ['s1'] }, ...failure })
-    const repair = createSendMessageChannelRepair(deps, { channel_id: 'bot', session_id: 'home-session' })
+    [{ content: 'x' }],
+    [{ session_id: 123, content: 'x' }],
+    [{ session_id: '', content: 'x' }],
+  ])('缺少有效 session_id 时零介入：%o', async (input) => {
+    const lookup = vi.fn(() => new Set(['bot']))
+    const repair = createSendMessageChannelRepair(lookup, {
+      channel_id: 'bot',
+      session_id: 'home-session',
+    })
+
+    expect(await repair(input)).toBe(input)
+    expect(lookup).not.toHaveBeenCalled()
+  })
+
+  it('无当前 Manager 目标时，唯一归属补全、多归属透传', async () => {
+    const single = createSendMessageChannelRepair(() => new Set(['a']))
+    expect(await single({ session_id: 's1', content: 'x' })).toEqual({
+      channel_id: 'a',
+      session_id: 's1',
+      content: 'x',
+    })
+
+    const multi = createSendMessageChannelRepair(() => new Set(['a', 'b']))
     const input = { session_id: 's1', content: 'x' }
-    expect(await repair(input)).toBe(input)
-  })
-
-  it('空字符串 session_id 零介入', async () => {
-    const { deps, calls } = makeDeps({ channels: { bot: [] } })
-    const repair = createSendMessageChannelRepair(deps, { channel_id: 'bot', session_id: 'home-session' })
-    const input = { session_id: '', content: 'x' }
-    expect(await repair(input)).toBe(input)
-    expect(calls).toHaveLength(0)
-  })
-
-  it('无归属目标信息时，多命中透传、唯一命中补全', async () => {
-    const multi = makeDeps({ channels: { a: ['s1'], b: ['s1'] } })
-    const repairMulti = createSendMessageChannelRepair(multi.deps)
-    expect(await repairMulti({ session_id: 's1', content: 'x' })).toEqual({ session_id: 's1', content: 'x' })
-
-    const single = makeDeps({ channels: { a: ['s1'], b: ['s2'] } })
-    const repairSingle = createSendMessageChannelRepair(single.deps)
-    expect(await repairSingle({ session_id: 's2', content: 'x' })).toEqual({ channel_id: 'b', session_id: 's2', content: 'x' })
+    expect(await multi(input)).toBe(input)
   })
 })

--- a/crabot-agent/tests/mcp/zod-registry-leak.test.ts
+++ b/crabot-agent/tests/mcp/zod-registry-leak.test.ts
@@ -14,6 +14,12 @@ import { describe, test, expect, vi } from 'vitest'
 import { globalRegistry } from 'zod/v4/core'
 import { createCrabMemoryServer, type MemoryTaskContext } from '../../src/mcp/crab-memory.js'
 import { createCrabMessagingServer } from '../../src/mcp/crab-messaging.js'
+import { buildManagerToolFace, type ToolFaceDeps } from '../../src/manager/tools/tool-face.js'
+import type { WorkerHarness } from '../../src/workers/harness/harness.js'
+import { ManagerWorkboardStore } from '../../src/manager/workboard-store.js'
+import type { ManagerKey } from '../../src/manager/types.js'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
 
 function registrySize(): number {
   return (globalRegistry as unknown as { _map: Map<unknown, unknown> })._map.size
@@ -43,6 +49,35 @@ const messagingDeps = {
   enableFeishuDocTool: true,
 }
 
+const managerKey = 'channel::session' as ManagerKey
+
+function managerDeps(): ToolFaceDeps {
+  return {
+    harness: {} as WorkerHarness,
+    workerContext: () => ({
+      managerKey,
+      reportTo: { channel_id: 'channel', session_id: 'session' },
+    }),
+    messagingDeps,
+    managerTarget: { channel_id: 'channel', session_id: 'session' },
+    memoryServer: createCrabMemoryServer(memoryDeps, memoryCtx),
+    callAdmin: vi.fn(async () => ({})) as unknown as ToolFaceDeps['callAdmin'],
+    isSystemThread: false,
+    workboard: {
+      store: new ManagerWorkboardStore(join(tmpdir(), 'manager-zod-registry-test')),
+      managerKey,
+    },
+    projectDocs: {
+      ledger: {
+        listWorkers: vi.fn(async () => []),
+        findWorker: vi.fn(async () => undefined),
+      } as never,
+      readWorkerContext: vi.fn(async () => undefined),
+      managerKey,
+    },
+  }
+}
+
 describe('zod globalRegistry 泄漏回归', () => {
   test('重复构建 crab-memory server 不增加 globalRegistry 条目', () => {
     // 首次构建：允许模块加载/首次执行注册 schema
@@ -62,6 +97,17 @@ describe('zod globalRegistry 泄漏回归', () => {
 
     for (let i = 0; i < 3; i++) {
       createCrabMessagingServer(messagingDeps)
+    }
+
+    expect(registrySize() - before).toBe(0)
+  })
+
+  test('重复构建 manager 工具面不增加 globalRegistry 条目', () => {
+    buildManagerToolFace(managerDeps())
+    const before = registrySize()
+
+    for (let i = 0; i < 3; i++) {
+      buildManagerToolFace(managerDeps())
     }
 
     expect(registrySize() - before).toBe(0)


### PR DESCRIPTION
## 背景

PR #140 为 Manager `send_message.channel_id` 增加了确定性参数修复，但首版在发送时分页枚举所有 Channel 并逐实例探测 Session。该热路径随 Channel 数量线性增长，而且 live offset pagination 在实例并发删除时可能漏掉第二个命中，把多渠道 Session ID 冲突误判为唯一命中。

## 改动

- 将归属来源改为当前 `ManagerLoop` 的运行时 provenance 索引：`session_id → Set<channel_id>`。
- 只在成功的结构化 messaging 结果中登记 canonical Session 归属：
  - `list_sessions`
  - `send_private_message` / `send_master_private`
  - 成功的 `send_message` / `get_history` / `get_message` / `list_group_members`
- 缺少 `channel_id` 时只做当前 Manager 的本地查询：
  - 当前 Manager 自身 Session 继续走 ManagerKey 快路径；
  - 唯一命中时补全；
  - 多命中时仅由当前 Manager 归属 Channel 消歧；
  - 未知、仍歧义或 lookup 异常时原样透传。
- 内部 typed observation metadata 由 Manager ToolFace 消费，不进入 Engine/LLM 结果；raw MCP bridge 显式剥离该 metadata，且仍要求显式 `channel_id`。
- 索引不持久化、不跨 Manager，不参与权限、身份、审计、状态机或 delivery evidence；Loop 回收或 Agent 重启后自然清空。
- 更新 `PROGRESS.md`。

正式协议与修订 Spec 已先行发布至 crabot-docs：`b725b1c`（crab-messaging v0.3.7）。

## 验证

- Session 索引定向回归：11 files / 163 tests passed
- 完整 crab-messaging MCP 回归：10 files / 71 tests passed
- Registry eviction 定向回归：3 passed / 41 skipped
- `tsc --noEmit --pretty false`：通过
- `git diff --check`：通过

完整 `tests/manager/registry.test.ts` 仍有一个与本 PR 无关的既有数量断言失败（期望 2、实际 4）；本 PR 修改的 eviction 用例已单独通过。

## 失败路径与收口

- 索引 lookup 或观察回调异常：吞掉派生错误，保持原工具输入/结果语义。
- 未知或仍歧义：不修复，交由原 `send_message` 返回既有错误。
- 陈旧映射：真实发送仍走原 dispatch/Channel RPC，失败由原工具收口。
- 未新增发送时 RPC、后台 reconcile、持久化目录或进程。
