### PR TITLE
fix(manager): 首次包含输入的 LLM 请求成功后发送 reaction

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5,6 +5,13 @@
 
 ## 当前状态
 
+### Manager 输入即时 reaction：实现与定向验证完成，待 PR 审查
+
+- 按已确认的 `2026-09-10-manager-input-reaction-timing-design.md`，运行中输入进入上下文且检查点保存成功后自动确认，不等待模型回复或 episode 收尾；Channel 与 Admin Chat 使用同一边界。
+- 历史仍在收尾提交，一次性确认责任独立保存；未消费尾部消息的回调随同进程下一轮继续，检查点失败不确认，确认失败或挂起不阻塞 loop。
+- 6 项时序/失败/尾部消息回归先失败后通过；覆盖批次去重、私聊/群聊/Admin 接线、图片与溢出重试后的重启恢复。
+- 定向 378 项通过，6 项缺少 `tmp-page` fixture 的失败在未修改 main `72a6025c` 全部复现；Agent 类型检查通过。尚未部署，飞书实际创建时间验收待合入部署后执行。
+
 ### Feishu 引用 interactive 消息：实现与定向验证完成，待 PR 审查
 
 - 按[已确认 spec](crabot-docs/superpowers/specs/2026-09-10-feishu-quoted-interactive-message-design.md)，get/list 请求原始卡片，统一 mapper 提取可读正文；Manager 初始、插话及恢复待注入消息接入共享引用预拉。

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5,12 +5,12 @@
 
 ## 当前状态
 
-### Manager 输入即时 reaction：实现与定向验证完成，待 PR 审查
+### Manager 首次 LLM 响应 reaction：实现与定向验证完成，待 PR 审查
 
-- 按已确认的 `2026-09-10-manager-input-reaction-timing-design.md`，运行中输入进入上下文且检查点保存成功后自动确认，不等待模型回复或 episode 收尾；Channel 与 Admin Chat 使用同一边界。
-- 历史仍在收尾提交，一次性确认责任独立保存；未消费尾部消息的回调随同进程下一轮继续，检查点失败不确认，确认失败或挂起不阻塞 loop。
-- 6 项时序/失败/尾部消息回归先失败后通过；覆盖批次去重、私聊/群聊/Admin 接线、图片与溢出重试后的重启恢复。
-- 定向 378 项通过，6 项缺少 `tmp-page` fixture 的失败在未修改 main `72a6025c` 全部复现；Agent 类型检查通过。尚未部署，飞书实际创建时间验收待合入部署后执行。
+- 按用户修订后的 `2026-09-10-manager-input-reaction-timing-design.md`，初始与追加输入在首次包含它的主处理 LLM 请求完整成功返回后自动确认，不等待工具或 episode 收尾；Channel 与 Admin Chat 同步。
+- lane 仍在初始历史提交后放行。首次 token、旧在途请求、仅入队/落盘或请求失败不确认；失败收尾保留的正文与尾部消息在同进程后续成功请求中确认，发送失败或挂起不阻塞、不重试。
+- 新时序要求先复现 5 项失败再修复；覆盖初始部分流响应、批次去重、未 drain/已 drain 失败、私聊/群聊/Admin 接线及图片/溢出恢复。
+- 定向 380 项通过，6 项缺少 `tmp-page` fixture 的失败在未修改 main `72a6025c` 全部复现；Agent 类型检查通过。尚未部署，飞书验收待合入部署后执行。
 
 ### Feishu 引用 interactive 消息：实现与定向验证完成，待 PR 审查
 
@@ -333,9 +333,7 @@
   5. ~~fail-loud 只闭合了「丢失」~~ → **已修**（eef9f991）：onEpisodeSettled 透传
      routeHumanMessages，私聊/Admin Chat 在真实收尾 failed/aborted 时补发 fail-loud
      （Admin Chat 带 request_id 走 delivery CAS 结占位气泡）。
-  6. 成功收尾时未被消费的注入留 mailbox 交自唤醒（五审修法），其 reaction 回调随之丢失
-     （自唤醒无调用方回调）——与「写入即已接收」自洽（尚未写入本就不该打），窗口窄，
-     如实记录不立项。
+  6. 尾部未消费输入的 reaction 回调丢失由当前“Manager 首次 LLM 响应 reaction”修复覆盖，见当前状态。
   7. commitPendingHumanInputs 在首个 await 前清空 pendingHumanCommit（六审非阻塞观察）：
      放弃分支里它自身抛错（store I/O 故障）时，catch 的二次调用看到空队列并报
      injectedHumansCommitted=true → 注入既未落盘也不重投。理论风险（收尾时 store 故障），

