### PR TITLE
feat(agent): 为 OpenAI 请求添加稳定 prompt_cache_key

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,9 +1,20 @@
 # Crabot 项目进度
 
-> 最后整理：2026-09-07
+> 最后整理：2026-09-08
 > 本文件只保留当前状态、明确 follow-up 和阶段性里程碑；详细实施流水、逐轮 review 与历史测试输出见 Git 历史。压缩前完整版本可用 `git show 49b9cb4:PROGRESS.md` 查看。
 
 ## 当前状态
+
+### OpenAI prompt_cache_key：实现与验证完成
+
+- `openai` / `openai-responses` 请求顶层统一添加稳定 key，按模型与完整 system prompt
+  确定性生成；明确排除 `gemini` / `anthropic`，不增加配置或改变现有错误处理。
+- 新增 17 项请求回归，覆盖消息增长、适配器重建、重试和切到 Gemini 后的字段省略；
+  相关 130 项测试与 Agent TypeScript 构建通过。
+- 新适配器向 mirror-xinshu / gpt-6-astra 实测 8 次请求全部成功，Chat 2/4、Responses 3/4
+  命中 5632 tokens，原始 usage 与解析一致；运行实例尚未部署。
+- 协议 Agent v3.13.1 已先行发布，依据
+  [设计 spec](crabot-docs/superpowers/specs/2026-09-08-openai-prompt-cache-key-design.md)。
 
 ### Manager 渠道消息逐轮注入：已修复
 

