### PR TITLE
feat(manager): 独立发布 55 工具语义精简基线

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5,6 +5,12 @@
 
 ## 当前状态
 
+### Manager 工具语义精简：独立 55 工具发布基线
+
+- 按已确认 `2026-09-03-manager-tool-surface-optimization-design.md` 的第一发布阶段，退役语义失真的 `get_system_status`，三项只读自省合并为 `inspect_crabot(view)`；数据源、脱敏和错误语义不变。
+- 普通 Manager 仍完整装配 55 项业务工具，含六项 Schedule 工具；保留 `send_private_message`。本版本不包含渐进加载、search_tools、外部 MCP 或权限迁移。
+- 本地验证后走独立 PR，不自行部署。部署后须观察至少 72 小时；后续加载器 full control 为 56 项，不能替代本基线。
+
 ### Manager 首次 LLM 响应 reaction：实现与定向验证完成，待 PR 审查
 
 - 按用户修订后的 `2026-09-10-manager-input-reaction-timing-design.md`，初始与追加输入在首次包含它的主处理 LLM 请求完整成功返回后自动确认，不等待工具或 episode 收尾；Channel 与 Admin Chat 同步。

--- a/crabot-agent/src/manager/tools/crabot-info.ts
+++ b/crabot-agent/src/manager/tools/crabot-info.ts
@@ -16,7 +16,7 @@
  */
 
 import { defineTool } from '../../engine/index.js'
-import type { ToolDefinition } from '../../engine/index.js'
+import type { ToolCallContext, ToolDefinition } from '../../engine/index.js'
 import type { ResolvedPermissions } from '../../types.js'
 import type { MasterAuthorization } from '../principal.js'
 
@@ -338,38 +338,10 @@ export function buildCrabotInfoTools(deps: CrabotInfoToolsDeps): ToolDefinition[
     return result.schedule
   }
 
-  // --- get_system_status ---
-  // 组合来源:admin RPC `get_task_stats`(任务积压快照) + `list_agent_instances` /
-  // `list_channel_instances` 的 pagination.total_items(实例数量)。admin 没有现成的
-  // "系统整体状态" RPC,这里只取数量级摘要;完整拓扑详情见 get_deployment_info。
-  const getSystemStatus = defineTool({
-    name: 'get_system_status',
-    description:
-      '查询 crabot 系统整体运行状态摘要:worker 任务积压情况(按 status/priority 计数)、' +
-      '已配置的 agent 实例数与 channel 实例数。用于回答"系统现在忙不忙/有多少任务在跑"一类问题。',
-    inputSchema: { type: 'object', properties: {} },
-    isReadOnly: true,
-    call: async () => {
-      try {
-        const [taskStats, agentInstances, channelInstances] = await Promise.all([
-          callAdmin<Record<string, never>, unknown>('get_task_stats', {}),
-          callAdmin<typeof FULL_PAGE, PaginatedResult<unknown>>('list_agent_instances', FULL_PAGE),
-          callAdmin<typeof FULL_PAGE, PaginatedResult<unknown>>('list_channel_instances', FULL_PAGE),
-        ])
-        return ok({
-          task_stats: taskStats,
-          agent_instance_count: agentInstances.pagination.total_items,
-          channel_instance_count: channelInstances.pagination.total_items,
-        })
-      } catch (error) {
-        return fail(error)
-      }
-    },
-  })
-
-  // --- get_deployment_info ---
+  // --- inspect_crabot views ---
   // P6-D：Agent 侧唯一是 exact core `crabot-agent`（静态身份，不再调 list_agent_instances）；
-  // channel 实例仍走 admin RPC。数量级摘要见 get_system_status。
+  // channel 实例仍走 admin RPC。三个旧入口共用一个带 view 的可调用工具，避免模型在同一
+  // 自省语义下重复选择工具；各 view 的数据源、脱敏和错误语义保持不变。
   interface AgentInstanceLite {
     readonly id: string
     readonly name: string
@@ -744,6 +716,32 @@ export function buildCrabotInfoTools(deps: CrabotInfoToolsDeps): ToolDefinition[
     },
   })
 
