### PR TITLE
fix(manager): 补齐重启续跑并展示处理中的已回复进展

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5,6 +5,17 @@
 
 ## 当前状态
 
+### Manager 重启续跑与处理中回复展示：实现与定向验证完成，待合入
+
+- 补齐 Manager 的 Engine 检查点与启动恢复接线；Worker 启动对账后沿用原会话、episode 和唤醒身份续跑，
+  保留完成的工具结果、排队/已消费插话及图片引用。未知工具结果明确 interrupted，恢复机制不直接重执行。
+- 在途消息合并 episode 后继续展示真实回复和后续动作；同轮已回复但未结束时显示“本轮已回复，继续处理”。
+- 修复 Engine 下一次 LLM 前 messagesRef 未刷新造成的插话快照遗漏；有效检查点不再因 Agent 重启一律 failed。
+  无检查点的旧中断记录仍据实收口，既有终态不重放。
+- 已覆盖首次 LLM 前中断、已发送结果、连续重启、排队/图片插话、原发起人权限、续跑失败及启动顺序。
+  Agent 类型检查、前端 21 项测试与构建通过，桌面/手机 Playwright 状态切换通过。
+  扩大检查中的 7 项失败均在未修改基线复现（6 项缺失 tmp-page 测试 fixture、1 项工具面调用次数断言）。
+
 ### Manager 取消按空闲时间提前压缩：实现完成，待合入
 
 - 取消空闲超过 5 分钟且旧历史超过 20K tokens 时的 `fold_at_wake`；保留完整请求容量压缩、
@@ -500,7 +511,7 @@
 - **Worker/subagent trace 写点的同类硬截断**：`agent-handler.ts`（`.slice(0, 200/500)`）与 `unified-agent.ts`（`.slice(0, 300)`）对工具 span 摘要仍用整段硬截，与已修复的 manager episode span 同模式；目前无消费方受害（episode 投影不读这些 trace），若未来对其启用结构化提取应先改造为 `span-summary.ts` 的字段级截断（2026-08-27，`7cd86abf`）。
 - **Worker 巡检调度收口**：启动对账与周期巡检应共享 due 投递排他；避免单个 Worker 的长锁阻塞全局活性巡检；默认巡检在全局 LLM 故障时需要有界的失败告警去重/退避。三项均需独立设计，不纳入当前任务巡检 PR。
 - **移除 Agent 内部 legacy `roles` seam**：`AgentLayerConfig.roles` 是 v2 前多 Agent 时代残留（正式协议从未包含），现仅作内部测试 seam/恒真分支；应替换为显式的 worker-layer 开关后删除。
-- **普通 Channel 未消费人类 wake 的跨重启恢复**：2026-08-19 实测，飞书私聊消息已落 Channel journal、reaction 已发且同 session Manager episode 已创建，但 Agent 在首次 LLM 调用前 OOM 重启；启动恢复只将遗留 episode 标为 `interrupted`，未将该 wake 重放，后续 worker 事件遂基于旧上下文回复。需独立设计普通 Channel 的持久化入站 wake、成功消费后结算、重启按原始顺序幂等重放；不得用扩大 Manager recent、滚动摘要或 prompt 约束替代。
+- **普通 Channel 在 Manager 接收前的跨重启恢复**：未进入 Manager 的 Channel/lane 内存缓冲仍不在本次检查点覆盖范围；若需保证这一阶段跨进程投递，另行处理。2026-09-06 核对确认已提交的原始人类输入保留在 Manager history，缺失的是未完成 episode 主动续跑，见当前修复。
 - 失败 Manager episode 的通用带退避 mailbox retry；跨 session 代发目标 Manager 持久注记（§4.2）；Codex provision `auth.json` 错误吞没；P8 调试工具/内部文档重写。
 - Claude project-scope MCP 文件（已接受边界）；权限 schema 纪律（新增 schema 前先迁移历史 worker context）。
 - Admin source manager 的完整两阶段回滚：当前 mutation 源写入失败且内存态已推进时，靠重启恢复 fail-loud 兜底；各 manager 的事务性回滚（磁盘为准）另行设计。

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,6 +1,6 @@
 # Crabot 项目进度
 
-> 最后整理：2026-09-06
+> 最后整理：2026-09-07
 > 本文件只保留当前状态、明确 follow-up 和阶段性里程碑；详细实施流水、逐轮 review 与历史测试输出见 Git 历史。压缩前完整版本可用 `git show 49b9cb4:PROGRESS.md` 查看。
 
 ## 当前状态
@@ -13,6 +13,8 @@
 - 修复 Engine 下一次 LLM 前 messagesRef 未刷新造成的插话快照遗漏；有效检查点不再因 Agent 重启一律 failed。
   无检查点的旧中断记录仍据实收口，既有终态不重放。
 - 已覆盖首次 LLM 前中断、已发送结果、连续重启、排队/图片插话、原发起人权限、续跑失败及启动顺序。
+  PR review 补齐工具结果并入历史的检查点边界与本轮人类输入的压缩保护；溢出重试、压缩后连续重启及
+  插话消息 ID 重建回归通过，后端定向 192 项通过。
   Agent 类型检查、前端 21 项测试与构建通过，桌面/手机 Playwright 状态切换通过。
   扩大检查中的 7 项失败均在未修改基线复现（6 项缺失 tmp-page 测试 fixture、1 项工具面调用次数断言）。
 
@@ -433,6 +435,10 @@
 - PR #76～#89 完成 CLI worker 输入/活性/权限/ManagerKey、legacy loop 退役、bg-shell durable notification、worker-scoped MCP、Admin Chat assertion、会话隔离与 v2 只读导入；生产切换见里程碑归档（`git show 49b9cb4:PROGRESS.md` 有完整细节）。
 
 ## 当前 follow-up
+
+- **Manager 重启续跑 PR #147 review（非阻塞）**：身份绑定存储异常下恢复准入的失败收口、启动对账中
+  关停时恢复 gate 的释放、磁盘异常下邮箱入队与重投的原子性，以及大上下文同步检查点写入的性能测量。
+  投递成功但结果未落盘仍属于 interrupted/unknown，恢复不承诺外部副作用 exactly-once。
 
 - **任务板 Admin Web 共管 review 遗留（均非阻塞）**：①任务板 notice 派发已失败后，重试调度本身若再读写
   `workboard.json` 失败会产生未处理 Promise；②中途注入失败后的同进程重投只依赖下次唤醒或重启；③大量

