### PR TITLE
feat(traces): 展示 Manager 排队与正在处理消息

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5,6 +5,16 @@
 
 ## 当前状态
 
+### Manager 会话在途消息统一时间流：实现完成
+
+- Admin 只读聚合 Manager 当前上下文、私聊 SessionLane 和群聊 AttentionScheduler，按
+  `platform_message_id` 去重后暴露 `queued / processing`；`processing` 只表示消息已进入
+  尚未结束的 episode 上下文，不新增运行时状态或持久化副本。
+- 会话详情将排队中、正在处理和已处理活动按消息/episode 时间统一倒序展示；轮询不重叠，页面
+  隐藏时暂停，旧页面响应不可覆盖新页面；running episode 与对应 processing 消息不重复。
+- Spec 与 agent-v3 `3.9.2` 已先行发布（crabot-docs `d44dc8e`）；Agent/Admin/Web 定向测试、
+  三包 TypeScript/生产构建及桌面/窄屏浏览器验收均通过。
+
 ### send_message 缺 channel_id 的确定性修复改为来源登记：已合入（PR #141，main `c8311d58`）
 
 - 已将发送时的 Channel 枚举与逐实例 `get_session` 探测替换为当前 Manager 的运行时多值索引：

--- a/crabot-admin/src/admin-web-api.test.ts
+++ b/crabot-admin/src/admin-web-api.test.ts
@@ -1606,6 +1606,32 @@ describe('Admin Web API', () => {
       )
     })
 