+  const inspectCrabot = defineTool({
+    name: 'inspect_crabot',
+    description:
+      '查询 crabot 的只读自省信息。view=deployment 查看部署拓扑，view=config 查看已脱敏运行配置，' +
+      'view=capabilities 查看已安装的 Agent/Worker/Channel 能力清单。',
+    inputSchema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        view: { type: 'string', enum: ['deployment', 'config', 'capabilities'] },
+      },
+      required: ['view'],
+    },
+    isReadOnly: true,
+    call: async (input, context: ToolCallContext) => {
+      const view = input.view
+      const target = view === 'deployment'
+        ? getDeploymentInfo
+        : view === 'config'
+          ? getConfigSummary
+          : view === 'capabilities' ? listCapabilities : undefined
+      if (!target) return fail(new Error('inspect_crabot.view 必须是 deployment、config 或 capabilities'))
+      return target.call({}, context)
+    },
+  })
+
   // --- get_friend_permissions ---
   // 直接对应 admin RPC `get_friend_permissions`(registerMethod 原样注册),参数/结果原样透传。
   const getFriendPermissions = defineTool({
@@ -776,15 +774,12 @@ export function buildCrabotInfoTools(deps: CrabotInfoToolsDeps): ToolDefinition[
   })
 
   return [
-    getSystemStatus,
-    getDeploymentInfo,
+    inspectCrabot,
     ...(createSchedule && getSchedule ? [createSchedule, getSchedule] : []),
     listSchedules,
     ...(updateSchedule && deleteSchedule && triggerSchedule
       ? [updateSchedule, deleteSchedule, triggerSchedule]
       : []),
-    getConfigSummary,
-    listCapabilities,
     getFriendPermissions,
   ]
 }