--- a/crabot-agent/src/engine/llm-adapter.ts
+++ b/crabot-agent/src/engine/llm-adapter.ts
@@ -54,7 +54,7 @@ export function createAdapter(config: CreateAdapterConfig): LLMAdapter {
     case 'openai':
       return new OpenAIAdapter({ endpoint: config.endpoint, apikey: config.apikey })
     case 'gemini':
-      return new OpenAIAdapter({ endpoint: config.endpoint, apikey: config.apikey })
+      return new OpenAIAdapter({ endpoint: config.endpoint, apikey: config.apikey }, 'gemini')
     case 'openai-responses':
       return new OpenAIResponsesAdapter({
         endpoint: config.endpoint,

--- a/crabot-agent/src/engine/openai-adapter.ts
+++ b/crabot-agent/src/engine/openai-adapter.ts
@@ -7,6 +7,7 @@ import { isToolResultMessage, extractText, buildImageUrl, readSSELines, mergeCon
 import type { EngineMessage, ToolDefinition, StreamChunk, ContentBlock, LLMTokenUsage } from './types.js'
 import { HttpResponseError, StreamProtocolError, parseRetryAfterMs } from './retry-utils.js'
 import { withStreamTimeout } from './stream-timeout.js'
+import { buildPromptCacheKey } from './prompt-cache-key.js'
 
 // --- OpenAI Message Types ---
 
@@ -152,7 +153,7 @@ function mapOpenAIFinishReason(raw: string | null | undefined): EngineStopReason
 export class OpenAIAdapter implements LLMAdapter {
   private config: LLMAdapterConfig
 
-  constructor(config: LLMAdapterConfig) {
+  constructor(config: LLMAdapterConfig, private readonly format: 'openai' | 'gemini' = 'openai') {
     this.config = config
   }
 
@@ -178,6 +179,10 @@ export class OpenAIAdapter implements LLMAdapter {
       messages: [{ role: 'system', content: params.systemPrompt }, ...messages],
       stream: true,
       stream_options: { include_usage: true },
+    }
+
+    if (this.format === 'openai') {
+      body.prompt_cache_key = buildPromptCacheKey(params.model, params.systemPrompt)
     }
 
     // 思考强度（spec 2026-08 §5.2）：跟随默认不发；off→'none'；low/medium/high/自定义字符串

--- a/crabot-agent/src/engine/openai-responses-adapter.ts
+++ b/crabot-agent/src/engine/openai-responses-adapter.ts
@@ -9,6 +9,7 @@ import { isToolResultMessage, extractText, buildImageUrl, readSSEEvents, capTool
 import type { EngineMessage, ToolDefinition, StreamChunk, ContentBlock, LLMTokenUsage } from './types.js'
 import { HttpResponseError, StreamProtocolError, parseRetryAfterMs } from './retry-utils.js'
 import { withStreamTimeout } from './stream-timeout.js'
+import { buildPromptCacheKey } from './prompt-cache-key.js'
 
 // --- Responses API Message Normalization ---
 
@@ -164,6 +165,7 @@ export class OpenAIResponsesAdapter implements LLMAdapter {
 
     const body: Record<string, unknown> = {
       model: params.model,
+      prompt_cache_key: buildPromptCacheKey(params.model, params.systemPrompt),
       instructions: params.systemPrompt,
       input,
       tools,

--- a/crabot-agent/src/engine/prompt-cache-key.ts
+++ b/crabot-agent/src/engine/prompt-cache-key.ts
@@ -1,0 +1,7 @@
+import { createHash } from 'crypto'
+
+export function buildPromptCacheKey(model: string, systemPrompt: string): string {
+  return createHash('sha256')
+    .update(JSON.stringify(['crabot-prompt-cache-v1', model, systemPrompt]), 'utf8')
+    .digest('hex')
+}

--- a/crabot-agent/tests/engine/anthropic-adapter.test.ts
+++ b/crabot-agent/tests/engine/anthropic-adapter.test.ts
@@ -58,6 +58,7 @@ async function captureRequestBody(params: {
   }
 
   expect(spy).toHaveBeenCalledTimes(1)
+  expect(spy.mock.calls[0][0]).not.toHaveProperty('prompt_cache_key')
   return spy.mock.calls[0][0] as Record<string, unknown>
 }
 

--- a/crabot-agent/tests/engine/prompt-cache-key.test.ts
+++ b/crabot-agent/tests/engine/prompt-cache-key.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { callNonStreaming, createAdapter, OpenAIAdapter, type LLMStreamParams } from '../../src/engine/llm-adapter'
+import { createAssistantMessage, createToolResultMessage, createUserMessage, type ToolDefinition } from '../../src/engine/types'
+
+const connection = { endpoint: 'https://example.test/v1', apikey: 'test-key' }
+const expectedKey = '1d5b695acfa33ddf798e8894e92ebf4356b859880d2698bc4bd8a51038b320f2'
+const params: LLMStreamParams = {
+  model: 'cache-test-model',
+  systemPrompt: 'Stable instructions',
+  messages: [createUserMessage('hello')],
+  tools: [],
+  maxTokens: 64,
+}
+const tool: ToolDefinition = {
+  name: 'lookup',
+  description: 'Look up a value',
+  inputSchema: { type: 'object', properties: {} },
+  isReadOnly: true,
+  call: async () => ({ output: 'found', isError: false }),
+}
+const formats = ['openai', 'openai-responses'] as const
+
+function mockFetch() {
+  const fetchMock = vi.fn(async (url: string, _init?: RequestInit) => {
+    const data = url.endsWith('/responses')
+      ? `event: response.completed\ndata: ${JSON.stringify({ response: { id: 'resp_1', output: [] } })}\n\n`
+      : `data: ${JSON.stringify({ id: 'chat_1', choices: [{ delta: { content: 'OK' }, finish_reason: 'stop' }] })}\n\ndata: [DONE]\n\n`
+    return new Response(data, { headers: { 'Content-Type': 'text/event-stream' } })
+  })
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+function requestBodies(fetchMock: ReturnType<typeof mockFetch>): Array<Record<string, unknown>> {
+  return fetchMock.mock.calls.map(([, init]) => JSON.parse(init!.body as string))
+}
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe('OpenAI prompt cache key', () => {
+  it.each(formats)('adds only the top-level key to the %s request', async (format) => {
+    const fetchMock = mockFetch()
+    await callNonStreaming(createAdapter({ ...connection, format }), { ...params, tools: [tool] })
+
+    const [body] = requestBodies(fetchMock)
+    expect(body).toEqual(format === 'openai' ? {
+      model: params.model,
+      max_tokens: 64,
+      messages: [{ role: 'system', content: params.systemPrompt }, { role: 'user', content: 'hello' }],
+      tools: [{ type: 'function', function: { name: tool.name, description: tool.description, parameters: tool.inputSchema } }],
+      stream: true,
+      stream_options: { include_usage: true },
+      prompt_cache_key: expectedKey,
+    } : {
+      model: params.model,
+      instructions: params.systemPrompt,
+      input: [{ type: 'message', role: 'user', content: 'hello' }],
+      tools: [{ type: 'function', name: tool.name, description: tool.description, parameters: tool.inputSchema, strict: false }],
+      tool_choice: 'auto',
+      parallel_tool_calls: false,
+      store: false,
+      stream: true,
+      max_output_tokens: 64,
+      prompt_cache_key: expectedKey,
+    })
+  })
+
+  it.each(formats)('keeps the %s key stable as history, tools and connection change', async (format) => {
+    const fetchMock = mockFetch()
+    const adapter = createAdapter({ ...connection, format })
+    await callNonStreaming(adapter, params)
+    const grown = {
+      ...params,
+      tools: [tool],
+      messages: [
+        ...params.messages,
+        createAssistantMessage([{ type: 'tool_use', id: 'call_1', name: tool.name, input: {} }], 'tool_use'),
+        createToolResultMessage('call_1', 'found', false),
+        createUserMessage('continue'),
+      ],
+    }
+    await callNonStreaming(adapter, grown)
+    adapter.updateConfig({ endpoint: 'https://changed.test/v1', apikey: 'rotated-key' })
+    await callNonStreaming(adapter, { ...params, messages: [createUserMessage('compacted history')] })
+    await callNonStreaming(createAdapter({ ...connection, format }), params)
+
+    expect(requestBodies(fetchMock).map((body) => body.prompt_cache_key)).toEqual(Array(4).fill(expectedKey))
+  })
+
+  it.each(formats)('changes the %s key with the model or exact system prompt', async (format) => {
+    const fetchMock = mockFetch()
+    const adapter = createAdapter({ ...connection, format })
+    for (const request of [
+      params,
+      { ...params, model: 'another-model' },
+      { ...params, systemPrompt: `${params.systemPrompt} ` },
+      { ...params, systemPrompt: 'Other instructions' },
+    ]) await callNonStreaming(adapter, request)
+
+    const keys = requestBodies(fetchMock).map((body) => body.prompt_cache_key)
+    expect(keys[0]).toBe(expectedKey)
+    expect(new Set(keys).size).toBe(4)
+  })
+
+  it.each(['', '\u4f60\u597d', 'x'.repeat(10_000)])('uses a bounded key for prompt case %#', async (systemPrompt) => {
+    const fetchMock = mockFetch()
+    for (const format of formats) {
+      await callNonStreaming(createAdapter({ ...connection, format }), { ...params, systemPrompt })
+    }
+    const bodies = requestBodies(fetchMock)
+    expect(bodies[0].prompt_cache_key).toMatch(/^[a-f0-9]{64}$/)
+    expect(bodies[1].prompt_cache_key).toBe(bodies[0].prompt_cache_key)
+  })
+
+  it('preserves OpenAI semantics for direct constructor callers', async () => {
+    const fetchMock = mockFetch()
+    await callNonStreaming(new OpenAIAdapter(connection), params)
+    expect(requestBodies(fetchMock)[0].prompt_cache_key).toBe(expectedKey)
+  })
+
+  it('omits the key for Gemini even after connection updates', async () => {
+    const fetchMock = mockFetch()
+    const adapter = createAdapter({ ...connection, format: 'gemini' })
+    await callNonStreaming(adapter, params)
+    adapter.updateConfig({ endpoint: 'https://changed.test/v1', apikey: 'rotated-key' })
+    await callNonStreaming(adapter, params)
+    for (const body of requestBodies(fetchMock)) expect(body).not.toHaveProperty('prompt_cache_key')
+  })
+
+  it('adds the key for the Codex Responses backend without changing account headers or defaults', async () => {
+    const fetchMock = mockFetch()
+    const adapter = createAdapter({
+      ...connection, endpoint: 'https://chatgpt.com/backend-api/codex', format: 'openai-responses', accountId: 'account-1',
+    })
+    await callNonStreaming(adapter, params)
+    const [body] = requestBodies(fetchMock)
+    expect(body.prompt_cache_key).toBe(expectedKey)
+    expect(body.reasoning).toEqual({ effort: 'medium', summary: 'auto' })
+    expect(body.include).toEqual(['reasoning.encrypted_content'])
+    expect(body).not.toHaveProperty('max_output_tokens')
+    expect(fetchMock.mock.calls[0][1]?.headers).toEqual({
+      'Content-Type': 'application/json', Authorization: 'Bearer test-key', 'ChatGPT-Account-Id': 'account-1',
+    })
+  })
+
+  it.each(formats)('retains the %s key when a failed request retries with a rebuilt adapter', async (format) => {
+    const fetchMock = mockFetch()
+    let generation = 0
+    fetchMock.mockImplementationOnce(async () => {
+      generation++
+      return new Response('temporary failure', { status: 503 })
+    })
+    await callNonStreaming(createAdapter({ ...connection, format }), {
+      ...params,
+      configGeneration: () => generation,
+      onConfigChanged: async () => ({ adapter: createAdapter({ ...connection, format }) }),
+    })
+    expect(requestBodies(fetchMock).map((body) => body.prompt_cache_key)).toEqual([expectedKey, expectedKey])
+  })
+
+  it('omits the key when buffered retry switches from OpenAI to Gemini', async () => {
+    const fetchMock = mockFetch()
+    let generation = 0
+    fetchMock.mockImplementationOnce(async () => {
+      generation++
+      return new Response('temporary failure', { status: 503 })
+    })
+    await callNonStreaming(createAdapter({ ...connection, format: 'openai' }), {
+      ...params,
+      configGeneration: () => generation,
+      onConfigChanged: async () => ({
+        adapter: createAdapter({ ...connection, format: 'gemini' }), model: 'gemini-test-model',
+      }),
+    })
+    const bodies = requestBodies(fetchMock)
+    expect(bodies).toHaveLength(2)
+    expect(bodies[0].prompt_cache_key).toBe(expectedKey)
+    expect(bodies[1]).not.toHaveProperty('prompt_cache_key')
+    expect(bodies[1].model).toBe('gemini-test-model')
+  })
+
+  it.each(formats)('surfaces a %s parameter rejection without retrying or dropping the key', async (format) => {
+    const fetchMock = mockFetch()
+    fetchMock.mockImplementation(async () => new Response(JSON.stringify({
+      error: { type: 'invalid_request_error', message: 'unsupported parameter: prompt_cache_key' },
+    }), { status: 400 }))
+    await expect(callNonStreaming(createAdapter({ ...connection, format }), params)).rejects.toThrow('prompt_cache_key')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(requestBodies(fetchMock)[0].prompt_cache_key).toBe(expectedKey)
+  })
+})


### PR DESCRIPTION
Crabot 的 OpenAI Chat 和 Responses 请求此前没有发送 `prompt_cache_key`。本次按已确认设计统一添加该标准字段，让相同模型与 system prompt 的请求使用稳定缓存提示；`gemini` 与 `anthropic` 明确不添加。

- key 由版本标记、模型名和完整 system prompt 的 SHA-256 生成，固定 64 位十六进制；追加消息、工具结果、配置凭据轮换或重建适配器不直接改变 key。
- 两个 OpenAI 适配器共用内部纯函数；工厂为复用 OpenAI 实现的 Gemini 保留实际格式，重试热切换后也省略该字段。
- 不新增 Admin 配置、连接字段、持久状态或缓存用量字段，不改提示词、消息、工具内容及既有重试流程。

验证：

- 旧实现先复现 16 项缺少 key 的失败，Gemini 排除项通过；实现后新增 17 项及相关既有测试共 130 项全部通过。
- Agent TypeScript 编译与构建通过；最终 diff review 未发现新增问题。
- 使用新构建的实际适配器向 mirror-xinshu / gpt-6-astra 发送 8 次固定合成输入请求，全部 200，生成的 key 一致。Chat 2/4、Responses 3/4 命中，每次 5632 tokens，原始 usage 与解析一致。这是集成验证结果，不是命中率保证。

失败路径：第三方可能拒绝新字段，仍交给现有 HTTP 错误分类与失败收口；没有新增自动删字段重发、额外重试、超时或持久状态。运行实例尚未部署。

已确认 [设计 spec](https://github.com/smilefufu/crabot-docs/blob/492f65d/superpowers/specs/2026-09-08-openai-prompt-cache-key-design.md)，[Agent v3.13.1 协议](https://github.com/smilefufu/crabot-docs/blob/492f65d/protocols/protocol-agent-v3.md)已先行发布。