--- a/crabot-agent/src/manager/loop.ts
+++ b/crabot-agent/src/manager/loop.ts
@@ -369,8 +369,11 @@ export class ManagerLoop {
    * commitHumanInputs 落盘。runEpisode 进入时清空。
    */
   private pendingHumanCommit: TimedWakeEnvelope[] = []
-  /** 同进程跨 episode 保留未消费输入的确认责任；不进入恢复检查点。 */
-  private readonly pendingHumanAcceptance = new Map<TimedWakeEnvelope, (lastAcceptedMessageId: string) => Promise<void>>()
+  /** 同进程保留尚未取得成功 LLM 响应的输入确认；不进入恢复检查点。 */
+  private readonly pendingHumanResponses = new Map<string, {
+    text: string
+    callback: (lastRespondedMessageId: string) => Promise<void>
+  }>()
   /**
    * 本 episode 已提交人类消息 id 的内存镜像(runEpisode 开头 commit 后置位):注入
    * 投影的同步判定依据。与 store 的偏差方向安全——镜像缺失的 id 在收尾提交时仍被
@@ -585,23 +588,16 @@ export class ManagerLoop {
       execution: this.checkpointExecution(),
     }
     this.deps.store.saveCheckpoint(this.resumeCheckpoint)
-    // 只有刷新了实际 Engine 上下文且保存成功的检查点，才能确认已注入的人类输入。
-    if (state && this.pendingHumanAcceptance.size > 0) {
-      this.acceptHumanInputs(envelopes.filter((envelope) => {
-        if (!this.pendingHumanAcceptance.has(envelope)) return false
-        const text = this.renderEnvelope(envelope)
-        return state.recent.some((message) => 'content' in message && message.content === text)
-      }))
-    }
   }
 
   /** 唯一入口:被唤醒 → 跑一个 episode → 回睡。同一 loop 串行,不同 loop 互不影响。 */
   async wakeUp(
     envelope: TimedWakeEnvelope,
-    onHumanInputAccepted?: (lastAcceptedMessageId: string) => Promise<void>,
+    onHumanInputResponse?: (lastRespondedMessageId: string) => Promise<void>,
+    onInitialInputCommitted?: () => void,
   ): Promise<EpisodeResult> {
     assertTimedWakeEnvelope(envelope)
-    return this.mutex.run(() => this.runEpisode(envelope, onHumanInputAccepted))
+    return this.mutex.run(() => this.runEpisode(envelope, onHumanInputResponse, undefined, onInitialInputCommitted))
   }
 
   /** Queue now, then refresh authorization at the exact episode boundary. */
@@ -678,7 +674,7 @@ export class ManagerLoop {
    *  人类消息默认拒绝:必须登记去重和历史提交责任，否则 failed/aborted 后会把
    *  LLM 已见过的输入当新 wake 重放。
    *  唯一合法入口是 `enqueueHumanWakeDuringActiveEpisode`，它登记去重与延后历史
-   *  提交责任后带 `humanWakePreCommitted` 放行，检查点持久接收后才确认。 */
+   *  提交责任后带 `humanWakePreCommitted` 放行，包含输入的 LLM 请求成功后才确认。 */
   enqueueDuringEpisode(envelope: TimedWakeEnvelope, opts?: {
     humanWakePreCommitted?: boolean
     onEpisodeSettled?: (result: EpisodeResult) => void
@@ -725,7 +721,7 @@ export class ManagerLoop {
    */
   enqueueHumanWakeDuringActiveEpisode(
     envelope: TimedWakeEnvelope,
-    onHumanInputAccepted?: (lastAcceptedMessageId: string) => Promise<void>,
+    onHumanInputResponse?: (lastRespondedMessageId: string) => Promise<void>,
     onEpisodeSettled?: (result: EpisodeResult) => void,
   ): void {
     assertTimedWakeEnvelope(envelope)
@@ -744,7 +740,7 @@ export class ManagerLoop {
       ? projectHumanEnvelope(envelope, newEntries)
       : envelope
     this.pendingHumanCommit.push(projected)
-    if (onHumanInputAccepted) this.pendingHumanAcceptance.set(projected, onHumanInputAccepted)
+    this.trackHumanResponse(projected, onHumanInputResponse)
     // 远程图预取:fire-and-forget,drain 时消费已就绪结果(见 TimedWakeMailbox.imagePrefetch)
     this.mailbox.prefetchRemoteImages(projected)
     // currentEpisodeInjected 由 enqueueDuringEpisode 内部统一入账,此处不重复 push
@@ -803,8 +799,9 @@ export class ManagerLoop {
   /** `event === undefined` ⇒ 自唤醒(见 `drainMailbox`):只处理 mailbox 残留,不渲染唤醒事件。 */
   private async runEpisode(
     envelope: TimedWakeEnvelope | undefined,
-    onHumanInputAccepted?: (lastAcceptedMessageId: string) => Promise<void>,
+    onHumanInputResponse?: (lastRespondedMessageId: string) => Promise<void>,
     recovery?: ManagerResumeCheckpoint,
+    onInitialInputCommitted?: () => void,
   ): Promise<EpisodeResult> {
     const episodeId = recovery?.episodeId ?? randomUUID()
     if (recovery) envelope = recovery.envelopes[recovery.wakeIndex]
@@ -864,7 +861,7 @@ export class ManagerLoop {
         messageCount: 0,
         humanMessages: protectedTailStart < 0 ? [] : restoredRecent.slice(protectedTailStart),
         hasNewDirectHumanMessages: false,
-        lastCurrentWakeCommittedMessageId: undefined,
+        currentHumanEnvelope: undefined,
       } : await this.commitHumanInputs(
         await this.deps.store.load(this.deps.key),
         [...carriedEnvelopes, ...(envelope ? [envelope] : [])],
@@ -891,10 +888,21 @@ export class ManagerLoop {
       if (committed.hasNewDirectHumanMessages) this.deps.markPendingReply()
       // 已提交人类消息 id 的内存镜像:mid-episode 注入的投影判定用它(同步、无 store I/O)
       this.knownCommittedHumanIds = new Set(state.committedHumanMessageIds ?? [])
-      if (committed.lastCurrentWakeCommittedMessageId) {
-        this.notifyHumanInputAccepted(onHumanInputAccepted, committed.lastCurrentWakeCommittedMessageId)
+      if (committed.currentHumanEnvelope) {
+        this.trackHumanResponse(committed.currentHumanEnvelope, onHumanInputResponse)
+        try {
+          onInitialInputCommitted?.()
+        } catch (err) {
+          console.warn('[ManagerLoop] initial input committed callback failed (ignored):', err)
+        }
       }
-      this.acceptHumanInputs(carriedEnvelopes)
+      // 失败收尾保存的输入可在本次请求中再次出现；只清理已不在历史或 mailbox 的责任。
+      const pendingTexts = new Set(this.mailbox.snapshotPendingEnvelopes().map((item) => this.renderEnvelope(item)))
+      for (const [id, pending] of this.pendingHumanResponses) {
+        if (!pendingTexts.has(pending.text) && !state.recent.some((message) =>
+          'content' in message && message.content === pending.text,
+        )) this.pendingHumanResponses.delete(id)
+      }
 
       const restoredMessages = recovery?.hasEngineMessages === true
       const carriedTexts = carriedEnvelopes
@@ -1035,10 +1043,6 @@ export class ManagerLoop {
       this.deps.store.clearCheckpoint(this.deps.key, episodeId)
       throw err
     } finally {
-      // 尚在 mailbox 的输入交给下一轮；其余未确认输入已终局收口，不能迟发确认。
-      for (const pending of this.pendingHumanAcceptance.keys()) {
-        if (!this.mailbox.isPending(pending)) this.pendingHumanAcceptance.delete(pending)
-      }
       this.currentEpisodeInjected = null
       this.currentWakeEvent = null
       this.currentEpisodeEnvelopes = []
@@ -1382,13 +1386,13 @@ export class ManagerLoop {
     readonly humanMessages: ReadonlyArray<EngineMessage>
     readonly messageCount: number
     readonly hasNewDirectHumanMessages: boolean
-    readonly lastCurrentWakeCommittedMessageId?: string
+    readonly currentHumanEnvelope?: TimedWakeEnvelope
   }> {
     const committedIds = new Set(state.committedHumanMessageIds ?? [])
     const committedMessages: EngineMessage[] = []
     const newImageRefs: ManagerImageRef[] = []
     let hasNewDirectHumanMessages = false
-    let lastCurrentWakeCommittedMessageId: string | undefined
+    let currentHumanEnvelope: TimedWakeEnvelope | undefined
 
     for (const envelope of envelopes) {
       if (!isHumanWake(envelope.wake)) continue
@@ -1400,13 +1404,14 @@ export class ManagerLoop {
       await this.prepareHumanWake(envelope)
       if (envelope.wake.kind === 'human_messages') hasNewDirectHumanMessages = true
       for (const { message } of newEntries) committedIds.add(message.platform_message_id)
-      const rendered = createUserMessage(this.renderEnvelope(projectHumanEnvelope(envelope, newEntries)))
+      const projected = projectHumanEnvelope(envelope, newEntries)
+      const rendered = createUserMessage(this.renderEnvelope(projected))
       committedMessages.push(rendered)
       // 记录本批消息的入站图片引用(轻量引用,见 image-vision.ts 文件头)
       const images = newEntries.flatMap(({ message }) => collectInboundImages(message))
       if (images.length > 0) newImageRefs.push({ message_id: rendered.id, images })
       if (envelope === currentEnvelope) {
-        lastCurrentWakeCommittedMessageId = newEntries[newEntries.length - 1].message.platform_message_id
+        currentHumanEnvelope = projected
       }
     }
 
@@ -1428,33 +1433,41 @@ export class ManagerLoop {
       humanMessages: committedMessages,
       messageCount: committedMessages.length,
       hasNewDirectHumanMessages,
-      lastCurrentWakeCommittedMessageId,
+      currentHumanEnvelope,
     }
   }
 
-  private acceptHumanInputs(envelopes: ReadonlyArray<TimedWakeEnvelope>): void {
-    for (const envelope of envelopes) {
-      const callback = this.pendingHumanAcceptance.get(envelope)
-      if (!callback) continue
-      this.pendingHumanAcceptance.delete(envelope)
-      const lastMessageId = isHumanWake(envelope.wake)
-        ? envelope.wake.messages.at(-1)?.platform_message_id
-        : undefined
-      if (lastMessageId) this.notifyHumanInputAccepted(callback, lastMessageId)
+  private trackHumanResponse(
+    envelope: TimedWakeEnvelope,
+    callback: ((messageId: string) => Promise<void>) | undefined,
+  ): void {
+    if (!callback || !isHumanWake(envelope.wake)) return
+    const id = envelope.wake.messages.at(-1)?.platform_message_id
+    if (id && !this.pendingHumanResponses.has(id)) {
+      this.pendingHumanResponses.set(id, { text: this.renderEnvelope(envelope), callback })
     }
   }
 
-  private notifyHumanInputAccepted(
-    callback: ((lastAcceptedMessageId: string) => Promise<void>) | undefined,
-    lastAcceptedMessageId: string,
+  private confirmHumanResponses(messageIds: ReadonlyArray<string>): void {
+    for (const id of messageIds) {
+      const pending = this.pendingHumanResponses.get(id)
+      if (!pending) continue
+      this.pendingHumanResponses.delete(id)
+      this.notifyHumanInputResponse(pending.callback, id)
+    }
+  }
+
+  private notifyHumanInputResponse(
+    callback: ((lastRespondedMessageId: string) => Promise<void>) | undefined,
+    lastRespondedMessageId: string,
   ): void {
     if (!callback) return
     try {
-      void callback(lastAcceptedMessageId).catch((err) => {
-        console.warn('[ManagerLoop] human input accepted callback failed (ignored):', err instanceof Error ? err.message : String(err))
+      void callback(lastRespondedMessageId).catch((err) => {
+        console.warn('[ManagerLoop] human input response callback failed (ignored):', err instanceof Error ? err.message : String(err))
       })
     } catch (err) {
-      console.warn('[ManagerLoop] human input accepted callback failed (ignored):', err instanceof Error ? err.message : String(err))
+      console.warn('[ManagerLoop] human input response callback failed (ignored):', err instanceof Error ? err.message : String(err))
     }
   }
 
@@ -1471,11 +1484,11 @@ export class ManagerLoop {
    *     envelope 原样留在 mailbox——收尾后 hasPendingMailbox 触发自唤醒(#54),下个
    *     episode 按正常路径提交+投喂,消息立即被处理(PR #131 五审:提交了就没有
    *     任何 episode 去回答它,「先提交再留邮箱」则自唤醒被去重键打成空转)。
-   *     pendingHumanAcceptance 保留该消息的确认责任，下一 episode 持久接收时触发;
+   *     pendingHumanResponses 保留确认责任，包含它的请求成功响应后触发;
    *   - recentReplaced=false(failed/aborted/throw,finalMessages 已丢弃):先从
    *     mailbox 移除,再正常提交(recent 追加文本+去重键)——消息必须以 recent
    *     形式保留,fail-loud 由 settle 回调补发。
-   * 此处只负责历史提交，自动确认由上下文持久接收点触发。调用方必须在 loop mutex 内。
+   * 此处只负责历史提交，自动确认由包含输入的请求成功响应触发。调用方必须在 loop mutex 内。
    */
   private async commitPendingHumanInputs(
     recentReplaced: boolean,
@@ -1966,6 +1979,7 @@ export class ManagerLoop {
         : [...tailMessages]
     let initialContextEnvelopes = [...(overrides?.contextEnvelopes ?? [])]
     const admittedContextEnvelopes: TimedWakeEnvelope[] = []
+    let responseHumanInputs: string[] = []
 
     const effectiveWake = this.effectiveWakeForCurrentEpisode()
     const isBuiltinDailyReflection = isBuiltinDailyReflectionWake(effectiveWake)
@@ -2022,6 +2036,11 @@ export class ManagerLoop {
       messagesRef,
       onBeforeLlmCall: () => {
         checkpoint()
+        // 捕获本次请求，响应期间进入 mailbox 的消息不能被旧请求确认。
+        const recent = this.resumeCheckpoint?.state.recent ?? []
+        responseHumanInputs = [...this.pendingHumanResponses]
+          .filter(([, pending]) => recent.some((message) => 'content' in message && message.content === pending.text))
+          .map(([id]) => id)
         const envelopes = [
           ...initialContextEnvelopes,
           ...this.mailbox.takeContextAdmissionEnvelopes(),
@@ -2056,6 +2075,8 @@ export class ManagerLoop {
       // P6-A §6.4：response/lifecycle 钩子即时投影，onTurn 负责补漏与 usage 结算；
       // 三者都只观察共享 Engine，不复制执行语义或新增第二个 query loop。
       onLlmResponse: (event) => {
+        this.confirmHumanResponses(responseHumanInputs)
+        responseHumanInputs = []
         this.recordLlmResponse(episodeId, event)
         if (this.resumeCheckpoint) {
           this.resumeCheckpoint = { ...this.resumeCheckpoint, responses: [...this.resumeCheckpoint.responses, event] }

--- a/crabot-agent/src/manager/loop.ts
+++ b/crabot-agent/src/manager/loop.ts
@@ -368,10 +368,9 @@ export class ManagerLoop {
    * 收尾 save 并发会互相覆盖),只登记到这里;episode 收尾临界区(mutex 内)统一
    * commitHumanInputs 落盘。runEpisode 进入时清空。
    */
-  private pendingHumanCommit: Array<{
-    envelope: TimedWakeEnvelope
-    onHumanInputCommitted?: (lastCommittedMessageId: string) => Promise<void>
-  }> = []
+  private pendingHumanCommit: TimedWakeEnvelope[] = []
+  /** 同进程跨 episode 保留未消费输入的确认责任；不进入恢复检查点。 */
+  private readonly pendingHumanAcceptance = new Map<TimedWakeEnvelope, (lastAcceptedMessageId: string) => Promise<void>>()
   /**
    * 本 episode 已提交人类消息 id 的内存镜像(runEpisode 开头 commit 后置位):注入
    * 投影的同步判定依据。与 store 的偏差方向安全——镜像缺失的 id 在收尾提交时仍被
@@ -586,15 +585,23 @@ export class ManagerLoop {
       execution: this.checkpointExecution(),
     }
     this.deps.store.saveCheckpoint(this.resumeCheckpoint)
+    // 只有刷新了实际 Engine 上下文且保存成功的检查点，才能确认已注入的人类输入。
+    if (state && this.pendingHumanAcceptance.size > 0) {
+      this.acceptHumanInputs(envelopes.filter((envelope) => {
+        if (!this.pendingHumanAcceptance.has(envelope)) return false
+        const text = this.renderEnvelope(envelope)
+        return state.recent.some((message) => 'content' in message && message.content === text)
+      }))
+    }
   }
 
   /** 唯一入口:被唤醒 → 跑一个 episode → 回睡。同一 loop 串行,不同 loop 互不影响。 */
   async wakeUp(
     envelope: TimedWakeEnvelope,
-    onHumanInputCommitted?: (lastCommittedMessageId: string) => Promise<void>,
+    onHumanInputAccepted?: (lastAcceptedMessageId: string) => Promise<void>,
   ): Promise<EpisodeResult> {
     assertTimedWakeEnvelope(envelope)
-    return this.mutex.run(() => this.runEpisode(envelope, onHumanInputCommitted))
+    return this.mutex.run(() => this.runEpisode(envelope, onHumanInputAccepted))
   }
 
   /** Queue now, then refresh authorization at the exact episode boundary. */
@@ -668,10 +675,10 @@ export class ManagerLoop {
   /** episode 进行中到达的新事件:渲染成文本推进内部邮箱,由 engine 的 humanMessageQueue
    *  在 turn 间隙注入;episode 不在跑时同样入队,行为见 `mailbox` 字段注释。
    *
-   *  人类消息默认拒绝:必须先经 commitHumanInputs 写入会话历史(协议 §4.1「人类入站
-   *  提交」)才可注入,否则 failed/aborted 后会把 LLM 已见过的输入当新 wake 重放。
-   *  唯一合法入口是 `enqueueHumanWakeDuringActiveEpisode`(先提交、再带
-   *  `humanWakePreCommitted` 放行)。 */
+   *  人类消息默认拒绝:必须登记去重和历史提交责任，否则 failed/aborted 后会把
+   *  LLM 已见过的输入当新 wake 重放。
+   *  唯一合法入口是 `enqueueHumanWakeDuringActiveEpisode`，它登记去重与延后历史
+   *  提交责任后带 `humanWakePreCommitted` 放行，检查点持久接收后才确认。 */
   enqueueDuringEpisode(envelope: TimedWakeEnvelope, opts?: {
     humanWakePreCommitted?: boolean
     onEpisodeSettled?: (result: EpisodeResult) => void
@@ -718,7 +725,7 @@ export class ManagerLoop {
    */
   enqueueHumanWakeDuringActiveEpisode(
     envelope: TimedWakeEnvelope,
-    onHumanInputCommitted?: (lastCommittedMessageId: string) => Promise<void>,
+    onHumanInputAccepted?: (lastAcceptedMessageId: string) => Promise<void>,
     onEpisodeSettled?: (result: EpisodeResult) => void,
   ): void {
     assertTimedWakeEnvelope(envelope)
@@ -736,7 +743,8 @@ export class ManagerLoop {
     const projected = isHumanWake(envelope.wake)
       ? projectHumanEnvelope(envelope, newEntries)
       : envelope
-    this.pendingHumanCommit.push({ envelope: projected, onHumanInputCommitted })
+    this.pendingHumanCommit.push(projected)
+    if (onHumanInputAccepted) this.pendingHumanAcceptance.set(projected, onHumanInputAccepted)
     // 远程图预取:fire-and-forget,drain 时消费已就绪结果(见 TimedWakeMailbox.imagePrefetch)
     this.mailbox.prefetchRemoteImages(projected)
     // currentEpisodeInjected 由 enqueueDuringEpisode 内部统一入账,此处不重复 push
@@ -795,7 +803,7 @@ export class ManagerLoop {
   /** `event === undefined` ⇒ 自唤醒(见 `drainMailbox`):只处理 mailbox 残留,不渲染唤醒事件。 */
   private async runEpisode(
     envelope: TimedWakeEnvelope | undefined,
-    onHumanInputCommitted?: (lastCommittedMessageId: string) => Promise<void>,
+    onHumanInputAccepted?: (lastAcceptedMessageId: string) => Promise<void>,
     recovery?: ManagerResumeCheckpoint,
   ): Promise<EpisodeResult> {
     const episodeId = recovery?.episodeId ?? randomUUID()
@@ -884,8 +892,9 @@ export class ManagerLoop {
       // 已提交人类消息 id 的内存镜像:mid-episode 注入的投影判定用它(同步、无 store I/O)
       this.knownCommittedHumanIds = new Set(state.committedHumanMessageIds ?? [])
       if (committed.lastCurrentWakeCommittedMessageId) {
-        this.notifyHumanInputCommitted(onHumanInputCommitted, committed.lastCurrentWakeCommittedMessageId)
+        this.notifyHumanInputAccepted(onHumanInputAccepted, committed.lastCurrentWakeCommittedMessageId)
       }
+      this.acceptHumanInputs(carriedEnvelopes)
 
       const restoredMessages = recovery?.hasEngineMessages === true
       const carriedTexts = carriedEnvelopes
@@ -1026,6 +1035,10 @@ export class ManagerLoop {
       this.deps.store.clearCheckpoint(this.deps.key, episodeId)
       throw err
     } finally {
+      // 尚在 mailbox 的输入交给下一轮；其余未确认输入已终局收口，不能迟发确认。
+      for (const pending of this.pendingHumanAcceptance.keys()) {
+        if (!this.mailbox.isPending(pending)) this.pendingHumanAcceptance.delete(pending)
+      }
       this.currentEpisodeInjected = null
       this.currentWakeEvent = null
       this.currentEpisodeEnvelopes = []
@@ -1419,17 +1432,29 @@ export class ManagerLoop {
     }
   }
 
-  private notifyHumanInputCommitted(
-    callback: ((lastCommittedMessageId: string) => Promise<void>) | undefined,
-    lastCommittedMessageId: string,
+  private acceptHumanInputs(envelopes: ReadonlyArray<TimedWakeEnvelope>): void {
+    for (const envelope of envelopes) {
+      const callback = this.pendingHumanAcceptance.get(envelope)
+      if (!callback) continue
+      this.pendingHumanAcceptance.delete(envelope)
+      const lastMessageId = isHumanWake(envelope.wake)
+        ? envelope.wake.messages.at(-1)?.platform_message_id
+        : undefined
+      if (lastMessageId) this.notifyHumanInputAccepted(callback, lastMessageId)
+    }
+  }
+
+  private notifyHumanInputAccepted(
+    callback: ((lastAcceptedMessageId: string) => Promise<void>) | undefined,
+    lastAcceptedMessageId: string,
   ): void {
     if (!callback) return
     try {
-      void callback(lastCommittedMessageId).catch((err) => {
-        console.warn('[ManagerLoop] human input committed callback failed (ignored):', err instanceof Error ? err.message : String(err))
+      void callback(lastAcceptedMessageId).catch((err) => {
+        console.warn('[ManagerLoop] human input accepted callback failed (ignored):', err instanceof Error ? err.message : String(err))
       })
     } catch (err) {
-      console.warn('[ManagerLoop] human input committed callback failed (ignored):', err instanceof Error ? err.message : String(err))
+      console.warn('[ManagerLoop] human input accepted callback failed (ignored):', err instanceof Error ? err.message : String(err))
     }
   }
 
@@ -1445,13 +1470,12 @@ export class ManagerLoop {
    *   - 未被消费且 recentReplaced(成功收尾):**不提交、不 discard、不记键、不回调**,
    *     envelope 原样留在 mailbox——收尾后 hasPendingMailbox 触发自唤醒(#54),下个
    *     episode 按正常路径提交+投喂,消息立即被处理(PR #131 五审:提交了就没有
-   *     任何 episode 去回答它,「先提交再留邮箱」则自唤醒被去重键打成空转);代价是
-   *     该消息的 reaction 回调挂起到自唤醒提交时——自唤醒无调用方回调,reaction
-   *     实际丢失,与「写入即已接收」自洽(尚未写入,本就不该打);
+   *     任何 episode 去回答它,「先提交再留邮箱」则自唤醒被去重键打成空转)。
+   *     pendingHumanAcceptance 保留该消息的确认责任，下一 episode 持久接收时触发;
    *   - recentReplaced=false(failed/aborted/throw,finalMessages 已丢弃):先从
    *     mailbox 移除,再正常提交(recent 追加文本+去重键)——消息必须以 recent
    *     形式保留,fail-loud 由 settle 回调补发。
-   * 回调(onHumanInputCommitted)在提交落定后触发。调用方必须在 loop mutex 内。
+   * 此处只负责历史提交，自动确认由上下文持久接收点触发。调用方必须在 loop mutex 内。
    */
   private async commitPendingHumanInputs(
     recentReplaced: boolean,
@@ -1462,24 +1486,21 @@ export class ManagerLoop {
     this.pendingHumanCommit = []
     let state = await this.deps.store.load(this.deps.key)
     let dirty = false
-    for (const rec of pending) {
-      if (recentReplaced && this.mailbox.isPending(rec.envelope)) continue // 留 mailbox 交自唤醒
-      const lastMessageId = isHumanWake(rec.envelope.wake)
-        ? rec.envelope.wake.messages.at(-1)?.platform_message_id
-        : undefined
+    for (const envelope of pending) {
+      if (recentReplaced && this.mailbox.isPending(envelope)) continue // 留 mailbox 交自唤醒
       if (recentReplaced) {
         // 已被 drain 消费且 recent 已替换:文本已进历史,只补去重键;
         // 带图插话同时补记 imageRefs——drain 消息(query-loop 随机 id)按渲染文本里的
         // platform_message_id 属性定位,图引用补齐后下一 episode 才能重新注入。
-        const ids = isHumanWake(rec.envelope.wake)
-          ? rec.envelope.wake.messages.map((m) => m.platform_message_id)
+        const ids = isHumanWake(envelope.wake)
+          ? envelope.wake.messages.map((m) => m.platform_message_id)
           : []
         const merged = new Set([...(state.committedHumanMessageIds ?? []), ...ids])
         const newImageRefs: ManagerImageRef[] = []
-        if (persistedFinalMessages && isHumanWake(rec.envelope.wake)) {
-          const images = rec.envelope.wake.messages.flatMap((m) => collectInboundImages(m))
+        if (persistedFinalMessages && isHumanWake(envelope.wake)) {
+          const images = envelope.wake.messages.flatMap((m) => collectInboundImages(m))
           if (images.length > 0) {
-            for (const message of rec.envelope.wake.messages) {
+            for (const message of envelope.wake.messages) {
               const marker = `id="${message.platform_message_id}"`
               const drainedMessage = persistedFinalMessages.find((m) => {
                 if (m.role !== 'user' || !('content' in m) || typeof m.content !== 'string') return false
@@ -1501,15 +1522,12 @@ export class ManagerLoop {
       } else {
         // 失败收尾(finalMessages 已随失败丢弃,必须以 recent 形式保留;残留 mailbox
         // 的先移除,避免与 settleFailedEpisodeEnvelopes 的 carry 重投重复):正常提交追加。
-        this.mailbox.discard(rec.envelope)
-        const committed = await this.commitHumanInputs(state, [rec.envelope], rec.envelope)
+        this.mailbox.discard(envelope)
+        const committed = await this.commitHumanInputs(state, [envelope], envelope)
         if (committed.messageCount > 0) {
           state = committed.state
           dirty = true
         }
-      }
-      if (lastMessageId) {
-        this.notifyHumanInputCommitted(rec.onHumanInputCommitted, lastMessageId)
       }
     }
     if (dirty) await this.deps.store.save(state)

--- a/crabot-agent/src/manager/registry.ts
+++ b/crabot-agent/src/manager/registry.ts
@@ -69,6 +69,11 @@ interface IdleReviewTimer {
   readonly handle: ReturnType<typeof setTimeout>
 }
 
+export interface HumanInputCallbacks {
+  readonly onInitialInputCommitted?: () => void
+  readonly onLlmResponse?: (lastMessageId: string) => Promise<void>
+}
+
 /**
  * scheduled 唤醒随行的**权限身份**(protocol-agent-v3 §8.2 的 `creator_friend_id` /
  * `is_builtin`;§4.4"scheduled 任务约束……权限按 `Schedule.creator_friend_id` 解析
@@ -417,14 +422,14 @@ export class ManagerRegistry {
     friend?: Friend,
     /** P6-A §3.2：system-only 关联元数据（不渲染进 LLM 正文）。 */
     correlation?: import('./loop.js').ManagerWakeCorrelation,
-    /** 人类输入已写入 Manager 历史或运行中上下文检查点后的非关键通知。 */
-    onHumanInputAccepted?: (lastAcceptedMessageId: string) => Promise<void>,
+    /** 历史提交放行队列；包含输入的 LLM 请求成功响应后才发外显确认。 */
+    humanInputCallbacks?: HumanInputCallbacks,
     /** 消息被注入在跑 episode 时(PR #131),处理结果的结算委托给该 episode 的真实
      * 收尾 result——调用方以此补跑 fail-loud,不用注入分支立即返回的占位值。 */
     onEpisodeSettled?: (result: EpisodeResult) => void,
   ): Promise<EpisodeResult> {
     const capture = this.captureIngress()
-    return this.routeHumanWake(capture, 'human_messages', channelId, sessionId, messages, friend, correlation, onHumanInputAccepted, onEpisodeSettled)
+    return this.routeHumanWake(capture, 'human_messages', channelId, sessionId, messages, friend, correlation, humanInputCallbacks, onEpisodeSettled)
   }
 
   /**
@@ -444,14 +449,14 @@ export class ManagerRegistry {
     sessionId: string,
     messages: ReadonlyArray<ChannelMessage>,
     friend?: Friend,
-    /** 人类输入已写入 Manager 历史或运行中上下文检查点后的非关键通知。 */
-    onHumanInputAccepted?: (lastAcceptedMessageId: string) => Promise<void>,
+    /** 历史提交放行队列；包含输入的 LLM 请求成功响应后才发外显确认。 */
+    humanInputCallbacks?: HumanInputCallbacks,
     /** flush 消息被注入在跑 episode 时(PR #131),处理结果的结算委托给该 episode 的
      * 真实收尾 result——调用方以此 reportResult,不用注入分支立即返回的占位值。 */
     onEpisodeSettled?: (result: EpisodeResult) => void,
   ): Promise<EpisodeResult> {
     const capture = this.captureIngress()
-    return this.routeHumanWake(capture, 'attention_flush', channelId, sessionId, messages, friend, undefined, onHumanInputAccepted, onEpisodeSettled)
+    return this.routeHumanWake(capture, 'attention_flush', channelId, sessionId, messages, friend, undefined, humanInputCallbacks, onEpisodeSettled)
   }
 
   /** 两个人类消息入口的公共路径:准备发起人身份与引用正文 → 按 kind 造事件唤醒。 */
@@ -463,7 +468,7 @@ export class ManagerRegistry {
     messages: ReadonlyArray<ChannelMessage>,
     friend?: Friend,
     correlation?: import('./loop.js').ManagerWakeCorrelation,
-    onHumanInputAccepted?: (lastAcceptedMessageId: string) => Promise<void>,
+    humanInputCallbacks?: HumanInputCallbacks,
     onEpisodeSettled?: (result: EpisodeResult) => void,
   ): Promise<EpisodeResult> {
     const key = `${channelId}::${sessionId}` as ManagerKey
@@ -499,7 +504,7 @@ export class ManagerRegistry {
           : { kind: 'attention_flush', messages, ...withFriend, ...withPerms }
       // P7 cutover 遗留接线补齐(2026-08-29):episode 运行中到达的人类消息进入当前
       // episode mailbox,turn 边界注入当前 episode 的下一轮 LLM——不再阻塞在 wakeUp 的
-      // mutex 上等本 episode 跑完。注入后的上下文检查点负责持久确认，历史在收尾合并。
+      // mutex 上等本 episode 跑完。注入检查点负责持久化，成功 LLM 响应负责外显确认。
       // 协议 §4.1「episode 进行中到达的事件直接
       // 进入当前 Manager mailbox」同样涵盖人类消息。
       const loop = this.getOrCreate(key)
@@ -507,7 +512,7 @@ export class ManagerRegistry {
       if (this.isEpisodeActive(key)) {
         // 同步入队(check 与 push 之间无 await,与 routeWorkerEvent 同构原子):
         // 提交延后到当前 episode 收尾临界区,由 settle hook 拿真实处理结果。
-        loop.enqueueHumanWakeDuringActiveEpisode({ ...envelope, wake: event }, onHumanInputAccepted, onEpisodeSettled)
+        loop.enqueueHumanWakeDuringActiveEpisode({ ...envelope, wake: event }, humanInputCallbacks?.onLlmResponse, onEpisodeSettled)
         return {
           episodeId: '',
           outcome: 'completed',
@@ -517,7 +522,7 @@ export class ManagerRegistry {
           successfulSendMessageTargets: [],
         }
       }
-      return this.runWake(key, { ...envelope, wake: event }, 0, onHumanInputAccepted)
+      return this.runWake(key, { ...envelope, wake: event }, 0, humanInputCallbacks)
     } finally {
       finishPreparation()
     }
@@ -930,7 +935,7 @@ export class ManagerRegistry {
     key: ManagerKey,
     envelope: TimedWakeEnvelope | undefined,
     selfWakeChain?: number,
-    onHumanInputAccepted?: (lastAcceptedMessageId: string) => Promise<void>,
+    humanInputCallbacks?: HumanInputCallbacks,
     shouldAdmit?: undefined,
     recovery?: ManagerResumeCheckpoint,
   ): Promise<EpisodeResult>
@@ -938,14 +943,14 @@ export class ManagerRegistry {
     key: ManagerKey,
     envelope: TimedWakeEnvelope | undefined,
     selfWakeChain: number,
-    onHumanInputAccepted: ((lastAcceptedMessageId: string) => Promise<void>) | undefined,
+    humanInputCallbacks: HumanInputCallbacks | undefined,
     shouldAdmit: () => Promise<boolean>,
   ): Promise<EpisodeResult | undefined>
   private runWake(
     key: ManagerKey,
     envelope: TimedWakeEnvelope,
     selfWakeChain: number,
-    onHumanInputAccepted: undefined,
+    humanInputCallbacks: undefined,
     shouldAdmit: undefined,
     recovery: undefined,
     admissionGuard: () => boolean,
@@ -954,7 +959,7 @@ export class ManagerRegistry {
     key: ManagerKey,
     envelope: TimedWakeEnvelope | undefined,
     selfWakeChain = 0,
-    onHumanInputAccepted?: (lastAcceptedMessageId: string) => Promise<void>,
+    humanInputCallbacks?: HumanInputCallbacks,
     shouldAdmit?: () => Promise<boolean>,
     recovery?: ManagerResumeCheckpoint,
     admissionGuard?: () => boolean,
@@ -975,14 +980,14 @@ export class ManagerRegistry {
     }
     let result: EpisodeResult | undefined
     try {
-      // `wakeUp()` 会在输入持久化后才触发非关键通知；这不是 LLM 已完成的确认。
+      // 输入提交放行 lane 与成功 LLM 响应的确认各用独立回调。
       if (recovery) {
         this.pendingResumes.delete(key)
         result = await loop.resume(recovery)
       } else if (envelope === undefined) {
         result = await loop.drainMailbox()
-      } else if (onHumanInputAccepted) {
-        result = await loop.wakeUp(envelope, onHumanInputAccepted)
+      } else if (humanInputCallbacks) {
+        result = await loop.wakeUp(envelope, humanInputCallbacks.onLlmResponse, humanInputCallbacks.onInitialInputCommitted)
       } else {
         result = await loop.wakeUp(envelope)
       }

--- a/crabot-agent/src/manager/registry.ts
+++ b/crabot-agent/src/manager/registry.ts
@@ -417,14 +417,14 @@ export class ManagerRegistry {
     friend?: Friend,
     /** P6-A §3.2：system-only 关联元数据（不渲染进 LLM 正文）。 */
     correlation?: import('./loop.js').ManagerWakeCorrelation,
-    /** 人类输入已持久化进对应 Manager 会话后的非关键通知。 */
-    onHumanInputCommitted?: (lastCommittedMessageId: string) => Promise<void>,
+    /** 人类输入已写入 Manager 历史或运行中上下文检查点后的非关键通知。 */
+    onHumanInputAccepted?: (lastAcceptedMessageId: string) => Promise<void>,
     /** 消息被注入在跑 episode 时(PR #131),处理结果的结算委托给该 episode 的真实
      * 收尾 result——调用方以此补跑 fail-loud,不用注入分支立即返回的占位值。 */
     onEpisodeSettled?: (result: EpisodeResult) => void,
   ): Promise<EpisodeResult> {
     const capture = this.captureIngress()
-    return this.routeHumanWake(capture, 'human_messages', channelId, sessionId, messages, friend, correlation, onHumanInputCommitted, onEpisodeSettled)
+    return this.routeHumanWake(capture, 'human_messages', channelId, sessionId, messages, friend, correlation, onHumanInputAccepted, onEpisodeSettled)
   }
 
   /**
@@ -444,14 +444,14 @@ export class ManagerRegistry {
     sessionId: string,
     messages: ReadonlyArray<ChannelMessage>,
     friend?: Friend,
-    /** 人类输入已持久化进对应 Manager 会话后的非关键通知。 */
-    onHumanInputCommitted?: (lastCommittedMessageId: string) => Promise<void>,
+    /** 人类输入已写入 Manager 历史或运行中上下文检查点后的非关键通知。 */
+    onHumanInputAccepted?: (lastAcceptedMessageId: string) => Promise<void>,
     /** flush 消息被注入在跑 episode 时(PR #131),处理结果的结算委托给该 episode 的
      * 真实收尾 result——调用方以此 reportResult,不用注入分支立即返回的占位值。 */
     onEpisodeSettled?: (result: EpisodeResult) => void,
   ): Promise<EpisodeResult> {
     const capture = this.captureIngress()
-    return this.routeHumanWake(capture, 'attention_flush', channelId, sessionId, messages, friend, undefined, onHumanInputCommitted, onEpisodeSettled)
+    return this.routeHumanWake(capture, 'attention_flush', channelId, sessionId, messages, friend, undefined, onHumanInputAccepted, onEpisodeSettled)
   }
 
   /** 两个人类消息入口的公共路径:准备发起人身份与引用正文 → 按 kind 造事件唤醒。 */
@@ -463,7 +463,7 @@ export class ManagerRegistry {
     messages: ReadonlyArray<ChannelMessage>,
     friend?: Friend,
     correlation?: import('./loop.js').ManagerWakeCorrelation,
-    onHumanInputCommitted?: (lastCommittedMessageId: string) => Promise<void>,
+    onHumanInputAccepted?: (lastAcceptedMessageId: string) => Promise<void>,
     onEpisodeSettled?: (result: EpisodeResult) => void,
   ): Promise<EpisodeResult> {
     const key = `${channelId}::${sessionId}` as ManagerKey
@@ -499,15 +499,15 @@ export class ManagerRegistry {
           : { kind: 'attention_flush', messages, ...withFriend, ...withPerms }
       // P7 cutover 遗留接线补齐(2026-08-29):episode 运行中到达的人类消息进入当前
       // episode mailbox,turn 边界注入当前 episode 的下一轮 LLM——不再阻塞在 wakeUp 的
-      // mutex 上等本 episode 跑完。先提交(写历史+去重+回调)再注入,语义与 builtin
-      // worker 输入注入一致(参照 PR #130)。协议 §4.1「episode 进行中到达的事件直接
+      // mutex 上等本 episode 跑完。注入后的上下文检查点负责持久确认，历史在收尾合并。
+      // 协议 §4.1「episode 进行中到达的事件直接
       // 进入当前 Manager mailbox」同样涵盖人类消息。
       const loop = this.getOrCreate(key)
       await loop.prepareHumanWake({ ...envelope, wake: event })
       if (this.isEpisodeActive(key)) {
         // 同步入队(check 与 push 之间无 await,与 routeWorkerEvent 同构原子):
         // 提交延后到当前 episode 收尾临界区,由 settle hook 拿真实处理结果。
-        loop.enqueueHumanWakeDuringActiveEpisode({ ...envelope, wake: event }, onHumanInputCommitted, onEpisodeSettled)
+        loop.enqueueHumanWakeDuringActiveEpisode({ ...envelope, wake: event }, onHumanInputAccepted, onEpisodeSettled)
         return {
           episodeId: '',
           outcome: 'completed',
@@ -517,7 +517,7 @@ export class ManagerRegistry {
           successfulSendMessageTargets: [],
         }
       }
-      return this.runWake(key, { ...envelope, wake: event }, 0, onHumanInputCommitted)
+      return this.runWake(key, { ...envelope, wake: event }, 0, onHumanInputAccepted)
     } finally {
       finishPreparation()
     }
@@ -930,7 +930,7 @@ export class ManagerRegistry {
     key: ManagerKey,
     envelope: TimedWakeEnvelope | undefined,
     selfWakeChain?: number,
-    onHumanInputCommitted?: (lastCommittedMessageId: string) => Promise<void>,
+    onHumanInputAccepted?: (lastAcceptedMessageId: string) => Promise<void>,
     shouldAdmit?: undefined,
     recovery?: ManagerResumeCheckpoint,
   ): Promise<EpisodeResult>
@@ -938,14 +938,14 @@ export class ManagerRegistry {
     key: ManagerKey,
     envelope: TimedWakeEnvelope | undefined,
     selfWakeChain: number,
-    onHumanInputCommitted: ((lastCommittedMessageId: string) => Promise<void>) | undefined,
+    onHumanInputAccepted: ((lastAcceptedMessageId: string) => Promise<void>) | undefined,
     shouldAdmit: () => Promise<boolean>,
   ): Promise<EpisodeResult | undefined>
   private runWake(
     key: ManagerKey,
     envelope: TimedWakeEnvelope,
     selfWakeChain: number,
-    onHumanInputCommitted: undefined,
+    onHumanInputAccepted: undefined,
     shouldAdmit: undefined,
     recovery: undefined,
     admissionGuard: () => boolean,
@@ -954,7 +954,7 @@ export class ManagerRegistry {
     key: ManagerKey,
     envelope: TimedWakeEnvelope | undefined,
     selfWakeChain = 0,
-    onHumanInputCommitted?: (lastCommittedMessageId: string) => Promise<void>,
+    onHumanInputAccepted?: (lastAcceptedMessageId: string) => Promise<void>,
     shouldAdmit?: () => Promise<boolean>,
     recovery?: ManagerResumeCheckpoint,
     admissionGuard?: () => boolean,
@@ -981,8 +981,8 @@ export class ManagerRegistry {
         result = await loop.resume(recovery)
       } else if (envelope === undefined) {
         result = await loop.drainMailbox()
-      } else if (onHumanInputCommitted) {
-        result = await loop.wakeUp(envelope, onHumanInputCommitted)
+      } else if (onHumanInputAccepted) {
+        result = await loop.wakeUp(envelope, onHumanInputAccepted)
       } else {
         result = await loop.wakeUp(envelope)
       }

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -2141,9 +2141,9 @@ export class UnifiedAgent extends ModuleBase {
         messages,
         friend,
         undefined,
-        (lastAcceptedMessageId) => {
-          release?.()
-          return this.reactToAcceptedHumanMessage(
+        {
+          onInitialInputCommitted: release,
+          onLlmResponse: (lastAcceptedMessageId) => this.reactToAcceptedHumanMessage(
             session.channel_id,
             session.session_id,
             lastAcceptedMessageId,
@@ -2227,9 +2227,9 @@ export class UnifiedAgent extends ModuleBase {
         sessionId,
         messages,
         lastEntry.friend,
-        (lastAcceptedMessageId) => {
-          release?.()
-          return this.reactToAcceptedHumanMessage(
+        {
+          onInitialInputCommitted: release,
+          onLlmResponse: (lastAcceptedMessageId) => this.reactToAcceptedHumanMessage(
             session.channel_id,
             sessionId,
             lastAcceptedMessageId,
@@ -2280,7 +2280,7 @@ export class UnifiedAgent extends ModuleBase {
   }
 
   /**
-   * 人类输入已写入 Manager 历史或运行中上下文检查点后，给本批最后一个新消息打「已接收」表情。
+   * 首次包含输入的 LLM 请求成功响应后，给本批最后一个新消息打「已接收」表情。
    *
    * 落在接线层而不是 manager 工具面：`add_reaction` 不是 crab-messaging 工具，它是编排层的
    * 机械动作，不该破坏 `assertClosedToolFace` 的封闭不变量。
@@ -2843,7 +2843,7 @@ export class UnifiedAgent extends ModuleBase {
    * 「三不」不变：不进 SessionLane（admin REST 前端 fetch 等响应才发下一条，天然单线）、
    * 不进注意力调度（master 直连每条都要处理）、不打 `add_reaction`（admin-web 没有
    * channel 侧 platform message 可回应——「已接收」标记改走 admin `chat_acknowledge`，
-   * 见 routeHumanMessages 的持久接收回调）。
+   * 见 routeHumanMessages 的 LLM 响应回调）。
    */
   private async processAdminChatMessage(
     message: ChannelMessage,
@@ -2877,9 +2877,9 @@ export class UnifiedAgent extends ModuleBase {
         MASTER_FRIEND,
         { admin_chat_request_ids: [callbackInfo.request_id] },
         // 「已接收」标记（protocol-agent-v3 §4.1 / protocol-admin §3.20.2）：人类输入
-        // 写入 manager 历史或运行中上下文检查点后 best-effort 通知 admin，web 在对应用户消息上渲染标记，
+        // 首次包含输入的 LLM 请求成功后 best-effort 通知 admin，web 在对应用户消息上渲染标记，
         // 与 channel 的 acknowledged reaction 同语义同时机。失败只落日志，不影响回复链路。
-        () => this.ackAdminChatHumanInput(callbackInfo.request_id),
+        { onLlmResponse: () => this.ackAdminChatHumanInput(callbackInfo.request_id) },
         // 注入在跑 episode 时(PR #131):占位 result 恒 completed,F1 判不到真实失败——
         // 若被注入 episode 最终 failed/aborted,结算委托给该 episode 的真实收尾 result,
         // 在此补发 fail-loud(否则 consumedEvents=false 不走 settleUnclaimedAdminChatWakes,

--- a/crabot-agent/src/unified-agent.ts
+++ b/crabot-agent/src/unified-agent.ts
@@ -2141,12 +2141,12 @@ export class UnifiedAgent extends ModuleBase {
         messages,
         friend,
         undefined,
-        (lastCommittedMessageId) => {
+        (lastAcceptedMessageId) => {
           release?.()
-          return this.reactToCommittedHumanMessage(
+          return this.reactToAcceptedHumanMessage(
             session.channel_id,
             session.session_id,
-            lastCommittedMessageId,
+            lastAcceptedMessageId,
           )
         },
         (settled) => {
@@ -2227,12 +2227,12 @@ export class UnifiedAgent extends ModuleBase {
         sessionId,
         messages,
         lastEntry.friend,
-        (lastCommittedMessageId) => {
+        (lastAcceptedMessageId) => {
           release?.()
-          return this.reactToCommittedHumanMessage(
+          return this.reactToAcceptedHumanMessage(
             session.channel_id,
             sessionId,
-            lastCommittedMessageId,
+            lastAcceptedMessageId,
           )
         },
         (settled) => {
@@ -2280,7 +2280,7 @@ export class UnifiedAgent extends ModuleBase {
   }
 
   /**
-   * 人类输入已持久化进 Manager 会话后，给本批最后一个**新提交**的消息打「已接收」表情。
+   * 人类输入已写入 Manager 历史或运行中上下文检查点后，给本批最后一个新消息打「已接收」表情。
    *
    * 落在接线层而不是 manager 工具面：`add_reaction` 不是 crab-messaging 工具，它是编排层的
    * 机械动作，不该破坏 `assertClosedToolFace` 的封闭不变量。
@@ -2290,7 +2290,7 @@ export class UnifiedAgent extends ModuleBase {
    *
    * Spec: 2026-06-04-channel-task-pickup-reaction-design.md §4
    */
-  private async reactToCommittedHumanMessage(
+  private async reactToAcceptedHumanMessage(
     channelId: string,
     sessionId: string,
     platformMessageId: string,
@@ -2843,7 +2843,7 @@ export class UnifiedAgent extends ModuleBase {
    * 「三不」不变：不进 SessionLane（admin REST 前端 fetch 等响应才发下一条，天然单线）、
    * 不进注意力调度（master 直连每条都要处理）、不打 `add_reaction`（admin-web 没有
    * channel 侧 platform message 可回应——「已接收」标记改走 admin `chat_acknowledge`，
-   * 见 routeHumanMessages 的 commit 回调）。
+   * 见 routeHumanMessages 的持久接收回调）。
    */
   private async processAdminChatMessage(
     message: ChannelMessage,
@@ -2877,7 +2877,7 @@ export class UnifiedAgent extends ModuleBase {
         MASTER_FRIEND,
         { admin_chat_request_ids: [callbackInfo.request_id] },
         // 「已接收」标记（protocol-agent-v3 §4.1 / protocol-admin §3.20.2）：人类输入
-        // commit 进 manager 会话后 best-effort 通知 admin，web 在对应用户消息上渲染标记，
+        // 写入 manager 历史或运行中上下文检查点后 best-effort 通知 admin，web 在对应用户消息上渲染标记，
         // 与 channel 的 acknowledged reaction 同语义同时机。失败只落日志，不影响回复链路。
         () => this.ackAdminChatHumanInput(callbackInfo.request_id),
         // 注入在跑 episode 时(PR #131):占位 result 恒 completed,F1 判不到真实失败——

--- a/crabot-agent/tests/inbound/process-admin-chat-message.test.ts
+++ b/crabot-agent/tests/inbound/process-admin-chat-message.test.ts
@@ -464,6 +464,51 @@ describe('processAdminChatMessage —— admin chat 入站（cutover 后下游�
   // ==========================================================================
 
   describe('已接收标记（chat_acknowledge）', () => {
+    it('运行中输入在包含它的模型请求返回前已标记接收', async () => {
+      boot({ turns: [[reply()], []] })
+      const gate = () => {
+        let resolve!: () => void
+        const promise = new Promise<void>((r) => { resolve = r })
+        return { promise, resolve }
+      }
+      const firstEntered = gate()
+      const firstRelease = gate()
+      const secondEntered = gate()
+      const secondRelease = gate()
+      let turn = 0
+      hoisted.managerAdapter = {
+        async *stream(params: unknown) {
+          if (++turn === 1) {
+            firstEntered.resolve()
+            await firstRelease.promise
+          } else if (turn === 2) {
+            secondEntered.resolve()
+            await secondRelease.promise
+          }
+          yield* script.adapter.stream(params as never)
+        }, updateConfig() {},
+      }
+      const episode = runAdminChat(amsg({ id: 'initial' }), 'req-initial')
+      try {
+        await firstEntered.promise
+        await runAdminChat(amsg({ id: 'supplement', text: 'follow up' }), 'req-supplement')
+        const acknowledgements = () => rpcCalls.filter((c) => c.method === 'chat_acknowledge' && c.params.request_ids?.includes('req-supplement'))
+        expect(acknowledgements()).toHaveLength(0)
+        firstRelease.resolve()
+        await secondEntered.promise
+        await vi.waitFor(() => expect(acknowledgements()).toHaveLength(1))
+        expect(acknowledgements()[0].port).toBe(ADMIN_PORT)
+        secondRelease.resolve()
+        await episode
+        expect(acknowledgements()).toHaveLength(1)
+        expectThreeNots()
+      } finally {
+        firstRelease.resolve()
+        secondRelease.resolve()
+        await episode
+      }
+    })
+
     it('人类输入 commit 后调用 chat_acknowledge，路由到 admin 模块并携带 request_id', async () => {
       boot({ turns: [[reply()]] })
       await runAdminChat(amsg({ id: 'a-ack-1' }), 'req-ack-1')

--- a/crabot-agent/tests/inbound/process-admin-chat-message.test.ts
+++ b/crabot-agent/tests/inbound/process-admin-chat-message.test.ts
@@ -464,7 +464,7 @@ describe('processAdminChatMessage —— admin chat 入站（cutover 后下游�
   // ==========================================================================
 
   describe('已接收标记（chat_acknowledge）', () => {
-    it('运行中输入在包含它的模型请求返回前已标记接收', async () => {
+    it('运行中输入只在包含它的模型请求成功返回后标记接收', async () => {
       boot({ turns: [[reply()], []] })
       const gate = () => {
         let resolve!: () => void
@@ -494,12 +494,15 @@ describe('processAdminChatMessage —— admin chat 入站（cutover 后下游�
         await runAdminChat(amsg({ id: 'supplement', text: 'follow up' }), 'req-supplement')
         const acknowledgements = () => rpcCalls.filter((c) => c.method === 'chat_acknowledge' && c.params.request_ids?.includes('req-supplement'))
         expect(acknowledgements()).toHaveLength(0)
+        expect(rpcCalls.filter((c) => c.method === 'chat_acknowledge')).toHaveLength(0)
         firstRelease.resolve()
         await secondEntered.promise
-        await vi.waitFor(() => expect(acknowledgements()).toHaveLength(1))
-        expect(acknowledgements()[0].port).toBe(ADMIN_PORT)
+        expect(acknowledgements()).toHaveLength(0)
+        await vi.waitFor(() => expect(rpcCalls.some((c) => c.method === 'chat_acknowledge' && c.params.request_ids?.includes('req-initial'))).toBe(true))
         secondRelease.resolve()
         await episode
+        await vi.waitFor(() => expect(acknowledgements()).toHaveLength(1))
+        expect(acknowledgements()[0].port).toBe(ADMIN_PORT)
         expect(acknowledgements()).toHaveLength(1)
         expectThreeNots()
       } finally {
@@ -509,10 +512,10 @@ describe('processAdminChatMessage —— admin chat 入站（cutover 后下游�
       }
     })
 
-    it('人类输入 commit 后调用 chat_acknowledge，路由到 admin 模块并携带 request_id', async () => {
+    it('包含人类输入的 LLM 请求成功后调用 chat_acknowledge，携带 request_id', async () => {
       boot({ turns: [[reply()]] })
       await runAdminChat(amsg({ id: 'a-ack-1' }), 'req-ack-1')
-      // commit 回调是 fire-and-forget：跑完一轮 episode 后补几个宏任务让它落地
+      // 响应回调是 fire-and-forget：跑完一轮 episode 后补几个宏任务让它落地
       await new Promise((resolve) => setTimeout(resolve, 0))
 
       const ack = rpcCalls.find((c) => c.method === 'chat_acknowledge')

--- a/crabot-agent/tests/inbound/process-direct-batch.test.ts
+++ b/crabot-agent/tests/inbound/process-direct-batch.test.ts
@@ -348,12 +348,12 @@ describe('processDirectBatch —— 私聊 lane handler（cutover 后下游是 m
         reactionRelease.resolve()
         firstTurnRelease.resolve()
         await secondTurnEntered.promise
-        await vi.waitFor(() => {
-          const reacted = rpcCalls.filter((c) => c.method === 'add_reaction').map((c) => c.params.platform_message_id)
-          expect(reacted).toContain('third')
-        })
+        const reacted = () => rpcCalls.filter((c) => c.method === 'add_reaction').map((c) => c.params.platform_message_id)
+        await vi.waitFor(() => expect(reacted()).toContain('first'))
+        expect(reacted()).not.toContain('third')
         expect(report).not.toHaveBeenCalled()
         secondTurnRelease.resolve()
+        await vi.waitFor(() => expect(reacted()).toContain('third'))
         await Promise.all(handlers())
 
         expect(requests.length).toBeGreaterThanOrEqual(2)
@@ -456,22 +456,22 @@ describe('processDirectBatch —— 私聊 lane handler（cutover 后下游是 m
       })
     })
 
-    it('Manager 提交消息后才 reaction，仍不依赖 LLM 决策结果', async () => {
+    it('Manager 成功收到 LLM 响应后才 reaction，仍不依赖 LLM 决策结果', async () => {
       boot([[sendMessageBlock({ channelId: 'wechat', sessionId: 'sess-1', text: '在的' })]])
 
       await internals.processDirectBatch(batchOf([makeMessage({ id: 'm-1', type: 'private' })]))
 
-      // 提交前先完成身份/场景解析。reaction 是非阻塞外显，可能与后续 LLM 并发。
+      // 提交前先完成身份/场景解析。reaction 是非阻塞外显，可能与后续工具/LLM 并发。
       expect(calls.indexOf('add_reaction')).toBeGreaterThan(calls.indexOf('resolve_permissions'))
       expect(calls.indexOf('add_reaction')).toBeGreaterThan(calls.indexOf('resolve_scene_profile'))
     })
 
-    it('只有 registry 确认消息已提交时才 reaction', async () => {
+    it('只有 registry 通知包含输入的 LLM 请求成功时才 reaction', async () => {
       boot()
       internals.managerStack.registry.routeHumanMessages = async (...args: unknown[]) => {
         calls.push('manager_accepted')
-        const onHumanInputCommitted = args[5] as ((messageId: string) => Promise<void>) | undefined
-        void onHumanInputCommitted?.('m-1')
+        const callbacks = args[5] as { onLlmResponse?: (messageId: string) => Promise<void> }
+        void callbacks.onLlmResponse?.('m-1')
         return { episodeId: 'ep-1', outcome: 'completed', turns: 0, consumedEvents: true, repliedToHuman: false }
       }
 

--- a/crabot-agent/tests/inbound/process-direct-batch.test.ts
+++ b/crabot-agent/tests/inbound/process-direct-batch.test.ts
@@ -277,6 +277,8 @@ describe('processDirectBatch —— 私聊 lane handler（cutover 后下游是 m
       const permissionsRelease = gate()
       const firstTurnEntered = gate()
       const firstTurnRelease = gate()
+      const secondTurnEntered = gate()
+      const secondTurnRelease = gate()
       const reactionRelease = gate()
       const requests: string[] = []
       hoisted.managerAdapter = {
@@ -285,6 +287,10 @@ describe('processDirectBatch —— 私聊 lane handler（cutover 后下游是 m
           if (requests.length === 1) {
             firstTurnEntered.resolve()
             await firstTurnRelease.promise
+          }
+          if (requests.length === 2) {
+            secondTurnEntered.resolve()
+            await secondTurnRelease.promise
           }
           yield* script.adapter.stream(params)
         },
@@ -341,6 +347,13 @@ describe('processDirectBatch —— 私聊 lane handler（cutover 后下游是 m
         expect(report).not.toHaveBeenCalled()
         reactionRelease.resolve()
         firstTurnRelease.resolve()
+        await secondTurnEntered.promise
+        await vi.waitFor(() => {
+          const reacted = rpcCalls.filter((c) => c.method === 'add_reaction').map((c) => c.params.platform_message_id)
+          expect(reacted).toContain('third')
+        })
+        expect(report).not.toHaveBeenCalled()
+        secondTurnRelease.resolve()
         await Promise.all(handlers())
 
         expect(requests.length).toBeGreaterThanOrEqual(2)
@@ -359,6 +372,7 @@ describe('processDirectBatch —— 私聊 lane handler（cutover 后下游是 m
         permissionsRelease.resolve()
         reactionRelease.resolve()
         firstTurnRelease.resolve()
+        secondTurnRelease.resolve()
         // 失败断言也要收完后台 handler，避免下一批落盘晚于临时目录清理。
         let count: number
         do {

--- a/crabot-agent/tests/inbound/process-group-lane-batch.test.ts
+++ b/crabot-agent/tests/inbound/process-group-lane-batch.test.ts
@@ -410,7 +410,7 @@ describe('processGroupLaneBatch —— 群聊 lane handler（cutover 后下游�
       })
     })
 
-    it('Manager 提交消息后才 reaction；manager 沉默时也照样发过', async () => {
+    it('Manager 成功收到 LLM 响应后才 reaction；manager 沉默时也照样发过', async () => {
       boot() // 空脚本 = manager 一句话都不说
       await runGroup([gmsg({ id: 'g-1', text: '你们中午吃啥' })])
 
@@ -418,12 +418,12 @@ describe('processGroupLaneBatch —— 群聊 lane handler（cutover 后下游�
       expect(rpcCalls.find((c) => c.method === 'send_message')).toBeUndefined()
     })
 
-    it('只有 registry 确认消息已提交时才 reaction', async () => {
+    it('只有 registry 通知包含输入的 LLM 请求成功时才 reaction', async () => {
       boot()
       internals.managerStack.registry.routeAttentionFlush = async (...args: unknown[]) => {
         calls.push('manager_accepted')
-        const onHumanInputCommitted = args[4] as ((messageId: string) => Promise<void>) | undefined
-        void onHumanInputCommitted?.('g-1')
+        const callbacks = args[4] as { onLlmResponse?: (messageId: string) => Promise<void> }
+        void callbacks.onLlmResponse?.('g-1')
         return { episodeId: 'ep-g1', outcome: 'completed', turns: 0, consumedEvents: true, repliedToHuman: false }
       }
 

--- a/crabot-agent/tests/manager/loop.test.ts
+++ b/crabot-agent/tests/manager/loop.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { promises as fs } from 'fs'
+import { promises as fs, readFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 
@@ -1221,6 +1221,97 @@ describe('ManagerLoop', () => {
     expect(committedIds).toHaveLength(1)
   })
 
+  it.each(['resolved', 'rejected', 'throwing', 'pending'] as const)('confirms persisted input before the slow model returns, with a %s callback', async (callbackResult) => {
+    let release!: () => void
+    const held = new Promise<void>((resolve) => { release = resolve })
+    let entered!: () => void
+    const secondTurn = new Promise<void>((resolve) => { entered = resolve })
+    const initial = makeChannelMessage('start')
+    const earlier = makeChannelMessage('earlier in batch')
+    const supplement = { ...makeChannelMessage('persisted supplement'), platform_message_id: 'pm-accepted' }
+    const duplicate = vi.fn(async () => {})
+    let acceptedCheckpoint = ''
+    const accepted = vi.fn(() => {
+      acceptedCheckpoint = readFileSync(join(dataDir, 'manager-sessions', encodeURIComponent(KEY), 'running.json'), 'utf8')
+      if (callbackResult === 'throwing') throw new Error('reaction unavailable')
+      if (callbackResult === 'rejected') return Promise.reject(new Error('reaction unavailable'))
+      if (callbackResult === 'pending') return new Promise<void>(() => {})
+      return Promise.resolve()
+    })
+    let turn = 0
+    let loop!: ManagerLoop
+    const adapter: LLMAdapter = {
+      async *stream() {
+        if (++turn === 1) {
+          yield* chunksFromContent([{ type: 'tool_use', id: 'inject', name: 'inject', input: {} }], 'tool_use')
+          return
+        }
+        entered()
+        await held
+        yield* chunksFromContent([], 'end_turn')
+      },
+      updateConfig() {},
+    }
+    loop = new ManagerLoop(baseDeps({ store, adapter, toolFace: () => [defineTool({
+      name: 'inject', description: 'inject', inputSchema: {}, isReadOnly: false,
+      call: async () => {
+        loop.enqueueHumanWakeDuringActiveEpisode(timed({ kind: 'human_messages', messages: [initial, earlier, supplement, initial] }), accepted)
+        loop.enqueueHumanWakeDuringActiveEpisode(timed({ kind: 'human_messages', messages: [supplement] }), duplicate)
+        expect(accepted).not.toHaveBeenCalled()
+        return { output: 'ok', isError: false }
+      },
+    })] }))
+    const episode = loop.wakeUp(timed({ kind: 'human_messages', messages: [initial] }))
+    try {
+      await secondTurn
+      const checkpoint = await store.loadCheckpoint(KEY)
+      expect(checkpoint?.state.committedHumanMessageIds).toContain(supplement.platform_message_id)
+      expect(JSON.stringify(checkpoint?.state.recent)).toContain('persisted supplement')
+      expect(JSON.stringify((await store.load(KEY)).recent)).not.toContain('persisted supplement')
+      expect(accepted).toHaveBeenCalledTimes(1)
+      expect(accepted).toHaveBeenCalledWith(supplement.platform_message_id)
+      const persistedAtAcceptance = JSON.parse(acceptedCheckpoint)
+      expect(persistedAtAcceptance.state.committedHumanMessageIds).toEqual(expect.arrayContaining([earlier.platform_message_id, supplement.platform_message_id]))
+      expect(JSON.stringify(persistedAtAcceptance.state.recent)).toContain('persisted supplement')
+      expect(duplicate).not.toHaveBeenCalled()
+    } finally {
+      release()
+      await episode
+    }
+    expect(accepted).toHaveBeenCalledTimes(1)
+    const state = await store.load(KEY)
+    expect(state.committedHumanMessageIds).toContain(supplement.platform_message_id)
+    expect(JSON.stringify(state.recent).split('persisted supplement')).toHaveLength(2)
+    expect(JSON.stringify(state.recent).split('earlier in batch')).toHaveLength(2)
+  })
+
+  it('does not confirm injected input when its context checkpoint fails', async () => {
+    const accepted = vi.fn(async () => {})
+    const supplement = { ...makeChannelMessage('checkpoint failure'), platform_message_id: 'pm-write-failed' }
+    const save = store.saveCheckpoint.bind(store)
+    vi.spyOn(store, 'saveCheckpoint').mockImplementation((checkpoint) => {
+      if (checkpoint.state.committedHumanMessageIds?.includes(supplement.platform_message_id)) {
+        throw new Error('checkpoint write failed')
+      }
+      save(checkpoint)
+    })
+    const { adapter, queue, calls } = makeAdapter()
+    queue.push({ toolCalls: [{ name: 'inject', id: 'inject', input: {} }], stopReason: 'tool_use' })
+    let loop!: ManagerLoop
+    loop = new ManagerLoop(baseDeps({ store, adapter, toolFace: () => [defineTool({
+      name: 'inject', description: 'inject', inputSchema: {}, isReadOnly: false,
+      call: async () => {
+        loop.enqueueHumanWakeDuringActiveEpisode(timed({ kind: 'human_messages', messages: [supplement] }), accepted)
+        return { output: 'ok', isError: false }
+      },
+    })] }))
+    await expect(loop.wakeUp(timed({ kind: 'human_messages', messages: [makeChannelMessage('start')] })))
+      .rejects.toThrow('checkpoint write failed')
+    expect(calls).toHaveLength(1)
+    expect(accepted).not.toHaveBeenCalled()
+    expect(JSON.stringify((await store.load(KEY)).recent)).toContain('checkpoint failure')
+  })
+
   it('只读快照将当前上下文标为 processing，mailbox 插话在 drain 前后从 queued 转为 processing', async () => {
     let releaseSecondTurn!: () => void
     const secondTurnRelease = new Promise<void>((resolve) => { releaseSecondTurn = resolve })
@@ -1285,6 +1376,7 @@ describe('ManagerLoop', () => {
   })
 
   it('episode 失败:被注入消费的人类消息补提交进 recent,下次唤醒经 tailMessages 重新可见且不重复', async () => {
+    const accepted = vi.fn(async () => {})
     const { adapter, queue } = makeAdapter()
     queue.push({ toolCalls: [{ name: 'noop_tool', id: 'call_1', input: {} }], stopReason: 'tool_use' })
 
@@ -1299,6 +1391,7 @@ describe('ManagerLoop', () => {
         }
         nonFoldCallCount++
         if (nonFoldCallCount === 2) {
+          expect(accepted).toHaveBeenCalledTimes(1)
           turn2Messages = [...params.messages]
           throw new Error('boom: simulated failure after human injection drain')
         }
@@ -1319,6 +1412,7 @@ describe('ManagerLoop', () => {
           call: async () => {
             await loop.enqueueHumanWakeDuringActiveEpisode(
               timed({ kind: 'human_messages', messages: [makeChannelMessage('失败前的人类指令')] }),
+              accepted,
             )
             return { output: 'ok', isError: false }
           },
@@ -1347,6 +1441,7 @@ describe('ManagerLoop', () => {
     const serialized = JSON.stringify(finalState.recent)
     expect(serialized).toContain('失败前的人类指令')
     expect(serialized).toContain('新的话')
+    expect(accepted).toHaveBeenCalledTimes(1)
     // 失败 episode 的重投不产生重复:该指令只出现一次
     expect(serialized.split('失败前的人类指令')).toHaveLength(2)
   })
@@ -1478,6 +1573,7 @@ describe('ManagerLoop', () => {
 
   it('注入未被消费(最后一轮 drain 之后)时不提交不 discard,留 mailbox 由自唤醒按正常路径提交+投喂', async () => {
     const { adapter, queue, calls } = makeAdapter()
+    const accepted = vi.fn(async () => {})
     // maxTurns=2:turn1 工具(注入未发生) → turn2 工具(此处注入,但其后 hasRemainingTurn=false 不 drain)
     // → 轮次耗尽 max_turns 收尾(consumedEvents=true)
     queue.push({ toolCalls: [{ name: 'noop_tool', id: 'call_1', input: {} }], stopReason: 'tool_use' })
@@ -1505,6 +1601,7 @@ describe('ManagerLoop', () => {
             // 最后一轮的工具执行后 engine 不再 drain——注入滞留 mailbox
             await loop.enqueueHumanWakeDuringActiveEpisode(
               timed({ kind: 'human_messages', messages: [makeChannelMessage('滞留指令')] }),
+              accepted,
             )
             return { output: 'ok', isError: false }
           },
@@ -1523,6 +1620,7 @@ describe('ManagerLoop', () => {
     expect(JSON.stringify(stateAfter.recent)).not.toContain('滞留指令')
     expect(stateAfter.committedHumanMessageIds ?? []).toHaveLength(1) // 仅主 wake
     expect(loop.hasPendingMailbox).toBe(true)
+    expect(accepted).not.toHaveBeenCalled()
 
     // 自唤醒/下次唤醒:mailbox 残留经 carry 正常提交(键未记,不被去重跳过),LLM 看到
     queue.push({ text: '补看滞留消息', stopReason: 'end_turn' })
@@ -1536,6 +1634,7 @@ describe('ManagerLoop', () => {
     expect(finalText).toContain('滞留指令')
     expect(finalText).toContain('新的话')
     expect(finalState.committedHumanMessageIds?.length).toBe(3) // 主 wake + 滞留 + 新的话
+    expect(accepted).toHaveBeenCalledTimes(1)
   })
 
   it('activity 仅入 mailbox 时保持 pending，进入下一次 LLM 输入前才确认', async () => {

--- a/crabot-agent/tests/manager/loop.test.ts
+++ b/crabot-agent/tests/manager/loop.test.ts
@@ -1221,11 +1221,93 @@ describe('ManagerLoop', () => {
     expect(committedIds).toHaveLength(1)
   })
 
-  it.each(['resolved', 'rejected', 'throwing', 'pending'] as const)('confirms persisted input before the slow model returns, with a %s callback', async (callbackResult) => {
+  it('initial input releases its lane on commit but waits for the complete response to confirm', async () => {
+    let release!: () => void
+    const held = new Promise<void>((resolve) => { release = resolve })
+    let entered!: () => void
+    const partialResponse = new Promise<void>((resolve) => { entered = resolve })
+    const confirmed = vi.fn(async () => {})
+    const committed = vi.fn()
+    const adapter: LLMAdapter = {
+      async *stream() {
+        yield { type: 'message_start', messageId: 'partial' }
+        yield { type: 'text_delta', text: 'still generating' }
+        entered()
+        await held
+        yield { type: 'message_end', stopReason: 'end_turn' }
+      }, updateConfig() {},
+    }
+    const loop = new ManagerLoop(baseDeps({ store, adapter }))
+    const message = makeChannelMessage('initial request')
+    const episode = loop.wakeUp(timed({ kind: 'human_messages', messages: [message] }), confirmed, committed)
+    try {
+      await partialResponse
+      expect(committed).toHaveBeenCalledTimes(1)
+      expect((await store.load(KEY)).committedHumanMessageIds).toContain(message.platform_message_id)
+      expect(confirmed).not.toHaveBeenCalled()
+    } finally {
+      release()
+      await episode
+    }
+    expect(confirmed).toHaveBeenCalledTimes(1)
+    expect(confirmed).toHaveBeenCalledWith(message.platform_message_id)
+  })
+
+  it('keeps callbacks for initial and queued inputs after a failed request until a later response contains them', async () => {
+    let release!: () => void
+    const held = new Promise<void>((resolve) => { release = resolve })
+    let entered!: () => void
+    const firstRequest = new Promise<void>((resolve) => { entered = resolve })
+    const initial = makeChannelMessage('initial failed request')
+    const supplement = makeChannelMessage('queued before failure')
+    const initialConfirmed = vi.fn(async () => {})
+    const supplementConfirmed = vi.fn(async () => {})
+    const duplicate = vi.fn(async () => {})
+    let calls = 0
+    const adapter: LLMAdapter = {
+      async *stream(params) {
+        if (++calls === 1) {
+          entered()
+          await held
+          throw new Error('non-retryable provider failure')
+        }
+        expect(JSON.stringify(params.messages)).toContain('initial failed request')
+        expect(JSON.stringify(params.messages)).toContain('queued before failure')
+        expect(initialConfirmed).not.toHaveBeenCalled()
+        expect(supplementConfirmed).not.toHaveBeenCalled()
+        yield* chunksFromContent([], 'end_turn')
+      }, updateConfig() {},
+    }
+    const loop = new ManagerLoop(baseDeps({ store, adapter }))
+    const episode = loop.wakeUp(timed({ kind: 'human_messages', messages: [initial] }), initialConfirmed)
+    try {
+      await firstRequest
+      loop.enqueueHumanWakeDuringActiveEpisode(timed({ kind: 'human_messages', messages: [supplement] }), supplementConfirmed)
+      loop.enqueueHumanWakeDuringActiveEpisode(timed({ kind: 'human_messages', messages: [supplement] }), duplicate)
+    } finally {
+      release()
+    }
+    expect((await episode).outcome).toBe('failed')
+    expect(initialConfirmed).not.toHaveBeenCalled()
+    expect(supplementConfirmed).not.toHaveBeenCalled()
+    expect(JSON.stringify((await store.load(KEY)).recent)).toContain('queued before failure')
+    await loop.wakeUp(timed({ kind: 'human_messages', messages: [makeChannelMessage('try again')] }))
+    expect(initialConfirmed).toHaveBeenCalledTimes(1)
+    expect(initialConfirmed).toHaveBeenCalledWith(initial.platform_message_id)
+    expect(supplementConfirmed).toHaveBeenCalledTimes(1)
+    expect(supplementConfirmed).toHaveBeenCalledWith(supplement.platform_message_id)
+    expect(duplicate).not.toHaveBeenCalled()
+  })
+
+  it.each(['resolved', 'rejected', 'throwing', 'pending'] as const)('confirms input after its complete response and before tools finish, with a %s callback', async (callbackResult) => {
     let release!: () => void
     const held = new Promise<void>((resolve) => { release = resolve })
     let entered!: () => void
     const secondTurn = new Promise<void>((resolve) => { entered = resolve })
+    let releaseTool!: () => void
+    const heldTool = new Promise<void>((resolve) => { releaseTool = resolve })
+    let toolEntered!: () => void
+    const inTool = new Promise<void>((resolve) => { toolEntered = resolve })
     const initial = makeChannelMessage('start')
     const earlier = makeChannelMessage('earlier in batch')
     const supplement = { ...makeChannelMessage('persisted supplement'), platform_message_id: 'pm-accepted' }
@@ -1246,8 +1328,12 @@ describe('ManagerLoop', () => {
           yield* chunksFromContent([{ type: 'tool_use', id: 'inject', name: 'inject', input: {} }], 'tool_use')
           return
         }
-        entered()
-        await held
+        if (turn === 2) {
+          entered()
+          await held
+          yield* chunksFromContent([{ type: 'tool_use', id: 'wait', name: 'wait', input: {} }], 'tool_use')
+          return
+        }
         yield* chunksFromContent([], 'end_turn')
       },
       updateConfig() {},
@@ -1260,6 +1346,13 @@ describe('ManagerLoop', () => {
         expect(accepted).not.toHaveBeenCalled()
         return { output: 'ok', isError: false }
       },
+    }), defineTool({
+      name: 'wait', description: 'wait', inputSchema: {}, isReadOnly: false,
+      call: async () => {
+        toolEntered()
+        await heldTool
+        return { output: 'ok', isError: false }
+      },
     })] }))
     const episode = loop.wakeUp(timed({ kind: 'human_messages', messages: [initial] }))
     try {
@@ -1268,6 +1361,9 @@ describe('ManagerLoop', () => {
       expect(checkpoint?.state.committedHumanMessageIds).toContain(supplement.platform_message_id)
       expect(JSON.stringify(checkpoint?.state.recent)).toContain('persisted supplement')
       expect(JSON.stringify((await store.load(KEY)).recent)).not.toContain('persisted supplement')
+      expect(accepted).not.toHaveBeenCalled()
+      release()
+      await inTool
       expect(accepted).toHaveBeenCalledTimes(1)
       expect(accepted).toHaveBeenCalledWith(supplement.platform_message_id)
       const persistedAtAcceptance = JSON.parse(acceptedCheckpoint)
@@ -1276,6 +1372,7 @@ describe('ManagerLoop', () => {
       expect(duplicate).not.toHaveBeenCalled()
     } finally {
       release()
+      releaseTool()
       await episode
     }
     expect(accepted).toHaveBeenCalledTimes(1)
@@ -1391,7 +1488,7 @@ describe('ManagerLoop', () => {
         }
         nonFoldCallCount++
         if (nonFoldCallCount === 2) {
-          expect(accepted).toHaveBeenCalledTimes(1)
+          expect(accepted).not.toHaveBeenCalled()
           turn2Messages = [...params.messages]
           throw new Error('boom: simulated failure after human injection drain')
         }
@@ -1423,6 +1520,7 @@ describe('ManagerLoop', () => {
 
     const first = await loop.wakeUp(timed({ kind: 'human_messages', messages: [makeChannelMessage('开始任务')] }))
     expect(first.outcome).toBe('failed')
+    expect(accepted).not.toHaveBeenCalled()
 
     // 证明确实被注入消费过:turn2 的请求里能看到人类指令
     expect(turn2Messages).toBeDefined()

--- a/crabot-agent/tests/manager/registry.test.ts
+++ b/crabot-agent/tests/manager/registry.test.ts
@@ -317,7 +317,7 @@ describe('ManagerRegistry', () => {
     expect(otherState.recent.length).toBe(0)
   })
 
-  it('human wake 持久化进 Manager history 后通知调用方', async () => {
+  it('human wake 的 LLM 请求成功响应后通知调用方', async () => {
     const { adapter, calls } = makeAdapter()
     const registry = new ManagerRegistry(baseRegistryDeps({ adapter }))
     const message = makeChannelMessage('你好')
@@ -332,11 +332,11 @@ describe('ManagerRegistry', () => {
       [message],
       undefined,
       undefined,
-      async (lastCommittedMessageId) => {
+      { onLlmResponse: async (lastCommittedMessageId) => {
         committedId = lastCommittedMessageId
         committedState = JSON.stringify(await store.load('wechat::sess-accepted' as ManagerKey))
         resolveCommitted()
-      },
+      } },
     )
 
     await committed
@@ -360,7 +360,7 @@ describe('ManagerRegistry', () => {
       [makeChannelMessage('你好')],
       undefined,
       undefined,
-      async () => { accepted = true },
+      { onLlmResponse: async () => { accepted = true } },
     )).rejects.toThrow('agent is closing')
 
     expect(accepted).toBe(false)

--- a/crabot-agent/tests/manager/restart-resume.test.ts
+++ b/crabot-agent/tests/manager/restart-resume.test.ts
@@ -418,13 +418,14 @@ describe('Manager restart continuation', () => {
   })
 
   it('protects a human supplement whose Engine message ID changed during an overflow retry', async () => {
+    const accepted = vi.fn(async () => {})
     await store.save({ key: KEY, foldedCount: 0, recent: [
       ...Array.from({ length: 3 }, (_, index) => createUserMessage(`old history ${index}: ` + 'x'.repeat(80000))),
       createUserMessage('last old history'),
     ] })
     const read = defineTool({ name: 'read', description: '', inputSchema: {}, isReadOnly: true,
       call: async () => {
-        await old.routeHumanMessages('feishu', 'restart-test', [message('supplement', 'Keep this correction literal')])
+        await old.routeHumanMessages('feishu', 'restart-test', [message('supplement', 'Keep this correction literal')], undefined, undefined, accepted)
         return { output: 'current result', isError: false }
       } })
     const next = defineTool({ name: 'next', description: '', inputSchema: {}, isReadOnly: true,
@@ -436,6 +437,7 @@ describe('Manager restart continuation', () => {
       } else if (calls++ === 0) {
         yield* chunksFromContent([{ type: 'tool_use', id: 'read-call', name: 'read', input: {} }], 'tool_use')
       } else if (calls === 2) {
+        expect(accepted).toHaveBeenCalledTimes(1)
         yield* chunksFromContent([], 'max_tokens')
       } else if (calls === 3) {
         yield* chunksFromContent([{ type: 'tool_use', id: 'retry-call', name: 'next', input: {} }], 'tool_use')
@@ -443,6 +445,7 @@ describe('Manager restart continuation', () => {
     }, updateConfig() {} }, { toolFace: () => [read, next], policy: { keepRecent: 2, hardCapTokens: 1000000 } })
     void old.routeWorkboardAdminUpdate({ key: KEY, noticeRevision: 1 })
     const checkpoint = await checkpointWhere((value) => value.state.foldedCount > 0 && calls === 4)
+    expect(accepted).toHaveBeenCalledTimes(1)
     const folds: string[] = []
     const inputs: string[] = []
     const restored = registry({ async *stream(params) {
@@ -461,9 +464,11 @@ describe('Manager restart continuation', () => {
     expect(inputs[0].match(/Keep this correction literal/g)).toHaveLength(1)
     expect((await store.load(KEY)).committedHumanMessageIds).toContain('supplement')
     expect(trace.getManagerEpisode(checkpoint.episodeId)?.status).toBe('completed')
+    expect(accepted).toHaveBeenCalledTimes(1)
   })
 
   it('restores a consumed image supplement from its reference without persisting inbound base64', async () => {
+    const accepted = vi.fn(async () => {})
     const path = join(dir, 'supplement.png')
     const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
     await fs.writeFile(path, bytes)
@@ -479,11 +484,14 @@ describe('Manager restart continuation', () => {
     const imageMessage = { ...message('image-supplement', 'See image'), content: {
       type: 'image' as const, file_path: path, filename: 'supplement.png', mime_type: 'image/png',
     } }
-    await old.routeHumanMessages('feishu', 'restart-test', [imageMessage])
+    await old.routeHumanMessages('feishu', 'restart-test', [imageMessage], undefined, undefined, accepted)
+    expect(accepted).not.toHaveBeenCalled()
     release()
     const checkpoint = await checkpointWhere((value) => value.state.committedHumanMessageIds?.includes('image-supplement') === true)
     expect(JSON.stringify(checkpoint)).not.toContain(bytes.toString('base64'))
     expect(checkpoint.state.imageRefs).toHaveLength(1)
+    expect(accepted).toHaveBeenCalledTimes(1)
+    expect(accepted).toHaveBeenCalledWith('image-supplement')
     const restored = registry({ async *stream(params) {
       expect(JSON.stringify(params.messages)).toContain(bytes.toString('base64'))
       yield* chunksFromContent([], 'end_turn')
@@ -493,6 +501,7 @@ describe('Manager restart continuation', () => {
     await restored.resumeInterruptedEpisodes()
     expect(JSON.stringify(await store.load(KEY))).not.toContain(bytes.toString('base64'))
     expect(trace.getManagerEpisode(checkpoint.episodeId)?.status).toBe('completed')
+    expect(accepted).toHaveBeenCalledTimes(1)
   })
 
   it('keeps restored workboard notices transient and acknowledges the original revision', async () => {

--- a/crabot-agent/tests/manager/restart-resume.test.ts
+++ b/crabot-agent/tests/manager/restart-resume.test.ts
@@ -425,7 +425,7 @@ describe('Manager restart continuation', () => {
     ] })
     const read = defineTool({ name: 'read', description: '', inputSchema: {}, isReadOnly: true,
       call: async () => {
-        await old.routeHumanMessages('feishu', 'restart-test', [message('supplement', 'Keep this correction literal')], undefined, undefined, accepted)
+        await old.routeHumanMessages('feishu', 'restart-test', [message('supplement', 'Keep this correction literal')], undefined, undefined, { onLlmResponse: accepted })
         return { output: 'current result', isError: false }
       } })
     const next = defineTool({ name: 'next', description: '', inputSchema: {}, isReadOnly: true,
@@ -437,7 +437,7 @@ describe('Manager restart continuation', () => {
       } else if (calls++ === 0) {
         yield* chunksFromContent([{ type: 'tool_use', id: 'read-call', name: 'read', input: {} }], 'tool_use')
       } else if (calls === 2) {
-        expect(accepted).toHaveBeenCalledTimes(1)
+        expect(accepted).not.toHaveBeenCalled()
         yield* chunksFromContent([], 'max_tokens')
       } else if (calls === 3) {
         yield* chunksFromContent([{ type: 'tool_use', id: 'retry-call', name: 'next', input: {} }], 'tool_use')
@@ -484,14 +484,13 @@ describe('Manager restart continuation', () => {
     const imageMessage = { ...message('image-supplement', 'See image'), content: {
       type: 'image' as const, file_path: path, filename: 'supplement.png', mime_type: 'image/png',
     } }
-    await old.routeHumanMessages('feishu', 'restart-test', [imageMessage], undefined, undefined, accepted)
+    await old.routeHumanMessages('feishu', 'restart-test', [imageMessage], undefined, undefined, { onLlmResponse: accepted })
     expect(accepted).not.toHaveBeenCalled()
     release()
     const checkpoint = await checkpointWhere((value) => value.state.committedHumanMessageIds?.includes('image-supplement') === true)
     expect(JSON.stringify(checkpoint)).not.toContain(bytes.toString('base64'))
     expect(checkpoint.state.imageRefs).toHaveLength(1)
-    expect(accepted).toHaveBeenCalledTimes(1)
-    expect(accepted).toHaveBeenCalledWith('image-supplement')
+    expect(accepted).not.toHaveBeenCalled()
     const restored = registry({ async *stream(params) {
       expect(JSON.stringify(params.messages)).toContain(bytes.toString('base64'))
       yield* chunksFromContent([], 'end_turn')
@@ -501,7 +500,7 @@ describe('Manager restart continuation', () => {
     await restored.resumeInterruptedEpisodes()
     expect(JSON.stringify(await store.load(KEY))).not.toContain(bytes.toString('base64'))
     expect(trace.getManagerEpisode(checkpoint.episodeId)?.status).toBe('completed')
-    expect(accepted).toHaveBeenCalledTimes(1)
+    expect(accepted).not.toHaveBeenCalled()
   })
 
   it('keeps restored workboard notices transient and acknowledges the original revision', async () => {


### PR DESCRIPTION
运行中的人类消息原先要等整个 Manager episode 收尾才收到 reaction。本修复由 Harness 在首次包含该输入的主处理 LLM 请求完整成功返回后自动发送一次 reaction；初始和追加输入规则一致，不等待工具或 episode 结束。Channel 与 Admin Chat 同步使用该条件。

请求前保存实际上下文检查点并捕获待确认来源；旧在途请求、首 token、仅入队/落盘或请求失败不触发。SessionLane 仍在初始输入提交历史后立即放行，后续消息不会等待模型。按平台消息 ID 保存一次性回调；失败收尾保存的输入及 mailbox 尾部在同进程后续包含原文的成功请求中确认。重复来源、重试、溢出恢复和收尾不重复发送。通知失败或挂起不阻塞、不重试；重启或空闲 loop 回收不补发。无新增 RPC、配置、持久字段、提示词或 Worker 行为。

依据：用户确认并修订的 `crabot-docs/superpowers/specs/2026-09-10-manager-input-reaction-timing-design.md`；Agent §4.1、Channel §3.15、Admin §3.20.2 已同步。

验证：新时序先在上一实现复现 5 项失败，修复后通过。Manager、恢复、入站接线、Engine 等定向测试共 380 通过；另 6 项 `tmp-page` builtin Skill fixture 缺失在未修改基线 `72a6025c` 同样复现。Agent `tsc --noEmit` 与 `git diff --check` 通过。测试覆盖部分流响应、旧请求隔离、工具阻塞期间确认、未 drain/已 drain 失败后跨轮确认、去重、通知错误/挂起、图片恢复及溢出重试。

尚未部署；合入部署后再验证真实飞书 OnIt 时间。不自行合并。