+    it('GET /api/agent/managers/:key/inbound-status 转发只读快照 RPC（path decode 一次）', async () => {
+      const token = await loginAndGetToken()
+      const spy = spyAgentRpc().mockResolvedValue({
+        manager_key: 'wechat::sess%2Fone',
+        snapshot_at: '2026-09-05T06:28:20.000Z',
+        items: [],
+      })
+      const key = encodeURIComponent('wechat::sess%2Fone')
+      const response = await makeWebRequest(TEST_WEB_PORT, `/api/agent/managers/${key}/inbound-status`, 'GET', null, token)
+      expect(response.statusCode).toBe(200)
+      expect(spy).toHaveBeenCalledWith(
+        expect.any(Number),
+        'get_manager_inbound_status_admin',
+        { manager_key: 'wechat::sess%2Fone' },
+        expect.any(String),
+      )
+    })
+
+    it('inbound-status 的 manager key 非法 percent-encoding → 400，不发 RPC', async () => {
+      const token = await loginAndGetToken()
+      const spy = spyAgentRpc()
+      const response = await makeWebRequest(TEST_WEB_PORT, '/api/agent/managers/%E0%A4%A/inbound-status', 'GET', null, token)
+      expect(response.statusCode).toBe(400)
+      expect(spy).not.toHaveBeenCalled()
+    })
+
     it('manager key 非法 percent-encoding → 400，不发 RPC', async () => {
       const token = await loginAndGetToken()
       const spy = spyAgentRpc()

--- a/crabot-admin/src/index.ts
+++ b/crabot-admin/src/index.ts
@@ -2442,6 +2442,11 @@ export class AdminModule extends ModuleBase {
         await this.handleListManagersApi(req, res, url)
         return
       }
+      const managerInboundStatusMatch = pathname.match(/^\/api\/agent\/managers\/([^/]+)\/inbound-status$/)
+      if (managerInboundStatusMatch && req.method === 'GET') {
+        await this.handleGetManagerInboundStatusApi(req, res, managerInboundStatusMatch[1])
+        return
+      }
       const managerEpisodesMatch = pathname.match(/^\/api\/agent\/managers\/([^/]+)\/episodes$/)
       if (managerEpisodesMatch && req.method === 'GET') {
         await this.handleListManagerEpisodesApi(req, res, managerEpisodesMatch[1], url)
@@ -10384,6 +10389,24 @@ export class AdminModule extends ModuleBase {
     await this.proxyAgentRpc(res, 'list_manager_episodes_admin', {
       manager_key: managerKey,
       pagination: { page, page_size: pageSize },
+    })
+  }
+
+  /** §8.4/§10.4：GET /api/agent/managers/:managerKey/inbound-status —— path 参数只 decode 一次。 */
+  private async handleGetManagerInboundStatusApi(
+    _req: IncomingMessage,
+    res: ServerResponse,
+    rawManagerKey: string,
+  ): Promise<void> {
+    let managerKey: string
+    try {
+      managerKey = decodeURIComponent(rawManagerKey)
+    } catch {
+      sendJson(res, 400, { error: 'Invalid percent-encoding in manager key' })
+      return
+    }
+    await this.proxyAgentRpc(res, 'get_manager_inbound_status_admin', {
+      manager_key: managerKey,
     })
   }
 

--- a/crabot-admin/web/src/pages/Traces/ManagerDetail.css
+++ b/crabot-admin/web/src/pages/Traces/ManagerDetail.css
@@ -74,6 +74,33 @@
   font-weight: 600;
 }
 
+.manager-detail__live-state {
+  align-items: center;
+  display: inline-flex;
+  gap: 6px;
+}
+
+.manager-detail__live-state > span {
+  background: var(--success);
+  border-radius: 50%;
+  box-shadow: 0 0 0 3px var(--success-glow);
+  height: 6px;
+  width: 6px;
+}
+
+.manager-detail__live-state.is-unknown,
+.manager-detail__summary dd.is-unknown {
+  color: var(--error);
+}
+
+.manager-detail__history-error {
+  border-left: 2px solid var(--error);
+  color: var(--error);
+  font-size: 12px;
+  margin: 0 0 16px 88px;
+  padding: 6px 10px;
+}
+
 .manager-detail__event-list {
   position: relative;
 }
@@ -121,12 +148,24 @@
   width: 9px;
 }
 
+.manager-detail__event:not(.is-worker):not(.is-failed):not(.is-processing):not(.is-queued) .manager-detail__event-body::before {
+  border-color: var(--success);
+}
+
 .manager-detail__event.is-worker .manager-detail__event-body::before {
   border-color: var(--success);
 }
 
 .manager-detail__event.is-failed .manager-detail__event-body::before {
   border-color: var(--error);
+}
+
+.manager-detail__event.is-processing .manager-detail__event-body::before {
+  border-color: var(--primary-light);
+}
+
+.manager-detail__event.is-queued .manager-detail__event-body::before {
+  border-color: var(--warning);
 }
 
 .manager-detail__event-header {
@@ -137,6 +176,29 @@
   font-weight: 600;
   justify-content: space-between;
   min-height: 20px;
+}
+
+.manager-detail__event-labels {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 9px;
+  min-width: 0;
+}
+
+.manager-detail__episode-status {
+  color: var(--success);
+  font-size: 10px;
+  font-weight: 500;
+}
+
+.manager-detail__event.is-processing .manager-detail__episode-status,
+.manager-detail__event.is-processing .manager-detail__event-header {
+  color: var(--primary-light);
+}
+
+.manager-detail__event.is-failed .manager-detail__episode-status {
+  color: var(--error);
 }
 
 .manager-detail__event.is-worker .manager-detail__event-header {
@@ -154,6 +216,112 @@
   line-height: 1.55;
   margin-top: 4px;
   overflow-wrap: anywhere;
+}
+
+.manager-detail__event--inbound .manager-detail__event-body {
+  background: var(--surface);
+  border: 1px solid var(--border-highlight);
+  border-left: 2px solid var(--primary-light);
+  border-radius: 6px;
+  padding: 11px 13px 12px;
+}
+
+.manager-detail__event--inbound.is-queued .manager-detail__event-body {
+  background: var(--warning-bg);
+  border-left-color: var(--warning);
+}
+
+.manager-detail__event--inbound .manager-detail__event-body::before {
+  background: var(--surface);
+  left: -20px;
+  top: 16px;
+}
+
+.manager-detail__event--inbound.is-queued .manager-detail__event-body::before {
+  background: var(--bg-primary);
+}
+
+.manager-detail__event-status {
+  align-items: center;
+  display: inline-flex;
+  gap: 6px;
+}
+
+.manager-detail__event.is-queued .manager-detail__event-status {
+  color: var(--warning);
+}
+
+.manager-detail__status-dot {
+  border: 2px solid currentColor;
+  border-radius: 50%;
+  height: 7px;
+  width: 7px;
+}
+
+.manager-detail__event.is-processing .manager-detail__status-dot {
+  animation: manager-processing-pulse 1.6s ease-out infinite;
+  background: currentColor;
+}
+
+.manager-detail__status-meta,
+.manager-detail__message-meta {
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 400;
+}
+
+.manager-detail__status-meta {
+  font-family: var(--font-mono);
+}
+
+.manager-detail__message-meta {
+  align-items: baseline;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px 10px;
+  margin-top: 6px;
+}
+
+.manager-detail__message-meta code {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  overflow-wrap: anywhere;
+}
+
+.manager-detail__inbound-details {
+  flex: 0 0 auto;
+}
+
+.manager-detail__inbound-details button {
+  background: transparent;
+  border: 0;
+  color: var(--text-muted);
+  cursor: pointer;
+  font: inherit;
+  font-size: 11px;
+  padding: 0;
+}
+
+.manager-detail__inbound-detail-body {
+  color: var(--text-muted);
+  display: grid;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  gap: 3px;
+  margin-top: 8px;
+  overflow-wrap: anywhere;
+}
+
+@keyframes manager-processing-pulse {
+  0% { box-shadow: 0 0 0 0 rgba(232, 146, 79, 0.4); }
+  70%, 100% { box-shadow: 0 0 0 6px rgba(232, 146, 79, 0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .manager-detail__event.is-processing .manager-detail__status-dot {
+    animation: none;
+  }
 }
 
 .manager-detail__reply,
@@ -485,6 +653,10 @@
   padding: 24px 0;
 }
 
+.manager-detail__event-list.is-empty::before {
+  display: none;
+}
+
 @media (max-width: 880px) {
   .manager-detail__content-grid {
     grid-template-columns: 1fr;
@@ -523,6 +695,21 @@
 
   .manager-detail__pagination {
     margin-left: 73px;
+  }
+
+  .manager-detail__history-error {
+    margin-left: 60px;
+  }
+
+  .manager-detail__event--inbound .manager-detail__event-header {
+    align-items: flex-start;
+    flex-wrap: wrap;
+    gap: 6px 12px;
+  }
+
+  .manager-detail__inbound-details {
+    flex: 1 1 100%;
+    min-width: 0;
   }
 
   .manager-detail__span-row {

--- a/crabot-admin/web/src/pages/Traces/ManagerDetail.tsx
+++ b/crabot-admin/web/src/pages/Traces/ManagerDetail.tsx
@@ -8,6 +8,7 @@ import {
   type ManagerAdminSummary,
   type ManagerEpisodeSpan,
   type ManagerEpisodeTrace,
+  type ManagerInboundMessageSnapshot,
 } from '../../services/agent-observability'
 import './ManagerDetail.css'
 
@@ -17,6 +18,10 @@ type RunningWorkers =
   | { status: 'loading' }
   | { status: 'ready'; items: LedgerWorker[] }
   | { status: 'unknown' }
+type InboundStatus =
+  | { status: 'loading'; items: [] }
+  | { status: 'ready'; items: ManagerInboundMessageSnapshot[]; snapshotAt: string }
+  | { status: 'unknown'; items: [] }
 
 const SPAN_STATUS_COLOR: Record<ManagerEpisodeSpan['status'], string> = {
   running: 'var(--warning)', completed: 'var(--success)', failed: 'var(--error)',
@@ -47,6 +52,16 @@ function displayTime(iso: string): string {
   return date.toDateString() === today.toDateString()
     ? date.toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit', hour12: false })
     : date.toLocaleString('zh-CN', { month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit', hour12: false })
+}
+
+function elapsedLabel(fromIso: string, snapshotIso: string): string {
+  const parsedSeconds = Math.floor((Date.parse(snapshotIso) - Date.parse(fromIso)) / 1000)
+  const elapsedSeconds = Number.isFinite(parsedSeconds) ? Math.max(0, parsedSeconds) : 0
+  if (elapsedSeconds < 60) return `${elapsedSeconds} 秒`
+  const minutes = Math.floor(elapsedSeconds / 60)
+  if (minutes < 60) return `${minutes} 分 ${elapsedSeconds % 60} 秒`
+  const hours = Math.floor(minutes / 60)
+  return `${hours} 小时 ${minutes % 60} 分`
 }
 
 function channelLabel(managerKey: string): string {
@@ -84,6 +99,10 @@ function workerStateLabel(status: string): string {
 
 function episodeStatusLabel(status: ManagerEpisodeTrace['status']): string {
   return status === 'running' ? '执行中' : status === 'failed' ? '失败' : '已完成'
+}
+
+function episodeActivityStatusLabel(status: ManagerEpisodeTrace['status']): string {
+  return status === 'running' ? '正在处理' : status === 'failed' ? '失败' : '已处理'
 }
 
 function TechnicalDetails({ episode }: { episode: ManagerEpisodeTrace }) {
@@ -225,15 +244,78 @@ function WorkerProgress({ progress, runningWorkerIds }: { progress: WorkerProgre
   )
 }
 
+function InboundDetails({ item }: { item: ManagerInboundMessageSnapshot }) {
+  const [open, setOpen] = useState(false)
+  return (
+    <div className="manager-detail__inbound-details">
+      <button type="button" onClick={() => setOpen(!open)} aria-expanded={open}>
+        {open ? '收起消息详情' : '查看消息详情'}
+      </button>
+      {open && (
+        <div className="manager-detail__inbound-detail-body">
+          <span>消息标识：{item.platform_message_id}</span>
+          {item.episode_id && <span>Episode：{item.episode_id}</span>}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function InboundEntry({
+  item,
+  queuePosition,
+  snapshotAt,
+}: {
+  item: ManagerInboundMessageSnapshot
+  queuePosition?: number
+  snapshotAt: string
+}) {
+  const processing = item.status === 'processing'
+  const statusMeta = processing
+    ? elapsedLabel(item.platform_timestamp, snapshotAt)
+    : `第 ${queuePosition ?? 1} 位 · ${elapsedLabel(item.platform_timestamp, snapshotAt)}`
+  return (
+    <article className={`manager-detail__event manager-detail__event--inbound is-${item.status}`}>
+      <time className="manager-detail__event-time" dateTime={item.platform_timestamp}>{displayTime(item.platform_timestamp)}</time>
+      <div className="manager-detail__event-body">
+        <div className="manager-detail__event-header">
+          <div className="manager-detail__event-labels">
+            <span className="manager-detail__event-status">
+              <span className="manager-detail__status-dot" aria-hidden="true" />
+              {processing ? '正在处理' : '排队中'}
+            </span>
+            <span className="manager-detail__status-meta">{statusMeta}</span>
+          </div>
+          <InboundDetails item={item} />
+        </div>
+        <div className="manager-detail__event-title">{item.preview}</div>
+        <div className="manager-detail__message-meta">
+          <span>{item.sender_display_name || '未知发送者'}</span>
+          {item.episode_id && <code>episode · {item.episode_id.slice(0, 8)}</code>}
+        </div>
+      </div>
+    </article>
+  )
+}
+
 function EpisodeEntry({ episode, progress, runningWorkerIds }: { episode: ManagerEpisodeTrace; progress: ManagerEpisodeTrace[]; runningWorkerIds: ReadonlySet<string> }) {
-  const tone = episode.status === 'failed' ? ' is-failed' : episode.trigger.type === 'worker_event' ? ' is-worker' : ''
+  const tone = episode.status === 'failed'
+    ? ' is-failed'
+    : episode.status === 'running'
+      ? ' is-processing'
+      : episode.trigger.type === 'worker_event'
+        ? ' is-worker'
+        : ''
   const workerProgress = groupWorkerProgress(progress)
   return (
     <article className={`manager-detail__event${tone}`}>
-      <time className="manager-detail__event-time">{displayTime(episode.started_at)}</time>
+      <time className="manager-detail__event-time" dateTime={episode.started_at}>{displayTime(episode.started_at)}</time>
       <div className="manager-detail__event-body">
         <div className="manager-detail__event-header">
-          <span>{TRIGGER_LABEL[episode.trigger.type]}</span>
+          <div className="manager-detail__event-labels">
+            <span>{TRIGGER_LABEL[episode.trigger.type]}</span>
+            <span className="manager-detail__episode-status">{episodeActivityStatusLabel(episode.status)}</span>
+          </div>
           <TechnicalDetails episode={episode} />
         </div>
         <div className="manager-detail__event-title">{triggerText(episode)}</div>
@@ -279,7 +361,12 @@ function Pagination({ page, totalPages, onPageChange }: { page: number; totalPag
   )
 }
 
-function groupEpisodes(episodes: ManagerEpisodeTrace[]): Array<{ episode: ManagerEpisodeTrace; progress: ManagerEpisodeTrace[] }> {
+interface GroupedEpisode {
+  episode: ManagerEpisodeTrace
+  progress: ManagerEpisodeTrace[]
+}
+
+function groupEpisodes(episodes: ManagerEpisodeTrace[]): GroupedEpisode[] {
   const nodes = new Map(episodes.map((episode) => [episode.trace_id, episode]))
 
   // Current page may contain only a late worker event; materialize its minimal parent context.
@@ -345,6 +432,57 @@ function keepsOwnTimelinePosition(episode: ManagerEpisodeTrace): boolean {
   return episode.trigger.type === 'worker_event' && (Boolean(episode.reply_excerpt) || Boolean(episode.actions?.length))
 }
 
+type ConversationTimelineItem =
+  | { kind: 'inbound'; id: string; timestamp: string; item: ManagerInboundMessageSnapshot; queuePosition?: number }
+  | { kind: 'episode'; id: string; timestamp: string; grouped: GroupedEpisode }
+
+function currentInboundMessages(
+  episodes: ReadonlyArray<ManagerEpisodeTrace>,
+  inbound: ReadonlyArray<ManagerInboundMessageSnapshot>,
+): ManagerInboundMessageSnapshot[] {
+  const endedEpisodeIds = new Set(
+    episodes.filter((episode) => episode.status !== 'running').map((episode) => episode.trace_id),
+  )
+  return inbound.filter((item) => (
+    item.status !== 'processing' || !item.episode_id || !endedEpisodeIds.has(item.episode_id)
+  ))
+}
+
+function mergeConversationTimeline(
+  groupedEpisodes: ReadonlyArray<GroupedEpisode>,
+  inbound: ReadonlyArray<ManagerInboundMessageSnapshot>,
+): ConversationTimelineItem[] {
+  const processingEpisodeIds = new Set(
+    inbound.flatMap((item) => item.status === 'processing' && item.episode_id ? [item.episode_id] : []),
+  )
+  const queuePosition = new Map(
+    inbound
+      .filter((item) => item.status === 'queued')
+      .sort((a, b) => a.platform_timestamp.localeCompare(b.platform_timestamp)
+        || a.platform_message_id.localeCompare(b.platform_message_id))
+      .map((item, index) => [item.platform_message_id, index + 1]),
+  )
+
+  const items: ConversationTimelineItem[] = [
+    ...inbound.map((item): ConversationTimelineItem => ({
+      kind: 'inbound',
+      id: `inbound:${item.platform_message_id}`,
+      timestamp: item.platform_timestamp,
+      item,
+      ...(item.status === 'queued' ? { queuePosition: queuePosition.get(item.platform_message_id) } : {}),
+    })),
+    ...groupedEpisodes
+      .filter(({ episode }) => episode.status !== 'running' || !processingEpisodeIds.has(episode.trace_id))
+      .map((grouped): ConversationTimelineItem => ({
+        kind: 'episode',
+        id: `episode:${grouped.episode.trace_id}`,
+        timestamp: grouped.episode.started_at,
+        grouped,
+      })),
+  ]
+  return items.sort((a, b) => b.timestamp.localeCompare(a.timestamp) || a.id.localeCompare(b.id))
+}
+
 async function listRunningWorkers(managerKey: string): Promise<LedgerWorker[]> {
   const items: LedgerWorker[] = []
   let page = 1
@@ -372,7 +510,22 @@ const ManagerDetailContent: React.FC = () => {
   const [error, setError] = useState<string | null>(null)
   const [view, setView] = useState<ViewMode>('conversation')
   const [runningWorkers, setRunningWorkers] = useState<RunningWorkers>({ status: 'loading' })
+  const [inboundStatus, setInboundStatus] = useState<InboundStatus>({ status: 'loading', items: [] })
   const grouped = useMemo(() => groupEpisodes(episodes), [episodes])
+  const currentInbound = useMemo(
+    () => currentInboundMessages(episodes, inboundStatus.status === 'ready' ? inboundStatus.items : []),
+    [episodes, inboundStatus],
+  )
+  const timeline = useMemo(
+    () => mergeConversationTimeline(grouped, currentInbound),
+    [grouped, currentInbound],
+  )
+  const queuedCount = inboundStatus.status === 'ready'
+    ? currentInbound.filter((item) => item.status === 'queued').length
+    : undefined
+  const processingCount = inboundStatus.status === 'ready'
+    ? currentInbound.filter((item) => item.status === 'processing').length
+    : undefined
   const runningWorkerIds = useMemo(
     () => new Set(runningWorkers.status === 'ready' ? runningWorkers.items.map((worker) => worker.worker_id) : []),
     [runningWorkers],
@@ -391,22 +544,66 @@ const ManagerDetailContent: React.FC = () => {
   }, [managerKey])
 
   useEffect(() => {
+    setPage(1)
+  }, [managerKey])
+
+  useEffect(() => {
     let cancelled = false
+    let requestInFlight = false
     setLoading(true)
     setError(null)
-    agentObservabilityService.listManagerEpisodes(managerKey, page, 20)
-      .then((result) => {
+    setInboundStatus({ status: 'loading', items: [] })
+
+    const refresh = async (initial: boolean): Promise<void> => {
+      if (cancelled || requestInFlight) return
+      requestInFlight = true
+      const refreshEpisodes = initial || page === 1
+      try {
+        const [inboundResult, episodeResult] = await Promise.allSettled([
+          agentObservabilityService.getManagerInboundStatus(managerKey),
+          refreshEpisodes
+            ? agentObservabilityService.listManagerEpisodes(managerKey, page, 20)
+            : Promise.resolve(null),
+        ])
         if (cancelled) return
-        setEpisodes(result.items)
-        setTotalPages(Math.max(1, result.pagination.total_pages))
-      })
-      .catch((err) => {
-        if (cancelled) return
-        setError(err instanceof Error ? err.message : String(err))
-        setEpisodes([])
-      })
-      .finally(() => { if (!cancelled) setLoading(false) })
-    return () => { cancelled = true }
+
+        if (inboundResult.status === 'fulfilled') {
+          setInboundStatus({
+            status: 'ready',
+            items: inboundResult.value.items,
+            snapshotAt: inboundResult.value.snapshot_at,
+          })
+        } else {
+          setInboundStatus({ status: 'unknown', items: [] })
+        }
+
+        if (episodeResult.status === 'fulfilled' && episodeResult.value) {
+          setEpisodes(episodeResult.value.items)
+          setTotalPages(Math.max(1, episodeResult.value.pagination.total_pages))
+          setError(null)
+        } else if (episodeResult.status === 'rejected') {
+          setError(episodeResult.reason instanceof Error ? episodeResult.reason.message : String(episodeResult.reason))
+          if (initial) setEpisodes([])
+        }
+      } finally {
+        requestInFlight = false
+        if (!cancelled && initial) setLoading(false)
+      }
+    }
+
+    void refresh(true)
+    const interval = window.setInterval(() => {
+      if (document.visibilityState !== 'hidden') void refresh(false)
+    }, 2_000)
+    const handleVisibilityChange = (): void => {
+      if (document.visibilityState !== 'hidden') void refresh(false)
+    }
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+    return () => {
+      cancelled = true
+      window.clearInterval(interval)
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+    }
   }, [managerKey, page])
 
   useEffect(() => {
@@ -432,11 +629,7 @@ const ManagerDetailContent: React.FC = () => {
         </div>
         {manager?.last_activity_at && <div className="manager-detail__last-activity">最近活动：{displayTime(manager.last_activity_at)}</div>}
       </header>
-      {loading ? <Loading /> : error ? (
-        <div className="manager-detail__empty">运行记录暂不可用：{error}</div>
-      ) : grouped.length === 0 ? (
-        <div className="manager-detail__empty">该会话暂无运行记录。</div>
-      ) : (
+      {loading ? <Loading /> : (
         <>
           <div className="manager-detail__tabs" role="tablist" aria-label="会话视图">
             <button className={view === 'conversation' ? 'is-active' : ''} type="button" role="tab" aria-selected={view === 'conversation'} onClick={() => setView('conversation')}>对话与操作</button>
@@ -445,9 +638,38 @@ const ManagerDetailContent: React.FC = () => {
           {view === 'conversation' ? (
             <div className="manager-detail__content-grid" role="tabpanel" aria-label="对话与操作">
               <section>
-                <div className="manager-detail__stream-heading"><strong>活动记录</strong><span>按会话因果关系归并</span></div>
-                <div className="manager-detail__event-list">
-                  {grouped.map(({ episode, progress }) => <EpisodeEntry key={episode.trace_id} episode={episode} progress={progress} runningWorkerIds={runningWorkerIds} />)}
+                <div className="manager-detail__stream-heading">
+                  <strong>会话动态</strong>
+                  {inboundStatus.status === 'unknown' ? (
+                    <span className="manager-detail__live-state is-unknown">在途状态暂不可用</span>
+                  ) : (
+                    <span className="manager-detail__live-state">
+                      <span aria-hidden="true" />最新在上 · 刚刚更新
+                    </span>
+                  )}
+                </div>
+                {error && <div className="manager-detail__history-error">历史活动暂不可用：{error}</div>}
+                <div className={`manager-detail__event-list${timeline.length === 0 ? ' is-empty' : ''}`} aria-live="polite">
+                  {timeline.map((timelineItem) => timelineItem.kind === 'inbound' ? (
+                    <InboundEntry
+                      key={timelineItem.id}
+                      item={timelineItem.item}
+                      queuePosition={timelineItem.queuePosition}
+                      snapshotAt={inboundStatus.status === 'ready' ? inboundStatus.snapshotAt : timelineItem.timestamp}
+                    />
+                  ) : (
+                    <EpisodeEntry
+                      key={timelineItem.id}
+                      episode={timelineItem.grouped.episode}
+                      progress={timelineItem.grouped.progress}
+                      runningWorkerIds={runningWorkerIds}
+                    />
+                  ))}
+                  {timeline.length === 0 && (
+                    <div className="manager-detail__empty">
+                      {inboundStatus.status === 'unknown' ? '当前消息状态未知，且暂无可显示的历史活动。' : '该会话暂无动态。'}
+                    </div>
+                  )}
                 </div>
                 <Pagination page={page} totalPages={totalPages} onPageChange={setPage} />
               </section>
@@ -460,6 +682,9 @@ const ManagerDetailContent: React.FC = () => {
                 <section>
                   <h2>当前状态</h2>
                   <dl>
+                    {processingCount !== undefined && <div><dt>正在处理</dt><dd>{processingCount} 条</dd></div>}
+                    {queuedCount !== undefined && <div><dt>排队中</dt><dd>{queuedCount} 条</dd></div>}
+                    {inboundStatus.status === 'unknown' && <div><dt>消息状态</dt><dd className="is-unknown">未知</dd></div>}
                     {manager && <div><dt>未结束</dt><dd>{manager.active_worker_count > 0 ? `${manager.active_worker_count} 个` : '—'}</dd></div>}
                     <div><dt>本页记录</dt><dd>{episodes.length} 条</dd></div>
                     <div><dt>当前页</dt><dd>{page} / {totalPages}</dd></div>
@@ -486,7 +711,10 @@ const ManagerDetailContent: React.FC = () => {
             </div>
           ) : (
             <>
-              <TechnicalEventList episodes={episodes} />
+              {error && <div className="manager-detail__history-error">技术事件暂不可用：{error}</div>}
+              {episodes.length > 0
+                ? <TechnicalEventList episodes={episodes} />
+                : !error && <div className="manager-detail__empty">该会话暂无技术事件。</div>}
               <Pagination page={page} totalPages={totalPages} onPageChange={setPage} />
             </>
           )}

--- a/crabot-admin/web/src/pages/Traces/ManagersView.test.tsx
+++ b/crabot-admin/web/src/pages/Traces/ManagersView.test.tsx
@@ -2,11 +2,14 @@
  * P6-A §10 UI 测试：Manager/Worker 视图的路由编解码、分页、错误态与 cursor 恢复。
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { ManagersView } from './ManagersView'
 import { ManagerDetail } from './ManagerDetail'
-import { agentObservabilityService } from '../../services/agent-observability'
+import {
+  agentObservabilityService,
+  type ManagerInboundStatusResult,
+} from '../../services/agent-observability'
 
 vi.mock('../../services/agent-observability')
 vi.mock('../../components/Layout/MainLayout', () => ({
@@ -16,6 +19,7 @@ vi.mock('../../components/Layout/MainLayout', () => ({
 const mocked = agentObservabilityService as unknown as {
   listManagers: ReturnType<typeof vi.fn>
   listManagerEpisodes: ReturnType<typeof vi.fn>
+  getManagerInboundStatus: ReturnType<typeof vi.fn>
   listWorkers: ReturnType<typeof vi.fn>
 }
 
@@ -94,6 +98,293 @@ describe('ManagerDetail', () => {
       items: [],
       pagination: { page: 1, page_size: 100, total_items: 0, total_pages: 1 },
     })
+    mocked.getManagerInboundStatus = vi.fn().mockResolvedValue({
+      manager_key: 'wechat::sess-1',
+      snapshot_at: '2026-09-05T06:28:20.000Z',
+      items: [],
+    })
+  })
+
+  it('排队、正在处理和已处理活动合并为一个最新在上的时间流，running episode 不重复', async () => {
+    mocked.getManagerInboundStatus = vi.fn().mockResolvedValue({
+      manager_key: 'wechat::sess-1',
+      snapshot_at: '2026-09-05T06:28:21.000Z',
+      items: [
+        {
+          platform_message_id: 'pm-processing', status: 'processing', preview: '帮我排查消息链路',
+          sender_display_name: '你', platform_timestamp: '2026-09-05T06:28:06.000Z', episode_id: 'ep-running',
+        },
+        {
+          platform_message_id: 'pm-queued-1', status: 'queued', preview: '补充看 Manager 上下文',
+          sender_display_name: '你', platform_timestamp: '2026-09-05T06:28:15.000Z',
+        },
+        {
+          platform_message_id: 'pm-queued-2', status: 'queued', preview: '把排队时长也显示出来',
+          sender_display_name: '你', platform_timestamp: '2026-09-05T06:28:20.000Z',
+        },
+      ],
+    })
+    mocked.listManagerEpisodes = vi.fn().mockResolvedValue({
+      items: [
+        {
+          trace_id: 'ep-running', manager_key: 'wechat::sess-1', started_at: '2026-09-05T06:28:06.000Z', status: 'running',
+          trigger: { type: 'human_message', summary: '人类消息 x1：帮我排查消息链路' }, spans: [], spawned_worker_ids: [],
+        },
+        {
+          trace_id: 'ep-complete', manager_key: 'wechat::sess-1', started_at: '2026-09-05T06:21:03.000Z', status: 'completed',
+          trigger: { type: 'human_message', summary: '人类消息 x1：目前只能看到处理完的消息' }, spans: [], spawned_worker_ids: [],
+          reply_excerpt: '我正在核对消息处理链路。',
+        },
+      ],
+      pagination: { page: 1, page_size: 20, total_items: 2, total_pages: 1 },
+    })
+
+    render(
+      <MemoryRouter initialEntries={[`/traces/managers/${encodeURIComponent('wechat::sess-1')}`]}>
+        <Routes><Route path="/traces/managers/:managerKey" element={<ManagerDetail />} /></Routes>
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => expect(screen.getByText('把排队时长也显示出来')).toBeInTheDocument())
+    const rows = Array.from(document.querySelectorAll('article.manager-detail__event'))
+    expect(rows).toHaveLength(4)
+    expect(rows.map((row) => row.textContent)).toEqual([
+      expect.stringContaining('把排队时长也显示出来'),
+      expect.stringContaining('补充看 Manager 上下文'),
+      expect.stringContaining('帮我排查消息链路'),
+      expect.stringContaining('目前只能看到处理完的消息'),
+    ])
+    expect(screen.getAllByText('帮我排查消息链路')).toHaveLength(1)
+    expect(screen.queryByText('你：「帮我排查消息链路」')).toBeNull()
+    expect(Array.from(document.querySelectorAll('.manager-detail__event-status')).map((node) => node.textContent))
+      .toEqual(['排队中', '排队中', '正在处理'])
+    expect(screen.getByText('已处理')).toBeInTheDocument()
+    expect(screen.getByText('会话动态')).toBeInTheDocument()
+  })
+
+  it('已结束 episode 优先于晚到的 processing 快照', async () => {
+    mocked.getManagerInboundStatus = vi.fn().mockResolvedValue({
+      manager_key: 'wechat::sess-1',
+      snapshot_at: '2026-09-05T06:28:21.000Z',
+      items: [{
+        platform_message_id: 'pm-stale', status: 'processing', preview: '不应出现的过时快照',
+        platform_timestamp: '2026-09-05T06:28:06.000Z', episode_id: 'ep-complete',
+      }],
+    })
+    mocked.listManagerEpisodes = vi.fn().mockResolvedValue({
+      items: [{
+        trace_id: 'ep-complete', manager_key: 'wechat::sess-1', started_at: '2026-09-05T06:28:06.000Z', status: 'completed',
+        trigger: { type: 'human_message', summary: '人类消息 x1：真实已处理消息' }, spans: [], spawned_worker_ids: [],
+      }],
+      pagination: { page: 1, page_size: 20, total_items: 1, total_pages: 1 },
+    })
+
+    render(
+      <MemoryRouter initialEntries={[`/traces/managers/${encodeURIComponent('wechat::sess-1')}`]}>
+        <Routes><Route path="/traces/managers/:managerKey" element={<ManagerDetail />} /></Routes>
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => expect(screen.getByText('你：「真实已处理消息」')).toBeInTheDocument())
+    expect(screen.queryByText('不应出现的过时快照')).toBeNull()
+    expect(document.querySelectorAll('article.manager-detail__event')).toHaveLength(1)
+    expect(screen.getByText('正在处理').parentElement).toHaveTextContent('正在处理0 条')
+  })
+
+  it('在途快照失败时保留历史，并明确显示状态暂不可用', async () => {
+    mocked.getManagerInboundStatus = vi.fn().mockRejectedValue(new Error('agent unavailable'))
+    mocked.listManagerEpisodes = vi.fn().mockResolvedValue({
+      items: [{
+        trace_id: 'ep-history', manager_key: 'wechat::sess-1', started_at: '2026-09-05T06:21:03.000Z', status: 'completed',
+        trigger: { type: 'human_message', summary: '人类消息 x1：保留这条历史' }, spans: [], spawned_worker_ids: [],
+      }],
+      pagination: { page: 1, page_size: 20, total_items: 1, total_pages: 1 },
+    })
+
+    render(
+      <MemoryRouter initialEntries={[`/traces/managers/${encodeURIComponent('wechat::sess-1')}`]}>
+        <Routes><Route path="/traces/managers/:managerKey" element={<ManagerDetail />} /></Routes>
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => expect(screen.getByText('在途状态暂不可用')).toBeInTheDocument())
+    expect(screen.getByText('你：「保留这条历史」')).toBeInTheDocument()
+  })
+
+  it('每 2 秒刷新在途状态和首页 episode；页面隐藏时暂停，恢复可见后立即刷新', async () => {
+    vi.useFakeTimers()
+    const originalVisibility = Object.getOwnPropertyDescriptor(document, 'visibilityState')
+    const setVisibility = (value: 'visible' | 'hidden') => {
+      Object.defineProperty(document, 'visibilityState', { configurable: true, value })
+    }
+    setVisibility('visible')
+    mocked.listManagerEpisodes = vi.fn().mockResolvedValue({
+      items: [],
+      pagination: { page: 1, page_size: 20, total_items: 0, total_pages: 0 },
+    })
+    const rendered = render(
+      <MemoryRouter initialEntries={[`/traces/managers/${encodeURIComponent('wechat::sess-1')}`]}>
+        <Routes><Route path="/traces/managers/:managerKey" element={<ManagerDetail />} /></Routes>
+      </MemoryRouter>,
+    )
+
+    try {
+      await act(async () => { await Promise.resolve(); await Promise.resolve() })
+      expect(mocked.getManagerInboundStatus).toHaveBeenCalledTimes(1)
+      expect(mocked.listManagerEpisodes).toHaveBeenCalledTimes(1)
+
+      await act(async () => { await vi.advanceTimersByTimeAsync(2_000) })
+      expect(mocked.getManagerInboundStatus).toHaveBeenCalledTimes(2)
+      expect(mocked.listManagerEpisodes).toHaveBeenCalledTimes(2)
+
+      setVisibility('hidden')
+      await act(async () => { await vi.advanceTimersByTimeAsync(4_000) })
+      expect(mocked.getManagerInboundStatus).toHaveBeenCalledTimes(2)
+      expect(mocked.listManagerEpisodes).toHaveBeenCalledTimes(2)
+
+      setVisibility('visible')
+      await act(async () => {
+        document.dispatchEvent(new Event('visibilitychange'))
+        await Promise.resolve()
+      })
+      expect(mocked.getManagerInboundStatus).toHaveBeenCalledTimes(3)
+      expect(mocked.listManagerEpisodes).toHaveBeenCalledTimes(3)
+    } finally {
+      rendered.unmount()
+      if (originalVisibility) Object.defineProperty(document, 'visibilityState', originalVisibility)
+      else delete (document as { visibilityState?: string }).visibilityState
+      vi.useRealTimers()
+    }
+  })
+
+  it('上一轮刷新未结束时不发起重叠请求', async () => {
+    vi.useFakeTimers()
+    let resolveFirstInbound: ((result: ManagerInboundStatusResult) => void) | undefined
+    mocked.getManagerInboundStatus = vi.fn()
+      .mockImplementationOnce(() => new Promise<ManagerInboundStatusResult>((resolve) => {
+        resolveFirstInbound = resolve
+      }))
+      .mockResolvedValue({
+        manager_key: 'wechat::sess-1',
+        snapshot_at: '2026-09-05T06:28:22.000Z',
+        items: [],
+      })
+    mocked.listManagerEpisodes = vi.fn().mockResolvedValue({
+      items: [],
+      pagination: { page: 1, page_size: 20, total_items: 0, total_pages: 0 },
+    })
+    const rendered = render(
+      <MemoryRouter initialEntries={[`/traces/managers/${encodeURIComponent('wechat::sess-1')}`]}>
+        <Routes><Route path="/traces/managers/:managerKey" element={<ManagerDetail />} /></Routes>
+      </MemoryRouter>,
+    )
+
+    try {
+      await act(async () => { await Promise.resolve() })
+      expect(mocked.getManagerInboundStatus).toHaveBeenCalledTimes(1)
+
+      await act(async () => { await vi.advanceTimersByTimeAsync(6_000) })
+      expect(mocked.getManagerInboundStatus).toHaveBeenCalledTimes(1)
+      expect(mocked.listManagerEpisodes).toHaveBeenCalledTimes(1)
+
+      await act(async () => {
+        resolveFirstInbound?.({
+          manager_key: 'wechat::sess-1',
+          snapshot_at: '2026-09-05T06:28:21.000Z',
+          items: [],
+        })
+        await Promise.resolve()
+      })
+      await act(async () => { await vi.advanceTimersByTimeAsync(2_000) })
+      expect(mocked.getManagerInboundStatus).toHaveBeenCalledTimes(2)
+      expect(mocked.listManagerEpisodes).toHaveBeenCalledTimes(2)
+    } finally {
+      rendered.unmount()
+      vi.useRealTimers()
+    }
+  })
+
+  it('翻页后旧轮询响应不覆盖新页数据', async () => {
+    vi.useFakeTimers()
+    let resolveStaleInbound: ((result: ManagerInboundStatusResult) => void) | undefined
+    mocked.getManagerInboundStatus = vi.fn()
+      .mockResolvedValueOnce({
+        manager_key: 'wechat::sess-1',
+        snapshot_at: '2026-09-05T06:28:20.000Z',
+        items: [],
+      })
+      .mockImplementationOnce(() => new Promise<ManagerInboundStatusResult>((resolve) => {
+        resolveStaleInbound = resolve
+      }))
+      .mockResolvedValueOnce({
+        manager_key: 'wechat::sess-1',
+        snapshot_at: '2026-09-05T06:28:24.000Z',
+        items: [{
+          platform_message_id: 'pm-current', status: 'queued', preview: '第二页请求拿到的新快照',
+          platform_timestamp: '2026-09-05T06:28:23.000Z',
+        }],
+      })
+    mocked.listManagerEpisodes = vi.fn()
+      .mockResolvedValueOnce({
+        items: [{
+          trace_id: 'ep-page-1', manager_key: 'wechat::sess-1', started_at: '2026-09-05T06:20:00.000Z', status: 'completed',
+          trigger: { type: 'human_message', summary: '人类消息 x1：第一页初始记录' }, spans: [], spawned_worker_ids: [],
+        }],
+        pagination: { page: 1, page_size: 20, total_items: 21, total_pages: 2 },
+      })
+      .mockResolvedValueOnce({
+        items: [{
+          trace_id: 'ep-stale-poll', manager_key: 'wechat::sess-1', started_at: '2026-09-05T06:22:00.000Z', status: 'completed',
+          trigger: { type: 'human_message', summary: '人类消息 x1：不应回写的首页轮询' }, spans: [], spawned_worker_ids: [],
+        }],
+        pagination: { page: 1, page_size: 20, total_items: 21, total_pages: 2 },
+      })
+      .mockResolvedValueOnce({
+        items: [{
+          trace_id: 'ep-page-2', manager_key: 'wechat::sess-1', started_at: '2026-09-05T06:10:00.000Z', status: 'completed',
+          trigger: { type: 'human_message', summary: '人类消息 x1：第二页历史记录' }, spans: [], spawned_worker_ids: [],
+        }],
+        pagination: { page: 2, page_size: 20, total_items: 21, total_pages: 2 },
+      })
+    const rendered = render(
+      <MemoryRouter initialEntries={[`/traces/managers/${encodeURIComponent('wechat::sess-1')}`]}>
+        <Routes><Route path="/traces/managers/:managerKey" element={<ManagerDetail />} /></Routes>
+      </MemoryRouter>,
+    )
+
+    try {
+      await act(async () => { await Promise.resolve(); await Promise.resolve() })
+      expect(screen.getByText('你：「第一页初始记录」')).toBeInTheDocument()
+
+      await act(async () => { await vi.advanceTimersByTimeAsync(2_000) })
+      expect(mocked.getManagerInboundStatus).toHaveBeenCalledTimes(2)
+      fireEvent.click(screen.getByRole('button', { name: '下一页' }))
+      await act(async () => { await Promise.resolve(); await Promise.resolve() })
+
+      expect(screen.getByText('第二页请求拿到的新快照')).toBeInTheDocument()
+      expect(screen.getByText('你：「第二页历史记录」')).toBeInTheDocument()
+      expect(mocked.listManagerEpisodes).toHaveBeenLastCalledWith('wechat::sess-1', 2, 20)
+
+      await act(async () => {
+        resolveStaleInbound?.({
+          manager_key: 'wechat::sess-1',
+          snapshot_at: '2026-09-05T06:28:21.000Z',
+          items: [{
+            platform_message_id: 'pm-stale', status: 'processing', preview: '不应回写的旧快照',
+            platform_timestamp: '2026-09-05T06:28:06.000Z', episode_id: 'ep-stale-poll',
+          }],
+        })
+        await Promise.resolve()
+      })
+
+      expect(screen.getByText('第二页请求拿到的新快照')).toBeInTheDocument()
+      expect(screen.getByText('你：「第二页历史记录」')).toBeInTheDocument()
+      expect(screen.queryByText('不应回写的旧快照')).toBeNull()
+      expect(screen.queryByText('你：「不应回写的首页轮询」')).toBeNull()
+    } finally {
+      rendered.unmount()
+      vi.useRealTimers()
+    }
   })
 
   it('episode 渲染：trigger/状态/时间/spawned worker 链接', async () => {

--- a/crabot-admin/web/src/services/agent-observability.ts
+++ b/crabot-admin/web/src/services/agent-observability.ts
@@ -82,6 +82,21 @@ export interface ManagerEpisodeTrace {
   }
 }
 
+export interface ManagerInboundMessageSnapshot {
+  platform_message_id: string
+  status: 'queued' | 'processing'
+  preview: string
+  sender_display_name?: string
+  platform_timestamp: string
+  episode_id?: string
+}
+
+export interface ManagerInboundStatusResult {
+  manager_key: string
+  snapshot_at: string
+  items: ManagerInboundMessageSnapshot[]
+}
+
 // ── Worker（§8.3 台账 read model）──────────────────────────────
 
 // 2026-08-31 状态机修正:4 态。旧值(waiting_input/completed/failed/cancelled)仅存在于
@@ -214,6 +229,10 @@ export const agentObservabilityService = {
 
   listManagerEpisodes(managerKey: string, page = 1, pageSize = 20): Promise<PaginatedResult<ManagerEpisodeTrace>> {
     return api.get(`/agent/managers/${encodeURIComponent(managerKey)}/episodes?${qs(page, pageSize)}`)
+  },
+
+  getManagerInboundStatus(managerKey: string): Promise<ManagerInboundStatusResult> {
+    return api.get(`/agent/managers/${encodeURIComponent(managerKey)}/inbound-status`)
   },
 
   listWorkers(params: {

--- a/crabot-agent/src/manager/inbound-status.ts
+++ b/crabot-agent/src/manager/inbound-status.ts
@@ -1,0 +1,91 @@
+import type { ChannelMessage } from '../types.js'
+import type { ManagerKey } from './types.js'
+
+export type ManagerInboundMessageStatus = 'queued' | 'processing'
+
+/** 运行时所有者提供的内部事实；只在同步快照期间存活。 */
+export interface ManagerInboundMessageFact {
+  message: ChannelMessage
+  status: ManagerInboundMessageStatus
+  episode_id?: string
+}
+
+export interface ManagerInboundMessageSnapshot {
+  platform_message_id: string
+  status: ManagerInboundMessageStatus
+  preview: string
+  sender_display_name?: string
+  platform_timestamp: string
+  episode_id?: string
+}
+
+export interface GetManagerInboundStatusAdminParams {
+  manager_key: ManagerKey
+}
+
+export interface GetManagerInboundStatusAdminResult {
+  manager_key: ManagerKey
+  snapshot_at: string
+  items: ManagerInboundMessageSnapshot[]
+}
+
+const PREVIEW_MAX_CHARS = 180
+
+function messagePreview(message: ChannelMessage): string {
+  const marker = message.content.type === 'image'
+    ? '[图片]'
+    : message.content.type === 'file'
+      ? '[文件]'
+      : message.content.type === 'system_event'
+        ? '[系统事件]'
+        : ''
+  return [marker, message.content.text]
+    .filter((part): part is string => typeof part === 'string' && part.length > 0)
+    .join(' ')
+    .replace(/\s+/g, ' ')
+    .trim() || '[空消息]'
+}
+
+function truncatePreview(text: string): string {
+  const chars = Array.from(text)
+  return chars.length > PREVIEW_MAX_CHARS
+    ? `${chars.slice(0, PREVIEW_MAX_CHARS).join('')}…`
+    : text
+}
+
+/** 按协议完成脱敏、去重和稳定排序，不修改任何运行时容器或消息对象。 */
+export function projectManagerInboundMessages(
+  facts: ReadonlyArray<ManagerInboundMessageFact>,
+  redact: (text: string) => string,
+): ManagerInboundMessageSnapshot[] {
+  const selected = new Map<string, ManagerInboundMessageFact>()
+  for (const fact of facts) {
+    const id = fact.message.platform_message_id
+    const current = selected.get(id)
+    if (
+      current === undefined
+      || (fact.status === 'processing' && current.status === 'queued')
+      || (fact.status === current.status
+        && fact.message.platform_timestamp < current.message.platform_timestamp)
+    ) {
+      selected.set(id, fact)
+    }
+  }
+
+  return Array.from(selected.values())
+    .map(({ message, status, episode_id }) => {
+      const senderDisplayName = message.sender.platform_display_name.trim()
+      return {
+        platform_message_id: message.platform_message_id,
+        status,
+        preview: truncatePreview(redact(messagePreview(message))),
+        ...(senderDisplayName ? { sender_display_name: senderDisplayName } : {}),
+        platform_timestamp: message.platform_timestamp,
+        ...(status === 'processing' && episode_id ? { episode_id } : {}),
+      }
+    })
+    .sort((a, b) => (
+      a.platform_timestamp.localeCompare(b.platform_timestamp)
+      || a.platform_message_id.localeCompare(b.platform_message_id)
+    ))
+}

--- a/crabot-agent/src/manager/loop.ts
+++ b/crabot-agent/src/manager/loop.ts
@@ -73,6 +73,7 @@ import type { WorkerHarness } from '../workers/harness/harness'
 import type { ActivityContextAdmissionReceipt, HarnessEvent } from '../workers/harness/worker-events'
 import type { ChannelMessage, Friend, ResolvedPermissions } from '../types'
 import type { SessionTarget } from '../mcp/crab-messaging.js'
+import type { ManagerInboundMessageFact } from './inbound-status.js'
 
 const ASSISTANT_TEXT_END_TURN_REMINDER = '[系统提醒] 你刚才直接输出了一段文字、没有调用 send_message，然后结束了回复。\n'
   + '请注意：直接输出的文字只留在系统内部，人类看不到；只有 send_message 发送的内容才能送达人类。\n'
@@ -496,6 +497,38 @@ export class ManagerLoop {
    */
   get hasPendingMailbox(): boolean {
     return this.mailbox.hasPending
+  }
+
+  /** 当前人类入站事实的同步只读投影；不 drain mailbox，也不修改 episode 上下文。 */
+  snapshotHumanInbound(): ManagerInboundMessageFact[] {
+    const facts: ManagerInboundMessageFact[] = []
+    const pending = new Set(this.mailbox.snapshotPendingEnvelopes())
+    const append = (
+      envelope: TimedWakeEnvelope,
+      status: ManagerInboundMessageFact['status'],
+      episodeId?: string,
+    ): void => {
+      if (!isHumanWake(envelope.wake)) return
+      for (const message of envelope.wake.messages) {
+        facts.push({
+          message,
+          status,
+          ...(status === 'processing' && episodeId ? { episode_id: episodeId } : {}),
+        })
+      }
+    }
+
+    if (this.currentTraceId) {
+      for (const envelope of this.currentEpisodeEnvelopes) {
+        append(envelope, 'processing', this.currentTraceId)
+      }
+    }
+    for (const envelope of this.currentEpisodeInjected ?? []) {
+      if (pending.delete(envelope)) append(envelope, 'queued')
+      else if (this.currentTraceId) append(envelope, 'processing', this.currentTraceId)
+    }
+    for (const envelope of pending) append(envelope, 'queued')
+    return facts
   }
 
   /** A failed final episode returns late activity receipts to their durable Harness producer. */
@@ -1821,6 +1854,10 @@ class TimedWakeMailbox implements HumanMessageQueueLike {
     const drained = this.pending
     this.pending = []
     return drained
+  }
+
+  snapshotPendingEnvelopes(): TimedWakeEnvelope[] {
+    return [...this.pending]
   }
 
   /** 该 envelope 是否仍在等待注入(引用比较)。收尾提交用它区分「已被 drain 消费/未消费」。 */

--- a/crabot-agent/src/manager/registry.ts
+++ b/crabot-agent/src/manager/registry.ts
@@ -44,6 +44,7 @@ import type { ChannelMessage, Friend, ResolvedPermissions } from '../types'
 import type { SessionTarget } from '../mcp/crab-messaging.js'
 import type { HumanPrincipal } from './principal.js'
 import { resolveTimezone } from '../utils/time.js'
+import type { ManagerInboundMessageFact } from './inbound-status.js'
 
 /** §4.4 保留线程:未配置目标 session 的 scheduled 触发 / 台账查不到监护 session 的 worker 事件落此。 */
 export const SYSTEM_TASKS_MANAGER_KEY = 'admin-web::system-tasks' as ManagerKey
@@ -217,6 +218,11 @@ export class ManagerRegistry {
   /** 内存 registry 当前 running manager 的只读快照（P6-A §7.3：补充尚未首次 save 的当前 manager）。 */
   listActiveManagers(): Array<{ key: ManagerKey; lastActiveAtMs?: number }> {
     return Array.from(this.loops.keys()).map((key) => ({ key, lastActiveAtMs: this.lastActiveAtMs.get(key) }))
+  }
+
+  /** 不创建 loop；只读取 exact ManagerKey 当前内存上下文与 mailbox。 */
+  snapshotHumanInbound(key: ManagerKey): ManagerInboundMessageFact[] {
+    return this.loops.get(key)?.snapshotHumanInbound() ?? []
   }
 
   /** 惰性拉起:key 无实例则建;同 key 幂等返回同一实例。实例常驻内存,session 状态在盘上。 */

--- a/crabot-agent/src/orchestration/attention-scheduler.ts
+++ b/crabot-agent/src/orchestration/attention-scheduler.ts
@@ -129,6 +129,11 @@ export class AttentionScheduler {
     return this.states.get(sessionId)?.buffer.length ?? 0
   }
 
+  /** Admin 可观测性只读快照：复制数组，不创建状态、不消费消息。 */
+  snapshotBuffer(sessionId: SessionId): BufferedMessage[] {
+    return [...(this.states.get(sessionId)?.buffer ?? [])]
+  }
+
   private getOrCreateState(sessionId: SessionId): SessionAttentionState {
     let state = this.states.get(sessionId)
     if (!state) {

--- a/crabot-agent/src/orchestration/session-lane.ts
+++ b/crabot-agent/src/orchestration/session-lane.ts
@@ -9,8 +9,14 @@
 
 export type BatchHandler<T> = (batch: ReadonlyArray<T>) => Promise<void>
 
+export interface SessionLaneSnapshot<T> {
+  current: T[]
+  queued: T[]
+}
+
 export class SessionLane<T> {
   private queue: T[] = []
+  private current: ReadonlyArray<T> = []
   private processing = false
 
   constructor(
@@ -28,17 +34,25 @@ export class SessionLane<T> {
     return !this.processing && this.queue.length === 0
   }
 
+  /** 当前 handler batch 与后续 queue 的同步副本；读取不改变 lane 顺序。 */
+  snapshot(): SessionLaneSnapshot<T> {
+    return { current: [...this.current], queued: [...this.queue] }
+  }
+
   private async kick(): Promise<void> {
     if (this.processing) return
     this.processing = true
     try {
       while (this.queue.length > 0) {
         const batch = this.queue.splice(0)
+        this.current = batch
         try {
           await this.handler(batch)
         } catch (err) {
           // handler 内部应该自己 catch；这里只防御性兜底
           console.error(`[session-lane:${this.key}] handler threw:`, err instanceof Error ? err.message : String(err))
+        } finally {
+          this.current = []
         }
       }
     } finally {
@@ -60,6 +74,10 @@ export class SessionLaneRegistry<T> {
       this.lanes.set(key, lane)
     }
     return lane
+  }
+
+  snapshot(key: string): SessionLaneSnapshot<T> {
+    return this.lanes.get(key)?.snapshot() ?? { current: [], queued: [] }
   }
 
   private dispose(key: string): void {

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -152,6 +152,12 @@ import {
 import { applyStatusTransition, isDecisionVisibleWorker } from './workers/harness/task-status.js'
 import { SYSTEM_TASKS_MANAGER_KEY } from './manager/registry.js'
 import { splitManagerKey } from './manager/principal.js'
+import {
+  projectManagerInboundMessages,
+  type GetManagerInboundStatusAdminParams,
+  type GetManagerInboundStatusAdminResult,
+  type ManagerInboundMessageFact,
+} from './manager/inbound-status.js'
 
 const BARRIER_TIMEOUT_MS = 8_000
 const CLI_SUBAGENT_HARVEST_DELAY_MS = 30_000
@@ -1489,6 +1495,7 @@ export class UnifiedAgent extends ModuleBase {
     this.registerMethod('inspect_worker_implementation_bootstrap', this.handleInspectWorkerBootstrap.bind(this))
     this.registerMethod('commit_worker_implementation_bootstrap', this.handleCommitWorkerBootstrap.bind(this))
     this.registerMethod('list_manager_episodes_admin', this.handleListManagerEpisodesAdmin.bind(this))
+    this.registerMethod('get_manager_inbound_status_admin', this.handleGetManagerInboundStatusAdmin.bind(this))
     this.registerMethod('get_worker_detail', this.handleGetWorkerDetail.bind(this))
     this.registerMethod('get_worker_terminal', this.handleGetWorkerTerminal.bind(this))
     this.registerMethod('get_worker_trace', this.handleGetWorkerTrace.bind(this))
@@ -3673,6 +3680,45 @@ export class UnifiedAgent extends ModuleBase {
           : undefined
         return withCausalParent(episode, parent)
       }),
+    }
+  }
+
+  /** §8.4：聚合既有 buffer/lane/Manager 上下文的同步只读入站快照。 */
+  private async handleGetManagerInboundStatusAdmin(
+    params: GetManagerInboundStatusAdminParams,
+  ): Promise<GetManagerInboundStatusAdminResult> {
+    const stack = this.requireManagerStack()
+    if (!params || typeof params.manager_key !== 'string' || params.manager_key.length === 0) {
+      throw new Error('manager_key is required')
+    }
+    const { channelId, sessionId } = splitManagerKey(params.manager_key)
+    const facts: ManagerInboundMessageFact[] = []
+    const addQueued = (messages: ReadonlyArray<ChannelMessage>): void => {
+      for (const message of messages) {
+        if (message.session.channel_id === channelId && message.session.session_id === sessionId) {
+          facts.push({ message, status: 'queued' })
+        }
+      }
+    }
+
+    addQueued(this.attentionScheduler.snapshotBuffer(sessionId).map(({ message }) => message))
+    const direct = this.directLaneRegistry.snapshot(params.manager_key)
+    addQueued([...direct.current, ...direct.queued].map(({ message }) => message))
+    const group = this.groupLaneRegistry.snapshot(params.manager_key)
+    addQueued(
+      [...group.current, ...group.queued]
+        .flatMap(({ messages }) => messages)
+        .map(({ message }) => message),
+    )
+    facts.push(...stack.registry.snapshotHumanInbound(params.manager_key))
+
+    return {
+      manager_key: params.manager_key,
+      snapshot_at: new Date().toISOString(),
+      items: projectManagerInboundMessages(
+        facts,
+        (text) => redactSecrets(text, [...this.knownSecrets]),
+      ),
     }
   }
 

--- a/crabot-agent/tests/manager/inbound-status.test.ts
+++ b/crabot-agent/tests/manager/inbound-status.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  projectManagerInboundMessages,
+  type ManagerInboundMessageFact,
+} from '../../src/manager/inbound-status.js'
+import type { ChannelMessage } from '../../src/types.js'
+
+function message(p: {
+  id: string
+  timestamp: string
+  text?: string
+  type?: ChannelMessage['content']['type']
+  sender?: string
+}): ChannelMessage {
+  return {
+    platform_message_id: p.id,
+    session: { session_id: 'sess-1', channel_id: 'wechat', type: 'private' },
+    sender: { platform_user_id: 'u-1', platform_display_name: p.sender ?? '测试用户' },
+    content: { type: p.type ?? 'text', ...(p.text === undefined ? {} : { text: p.text }) },
+    features: { is_mention_crab: false },
+    platform_timestamp: p.timestamp,
+  }
+}
+
+describe('projectManagerInboundMessages', () => {
+  it('按消息 ID 去重，processing 优先，并按平台时间与 ID 稳定升序', () => {
+    const queuedDuplicate = message({
+      id: 'pm-b',
+      timestamp: '2026-09-05T06:28:15.000Z',
+      text: '仍在 lane',
+    })
+    const processingDuplicate = { ...queuedDuplicate, platform_timestamp: '2026-09-05T06:28:16.000Z' }
+    const facts: ManagerInboundMessageFact[] = [
+      { message: message({ id: 'pm-c', timestamp: '2026-09-05T06:28:20.000Z', text: '最后到达' }), status: 'queued' },
+      { message: queuedDuplicate, status: 'queued' },
+      { message: processingDuplicate, status: 'processing', episode_id: 'ep-running' },
+      { message: message({ id: 'pm-a', timestamp: '2026-09-05T06:28:15.000Z', text: '同秒更早 ID' }), status: 'queued' },
+    ]
+
+    const result = projectManagerInboundMessages(facts, (text) => text)
+
+    expect(result.map((item) => item.platform_message_id)).toEqual(['pm-a', 'pm-b', 'pm-c'])
+    expect(result[1]).toMatchObject({
+      status: 'processing',
+      episode_id: 'ep-running',
+      platform_timestamp: '2026-09-05T06:28:16.000Z',
+    })
+  })
+
+  it('同状态重复项保留更早平台时间，不修改输入消息', () => {
+    const later = message({ id: 'pm-1', timestamp: '2026-09-05T06:28:20.000Z', text: 'later' })
+    const earlier = message({ id: 'pm-1', timestamp: '2026-09-05T06:28:10.000Z', text: 'earlier' })
+    const facts: ManagerInboundMessageFact[] = [
+      { message: later, status: 'queued' },
+      { message: earlier, status: 'queued' },
+    ]
+
+    expect(projectManagerInboundMessages(facts, (text) => text)[0]).toMatchObject({
+      platform_timestamp: '2026-09-05T06:28:10.000Z',
+      preview: 'earlier',
+    })
+    expect(later.content.text).toBe('later')
+    expect(earlier.content.text).toBe('earlier')
+  })
+
+  it('只输出脱敏截断预览与媒体类型标记，不泄漏消息 payload 字段', () => {
+    const secret = 'secret-value-123456'
+    const longText = `  请使用 ${secret}\n${'很长内容 '.repeat(80)}`
+    const facts: ManagerInboundMessageFact[] = [{
+      message: message({ id: 'pm-image', timestamp: '2026-09-05T06:28:20.000Z', text: longText, type: 'image', sender: ' 风言 ' }),
+      status: 'queued',
+    }]
+
+    const [item] = projectManagerInboundMessages(facts, (text) => text.replace(secret, '[REDACTED]'))
+
+    expect(item.preview).toMatch(/^\[图片\] 请使用 \[REDACTED\]/)
+    expect(item.preview.endsWith('…')).toBe(true)
+    expect(Array.from(item.preview).length).toBeLessThanOrEqual(181)
+    expect(item.sender_display_name).toBe('风言')
+    expect(item).not.toHaveProperty('content')
+    expect(item).not.toHaveProperty('sender')
+    expect(item).not.toHaveProperty('session')
+  })
+})

--- a/crabot-agent/tests/manager/loop.test.ts
+++ b/crabot-agent/tests/manager/loop.test.ts
@@ -957,6 +957,69 @@ describe('ManagerLoop', () => {
     expect(committedIds).toHaveLength(1)
   })
 
+  it('只读快照将当前上下文标为 processing，mailbox 插话在 drain 前后从 queued 转为 processing', async () => {
+    let releaseSecondTurn!: () => void
+    const secondTurnRelease = new Promise<void>((resolve) => { releaseSecondTurn = resolve })
+    let enterSecondTurn!: () => void
+    const secondTurnEntered = new Promise<void>((resolve) => { enterSecondTurn = resolve })
+    let turn = 0
+    let loop!: ManagerLoop
+    let initialSnapshot: ReturnType<ManagerLoop['snapshotHumanInbound']> = []
+    let queuedSnapshot: ReturnType<ManagerLoop['snapshotHumanInbound']> = []
+    let drainedSnapshot: ReturnType<ManagerLoop['snapshotHumanInbound']> = []
+
+    const first = { ...makeChannelMessage('开始任务'), platform_message_id: 'pm-first' }
+    const supplement = { ...makeChannelMessage('中途补充'), platform_message_id: 'pm-supplement' }
+    const adapter: LLMAdapter = {
+      async *stream() {
+        turn++
+        if (turn === 1) {
+          initialSnapshot = loop.snapshotHumanInbound()
+          yield* chunksFromContent([
+            { type: 'tool_use', id: 'call-snapshot', name: 'snapshot_tool', input: {} },
+          ], 'tool_use', { inputTokens: 10, outputTokens: 5 })
+          return
+        }
+        drainedSnapshot = loop.snapshotHumanInbound()
+        enterSecondTurn()
+        await secondTurnRelease
+        yield* chunksFromContent([], 'end_turn', { inputTokens: 10, outputTokens: 5 })
+      },
+      updateConfig: () => {},
+    }
+    loop = new ManagerLoop(baseDeps({
+      store,
+      adapter,
+      toolFace: () => [{
+        name: 'snapshot_tool',
+        description: 'capture mailbox state',
+        inputSchema: { type: 'object', properties: {} },
+        isReadOnly: false,
+        call: async () => {
+          loop.enqueueHumanWakeDuringActiveEpisode(timed({ kind: 'human_messages', messages: [supplement] }))
+          queuedSnapshot = loop.snapshotHumanInbound()
+          return { output: 'ok', isError: false }
+        },
+      }],
+    }))
+
+    const episode = loop.wakeUp(timed({ kind: 'human_messages', messages: [first] }))
+    await secondTurnEntered
+
+    const initial = initialSnapshot.find(({ message }) => message.platform_message_id === 'pm-first')
+    const queued = queuedSnapshot.find(({ message }) => message.platform_message_id === 'pm-supplement')
+    const drained = drainedSnapshot.find(({ message }) => message.platform_message_id === 'pm-supplement')
+    expect(initial).toMatchObject({ status: 'processing', episode_id: expect.any(String) })
+    expect(queued).toMatchObject({ status: 'queued' })
+    expect(queued).not.toHaveProperty('episode_id')
+    expect(drained).toMatchObject({ status: 'processing', episode_id: initial?.episode_id })
+    expect(loop.snapshotHumanInbound()).toEqual(drainedSnapshot)
+
+    releaseSecondTurn()
+    await episode
+    expect(loop.snapshotHumanInbound()).toEqual([])
+  })
+
   it('episode 失败:被注入消费的人类消息补提交进 recent,下次唤醒经 tailMessages 重新可见且不重复', async () => {
     const { adapter, queue } = makeAdapter()
     queue.push({ toolCalls: [{ name: 'noop_tool', id: 'call_1', input: {} }], stopReason: 'tool_use' })

--- a/crabot-agent/tests/manager/rpc-handlers.test.ts
+++ b/crabot-agent/tests/manager/rpc-handlers.test.ts
@@ -39,6 +39,7 @@ import type {
   GetWorkerSubagentTraceResult,
 } from '../../src/manager/read-model.js'
 import type { TriggerScheduleParams, TriggerScheduleResult } from '../../src/unified-agent.js'
+import type { ChannelMessage } from '../../src/types.js'
 
 // ============================================================================
 // helpers
@@ -1519,6 +1520,7 @@ describe('manager 读模型 RPC（P6-A §7/§8.4）', () => {
     return agent as unknown as {
       handleListManagersAdmin(p: unknown): Promise<unknown>
       handleListManagerEpisodesAdmin(p: unknown): Promise<unknown>
+      handleGetManagerInboundStatusAdmin(p: unknown): Promise<unknown>
     }
   }
 
@@ -1543,6 +1545,7 @@ describe('manager 读模型 RPC（P6-A §7/§8.4）', () => {
     const agent = buildAgentWithTraceStack({ noStack: true })
     await expect(agent.handleListManagersAdmin({})).rejects.toThrow('Manager stack not initialized')
     await expect(agent.handleListManagerEpisodesAdmin({ manager_key: 'wechat::sess-a' })).rejects.toThrow('Manager stack not initialized')
+    await expect(agent.handleGetManagerInboundStatusAdmin({ manager_key: 'wechat::sess-a' })).rejects.toThrow('Manager stack not initialized')
   })
 
   it('list_manager_episodes_admin 按 exact key 透传 TraceStore 分页', async () => {
@@ -1562,6 +1565,101 @@ describe('manager 读模型 RPC（P6-A §7/§8.4）', () => {
     expect(result.pagination.page).toBe(2)
     expect(seen).toEqual([['wechat::sess-a', { page: 2, page_size: 5 }]])
     await expect(agent.handleListManagerEpisodesAdmin({ manager_key: '' })).rejects.toThrow('manager_key')
+  })
+
+  it('get_manager_inbound_status_admin 聚合运行时所有者，exact 过滤、processing 去重并脱敏', async () => {
+    const makeMessage = (p: {
+      id: string
+      channel?: string
+      timestamp: string
+      text: string
+    }): ChannelMessage => ({
+      platform_message_id: p.id,
+      session: { session_id: 'sess-a', channel_id: p.channel ?? 'wechat', type: 'private' },
+      sender: { platform_user_id: `user-${p.id}`, platform_display_name: '测试用户' },
+      content: { type: 'text', text: p.text, file_path: '/private/hidden' },
+      features: { is_mention_crab: false },
+      platform_timestamp: p.timestamp,
+    })
+    const duplicate = makeMessage({
+      id: 'pm-duplicate',
+      timestamp: '2026-09-05T06:28:15.000Z',
+      text: 'token secret-value-123456',
+    })
+    const queued = makeMessage({
+      id: 'pm-queued',
+      timestamp: '2026-09-05T06:28:20.000Z',
+      text: '仍在排队',
+    })
+    const attentionQueued = makeMessage({
+      id: 'pm-attention',
+      timestamp: '2026-09-05T06:28:21.000Z',
+      text: '仍在注意力缓冲',
+    })
+    const groupQueued = makeMessage({
+      id: 'pm-group',
+      timestamp: '2026-09-05T06:28:22.000Z',
+      text: '仍在群聊 lane',
+    })
+    const foreign = makeMessage({
+      id: 'pm-foreign',
+      channel: 'feishu',
+      timestamp: '2026-09-05T06:28:10.000Z',
+      text: '其它渠道',
+    })
+    const agent = buildAgentWithTraceStack({}) as unknown as Record<string, any>
+    agent.knownSecrets = new Set(['secret-value-123456'])
+    agent.attentionScheduler = {
+      snapshotBuffer: vi.fn(() => [{ message: foreign, friend: {} }, { message: attentionQueued, friend: {} }]),
+    }
+    agent.directLaneRegistry = {
+      snapshot: vi.fn(() => ({ current: [{ message: duplicate, friend: {} }], queued: [{ message: queued, friend: {} }] })),
+    }
+    agent.groupLaneRegistry = {
+      snapshot: vi.fn(() => ({ current: [{ messages: [{ message: groupQueued, friend: {} }], sessionId: 'sess-a' }], queued: [] })),
+    }
+    agent.managerStack.registry.snapshotHumanInbound = vi.fn(() => [{
+      message: duplicate,
+      status: 'processing',
+      episode_id: 'ep-running',
+    }])
+
+    const result = await agent.handleGetManagerInboundStatusAdmin({ manager_key: 'wechat::sess-a' })
+
+    expect(result).toMatchObject({
+      manager_key: 'wechat::sess-a',
+      snapshot_at: expect.any(String),
+      items: [
+        {
+          platform_message_id: 'pm-duplicate',
+          status: 'processing',
+          preview: 'token [REDACTED]',
+          episode_id: 'ep-running',
+        },
+        {
+          platform_message_id: 'pm-queued',
+          status: 'queued',
+          preview: '仍在排队',
+        },
+        {
+          platform_message_id: 'pm-attention',
+          status: 'queued',
+          preview: '仍在注意力缓冲',
+        },
+        {
+          platform_message_id: 'pm-group',
+          status: 'queued',
+          preview: '仍在群聊 lane',
+        },
+      ],
+    })
+    expect(JSON.stringify(result)).not.toContain('/private/hidden')
+    expect(JSON.stringify(result)).not.toContain('user-pm')
+    expect(agent.attentionScheduler.snapshotBuffer).toHaveBeenCalledWith('sess-a')
+    expect(agent.directLaneRegistry.snapshot).toHaveBeenCalledWith('wechat::sess-a')
+    expect(agent.groupLaneRegistry.snapshot).toHaveBeenCalledWith('wechat::sess-a')
+    expect(agent.managerStack.registry.snapshotHumanInbound).toHaveBeenCalledWith('wechat::sess-a')
+    await expect(agent.handleGetManagerInboundStatusAdmin({ manager_key: '' })).rejects.toThrow('manager_key')
   })
 
   it('worker_event 的 spawn 父 episode 跨分页时返回 causal_parent', async () => {

--- a/crabot-agent/tests/orchestration/attention-scheduler.test.ts
+++ b/crabot-agent/tests/orchestration/attention-scheduler.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { AttentionScheduler } from '../../src/orchestration/attention-scheduler.js'
+import type { ChannelMessage, Friend } from '../../src/types.js'
+
+function message(id: string, text: string): ChannelMessage {
+  return {
+    platform_message_id: id,
+    session: { session_id: 'group-1', channel_id: 'feishu-fengyan', type: 'group' },
+    sender: { platform_user_id: 'u-1', platform_display_name: '风言' },
+    content: { type: 'text', text },
+    features: { is_mention_crab: false },
+    platform_timestamp: '2026-09-05T06:28:20.000Z',
+  }
+}
+
+describe('AttentionScheduler snapshot', () => {
+  it('返回 buffer 浅拷贝，读取和修改返回数组都不消费原队列', () => {
+    const flush = vi.fn(async () => undefined)
+    const scheduler = new AttentionScheduler(
+      { group_attention_min_ms: 60_000, group_attention_max_ms: 60_000 },
+      flush,
+    )
+    const first = message('pm-1', '第一条')
+    const second = message('pm-2', '第二条')
+    scheduler.enqueue('group-1', first, {} as Friend)
+    scheduler.enqueue('group-1', second, {} as Friend)
+
+    const snapshot = scheduler.snapshotBuffer('group-1')
+    expect(snapshot.map(({ message: item }) => item.platform_message_id)).toEqual(['pm-1', 'pm-2'])
+    snapshot.reverse()
+
+    expect(scheduler.snapshotBuffer('group-1').map(({ message: item }) => item.platform_message_id))
+      .toEqual(['pm-1', 'pm-2'])
+    expect(scheduler.getBufferSize('group-1')).toBe(2)
+    expect(flush).not.toHaveBeenCalled()
+    scheduler.stopAll()
+  })
+
+  it('未知 session 返回空数组且不创建状态', () => {
+    const scheduler = new AttentionScheduler(
+      { group_attention_min_ms: 60_000, group_attention_max_ms: 60_000 },
+      async () => undefined,
+    )
+    expect(scheduler.snapshotBuffer('missing')).toEqual([])
+    expect(scheduler.getBufferSize('missing')).toBe(0)
+  })
+})

--- a/crabot-agent/tests/orchestration/session-lane.test.ts
+++ b/crabot-agent/tests/orchestration/session-lane.test.ts
@@ -100,6 +100,36 @@ describe('SessionLane', () => {
     // 第二批应该是 b/c/d 合并
     expect(calls).toEqual([['a'], ['b', 'c', 'd']])
   })
+
+  it('snapshot 同时返回当前 batch 和后续队列，读取不消费或重排', async () => {
+    let release: () => void = () => {}
+    const blocker = new Promise<void>(resolve => { release = resolve })
+    const calls: string[][] = []
+    const lane = new SessionLane<string>(
+      'k',
+      async (batch) => {
+        calls.push([...batch])
+        if (calls.length === 1) await blocker
+      },
+      vi.fn(),
+    )
+
+    lane.enqueue('a')
+    await new Promise(setImmediate)
+    lane.enqueue('b')
+    lane.enqueue('c')
+
+    const snapshot = lane.snapshot()
+    expect(snapshot).toEqual({ current: ['a'], queued: ['b', 'c'] })
+    snapshot.current.splice(0)
+    snapshot.queued.reverse()
+
+    expect(lane.snapshot()).toEqual({ current: ['a'], queued: ['b', 'c'] })
+    release()
+    await new Promise(setImmediate)
+    await new Promise(setImmediate)
+    expect(calls).toEqual([['a'], ['b', 'c']])
+  })
 })
 
 describe('SessionLaneRegistry', () => {
@@ -141,5 +171,20 @@ describe('SessionLaneRegistry', () => {
     const second = registry.getOrCreate('k')
     expect(second).not.toBe(first)
     expect(registry.size()).toBe(1)
+  })
+
+  it('snapshot 只读取 exact key，未知或已注销 lane 返回空快照', async () => {
+    let release: () => void = () => {}
+    const blocker = new Promise<void>(resolve => { release = resolve })
+    const registry = new SessionLaneRegistry<string>(async () => blocker)
+    registry.getOrCreate('target').enqueue('a')
+    await new Promise(setImmediate)
+
+    expect(registry.snapshot('target')).toEqual({ current: ['a'], queued: [] })
+    expect(registry.snapshot('other')).toEqual({ current: [], queued: [] })
+
+    release()
+    await new Promise(setImmediate)
+    expect(registry.snapshot('target')).toEqual({ current: [], queued: [] })
   })
 })


### PR DESCRIPTION
## 需求\n\n在 Manager 会话详情中，把排队中、正在处理和已处理活动合并成按事件时间倒序的统一时间流。“正在处理”严格表示消息已进入尚未结束的 Manager episode 上下文，不新增状态记录，也不以 Provider 请求准入为条件。\n\n## 实现\n\n- 从 AttentionScheduler、SessionLane 和 ManagerLoop 当前上下文同步只读投影 queued / processing\n- 按 exact ManagerKey 聚合，按 platform_message_id 去重，processing 优先；预览脱敏并截断\n- 新增 get_manager_inbound_status_admin 与 GET /api/agent/managers/:managerKey/inbound-status\n- 会话详情每 2 秒非重叠刷新；隐藏页暂停，恢复后立即刷新，隔离旧响应\n- running episode 与对应 processing 消息去重；快照失败时保留历史并明确显示状态未知\n\n## 契约\n\n- 已确认 spec 与 agent-v3 3.9.2：crabot-docs d44dc8e\n\n## 验证\n\n- Agent 定向测试：141/141\n- Admin API：72/72\n- Web：20/20\n- Agent / Admin / Web TypeScript 检查通过\n- Agent / Admin / Web 生产构建通过\n- Playwright：1440x1000、390x844；无横向溢出、重叠、裁切、页面错误或未知 API 请求\n\n## 新增失败路径与收口\n\n- Agent/RPC 不可用：页面显示“在途状态暂不可用”，不把失败伪装成空队列，历史仍保留\n- 单轮轮询未结束：跳过下一 tick，避免请求重叠\n- 页面隐藏、卸载、切换 ManagerKey 或翻页：暂停或取消状态写回，旧响应不能覆盖当前页面\n