### PR TITLE
fix(worker): 修复 builtin 重启观测、subagent 通知与停止确认

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -11,6 +11,8 @@
 - subagent 终态与退出通知原子持久化，通过 WorkerInbox 确认；ListEntities 按 Worker 归属查询，Kill 命中实际执行者，整体停止仍核验后台实体。
 - 真实装配验证两次重启后的工具 trace、无需人类输入的 child 中断唤醒、工具阻塞期间 Kill 和整体 stop unknown。定向扩大回归 268 通过、1 项既有 shell 进程时间测试失败；TypeScript 通过。
 - Agent 全量首轮 3209/3251 通过；失败项在未修改基线复现 40 项，其余 2 项并发用例单独复跑通过。本次引入的旧 mock 配置读取问题已修复并对齐基线结果。
+- PR #152 review：启动 trace 恢复纳入 Worker 互斥并跳过常驻实例；已持有写者时跳过重复快照，仍校验 cursor。3 项新增回归先失败后通过；相关 114 项首轮 113 通过，1 项目录清理 ENOTEMPTY，adapter 全文件重跑 82 项通过；TypeScript 通过。
+- 待决策：上述去重仍保留每轮全量归档的容量增长，改变快照持久化模型需另行确认。follow-up：启动时 idle session 全量常驻；结果文件不可读、非 Worker 退出写盘失败及启动对账提前失败的异常收口，详见 PR #152 review。
 - 尚未部署或修改故障 Worker 现场；合并后的独立测试 Worker 重启验收与存量 trace 保全/受控接续仍待执行。
 
 ### 项目初始化与 Harness Git 检测：实现与验收完成，待 PR 审查

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5,6 +5,14 @@
 
 ## 当前状态
 
+### builtin Worker 恢复、观测与 subagent 控制：实现完成，待 PR 审查
+
+- 按[已确认 spec](crabot-docs/superpowers/specs/2026-09-08-builtin-worker-recovery-observation-control-design.md) 先发布 Agent v3.14.3；恢复同一 idle 化身的可写 trace，拒绝向已缺失的历史位置续写。
+- subagent 终态与退出通知原子持久化，通过 WorkerInbox 确认；ListEntities 按 Worker 归属查询，Kill 命中实际执行者，整体停止仍核验后台实体。
+- 真实装配验证两次重启后的工具 trace、无需人类输入的 child 中断唤醒、工具阻塞期间 Kill 和整体 stop unknown。定向扩大回归 268 通过、1 项既有 shell 进程时间测试失败；TypeScript 通过。
+- Agent 全量首轮 3209/3251 通过；失败项在未修改基线复现 40 项，其余 2 项并发用例单独复跑通过。本次引入的旧 mock 配置读取问题已修复并对齐基线结果。
+- 尚未部署或修改故障 Worker 现场；合并后的独立测试 Worker 重启验收与存量 trace 保全/受控接续仍待执行。
+
 ### 项目初始化与 Harness Git 检测：实现与验收完成，待 PR 审查
 
 - 按[已确认 spec](crabot-docs/superpowers/specs/2026-09-08-project-bootstrap-git-observation-design.md) 先发布 Agent v3.14.0，

--- a/crabot-agent/src/agent/agent-handler.ts
+++ b/crabot-agent/src/agent/agent-handler.ts
@@ -23,6 +23,7 @@ import { buildChildEnv } from '../core/runtime-env.js'
 import { killShellTree } from '../engine/bg-entities/bg-shell.js'
 import { ReadoptReaper } from '../engine/bg-entities/reaper.js'
 import type { BgEntityOwner, BgEntityRecord, BgEntityStatus, BgEntityType, BgShellRegistryRecord } from '../engine/bg-entities/types.js'
+import { BG_EXIT_RETRY_DELAYS_MS } from '../engine/bg-entities/types.js'
 import type { BashBgContext } from '../engine/tools/index.js'
 import type { BgToolDeps } from '../engine/tools/index.js'
 import type { TaskContext } from '../mcp/crab-messaging.js'
@@ -527,7 +528,7 @@ type ShellExitSettlement =
   | { readonly status: 'delivered' }
   | { readonly status: 'dead_letter'; readonly reason: string }
 
-const BG_EXIT_RETRY_DELAYS_MS = [1_000, 2_000, 4_000, 8_000, 10_000] as const
+type WorkerEntityExitInfo = ShellExitInfo | { entity_id: string; worker_id: string }
 
 export class AgentHandler {
   private sdkEnv: SdkEnvConfig
@@ -589,20 +590,25 @@ export class AgentHandler {
     info: ShellExitInfo,
     onSettled: (settlement: ShellExitSettlement) => Promise<void>,
   ) => Promise<void>
+  private builtinChildExitDispatcher?: (
+    workerId: string,
+    entityId: string,
+    onSettled: (settlement: ShellExitSettlement) => Promise<void>,
+  ) => Promise<void>
   /**
    * Recovered worker-owned shells must wait for harness reconciliation: before
    * `scanOrphans()` a restarted builtin adapter has no resident incarnation and
    * WorkerInbox would retain the notification at its head until unrelated input.
    */
-  private workerShellExitRoutingReady = false
-  private readonly queuedWorkerShellExits: ShellExitInfo[] = []
+  private workerEntityExitRoutingReady = false
+  private readonly queuedWorkerEntityExits: WorkerEntityExitInfo[] = []
   /** Per-worker FIFO retained at the head while delivery is retrying. */
-  private readonly workerShellExitQueues = new Map<string, ShellExitInfo[]>()
-  private readonly drainingWorkerShellExitQueues = new Set<string>()
+  private readonly workerEntityExitQueues = new Map<string, WorkerEntityExitInfo[]>()
+  private readonly drainingWorkerEntityExitQueues = new Set<string>()
   /** Per-process delivery retries; delay is capped while durable pending survives restart. */
-  private readonly workerShellExitRetryTimers = new Map<string, NodeJS.Timeout>()
+  private readonly workerEntityExitRetryTimers = new Map<string, NodeJS.Timeout>()
   /** Settlement-only retries never re-enqueue an input already accepted by WorkerInbox. */
-  private readonly workerShellExitSettlementTimers = new Map<string, NodeJS.Timeout>()
+  private readonly workerEntityExitSettlementTimers = new Map<string, NodeJS.Timeout>()
   /** Interval handle for periodic 24h GC of dead entities */
   private gcIntervalHandle?: NodeJS.Timeout
   /** 运行时配置原子替换通知源与代数 getter（见 AgentHandlerOptions 同名字段）。 */
@@ -689,12 +695,12 @@ export class AgentHandler {
       this.gcIntervalHandle = undefined
     }
     this.readoptReaper.stop()
-    this.workerShellExitQueues.clear()
-    this.drainingWorkerShellExitQueues.clear()
-    for (const timer of this.workerShellExitRetryTimers.values()) clearTimeout(timer)
-    this.workerShellExitRetryTimers.clear()
-    for (const timer of this.workerShellExitSettlementTimers.values()) clearTimeout(timer)
-    this.workerShellExitSettlementTimers.clear()
+    this.workerEntityExitQueues.clear()
+    this.drainingWorkerEntityExitQueues.clear()
+    for (const timer of this.workerEntityExitRetryTimers.values()) clearTimeout(timer)
+    this.workerEntityExitRetryTimers.clear()
+    for (const timer of this.workerEntityExitSettlementTimers.values()) clearTimeout(timer)
+    this.workerEntityExitSettlementTimers.clear()
   }
 
   /**
@@ -740,36 +746,57 @@ export class AgentHandler {
     this.builtinShellExitDispatcher = dispatcher
   }
 
+  setBuiltinChildExitDispatcher(dispatcher: NonNullable<AgentHandler['builtinChildExitDispatcher']>): void {
+    this.builtinChildExitDispatcher = dispatcher
+  }
+
+  async routeBuiltinChildExit(workerId: string, entityId: string): Promise<void> {
+    const info = { worker_id: workerId, entity_id: entityId }
+    if (!this.workerEntityExitRoutingReady) {
+      this.queuedWorkerEntityExits.push(info)
+      return
+    }
+    this.enqueueWorkerEntityExit(workerId, info)
+    await this.drainWorkerEntityExitQueue(workerId)
+  }
+
   /**
    * Called after builtin orphan scan and harness reconciliation complete. This
    * releases recovered worker-owned shell exits without waiting on agent startup.
    */