--- a/crabot-admin/web/src/pages/Traces/ManagerDetail.tsx
+++ b/crabot-admin/web/src/pages/Traces/ManagerDetail.tsx
@@ -267,12 +267,18 @@ function InboundEntry({
   item,
   queuePosition,
   snapshotAt,
+  activity,
+  runningWorkerIds,
 }: {
   item: ManagerInboundMessageSnapshot
   queuePosition?: number
   snapshotAt: string
+  activity?: GroupedEpisode
+  runningWorkerIds: ReadonlySet<string>
 }) {
   const processing = item.status === 'processing'
+  let statusLabel = processing ? '正在处理' : '排队中'
+  if (processing && activity?.episode.reply_excerpt) statusLabel = '本轮已回复，继续处理'
   const statusMeta = processing
     ? elapsedLabel(item.platform_timestamp, snapshotAt)
     : `第 ${queuePosition ?? 1} 位 · ${elapsedLabel(item.platform_timestamp, snapshotAt)}`
@@ -284,7 +290,7 @@ function InboundEntry({
           <div className="manager-detail__event-labels">
             <span className="manager-detail__event-status">
               <span className="manager-detail__status-dot" aria-hidden="true" />
-              {processing ? '正在处理' : '排队中'}
+              {statusLabel}
             </span>
             <span className="manager-detail__status-meta">{statusMeta}</span>
           </div>
@@ -295,6 +301,7 @@ function InboundEntry({
           <span>{item.sender_display_name || '未知发送者'}</span>
           {item.episode_id && <code>episode · {item.episode_id.slice(0, 8)}</code>}
         </div>
+        {activity && <EpisodeActivity episode={activity.episode} progress={activity.progress} runningWorkerIds={runningWorkerIds} />}
       </div>
     </article>
   )
@@ -308,7 +315,6 @@ function EpisodeEntry({ episode, progress, runningWorkerIds }: { episode: Manage
       : episode.trigger.type === 'worker_event'
         ? ' is-worker'
         : ''
-  const workerProgress = groupWorkerProgress(progress)
   return (
     <article className={`manager-detail__event${tone}`}>
       <time className="manager-detail__event-time" dateTime={episode.started_at}>{displayTime(episode.started_at)}</time>
@@ -321,16 +327,25 @@ function EpisodeEntry({ episode, progress, runningWorkerIds }: { episode: Manage
           <TechnicalDetails episode={episode} />
         </div>
         <div className="manager-detail__event-title">{triggerText(episode)}</div>
-        {episode.reply_excerpt && <div className="manager-detail__reply"><strong>管理会话回复</strong>：{episode.reply_excerpt}</div>}
-        <ActionList episode={episode} runningWorkerIds={runningWorkerIds} />
-        {episode.status === 'failed' && <div className="manager-detail__failure">失败原因：{episode.outcome?.error ?? episode.outcome?.summary ?? '未知原因'}</div>}
-        {workerProgress.length > 0 && (
-          <div className="manager-detail__worker-chain">
-            {workerProgress.map((child) => <WorkerProgress key={child.latest.worker_ref?.worker_id ?? child.latest.trace_id} progress={child} runningWorkerIds={runningWorkerIds} />)}
-          </div>
-        )}
+        <EpisodeActivity episode={episode} progress={progress} runningWorkerIds={runningWorkerIds} />
       </div>
     </article>
+  )
+}
+
+function EpisodeActivity({ episode, progress, runningWorkerIds }: { episode: ManagerEpisodeTrace; progress: ManagerEpisodeTrace[]; runningWorkerIds: ReadonlySet<string> }) {
+  const workerProgress = groupWorkerProgress(progress)
+  return (
+    <>
+      {episode.reply_excerpt && <div className="manager-detail__reply"><strong>管理会话回复</strong>：{episode.reply_excerpt}</div>}
+      <ActionList episode={episode} runningWorkerIds={runningWorkerIds} />
+      {episode.status === 'failed' && <div className="manager-detail__failure">失败原因：{episode.outcome?.error ?? episode.outcome?.summary ?? '未知原因'}</div>}
+      {workerProgress.length > 0 && (
+        <div className="manager-detail__worker-chain">
+          {workerProgress.map((child) => <WorkerProgress key={child.latest.worker_ref?.worker_id ?? child.latest.trace_id} progress={child} runningWorkerIds={runningWorkerIds} />)}
+        </div>
+      )}
+    </>
   )
 }
 
@@ -435,7 +450,7 @@ function keepsOwnTimelinePosition(episode: ManagerEpisodeTrace): boolean {
 }
 
 type ConversationTimelineItem =
-  | { kind: 'inbound'; id: string; timestamp: string; item: ManagerInboundMessageSnapshot; queuePosition?: number }
+  | { kind: 'inbound'; id: string; timestamp: string; item: ManagerInboundMessageSnapshot; queuePosition?: number; activity?: GroupedEpisode }
   | { kind: 'episode'; id: string; timestamp: string; grouped: GroupedEpisode }
 
 function currentInboundMessages(
@@ -457,6 +472,8 @@ function mergeConversationTimeline(
   const processingEpisodeIds = new Set(
     inbound.flatMap((item) => item.status === 'processing' && item.episode_id ? [item.episode_id] : []),
   )
+  const activities = new Map(groupedEpisodes.map((grouped) => [grouped.episode.trace_id, grouped]))
+  const attachedActivities = new Set<string>()
   const queuePosition = new Map(
     inbound
       .filter((item) => item.status === 'queued')
@@ -466,13 +483,20 @@ function mergeConversationTimeline(
   )
 
   const items: ConversationTimelineItem[] = [
-    ...inbound.map((item): ConversationTimelineItem => ({
-      kind: 'inbound',
-      id: `inbound:${item.platform_message_id}`,
-      timestamp: item.platform_timestamp,
-      item,
-      ...(item.status === 'queued' ? { queuePosition: queuePosition.get(item.platform_message_id) } : {}),
-    })),
+    ...inbound.map((item): ConversationTimelineItem => {
+      const activity = item.status === 'processing' && item.episode_id && !attachedActivities.has(item.episode_id)
+        ? activities.get(item.episode_id)
+        : undefined
+      if (activity) attachedActivities.add(activity.episode.trace_id)
+      return {
+        kind: 'inbound',
+        id: `inbound:${item.platform_message_id}`,
+        timestamp: item.platform_timestamp,
+        item,
+        ...(activity ? { activity } : {}),
+        ...(item.status === 'queued' ? { queuePosition: queuePosition.get(item.platform_message_id) } : {}),
+      }
+    }),
     ...groupedEpisodes
       .filter(({ episode }) => episode.status !== 'running' || !processingEpisodeIds.has(episode.trace_id))
       .map((grouped): ConversationTimelineItem => ({
@@ -658,6 +682,8 @@ const ManagerDetailContent: React.FC = () => {
                       item={timelineItem.item}
                       queuePosition={timelineItem.queuePosition}
                       snapshotAt={inboundStatus.status === 'ready' ? inboundStatus.snapshotAt : timelineItem.timestamp}
+                      activity={timelineItem.activity}
+                      runningWorkerIds={runningWorkerIds}
                     />
                   ) : (
                     <EpisodeEntry

--- a/crabot-admin/web/src/pages/Traces/ManagersView.test.tsx
+++ b/crabot-admin/web/src/pages/Traces/ManagersView.test.tsx
@@ -164,6 +164,35 @@ describe('ManagerDetail', () => {
     expect(screen.getByText('会话动态')).toBeInTheDocument()
   })
 
+  it('运行中的消息保留本轮已发送的回复和动作，多条插话不重复展示活动', async () => {
+    mocked.getManagerInboundStatus = vi.fn().mockResolvedValue({
+      manager_key: 'wechat::sess-1',
+      snapshot_at: '2026-09-05T06:28:21.000Z',
+      items: [
+        { platform_message_id: 'pm-1', status: 'processing', preview: '换个执行器继续', platform_timestamp: '2026-09-05T06:26:00.000Z', episode_id: 'ep-running' },
+        { platform_message_id: 'pm-2', status: 'processing', preview: '保留测试结果', platform_timestamp: '2026-09-05T06:28:00.000Z', episode_id: 'ep-running' },
+      ],
+    })
+    mocked.listManagerEpisodes = vi.fn().mockResolvedValue({
+      items: [{
+        trace_id: 'ep-running', manager_key: 'wechat::sess-1', started_at: '2026-09-05T06:26:00.000Z', status: 'running',
+        trigger: { type: 'human_message', summary: '人类消息 x1：换个执行器继续' }, spans: [], spawned_worker_ids: ['w-new'],
+        reply_excerpt: '已经回复，接着交接测试工作。',
+        actions: [{ kind: 'spawn_worker', label: '派活：接手测试', worker_id: 'w-new' }],
+      }],
+      pagination: { page: 1, page_size: 20, total_items: 1, total_pages: 1 },
+    })
+    render(<MemoryRouter initialEntries={['/traces/managers/wechat%3A%3Asess-1']}><Routes>
+      <Route path="/traces/managers/:managerKey" element={<ManagerDetail />} />
+    </Routes></MemoryRouter>)
+
+    await waitFor(() => expect(screen.getByText('本轮已回复，继续处理')).toBeInTheDocument())
+    expect(screen.getAllByText('已经回复，接着交接测试工作。', { exact: false })).toHaveLength(1)
+    expect(screen.getAllByText('接手测试')).toHaveLength(1)
+    expect(document.querySelectorAll('article.manager-detail__event')).toHaveLength(2)
+    expect(screen.queryByText('已处理')).toBeNull()
+  })
+
   it('已结束 episode 优先于晚到的 processing 快照', async () => {
     mocked.getManagerInboundStatus = vi.fn().mockResolvedValue({
       manager_key: 'wechat::sess-1',

--- a/crabot-agent/src/core/trace-store.ts
+++ b/crabot-agent/src/core/trace-store.ts
@@ -1257,7 +1257,9 @@ export class TraceStore {
    * 持久化失败必须 throw——调用方（ManagerLoop）不得继续调用 LLM/tool，
    * 原 wake 保持未结算走失败重投语义。
    */
-  startManagerEpisode(traceId: string, managerKey: ManagerKey, trigger: ManagerEpisodeTrigger): void {
+  startManagerEpisode(traceId: string, managerKey: ManagerKey, trigger: ManagerEpisodeTrigger, resume = false): void {
+    const existing = this.managerEpisodes.get(traceId)
+    if (resume && existing?.manager_key === managerKey && existing.status === 'running') return
     if (this.managerEpisodes.has(traceId)) throw new Error(`[TraceStore] duplicate manager episode ${traceId}`)
     const episode: ManagerEpisodeTrace = {
       trace_id: traceId,
@@ -1279,7 +1281,9 @@ export class TraceStore {
   appendManagerSpan(traceId: string, span: ManagerEpisodeSpan): void {
     const episode = this.managerEpisodes.get(traceId)
     if (!episode) return
-    episode.spans.push(span)
+    const existing = episode.spans.findIndex((item) => item.span_id === span.span_id)
+    if (existing < 0) episode.spans.push(span)
+    else episode.spans[existing] = { ...span, started_at: episode.spans[existing].started_at }
     // span 级变更不整份重写归档（否则单 episode 落盘量随 span 数 O(n²)）：
     // running flush 每 15s 全量覆盖 running 文件兜底崩溃现场；start/finish 各落一行。
     this.persistManagerEpisode(episode, false, true)
@@ -1383,10 +1387,10 @@ export class TraceStore {
   }
 
   /**
-   * 启动收口：遗留 running episode 标 failed（outcome 写明 interrupted），保留 spans。
+   * 启动收口：可续跑 episode 保持 running；无检查点的遗留 episode 标 failed/interrupted。
    * 必须在开放 Manager read model 前调用（UnifiedAgent.onStart）。
    */
-  reconcileInterruptedManagerEpisodes(): void {
+  reconcileInterruptedManagerEpisodes(resumableIds: ReadonlySet<string> = new Set()): void {
     for (const id of [...this.runningManagerEpisodeIds]) {
       const episode = this.managerEpisodes.get(id)
       if (!episode || episode.status !== 'running') {
@@ -1394,10 +1398,13 @@ export class TraceStore {
         continue
       }
       const endedAt = new Date().toISOString()
-      episode.status = 'failed'
-      episode.ended_at = endedAt
-      episode.duration_ms = new Date(endedAt).getTime() - new Date(episode.started_at).getTime()
-      episode.outcome = { summary: '[interrupted: agent restarted]' }
+      const resumable = resumableIds.has(id)
+      if (!resumable) {
+        episode.status = 'failed'
+        episode.ended_at = endedAt
+        episode.duration_ms = new Date(endedAt).getTime() - new Date(episode.started_at).getTime()
+        episode.outcome = { summary: '[interrupted: agent restarted]' }
+      }
       for (const span of episode.spans) {
         if (span.status === 'running') {
           span.status = 'failed'
@@ -1413,8 +1420,10 @@ export class TraceStore {
         }
       }
       this.persistManagerEpisode(episode, false)
-      this.runningManagerEpisodeIds.delete(id)
-      this.trackFinishedManagerEpisode(id)
+      if (!resumable) {
+        this.runningManagerEpisodeIds.delete(id)
+        this.trackFinishedManagerEpisode(id)
+      }
     }
   }
 
@@ -1437,7 +1446,7 @@ export class TraceStore {
       ...(trigger.source ? { source: redact(trigger.source) } : {}),
     })
     return {
-      startEpisode: (traceId, managerKey, trigger) => this.startManagerEpisode(traceId, managerKey, redactTrigger(trigger)),
+      startEpisode: (traceId, managerKey, trigger, resume) => this.startManagerEpisode(traceId, managerKey, redactTrigger(trigger), resume),
       appendSpan: (traceId, span) => this.appendManagerSpan(traceId, { ...span, details: redactDetails(span.details) }),
       finishSpan: (traceId, spanId, patch) => this.finishManagerSpan(traceId, spanId, {
         ...patch,

--- a/crabot-agent/src/engine/query-loop.ts
+++ b/crabot-agent/src/engine/query-loop.ts
@@ -187,6 +187,7 @@ export async function runEngine(params: RunEngineParams): Promise<EngineResult> 
       messagesRef.systemPrompt = currentSystemPrompt
       messagesRef.tools = currentTools
     }
+    refreshMessagesRef()
     const beforeLlmCall = options.onBeforeLlmCall?.()
     if (beforeLlmCall) await beforeLlmCall
     const llmStartedAtMs = Date.now()

--- a/crabot-agent/src/manager/loop.ts
+++ b/crabot-agent/src/manager/loop.ts
@@ -76,6 +76,7 @@ import type { ActivityContextAdmissionReceipt, HarnessEvent } from '../workers/h
 import type { ChannelMessage, Friend, ResolvedPermissions } from '../types'
 import type { SessionTarget } from '../mcp/crab-messaging.js'
 import type { ManagerInboundMessageFact } from './inbound-status.js'
+import { resumeManagerMessages, settleInterruptedManagerTools, type ManagerResumeCheckpoint } from './resume-checkpoint.js'
 
 const ASSISTANT_TEXT_END_TURN_REMINDER = '[系统提醒] 你刚才直接输出了一段文字、没有调用 send_message，然后结束了回复。\n'
   + '请注意：直接输出的文字只留在系统内部，人类看不到；只有 send_message 发送的内容才能送达人类。\n'
@@ -435,6 +436,9 @@ export class ManagerLoop {
   /** spawn_worker 成功回调（registry 桥经 worker-tools 调）：把 worker ID 追加进当前 trace。 */
   recordSpawnedWorker(workerId: string): void {
     if (this.currentTraceId) this.deps.traceWriter?.addSpawnedWorker(this.currentTraceId, workerId)
+    if (this.resumeCheckpoint) {
+      this.resumeCheckpoint = { ...this.resumeCheckpoint, spawnedWorkerIds: [...this.resumeCheckpoint.spawnedWorkerIds, workerId] }
+    }
     if (!this.needsSpawnRecheck) return
     this.needsSpawnRecheck = false
     this.spawnRecheckInjected = false
@@ -477,6 +481,70 @@ export class ManagerLoop {
 
   constructor(deps: ManagerLoopDeps) {
     this.deps = deps
+  }
+
+  private resumeCheckpoint?: ManagerResumeCheckpoint
+  private checkpointError?: unknown
+  private readonly restoredContextEnvelopes = new Set<TimedWakeEnvelope>()
+
+  async resume(checkpoint: ManagerResumeCheckpoint): Promise<EpisodeResult> {
+    if (checkpoint.state.key !== this.deps.key) throw new Error('Manager checkpoint owner mismatch')
+    return this.mutex.run(() => this.runEpisode(undefined, undefined, settleInterruptedManagerTools(checkpoint)))
+  }
+
+  private checkpointExecution(): ManagerResumeCheckpoint['execution'] {
+    return {
+      needsSpawnRecheck: this.needsSpawnRecheck,
+      spawnRecheckInjected: this.spawnRecheckInjected,
+      spawnRecheckOutcomeRecorded: this.spawnRecheckOutcomeRecorded,
+      postSendRecheckSequence: this.postSendRecheckSequence,
+      successfulSendMessageTargets: [...this.successfulSendMessageTargetsInCurrentEpisode],
+      continuedWorkers: [...this.continuedWorkersInCurrentEpisode],
+    }
+  }
+
+  private flushObservedCheckpoint(): void {
+    try {
+      this.flushCheckpoint()
+    } catch (error) {
+      // Lifecycle observers cannot interrupt a tool. Fail at the next clean checkpoint instead.
+      this.checkpointError = error
+    }
+  }
+
+  private flushCheckpoint(state?: ManagerSessionState): void {
+    if (!this.resumeCheckpoint) return
+    const pending = this.mailbox.snapshotPendingEnvelopes()
+    const pendingSet = new Set(pending)
+    const envelopes = [...this.currentEpisodeEnvelopes, ...(this.currentEpisodeInjected ?? [])]
+      .filter((item) => !pendingSet.has(item))
+    const nextState = state ?? this.resumeCheckpoint.state
+    const committedIds = new Set(nextState.committedHumanMessageIds ?? [])
+    const imageRefs = new Map((nextState.imageRefs ?? []).map((ref) => [ref.message_id, ref]))
+    if (state) {
+      for (const item of envelopes) {
+        if (isHumanWake(item.wake)) {
+          for (const message of item.wake.messages) committedIds.add(message.platform_message_id)
+          const images = item.wake.messages.flatMap(collectInboundImages)
+          if (images.length > 0) {
+            const text = this.renderEnvelope(item)
+            const message = state.recent.find((message) => 'content' in message && message.content === text)
+            if (message) imageRefs.set(message.id, { message_id: message.id, images })
+          }
+        }
+      }
+    }
+    this.resumeCheckpoint = {
+      ...this.resumeCheckpoint,
+      state: { ...nextState, committedHumanMessageIds: [...committedIds], ...(imageRefs.size > 0 ? { imageRefs: [...imageRefs.values()] } : {}) },
+      envelopes,
+      wakeIndex: this.currentWakeEvent ? envelopes.indexOf(this.currentWakeEvent) : -1,
+      pending,
+      hasEngineMessages: state !== undefined || this.resumeCheckpoint.hasEngineMessages,
+      adminChatClaims: [...this.adminChatClaims],
+      execution: this.checkpointExecution(),
+    }
+    this.deps.store.saveCheckpoint(this.resumeCheckpoint)
   }
 
   /** 唯一入口:被唤醒 → 跑一个 episode → 回睡。同一 loop 串行,不同 loop 互不影响。 */
@@ -572,6 +640,7 @@ export class ManagerLoop {
       if (!this.adminChatClaims.has(id)) this.adminChatClaims.set(id, 'unclaimed')
     }
     if (opts?.onEpisodeSettled) this.currentEpisodeSettleHooks.push(opts.onEpisodeSettled)
+    this.flushCheckpoint()
   }
 
   /** 连续 Admin 保存只保留尚未注入的最新任务板系统事件。 */
@@ -586,6 +655,7 @@ export class ManagerLoop {
     } else if (!replaced) {
       this.currentEpisodeInjected?.push(envelope)
     }
+    this.flushCheckpoint()
   }
 
   /**
@@ -598,8 +668,7 @@ export class ManagerLoop {
    * - 投影按 knownCommittedHumanIds 内存镜像同步计算:整批已提交(重放/渠道重发)→
    *   只登记 admin chat claims 后返回,不进 LLM(协议 §4.1 重复来源守卫,与 idle
    *   空转守卫同语义);部分重叠 → 只注入新消息投影。
-   * - 崩溃窗口如实说明:提交延后意味着「注入后、收尾前」进程崩溃时该消息丢失——
-   *   与修复前消息在 lane 内存队列等 mutex 的崩溃窗口同级,不劣于现状。
+   * - 运行中输入同步进入恢复检查点；重启后按已消费上下文或待注入邮箱续接。
    */
   enqueueHumanWakeDuringActiveEpisode(
     envelope: TimedWakeEnvelope,
@@ -657,14 +726,18 @@ export class ManagerLoop {
   private async runEpisode(
     envelope: TimedWakeEnvelope | undefined,
     onHumanInputCommitted?: (lastCommittedMessageId: string) => Promise<void>,
+    recovery?: ManagerResumeCheckpoint,
   ): Promise<EpisodeResult> {
-    const episodeId = randomUUID()
+    const episodeId = recovery?.episodeId ?? randomUUID()
+    if (recovery) envelope = recovery.envelopes[recovery.wakeIndex]
     this.mailbox.clearContextAdmissions()
     this.admittedActivityReceipts.clear()
     this.rejectedActivityReceipts.clear()
-    const carriedEnvelopes = this.mailbox.drainEnvelopes()
-    const episodeEnvelopes = [...carriedEnvelopes, ...(envelope ? [envelope] : [])]
-    if (envelope === undefined && carriedEnvelopes.length === 0) {
+    const carriedEnvelopes = recovery
+      ? recovery.envelopes.filter((_, index) => index !== recovery.wakeIndex)
+      : this.mailbox.drainEnvelopes()
+    const episodeEnvelopes = recovery ? [...recovery.envelopes] : [...carriedEnvelopes, ...(envelope ? [envelope] : [])]
+    if (!recovery && envelope === undefined && carriedEnvelopes.length === 0) {
       // 自唤醒但 mailbox 已空(残留被排在前面的另一个 episode 顺带 drain 走了)——
       // 没有任何新内容,直接空转返回,不开 episode(见 drainMailbox 注释)。
       return {
@@ -687,6 +760,7 @@ export class ManagerLoop {
     this.spawnRecheckOutcomeRecorded = false
     this.postSendRecheckSequence = 0
     this.adminChatClaims = new Map()
+    this.checkpointError = undefined
     this.successfulSendMessageTargetsInCurrentEpisode.clear()
     this.continuedWorkersInCurrentEpisode.clear()
     for (const item of episodeEnvelopes) {
@@ -703,12 +777,32 @@ export class ManagerLoop {
     let traceStarted = false
     try {
       await this.deps.store.ensureSession(this.deps.key)
-      const committed = await this.commitHumanInputs(
+      const committed = recovery ? {
+        state: { ...recovery.state, recent: resumeManagerMessages(recovery).filter((message) => !recovery.transientMessageIds.includes(message.id)) },
+        messageCount: 0,
+        humanMessages: [],
+        lastCurrentWakeCommittedMessageId: undefined,
+      } : await this.commitHumanInputs(
         await this.deps.store.load(this.deps.key),
         [...carriedEnvelopes, ...(envelope ? [envelope] : [])],
         envelope,
       )
       state = committed.state
+      if (recovery) {
+        await this.deps.store.save(state)
+        if (recovery.hasEngineMessages) {
+          for (const item of episodeEnvelopes) {
+            if (item.wake.kind !== 'workboard_admin_update') this.restoredContextEnvelopes.add(item)
+          }
+        }
+        this.adminChatClaims = new Map(recovery.adminChatClaims)
+        this.needsSpawnRecheck = recovery.execution.needsSpawnRecheck
+        this.spawnRecheckInjected = recovery.execution.spawnRecheckInjected
+        this.spawnRecheckOutcomeRecorded = recovery.execution.spawnRecheckOutcomeRecorded
+        this.postSendRecheckSequence = recovery.execution.postSendRecheckSequence
+        for (const target of recovery.execution.successfulSendMessageTargets) this.successfulSendMessageTargetsInCurrentEpisode.add(target)
+        for (const worker of recovery.execution.continuedWorkers) this.continuedWorkersInCurrentEpisode.add(worker)
+      }
       committedHumanMessages = committed.messageCount
       humanInputsCommitted = true
       // 已提交人类消息 id 的内存镜像:mid-episode 注入的投影判定用它(同步、无 store I/O)
@@ -717,13 +811,17 @@ export class ManagerLoop {
         this.notifyHumanInputCommitted(onHumanInputCommitted, committed.lastCurrentWakeCommittedMessageId)
       }
 
+      const restoredMessages = recovery?.hasEngineMessages === true
       const carriedTexts = carriedEnvelopes
-        .filter((item) => !isHumanWake(item.wake) || isEmptyHumanWake(item.wake))
+        .filter((item) => restoredMessages
+          ? item.wake.kind === 'workboard_admin_update'
+          : !isHumanWake(item.wake) || isEmptyHumanWake(item.wake))
         .map((item) => this.renderEnvelope(item))
-      const eventText = envelope && (!isHumanWake(envelope.wake) || isEmptyHumanWake(envelope.wake))
+      const eventText = envelope && (!restoredMessages || envelope.wake.kind === 'workboard_admin_update')
+        && (!isHumanWake(envelope.wake) || isEmptyHumanWake(envelope.wake))
         ? this.renderEnvelope(envelope)
         : undefined
-      if (committedHumanMessages === 0 && carriedTexts.length === 0 && eventText === undefined) {
+      if (!recovery && committedHumanMessages === 0 && carriedTexts.length === 0 && eventText === undefined) {
         await this.settleUnclaimedAdminChatWakes()
         return {
           episodeId,
@@ -735,11 +833,28 @@ export class ManagerLoop {
         }
       }
 
+      if (recovery) {
+        for (const pending of recovery.pending) {
+          if (isHumanWake(pending.wake)) this.enqueueHumanWakeDuringActiveEpisode(pending)
+          else this.enqueueDuringEpisode(pending)
+        }
+      }
+      this.resumeCheckpoint = recovery
+        ? { ...recovery, state, transientMessageIds: [] }
+        : {
+            episodeId, state, envelopes: episodeEnvelopes, wakeIndex: envelope ? episodeEnvelopes.indexOf(envelope) : -1,
+            pending: [], hasEngineMessages: false, turns: [], responses: [], tools: [],
+            adminChatClaims: [...this.adminChatClaims], transientMessageIds: [], spawnedWorkerIds: [],
+            execution: this.checkpointExecution(),
+          }
+      this.flushCheckpoint()
+
       // 人类提交成功后，trace admission 的失败也不得倒回已提交输入。
       this.deps.traceWriter?.startEpisode(
         episodeId,
         this.deps.managerKey(),
-        managerTriggerFromWake(envelope ?? carriedEnvelopes[0], carriedEnvelopes.length + (envelope ? 1 : 0)),
+        managerTriggerFromWake(envelope ?? carriedEnvelopes[0], episodeEnvelopes.length),
+        recovery !== undefined,
       )
       this.currentTraceId = episodeId
       traceStarted = true
@@ -749,8 +864,14 @@ export class ManagerLoop {
         type: 'agent_loop',
         started_at: new Date().toISOString(),
         status: 'running',
-        details: { merged_envelopes: carriedEnvelopes.length + (envelope ? 1 : 0) },
+        details: { merged_envelopes: episodeEnvelopes.length },
       })
+      if (recovery) {
+        for (const response of recovery.responses) this.recordLlmResponse(episodeId, response)
+        for (const turn of recovery.turns) this.recordTurnSpans(episodeId, turn)
+        for (const event of recovery.tools) this.recordToolLifecycle(episodeId, event)
+        for (const workerId of recovery.spawnedWorkerIds) this.deps.traceWriter?.addSpawnedWorker(episodeId, workerId)
+      }
       const result = await this.runEpisodeBody(
         episodeId,
         state,
@@ -777,6 +898,7 @@ export class ManagerLoop {
       // confirm 结算；失败（consumedEvents=false）的整批重投不结算。
       if (result.consumedEvents) await this.settleUnclaimedAdminChatWakes()
       this.settleInjectedHooks(result)
+      this.deps.store.clearCheckpoint(this.deps.key, episodeId)
       return result
     } catch (err) {
       // admission 与直接 throw 都在这里收口。人类提交一旦完成，仅重投非人类事件；否则保留
@@ -823,6 +945,7 @@ export class ManagerLoop {
         repliedToHuman: false,
         successfulSendMessageTargets: [],
       })
+      this.deps.store.clearCheckpoint(this.deps.key, episodeId)
       throw err
     } finally {
       this.currentEpisodeInjected = null
@@ -841,6 +964,9 @@ export class ManagerLoop {
       this.postSendRecheckSequence = 0
       this.currentUsage = { input_tokens: 0, output_tokens: 0, cache_creation_tokens: 0, cache_read_tokens: 0 }
       this.attemptCounter = 0
+      this.resumeCheckpoint = undefined
+      this.checkpointError = undefined
+      this.restoredContextEnvelopes.clear()
     }
   }
 
@@ -1070,6 +1196,7 @@ export class ManagerLoop {
     const durablePrefixLength = state.recent.length + (attempt.hasSummaryMarker ? 1 : 0)
     let remainingTransientWorkboardUpdates = transientWorkboardUpdates
     const persistedFinalMessages = attempt.result.finalMessages.flatMap((m, index) => {
+      if (this.resumeCheckpoint?.transientMessageIds.includes(m.id)) return []
       // 系统提示只服务当前 LLM 请求。只在本次动态尾部之后按数量剔除，避免误删旧 history
       // 中恰好同文的人类消息；Worker/任务板正文从未进入这里。
       if (
@@ -1328,6 +1455,7 @@ export class ManagerLoop {
     humanInputsCommitted: boolean,
   ): void {
     for (const envelope of envelopes) {
+      if (this.restoredContextEnvelopes.has(envelope)) continue
       if (envelope.activity_context_receipt) continue
       if (humanInputsCommitted && isHumanWake(envelope.wake)) continue
       this.mailbox.push(envelope)
@@ -1397,6 +1525,7 @@ export class ManagerLoop {
   }
 
   private shouldReplayInAttempt(envelope: TimedWakeEnvelope): boolean {
+    if (this.restoredContextEnvelopes.has(envelope)) return false
     const receipt = envelope.activity_context_receipt
     return !receipt || !this.admittedActivityReceipts.has(activityReceiptKey(receipt))
   }
@@ -1758,6 +1887,31 @@ export class ManagerLoop {
     const isBuiltinDailyReflection = isBuiltinDailyReflectionWake(effectiveWake)
     const systemPrompt = (): string => this.managerSystemPrompt(this.effectiveWakeForCurrentEpisode())
     const tools = (): ReadonlyArray<ToolDefinition> => this.deps.toolFace(this.effectiveWakeForCurrentEpisode())
+    const messagesRef = { current: initialMessages as ReadonlyArray<EngineMessage> }
+    const checkpoint = (): void => {
+      if (this.checkpointError) throw this.checkpointError
+      const originals = new Map(state.recent.map((message) => [message.id, message]))
+      const recent = messagesRef.current.slice(hasSummaryMarker ? 1 : 0).map((message) => {
+        if (message.role !== 'user' || !('content' in message) || !Array.isArray(message.content)) return message
+        const original = originals.get(message.id)
+        if (original) return original
+        const first = message.content[0]
+        return first?.type === 'text' ? { ...message, content: first.text } : message
+      })
+      if (this.resumeCheckpoint) {
+        const transientIds = new Set(this.resumeCheckpoint.transientMessageIds)
+        let remaining = [...this.currentEpisodeEnvelopes, ...(this.currentEpisodeInjected ?? [])]
+          .filter((item) => item.wake.kind === 'workboard_admin_update').length
+        for (const message of recent.slice(state.recent.length)) {
+          if (remaining > 0 && 'content' in message && message.content === '[系统提示]\n管理员已更新任务板。请查阅最新任务板，并核对后续安排。') {
+            transientIds.add(message.id)
+            remaining -= 1
+          }
+        }
+        this.resumeCheckpoint = { ...this.resumeCheckpoint, transientMessageIds: [...transientIds] }
+      }
+      this.flushCheckpoint({ ...state, recent })
+    }
 
     // LLM 重试期间配置热切换的订阅（spec 2026-08-30-llm-retry-config-hotreload）：
     // 只覆盖本 attempt 的 runEngine 生命周期，结束时确定性退订，不泄漏监听器。
@@ -1774,7 +1928,9 @@ export class ManagerLoop {
       ...(overrides?.thinking !== undefined ? { thinking: overrides.thinking } : {}),
       disableCompaction: true,
       humanMessageQueue: this.mailbox,
+      messagesRef,
       onBeforeLlmCall: () => {
+        checkpoint()
         const envelopes = [
           ...initialContextEnvelopes,
           ...this.mailbox.takeContextAdmissionEnvelopes(),
@@ -1807,9 +1963,29 @@ export class ManagerLoop {
       endTurnGate: async () => this.takeSpawnRecheckPrompt(),
       // P6-A §6.4：response/lifecycle 钩子即时投影，onTurn 负责补漏与 usage 结算；
       // 三者都只观察共享 Engine，不复制执行语义或新增第二个 query loop。
-      onLlmResponse: (event) => this.recordLlmResponse(episodeId, event),
-      onTurn: (event) => this.recordTurnSpans(episodeId, event),
-      onToolLifecycle: (event) => this.recordToolLifecycle(episodeId, event),
+      onLlmResponse: (event) => {
+        this.recordLlmResponse(episodeId, event)
+        if (this.resumeCheckpoint) {
+          this.resumeCheckpoint = { ...this.resumeCheckpoint, responses: [...this.resumeCheckpoint.responses, event] }
+          this.flushObservedCheckpoint()
+        }
+      },
+      onTurn: (event) => {
+        this.recordTurnSpans(episodeId, event)
+        if (this.resumeCheckpoint) {
+          this.resumeCheckpoint = { ...this.resumeCheckpoint, turns: [...this.resumeCheckpoint.turns, event] }
+        }
+        checkpoint()
+      },
+      onToolLifecycle: (event) => {
+        this.recordToolLifecycle(episodeId, event)
+        if (this.resumeCheckpoint) {
+          const tools = new Map(this.resumeCheckpoint.tools.map((item) => [item.callId, item]))
+          tools.set(event.callId, event)
+          this.resumeCheckpoint = { ...this.resumeCheckpoint, tools: [...tools.values()] }
+          this.flushObservedCheckpoint()
+        }
+      },
       // LLM 重试期间配置热切换（spec 2026-08-30-llm-retry-config-hotreload）：
       // onRuntimeConfigApplied 在 agentConfig 原子替换完成后触发 → abort signal →
       // callNonStreaming 的重试 sleep 提前结束；configGeneration 探针由 engine 记账，

--- a/crabot-agent/src/manager/loop.ts
+++ b/crabot-agent/src/manager/loop.ts
@@ -521,17 +521,20 @@ export class ManagerLoop {
     const nextState = state ?? this.resumeCheckpoint.state
     const committedIds = new Set(nextState.committedHumanMessageIds ?? [])
     const imageRefs = new Map((nextState.imageRefs ?? []).map((ref) => [ref.message_id, ref]))
+    let protectedTailMessageId = this.resumeCheckpoint.protectedTailMessageId
     if (state) {
+      // Overflow retries can recreate injected human messages with new Engine IDs.
+      if (!state.recent.some((message) => message.id === protectedTailMessageId)) protectedTailMessageId = undefined
       for (const item of envelopes) {
-        if (isHumanWake(item.wake)) {
-          for (const message of item.wake.messages) committedIds.add(message.platform_message_id)
-          const images = item.wake.messages.flatMap(collectInboundImages)
-          if (images.length > 0) {
-            const text = this.renderEnvelope(item)
-            const message = state.recent.find((message) => 'content' in message && message.content === text)
-            if (message) imageRefs.set(message.id, { message_id: message.id, images })
-          }
-        }
+        if (!isHumanWake(item.wake)) continue
+        for (const message of item.wake.messages) committedIds.add(message.platform_message_id)
+        const images = item.wake.messages.flatMap(collectInboundImages)
+        if (images.length === 0 && protectedTailMessageId !== undefined) continue
+        const text = this.renderEnvelope(item)
+        const message = state.recent.find((message) => 'content' in message && message.content === text)
+        if (!message) continue
+        protectedTailMessageId ??= message.id
+        if (images.length > 0) imageRefs.set(message.id, { message_id: message.id, images })
       }
     }
     this.resumeCheckpoint = {
@@ -540,6 +543,7 @@ export class ManagerLoop {
       envelopes,
       wakeIndex: this.currentWakeEvent ? envelopes.indexOf(this.currentWakeEvent) : -1,
       pending,
+      protectedTailMessageId,
       hasEngineMessages: state !== undefined || this.resumeCheckpoint.hasEngineMessages,
       adminChatClaims: [...this.adminChatClaims],
       execution: this.checkpointExecution(),
@@ -777,10 +781,14 @@ export class ManagerLoop {
     let traceStarted = false
     try {
       await this.deps.store.ensureSession(this.deps.key)
+      const restoredRecent = recovery
+        ? resumeManagerMessages(recovery).filter((message) => !recovery.transientMessageIds.includes(message.id))
+        : []
+      const protectedTailStart = restoredRecent.findIndex((message) => message.id === recovery?.protectedTailMessageId)
       const committed = recovery ? {
-        state: { ...recovery.state, recent: resumeManagerMessages(recovery).filter((message) => !recovery.transientMessageIds.includes(message.id)) },
+        state: { ...recovery.state, recent: restoredRecent },
         messageCount: 0,
-        humanMessages: [],
+        humanMessages: protectedTailStart < 0 ? [] : restoredRecent.slice(protectedTailStart),
         lastCurrentWakeCommittedMessageId: undefined,
       } : await this.commitHumanInputs(
         await this.deps.store.load(this.deps.key),
@@ -840,10 +848,11 @@ export class ManagerLoop {
         }
       }
       this.resumeCheckpoint = recovery
-        ? { ...recovery, state, transientMessageIds: [] }
+        ? { ...recovery, state, pendingToolCallIds: [], transientMessageIds: [] }
         : {
             episodeId, state, envelopes: episodeEnvelopes, wakeIndex: envelope ? episodeEnvelopes.indexOf(envelope) : -1,
             pending: [], hasEngineMessages: false, turns: [], responses: [], tools: [],
+            pendingToolCallIds: [], protectedTailMessageId: committed.humanMessages[0]?.id,
             adminChatClaims: [...this.adminChatClaims], transientMessageIds: [], spawnedWorkerIds: [],
             execution: this.checkpointExecution(),
           }
@@ -973,7 +982,7 @@ export class ManagerLoop {
   private async runEpisodeBody(
     episodeId: string,
     initialState: ManagerSessionState,
-    committedHumanMessages: ReadonlyArray<EngineMessage>,
+    protectedTail: ReadonlyArray<EngineMessage>,
     carriedTexts: ReadonlyArray<string>,
     eventText: string | undefined,
     carriedEnvelopes: ReadonlyArray<TimedWakeEnvelope>,
@@ -1011,12 +1020,12 @@ export class ManagerLoop {
     })
 
     let state = initialState
-    let historyState = withoutProtectedTail(state, committedHumanMessages.length)
+    let historyState = withoutProtectedTail(state, protectedTail.length)
 
     const wakeDecision = decideCompaction({
       policy,
       mainRequestTokens: contextManager.estimateCompactionStateTokens(
-        toManagerCompactionState(historyState, committedHumanMessages),
+        toManagerCompactionState(historyState, protectedTail),
         compactionProfile,
       ),
     })
@@ -1030,9 +1039,9 @@ export class ManagerLoop {
         target: { kind: 'fit_hard_cap', hardCapTokens: policy.hardCapTokens },
         adapter,
         model,
-        protectedTail: committedHumanMessages,
+        protectedTail,
       })
-      historyState = withoutProtectedTail(state, committedHumanMessages.length)
+      historyState = withoutProtectedTail(state, protectedTail.length)
     }
 
     // 入站图片视觉注入:窗口内 human 消息引用的图片读盘转 ImageBlock(VLM 模型才有)。
@@ -1092,9 +1101,9 @@ export class ManagerLoop {
         target: { kind: 'fit_hard_cap', hardCapTokens: policy.hardCapTokens, force: true },
         adapter,
         model,
-        protectedTail: committedHumanMessages,
+        protectedTail,
       })
-      historyState = withoutProtectedTail(state, committedHumanMessages.length)
+      historyState = withoutProtectedTail(state, protectedTail.length)
       // 清空 mailbox 残留后缀(见上方注释),再按 currentEpisodeInjected 的到达顺序整体追加
       this.mailbox.drainEnvelopes()
       this.mailbox.clearContextAdmissions()
@@ -1973,7 +1982,7 @@ export class ManagerLoop {
       onTurn: (event) => {
         this.recordTurnSpans(episodeId, event)
         if (this.resumeCheckpoint) {
-          this.resumeCheckpoint = { ...this.resumeCheckpoint, turns: [...this.resumeCheckpoint.turns, event] }
+          this.resumeCheckpoint = { ...this.resumeCheckpoint, turns: [...this.resumeCheckpoint.turns, event], pendingToolCallIds: [] }
         }
         checkpoint()
       },
@@ -1982,7 +1991,9 @@ export class ManagerLoop {
         if (this.resumeCheckpoint) {
           const tools = new Map(this.resumeCheckpoint.tools.map((item) => [item.callId, item]))
           tools.set(event.callId, event)
-          this.resumeCheckpoint = { ...this.resumeCheckpoint, tools: [...tools.values()] }
+          const pendingToolCallIds = new Set(this.resumeCheckpoint.pendingToolCallIds)
+          pendingToolCallIds.add(event.callId)
+          this.resumeCheckpoint = { ...this.resumeCheckpoint, tools: [...tools.values()], pendingToolCallIds: [...pendingToolCallIds] }
           this.flushObservedCheckpoint()
         }
       },

--- a/crabot-agent/src/manager/registry.ts
+++ b/crabot-agent/src/manager/registry.ts
@@ -41,6 +41,7 @@ import type {
   HarnessEventDelivery,
 } from '../workers/harness/worker-events'
 import type { ChannelMessage, Friend, ResolvedPermissions } from '../types'
+import type { ManagerResumeCheckpoint } from './resume-checkpoint.js'
 import type { SessionTarget } from '../mcp/crab-messaging.js'
 import type { HumanPrincipal } from './principal.js'
 import { resolveTimezone } from '../utils/time.js'
@@ -213,8 +214,62 @@ export class ManagerRegistry {
   private readonly activeEpisodes = new Map<ManagerKey, number>()
   /** 每个 key 最近一次"活跃"的时间戳(创建时 / 每次 episode 结束时刷新),evictIdle 的判据。 */
   private readonly lastActiveAtMs = new Map<ManagerKey, number>()
+  private readonly pendingResumes = new Map<ManagerKey, ManagerResumeCheckpoint>()
+  private readonly resumeTasks = new Map<ManagerKey, Promise<void>>()
+  private resumeReady: Promise<void> = Promise.resolve()
+  private releaseResumes?: () => void
 
   constructor(private readonly deps: ManagerRegistryDeps) {}
+
+  registerResumeCheckpoints(checkpoints: ReadonlyArray<ManagerResumeCheckpoint>): void {
+    for (const checkpoint of checkpoints) this.pendingResumes.set(checkpoint.state.key, checkpoint)
+    if (checkpoints.length > 0) {
+      this.resumeReady = new Promise((resolve) => { this.releaseResumes = resolve })
+    }
+  }
+
+  async resumeInterruptedEpisodes(): Promise<void> {
+    this.releaseResumes?.()
+    this.releaseResumes = undefined
+    await Promise.all([...this.pendingResumes.keys()].map(async (key) => {
+      try { await this.ensureResumed(key) } catch (error) {
+        console.error(`[ManagerRegistry] resume failed for ${key}:`, error)
+      }
+    }))
+  }
+
+  private async ensureResumed(key: ManagerKey): Promise<void> {
+    const checkpoint = this.pendingResumes.get(key)
+    if (!checkpoint) return
+    const existing = this.resumeTasks.get(key)
+    if (existing) return existing
+    const task = this.resumeReady.then(async () => {
+      const envelopes: TimedWakeEnvelope[] = []
+      for (const [index, item] of checkpoint.envelopes.entries()) {
+        const wake = item.wake
+        if (index === checkpoint.wakeIndex || (wake.kind === 'schedule' && wake.isBuiltin && wake.taskType === 'daily_reflection')) {
+          envelopes.push(await this.refreshResumeEnvelope(key, item))
+        } else envelopes.push(item)
+      }
+      await this.runWake(key, envelopes[checkpoint.wakeIndex], 0, undefined, undefined, { ...checkpoint, envelopes })
+    }).finally(() => { this.resumeTasks.delete(key) })
+    this.resumeTasks.set(key, task)
+    return task
+  }
+
+  private async refreshResumeEnvelope(key: ManagerKey, envelope: TimedWakeEnvelope): Promise<TimedWakeEnvelope> {
+    const wake = envelope.wake
+    let permissions: ResolvedPermissions | null | void
+    if (wake.kind === 'human_messages' || wake.kind === 'attention_flush') {
+      permissions = await this.deps.onHumanWake?.(key, {
+        friend: wake.friend,
+        sessionType: wake.messages[0]?.session.type === 'group' ? 'group' : 'private',
+      })
+    } else if (wake.kind === 'schedule') {
+      permissions = await this.deps.onScheduleWake?.({ key, creatorFriendId: wake.creatorFriendId, isBuiltin: wake.isBuiltin })
+    } else return envelope
+    return { ...envelope, wake: { ...wake, principalPermissions: permissions ?? undefined } }
+  }
 
   /** 内存 registry 当前 running manager 的只读快照（P6-A §7.3：补充尚未首次 save 的当前 manager）。 */
   listActiveManagers(): Array<{ key: ManagerKey; lastActiveAtMs?: number }> {
@@ -360,6 +415,7 @@ export class ManagerRegistry {
     onEpisodeSettled?: (result: EpisodeResult) => void,
   ): Promise<EpisodeResult> {
     const key = `${channelId}::${sessionId}` as ManagerKey
+    if (this.pendingResumes.has(key)) await this.ensureResumed(key)
     // 私/群不新增数据来源:它就在消息自己的 session 上。空批(理论上不该发生)按私聊算,
     // 与 `handleMessageReceived` 的默认分流一致。
     const sessionType = messages[0]?.session.type === 'group' ? 'group' : 'private'
@@ -727,6 +783,8 @@ export class ManagerRegistry {
     envelope: TimedWakeEnvelope | undefined,
     selfWakeChain?: number,
     onHumanInputCommitted?: (lastCommittedMessageId: string) => Promise<void>,
+    shouldAdmit?: undefined,
+    recovery?: ManagerResumeCheckpoint,
   ): Promise<EpisodeResult>
   private runWake(
     key: ManagerKey,
@@ -741,7 +799,9 @@ export class ManagerRegistry {
     selfWakeChain = 0,
     onHumanInputCommitted?: (lastCommittedMessageId: string) => Promise<void>,
     shouldAdmit?: () => Promise<boolean>,
+    recovery?: ManagerResumeCheckpoint,
   ): Promise<EpisodeResult | undefined> {
+    if (!recovery && this.pendingResumes.has(key)) await this.ensureResumed(key)
     this.assertWakeAdmission()
     if (this.deps.beforeWake) await this.deps.beforeWake(key, envelope)
     this.assertWakeAdmission()
@@ -751,7 +811,10 @@ export class ManagerRegistry {
     let result: EpisodeResult | undefined
     try {
       // `wakeUp()` 会在输入持久化后才触发非关键通知；这不是 LLM 已完成的确认。
-      if (envelope === undefined) {
+      if (recovery) {
+        this.pendingResumes.delete(key)
+        result = await loop.resume(recovery)
+      } else if (envelope === undefined) {
         result = await loop.drainMailbox()
       } else if (onHumanInputCommitted) {
         result = await loop.wakeUp(envelope, onHumanInputCommitted)

--- a/crabot-agent/src/manager/resume-checkpoint.ts
+++ b/crabot-agent/src/manager/resume-checkpoint.ts
@@ -1,0 +1,65 @@
+import {
+  createAssistantMessage,
+  createBatchToolResultMessage,
+  type EngineMessage,
+  type EngineLlmResponseEvent,
+  type EngineToolLifecycleEvent,
+  type EngineTurnEvent,
+} from '../engine/types.js'
+import type { TimedWakeEnvelope } from './loop.js'
+import type { ManagerSessionState } from './types.js'
+
+/** Private execution state; never returned by the Manager read model. */
+export interface ManagerResumeCheckpoint {
+  readonly episodeId: string
+  readonly state: ManagerSessionState
+  readonly envelopes: ReadonlyArray<TimedWakeEnvelope>
+  readonly wakeIndex: number
+  readonly pending: ReadonlyArray<TimedWakeEnvelope>
+  readonly hasEngineMessages: boolean
+  readonly turns: ReadonlyArray<EngineTurnEvent>
+  readonly responses: ReadonlyArray<EngineLlmResponseEvent>
+  readonly tools: ReadonlyArray<EngineToolLifecycleEvent>
+  readonly adminChatClaims: ReadonlyArray<readonly [string, 'unclaimed' | 'claimed']>
+  readonly transientMessageIds: ReadonlyArray<string>
+  readonly spawnedWorkerIds: ReadonlyArray<string>
+  readonly execution: {
+    readonly needsSpawnRecheck: boolean
+    readonly spawnRecheckInjected: boolean
+    readonly spawnRecheckOutcomeRecorded: boolean
+    readonly postSendRecheckSequence: number
+    readonly successfulSendMessageTargets: ReadonlyArray<string>
+    readonly continuedWorkers: ReadonlyArray<string>
+  }
+}
+
+export function settleInterruptedManagerTools(checkpoint: ManagerResumeCheckpoint): ManagerResumeCheckpoint {
+  const endedAtMs = Date.now()
+  return {
+    ...checkpoint,
+    tools: checkpoint.tools.map((event) => event.type === 'tool_finished' ? event : {
+      ...event, type: 'tool_finished', output: '[interrupted: agent restarted]', isError: true,
+      endedAtMs, durationMs: endedAtMs - event.startedAtMs,
+    }),
+  }
+}
+
+export function resumeManagerMessages(checkpoint: ManagerResumeCheckpoint): ReadonlyArray<EngineMessage> {
+  const results = new Set(checkpoint.state.recent.flatMap((message) =>
+    'toolResults' in message ? message.toolResults.map((result) => result.tool_use_id) : [],
+  ))
+  const tools = checkpoint.tools.filter((event) => !results.has(event.toolUseId))
+  if (tools.length === 0) return checkpoint.state.recent
+  // Completed calls keep their real results. An interrupted call is not executed again by recovery.
+  return [
+    ...checkpoint.state.recent,
+    createAssistantMessage(tools.map((event) => ({
+      type: 'tool_use' as const, id: event.toolUseId, name: event.name, input: event.input,
+    })), 'tool_use'),
+    createBatchToolResultMessage(tools.map((event) => ({
+      tool_use_id: event.toolUseId,
+      content: event.type === 'tool_finished' ? event.output : '[interrupted: agent restarted]',
+      is_error: event.type === 'tool_finished' ? event.isError : true,
+    }))),
+  ]
+}

--- a/crabot-agent/src/manager/resume-checkpoint.ts
+++ b/crabot-agent/src/manager/resume-checkpoint.ts
@@ -20,6 +20,9 @@ export interface ManagerResumeCheckpoint {
   readonly turns: ReadonlyArray<EngineTurnEvent>
   readonly responses: ReadonlyArray<EngineLlmResponseEvent>
   readonly tools: ReadonlyArray<EngineToolLifecycleEvent>
+  /** Calls whose results have not yet been committed to state.recent. */
+  readonly pendingToolCallIds: ReadonlyArray<string>
+  readonly protectedTailMessageId?: string
   readonly adminChatClaims: ReadonlyArray<readonly [string, 'unclaimed' | 'claimed']>
   readonly transientMessageIds: ReadonlyArray<string>
   readonly spawnedWorkerIds: ReadonlyArray<string>
@@ -45,10 +48,11 @@ export function settleInterruptedManagerTools(checkpoint: ManagerResumeCheckpoin
 }
 
 export function resumeManagerMessages(checkpoint: ManagerResumeCheckpoint): ReadonlyArray<EngineMessage> {
+  const pending = new Set(checkpoint.pendingToolCallIds)
   const results = new Set(checkpoint.state.recent.flatMap((message) =>
     'toolResults' in message ? message.toolResults.map((result) => result.tool_use_id) : [],
   ))
-  const tools = checkpoint.tools.filter((event) => !results.has(event.toolUseId))
+  const tools = checkpoint.tools.filter((event) => pending.has(event.callId) && !results.has(event.toolUseId))
   if (tools.length === 0) return checkpoint.state.recent
   // Completed calls keep their real results. An interrupted call is not executed again by recovery.
   return [

--- a/crabot-agent/src/manager/session-store.ts
+++ b/crabot-agent/src/manager/session-store.ts
@@ -9,6 +9,7 @@
  */
 
 import { promises as fs } from 'fs'
+import { writeFileSync, renameSync, unlinkSync, readFileSync } from 'fs'
 import { join, dirname } from 'path'
 import { randomUUID } from 'crypto'
 import { AsyncMutex } from '../workers/async-mutex'
@@ -16,9 +17,12 @@ import { encodeSegment, decodeSegment } from '../workers/harness/ledger-store'
 import type { ManagerKey, ManagerSessionState } from './types'
 import { normalizeImageRefs } from './image-vision'
 import type { EngineMessage } from '../engine/index.js'
+import type { ManagerResumeCheckpoint } from './resume-checkpoint.js'
+import type { TimedWakeEnvelope } from './loop.js'
 
 const STATE_FILE = 'state.json'
 const EPISODES_DIR = 'episodes'
+const CHECKPOINT_FILE = 'running.json'
 
 async function writeJsonAtomic(path: string, data: unknown): Promise<void> {
   const tmpPath = join(dirname(path), `.tmp-${randomUUID()}.json`)
@@ -124,6 +128,70 @@ export class ManagerSessionStore {
       await fs.mkdir(this.dirFor(state.key), { recursive: true })
       await writeJsonAtomic(this.statePathFor(state.key), state)
     })
+  }
+
+  /** Same atomic, synchronous turn-boundary flush used by the existing Engine resume path. */
+  saveCheckpoint(checkpoint: ManagerResumeCheckpoint): void {
+    const target = join(this.dirFor(checkpoint.state.key), CHECKPOINT_FILE)
+    const temporary = `${target}.${randomUUID()}.tmp`
+    const durableEnvelope = ({ activity_context_receipt: _receipt, ...envelope }: TimedWakeEnvelope): TimedWakeEnvelope => envelope
+    try {
+      writeFileSync(temporary, JSON.stringify({
+        ...checkpoint,
+        envelopes: checkpoint.envelopes.map(durableEnvelope),
+        pending: checkpoint.pending.map(durableEnvelope),
+      }), { encoding: 'utf-8', mode: 0o600 })
+      renameSync(temporary, target)
+    } finally {
+      try { unlinkSync(temporary) } catch { /* rename already removed the temporary file */ }
+    }
+  }
+
+  async loadCheckpoint(key: ManagerKey): Promise<ManagerResumeCheckpoint | undefined> {
+    let raw: string
+    try {
+      raw = await fs.readFile(join(this.dirFor(key), CHECKPOINT_FILE), 'utf-8')
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined
+      throw error
+    }
+    const checkpoint = JSON.parse(raw) as ManagerResumeCheckpoint
+    if (checkpoint.state?.key !== key || typeof checkpoint.episodeId !== 'string'
+      || !Array.isArray(checkpoint.state.recent) || !Array.isArray(checkpoint.envelopes)
+      || !Number.isInteger(checkpoint.wakeIndex) || checkpoint.wakeIndex < -1 || checkpoint.wakeIndex >= checkpoint.envelopes.length
+      || !Array.isArray(checkpoint.pending) || !Array.isArray(checkpoint.turns)
+      || !Array.isArray(checkpoint.responses) || !Array.isArray(checkpoint.tools)
+      || !Array.isArray(checkpoint.adminChatClaims) || !Array.isArray(checkpoint.transientMessageIds)
+      || !Array.isArray(checkpoint.spawnedWorkerIds) || typeof checkpoint.hasEngineMessages !== 'boolean'
+      || !Array.isArray(checkpoint.execution?.successfulSendMessageTargets) || !Array.isArray(checkpoint.execution?.continuedWorkers)) {
+      throw new Error(`[ManagerSessionStore] invalid resume checkpoint for ${key}`)
+    }
+    return checkpoint
+  }
+
+  clearCheckpoint(key: ManagerKey, episodeId: string): void {
+    const target = join(this.dirFor(key), CHECKPOINT_FILE)
+    try {
+      const checkpoint = JSON.parse(readFileSync(target, 'utf-8')) as ManagerResumeCheckpoint
+      if (checkpoint.episodeId === episodeId) unlinkSync(target)
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        console.warn(`[ManagerSessionStore] checkpoint cleanup failed for ${key}:`, error)
+      }
+    }
+  }
+
+  async listCheckpoints(): Promise<ManagerResumeCheckpoint[]> {
+    const checkpoints: ManagerResumeCheckpoint[] = []
+    for (const key of await this.listManagerKeys()) {
+      try {
+        const checkpoint = await this.loadCheckpoint(key)
+        if (checkpoint) checkpoints.push(checkpoint)
+      } catch (error) {
+        console.error(`[ManagerSessionStore] resume checkpoint unavailable for ${key}:`, error)
+      }
+    }
+    return checkpoints
   }
 
   /** episode 进行中的消息增量落盘(崩溃后可诊断,不参与 load);目录不存在自动创建 */

--- a/crabot-agent/src/manager/session-store.ts
+++ b/crabot-agent/src/manager/session-store.ts
@@ -160,7 +160,7 @@ export class ManagerSessionStore {
       || !Array.isArray(checkpoint.state.recent) || !Array.isArray(checkpoint.envelopes)
       || !Number.isInteger(checkpoint.wakeIndex) || checkpoint.wakeIndex < -1 || checkpoint.wakeIndex >= checkpoint.envelopes.length
       || !Array.isArray(checkpoint.pending) || !Array.isArray(checkpoint.turns)
-      || !Array.isArray(checkpoint.responses) || !Array.isArray(checkpoint.tools)
+      || !Array.isArray(checkpoint.responses) || !Array.isArray(checkpoint.tools) || !Array.isArray(checkpoint.pendingToolCallIds)
       || !Array.isArray(checkpoint.adminChatClaims) || !Array.isArray(checkpoint.transientMessageIds)
       || !Array.isArray(checkpoint.spawnedWorkerIds) || typeof checkpoint.hasEngineMessages !== 'boolean'
       || !Array.isArray(checkpoint.execution?.successfulSendMessageTargets) || !Array.isArray(checkpoint.execution?.continuedWorkers)) {

--- a/crabot-agent/src/manager/trace-types.ts
+++ b/crabot-agent/src/manager/trace-types.ts
@@ -101,7 +101,7 @@ export function isValidManagerEpisodeTrace(trace: unknown): trace is ManagerEpis
  */
 export interface ManagerTraceWriter {
   /** episode admission：持久化失败必须 throw（调用方不得继续调用 LLM/tool）。 */
-  startEpisode(traceId: string, managerKey: ManagerKey, trigger: ManagerEpisodeTrigger): void
+  startEpisode(traceId: string, managerKey: ManagerKey, trigger: ManagerEpisodeTrigger, resume?: boolean): void
   appendSpan(traceId: string, span: ManagerEpisodeSpan): void
   finishSpan(traceId: string, spanId: string, patch: { status: 'completed' | 'failed'; ended_at?: string; details?: unknown }): void
   finishEpisode(traceId: string, patch: { status: 'completed' | 'failed'; outcome?: { summary: string; error?: string }; total_usage?: ManagerEpisodeUsage }): void

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -5191,8 +5191,15 @@ export class UnifiedAgent extends ModuleBase {
     // Business ingress is registered only after onStart resolves; initialize durable
     // subject bindings before any Manager tool face can mint a continuation credential.
     await this.managerStack?.principals.init()
-    // P6-A §7.7：开放 Manager read model 前先收口遗留 running episode（failed/interrupted）。
-    this.traceStore.reconcileInterruptedManagerEpisodes()
+    const managerCheckpoints = await this.managerStack?.store.listCheckpoints() ?? []
+    const resumableManagerCheckpoints = managerCheckpoints.filter((checkpoint) => {
+      const episode = this.traceStore.getManagerEpisode(checkpoint.episodeId)
+      if (!episode || episode.status === 'running') return true
+      this.managerStack!.store.clearCheckpoint(checkpoint.state.key, checkpoint.episodeId)
+      return false
+    })
+    this.managerStack?.registry.registerResumeCheckpoints(resumableManagerCheckpoints)
+    this.traceStore.reconcileInterruptedManagerEpisodes(new Set(resumableManagerCheckpoints.map((checkpoint) => checkpoint.episodeId)))
     // P6-B §6：activation registry 载入持久 verification 状态；runtime config 已在
     // constructor/pull 路径应用过时 applyRuntimeConfigCandidate 会补 apply（见下）。
     await this.activationRegistry.load()
@@ -5302,6 +5309,9 @@ export class UnifiedAgent extends ModuleBase {
         // reconciliation must not keep the routing gate closed for this process.
         this.managerReconciliationSettled = true
         if (this.runtimeClosing) return
+        void stack.registry.resumeInterruptedEpisodes().catch((error) => {
+          console.error(`[${this.config.moduleId}] Manager startup resume failed:`, error)
+        })
         await this.agentHandler?.releaseRecoveredWorkerShellExits()
         // CLI child copy is a terminal artifact: retry only after the startup state reconciliation
         // has decided which parent incarnations are actually terminal.

--- a/crabot-agent/tests/manager/manager-trace.test.ts
+++ b/crabot-agent/tests/manager/manager-trace.test.ts
@@ -73,6 +73,20 @@ describe('TraceStore manager episode traces', () => {
     expect(episode.spawned_worker_ids).toEqual(['w-1', 'w-2'])
   })
 
+  it('keeps an interrupted episode resumable instead of marking the whole episode failed', () => {
+    store.startManagerEpisode('ep-resume', KEY_A, TRIGGER)
+    store.appendManagerSpan('ep-resume', {
+      span_id: 'interrupted-call', type: 'tool_call', started_at: new Date().toISOString(), status: 'running', details: { name: 'send_message' },
+    })
+    store.reconcileInterruptedManagerEpisodes(new Set(['ep-resume']))
+    expect(store.getManagerEpisode('ep-resume')!.status).toBe('running')
+    expect(store.getManagerEpisode('ep-resume')!.spans[0].status).toBe('failed')
+    store.startManagerEpisode('ep-resume', KEY_A, TRIGGER, true)
+    store.finishManagerEpisode('ep-resume', { status: 'completed', outcome: { summary: 'resumed' } })
+    expect(store.getManagerEpisode('ep-resume')!.status).toBe('completed')
+    expect(store.listManagerEpisodes(KEY_A).items).toHaveLength(1)
+  })
+
   it('finish closes leftover running spans with the episode status', () => {
     store.startManagerEpisode('ep-3', KEY_A, TRIGGER)
     store.appendManagerSpan('ep-3', {

--- a/crabot-agent/tests/manager/p5-integration.test.ts
+++ b/crabot-agent/tests/manager/p5-integration.test.ts
@@ -645,6 +645,31 @@ describe('P5 集成：manager 栈启动接线（Task 6）', () => {
 
   // --- ⑥ onStart 的启动对账 ---
 
+  it('启动只登记未完成 Manager 检查点，丢弃已完成 episode 的迟到检查点', async () => {
+    boot()
+    const stack = internals.managerStack!
+    const traces = (agent as unknown as { traceStore: import('../../src/core/trace-store.js').TraceStore }).traceStore
+    const pending = { episodeId: 'resume-pending', state: { key: 'test::pending' } } as import('../../src/manager/resume-checkpoint.js').ManagerResumeCheckpoint
+    const completed = { episodeId: 'resume-completed', state: { key: 'test::completed' } } as import('../../src/manager/resume-checkpoint.js').ManagerResumeCheckpoint
+    traces.startManagerEpisode(pending.episodeId, pending.state.key, { type: 'human_message', summary: 'pending' })
+    traces.startManagerEpisode(completed.episodeId, completed.state.key, { type: 'human_message', summary: 'completed' })
+    traces.finishManagerEpisode(completed.episodeId, { status: 'completed', outcome: { summary: 'done' } })
+    vi.spyOn(stack.store, 'listCheckpoints').mockResolvedValue([pending, completed])
+    const cleanup = vi.spyOn(stack.store, 'clearCheckpoint').mockImplementation(() => {})
+    const register = vi.spyOn(stack.registry, 'registerResumeCheckpoints').mockImplementation(() => {})
+    const resume = vi.spyOn(stack.registry, 'resumeInterruptedEpisodes').mockResolvedValue(undefined)
+    await internals.onStart()
+    try {
+      expect(register).toHaveBeenCalledWith([pending])
+      expect(cleanup).toHaveBeenCalledWith(completed.state.key, completed.episodeId)
+      expect(traces.getManagerEpisode(pending.episodeId)?.status).toBe('running')
+      expect(traces.getManagerEpisode(completed.episodeId)?.status).toBe('completed')
+      expect(resume).not.toHaveBeenCalled()
+    } finally {
+      await internals.onStop()
+    }
+  })
+
   /**
    * 对账的**发起点在 register 之后**（`main.ts`：start → register → startManagerStackReconciliation），
    * 不再挂在 `onStart()` 里：它的 fs 扫描 + tmux 子进程会和 `register()` 的 getaddrinfo 抢同一个
@@ -658,12 +683,33 @@ describe('P5 集成：manager 栈启动接线（Task 6）', () => {
     const release = vi.fn().mockResolvedValue(undefined)
     internals.agentHandler = { releaseRecoveredWorkerShellExits: release } as any
     const sweep = vi.spyOn(stack.harness, 'startLivenessSweep').mockImplementation(() => {})
+    const resume = vi.spyOn(stack.registry, 'resumeInterruptedEpisodes').mockResolvedValue(undefined)
     vi.spyOn(console, 'warn').mockImplementation(() => {})
 
     agent.startManagerStackReconciliation()
     await waitUntil(async () => release.mock.calls.length === 1)
 
     expect(sweep).toHaveBeenCalledOnce()
+    expect(resume).toHaveBeenCalledOnce()
+  })
+
+  it('Worker 对账完成后才恢复 Manager，Manager LLM 不阻塞后台恢复和巡检', async () => {
+    boot()
+    const stack = internals.managerStack!
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => { release = resolve })
+    vi.spyOn(stack.harness, 'reconcileOnStartup').mockImplementation(async () => {
+      await gate
+      return { revived: [], failed: [], unchanged: [] }
+    })
+    const resume = vi.spyOn(stack.registry, 'resumeInterruptedEpisodes').mockImplementation(async () => new Promise(() => {}))
+    const sweep = vi.spyOn(stack.harness, 'startLivenessSweep').mockImplementation(() => {})
+    agent.startManagerStackReconciliation()
+    await Promise.resolve()
+    expect(resume).not.toHaveBeenCalled()
+    release()
+    await waitUntil(() => sweep.mock.calls.length === 1)
+    expect(resume).toHaveBeenCalledOnce()
   })
 
   it('启动对账收尾在 bg-shell 结算后后台投递恢复提醒，不阻塞活性巡检', async () => {

--- a/crabot-agent/tests/manager/restart-resume.test.ts
+++ b/crabot-agent/tests/manager/restart-resume.test.ts
@@ -1,0 +1,317 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { promises as fs } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { ManagerRegistry, type ManagerRegistryDeps } from '../../src/manager/registry.js'
+import { ManagerSessionStore } from '../../src/manager/session-store.js'
+import { TraceStore } from '../../src/core/trace-store.js'
+import { defineTool, type LLMAdapter, type LLMStreamParams } from '../../src/engine/index.js'
+import type { ChannelMessage, Friend, ResolvedPermissions } from '../../src/types.js'
+import type { ManagerResumeCheckpoint } from '../../src/manager/resume-checkpoint.js'
+import { chunksFromContent } from '../engine/helpers/mock-stream.js'
+
+const KEY = 'feishu::restart-test'
+const message = (id: string, text: string): ChannelMessage => ({
+  platform_message_id: id,
+  session: { channel_id: 'feishu', session_id: 'restart-test', type: 'private' },
+  sender: { platform_user_id: 'human', platform_display_name: 'Human' },
+  content: { type: 'text', text },
+  features: { is_mention_crab: false },
+  platform_timestamp: '2026-09-06T14:05:00.000Z',
+})
+
+describe('Manager restart continuation', () => {
+  let dir: string
+  let store: ManagerSessionStore
+  let trace: TraceStore
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(join(tmpdir(), 'manager-resume-'))
+    store = new ManagerSessionStore(join(dir, 'managers'))
+    trace = new TraceStore(100, join(dir, 'traces'), 'running.jsonl', 'traces-v3-')
+  })
+  afterEach(async () => {
+    trace.stopFlushTimer()
+    await fs.rm(dir, { recursive: true, force: true })
+  })
+
+  function registry(adapter: LLMAdapter, overrides: Partial<ManagerRegistryDeps> = {}) {
+    return new ManagerRegistry({
+      store, adapter: () => adapter, model: () => 'test-model',
+      policy: { keepRecent: 20, hardCapTokens: 1000000 },
+      managerKeyFor: (key) => key,
+      promptInputs: () => ({}),
+      toolFace: () => [],
+      now: () => new Date('2026-09-06T14:05:00.000Z'),
+      timezone: () => 'Asia/Shanghai',
+      harness: {} as ManagerRegistryDeps['harness'],
+      ledger: {} as ManagerRegistryDeps['ledger'],
+      traceWriter: trace.managerTraceWriter((text) => text),
+      ...overrides,
+    })
+  }
+
+  async function checkpointWhere(predicate: (checkpoint: ManagerResumeCheckpoint) => boolean) {
+    let checkpoint: ManagerResumeCheckpoint | undefined
+    await vi.waitFor(async () => {
+      checkpoint = await store.loadCheckpoint(KEY)
+      expect(checkpoint && predicate(checkpoint)).toBe(true)
+    })
+    return checkpoint!
+  }
+
+  it('resumes the same episode after a successful send without a new human wake or repeated send', async () => {
+    const sent = vi.fn(async () => {
+      old.getOrCreate(KEY).recordSuccessfulSendMessage({ channel_id: 'feishu', session_id: 'restart-test' })
+      old.getOrCreate(KEY).recordWorkerContinuation('continued-worker')
+      old.getOrCreate(KEY).recordSpawnedWorker('spawned-worker')
+      return { output: 'delivered', isError: false }
+    })
+    const send = defineTool({ name: 'send_message', description: 'send', inputSchema: {}, isReadOnly: false, call: sent })
+    let calls = 0
+    const old = registry({
+      async *stream() {
+        if (calls++ === 0) {
+          yield* chunksFromContent([{ type: 'tool_use', id: 'sent-once', name: 'send_message', input: { text: 'reply' } }], 'tool_use')
+        } else {
+          await new Promise(() => {})
+        }
+      }, updateConfig() {},
+    }, { toolFace: () => [send] })
+    void old.routeHumanMessages('feishu', 'restart-test', [message('original', 'Continue the work')])
+    const checkpoint = await checkpointWhere((value) => value.turns.length === 1 && calls === 2)
+    expect(sent).toHaveBeenCalledTimes(1)
+
+    const inputs: LLMStreamParams[] = []
+    const restored = registry({
+      async *stream(params) {
+        inputs.push({ ...params, messages: [...params.messages] })
+        expect(restored.getOrCreate(KEY).hasSuccessfulSendMessageTo({ channel_id: 'feishu', session_id: 'restart-test' })).toBe(true)
+        expect(restored.getOrCreate(KEY).hasContinuedWorker('continued-worker')).toBe(true)
+        yield* chunksFromContent([], 'end_turn')
+      }, updateConfig() {},
+    }, { toolFace: () => [send] })
+    restored.registerResumeCheckpoints([checkpoint])
+    trace.reconcileInterruptedManagerEpisodes(new Set([checkpoint.episodeId]))
+    await restored.resumeInterruptedEpisodes()
+    await restored.resumeInterruptedEpisodes()
+
+    expect(inputs).toHaveLength(1)
+    expect(JSON.stringify(inputs[0].messages)).toContain('delivered')
+    expect(JSON.stringify(inputs[0].messages).match(/Continue the work/g)).toHaveLength(1)
+    expect(sent).toHaveBeenCalledTimes(1)
+    expect(trace.getManagerEpisode(checkpoint.episodeId)?.status).toBe('completed')
+    expect(trace.getManagerEpisode(checkpoint.episodeId)?.spawned_worker_ids).toEqual(['spawned-worker'])
+    expect(trace.listManagerEpisodes(KEY).items).toHaveLength(1)
+    expect(await store.loadCheckpoint(KEY)).toBeUndefined()
+  })
+
+  it('preserves an interrupted tool call as unknown instead of executing it again during recovery', async () => {
+    const calls = vi.fn(async () => new Promise<{ output: string; isError: boolean }>(() => {}))
+    const tool = defineTool({ name: 'send_message', description: 'send', inputSchema: {}, isReadOnly: false, call: calls })
+    const old = registry({
+      async *stream() {
+        yield* chunksFromContent([{ type: 'tool_use', id: 'in-flight', name: 'send_message', input: { text: 'reply' } }], 'tool_use')
+      }, updateConfig() {},
+    }, { toolFace: () => [tool] })
+    void old.routeHumanMessages('feishu', 'restart-test', [message('original', 'Continue the work')])
+    const checkpoint = await checkpointWhere((value) => value.tools.some((event) => event.type === 'tool_started'))
+    let input = ''
+    const restored = registry({
+      async *stream(params) {
+        input = JSON.stringify(params.messages)
+        yield* chunksFromContent([], 'end_turn')
+      }, updateConfig() {},
+    }, { toolFace: () => [tool] })
+    restored.registerResumeCheckpoints([checkpoint])
+    trace.reconcileInterruptedManagerEpisodes(new Set([checkpoint.episodeId]))
+    await restored.resumeInterruptedEpisodes()
+    expect(input).toContain('[interrupted: agent restarted]')
+    expect(input).toContain('in-flight')
+    expect(calls).toHaveBeenCalledTimes(1)
+    expect(trace.getManagerEpisode(checkpoint.episodeId)?.status).toBe('completed')
+    expect(trace.getManagerEpisode(checkpoint.episodeId)?.spans.find((span) => span.type === 'tool_call')?.status).toBe('failed')
+  })
+
+  it('retains queued human input and waits for startup reconciliation before accepting a new episode', async () => {
+    const old = registry({ async *stream() { await new Promise(() => {}) }, updateConfig() {} })
+    void old.routeHumanMessages('feishu', 'restart-test', [message('original', 'Original instruction')])
+    await checkpointWhere((value) => value.hasEngineMessages)
+    await old.routeHumanMessages('feishu', 'restart-test', [message('queued', 'Queued correction')])
+    const checkpoint = await checkpointWhere((value) => value.pending.length === 1)
+    const inputs: string[] = []
+    const restored = registry({
+      async *stream(params) { inputs.push(JSON.stringify(params.messages)); yield* chunksFromContent([], 'end_turn') },
+      updateConfig() {},
+    })
+    restored.registerResumeCheckpoints([checkpoint])
+    trace.reconcileInterruptedManagerEpisodes(new Set([checkpoint.episodeId]))
+    const newWake = restored.routeHumanMessages('feishu', 'restart-test', [message('new', 'New instruction')])
+    await Promise.resolve()
+    expect(inputs).toHaveLength(0)
+    await restored.resumeInterruptedEpisodes()
+    await newWake
+    expect(inputs[0]).toContain('Original instruction')
+    expect(inputs.slice(0, -1).join('\n')).toContain('Queued correction')
+    expect(inputs[0]).not.toContain('New instruction')
+    expect(inputs.at(-1)).toContain('New instruction')
+    expect((await store.load(KEY)).committedHumanMessageIds).toEqual(expect.arrayContaining(['original', 'queued', 'new']))
+  })
+
+  it('resumes an initial checkpoint with the original human identity and freshly resolved permissions', async () => {
+    const friend: Friend = {
+      id: 'original-friend', display_name: 'Original friend', permission: 'normal',
+      channel_identities: [], created_at: '', updated_at: '',
+    }
+    let initial: ManagerResumeCheckpoint | undefined
+    const save = store.saveCheckpoint.bind(store)
+    vi.spyOn(store, 'saveCheckpoint').mockImplementation((checkpoint) => {
+      if (!initial) initial = JSON.parse(JSON.stringify(checkpoint))
+      save(checkpoint)
+    })
+    const old = registry({ async *stream() { await new Promise(() => {}) }, updateConfig() {} })
+    void old.routeHumanMessages('feishu', 'restart-test', [message('original', 'Original instruction')], friend)
+    await checkpointWhere((value) => value.hasEngineMessages)
+    expect(initial?.hasEngineMessages).toBe(false)
+
+    const permissions = { memory_scopes: ['current-scope'] } as ResolvedPermissions
+    const resolve = vi.fn(async () => permissions)
+    const tools = vi.fn(() => [])
+    const restored = registry({ async *stream(params) {
+      expect(JSON.stringify(params.messages).match(/Original instruction/g)).toHaveLength(1)
+      yield* chunksFromContent([], 'end_turn')
+    }, updateConfig() {} }, { onHumanWake: resolve, toolFace: tools })
+    restored.registerResumeCheckpoints([initial!])
+    trace.reconcileInterruptedManagerEpisodes(new Set([initial!.episodeId]))
+    await restored.resumeInterruptedEpisodes()
+    expect(resolve).toHaveBeenCalledWith(KEY, { friend, sessionType: 'private' })
+    expect(tools).toHaveBeenCalledWith(KEY, false, undefined, { friend, sessionType: 'private' }, permissions, expect.any(Object), expect.objectContaining({ kind: 'human_messages', friend }))
+    expect(trace.getManagerEpisode(initial!.episodeId)?.trigger.type).toBe('human_message')
+    expect(trace.getManagerEpisode(initial!.episodeId)?.status).toBe('completed')
+  })
+
+  it('retains completed calls across repeated restarts during an unfinished tool turn', async () => {
+    const sent = vi.fn(async () => ({ output: 'delivered once', isError: false }))
+    const send = defineTool({ name: 'send_message', description: '', inputSchema: {}, isReadOnly: false, call: sent })
+    const wait = defineTool({ name: 'wait', description: '', inputSchema: {}, isReadOnly: true,
+      call: async () => new Promise<{ output: string; isError: boolean }>(() => {}) })
+    const old = registry({ async *stream() {
+      yield* chunksFromContent([
+        { type: 'tool_use', id: 'sent', name: 'send_message', input: {} },
+        { type: 'tool_use', id: 'waiting', name: 'wait', input: {} },
+      ], 'tool_use')
+    }, updateConfig() {} }, { toolFace: () => [send, wait] })
+    void old.routeHumanMessages('feishu', 'restart-test', [message('original', 'Continue')])
+    const checkpoint = await checkpointWhere((value) => value.tools.some((event) => event.name === 'wait'))
+    const firstRestart = registry({ async *stream() { await new Promise(() => {}) }, updateConfig() {} })
+    firstRestart.registerResumeCheckpoints([checkpoint])
+    trace.reconcileInterruptedManagerEpisodes(new Set([checkpoint.episodeId]))
+    void firstRestart.resumeInterruptedEpisodes()
+    const continued = await checkpointWhere((value) => JSON.stringify(value.state.recent).includes('[interrupted: agent restarted]'))
+    const secondRestart = registry({ async *stream(params) {
+      const text = JSON.stringify(params.messages)
+      expect(text.match(/delivered once/g)).toHaveLength(1)
+      expect(text.match(/\[interrupted: agent restarted\]/g)).toHaveLength(1)
+      yield* chunksFromContent([], 'end_turn')
+    }, updateConfig() {} })
+    secondRestart.registerResumeCheckpoints([continued])
+    trace.reconcileInterruptedManagerEpisodes(new Set([continued.episodeId]))
+    await secondRestart.resumeInterruptedEpisodes()
+    expect(trace.getManagerEpisode(continued.episodeId)?.status).toBe('completed')
+    expect(sent).toHaveBeenCalledTimes(1)
+    const spans = trace.getManagerEpisode(continued.episodeId)!.spans
+    expect(spans.filter((span) => span.type === 'tool_call')).toHaveLength(2)
+    expect(spans.filter((span) => span.type === 'tool_call' && span.status === 'failed')).toHaveLength(1)
+    for (const span of spans.filter((span) => span.type === 'tool_call')) {
+      expect(spans.some((parent) => parent.span_id === span.parent_span_id)).toBe(true)
+    }
+  })
+
+  it('restores a consumed image supplement from its reference without persisting inbound base64', async () => {
+    const path = join(dir, 'supplement.png')
+    const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+    await fs.writeFile(path, bytes)
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => { release = resolve })
+    let calls = 0
+    const old = registry({ async *stream() {
+      if (calls++ === 0) { await gate; yield* chunksFromContent([], 'end_turn') }
+      else await new Promise(() => {})
+    }, updateConfig() {} }, { supportsVision: () => true })
+    void old.routeHumanMessages('feishu', 'restart-test', [message('original', 'Original instruction')])
+    await checkpointWhere((value) => value.hasEngineMessages)
+    const imageMessage = { ...message('image-supplement', 'See image'), content: {
+      type: 'image' as const, file_path: path, filename: 'supplement.png', mime_type: 'image/png',
+    } }
+    await old.routeHumanMessages('feishu', 'restart-test', [imageMessage])
+    release()
+    const checkpoint = await checkpointWhere((value) => value.state.committedHumanMessageIds?.includes('image-supplement') === true)
+    expect(JSON.stringify(checkpoint)).not.toContain(bytes.toString('base64'))
+    expect(checkpoint.state.imageRefs).toHaveLength(1)
+    const restored = registry({ async *stream(params) {
+      expect(JSON.stringify(params.messages)).toContain(bytes.toString('base64'))
+      yield* chunksFromContent([], 'end_turn')
+    }, updateConfig() {} }, { supportsVision: () => true })
+    restored.registerResumeCheckpoints([checkpoint])
+    trace.reconcileInterruptedManagerEpisodes(new Set([checkpoint.episodeId]))
+    await restored.resumeInterruptedEpisodes()
+    expect(JSON.stringify(await store.load(KEY))).not.toContain(bytes.toString('base64'))
+    expect(trace.getManagerEpisode(checkpoint.episodeId)?.status).toBe('completed')
+  })
+
+  it('keeps restored workboard notices transient and acknowledges the original revision', async () => {
+    const old = registry({ async *stream() { await new Promise(() => {}) }, updateConfig() {} })
+    void old.routeWorkboardAdminUpdate({ key: KEY, noticeRevision: 17 })
+    const checkpoint = await checkpointWhere((value) => value.hasEngineMessages)
+    expect(checkpoint.transientMessageIds).toHaveLength(1)
+    const consumed = vi.fn(async () => {})
+    const restored = registry({ async *stream(params) {
+      expect(JSON.stringify(params.messages).match(/管理员已更新任务板/g)).toHaveLength(1)
+      yield* chunksFromContent([], 'end_turn')
+    }, updateConfig() {} }, { onWorkboardAdminUpdateConsumed: consumed })
+    restored.registerResumeCheckpoints([checkpoint])
+    trace.reconcileInterruptedManagerEpisodes(new Set([checkpoint.episodeId]))
+    await restored.resumeInterruptedEpisodes()
+    expect(JSON.stringify(await store.load(KEY))).not.toContain('管理员已更新任务板')
+    expect(consumed).toHaveBeenCalledWith(KEY, [17])
+    expect(trace.getManagerEpisode(checkpoint.episodeId)?.status).toBe('completed')
+  })
+
+  it('isolates a corrupt checkpoint and fails its trace without blocking other Manager sessions', async () => {
+    const old = registry({ async *stream() { await new Promise(() => {}) }, updateConfig() {} })
+    void old.routeHumanMessages('feishu', 'restart-test', [message('original', 'Continue')])
+    const checkpoint = await checkpointWhere((value) => value.hasEngineMessages)
+    await fs.writeFile(join(dir, 'managers', encodeURIComponent(KEY), 'running.json'), '{')
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    expect(await store.listCheckpoints()).toEqual([])
+    trace.reconcileInterruptedManagerEpisodes()
+    expect(trace.getManagerEpisode(checkpoint.episodeId)?.status).toBe('failed')
+    expect(error).toHaveBeenCalledWith(expect.stringContaining('resume checkpoint unavailable'), expect.any(Error))
+    error.mockRestore()
+  })
+
+  it('settles a failed continuation without replaying the restored schedule as a new wake', async () => {
+    const old = registry({ async *stream() { await new Promise(() => {}) }, updateConfig() {} })
+    void old.routeSchedule({ scheduleId: 'original-schedule', title: 'Original schedule', description: 'Original scheduled instruction',
+      creatorFriendId: 'creator', targetSession: { channel_id: 'feishu', session_id: 'restart-test' } })
+    const checkpoint = await checkpointWhere((value) => value.hasEngineMessages)
+    const resolve = vi.fn(async () => null)
+    let shouldFail = true
+    const restored = registry({ async *stream(params) {
+      if (shouldFail) throw new Error('provider unavailable')
+      expect(JSON.stringify(params.messages).match(/Original scheduled instruction/g)).toHaveLength(1)
+      yield* chunksFromContent([], 'end_turn')
+    }, updateConfig() {} }, { onScheduleWake: resolve })
+    restored.registerResumeCheckpoints([checkpoint])
+    trace.reconcileInterruptedManagerEpisodes(new Set([checkpoint.episodeId]))
+    await restored.resumeInterruptedEpisodes()
+    expect(resolve).toHaveBeenCalledWith({ key: KEY, creatorFriendId: 'creator', isBuiltin: undefined })
+    expect(trace.getManagerEpisode(checkpoint.episodeId)?.status).toBe('failed')
+    expect(await store.loadCheckpoint(KEY)).toBeUndefined()
+    expect(restored.getOrCreate(KEY).hasPendingMailbox).toBe(false)
+    shouldFail = false
+    const result = await restored.routeHumanMessages('feishu', 'restart-test', [message('new', 'New instruction')])
+    expect(result.outcome).toBe('completed')
+    expect(trace.listManagerEpisodes(KEY).items).toHaveLength(2)
+  })
+})

--- a/crabot-agent/tests/manager/restart-resume.test.ts
+++ b/crabot-agent/tests/manager/restart-resume.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'os'
 import { ManagerRegistry, type ManagerRegistryDeps } from '../../src/manager/registry.js'
 import { ManagerSessionStore } from '../../src/manager/session-store.js'
 import { TraceStore } from '../../src/core/trace-store.js'
-import { defineTool, type LLMAdapter, type LLMStreamParams } from '../../src/engine/index.js'
+import { createUserMessage, defineTool, type LLMAdapter, type LLMStreamParams } from '../../src/engine/index.js'
 import type { ChannelMessage, Friend, ResolvedPermissions } from '../../src/types.js'
 import type { ManagerResumeCheckpoint } from '../../src/manager/resume-checkpoint.js'
 import { chunksFromContent } from '../engine/helpers/mock-stream.js'
@@ -225,6 +225,170 @@ describe('Manager restart continuation', () => {
     for (const span of spans.filter((span) => span.type === 'tool_call')) {
       expect(spans.some((parent) => parent.span_id === span.parent_span_id)).toBe(true)
     }
+  })
+
+  it('does not restore completed calls discarded by an overflow retry', async () => {
+    await store.save({ key: KEY, foldedCount: 0, recent: [
+      createUserMessage('old history: ' + 'x'.repeat(3000)),
+      createUserMessage('more old history: ' + 'x'.repeat(3000)),
+    ] })
+    const sent = vi.fn(async () => ({ output: 'already delivered', isError: false }))
+    const send = defineTool({ name: 'send_message', description: '', inputSchema: {}, isReadOnly: false, call: sent })
+    let calls = 0
+    const old = registry({ async *stream(params) {
+      if (params.systemPrompt.includes('对话历史压缩助手')) {
+        yield* chunksFromContent([{ type: 'text', text: 'Old history summary' }], 'end_turn')
+      } else if (calls++ === 0) {
+        yield* chunksFromContent([{ type: 'tool_use', id: 'discarded-call', name: 'send_message', input: {} }], 'tool_use')
+      } else if (calls === 2) {
+        yield* chunksFromContent([], 'max_tokens')
+      } else await new Promise(() => {})
+    }, updateConfig() {} }, { toolFace: () => [send], policy: { keepRecent: 0, hardCapTokens: 1000000 } })
+    void old.routeHumanMessages('feishu', 'restart-test', [message('original', 'Continue after overflow')])
+    const checkpoint = await checkpointWhere((value) => value.state.foldedCount > 0 && calls === 3)
+    expect(checkpoint.tools).toHaveLength(1)
+    expect(JSON.stringify(checkpoint.state.recent)).not.toContain('discarded-call')
+    const inputs: string[] = []
+    const restored = registry({ async *stream(params) {
+      inputs.push(JSON.stringify(params.messages))
+      yield* chunksFromContent([], 'end_turn')
+    }, updateConfig() {} })
+    restored.registerResumeCheckpoints([checkpoint])
+    await restored.resumeInterruptedEpisodes()
+    expect(inputs).toHaveLength(1)
+    expect(inputs[0]).not.toContain('discarded-call')
+    expect(JSON.stringify(await store.load(KEY))).not.toContain('discarded-call')
+    expect(sent).toHaveBeenCalledTimes(1)
+    expect(trace.getManagerEpisode(checkpoint.episodeId)?.spans.filter((span) => span.type === 'tool_call')).toHaveLength(1)
+  })
+
+  it('does not reconstruct settled interrupted calls after compaction and another restart', async () => {
+    const read = defineTool({ name: 'read', description: '', inputSchema: {}, isReadOnly: true,
+      call: async () => ({ output: 'old-tool-result:' + 'x'.repeat(160000), isError: false }) })
+    const wait = defineTool({ name: 'wait', description: '', inputSchema: {}, isReadOnly: false,
+      call: async () => new Promise<{ output: string; isError: boolean }>(() => {}) })
+    const old = registry({ async *stream() {
+      yield* chunksFromContent([
+        { type: 'tool_use', id: 'old-read', name: 'read', input: {} },
+        { type: 'tool_use', id: 'old-wait', name: 'wait', input: {} },
+      ], 'tool_use')
+    }, updateConfig() {} }, { toolFace: () => [read, wait] })
+    void old.routeWorkboardAdminUpdate({ key: KEY, noticeRevision: 1 })
+    const checkpoint = await checkpointWhere((value) => value.tools.some((event) => event.name === 'wait'))
+    const next = defineTool({ name: 'next', description: '', inputSchema: {}, isReadOnly: true,
+      call: async () => ({ output: 'new result', isError: false }) })
+    let resumedCalls = 0
+    const firstRestart = registry({ async *stream() {
+      if (resumedCalls++ === 0) {
+        yield* chunksFromContent([{ type: 'tool_use', id: 'new-call', name: 'next', input: {} }], 'tool_use')
+      } else await new Promise(() => {})
+    }, updateConfig() {} }, { toolFace: () => [next] })
+    firstRestart.registerResumeCheckpoints([checkpoint])
+    void firstRestart.resumeInterruptedEpisodes()
+    const materialized = await checkpointWhere((value) => value.turns.length === 1 && resumedCalls === 2)
+    const secondRestart = registry({ async *stream(params) {
+      if (params.systemPrompt.includes('对话历史压缩助手')) {
+        yield* chunksFromContent([{ type: 'text', text: 'Prior tools were settled after interruption' }], 'end_turn')
+      } else await new Promise(() => {})
+    }, updateConfig() {} }, { policy: { keepRecent: 0, hardCapTokens: 12000 } })
+    secondRestart.registerResumeCheckpoints([materialized])
+    void secondRestart.resumeInterruptedEpisodes()
+    const continued = await checkpointWhere((value) => value.state.foldedCount > 0)
+    expect(JSON.stringify(continued.state.recent)).not.toContain('old-tool-result:')
+    const inputs: string[] = []
+    const thirdRestart = registry({ async *stream(params) {
+      inputs.push(JSON.stringify(params.messages))
+      yield* chunksFromContent([], 'end_turn')
+    }, updateConfig() {} })
+    thirdRestart.registerResumeCheckpoints([continued])
+    await thirdRestart.resumeInterruptedEpisodes()
+    expect(inputs).toHaveLength(1)
+    expect(inputs[0]).not.toContain('old-tool-result:')
+    expect(inputs[0]).not.toContain('old-wait')
+    expect(JSON.stringify(await store.load(KEY))).not.toContain('old-read')
+    const spans = trace.getManagerEpisode(continued.episodeId)!.spans
+    expect(spans.filter((span) => span.type === 'tool_call')).toHaveLength(3)
+    expect(spans.filter((span) => span.type === 'tool_call' && span.status === 'failed')).toHaveLength(1)
+  })
+
+  it('keeps the current human input protected when a resumed episode compacts history', async () => {
+    await store.save({ key: KEY, foldedCount: 0, recent: [
+      createUserMessage('old history: ' + 'x'.repeat(80000)),
+      createUserMessage('last old history'),
+    ] })
+    const read = defineTool({ name: 'read', description: '', inputSchema: {}, isReadOnly: true,
+      call: async () => ({ output: 'current result', isError: false }) })
+    let calls = 0
+    const old = registry({ async *stream() {
+      if (calls++ === 0) {
+        yield* chunksFromContent([{ type: 'tool_use', id: 'current-call', name: 'read', input: {} }], 'tool_use')
+      } else await new Promise(() => {})
+    }, updateConfig() {} }, { toolFace: () => [read] })
+    void old.routeHumanMessages('feishu', 'restart-test', [message('original', 'Current request stays literal')])
+    const checkpoint = await checkpointWhere((value) => value.turns.length === 1 && calls === 2)
+    const folds: string[] = []
+    const inputs: string[] = []
+    const restored = registry({ async *stream(params) {
+      if (params.systemPrompt.includes('对话历史压缩助手')) {
+        folds.push(JSON.stringify(params.messages))
+        yield* chunksFromContent([{ type: 'text', text: 'Old history summary' }], 'end_turn')
+      } else {
+        inputs.push(JSON.stringify(params.messages))
+        yield* chunksFromContent([], 'end_turn')
+      }
+    }, updateConfig() {} }, { policy: { keepRecent: 0, hardCapTokens: 12000 } })
+    restored.registerResumeCheckpoints([checkpoint])
+    await restored.resumeInterruptedEpisodes()
+    expect(folds).not.toHaveLength(0)
+    expect(folds.join('\n')).not.toContain('Current request stays literal')
+    expect(inputs[0].match(/Current request stays literal/g)).toHaveLength(1)
+    expect(trace.getManagerEpisode(checkpoint.episodeId)?.status).toBe('completed')
+  })
+
+  it('protects a human supplement whose Engine message ID changed during an overflow retry', async () => {
+    await store.save({ key: KEY, foldedCount: 0, recent: [
+      ...Array.from({ length: 3 }, (_, index) => createUserMessage(`old history ${index}: ` + 'x'.repeat(80000))),
+      createUserMessage('last old history'),
+    ] })
+    const read = defineTool({ name: 'read', description: '', inputSchema: {}, isReadOnly: true,
+      call: async () => {
+        await old.routeHumanMessages('feishu', 'restart-test', [message('supplement', 'Keep this correction literal')])
+        return { output: 'current result', isError: false }
+      } })
+    const next = defineTool({ name: 'next', description: '', inputSchema: {}, isReadOnly: true,
+      call: async () => ({ output: 'retry result', isError: false }) })
+    let calls = 0
+    const old = registry({ async *stream(params) {
+      if (params.systemPrompt.includes('对话历史压缩助手')) {
+        yield* chunksFromContent([{ type: 'text', text: 'Old history summary' }], 'end_turn')
+      } else if (calls++ === 0) {
+        yield* chunksFromContent([{ type: 'tool_use', id: 'read-call', name: 'read', input: {} }], 'tool_use')
+      } else if (calls === 2) {
+        yield* chunksFromContent([], 'max_tokens')
+      } else if (calls === 3) {
+        yield* chunksFromContent([{ type: 'tool_use', id: 'retry-call', name: 'next', input: {} }], 'tool_use')
+      } else await new Promise(() => {})
+    }, updateConfig() {} }, { toolFace: () => [read, next], policy: { keepRecent: 2, hardCapTokens: 1000000 } })
+    void old.routeWorkboardAdminUpdate({ key: KEY, noticeRevision: 1 })
+    const checkpoint = await checkpointWhere((value) => value.state.foldedCount > 0 && calls === 4)
+    const folds: string[] = []
+    const inputs: string[] = []
+    const restored = registry({ async *stream(params) {
+      if (params.systemPrompt.includes('对话历史压缩助手')) {
+        folds.push(JSON.stringify(params.messages))
+        yield* chunksFromContent([{ type: 'text', text: 'Old history summary' }], 'end_turn')
+      } else {
+        inputs.push(JSON.stringify(params.messages))
+        yield* chunksFromContent([], 'end_turn')
+      }
+    }, updateConfig() {} }, { policy: { keepRecent: 0, hardCapTokens: 12000 } })
+    restored.registerResumeCheckpoints([checkpoint])
+    await restored.resumeInterruptedEpisodes()
+    expect(folds).not.toHaveLength(0)
+    expect(folds.join('\n')).not.toContain('Keep this correction literal')
+    expect(inputs[0].match(/Keep this correction literal/g)).toHaveLength(1)
+    expect((await store.load(KEY)).committedHumanMessageIds).toContain('supplement')
+    expect(trace.getManagerEpisode(checkpoint.episodeId)?.status).toBe('completed')
   })
 
   it('restores a consumed image supplement from its reference without persisting inbound base64', async () => {


### PR DESCRIPTION
Agent 重启后，旧实现把所有未完成的 Manager episode 标为 failed，未接回 Engine 的续跑能力；会话页面合并在途消息时也隐藏了同轮已经发送的回复和后续动作。

现在 Worker 启动对账结束后，Manager 从检查点沿用原会话、发起人、唤醒来源和 episode ID 继续运行，并重新解析当前权限。已经完成的工具结果、投递和 Worker 续办事实、排队与已消费的插话一起保留。执行中丢失结果的工具明确记录 interrupted，恢复机制不直接重执行。页面显示“本轮已回复，继续处理”，轮次结束后自动切换为已处理。

- 恢复接线只使用共享 Engine 和 Manager 自身会话边界；没有调用旧 Worker resume_task 或构造新的 recovery/Schedule 任务。Engine 在下一次 LLM 调用前刷新 messagesRef，修复插话快照遗漏。
- 检查点区分全量工具审计与尚未并入历史的调用：恢复只补齐后者，已被压缩或溢出重试移出的结果不重新追加。当前 episode 的人类输入按稳定消息 ID 恢复 protected tail，插话在重试中重建 ID 后同步刷新保护边界。
- 检查点在现有 Manager 目录中原子写入，权限为 0600；入站图片只存引用，运行时回调不持久化。写入失败在可中止的检查点收口，清理失败只告警；坏记录隔离，已终态记录不重放。无检查点的旧中断记录仍据实标明 interrupted。
- 已恢复进历史的原输入不会在续跑失败后再次作为新唤醒入队；真实 Provider 失败沿用既有错误处理，不新增自动重试循环。发送成功但结果未落盘仍为 unknown，恢复不承诺外部副作用 exactly-once。

验证：后端 7 文件 192 项定向测试通过，含 13 项重启续跑回归；Agent TypeScript 构建通过。前端 21 项测试与构建通过；Playwright 桌面 1440x1000、手机 390x844 验证回复/动作展示、无重复条目、状态轮询切换和布局均通过。

扩大检查有 686 项通过、7 项失败，全部失败在未修改基线复现：6 项 inbound 测试缺少 tmp-page fixture，1 项 Registry 工具面调用次数预期 2、实际 4。运行实例尚未重启部署。

正式协议已更新并发布：[crabot-docs 22b9605](https://github.com/smilefufu/crabot-docs/commit/22b9605)。PROGRESS 记录实现、验证、Channel 接收前仍不在检查点覆盖内的边界，以及审查确认的非阻塞故障/性能 follow-up。