--- a/crabot-agent/tests/manager/crabot-info.test.ts
+++ b/crabot-agent/tests/manager/crabot-info.test.ts
@@ -59,16 +59,13 @@ function scheduleContext(overrides: Partial<ManagerScheduleToolsContext> = {}): 
 }
 
 describe('buildCrabotInfoTools', () => {
-  it('工具名集合恰为六项', () => {
+  it('无 Schedule 管理上下文时恰为三项，三个自省入口合并为 inspect_crabot', () => {
     const tools = buildCrabotInfoTools({ callAdmin: makeCallAdmin({}) })
     const names = tools.map((t) => t.name).sort()
     expect(names).toEqual(
       [
-        'get_config_summary',
-        'get_deployment_info',
         'get_friend_permissions',
-        'get_system_status',
-        'list_capabilities',
+        'inspect_crabot',
         'list_schedules',
       ].sort(),
     )
@@ -81,31 +78,21 @@ describe('buildCrabotInfoTools', () => {
     }
   })
 
-  describe('get_system_status', () => {
-    it('组合 get_task_stats / list_agent_instances / list_channel_instances 返回摘要', async () => {
+  describe('inspect_crabot deployment', () => {
+    it('查询部署拓扑且不调用已退役的系统状态 RPC', async () => {
       const callAdmin = makeCallAdmin({
-        get_task_stats: () => ({
-          total: 5,
-          by_status: { executing: 2, completed: 3 },
-          by_priority: { normal: 5 },
-        }),
-        list_agent_instances: () => ({
-          items: [{ id: 'crabot-agent' }],
-          pagination: { page: 1, page_size: 100, total_items: 1, total_pages: 1 },
-        }),
         list_channel_instances: () => ({
           items: [{ id: 'wechat-1' }, { id: 'web-1' }],
           pagination: { page: 1, page_size: 100, total_items: 2, total_pages: 1 },
         }),
       })
       const tools = buildCrabotInfoTools({ callAdmin, getRuntimeConfigSummary: () => runtimeConfigSummary(callAdmin) })
-      const tool = tools.find((t) => t.name === 'get_system_status')!
-      const result = await tool.call({}, {})
+      const tool = tools.find((t) => t.name === 'inspect_crabot')!
+      const result = await tool.call({ view: 'deployment' }, {})
       expect(result.isError).toBe(false)
       const parsed = JSON.parse(result.output)
-      expect(parsed.task_stats.total).toBe(5)
-      expect(parsed.agent_instance_count).toBe(1)
-      expect(parsed.channel_instance_count).toBe(2)
+      expect(parsed.channel_instances).toHaveLength(2)
+      expect(callAdmin).not.toHaveBeenCalledWith('get_task_stats', {})
     })
 
     it('admin RPC 失败时返回 isError', async () => {
@@ -113,14 +100,14 @@ describe('buildCrabotInfoTools', () => {
         throw new Error('admin unreachable')
       })
       const tools = buildCrabotInfoTools({ callAdmin, getRuntimeConfigSummary: () => runtimeConfigSummary(callAdmin) })
-      const tool = tools.find((t) => t.name === 'get_system_status')!
-      const result = await tool.call({}, {})
+      const tool = tools.find((t) => t.name === 'inspect_crabot')!
+      const result = await tool.call({ view: 'deployment' }, {})
       expect(result.isError).toBe(true)
       expect(result.output).toContain('admin unreachable')
     })
   })
 
-  describe('get_deployment_info', () => {
+  describe('inspect_crabot deployment', () => {
     it('P6-D：agent 实例为静态 core 身份，不再调 list_agent_instances；channel 仍走 admin', async () => {
       const called: string[] = []
       const callAdmin = makeCallAdmin({
@@ -133,8 +120,8 @@ describe('buildCrabotInfoTools', () => {
         }),
       })
       const tools = buildCrabotInfoTools({ callAdmin, getRuntimeConfigSummary: () => runtimeConfigSummary(callAdmin) })
-      const tool = tools.find((t) => t.name === 'get_deployment_info')!
-      const result = await tool.call({}, {})
+      const tool = tools.find((t) => t.name === 'inspect_crabot')!
+      const result = await tool.call({ view: 'deployment' }, {})
       expect(result.isError).toBe(false)
       const parsed = JSON.parse(result.output)
       expect(parsed.agent_instances).toEqual([
@@ -354,8 +341,8 @@ describe('buildCrabotInfoTools', () => {
         },
       })
       const tools = buildCrabotInfoTools({ callAdmin, getRuntimeConfigSummary: () => runtimeConfigSummary(callAdmin) })
-      const tool = tools.find((t) => t.name === 'get_config_summary')!
-      const result = await tool.call({}, {})
+      const tool = tools.find((t) => t.name === 'inspect_crabot')!
+      const result = await tool.call({ view: 'config' }, {})
       expect(result.isError).toBe(false)
       const parsed = JSON.parse(result.output)
 
@@ -389,8 +376,8 @@ describe('buildCrabotInfoTools', () => {
         }),
       })
       const tools = buildCrabotInfoTools({ callAdmin, getRuntimeConfigSummary: () => runtimeConfigSummary(callAdmin) })
-      const tool = tools.find((t) => t.name === 'get_config_summary')!
-      const result = await tool.call({}, {})
+      const tool = tools.find((t) => t.name === 'inspect_crabot')!
+      const result = await tool.call({ view: 'config' }, {})
       expect(result.isError).toBe(false)
       const parsed = JSON.parse(result.output)
       const output_str = JSON.stringify(parsed)
@@ -434,8 +421,8 @@ describe('buildCrabotInfoTools', () => {
         }),
       })
       const tools = buildCrabotInfoTools({ callAdmin, getRuntimeConfigSummary: () => runtimeConfigSummary(callAdmin) })
-      const tool = tools.find((t) => t.name === 'get_config_summary')!
-      const result = await tool.call({}, {})
+      const tool = tools.find((t) => t.name === 'inspect_crabot')!
+      const result = await tool.call({ view: 'config' }, {})
       expect(result.isError).toBe(false)
       const parsed = JSON.parse(result.output)
       const output_str = JSON.stringify(parsed)
@@ -477,8 +464,8 @@ describe('buildCrabotInfoTools', () => {
         }),
       })
       const tools = buildCrabotInfoTools({ callAdmin, getRuntimeConfigSummary: () => runtimeConfigSummary(callAdmin) })
-      const tool = tools.find((t) => t.name === 'get_config_summary')!
-      const result = await tool.call({}, {})
+      const tool = tools.find((t) => t.name === 'inspect_crabot')!
+      const result = await tool.call({ view: 'config' }, {})
       expect(result.isError).toBe(false)
       const parsed = JSON.parse(result.output)
       const output_str = JSON.stringify(parsed)
@@ -500,8 +487,8 @@ describe('buildCrabotInfoTools', () => {
         }),
       })
       const tools = buildCrabotInfoTools({ callAdmin, getRuntimeConfigSummary: () => runtimeConfigSummary(callAdmin) })
-      const tool = tools.find((t) => t.name === 'get_config_summary')!
-      const result = await tool.call({}, {})
+      const tool = tools.find((t) => t.name === 'inspect_crabot')!
+      const result = await tool.call({ view: 'config' }, {})
       expect(result.isError).toBe(false)
       const parsed = JSON.parse(result.output)
       const output_str = JSON.stringify(parsed)
@@ -527,8 +514,8 @@ describe('buildCrabotInfoTools', () => {
         }),
       })
       const tools = buildCrabotInfoTools({ callAdmin, getRuntimeConfigSummary: () => runtimeConfigSummary(callAdmin) })
-      const tool = tools.find((t) => t.name === 'get_config_summary')!
-      const result = await tool.call({}, {})
+      const tool = tools.find((t) => t.name === 'inspect_crabot')!
+      const result = await tool.call({ view: 'config' }, {})
       expect(result.isError).toBe(false)
       const parsed = JSON.parse(result.output)
       const output_str = JSON.stringify(parsed)
@@ -569,8 +556,8 @@ describe('buildCrabotInfoTools', () => {
         }),
       })
       const tools = buildCrabotInfoTools({ callAdmin, getRuntimeConfigSummary: () => runtimeConfigSummary(callAdmin) })
-      const tool = tools.find((t) => t.name === 'get_config_summary')!
-      const result = await tool.call({}, {})
+      const tool = tools.find((t) => t.name === 'inspect_crabot')!
+      const result = await tool.call({ view: 'config' }, {})
       expect(result.isError).toBe(false)
       const parsed = JSON.parse(result.output)
 
@@ -595,8 +582,8 @@ describe('buildCrabotInfoTools', () => {
         get_agent_config: () => ({ config: { instance_id: 'crabot-agent', model_config: {} } }),
       })
       const tools = buildCrabotInfoTools({ callAdmin, getRuntimeConfigSummary: () => runtimeConfigSummary(callAdmin) })
-      const tool = tools.find((t) => t.name === 'get_config_summary')!
-      const result = await tool.call({ instance_id: 'other-instance' }, {})
+      const tool = tools.find((t) => t.name === 'inspect_crabot')!
+      const result = await tool.call({ view: 'config', instance_id: 'other-instance' }, {})
       expect(result.isError).toBe(false)
       expect(callAdmin).not.toHaveBeenCalled()
     })
@@ -617,8 +604,8 @@ describe('buildCrabotInfoTools', () => {
         statuses: [{ impl: 'claude-code', ready: true, enabled: true, capabilities: { fork: true } }],
       })
       const tools = buildCrabotInfoTools({ callAdmin, workerImplSnapshot, getRuntimeConfigSummary: () => runtimeConfigSummary(callAdmin) })
-      const tool = tools.find((t) => t.name === 'list_capabilities')!
-      const result = await tool.call({}, {})
+      const tool = tools.find((t) => t.name === 'inspect_crabot')!
+      const result = await tool.call({ view: 'capabilities' }, {})
       expect(result.isError).toBe(false)
       const parsed = JSON.parse(result.output)
       expect(parsed.agent_implementations).toEqual([

--- a/crabot-agent/tests/manager/tool-face.test.ts
+++ b/crabot-agent/tests/manager/tool-face.test.ts
@@ -46,11 +46,8 @@ const FEISHU_READ_ONLY_TOOLS = ['read_feishu_document', 'feishu_raw_get', 'feish
 const WORKER_TOOLS = ['spawn_worker', 'send_to_worker', 'query_worker', 'get_worker_state', 'get_worker_activity', 'get_worker_turn', 'resolve_worker_turn', 'get_worker_terminal', 'request_worker_interrupt', 'request_worker_stop', 'respond_to_worker_ui', 'list_workers', 'get_worker_detail', 'list_worker_implementations']
 
 const CRABOT_INFO_TOOLS = [
-  'get_system_status',
-  'get_deployment_info',
+  'inspect_crabot',
   'list_schedules',
-  'get_config_summary',
-  'list_capabilities',
   'get_friend_permissions',
 ]
 
@@ -121,6 +118,21 @@ function memoryToolNames(tools: ToolDefinition[]): string[] {
 }
 
 describe('buildManagerToolFace', () => {
+  it('独立语义精简发布版本保持完整 55 项，不装配 search_tools 或外部 MCP', () => {
+    const tools = buildManagerToolFace(makeDeps({ schedule: {
+      targetSession: { channel_id: 'ch-1', session_id: 'sess-1', type: 'private' },
+      creatorFriendId: 'creator', canCreate: true, resolvePermissions: async () => null,
+    } }))
+    expect(tools).toHaveLength(55)
+    expect(tools.map(tool => tool.name).filter(name => name.startsWith('mcp__') && !name.startsWith('mcp__crab-memory__'))).toEqual([])
+    for (const name of ['search_tools', 'get_system_status', 'get_deployment_info', 'get_config_summary', 'list_capabilities']) {
+      expect(tools.map(tool => tool.name)).not.toContain(name)
+    }
+    for (const name of ['inspect_crabot', 'create_schedule', 'get_schedule', 'list_schedules', 'update_schedule', 'delete_schedule', 'trigger_schedule', 'send_private_message']) {
+      expect(tools.map(tool => tool.name)).toContain(name)
+    }
+  })
+
   it('普通 manager 工具名集合精确匹配预期清单', () => {
     const tools = buildManagerToolFace(makeDeps())
     const names = tools.map((t) => t.name)


### PR DESCRIPTION
## 范围与依据

依据已确认的 Manager 工具优化 spec §5/§14，先独立发布语义精简基线。

- 退役把 legacy TaskStore 当作 Worker 积压的 get_system_status。
- 将三个只读自省入口合为 inspect_crabot(view)，保持数据源、返回结构、脱敏与错误语义。
- 普通 Manager 保持完整 55 项工具，含六项 Schedule 和 send_private_message。
- 不包含 search_tools、加载器、外部 MCP、权限迁移或提示词调整。后续加载器另以 draft 保存。

## 验证

4 文件、221 项回归及 Agent TypeScript 通过；精确工具清单、条件消息工具、Schedule 和原自省 view 回归均覆盖。完整 diff 已自审。

## 失败路径与发布门禁

新入口的无效 view 返回现有失败结构，不触发 RPC。没有新增进程、目录、网络请求或权限语义。

未部署。合入后需单独部署本版本并观察至少 72 小时，确认无旧工具名错误及自省语义回归后，才推进后续加载器。Agent 不自行合并或部署。