-  async releaseRecoveredWorkerShellExits(): Promise<void> {
-    this.workerShellExitRoutingReady = true
-    const recovered = this.queuedWorkerShellExits.splice(0)
+  async releaseRecoveredWorkerEntityExits(): Promise<void> {
+    for (const record of await this.bgRegistry.list({ type: 'agent' })) {
+      if (record.owner.worker_id && record.spawned_by_task_id === record.owner.worker_id && record.exit_notification?.status === 'pending') {
+        this.queuedWorkerEntityExits.push({ worker_id: record.owner.worker_id, entity_id: record.entity_id })
+      }
+    }
+    this.workerEntityExitRoutingReady = true
+    const recovered = this.queuedWorkerEntityExits.splice(0)
     const workerIds = new Set<string>()
     for (const info of recovered) {
-      if (!info.worker_id) {
+      if (!info.worker_id && 'command' in info) {
         void this.deliverShellExitNotification(info).catch((error) => {
           console.error(`[AgentHandler] recovered legacy shell notification failed for ${info.entity_id}:`, error)
         })
         continue
       }
-      this.enqueueWorkerShellExit(info.worker_id, info)
-      workerIds.add(info.worker_id)
+      if (info.worker_id) {
+        this.enqueueWorkerEntityExit(info.worker_id, info)
+        workerIds.add(info.worker_id)
+      }
     }
     // Start one independent FIFO drain per worker. Startup/liveness must not wait
     // for adapter I/O from an unrelated worker that may remain hung indefinitely.
     for (const workerId of workerIds) {
-      void this.drainWorkerShellExitQueue(workerId).catch((error) => {
+      void this.drainWorkerEntityExitQueue(workerId).catch((error) => {
         console.error(`[AgentHandler] recovered worker shell queue failed for ${workerId}:`, error)
       })
     }
   }
 
   private async routeShellExit(info: ShellExitInfo): Promise<void> {
-    if (info.worker_id && !this.workerShellExitRoutingReady) {
-      this.queuedWorkerShellExits.push(info)
+    if (info.worker_id && !this.workerEntityExitRoutingReady) {
+      this.queuedWorkerEntityExits.push(info)
       return
     }
     if (!info.worker_id) {
@@ -777,50 +804,54 @@ export class AgentHandler {
       return
     }
 
-    this.enqueueWorkerShellExit(info.worker_id, info)
-    await this.drainWorkerShellExitQueue(info.worker_id)
+    this.enqueueWorkerEntityExit(info.worker_id, info)
+    await this.drainWorkerEntityExitQueue(info.worker_id)
   }
 
-  private enqueueWorkerShellExit(workerId: string, info: ShellExitInfo): void {
-    const queue = this.workerShellExitQueues.get(workerId) ?? []
+  private enqueueWorkerEntityExit(workerId: string, info: WorkerEntityExitInfo): void {
+    const queue = this.workerEntityExitQueues.get(workerId) ?? []
     if (!queue.some((queued) => queued.entity_id === info.entity_id)) queue.push(info)
-    this.workerShellExitQueues.set(workerId, queue)
+    this.workerEntityExitQueues.set(workerId, queue)
   }
 
-  private async drainWorkerShellExitQueue(workerId: string, retryIndex = 0): Promise<void> {
-    if (this.drainingWorkerShellExitQueues.has(workerId)) return
-    this.drainingWorkerShellExitQueues.add(workerId)
+  private async drainWorkerEntityExitQueue(workerId: string, retryIndex = 0): Promise<void> {
+    if (this.drainingWorkerEntityExitQueues.has(workerId)) return
+    this.drainingWorkerEntityExitQueues.add(workerId)
     try {
-      const queue = this.workerShellExitQueues.get(workerId)
+      const queue = this.workerEntityExitQueues.get(workerId)
       while (queue && queue.length > 0) {
         const info = queue[0]
-        if (!await this.tryRouteWorkerShellExit(workerId, info)) {
-          this.scheduleWorkerShellExitRetry(workerId, info.entity_id, retryIndex)
+        if (!await this.tryRouteWorkerEntityExit(workerId, info)) {
+          this.scheduleWorkerEntityExitRetry(workerId, info.entity_id, retryIndex)
           return
         }
-        const retryTimer = this.workerShellExitRetryTimers.get(info.entity_id)
+        const retryTimer = this.workerEntityExitRetryTimers.get(info.entity_id)
         if (retryTimer) clearTimeout(retryTimer)
-        this.workerShellExitRetryTimers.delete(info.entity_id)
+        this.workerEntityExitRetryTimers.delete(info.entity_id)
         queue.shift()
       }
-      this.workerShellExitQueues.delete(workerId)
+      this.workerEntityExitQueues.delete(workerId)
     } finally {
-      this.drainingWorkerShellExitQueues.delete(workerId)
+      this.drainingWorkerEntityExitQueues.delete(workerId)
     }
   }
 
-  private async tryRouteWorkerShellExit(workerId: string, info: ShellExitInfo): Promise<boolean> {
+  private async tryRouteWorkerEntityExit(workerId: string, info: WorkerEntityExitInfo): Promise<boolean> {
     try {
       const record = await this.bgRegistry.get(info.entity_id)
-      if (record?.type !== 'shell' || record.exit_notification?.status !== 'pending') return true
-      if (!this.builtinShellExitDispatcher) {
-        throw new Error('builtin shell exit dispatcher is not attached')
-      }
+      if (record?.exit_notification?.status !== 'pending') return true
 
       await this.bgRegistry.beginExitNotificationAttempt(info.entity_id)
-      await this.builtinShellExitDispatcher(workerId, info, async (settlement) => {
-        await this.settleWorkerShellExit(info.entity_id, settlement)
-      })
+      const settle = async (settlement: ShellExitSettlement) => {
+        await this.settleWorkerEntityExit(info.entity_id, settlement)
+      }
+      if ('command' in info) {
+        if (!this.builtinShellExitDispatcher) throw new Error('builtin shell exit dispatcher is not attached')
+        await this.builtinShellExitDispatcher(workerId, info, settle)
+      } else {
+        if (!this.builtinChildExitDispatcher) throw new Error('builtin child exit dispatcher is not attached')
+        await this.builtinChildExitDispatcher(workerId, info.entity_id, settle)
+      }
       return true
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
@@ -835,21 +866,21 @@ export class AgentHandler {
     }
   }
 
-  private scheduleWorkerShellExitRetry(workerId: string, entityId: string, retryIndex: number): void {
-    if (this.workerShellExitRetryTimers.has(entityId)) return
+  private scheduleWorkerEntityExitRetry(workerId: string, entityId: string, retryIndex: number): void {
+    if (this.workerEntityExitRetryTimers.has(entityId)) return
     const delayIndex = Math.min(retryIndex, BG_EXIT_RETRY_DELAYS_MS.length - 1)
     const timer = setTimeout(() => {
-      this.workerShellExitRetryTimers.delete(entityId)
-      void this.drainWorkerShellExitQueue(
+      this.workerEntityExitRetryTimers.delete(entityId)
+      void this.drainWorkerEntityExitQueue(
         workerId,
         Math.min(delayIndex + 1, BG_EXIT_RETRY_DELAYS_MS.length - 1),
       )
     }, BG_EXIT_RETRY_DELAYS_MS[delayIndex])
     timer.unref?.()
-    this.workerShellExitRetryTimers.set(entityId, timer)
+    this.workerEntityExitRetryTimers.set(entityId, timer)
   }
 
-  private async settleWorkerShellExit(
+  private async settleWorkerEntityExit(
     entityId: string,
     settlement: ShellExitSettlement,
     retryIndex = 0,
@@ -863,21 +894,21 @@ export class AgentHandler {
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       await this.bgRegistry.recordExitNotificationFailure(entityId, `settlement failed: ${message}`).catch(() => undefined)
-      this.scheduleWorkerShellExitSettlementRetry(entityId, settlement, retryIndex)
+      this.scheduleWorkerEntityExitSettlementRetry(entityId, settlement, retryIndex)
       throw error
     }
   }
 
-  private scheduleWorkerShellExitSettlementRetry(
+  private scheduleWorkerEntityExitSettlementRetry(
     entityId: string,
     settlement: ShellExitSettlement,
     retryIndex: number,
   ): void {
-    if (this.workerShellExitSettlementTimers.has(entityId)) return
+    if (this.workerEntityExitSettlementTimers.has(entityId)) return
     const delayIndex = Math.min(retryIndex, BG_EXIT_RETRY_DELAYS_MS.length - 1)
     const timer = setTimeout(() => {
-      this.workerShellExitSettlementTimers.delete(entityId)
-      void this.settleWorkerShellExit(
+      this.workerEntityExitSettlementTimers.delete(entityId)
+      void this.settleWorkerEntityExit(
         entityId,
         settlement,
         Math.min(delayIndex + 1, BG_EXIT_RETRY_DELAYS_MS.length - 1),
@@ -886,7 +917,7 @@ export class AgentHandler {
       })
     }, BG_EXIT_RETRY_DELAYS_MS[delayIndex])
     timer.unref?.()
-    this.workerShellExitSettlementTimers.set(entityId, timer)
+    this.workerEntityExitSettlementTimers.set(entityId, timer)
   }
 
   /**
@@ -916,6 +947,7 @@ export class AgentHandler {
         cursorMap: this.bgCursorMap,
         taskId: workerId,
         ownerFriendId: owner.friend_id,
+        ownerWorkerId: workerId,
         agentAbortControllers: this.agentAbortControllers,
       },
     }
@@ -926,7 +958,7 @@ export class AgentHandler {
     return entities.some((entity) =>
       entity.owner.worker_id === workerId && (
         entity.status === 'running' ||
-        (entity.type === 'shell' && entity.exit_notification?.status === 'pending')
+        entity.exit_notification?.status === 'pending'
       ),
     )
   }

--- a/crabot-agent/src/core/trace-store.ts
+++ b/crabot-agent/src/core/trace-store.ts
@@ -660,6 +660,7 @@ export class TraceStore {
     const trace = await this.getFullTrace(traceId)
     if (!trace) throw new Error(`builtin trace writer unavailable: ${traceId}`)
     if (trace.spans.length < minimumOffset) throw new Error(`builtin trace source incomplete: ${traceId}, spans=${trace.spans.length}, cursor=${minimumOffset}`)
+    if (this.activeTraceWriters.has(traceId) && this.traces.has(traceId)) return
     // Only the adapter's validated live/idle incarnation may reopen its own trace.
     trace.status = 'running'
     delete trace.ended_at

--- a/crabot-agent/src/core/trace-store.ts
+++ b/crabot-agent/src/core/trace-store.ts
@@ -115,6 +115,9 @@ export class TraceStore {
   // traces-running-<taskId>.jsonl。启动时 loadResumableCheckpoints 把这些文件
   // 读进此 Map，等 admin 裁决（HOLD，不立即标 failed）。
   private resumableCheckpoints = new Map<string, { traceId: string; checkpoint: import('../types.js').ResumeCheckpoint }>()
+  private readonly deferredBuiltinTraces = new Set<string>()
+  private readonly idleBuiltinTraces = new Set<string>()
+  private readonly activeTraceWriters = new Set<string>()
 
   constructor(
     maxSize = 100,
@@ -122,6 +125,7 @@ export class TraceStore {
     runningFlushFile = 'traces-running.jsonl',
     archiveFilePrefix = 'traces-',
     readableArchiveFilePrefixes: readonly string[] = [archiveFilePrefix],
+    private readonly deferBuiltinRecovery = false,
   ) {
     this.maxSize = maxSize
     this.persistDir = persistDir
@@ -448,6 +452,15 @@ export class TraceStore {
         if (record && record.kind === 'legacy_agent_trace') {
           try {
           const trace = record.trace as AgentTrace
+          if (this.deferBuiltinRecovery && trace.trigger.type === 'task' && !trace.related_task_id) {
+            const archived = this.readTraceFromIndex(trace.trace_id)
+            if (!archived || (archived.status === 'running' && trace.spans.length >= archived.spans.length)) {
+              this.traces.set(trace.trace_id, trace)
+              if (!this.order.includes(trace.trace_id)) this.order.push(trace.trace_id)
+              this.deferredBuiltinTraces.add(trace.trace_id)
+            }
+            continue
+          }
           // 正在等 resume 裁决的 worker 保持 running；全局快照可能比 per-task checkpoint
           // 多出尚未走到 onTurn 的工具生命周期 spans，只在确实更完整时接管 trace 正文。
           if (resumableTraceIds.has(trace.trace_id)) {
@@ -479,7 +492,8 @@ export class TraceStore {
         }
       }
       // 清空 running 文件——这些 trace 已落到日期文件
-      fs.writeFileSync(filePath, '', 'utf-8')
+      if (this.deferredBuiltinTraces.size > 0) this.flushInFlightTraces()
+      else fs.writeFileSync(filePath, '', 'utf-8')
     } catch (err) {
       console.warn(`[TraceStore] loadRunningTraces failed: ${err instanceof Error ? err.message : err}`)
     }
@@ -624,14 +638,59 @@ export class TraceStore {
     }
 
     // Ring Buffer：超出容量时淘汰最旧的
-    if (this.order.length >= this.maxSize) {
-      const oldest = this.order.shift()!
-      this.traces.delete(oldest)
-    }
+    this.evictHistory()
 
     this.traces.set(trace.trace_id, trace)
     this.order.push(trace.trace_id)
     return trace
+  }
+
+  private evictHistory(): void {
+    while (this.order.length >= this.maxSize) {
+      const index = this.order.findIndex((id) => !this.activeTraceWriters.has(id) &&
+        (this.traces.get(id)?.status !== 'running' || this.idleBuiltinTraces.has(id)))
+      if (index < 0) break
+      const [id] = this.order.splice(index, 1)
+      this.traces.delete(id)
+      this.idleBuiltinTraces.delete(id)
+    }
+  }
+
+  async acquireBuiltinTraceWriter(traceId: string, minimumOffset = 0): Promise<void> {
+    const trace = await this.getFullTrace(traceId)
+    if (!trace) throw new Error(`builtin trace writer unavailable: ${traceId}`)
+    if (trace.spans.length < minimumOffset) throw new Error(`builtin trace source incomplete: ${traceId}, spans=${trace.spans.length}, cursor=${minimumOffset}`)
+    // Only the adapter's validated live/idle incarnation may reopen its own trace.
+    trace.status = 'running'
+    delete trace.ended_at
+    delete trace.duration_ms
+    delete trace.outcome
+    this.persistTrace(trace, true)
+    this.traces.set(traceId, trace)
+    if (!this.order.includes(traceId)) this.order.push(traceId)
+    this.activeTraceWriters.add(traceId)
+    this.idleBuiltinTraces.delete(traceId)
+    this.deferredBuiltinTraces.delete(traceId)
+  }
+
+  releaseBuiltinTraceWriter(traceId: string): void {
+    const trace = this.traces.get(traceId)
+    if (!trace) throw new Error(`builtin trace writer lost: ${traceId}`)
+    this.persistTrace(trace, true)
+    this.activeTraceWriters.delete(traceId)
+    this.idleBuiltinTraces.add(traceId)
+    this.evictHistory()
+  }
+
+  reconcileDeferredBuiltinTraces(): void {
+    for (const id of this.deferredBuiltinTraces) {
+      const trace = this.traces.get(id)
+      if (!trace) continue
+      this.appendInterruptedToolResults(trace, new Date().toISOString())
+      this.endTrace(id, 'failed', { summary: '[interrupted: agent restarted]' })
+    }
+    this.deferredBuiltinTraces.clear()
+    this.flushInFlightTraces()
   }
 
   startSpan(
@@ -693,7 +752,7 @@ export class TraceStore {
     status: 'completed' | 'failed',
     outcome?: AgentTrace['outcome']
   ): void {
-    const trace = this.traces.get(traceId)
+    const trace = this.traces.get(traceId) ?? this.readTraceFromIndex(traceId)
     if (!trace) return
 
     const now = new Date()
@@ -709,6 +768,8 @@ export class TraceStore {
     }
 
     this.persistTrace(trace)
+    this.activeTraceWriters.delete(traceId)
+    this.idleBuiltinTraces.delete(traceId)
   }
 
   /**
@@ -1156,7 +1217,7 @@ export class TraceStore {
     }
   }
 
-  private persistTrace(trace: AgentTrace): void {
+  private persistTrace(trace: AgentTrace, required = false): void {
     if (!this.persistDir) return
     try {
       const date = trace.started_at.slice(0, 10)
@@ -1184,6 +1245,7 @@ export class TraceStore {
       // persist failure must not affect main flow
       const msg = err instanceof Error ? err.message : String(err)
       console.warn(`[TraceStore] persistTrace failed for ${trace.trace_id}: ${msg}`)
+      if (required) throw err
     }
   }
 

--- a/crabot-agent/src/engine/bg-entities/bg-agent.ts
+++ b/crabot-agent/src/engine/bg-entities/bg-agent.ts
@@ -19,6 +19,7 @@ import { getErrorMessage } from '../tools/utils.js'
 import { getBgEntitiesLogsDir } from '../../core/data-paths.js'
 import type { BgEntityRegistry } from './registry.js'
 import type { BgEntityOwner, BgAgentRegistryRecord } from './types.js'
+import { BG_EXIT_RETRY_DELAYS_MS } from './types.js'
 import { emitInstantSpan, type BgEntityTraceContext } from './trace.js'
 import type { TraceStore } from '../../core/trace-store.js'
 import { recordEngineLlmResponse, recordEngineToolLifecycle, recordSubAgentTurn } from '../sub-agent-trace.js'
@@ -175,6 +176,20 @@ export async function spawnPersistentAgent(opts: SpawnPersistentAgentOpts): Prom
   await opts.registry.register(record)
 
   const agentSpawnedAtMs = Date.now()
+  const commitExit = async (patch: Partial<BgAgentRegistryRecord>): Promise<void> => {
+    let attempt = 0
+    for (;;) {
+      try {
+        await opts.registry.update(entity_id, patch)
+        return
+      } catch (error) {
+        if (!opts.owner.worker_id || opts.owner.worker_id !== opts.spawned_by_task_id) throw error
+        console.error(`[bg-agent] exit persistence pending for ${entity_id}:`, error)
+        const delay = BG_EXIT_RETRY_DELAYS_MS[Math.min(attempt++, BG_EXIT_RETRY_DELAYS_MS.length - 1)]
+        await new Promise<void>((resolve) => { const timer = setTimeout(resolve, delay); timer.unref?.() })
+      }
+    }
+  }
 
   // fire-and-forget — intentionally not awaited by caller
   void (async () => {
@@ -248,15 +263,13 @@ export async function spawnPersistentAgent(opts: SpawnPersistentAgentOpts): Prom
           ...(failureError ? { error: failureError.slice(0, 200) } : {}),
         })
       }
-      await opts.registry
-        .update(entity_id, {
-          status: endedStatus,
-          result_file: resultFile,
-          exit_code: exitCode,
-          ended_at: new Date().toISOString(),
-          ...(failureError ? { error: failureError } : {}),
-        } as Partial<BgAgentRegistryRecord>)
-        .catch(() => {})
+      await commitExit({
+        status: endedStatus,
+        result_file: resultFile,
+        exit_code: exitCode,
+        ended_at: new Date().toISOString(),
+        ...(failureError ? { error: failureError } : {}),
+      })
       if (opts.onExit) {
         try {
           await opts.onExit({
@@ -297,14 +310,12 @@ export async function spawnPersistentAgent(opts: SpawnPersistentAgentOpts): Prom
           error: errMsg.slice(0, 200),
         })
       }
-      await opts.registry
-        .update(entity_id, {
-          status: 'failed' as const,
-          exit_code: 1,
-          ended_at: new Date().toISOString(),
-          error: errMsg,
-        } as Partial<BgAgentRegistryRecord>)
-        .catch(() => {})
+      await commitExit({
+        status: 'failed',
+        exit_code: 1,
+        ended_at: new Date().toISOString(),
+        error: errMsg,
+      })
       if (opts.onExit) {
         try {
           await opts.onExit({
@@ -325,7 +336,9 @@ export async function spawnPersistentAgent(opts: SpawnPersistentAgentOpts): Prom
     } finally {
       opts.abortControllers.delete(entity_id)
     }
-  })()
+  })().catch((error) => {
+    console.error(`[bg-agent] failed to persist exit for ${entity_id}:`, error)
+  })
 
   return entity_id
 }

--- a/crabot-agent/src/engine/bg-entities/registry.ts
+++ b/crabot-agent/src/engine/bg-entities/registry.ts
@@ -52,7 +52,7 @@ class AsyncMutex {
 }
 
 function hasPendingExitNotification(record: BgEntityRecord): boolean {
-  return record.type === 'shell' && record.exit_notification?.status === 'pending'
+  return record.exit_notification?.status === 'pending'
 }
 
 /** Worker delegate_task identities belong to Worker observability retention, not the 7d entity GC. */
@@ -100,6 +100,9 @@ export class BgEntityRegistry {
       const existing = file.entities[entity_id]
       if (!existing) return null
 
+      if (isWorkerOwnedBuiltinAgent(existing) && existing.status !== 'running' &&
+        (patch.status !== undefined || ('stop_requested_at' in patch))) return existing
+
       // Do not allow downgrading from a terminal state that was set intentionally
       // (e.g. kill tool sets 'killed'; exit handler must not overwrite with 'failed').
       const TERMINAL_PRIORITY: ReadonlyArray<BgEntityStatus> = ['killed', 'stalled']
@@ -112,6 +115,12 @@ export class BgEntityRegistry {
       }
 
       const next = { ...existing, ...patch } as BgEntityRecord
+      if (next.type === 'agent' && isWorkerOwnedBuiltinAgent(next) && existing.status === 'running' && next.status !== 'running') {
+        if (next.stop_requested_at) next.status = 'killed'
+        else if (!next.exit_notification) {
+          next.exit_notification = { status: 'pending', updated_at: next.ended_at ?? new Date().toISOString(), attempts: 0 }
+        }
+      }
       if (
         next.type === 'shell' &&
         next.owner.worker_id &&
@@ -367,8 +376,8 @@ export class BgEntityRegistry {
     await this.mutex.run(async () => {
       const file = await this.readFile()
       const existing = file.entities[entityId]
-      if (existing?.type !== 'shell' || existing.exit_notification === undefined) return
-      const next: BgShellRegistryRecord = {
+      if (!existing || existing.exit_notification === undefined) return
+      const next: BgEntityRecord = {
         ...existing,
         exit_notification: mutate(existing.exit_notification, new Date().toISOString()),
       }
@@ -385,8 +394,9 @@ export class BgEntityRegistry {
     try {
       const raw = await fs.readFile(this.registryPath, 'utf8')
       return JSON.parse(raw) as RegistryFile
-    } catch {
-      return { entities: {} }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return { entities: {} }
+      throw error
     }
   }
 

--- a/crabot-agent/src/engine/bg-entities/types.ts
+++ b/crabot-agent/src/engine/bg-entities/types.ts
@@ -6,6 +6,7 @@
 export type BgEntityType = 'shell' | 'agent'
 export type BgEntityStatus = 'running' | 'completed' | 'failed' | 'killed' | 'stalled'
 export type BgExitNotificationStatus = 'pending' | 'delivered' | 'dead_letter'
+export const BG_EXIT_RETRY_DELAYS_MS = [1_000, 2_000, 4_000, 8_000, 10_000] as const
 
 export interface BgExitNotificationState {
   readonly status: BgExitNotificationStatus
@@ -49,6 +50,8 @@ export interface BgShellRegistryRecord extends BgEntityBase {
 
 export interface BgAgentRegistryRecord extends BgEntityBase {
   readonly type: 'agent'
+  exit_notification?: BgExitNotificationState
+  stop_requested_at?: string
   /** Present when this persistent agent was started through delegate_task. */
   readonly subagent_type?: string
   /** Its independent TraceStore trace, when the caller enabled tracing. */

--- a/crabot-agent/src/engine/tools/kill-tool.ts
+++ b/crabot-agent/src/engine/tools/kill-tool.ts
@@ -51,6 +51,10 @@ async function killAgent(
   entityId: string,
   deps: BgToolDeps,
 ): Promise<{ output: string; isError: boolean }> {
+  if (deps.ownerWorkerId) {
+    if (!deps.stopWorkerAgent) return { output: 'Worker child control unavailable; stop not confirmed.', isError: true }
+    return deps.stopWorkerAgent(entityId)
+  }
   const record = await deps.registry.get(entityId)
   if (!record) {
     return { output: `Entity not found: ${entityId}`, isError: true }

--- a/crabot-agent/src/engine/tools/list-entities-tool.ts
+++ b/crabot-agent/src/engine/tools/list-entities-tool.ts
@@ -122,11 +122,12 @@ export function createListEntitiesTool(deps: BgToolDeps): ToolDefinition {
 
       // Persistent (disk-backed) entities — 后台 shell / sub-agent 现在全是持久实体
       const persistentRecords = await deps.registry.list({
-        owner_friend_id: deps.ownerFriendId,
+        ...(deps.ownerWorkerId ? { spawned_by_task_id: deps.ownerWorkerId } : { owner_friend_id: deps.ownerFriendId }),
         status: wantedStatuses,
       })
 
       const allRows: RowData[] = persistentRecords
+        .filter((rec) => !deps.ownerWorkerId || rec.owner.worker_id === deps.ownerWorkerId)
         .map((rec: BgEntityRecord) => ({
           type: rec.type,
           entityId: rec.entity_id,

--- a/crabot-agent/src/engine/tools/output-tool.ts
+++ b/crabot-agent/src/engine/tools/output-tool.ts
@@ -16,6 +16,8 @@ export interface BgToolDeps {
   readonly cursorMap: Map<string, number>
   readonly taskId: string
   readonly ownerFriendId?: string
+  readonly ownerWorkerId?: string
+  readonly stopWorkerAgent?: (entityId: string) => Promise<{ output: string; isError: boolean }>
   /** Sub-agent abortControllers map (key=entity_id); used to abort a running bg agent on Kill */
   readonly agentAbortControllers?: Map<string, AbortController>
 }

--- a/crabot-agent/src/manager/bootstrap.ts
+++ b/crabot-agent/src/manager/bootstrap.ts
@@ -717,6 +717,10 @@ export async function reconcileManagerStack(stack: ManagerStack): Promise<Reconc
   // 第一次追加回调把升级前会话重放成新 activity。
   await stack.harness.reconcileNativeActivityOnStartup()
   const report = await stack.harness.reconcileOnStartup()
+  const builtin = stack.adapters.get('builtin')
+  if (builtin instanceof BuiltinWorkerAdapter) {
+    await builtin.reconcileTraces((await stack.ledger.listAllWorkers()).map(({ worker }) => worker))
+  }
   await stack.harness.reconcileInputDeliveriesOnStartup()
   await stack.harness.reconcileQueryReceiptsOnStartup()
   await stack.harness.reconcileControlOperationsOnStartup()

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -875,13 +875,15 @@ export class UnifiedAgent extends ModuleBase {
       'traces-running-v3.jsonl',
       'traces-v3-',
       ['traces-', 'traces-v3-'],
+      true,
     )
     this.lspManager = createLSPManager()
     this.builtinSubagentRunner = new BuiltinSubagentRunner(
       this.traceStore,
       this.lspManager,
-      async (workerId, text) => {
-        await this.requireManagerStack().harness.sendToWorker(workerId, text)
+      async (workerId, entityId) => {
+        if (!this.agentHandler) throw new Error('child notification route is not ready')
+        await this.agentHandler.routeBuiltinChildExit(workerId, entityId)
       },
       this.builtinBgRegistry,
       (text) => redactSecrets(text, [...this.knownSecrets]),
@@ -1308,6 +1310,20 @@ export class UnifiedAgent extends ModuleBase {
     },
     onSettled: (settlement: { status: 'delivered' } | { status: 'dead_letter'; reason: string }) => Promise<void>,
   ): Promise<void> {
+    return this.deliverBuiltinEntityExit(workerId, `bg-shell:${info.entity_id}`, async () => {
+      if (!this.agentHandler) throw new Error('builtin shell renderer is not ready')
+      const text = await this.agentHandler.renderShellExitNotification(info)
+      return `<bg-notification>\n${text}\n</bg-notification>`
+    }, onSettled)
+  }
+
+  private deliverBuiltinEntityExit(
+    workerId: string,
+    dedupeKey: string,
+    render: () => Promise<string>,
+    onSettled: (settlement: { status: 'delivered' } | { status: 'dead_letter'; reason: string }) => Promise<void>,
+    rejectStoppedParent = false,
+  ): Promise<void> {
     const complete = this.requireManagerStack().harness.beginBgNotification(workerId)
     let completed = false
     const completeOnce = (): void => {
@@ -1327,7 +1343,7 @@ export class UnifiedAgent extends ModuleBase {
     const previous = this.builtinBgDeliveryTails.get(workerId) ?? Promise.resolve()
     const delivery = previous
       .catch(() => undefined)
-      .then(() => this.deliverBuiltinShellExitNow(workerId, info, settle, completeOnce))
+      .then(() => this.deliverBuiltinEntityExitNow(workerId, dedupeKey, render, settle, completeOnce, rejectStoppedParent))
       .catch((error) => {
         completeOnce()
         throw error
@@ -1339,25 +1355,20 @@ export class UnifiedAgent extends ModuleBase {
     return delivery
   }
 
-  private async deliverBuiltinShellExitNow(
+  private async deliverBuiltinEntityExitNow(
     workerId: string,
-    info: {
-      entity_id: string
-      command: string
-      status: 'completed' | 'failed' | 'killed'
-      exit_code: number
-      runtime_ms?: number
-    },
+    dedupeKey: string,
+    render: () => Promise<string>,
     onSettled: (settlement: { status: 'delivered' } | { status: 'dead_letter'; reason: string }) => Promise<void>,
     onDeduplicated: () => void,
+    rejectStoppedParent: boolean,
   ): Promise<void> {
-    const handler = this.agentHandler
-    if (!handler) throw new Error('builtin shell exit cannot be delivered before AgentHandler initialization')
     const harness = this.requireManagerStack().harness
     try {
-      const text = await handler.renderShellExitNotification(info)
-      await harness.sendToWorker(workerId, `<bg-notification>\n${text}\n</bg-notification>`, {
-        dedupeKey: `bg-shell:${info.entity_id}`,
+      const text = await render()
+      await harness.sendToWorker(workerId, text, {
+        dedupeKey,
+        ...(rejectStoppedParent ? { rejectStoppedParent: true } : {}),
         onDeduplicated,
         onSettled: async (settlement) => {
           await onSettled(
@@ -1407,6 +1418,12 @@ export class UnifiedAgent extends ModuleBase {
       throw new Error('[builtin-worker] AgentHandler is required to provide persistent background shell support')
     }
     const bgOptions = handler.createBuiltinBgToolOptions(ctx.worker_id)
+    if (bgOptions) {
+      bgOptions.bgToolDeps = {
+        ...bgOptions.bgToolDeps,
+        stopWorkerAgent: (entityId) => this.builtinSubagentRunner.stopAgent(ctx.worker_id, entityId),
+      }
+    }
     const workerSkills = this.resolveMainlineWorkerSkills(ctx)
     const builtinTools = getConfiguredBuiltinTools(
       () => workspaceRoot,
@@ -1633,6 +1650,10 @@ export class UnifiedAgent extends ModuleBase {
   }
 
   private attachBuiltinShellExitDispatcher(handler: AgentHandler): void {
+    handler.setBuiltinChildExitDispatcher((workerId, entityId, onSettled) =>
+      this.deliverBuiltinEntityExit(workerId, `bg-agent:${entityId}`,
+        () => this.builtinSubagentRunner.renderCompletion(workerId, entityId), onSettled, true),
+    )
     handler.setBuiltinShellExitDispatcher((workerId, info, onSettled) =>
       this.deliverBuiltinShellExit(workerId, info, onSettled),
     )
@@ -1640,7 +1661,7 @@ export class UnifiedAgent extends ModuleBase {
     // handler. Open that handler's routing gate immediately instead of waiting
     // for a process restart that may never happen.
     if (this.managerReconciliationSettled && !this.runtimeClosing) {
-      void handler.releaseRecoveredWorkerShellExits().catch((error) => {
+      void handler.releaseRecoveredWorkerEntityExits().catch((error) => {
         console.error(`[${this.config.moduleId}] failed to release late worker shell exits:`, error)
       })
     }
@@ -4556,6 +4577,13 @@ export class UnifiedAgent extends ModuleBase {
   private builtinTraceHooks(): import('./workers/builtin/adapter.js').BuiltinTraceHooks {
     const redact = (text: string) => redactSecrets(text, [...this.knownSecrets])
     return {
+      acquireTraceWriter: async (traceId, workerId, incarnationId) => {
+        const offset = incarnationId && this.managerStack
+          ? await this.managerStack.harness.nativeTraceOffset(workerId, incarnationId) : 0
+        await this.traceStore.acquireBuiltinTraceWriter(traceId, offset)
+      },
+      releaseTraceWriter: (traceId) => this.traceStore.releaseBuiltinTraceWriter(traceId),
+      finishTraceRecovery: () => this.traceStore.reconcileDeferredBuiltinTraces(),
       startIncarnationTrace: ({ worker_id, seq, summary, initial_input }) => {
         const trace = this.traceStore.startTrace({
           module_id: this.config.moduleId,
@@ -4606,11 +4634,7 @@ export class UnifiedAgent extends ModuleBase {
       finishIncarnationTrace: (traceId, patch) => {
         this.traceStore.endTrace(traceId, patch.status, { summary: redact(patch.summary) })
       },
-      stopWorkerSubagents: (workerId) => {
-        void this.builtinSubagentRunner.stopWorker(workerId).catch((error) => {
-          console.warn(`[${this.config.moduleId}] builtin subagent stop failed for ${workerId}:`, error)
-        })
-      },
+      stopWorkerSubagents: (workerId) => this.builtinSubagentRunner.stopWorker(workerId),
       // finish_task 终态守卫(拆分 spec 2026-08-28 修订)的查询口径与 harness deps 的
       // hasRunningBg 相同:bg-shell 与 subagent 都注册在 bg registry、按 owner.worker_id 归属。
       hasRunningBgEntities: (workerId) => this.agentHandler?.hasRunningBgForWorker(workerId) ?? Promise.resolve(false),
@@ -4619,6 +4643,8 @@ export class UnifiedAgent extends ModuleBase {
 
   private builtinTraceReader(): import('./workers/builtin/adapter.js').BuiltinTraceReader {
     return {
+      minimumOffset: (workerId, incarnationId) => incarnationId && this.managerStack
+        ? this.managerStack.harness.nativeTraceOffset(workerId, incarnationId) : Promise.resolve(0),
       readTrace: async (traceId) => this.traceStore.getFullTrace(traceId),
       listSubagents: (workerId) => this.builtinSubagentRunner.list(workerId),
       getSubagent: (workerId, subagentId) => this.builtinSubagentRunner.get(workerId, subagentId),
@@ -5339,7 +5365,7 @@ export class UnifiedAgent extends ModuleBase {
         void stack.registry.resumeInterruptedEpisodes().catch((error) => {
           console.error(`[${this.config.moduleId}] Manager startup resume failed:`, error)
         })
-        await this.agentHandler?.releaseRecoveredWorkerShellExits()
+        await this.agentHandler?.releaseRecoveredWorkerEntityExits()
         // CLI child copy is a terminal artifact: retry only after the startup state reconciliation
         // has decided which parent incarnations are actually terminal.
         void this.recoverTerminalCliSubagentTraces().catch((error) => {

--- a/crabot-agent/src/workers/builtin/adapter.ts
+++ b/crabot-agent/src/workers/builtin/adapter.ts
@@ -793,11 +793,14 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
       const incarnation = [...worker.incarnations].reverse().find((item) => !item.forked_from)
       if (incarnation?.impl !== 'builtin' || incarnation.state !== 'idle') continue
       try {
-        const h: IncarnationHandle = { ...incarnation, worker_id: worker.worker_id }
-        const recovered = await this.rehydrateIdleInstance(h)
-        if (!recovered) throw new Error('idle incarnation meta/session does not match')
-        await this.ensureTraceId(recovered.instance, `worker ${worker.worker_id}#${incarnation.seq}`)
-        if (recovered.instance.traceId) this.deps.traceHooks?.releaseTraceWriter?.(recovered.instance.traceId)
+        await this.getMutex(worker.worker_id).run(async () => {
+          if (this.instances.has(instanceKey(worker.worker_id, incarnation.seq))) return
+          const h: IncarnationHandle = { ...incarnation, worker_id: worker.worker_id }
+          const recovered = await this.rehydrateIdleInstance(h)
+          if (!recovered) throw new Error('idle incarnation meta/session does not match')
+          await this.ensureTraceId(recovered.instance, `worker ${worker.worker_id}#${incarnation.seq}`)
+          if (recovered.instance.traceId) this.deps.traceHooks?.releaseTraceWriter?.(recovered.instance.traceId)
+        })
       } catch (error) {
         console.warn(`[builtin-adapter] trace recovery failed for ${worker.worker_id}:`, error)
       }

--- a/crabot-agent/src/workers/builtin/adapter.ts
+++ b/crabot-agent/src/workers/builtin/adapter.ts
@@ -299,7 +299,10 @@ export interface BuiltinTraceHooks {
    */
   appendManagerInput?(traceId: string, text: string): void
   finishIncarnationTrace(traceId: string, patch: { status: 'completed' | 'failed'; summary: string }): void
-  stopWorkerSubagents?(workerId: string): void
+  stopWorkerSubagents?(workerId: string): Promise<void> | void
+  acquireTraceWriter?(traceId: string, workerId: string, incarnationId?: string): Promise<void>
+  releaseTraceWriter?(traceId: string): void
+  finishTraceRecovery?(): void
   /**
    * 该 worker 名下是否仍有 running 的 bg entity(bg-shell / subagent),供 finish_task
    * 终态守卫查询(拆分 spec 2026-08-28 修订)。缺省视为无,守卫静默关闭。
@@ -309,6 +312,7 @@ export interface BuiltinTraceHooks {
 
 export interface BuiltinTraceReader {
   readTrace(traceId: string): Promise<import('../../types.js').AgentTrace | undefined>
+  minimumOffset?(workerId: string, incarnationId?: string): Promise<number>
   listSubagents?(workerId: string): Promise<WorkerSubagentSummary[]>
   getSubagent?(workerId: string, subagentId: string): Promise<WorkerSubagentSummary | undefined>
   readSubagentTrace?(workerId: string, subagentId: string, cursor?: TraceCursor): Promise<{
@@ -686,6 +690,7 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
       // 运行配置现取：idle 态下没有 burst 在跑，重新解析一次不会干扰任何正在执行的东西，
       // 语义与"起化身现取"一致（正在跑的 burst 用旧配置，见 runBurst 续 burst 路径）。
       const builtin = rehydratedRuntime ?? await this.runtimeFor(h.worker_id, 'sendInput', instance.workspaceInstructions, instance.workspaceGit)
+      await this.ensureTraceId(instance, `worker ${instance.worker_id}#${instance.seq}`)
       const currentMessages = this.messagesAtTip(instance, instance.tip)
       const inputMessage = createUserMessage(text)
       instance.tip = await instance.sessionTree.append(instance.tip, inputMessage)
@@ -782,19 +787,37 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     return { instance, runtime }
   }
 
+  async reconcileTraces(workers: ReadonlyArray<import('../harness/ledger-types.js').LedgerWorker>): Promise<void> {
+    for (const worker of workers) {
+      if (worker.task.status === 'closed') continue
+      const incarnation = [...worker.incarnations].reverse().find((item) => !item.forked_from)
+      if (incarnation?.impl !== 'builtin' || incarnation.state !== 'idle') continue
+      try {
+        const h: IncarnationHandle = { ...incarnation, worker_id: worker.worker_id }
+        const recovered = await this.rehydrateIdleInstance(h)
+        if (!recovered) throw new Error('idle incarnation meta/session does not match')
+        await this.ensureTraceId(recovered.instance, `worker ${worker.worker_id}#${incarnation.seq}`)
+        if (recovered.instance.traceId) this.deps.traceHooks?.releaseTraceWriter?.(recovered.instance.traceId)
+      } catch (error) {
+        console.warn(`[builtin-adapter] trace recovery failed for ${worker.worker_id}:`, error)
+      }
+    }
+    this.deps.traceHooks?.finishTraceRecovery?.()
+  }
+
   /**
    * builtin 结构化 trace（P6-A §8.4）：从 TraceStore 读本化身的结构化事件，
    * trace 引用显式来自 meta-<seq>.json 的 trace_id（不按 task ID 猜）。
    * cursor.offset 是已消费 span 数。
    */
   async readTrace(h: IncarnationHandle, cursor?: import('../types.js').TraceCursor): Promise<{ events: import('../types.js').NormalizedTraceEvent[]; nextCursor: import('../types.js').TraceCursor; unavailableReason?: string }> {
-    const { sourceAvailable, events, nextCursor } = await this.readTraceWindow(h, cursor)
+    const { sourceAvailable, events, nextCursor, unavailableReason } = await this.readTraceWindow(h, cursor)
     // 对齐 claude-code/codex 的既有语义：数据源不可用时带 unavailableReason，让调用方
     // （harness 的活动收集）能把"源不可用"与"没有新内容"区分开——否则不可用会被当成
     // 零增量静默放过，收集从此失效且无迹可查（2026-08-28 w-7e31305e 调查）。
     return sourceAvailable
       ? { events, nextCursor }
-      : { events, nextCursor, unavailableReason: 'builtin trace source unavailable' }
+      : { events, nextCursor, unavailableReason: unavailableReason ?? 'builtin trace source unavailable' }
   }
 
   async listSubagents(h: IncarnationHandle): Promise<WorkerSubagentSummary[]> {
@@ -821,6 +844,7 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     cursor?: import('../types.js').TraceCursor,
   ): Promise<{
     sourceAvailable: boolean
+    unavailableReason?: string
     spans: ReadonlyArray<import('../../types.js').AgentSpan>
     events: import('../types.js').NormalizedTraceEvent[]
     nextCursor: import('../types.js').TraceCursor
@@ -847,6 +871,11 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
       return { sourceAvailable: false, spans: [], events: [], nextCursor: cursor ?? { offset: 0 } }
     }
     const start = cursor?.offset ?? 0
+    const publishedOffset = await this.deps.traceReader.minimumOffset?.(h.worker_id, h.incarnation_id) ?? 0
+    if (Math.max(start, publishedOffset) > trace.spans.length) {
+      console.warn(`[BuiltinWorkerAdapter] trace source incomplete: ${traceId}, cursor=${start}, spans=${trace.spans.length}`)
+      return { sourceAvailable: false, unavailableReason: 'builtin trace source incomplete', spans: [], events: [], nextCursor: cursor ?? { offset: 0 } }
+    }
     const spans = trace.spans.slice(start)
     const events: import('../types.js').NormalizedTraceEvent[] = []
     let consumed = start
@@ -900,6 +929,7 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
       instance.killRequested = true
       instance.abortController?.abort()
     })
+    if (h.query_id === undefined) await this.deps.traceHooks?.stopWorkerSubagents?.(h.worker_id)
   }
 
   async interrupt(h: IncarnationHandle): Promise<void> {
@@ -1039,12 +1069,11 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
 
   /**
    * 保证本化身的 trace 引用存在（P6-A §8.4）：spawn 时随 meta 持久化；旧 meta 缺
-   * trace_id（升级前写入）时现建并补写 meta。所有 burst 入口共用，失败不阻塞 burst
-   * （trace 是观测面，不是执行面）。
+   * trace_id（升级前写入）时现建并补写 meta。所有 burst 入口必须取得可写 trace 后执行。
    */
   private async ensureTraceId(instance: WorkerInstance, summary: string): Promise<void> {
-    if (instance.traceId || !this.deps.traceHooks) return
-    try {
+    if (!this.deps.traceHooks) return
+    if (!instance.traceId) {
       instance.traceId = this.deps.traceHooks.startIncarnationTrace({
         worker_id: instance.worker_id,
         seq: instance.seq,
@@ -1052,10 +1081,8 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
         ...(instance.initialTraceInput !== undefined ? { initial_input: instance.initialTraceInput } : {}),
       })
       await this.writeMeta(instance)
-    } catch (error) {
-      console.warn(`[BuiltinWorkerAdapter] trace start failed for ${instance.worker_id}#${instance.seq}:`,
-        error instanceof Error ? error.message : String(error))
     }
+    await this.deps.traceHooks.acquireTraceWriter?.(instance.traceId, instance.worker_id, instance.incarnation_id)
   }
 
   private async runBurst(
@@ -1861,6 +1888,10 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
     lastText?: string,
     completionHint = true,
   ): Promise<void> {
+    if (state === 'idle' && instance.traceId) {
+      try { this.deps.traceHooks?.releaseTraceWriter?.(instance.traceId) }
+      catch (error) { console.warn(`[builtin-adapter] trace snapshot unavailable for ${instance.worker_id}:`, error) }
+    }
     await this.writeMeta(instance, { state })
     instance.state = state
     // 观察者（onStateChange）的异常永远不能中断状态机的推进。任何回调错误都被捕获
@@ -1892,7 +1923,10 @@ export class BuiltinWorkerAdapter implements WorkerAdapter {
      */
     summary?: string,
   ): Promise<void> {
-    if (handle.query_id === undefined) this.deps.traceHooks?.stopWorkerSubagents?.(instance.worker_id)
+    if (handle.query_id === undefined && ended_reason !== 'killed') {
+      try { await this.deps.traceHooks?.stopWorkerSubagents?.(instance.worker_id) }
+      catch (error) { console.warn(`[builtin-adapter] child exit not confirmed for ${instance.worker_id}:`, error) }
+    }
     const pending = [...instance.pendingImmediateInputs, ...instance.pendingInputs]
     if (pending.length > 0) {
       const deadLetterMsg = `[dead-letter] incarnation ${instance.worker_id}#${instance.seq} exited with ${pending.length} unsent message(s): ${pending.join(' | ')}\n`

--- a/crabot-agent/src/workers/builtin/subagent-runner.ts
+++ b/crabot-agent/src/workers/builtin/subagent-runner.ts
@@ -1,4 +1,5 @@
 import { createAdapter } from '../../engine/llm-adapter.js'
+import { readFile } from 'node:fs/promises'
 import { thinkingParam } from '../../engine/llm-adapter-types.js'
 import { spawnPersistentAgent } from '../../engine/bg-entities/bg-agent.js'
 import type { BgEntityRegistry } from '../../engine/bg-entities/registry.js'
@@ -62,7 +63,7 @@ export class BuiltinSubagentRunner {
   constructor(
     private readonly traceStore: TraceStore,
     private readonly lspManager: import('../../lsp/lsp-manager.js').LSPManager,
-    private readonly deliverCompletion?: (workerId: string, text: string) => Promise<void>,
+    private readonly deliverCompletion?: (workerId: string, entityId: string) => Promise<void>,
     registry?: BgEntityRegistry,
     redactText: (text: string) => string = (text) => text,
   ) {
@@ -153,10 +154,8 @@ export class BuiltinSubagentRunner {
       },
       onExit: async (info) => {
         const current = await registry.get(info.entity_id)
-        if (current?.status === 'killed') return
-        const outcome = info.status === 'completed' ? '已完成' : '失败'
-        const detail = info.finalText || info.error || '无可读结果'
-        await this.deliverCompletion?.(worker.worker_id, `<sub_agent_notification>\n${subagent.name} ${outcome}：${detail}\n</sub_agent_notification>`)
+        if (current?.exit_notification?.status !== 'pending') return
+        await this.deliverCompletion?.(worker.worker_id, info.entity_id)
       },
     })
     const record = await registry.get(entityId)
@@ -176,6 +175,18 @@ export class BuiltinSubagentRunner {
       .filter((record): record is BgAgentRegistryRecord => record.type === 'agent' && record.owner.worker_id === workerId)
       .map((record) => summaryOf(workerId, record))
       .sort((left, right) => (right.started_at ?? '').localeCompare(left.started_at ?? ''))
+  }
+
+  async renderCompletion(workerId: string, entityId: string): Promise<string> {
+    const record = await this.requireRegistry().get(entityId)
+    if (record?.type !== 'agent' || record.owner.worker_id !== workerId || record.spawned_by_task_id !== workerId) {
+      throw new Error(`Worker child not found: ${entityId}`)
+    }
+    const detail = record.result_file ? await readFile(record.result_file, 'utf8') : record.error
+    const fallback = record.status === 'stalled'
+      ? 'Agent restarted; child execution interrupted.'
+      : 'No readable result.'
+    return this.redactText(`<sub_agent_notification>\n${entityId} (${record.subagent_type ?? 'subagent'}) status=${statusOf(record.status)}: ${detail || record.error || fallback}\n</sub_agent_notification>`)
   }
 
   async get(workerId: string, subagentId: string): Promise<WorkerSubagentSummary | undefined> {
@@ -211,10 +222,23 @@ export class BuiltinSubagentRunner {
     const records = await registry.list({ type: 'agent', spawned_by_task_id: workerId })
     await Promise.all(records
       .filter((record): record is BgAgentRegistryRecord => record.type === 'agent' && record.owner.worker_id === workerId && record.status === 'running')
-      .map(async (record) => {
-        this.abortControllers.get(record.entity_id)?.abort()
-        await registry.update(record.entity_id, { status: 'killed', ended_at: new Date().toISOString() })
-      }))
+      .map((record) => this.stopAgent(workerId, record.entity_id)))
+    // Harness verifies the remaining running records; abort submission is not exit proof.
+  }
+
+  async stopAgent(workerId: string, entityId: string): Promise<ToolCallResult> {
+    const registry = this.requireRegistry()
+    const record = await registry.get(entityId)
+    if (record?.type !== 'agent' || record.owner.worker_id !== workerId || record.spawned_by_task_id !== workerId) {
+      return { output: `Worker child not found: ${entityId}`, isError: true }
+    }
+    if (record.status !== 'running') return { output: `Already ${record.status}, no-op`, isError: false }
+    const controller = this.abortControllers.get(entityId)
+    if (!controller) return { output: `Child ${entityId} controller unavailable; stop not confirmed.`, isError: true }
+    const updated = await registry.update(entityId, { stop_requested_at: new Date().toISOString() })
+    if (updated?.status !== 'running') return { output: `Already ${updated?.status}, no-op`, isError: false }
+    controller.abort()
+    return { output: `Child ${entityId}: stop requested; execution exit not confirmed.`, isError: false }
   }
 
   private capabilitiesFor(

--- a/crabot-agent/src/workers/harness/harness.ts
+++ b/crabot-agent/src/workers/harness/harness.ts
@@ -782,6 +782,7 @@ export interface SpawnWorkerParams {
 }
 
 export interface HarnessSendToWorkerOptions {
+  readonly rejectStoppedParent?: boolean
   readonly raw?: boolean
   /** Interrupt a non-builtin mainline before delivering this direction change. */
   readonly immediate_redirect?: boolean
@@ -942,6 +943,10 @@ export class WorkerHarness {
   private recoveryNoticeDrainInFlight = false
   private recoveryNoticeTimer?: ReturnType<typeof setTimeout>
   private recoveryNoticeDeliveryStopped = false
+
+  nativeTraceOffset(workerId: string, incarnationId: IncarnationId): Promise<number> {
+    return this.nativeActivityStore.cursor(workerId, incarnationId)
+  }
 
   constructor(private readonly deps: HarnessDeps) {
     this.contextStore = new WorkerContextStore(deps.workersDir)
@@ -1313,6 +1318,7 @@ export class WorkerHarness {
       if (!found) throw new WorkerNotFoundError(workerId)
       if (found.worker.task.status === 'closed') throw new TaskCancelledError(workerId)
       const mainline = requireMainlineIncarnation(found.worker)
+      if (opts?.rejectStoppedParent && mainline.ended_reason === 'killed') throw new TaskCancelledError(workerId)
       if (
         opts?.immediate_redirect === true &&
         isExecutableIncarnation(mainline) &&
@@ -1367,6 +1373,7 @@ export class WorkerHarness {
         raw: opts?.raw ?? false,
         enqueued_at: this.deps.now(),
         allow_terminal_continuation: true,
+        ...(opts?.rejectStoppedParent ? { reject_stopped_parent: true } : {}),
         ...(opts?.immediate_redirect === true ? { immediate_redirect: true } : {}),
         ...(durableReceipt
           ? {
@@ -2034,6 +2041,7 @@ export class WorkerHarness {
       const handle: IncarnationHandle = {
         worker_id: workerId,
         seq: incarnation.seq,
+        incarnation_id: incarnation.incarnation_id,
         impl: incarnation.impl,
         session_ref: incarnation.session_ref,
       }
@@ -2607,6 +2615,8 @@ export class WorkerHarness {
         const found = await this.deps.ledger.findWorker(workerId)
         if (!found) throw new WorkerNotFoundError(workerId)
         const { worker, managerKey } = found
+        if (item?.reject_stopped_parent &&
+          (curEndReason === 'killed' || requireMainlineIncarnation(worker).ended_reason === 'killed')) return 'dead_letter'
         const expired = this.expiredInboxDelivery(item, curSeq)
         if (expired) return expired
 

--- a/crabot-agent/src/workers/harness/inbox.ts
+++ b/crabot-agent/src/workers/harness/inbox.ts
@@ -48,6 +48,8 @@ export interface InboxItem {
   readonly deadline_at?: string
   /** False for untrusted wakeups that must never revive a terminal task. */
   readonly allow_terminal_continuation?: boolean
+  /** Child completion must not revive a parent explicitly stopped by the caller. */
+  readonly reject_stopped_parent?: boolean
   /** Process-local receipt; durable truth remains with the producer. */
   readonly onSettled?: (settlement: InboxSettlement, detail?: InboxSettlementDetail) => void | Promise<void>
   /** Pending is diagnostic only and never settles the producer receipt. */

--- a/crabot-agent/tests/agent/builtin-bg-delivery.test.ts
+++ b/crabot-agent/tests/agent/builtin-bg-delivery.test.ts
@@ -15,12 +15,12 @@ const shellInfo = (entityId: string, workerId?: string) => ({
 
 function makeHandler(): any {
   const handler = Object.create(AgentHandler.prototype) as any
-  handler.workerShellExitRoutingReady = true
-  handler.queuedWorkerShellExits = []
-  handler.workerShellExitRetryTimers = new Map()
-  handler.workerShellExitSettlementTimers = new Map()
-  handler.workerShellExitQueues = new Map()
-  handler.drainingWorkerShellExitQueues = new Set()
+  handler.workerEntityExitRoutingReady = true
+  handler.queuedWorkerEntityExits = []
+  handler.workerEntityExitRetryTimers = new Map()
+  handler.workerEntityExitSettlementTimers = new Map()
+  handler.workerEntityExitQueues = new Map()
+  handler.drainingWorkerEntityExitQueues = new Set()
   handler.bgRegistry = {
     get: vi.fn(async (entityId: string) => ({
       entity_id: entityId,
@@ -42,6 +42,19 @@ afterEach(() => {
 })
 
 describe('builtin background shell exit routing', () => {
+  it('child uses the shared queue while hold leaves its durable receipt pending', async () => {
+    const handler = makeHandler()
+    const record = { type: 'agent', entity_id: 'agent-child', exit_notification: { status: 'pending', attempts: 0 } }
+    handler.bgRegistry.get.mockImplementation(async () => record)
+    let settle!: (value: { status: 'delivered' }) => Promise<void>
+    handler.setBuiltinChildExitDispatcher(async (_worker, _entity, callback) => { settle = callback })
+    await handler.routeBuiltinChildExit('worker-1', 'agent-child')
+    expect(handler.bgRegistry.settleExitNotification).not.toHaveBeenCalled()
+    expect(handler.deliverShellExitNotification).not.toHaveBeenCalled()
+    await settle({ status: 'delivered' })
+    expect(handler.bgRegistry.settleExitNotification).toHaveBeenCalledWith('agent-child', 'delivered', undefined)
+  })
+
   it('worker owner routes through dispatcher and durably settles; missing worker_id keeps legacy delivery', async () => {
     const handler = makeHandler()
     const dispatch = vi.fn(async (_workerId, _info, settle) => settle({ status: 'delivered' }))
@@ -90,15 +103,15 @@ describe('builtin background shell exit routing', () => {
 
   it('holds recovered worker exits until reconciliation release, then dispatches without unrelated input', async () => {
     const handler = makeHandler()
-    handler.workerShellExitRoutingReady = false
+    handler.workerEntityExitRoutingReady = false
     const dispatch = vi.fn(async (_workerId, _info, settle) => settle({ status: 'delivered' }))
     handler.builtinShellExitDispatcher = dispatch
 
     await handler.routeShellExit(shellInfo('bg-recovered', 'worker-1'))
     expect(dispatch).not.toHaveBeenCalled()
-    expect(handler.queuedWorkerShellExits).toHaveLength(1)
+    expect(handler.queuedWorkerEntityExits).toHaveLength(1)
 
-    await handler.releaseRecoveredWorkerShellExits()
+    await handler.releaseRecoveredWorkerEntityExits()
     await vi.waitFor(() => {
       expect(dispatch).toHaveBeenCalledWith(
         'worker-1',
@@ -106,12 +119,12 @@ describe('builtin background shell exit routing', () => {
         expect.any(Function),
       )
     })
-    expect(handler.queuedWorkerShellExits).toHaveLength(0)
+    expect(handler.queuedWorkerEntityExits).toHaveLength(0)
   })
 
   it('releases recovered queues independently so one hung worker does not block another or startup', async () => {
     const handler = makeHandler()
-    handler.workerShellExitRoutingReady = false
+    handler.workerEntityExitRoutingReady = false
     let releaseWorkerA!: () => void
     const workerAGate = new Promise<void>((resolve) => { releaseWorkerA = resolve })
     const delivered: string[] = []
@@ -123,7 +136,7 @@ describe('builtin background shell exit routing', () => {
 
     await handler.routeShellExit(shellInfo('bg-a', 'worker-a'))
     await handler.routeShellExit(shellInfo('bg-b', 'worker-b'))
-    await expect(handler.releaseRecoveredWorkerShellExits()).resolves.toBeUndefined()
+    await expect(handler.releaseRecoveredWorkerEntityExits()).resolves.toBeUndefined()
 
     await vi.waitFor(() => expect(delivered).toContain('worker-b'))
     expect(delivered).not.toContain('worker-a')
@@ -135,7 +148,7 @@ describe('builtin background shell exit routing', () => {
   it('retains a failed recovered delivery as pending, retries it, and does not block another worker', async () => {
     vi.useFakeTimers()
     const handler = makeHandler()
-    handler.workerShellExitRoutingReady = false
+    handler.workerEntityExitRoutingReady = false
     const dispatch = vi.fn()
       .mockRejectedValueOnce(new Error('adapter unavailable'))
       .mockImplementation(async (_workerId, _info, settle) => settle({ status: 'delivered' }))
@@ -144,7 +157,7 @@ describe('builtin background shell exit routing', () => {
 
     await handler.routeShellExit(shellInfo('bg-failed', 'worker-1'))
     await handler.routeShellExit(shellInfo('bg-next', 'worker-2'))
-    await handler.releaseRecoveredWorkerShellExits()
+    await handler.releaseRecoveredWorkerEntityExits()
 
     await vi.advanceTimersByTimeAsync(0)
     expect(dispatch).toHaveBeenCalledTimes(2)
@@ -198,7 +211,7 @@ describe('builtin background shell exit routing', () => {
     }
 
     expect(handler.builtinShellExitDispatcher).toHaveBeenCalledTimes(7)
-    expect(handler.workerShellExitRetryTimers.has('bg-long-outage')).toBe(true)
+    expect(handler.workerEntityExitRetryTimers.has('bg-long-outage')).toBe(true)
   })
 
   it('retries only the durable settlement after input delivery, without enqueueing the input again', async () => {
@@ -209,13 +222,13 @@ describe('builtin background shell exit routing', () => {
       .mockResolvedValue(undefined)
     vi.spyOn(console, 'error').mockImplementation(() => {})
 
-    await expect(handler.settleWorkerShellExit('bg-settlement', { status: 'delivered' }))
+    await expect(handler.settleWorkerEntityExit('bg-settlement', { status: 'delivered' }))
       .rejects.toThrow('registry rename failed')
-    expect(handler.workerShellExitSettlementTimers.has('bg-settlement')).toBe(true)
+    expect(handler.workerEntityExitSettlementTimers.has('bg-settlement')).toBe(true)
 
     await vi.advanceTimersByTimeAsync(1_000)
     expect(handler.bgRegistry.settleExitNotification).toHaveBeenCalledTimes(2)
-    expect(handler.workerShellExitSettlementTimers.has('bg-settlement')).toBe(false)
+    expect(handler.workerEntityExitSettlementTimers.has('bg-settlement')).toBe(false)
   })
 
   it('marks pending synchronously, serializes same-worker delivery, and clears only after settlement', async () => {

--- a/crabot-agent/tests/core/builtin-trace-recovery.test.ts
+++ b/crabot-agent/tests/core/builtin-trace-recovery.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { TraceStore } from '../../src/core/trace-store.js'
+
+describe('builtin writable trace snapshots', () => {
+  let dir: string
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'builtin-trace-')) })
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
+  const make = (dir: string) => new TraceStore(1, dir, 'running.jsonl', 'trace-', ['trace-'], true)
+
+  it('pins an active writer over capacity, evicts idle history, and reloads the exact prefix twice', async () => {
+    let store = make(dir)
+    const trace = store.startTrace({ module_id: 'crabot-agent', trigger: { type: 'task', summary: 'worker' } })
+    await store.acquireBuiltinTraceWriter(trace.trace_id)
+    store.startSpan(trace.trace_id, { type: 'llm_call', details: { assistant_text: 'first' } })
+    const prefix = structuredClone(trace.spans)
+    store.startTrace({ module_id: 'sub-agent', trigger: { type: 'sub_agent_call', summary: 'other' } })
+    expect(store.getTrace(trace.trace_id)).toBe(trace)
+    store.releaseBuiltinTraceWriter(trace.trace_id)
+    expect(store.getTrace(trace.trace_id)).toBeUndefined()
+    for (let restart = 0; restart < 2; restart++) {
+      store = make(dir)
+      await store.acquireBuiltinTraceWriter(trace.trace_id)
+      store.reconcileDeferredBuiltinTraces()
+      store.startSpan(trace.trace_id, { type: 'tool_result', details: { output_summary: `result-${restart}` } })
+      store.releaseBuiltinTraceWriter(trace.trace_id)
+      const saved = await store.getFullTrace(trace.trace_id)
+      expect(saved?.spans.slice(0, prefix.length)).toEqual(prefix)
+      expect(saved?.spans).toHaveLength(2 + restart)
+      expect(saved?.status).toBe('running')
+    }
+  })
+
+  it('holds the latest running snapshot until eligibility is decided, and interrupts rejected traces', async () => {
+    const first = make(dir)
+    const trace = first.startTrace({ module_id: 'crabot-agent', trigger: { type: 'task', summary: 'worker' } })
+    await first.acquireBuiltinTraceWriter(trace.trace_id)
+    first.startSpan(trace.trace_id, { type: 'tool_call', details: { call_id: 'pending-call' } })
+    ;(first as unknown as { flushInFlightTraces(): void }).flushInFlightTraces()
+    const second = make(dir)
+    expect((await second.getFullTrace(trace.trace_id))?.status).toBe('running')
+    second.reconcileDeferredBuiltinTraces()
+    expect(await second.getFullTrace(trace.trace_id)).toMatchObject({ status: 'failed', spans: [expect.anything(), expect.objectContaining({ type: 'tool_result' })] })
+  })
+
+  it('fails writer acquisition for a missing persistent source', async () => {
+    await expect(make(dir).acquireBuiltinTraceWriter('missing')).rejects.toThrow('unavailable')
+  })
+
+  it('can finalize an idle trace already evicted from memory', async () => {
+    const store = make(dir)
+    const trace = store.startTrace({ module_id: 'crabot-agent', trigger: { type: 'task', summary: 'idle' } })
+    await store.acquireBuiltinTraceWriter(trace.trace_id)
+    store.releaseBuiltinTraceWriter(trace.trace_id)
+    expect(store.getTrace(trace.trace_id)).toBeUndefined()
+    store.endTrace(trace.trace_id, 'failed', { summary: '[killed]' })
+    expect(await store.getFullTrace(trace.trace_id)).toMatchObject({ status: 'failed', outcome: { summary: '[killed]' } })
+  })
+
+  it('refuses the incident 270/787 gap without reusing published offsets', async () => {
+    const store = make(dir)
+    const trace = store.startTrace({ module_id: 'crabot-agent', trigger: { type: 'task', summary: 'damaged' } })
+    for (let i = 0; i < 270; i++) store.startSpan(trace.trace_id, { type: 'llm_call', details: {} })
+    const prefix = structuredClone(trace.spans)
+    await expect(store.acquireBuiltinTraceWriter(trace.trace_id, 787)).rejects.toThrow('source incomplete')
+    expect(trace.spans).toEqual(prefix)
+  })
+})

--- a/crabot-agent/tests/core/builtin-trace-recovery.test.ts
+++ b/crabot-agent/tests/core/builtin-trace-recovery.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { mkdtempSync, rmSync } from 'node:fs'
+import { mkdtempSync, rmSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { TraceStore } from '../../src/core/trace-store.js'
@@ -9,6 +9,24 @@ describe('builtin writable trace snapshots', () => {
   beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'builtin-trace-')) })
   afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
   const make = (dir: string) => new TraceStore(1, dir, 'running.jsonl', 'trace-', ['trace-'], true)
+
+  it('does not append another full snapshot when an active writer is acquired again', async () => {
+    const store = make(dir)
+    const trace = store.startTrace({ module_id: 'crabot-agent', trigger: { type: 'task', summary: 'worker' } })
+    const archive = join(dir, `trace-${trace.started_at.slice(0, 10)}.jsonl`)
+    await store.acquireBuiltinTraceWriter(trace.trace_id)
+    const initial = readFileSync(archive, 'utf8')
+    store.startSpan(trace.trace_id, { type: 'llm_call', details: { assistant_text: 'new span' } })
+    await store.acquireBuiltinTraceWriter(trace.trace_id, 1)
+    await store.acquireBuiltinTraceWriter(trace.trace_id, 1)
+    await expect(store.acquireBuiltinTraceWriter(trace.trace_id, 2)).rejects.toThrow('source incomplete')
+    expect(readFileSync(archive, 'utf8')).toBe(initial)
+    store.releaseBuiltinTraceWriter(trace.trace_id)
+    const snapshots = readFileSync(archive, 'utf8').trim().split('\n').map(line => JSON.parse(line))
+    expect(snapshots).toHaveLength(2)
+    expect(snapshots[1].spans).toEqual(trace.spans)
+    expect((await make(dir).getFullTrace(trace.trace_id))?.spans).toEqual(trace.spans)
+  })
 
   it('pins an active writer over capacity, evicts idle history, and reloads the exact prefix twice', async () => {
     let store = make(dir)

--- a/crabot-agent/tests/manager/p5-integration.test.ts
+++ b/crabot-agent/tests/manager/p5-integration.test.ts
@@ -681,7 +681,7 @@ describe('P5 集成：manager 栈启动接线（Task 6）', () => {
     const stack = internals.managerStack!
     vi.spyOn(stack.harness, 'reconcileOnStartup').mockRejectedValue(new Error('reconcile failed'))
     const release = vi.fn().mockResolvedValue(undefined)
-    internals.agentHandler = { releaseRecoveredWorkerShellExits: release } as any
+    internals.agentHandler = { releaseRecoveredWorkerEntityExits: release } as any
     const sweep = vi.spyOn(stack.harness, 'startLivenessSweep').mockImplementation(() => {})
     const resume = vi.spyOn(stack.registry, 'resumeInterruptedEpisodes').mockResolvedValue(undefined)
     vi.spyOn(console, 'warn').mockImplementation(() => {})
@@ -720,7 +720,7 @@ describe('P5 集成：manager 栈启动接线（Task 6）', () => {
     let recoveryFinished = false
     const recoveryGate = new Promise<void>((resolve) => { releaseRecovery = resolve })
     internals.agentHandler = {
-      releaseRecoveredWorkerShellExits: vi.fn(async () => { order.push('bg-shell') }),
+      releaseRecoveredWorkerEntityExits: vi.fn(async () => { order.push('bg-shell') }),
     } as any
     vi.spyOn(stack.harness, 'reconcileRecoveryNoticesOnStartup').mockImplementation(async () => {
       order.push('recovery-notices')
@@ -765,7 +765,7 @@ describe('P5 集成：manager 栈启动接线（Task 6）', () => {
       return { revived: [], failed: [], unchanged: [] }
     })
     const release = vi.fn().mockResolvedValue(undefined)
-    internals.agentHandler = { releaseRecoveredWorkerShellExits: release } as any
+    internals.agentHandler = { releaseRecoveredWorkerEntityExits: release } as any
     const sweep = vi.spyOn(stack.harness, 'startLivenessSweep')
 
     agent.startManagerStackReconciliation()
@@ -784,7 +784,8 @@ describe('P5 集成：manager 栈启动接线（Task 6）', () => {
     const release = vi.fn().mockResolvedValue(undefined)
     const lateHandler = {
       setBuiltinShellExitDispatcher: setDispatcher,
-      releaseRecoveredWorkerShellExits: release,
+      setBuiltinChildExitDispatcher: vi.fn(),
+      releaseRecoveredWorkerEntityExits: release,
     }
 
     ;(agent as any).attachBuiltinShellExitDispatcher(lateHandler)

--- a/crabot-agent/tests/workers/builtin-adapter.test.ts
+++ b/crabot-agent/tests/workers/builtin-adapter.test.ts
@@ -1331,6 +1331,42 @@ describe('BuiltinWorkerAdapter', () => {
     })
   })
 
+  it.each([true, false])('startup trace recovery serializes with input without replacing its session (recoveryFirst=%s)', async (recoveryFirst) => {
+    const adapter1 = new BuiltinWorkerAdapter({ dataDir: tmp })
+    const h = await adapter1.spawn(spec({ adapter: makeAdapter([{ text: 'initial reply', stopReason: 'end_turn' }]) }))
+    await waitState(adapter1, h, 'idle')
+    const entered = deferred()
+    const gate = deferred()
+    const resolveRuntime = vi.fn(async () => {
+      if (resolveRuntime.mock.calls.length === 1) {
+        entered.resolve()
+        await gate.promise
+      }
+      return { adapter: makeAdapter([{ text: 'continued reply', stopReason: 'end_turn' }]), model: 'test', systemPrompt: '', tools: [] }
+    })
+    const adapter2 = new BuiltinWorkerAdapter({ dataDir: tmp, resolveRuntime })
+    const recover = () => adapter2.reconcileTraces([{ worker_id: h.worker_id, task: { status: 'executing' }, incarnations: [{ ...h, impl: 'builtin', state: 'idle' }] }] as any)
+    const input = () => adapter2.sendInput(h, 'first concurrent input')
+    const first = recoveryFirst ? recover() : input()
+    await entered.promise
+    const second = recoveryFirst ? input() : recover()
+    // Drain the competing filesystem reads while the first rehydration is suspended.
+    await new Promise(resolve => setTimeout(resolve, 50))
+    const callsWhileBlocked = resolveRuntime.mock.calls.length
+    gate.resolve()
+    await Promise.all([first, second])
+    await waitState(adapter2, h, 'idle')
+    await adapter2.sendInput(h, 'second input')
+    await waitState(adapter2, h, 'idle')
+    const meta = JSON.parse(await fs.readFile(join(tmp, h.worker_id, 'meta-1.json'), 'utf8'))
+    const tree = await SessionTree.load(join(tmp, h.worker_id, 'session.jsonl'))
+    const path = JSON.stringify(tree.pathTo(meta.tip_node_id))
+    expect(callsWhileBlocked).toBe(1)
+    expect(path).toContain('initial reply')
+    expect(path).toContain('first concurrent input')
+    expect(path).toContain('second input')
+  })
+
   it('进程重启后的 idle 化身按下一条普通输入重建同一 session，并起新的 burst', async () => {
     const workerId = randomUUID()
     const adapter1 = new BuiltinWorkerAdapter({ dataDir: tmp })

--- a/crabot-agent/tests/workers/builtin-child-recovery-control.test.ts
+++ b/crabot-agent/tests/workers/builtin-child-recovery-control.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { promises as fs } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { BgEntityRegistry } from '../../src/engine/bg-entities/registry.js'
+import type { BgAgentRegistryRecord } from '../../src/engine/bg-entities/types.js'
+import { createListEntitiesTool } from '../../src/engine/tools/list-entities-tool.js'
+import { createKillTool } from '../../src/engine/tools/kill-tool.js'
+import { BuiltinSubagentRunner } from '../../src/workers/builtin/subagent-runner.js'
+import type { TraceStore } from '../../src/core/trace-store.js'
+import type { LSPManager } from '../../src/lsp/lsp-manager.js'
+import * as llmModule from '../../src/engine/llm-adapter.js'
+import { TraceStore as RealTraceStore } from '../../src/core/trace-store.js'
+import { BUILTIN_WORKER_PERMISSIONS } from '../../src/workers/builtin/runtime.js'
+import type { SubAgentConfig } from '../../src/types.js'
+import { chunksFromContent } from '../engine/helpers/mock-stream.js'
+
+describe('builtin child durable recovery and control', () => {
+  let dir: string
+  let registry: BgEntityRegistry
+  function child(id = 'agent_own', worker = 'worker-1'): BgAgentRegistryRecord {
+    const now = new Date().toISOString()
+    return { entity_id: id, type: 'agent', status: 'running', owner: { friend_id: '__builtin_worker__', worker_id: worker }, spawned_by_task_id: worker, spawned_at: now, last_activity_at: now, ended_at: null, exit_code: null, task_description: 'test', messages_log_file: join(dir, id), result_file: null }
+  }
+  function runner() { return new BuiltinSubagentRunner({} as TraceStore, {} as LSPManager, undefined, registry) }
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(join(tmpdir(), 'child-control-'))
+    registry = new BgEntityRegistry(join(dir, 'registry.json'))
+    await registry.register(child())
+  })
+  afterEach(async () => { vi.restoreAllMocks(); await fs.rm(dir, { recursive: true, force: true }) })
+
+  it.each([true, false])('recovery order registry-first=%s preserves one pending receipt across two restarts', async (registryFirst) => {
+    if (registryFirst) await registry.recoverPersistent()
+    await runner().recoverAfterRestart()
+    if (!registryFirst) await registry.recoverPersistent()
+    const first = await registry.get('agent_own')
+    expect(first).toMatchObject({ status: 'stalled', exit_notification: { status: 'pending', attempts: 0 } })
+    registry = new BgEntityRegistry(join(dir, 'registry.json'))
+    await registry.recoverPersistent()
+    await runner().recoverAfterRestart()
+    expect(await registry.get('agent_own')).toEqual(first)
+  })
+
+  it('all scope includes own child despite friend sentinel and excludes another worker', async () => {
+    await registry.register(child('agent_other', 'worker-2'))
+    const tool = createListEntitiesTool({ registry, taskId: 'worker-1', ownerWorkerId: 'worker-1', ownerFriendId: '__system_worker-1', cursorMap: new Map() })
+    const result = await tool.call({ scope: 'all' }, {})
+    expect(result.output).toContain('agent_own')
+    expect(result.output).not.toContain('agent_other')
+  })
+
+  it('failed atomic write publishes neither terminal nor receipt; retry persists both', async () => {
+    const rename = vi.spyOn(fs, 'rename').mockRejectedValueOnce(new Error('disk write failed'))
+    await expect(registry.update('agent_own', { status: 'completed', ended_at: new Date().toISOString() })).rejects.toThrow('disk write failed')
+    expect(await registry.get('agent_own')).toMatchObject({ status: 'running' })
+    expect((await registry.get('agent_own'))?.exit_notification).toBeUndefined()
+    rename.mockRestore()
+    await registry.update('agent_own', { status: 'completed', ended_at: new Date().toISOString() })
+    expect(await registry.get('agent_own')).toMatchObject({ status: 'completed', exit_notification: { status: 'pending' } })
+  })
+
+  it('missing controller never fabricates a killed terminal record', async () => {
+    const owner = runner()
+    const tool = createKillTool({ registry, taskId: 'worker-1', ownerWorkerId: 'worker-1', cursorMap: new Map(), stopWorkerAgent: (id) => owner.stopAgent('worker-1', id) })
+    expect((await tool.call({ entity_id: 'agent_own' }, {})).isError).toBe(true)
+    expect((await registry.get('agent_own'))?.status).toBe('running')
+  })
+
+  it('stop remains running until executor exits; restart settles killed without a notification', async () => {
+    const owner = runner()
+    const controller = new AbortController()
+    ;(owner as unknown as { abortControllers: Map<string, AbortController> }).abortControllers.set('agent_own', controller)
+    const result = await owner.stopAgent('worker-1', 'agent_own')
+    expect(controller.signal.aborted).toBe(true)
+    expect(result.output).toContain('not confirmed')
+    expect(await registry.get('agent_own')).toMatchObject({ status: 'running', stop_requested_at: expect.any(String) })
+    await registry.recoverPersistent()
+    expect(await registry.get('agent_own')).toMatchObject({ status: 'killed' })
+    expect((await registry.get('agent_own'))?.exit_notification).toBeUndefined()
+  })
+
+  it('does not add a receipt to old terminal records or overwrite a confirmed natural outcome', async () => {
+    await registry.register({ ...child(), status: 'completed' })
+    await registry.update('agent_own', { last_activity_at: new Date().toISOString() })
+    expect((await registry.get('agent_own'))?.exit_notification).toBeUndefined()
+    await runner().stopAgent('worker-1', 'agent_own')
+    expect((await registry.get('agent_own'))?.status).toBe('completed')
+  })
+
+  it('real child engine blocked in a tool stays running after Kill, then exits without another call', async () => {
+    const previous = process.env.DATA_DIR
+    process.env.DATA_DIR = dir
+    let release!: () => void
+    let entered!: () => void
+    const inTool = new Promise<void>((resolve) => { entered = resolve })
+    const blocked = new Promise<void>((resolve) => { release = resolve })
+    let calls = 0
+    vi.spyOn(llmModule, 'createAdapter').mockReturnValue({
+      async *stream() {
+        calls++
+        yield* chunksFromContent([{ type: 'tool_use', id: 'blocked-read', name: 'Read', input: { file_path: 'test' } }], 'tool_use', { inputTokens: 1, outputTokens: 1 })
+      },
+      updateConfig() {},
+    } as any)
+    const store = new RealTraceStore(1, join(dir, 'traces'))
+    const parent = store.startTrace({ module_id: 'test', trigger: { type: 'task', summary: 'parent' } })
+    const notify = vi.fn()
+    const owner = new BuiltinSubagentRunner(store, {} as LSPManager, notify, registry)
+    try {
+      const launched = await owner.run({ id: 'reader', name: 'reader', description: 'reader', when_to_use: 'test', model: { endpoint: 'https://test.invalid', apikey: 'test', model_id: 'test', format: 'openai' }, builtin_capabilities: { file_system: true }, allowed_mcp_server_ids: [], allowed_skill_ids: [] } as unknown as SubAgentConfig,
+        { task: 'read test' }, { worker_subagent: { worker_id: 'worker-1', parent_trace_id: parent.trace_id } },
+        [{ name: 'Read', description: 'read', inputSchema: { type: 'object' }, isReadOnly: true, call: async () => { entered(); await blocked; return { output: 'read result', isError: false } } }],
+        { permissionConfig: { mode: 'bypass' }, resolvedPermissions: BUILTIN_WORKER_PERMISSIONS, availableSkills: [], getCwd: () => dir })
+      const id = JSON.parse(launched.output).agent_id
+      await inTool
+      const result = await createKillTool({ registry, taskId: 'worker-1', ownerWorkerId: 'worker-1', cursorMap: new Map(), stopWorkerAgent: (entityId) => owner.stopAgent('worker-1', entityId) }).call({ entity_id: id }, {})
+      expect(result.output).toContain('not confirmed')
+      expect((await registry.get(id))?.status).toBe('running')
+      release()
+      await vi.waitFor(async () => expect((await registry.get(id))?.status).toBe('killed'))
+      await vi.waitFor(() => expect((owner as any).abortControllers.size).toBe(0))
+      expect(calls).toBe(1)
+      expect(notify).not.toHaveBeenCalled()
+      expect((await registry.get(id))?.exit_notification).toBeUndefined()
+    } finally {
+      release()
+      if (previous === undefined) delete process.env.DATA_DIR
+      else process.env.DATA_DIR = previous
+    }
+  })
+})

--- a/crabot-agent/tests/workers/builtin-production-runtime.test.ts
+++ b/crabot-agent/tests/workers/builtin-production-runtime.test.ts
@@ -25,7 +25,7 @@ import { ConfigLoader } from '../../src/core/config-loader.js'
 import * as agentHandlerModule from '../../src/agent/agent-handler.js'
 import * as engineModule from '../../src/engine/query-loop.js'
 import type { ManagerKey } from '../../src/workers/harness/ledger-types.js'
-import type { ManagerStack } from '../../src/manager/bootstrap.js'
+import { reconcileManagerStack, type ManagerStack } from '../../src/manager/bootstrap.js'
 import type { LLMAdapter, ToolDefinition } from '../../src/engine/index.js'
 import type {
   UnifiedAgentConfig,
@@ -802,6 +802,92 @@ describe('builtin worker 生产装配（PR F 第 2 步）', () => {
   })
 
   // --- systemPrompt：v3 worker 契约尾巴 ---
+
+  it('整体停止不能因主线退出就掩盖仍未确认退出的 child', async () => {
+    const { internals } = boot()
+    const key = 'test::child-stop' as ManagerKey
+    llm.queue.push({ text: '等待 child', stopReason: 'end_turn' })
+    const { workerId } = await spawnBuiltin(internals, key)
+    const harness = internals.managerStack!.harness
+    await waitUntil(async () => (await harness.listWorkers(key))[0].incarnations[0].state === 'idle')
+    const registry = (internals as any).agentHandler.getBuiltinBgEntityRegistry()
+    const now = new Date().toISOString()
+    await registry.register({ entity_id: 'agent_unconfirmed', type: 'agent', status: 'running', owner: { friend_id: '__builtin_worker__', worker_id: workerId }, spawned_by_task_id: workerId, spawned_at: now, last_activity_at: now, ended_at: null, exit_code: null, task_description: 'unconfirmed child', messages_log_file: join(tmpRoot, 'child.jsonl'), result_file: null })
+    const operation = await harness.requestWorkerStop(workerId)
+    expect(operation.status).toBe('unknown')
+    expect((await registry.get('agent_unconfirmed'))?.status).toBe('running')
+    expect((await harness.listWorkers(key))[0].task.status).toBe('halted')
+    await registry.update('agent_unconfirmed', { status: 'completed', ended_at: new Date().toISOString() })
+    await (internals as any).agentHandler.releaseRecoveredWorkerEntityExits()
+    await waitUntil(async () => (await registry.get('agent_unconfirmed'))?.exit_notification?.status === 'dead_letter')
+    expect((await harness.listWorkers(key))[0].incarnations).toHaveLength(1)
+  })
+
+  it('重启中断 child 后无需人类输入，持久通知实际进入父 Worker 下一轮', async () => {
+    const first = boot()
+    const key = 'test::child-restart' as ManagerKey
+    llm.queue.push({ text: '等待 child', stopReason: 'end_turn' })
+    const { workerId } = await spawnBuiltin(first.internals, key)
+    await waitUntil(async () => (await first.internals.managerStack!.harness.listWorkers(key))[0].incarnations[0].state === 'idle')
+    const registry = (first.internals as any).agentHandler.getBuiltinBgEntityRegistry()
+    const now = new Date().toISOString()
+    await registry.register({ entity_id: 'agent_interrupted', type: 'agent', status: 'running', owner: { friend_id: '__builtin_worker__', worker_id: workerId }, spawned_by_task_id: workerId, spawned_at: now, last_activity_at: now, ended_at: null, exit_code: null, task_description: 'child test', messages_log_file: join(tmpRoot, 'child.jsonl'), result_file: null })
+    await first.agent.stop()
+    const restarted = boot()
+    const handler = (restarted.internals as any).agentHandler
+    const runner = (restarted.internals as any).builtinSubagentRunner
+    await handler.getBuiltinBgEntityRegistry().recoverPersistent()
+    await runner.recoverAfterRestart()
+    await reconcileManagerStack(restarted.internals.managerStack!)
+    llm.queue.push({ text: '已收到子任务中断事实', stopReason: 'end_turn' })
+    await handler.releaseRecoveredWorkerEntityExits()
+    await waitUntil(async () => (await registry.get('agent_interrupted'))?.exit_notification?.status === 'delivered')
+    await waitUntil(async () => (await restarted.internals.managerStack!.harness.listWorkers(key))[0].incarnations[0].state === 'idle')
+    const session = await fs.readFile(join(restarted.internals.managerStack!.builtinDataDir, workerId, 'session.jsonl'), 'utf8')
+    expect(session).toContain('<sub_agent_notification>')
+    expect(session).toContain('agent_interrupted')
+    expect(session).toContain('interrupted')
+    expect((await registry.list({ type: 'agent' })).length).toBe(1)
+  })
+
+  it('idle 重启两次仍续写同一 trace，旧 cursor 可读取真实新增工具结果', async () => {
+    let current = boot()
+    llm.queue.push({ text: '等待下一步', stopReason: 'end_turn' })
+    const key = 'test::trace-restart' as ManagerKey
+    const { workerId } = await spawnBuiltin(current.internals, key)
+    const idle = async () => {
+      const [worker] = await current.internals.managerStack!.harness.listWorkers(key)
+      return worker.incarnations[0].state === 'idle' && Boolean(await current.internals.managerStack!.harness.getWorkerTurn(workerId))
+    }
+    await waitUntil(idle)
+    const metaPath = join(current.internals.managerStack!.builtinDataDir, workerId, 'meta-1.json')
+    const traceId = JSON.parse(await fs.readFile(metaPath, 'utf8')).trace_id
+    const store = () => (current.internals as any).traceStore
+    const prefix = structuredClone((await store().getFullTrace(traceId)).spans)
+    let offset = prefix.length
+    for (let restart = 0; restart < 2; restart++) {
+      await current.agent.stop()
+      current = boot()
+      await reconcileManagerStack(current.internals.managerStack!)
+      llm.queue.push(
+        { toolCalls: [{ name: 'Bash', id: `restart-${restart}`, input: { command: `printf test-${restart}` } }], stopReason: 'tool_use' },
+        { text: `已检查 ${restart}`, stopReason: 'end_turn' },
+      )
+      await current.internals.managerStack!.harness.sendToWorker(workerId, '继续检查')
+      await waitUntil(idle)
+      const [worker] = await current.internals.managerStack!.harness.listWorkers(key)
+      expect(worker.incarnations).toHaveLength(1)
+      expect(JSON.parse(await fs.readFile(metaPath, 'utf8')).trace_id).toBe(traceId)
+      const adapter = current.internals.managerStack!.adapters.get('builtin')!
+      const window = await adapter.readTrace({ ...worker.incarnations[0], worker_id: workerId } as any, { offset })
+      expect(window.unavailableReason).toBeUndefined()
+      expect(window.events.some((event) => event.kind === 'tool_result')).toBe(true)
+      const trace = await store().getFullTrace(traceId)
+      expect(trace.spans.slice(0, prefix.length)).toEqual(prefix)
+      expect(window.nextCursor.offset).toBeGreaterThan(offset)
+      offset = window.nextCursor.offset
+    }
+  })
 
   it.each([false, true])('systemPrompt 按 builtin 能力装配并保留人格、Skill 与 workspace 快照（subagents=%s）', (withSubagents) => {
     const { internals } = boot(makeConfig({


### PR DESCRIPTION
builtin Worker 在 Agent 重启后可能一直等待已中断的 subagent，实际继续执行却丢失 trace；ListEntities 还会漏掉自身 child，Kill 则可能只改状态而未中止执行。

本 PR 按已确认 spec 和已发布的 Agent v3.14.3 修复这四个断点：可续 idle 化身恢复同一 trace 的写者并保留 cursor；child 终态与通知责任原子落盘，经 WorkerInbox 实际交付后确认；查询按 Worker 归属，停止交给实际 runner，执行尚未退出时保持 running。整体停止继续使用现有后台核验，迟到 child 通知不能复活显式停止的父 Worker。

设计与协议：[修复 spec](https://github.com/smilefufu/crabot-docs/blob/main/superpowers/specs/2026-09-08-builtin-worker-recovery-observation-control-design.md)、[实施计划](https://github.com/smilefufu/crabot-docs/blob/main/superpowers/plans/2026-09-09-builtin-worker-recovery-control-plan.md)。

验证：

- 真实 UnifiedAgent 两次重启后同一化身、同一 trace、旧 cursor 读取新增工具结果；无新增人类输入时 child 中断通知进入父 Worker 会话。
- 真实 Engine 阻塞在工具内时 Kill 不提前标 killed，退出后不再调用模型；整体 stop 未确认为 unknown，迟到 child 通知落 dead-letter。
- writer 缓存淘汰、270/787 损坏前缀、恢复入口顺序、原子写失败及 hold/ack 回归覆盖。
- 最新相关 94 项及 TypeScript 通过；扩大回归 268 通过、1 项基线 shell 进程时间失败。
- Agent 全量首轮 3209/3251 通过。未修改基线复现 40 项同名失败（包含沙箱 tmux/socket/文件监听限制、现有 Skill fixture、路径与进程时间测试）；其余 2 项并发测试单独复跑通过。旧 mock 空配置读取的本次回归已修复，其用例现与基线 Skill fixture 失败一致。

失败路径：无法取得 trace 写者时不执行 burst；运行后快照失败保留内存写者并记录观测错误；registry 写失败按既有退避重试，通知投递或确认失败保留 pending。缺 controller 或工具未退出不伪造停止；不自动重跑 child，不重置 cursor 或重建已丢失事实。

尚未部署，未修改事故 Worker 或补测进程。合并后仍需独立测试 Worker 的真实重启验收；事故历史须保全后，等待实际后台工作结束或确认停止，再按 spec 受控接续。主仓不自行合并。
